### PR TITLE
Change which parent run tree is re-assigned

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "langsmith"
-version = "0.0.50"
+version = "0.0.51"
 description = "Client library to connect to the LangSmith LLM Tracing and Evaluation Platform."
 authors = ["LangChain <support@langchain.dev>"]
 license = "MIT"


### PR DESCRIPTION
The outer context should be re-assigned to whatever it was before and not overwritted to whatever was manually passed in