### PR TITLE
Add method to consistently get project

### DIFF
--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -658,12 +658,12 @@ class Client:
             If the API key is not provided when using the hosted service.
         """
         project_name = kwargs.pop(
-            "project_name", 
+            "project_name",
             kwargs.pop(
-                "session_name", 
+                "session_name",
                 # if the project is not provided, use the environment's project
-                ls_utils.get_tracer_project()
-            )
+                ls_utils.get_tracer_project(),
+            ),
         )
         run_create = {
             **kwargs,

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -658,8 +658,7 @@ class Client:
             If the API key is not provided when using the hosted service.
         """
         project_name_opt_from_args = kwargs.pop(
-            "project_name",
-            kwargs.pop("session_name", None)
+            "project_name", kwargs.pop("session_name", None)
         )
         project_name = project_name_opt_from_args or ls_utils.get_tracer_project()
         run_create = {

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -657,17 +657,11 @@ class Client:
         LangSmithUserError
             If the API key is not provided when using the hosted service.
         """
-        project_name = kwargs.pop(
+        project_name_opt_from_args = kwargs.pop(
             "project_name",
-            kwargs.pop(
-                "session_name",
-                os.environ.get(
-                    # TODO: Deprecate LANGCHAIN_SESSION
-                    "LANGCHAIN_PROJECT",
-                    os.environ.get("LANGCHAIN_SESSION", "default"),
-                ),
-            ),
+            kwargs.pop("session_name", None)
         )
+        project_name = project_name_opt_from_args or ls_utils.get_tracer_project()
         run_create = {
             **kwargs,
             "session_name": project_name,
@@ -925,10 +919,7 @@ class Client:
         elif project_name is not None:
             session_id = self.read_project(project_name=project_name).id
         else:
-            project_name = os.environ.get(
-                "LANGCHAIN_PROJECT",
-                "default",
-            )
+            project_name = ls_utils.get_tracer_project()
             session_id = self.read_project(project_name=project_name).id
         return (
             f"{self._host_url}/o/{self._get_tenant_id()}/projects/p/{_as_uuid(session_id)}/"

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -667,8 +667,6 @@ class Client:
         )
         run_create = {
             **kwargs,
-            # We have to cast this since get_tracer_project can return None even
-            # though it won't, since we don't pass in return_default_value=False
             "session_name": project_name,
             "name": name,
             "inputs": _hide_inputs(inputs),

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -657,12 +657,18 @@ class Client:
         LangSmithUserError
             If the API key is not provided when using the hosted service.
         """
-        project_name_opt_from_args = kwargs.pop(
-            "project_name", kwargs.pop("session_name", None)
+        project_name = kwargs.pop(
+            "project_name", 
+            kwargs.pop(
+                "session_name", 
+                # if the project is not provided, use the environment's project
+                ls_utils.get_tracer_project()
+            )
         )
-        project_name = project_name_opt_from_args or ls_utils.get_tracer_project()
         run_create = {
             **kwargs,
+            # We have to cast this since get_tracer_project can return None even
+            # though it won't, since we don't pass in return_default_value=False
             "session_name": project_name,
             "name": name,
             "inputs": _hide_inputs(inputs),

--- a/python/langsmith/utils.py
+++ b/python/langsmith/utils.py
@@ -4,7 +4,7 @@ import functools
 import logging
 import os
 import subprocess
-from typing import Any, Callable, Dict, List, Mapping, Tuple, Union
+from typing import Any, Callable, Dict, List, Mapping, Optional, Tuple, Union
 
 import requests
 
@@ -249,6 +249,25 @@ def is_base_message_like(obj: object) -> bool:
             isinstance(getattr(obj, "additional_kwargs", None), dict),
             hasattr(obj, "type") and isinstance(getattr(obj, "type"), str),
         ]
+    )
+
+def get_tracer_project(return_default_value=True) -> Optional[str]:
+    """Get the project name for a LangSmith tracer."""
+    return os.environ.get(
+        # Hosted LangServe projects get precedence over all other defaults.
+        # This is to make sure that we always use the associated project
+        # for a hosted langserve deployment even if the customer sets some
+        # other project name in their environment.
+        "HOSTED_LANGSERVE_PROJECT_NAME",
+        os.environ.get(
+            "LANGCHAIN_PROJECT",
+            os.environ.get(
+                # This is the legacy name for a LANGCHAIN_PROJECT, so we it
+                # has lower precedence than LANGCHAIN_PROJECT
+                "LANGCHAIN_SESSION",
+                "default" if return_default_value else None,
+            ),
+        ),
     )
 
 

--- a/python/langsmith/utils.py
+++ b/python/langsmith/utils.py
@@ -263,7 +263,7 @@ def get_tracer_project(return_default_value=True) -> Optional[str]:
         os.environ.get(
             "LANGCHAIN_PROJECT",
             os.environ.get(
-                # This is the legacy name for a LANGCHAIN_PROJECT, so we it
+                # This is the legacy name for a LANGCHAIN_PROJECT, so it
                 # has lower precedence than LANGCHAIN_PROJECT
                 "LANGCHAIN_SESSION",
                 "default" if return_default_value else None,

--- a/python/langsmith/utils.py
+++ b/python/langsmith/utils.py
@@ -251,6 +251,7 @@ def is_base_message_like(obj: object) -> bool:
         ]
     )
 
+
 def get_tracer_project(return_default_value=True) -> Optional[str]:
     """Get the project name for a LangSmith tracer."""
     return os.environ.get(

--- a/python/poetry.lock
+++ b/python/poetry.lock
@@ -470,6 +470,7 @@ files = [
     {file = "greenlet-2.0.2-cp27-cp27m-win32.whl", hash = "sha256:6c3acb79b0bfd4fe733dff8bc62695283b57949ebcca05ae5c129eb606ff2d74"},
     {file = "greenlet-2.0.2-cp27-cp27m-win_amd64.whl", hash = "sha256:283737e0da3f08bd637b5ad058507e578dd462db259f7f6e4c5c365ba4ee9343"},
     {file = "greenlet-2.0.2-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:d27ec7509b9c18b6d73f2f5ede2622441de812e7b1a80bbd446cb0633bd3d5ae"},
+    {file = "greenlet-2.0.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:d967650d3f56af314b72df7089d96cda1083a7fc2da05b375d2bc48c82ab3f3c"},
     {file = "greenlet-2.0.2-cp310-cp310-macosx_11_0_x86_64.whl", hash = "sha256:30bcf80dda7f15ac77ba5af2b961bdd9dbc77fd4ac6105cee85b0d0a5fcf74df"},
     {file = "greenlet-2.0.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:26fbfce90728d82bc9e6c38ea4d038cba20b7faf8a0ca53a9c07b67318d46088"},
     {file = "greenlet-2.0.2-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9190f09060ea4debddd24665d6804b995a9c122ef5917ab26e1566dcc712ceeb"},
@@ -478,6 +479,7 @@ files = [
     {file = "greenlet-2.0.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:76ae285c8104046b3a7f06b42f29c7b73f77683df18c49ab5af7983994c2dd91"},
     {file = "greenlet-2.0.2-cp310-cp310-win_amd64.whl", hash = "sha256:2d4686f195e32d36b4d7cf2d166857dbd0ee9f3d20ae349b6bf8afc8485b3645"},
     {file = "greenlet-2.0.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:c4302695ad8027363e96311df24ee28978162cdcdd2006476c43970b384a244c"},
+    {file = "greenlet-2.0.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d4606a527e30548153be1a9f155f4e283d109ffba663a15856089fb55f933e47"},
     {file = "greenlet-2.0.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c48f54ef8e05f04d6eff74b8233f6063cb1ed960243eacc474ee73a2ea8573ca"},
     {file = "greenlet-2.0.2-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a1846f1b999e78e13837c93c778dcfc3365902cfb8d1bdb7dd73ead37059f0d0"},
     {file = "greenlet-2.0.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3a06ad5312349fec0ab944664b01d26f8d1f05009566339ac6f63f56589bc1a2"},
@@ -507,6 +509,7 @@ files = [
     {file = "greenlet-2.0.2-cp37-cp37m-win32.whl", hash = "sha256:3f6ea9bd35eb450837a3d80e77b517ea5bc56b4647f5502cd28de13675ee12f7"},
     {file = "greenlet-2.0.2-cp37-cp37m-win_amd64.whl", hash = "sha256:7492e2b7bd7c9b9916388d9df23fa49d9b88ac0640db0a5b4ecc2b653bf451e3"},
     {file = "greenlet-2.0.2-cp38-cp38-macosx_10_15_x86_64.whl", hash = "sha256:b864ba53912b6c3ab6bcb2beb19f19edd01a6bfcbdfe1f37ddd1778abfe75a30"},
+    {file = "greenlet-2.0.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:1087300cf9700bbf455b1b97e24db18f2f77b55302a68272c56209d5587c12d1"},
     {file = "greenlet-2.0.2-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:ba2956617f1c42598a308a84c6cf021a90ff3862eddafd20c3333d50f0edb45b"},
     {file = "greenlet-2.0.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fc3a569657468b6f3fb60587e48356fe512c1754ca05a564f11366ac9e306526"},
     {file = "greenlet-2.0.2-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8eab883b3b2a38cc1e050819ef06a7e6344d4a990d24d45bc6f2cf959045a45b"},
@@ -515,6 +518,7 @@ files = [
     {file = "greenlet-2.0.2-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:b0ef99cdbe2b682b9ccbb964743a6aca37905fda5e0452e5ee239b1654d37f2a"},
     {file = "greenlet-2.0.2-cp38-cp38-win32.whl", hash = "sha256:b80f600eddddce72320dbbc8e3784d16bd3fb7b517e82476d8da921f27d4b249"},
     {file = "greenlet-2.0.2-cp38-cp38-win_amd64.whl", hash = "sha256:4d2e11331fc0c02b6e84b0d28ece3a36e0548ee1a1ce9ddde03752d9b79bba40"},
+    {file = "greenlet-2.0.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:8512a0c38cfd4e66a858ddd1b17705587900dd760c6003998e9472b77b56d417"},
     {file = "greenlet-2.0.2-cp39-cp39-macosx_11_0_x86_64.whl", hash = "sha256:88d9ab96491d38a5ab7c56dd7a3cc37d83336ecc564e4e8816dbed12e5aaefc8"},
     {file = "greenlet-2.0.2-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:561091a7be172ab497a3527602d467e2b3fbe75f9e783d8b8ce403fa414f71a6"},
     {file = "greenlet-2.0.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:971ce5e14dc5e73715755d0ca2975ac88cfdaefcaab078a284fea6cfabf866df"},
@@ -575,6 +579,7 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, !=3.6.*"
 files = [
     {file = "jsonpointer-2.4-py2.py3-none-any.whl", hash = "sha256:15d51bba20eea3165644553647711d150376234112651b4f1811022aecad7d7a"},
+    {file = "jsonpointer-2.4.tar.gz", hash = "sha256:585cee82b70211fa9e6043b7bb89db6e1aa49524340dde8ad6b63206ea689d88"},
 ]
 
 [[package]]
@@ -1013,6 +1018,21 @@ docs = ["sphinx (>=5.3)", "sphinx-rtd-theme (>=1.0)"]
 testing = ["coverage (>=6.2)", "flaky (>=3.5.0)", "hypothesis (>=5.7.1)", "mypy (>=0.931)", "pytest-trio (>=0.7.0)"]
 
 [[package]]
+name = "pytest-subtests"
+version = "0.11.0"
+description = "unittest subTest() support and subtests fixture"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "pytest-subtests-0.11.0.tar.gz", hash = "sha256:51865c88457545f51fb72011942f0a3c6901ee9e24cbfb6d1b9dc1348bafbe37"},
+    {file = "pytest_subtests-0.11.0-py3-none-any.whl", hash = "sha256:453389984952eec85ab0ce0c4f026337153df79587048271c7fd0f49119c07e4"},
+]
+
+[package.dependencies]
+attrs = ">=19.2.0"
+pytest = ">=7.0"
+
+[[package]]
 name = "python-dateutil"
 version = "2.8.2"
 description = "Extensions to the standard Python datetime module"
@@ -1038,6 +1058,7 @@ files = [
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:69b023b2b4daa7548bcfbd4aa3da05b3a74b772db9e23b982788168117739938"},
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:81e0b275a9ecc9c0c0c07b4b90ba548307583c125f54d5b6946cfee6360c733d"},
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ba336e390cd8e4d1739f42dfe9bb83a3cc2e80f567d8805e11b46f4a943f5515"},
+    {file = "PyYAML-6.0.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:326c013efe8048858a6d312ddd31d56e468118ad4cdeda36c719bf5bb6192290"},
     {file = "PyYAML-6.0.1-cp310-cp310-win32.whl", hash = "sha256:bd4af7373a854424dabd882decdc5579653d7868b8fb26dc7d0e99f823aa5924"},
     {file = "PyYAML-6.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:fd1592b3fdf65fff2ad0004b5e363300ef59ced41c2e6b3a99d4089fa8c5435d"},
     {file = "PyYAML-6.0.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:6965a7bc3cf88e5a1c3bd2e0b5c22f8d677dc88a455344035f03399034eb3007"},
@@ -1045,8 +1066,15 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:42f8152b8dbc4fe7d96729ec2b99c7097d656dc1213a3229ca5383f973a5ed6d"},
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:062582fca9fabdd2c8b54a3ef1c978d786e0f6b3a1510e0ac93ef59e0ddae2bc"},
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d2b04aac4d386b172d5b9692e2d2da8de7bfb6c387fa4f801fbf6fb2e6ba4673"},
+    {file = "PyYAML-6.0.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:e7d73685e87afe9f3b36c799222440d6cf362062f78be1013661b00c5c6f678b"},
     {file = "PyYAML-6.0.1-cp311-cp311-win32.whl", hash = "sha256:1635fd110e8d85d55237ab316b5b011de701ea0f29d07611174a1b42f1444741"},
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
+    {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
+    {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
+    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
+    {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
+    {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
+    {file = "PyYAML-6.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:0d3304d8c0adc42be59c5f8a4d9e3d7379e6955ad754aa9d6ab7a398b59dd1df"},
     {file = "PyYAML-6.0.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:50550eb667afee136e9a77d6dc71ae76a44df8b3e51e41b77f6de2932bfe0f47"},
     {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1fe35611261b29bd1de0070f0b2f47cb6ff71fa6595c077e42bd0c419fa27b98"},
     {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:704219a11b772aea0d8ecd7058d0082713c3562b4e271b849ad7dc4a5c90c13c"},
@@ -1063,6 +1091,7 @@ files = [
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a0cd17c15d3bb3fa06978b4e8958dcdc6e0174ccea823003a106c7d4d7899ac5"},
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:28c119d996beec18c05208a8bd78cbe4007878c6dd15091efb73a30e90539696"},
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7e07cbde391ba96ab58e532ff4803f79c4129397514e1413a7dc761ccd755735"},
+    {file = "PyYAML-6.0.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:49a183be227561de579b4a36efbb21b3eab9651dd81b1858589f796549873dd6"},
     {file = "PyYAML-6.0.1-cp38-cp38-win32.whl", hash = "sha256:184c5108a2aca3c5b3d3bf9395d50893a7ab82a38004c8f61c258d4428e80206"},
     {file = "PyYAML-6.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:1e2722cc9fbb45d9b87631ac70924c11d3a401b2d7f410cc0e3bbf249f2dca62"},
     {file = "PyYAML-6.0.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:9eb6caa9a297fc2c2fb8862bc5370d0303ddba53ba97e71f08023b6cd73d16a8"},
@@ -1070,6 +1099,7 @@ files = [
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5773183b6446b2c99bb77e77595dd486303b4faab2b086e7b17bc6bef28865f6"},
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b786eecbdf8499b9ca1d697215862083bd6d2a99965554781d0d8d1ad31e13a0"},
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bc1bf2925a1ecd43da378f4db9e4f799775d6367bdb94671027b73b393a7c42c"},
+    {file = "PyYAML-6.0.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:04ac92ad1925b2cff1db0cfebffb6ffc43457495c9b3c39d3fcae417d7125dc5"},
     {file = "PyYAML-6.0.1-cp39-cp39-win32.whl", hash = "sha256:faca3bdcf85b2fc05d06ff3fbc1f83e1391b3e724afa3feba7d13eeab355484c"},
     {file = "PyYAML-6.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:510c9deebc5c0225e8c96813043e62b680ba2f9c50a08d3724c7f28a747d1486"},
     {file = "PyYAML-6.0.1.tar.gz", hash = "sha256:bfdf460b1736c775f2ba9f6a92bca30bc2095067b8a9d77876d1fad6cc3b4a43"},
@@ -1438,4 +1468,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8.1,<4.0"
-content-hash = "2888e2d6180b1e74d377a4a6dd459d70cc745f0717aa8584023633e169508c07"
+content-hash = "34b5fd8fc91b927786f123d02db1332f9c1489f47cde64a90b50b21fc8018325"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -28,6 +28,7 @@ langsmith = "langsmith.cli.main:main"
 python = ">=3.8.1,<4.0"
 pydantic = ">=1,<3"
 requests = "^2"
+pytest-subtests = "^0.11.0"
 
 
 [tool.poetry.group.dev.dependencies]

--- a/python/tests/unit_tests/test_utils.py
+++ b/python/tests/unit_tests/test_utils.py
@@ -1,0 +1,71 @@
+import unittest
+
+import pytest
+
+import langsmith.utils as ls_utils
+
+class LangSmithProjectNameTest(unittest.TestCase):
+
+    class GetTracerProjectTestCase:
+        def __init__(self, test_name, envvars, expected_project_name, return_default_value=None):
+            self.test_name = test_name
+            self.envvars = envvars
+            self.expected_project_name = expected_project_name
+            self.return_default_value = return_default_value
+
+    def test_correct_get_tracer_project(self):
+        cases = [
+            self.GetTracerProjectTestCase(
+                test_name = "default to 'default' when no project provided",
+                envvars = {},
+                expected_project_name = "default",
+            ),
+            self.GetTracerProjectTestCase(
+                test_name = "default to 'default' when return_default_value=True and no project provided",
+                envvars = {},
+                expected_project_name = "default",
+            ),
+            self.GetTracerProjectTestCase(
+                test_name = "do not default if return_default_value=False when no project provided",
+                envvars = {},
+                expected_project_name = None,
+                return_default_value=False,
+            ),
+            self.GetTracerProjectTestCase(
+                test_name = "use session_name for legacy tracers",
+                envvars = {
+                    "LANGCHAIN_SESSION": "old_timey_session"
+                },
+                expected_project_name = "old_timey_session",
+            ),
+            self.GetTracerProjectTestCase(
+                test_name = "use LANGCHAIN_PROJECT over SESSION_NAME",
+                envvars = {
+                    "LANGCHAIN_SESSION": "old_timey_session",
+                    "LANGCHAIN_PROJECT": "modern_session"
+                },
+                expected_project_name = "modern_session",
+            ),
+            self.GetTracerProjectTestCase(
+                test_name = "hosted projects get precedence over all other defaults",
+                envvars = {
+                    "HOSTED_LANGSERVE_PROJECT_NAME": "hosted_project",
+                    "LANGCHAIN_SESSION": "old_timey_session",
+                    "LANGCHAIN_PROJECT": "modern_session"
+                },
+                expected_project_name = "hosted_project",
+            ),
+        ]
+
+        for case in cases:
+            with self.subTest(msg=case.test_name):
+                with pytest.MonkeyPatch.context() as mp:
+                    for k, v in case.envvars.items():
+                        mp.setenv(k, v)
+                    
+                    project = (
+                        ls_utils.get_tracer_project() 
+                        if case.return_default_value is None 
+                        else ls_utils.get_tracer_project(case.return_default_value)
+                    )
+                    self.assertEqual(project, case.expected_project_name)

--- a/python/tests/unit_tests/test_utils.py
+++ b/python/tests/unit_tests/test_utils.py
@@ -4,10 +4,12 @@ import pytest
 
 import langsmith.utils as ls_utils
 
-class LangSmithProjectNameTest(unittest.TestCase):
 
+class LangSmithProjectNameTest(unittest.TestCase):
     class GetTracerProjectTestCase:
-        def __init__(self, test_name, envvars, expected_project_name, return_default_value=None):
+        def __init__(
+            self, test_name, envvars, expected_project_name, return_default_value=None
+        ):
             self.test_name = test_name
             self.envvars = envvars
             self.expected_project_name = expected_project_name
@@ -16,44 +18,44 @@ class LangSmithProjectNameTest(unittest.TestCase):
     def test_correct_get_tracer_project(self):
         cases = [
             self.GetTracerProjectTestCase(
-                test_name = "default to 'default' when no project provided",
-                envvars = {},
-                expected_project_name = "default",
+                test_name="default to 'default' when no project provided",
+                envvars={},
+                expected_project_name="default",
             ),
             self.GetTracerProjectTestCase(
-                test_name = "default to 'default' when return_default_value=True and no project provided",
-                envvars = {},
-                expected_project_name = "default",
+                test_name="default to 'default' when "
+                + "return_default_value=True and no project provided",
+                envvars={},
+                expected_project_name="default",
             ),
             self.GetTracerProjectTestCase(
-                test_name = "do not default if return_default_value=False when no project provided",
-                envvars = {},
-                expected_project_name = None,
+                test_name="do not default if return_default_value=False "
+                + "when no project provided",
+                envvars={},
+                expected_project_name=None,
                 return_default_value=False,
             ),
             self.GetTracerProjectTestCase(
-                test_name = "use session_name for legacy tracers",
-                envvars = {
-                    "LANGCHAIN_SESSION": "old_timey_session"
-                },
-                expected_project_name = "old_timey_session",
+                test_name="use session_name for legacy tracers",
+                envvars={"LANGCHAIN_SESSION": "old_timey_session"},
+                expected_project_name="old_timey_session",
             ),
             self.GetTracerProjectTestCase(
-                test_name = "use LANGCHAIN_PROJECT over SESSION_NAME",
-                envvars = {
+                test_name="use LANGCHAIN_PROJECT over SESSION_NAME",
+                envvars={
                     "LANGCHAIN_SESSION": "old_timey_session",
-                    "LANGCHAIN_PROJECT": "modern_session"
+                    "LANGCHAIN_PROJECT": "modern_session",
                 },
-                expected_project_name = "modern_session",
+                expected_project_name="modern_session",
             ),
             self.GetTracerProjectTestCase(
-                test_name = "hosted projects get precedence over all other defaults",
-                envvars = {
+                test_name="hosted projects get precedence over all other defaults",
+                envvars={
                     "HOSTED_LANGSERVE_PROJECT_NAME": "hosted_project",
                     "LANGCHAIN_SESSION": "old_timey_session",
-                    "LANGCHAIN_PROJECT": "modern_session"
+                    "LANGCHAIN_PROJECT": "modern_session",
                 },
-                expected_project_name = "hosted_project",
+                expected_project_name="hosted_project",
             ),
         ]
 
@@ -62,10 +64,10 @@ class LangSmithProjectNameTest(unittest.TestCase):
                 with pytest.MonkeyPatch.context() as mp:
                     for k, v in case.envvars.items():
                         mp.setenv(k, v)
-                    
+
                     project = (
-                        ls_utils.get_tracer_project() 
-                        if case.return_default_value is None 
+                        ls_utils.get_tracer_project()
+                        if case.return_default_value is None
                         else ls_utils.get_tracer_project(case.return_default_value)
                     )
                     self.assertEqual(project, case.expected_project_name)


### PR DESCRIPTION
We plan to introduce an environment variable in hosted langserve that will overwrite the project used for traces from hosted deployments. We don't centralize how we refer to projects in any of our repos, so in order to ensure that our tracing works properly and our project selection is consistent, we need to introduce a shared method for getting the project that we can use throughout our different repos