### PR TITLE
[RFC] Preprocessor

### DIFF
--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -226,6 +226,7 @@ class Client:
         "_get_data_type_cached",
         "_web_url",
         "_tenant_id",
+        "_preprocessors",
     ]
 
     def __init__(


### PR DESCRIPTION
Maybe not a beautiful UX so not something to implement immediately, but seems pretty straightforward to support redaction or other things by configuring a preprocessor? To make it easier to use in langchain or elsewhere we could have fallbacks when initializing to `get_preprocessor` to let them set globally or via a config at some point