### PR TITLE
Support urllib3<1.26

### DIFF
--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -8,7 +8,6 @@ import io
 import json
 import logging
 import os
-import pkg_resources
 import socket
 import uuid
 import weakref
@@ -29,6 +28,7 @@ from typing import (
 )
 from urllib import parse as urllib_parse
 
+import pkg_resources
 import requests
 from requests import adapters as requests_adapters
 from urllib3.util import Retry

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import collections
 import datetime
 import functools
+import importlib
 import io
 import json
 import logging
@@ -28,7 +29,6 @@ from typing import (
 )
 from urllib import parse as urllib_parse
 
-import pkg_resources
 import requests
 from requests import adapters as requests_adapters
 from urllib3.util import Retry
@@ -110,15 +110,14 @@ def _default_retry_config() -> Retry:
     # the `allowed_methods` keyword is not available in urllib3 < 1.26
 
     # check to see if urllib3 version is 1.26 or greater
-    urllib3_version = pkg_resources.get_distribution("urllib3").version
-    parsed_urlib3_version = pkg_resources.parse_version(urllib3_version)
-    use_allowed_methods = parsed_urlib3_version >= pkg_resources.parse_version("1.26")
+    urllib3_version = importlib.metadata.version("urllib3")
+    use_allowed_methods = tuple(map(int, urllib3_version.split("."))) >= (1, 26)
 
     if use_allowed_methods:
         # Retry on all methods
         retry_params["allowed_methods"] = None
 
-    return Retry(**retry_params)
+    return Retry(**retry_params)  # type: ignore
 
 
 def _serialize_json(obj: Any) -> str:


### PR DESCRIPTION
The `allowed_methods` keyword argument was added to `urllib3.util.Retry` in version 1.26.

This PR alters `langsmith.client._default_retry_config` to:

1. Check the version of `urllib3`
2. If version is >= 1.26, use the `allowed_methods` keyword of the `Retry` object
3. Otherwise, do not use the `allowed_methods` keyword.