### PR TITLE
Write Queue Compatible

### DIFF
--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -1707,6 +1707,8 @@ class Client:
             correction=correction,
             comment=comment,
             feedback_source=feedback_source,
+            created_at=datetime.datetime.now(datetime.timezone.utc),
+            modified_at=datetime.datetime.now(datetime.timezone.utc),
         )
         response = self.session.post(
             self.api_url + "/feedback",
@@ -1714,7 +1716,7 @@ class Client:
             data=feedback.json(exclude_none=True),
         )
         ls_utils.raise_for_status_with_text(response)
-        return ls_schemas.Feedback(**response.json())
+        return ls_schemas.Feedback(**feedback.dict())
 
     def update_feedback(
         self,

--- a/python/tests/integration_tests/test_client.py
+++ b/python/tests/integration_tests/test_client.py
@@ -13,9 +13,9 @@ from freezegun import freeze_time
 from langchain.schema import FunctionMessage, HumanMessage
 
 from langsmith.client import Client
-from langsmith.evaluation import StringEvaluator
+from langsmith.evaluation import EvaluationResult, StringEvaluator
 from langsmith.run_trees import RunTree
-from langsmith.schemas import DataType, Feedback
+from langsmith.schemas import DataType
 from langsmith.utils import LangSmithConnectionError, LangSmithError
 
 
@@ -321,12 +321,11 @@ def test_evaluate_run(
         execution_order=1,
         error=False,
     )
-    all_feedback: List[Feedback] = []
+    all_eval_results: List[EvaluationResult] = []
     for run in runs:
-        all_feedback.append(langchain_client.evaluate_run(run, evaluator))
-    assert len(all_feedback) == 1
+        all_eval_results.append(langchain_client.evaluate_run(run, evaluator))
+    assert len(all_eval_results) == 1
     fetched_feedback = list(langchain_client.list_feedback(run_ids=[run.id]))
-    assert fetched_feedback[0].id == all_feedback[0].id
     assert fetched_feedback[0].score == jaccard_chars(predicted, ground_truth)
     assert fetched_feedback[0].value == "INCORRECT"
     langchain_client.delete_dataset(dataset_id=dataset.id)

--- a/python/tests/integration_tests/test_client.py
+++ b/python/tests/integration_tests/test_client.py
@@ -349,6 +349,11 @@ def test_create_project(
 ) -> None:
     """Test the project creation"""
     monkeypatch.setenv("LANGCHAIN_ENDPOINT", "http://localhost:1984")
+    try:
+        langchain_client.read_project(project_name="__test_create_project")
+        langchain_client.delete_project(project_name="__test_create_project")
+    except LangSmithError:
+        pass
     project_name = "__test_create_project"
     project = langchain_client.create_project(project_name=project_name)
     assert project.name == project_name


### PR DESCRIPTION
Context: feedback is entering the write queue and so we can't get the info back in the response.

- Update the return object to be populated from the creation object rather than the API response.
- Permit manual specification of the ID's
- Update the evaluate_run() return object to be the evaluationresult
 