### PR TITLE
Add Annotation Queue API Methods

### DIFF
--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -1816,7 +1816,9 @@ class Client:
         )
         ls_utils.raise_for_status_with_text(response)
         result = response.json()
-        return ls_schemas.Example(**result)
+        return ls_schemas.Example(
+            **result, _host_url=self._host_url, _tenant_id=self._get_tenant_id()
+        )
 
     def read_example(self, example_id: ID_TYPE) -> ls_schemas.Example:
         """Read an example from the LangSmith API.
@@ -1832,7 +1834,11 @@ class Client:
             The example.
         """
         response = self._get_with_retries(f"/examples/{_as_uuid(example_id)}")
-        return ls_schemas.Example(**response.json())
+        return ls_schemas.Example(
+            **response.json(),
+            _host_url=self._host_url,
+            _tenant_id=self._get_tenant_id(),
+        )
 
     def list_examples(
         self,
@@ -1869,7 +1875,9 @@ class Client:
             params["id"] = example_ids
         params["inline_s3_urls"] = inline_s3_urls
         yield from (
-            ls_schemas.Example(**example)
+            ls_schemas.Example(
+                **example, _host_url=self._host_url, _tenant_id=self._get_tenant_id()
+            )
             for example in self._get_paginated_list("/examples", params=params)
         )
 
@@ -1980,7 +1988,9 @@ class Client:
         elif isinstance(example, ls_schemas.Example):
             reference_example_ = example
         elif isinstance(example, dict):
-            reference_example_ = ls_schemas.Example(**example)
+            reference_example_ = ls_schemas.Example(
+                **example, _host_url=self._host_url, _tenant_id=self._get_tenant_id()
+            )
         elif run.reference_example_id is not None:
             reference_example_ = self.read_example(run.reference_example_id)
         else:

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -609,7 +609,9 @@ class Client:
             file_name = csv_file if isinstance(csv_file, str) else csv_file[0]
             file_name = file_name.split("/")[-1]
             raise ValueError(f"Dataset {file_name} already exists")
-        return ls_schemas.Dataset(**result, _host_url=self._host_url)
+        return ls_schemas.Dataset(
+            **result, _host_url=self._host_url, _tenant_id=self._get_tenant_id()
+        )
 
     def create_run(
         self,
@@ -1034,7 +1036,11 @@ class Client:
             headers=self._headers,
         )
         ls_utils.raise_for_status_with_text(response)
-        return ls_schemas.Dataset(**response.json(), _host_url=self._host_url)
+        return ls_schemas.Dataset(
+            **response.json(),
+            _host_url=self._host_url,
+            _tenant_id=self._get_tenant_id(),
+        )
 
     def list_shared_examples(
         self, share_token: str, *, example_ids: Optional[List[ID_TYPE]] = None
@@ -1539,7 +1545,9 @@ class Client:
             params["name_contains"] = dataset_name_contains
 
         yield from (
-            ls_schemas.Dataset(**dataset, _host_url=self._host_url)
+            ls_schemas.Dataset(
+                **dataset, _host_url=self._host_url, _tenant_id=self._get_tenant_id()
+            )
             for dataset in self._get_paginated_list("/datasets", params=params)
         )
 

--- a/python/langsmith/evaluation/evaluator.py
+++ b/python/langsmith/evaluation/evaluator.py
@@ -98,14 +98,13 @@ class DynamicRunEvaluator(RunEvaluator):
 
     @staticmethod
     def _coerce_evaluation_result(
-        result: Union[EvaluationResult, dict]
+        result: Union[EvaluationResult, dict, EvaluationResults]
     ) -> EvaluationResult:
         if isinstance(result, EvaluationResult):
             return result
         try:
             return EvaluationResult(**result)
         except ValidationError as e:
-            EvaluationResult.schema().validate(result)
             raise ValidationError(
                 "Expected an EvaluationResult object, or dict with a metric"
                 f" 'key' and optional 'score'; got {result}"

--- a/python/langsmith/evaluation/evaluator.py
+++ b/python/langsmith/evaluation/evaluator.py
@@ -83,7 +83,7 @@ class DynamicRunEvaluator(RunEvaluator):
     def __init__(
         self,
         func: Callable[
-            [Run, Optional[Example]], Union[EvaluationResult, EvaluationResults]
+            [Run, Optional[Example]], Union[EvaluationResult, EvaluationResults, dict]
         ],
     ):
         """

--- a/python/langsmith/schemas.py
+++ b/python/langsmith/schemas.py
@@ -259,6 +259,15 @@ class Run(RunBase):
         return None
 
 
+class RunWithAnnotationQueueInfo(RunBase):
+    """Run schema with annotation queue info."""
+
+    last_reviewed_time: Optional[datetime] = None
+    """The last time this run was reviewed."""
+    added_at: Optional[datetime] = None
+    """The time this run was added to the queue."""
+
+
 class FeedbackSourceBase(BaseModel):
     type: str
     metadata: Optional[Dict[str, Any]] = Field(default_factory=dict)
@@ -408,6 +417,15 @@ class DatasetShareSchema(TypedDict, total=False):
     dataset_id: UUID
     share_token: UUID
     url: str
+
+
+class AnnotationQueue(BaseModel):
+    id: UUID
+    name: str
+    description: Optional[str] = None
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+    updated_at: datetime = Field(default_factory=datetime.utcnow)
+    tenant_id: UUID
 
 
 Example.update_forward_refs()

--- a/python/langsmith/schemas.py
+++ b/python/langsmith/schemas.py
@@ -65,6 +65,29 @@ class Example(ExampleBase):
     created_at: datetime
     modified_at: Optional[datetime] = Field(default=None)
     runs: List[Run] = Field(default_factory=list)
+    _host_url: Optional[str] = PrivateAttr(default=None)
+    _tenant_id: Optional[UUID] = PrivateAttr(default=None)
+
+    def __init__(
+        self,
+        _host_url: Optional[str] = None,
+        _tenant_id: Optional[UUID] = None,
+        **kwargs: Any,
+    ) -> None:
+        """Initialize a Dataset object."""
+        super().__init__(**kwargs)
+        self._host_url = _host_url
+        self._tenant_id = _tenant_id
+
+    @property
+    def url(self) -> Optional[str]:
+        """URL of this run within the app."""
+        if self._host_url:
+            path = f"/datasets/{self.dataset_id}/e/{self.id}"
+            if self._tenant_id:
+                return f"{self._host_url}/o/{str(self._tenant_id)}{path}"
+            return f"{self._host_url}{path}"
+        return None
 
 
 class ExampleUpdate(BaseModel):

--- a/python/tests/unit_tests/test_client.py
+++ b/python/tests/unit_tests/test_client.py
@@ -91,6 +91,7 @@ def test_upload_csv(mock_session_cls: mock.Mock) -> None:
         api_url="http://localhost:1984",
         api_key="123",
     )
+    client._tenant_id = uuid.uuid4()
     csv_file = ("test.csv", BytesIO(b"input,output\n1,2\n3,4\n"))
 
     dataset = client.upload_csv(


### PR DESCRIPTION
Add methods from the Annotation Queue API to the python package.
Also improve the run evaluator decorator and add a URL for example objects