### PR TITLE
Update RunUpdate schema to allow updated inputs

### DIFF
--- a/js/src/schemas.ts
+++ b/js/src/schemas.ts
@@ -89,12 +89,14 @@ export interface RunUpdate {
   end_time?: number;
   extra?: KVMap;
   error?: string;
+  inputs?: KVMap;
   outputs?: KVMap;
   parent_run_id?: string;
   reference_example_id?: string;
   events?: KVMap[];
   session_id?: string;
 }
+
 export interface ExampleCreate extends BaseExample {
   id?: string;
   created_at: string;


### PR DESCRIPTION
This is useful to trace full inputs in runnable .transform() calls.