### PR TITLE
fix infinite loop when paginating via cursor

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langsmith",
-  "version": "0.0.54",
+  "version": "0.0.55",
   "description": "Client library to connect to the LangSmith LLM Tracing and Evaluation Platform.",
   "files": [
     "dist/",

--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -317,9 +317,9 @@ export class Client {
     while (true) {
       const response = await this.caller.call(fetch, `${this.apiUrl}${path}`, {
         method: requestMethod,
-        headers: this.headers,
+        headers: { ...this.headers, "Content-Type": "application/json" },
         signal: AbortSignal.timeout(this.timeout_ms),
-        body: JSON.stringify(bodyParams),
+        body: JSON.stringify(body),
       });
       const responseBody = await response.json();
       if (!responseBody) {

--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -319,7 +319,7 @@ export class Client {
         method: requestMethod,
         headers: { ...this.headers, "Content-Type": "application/json" },
         signal: AbortSignal.timeout(this.timeout_ms),
-        body: JSON.stringify(body),
+        body: JSON.stringify(bodyParams),
       });
       const responseBody = await response.json();
       if (!responseBody) {


### PR DESCRIPTION
Reverts a change [here](https://github.com/langchain-ai/langsmith-sdk/pull/346) that causes an infinite loop.

(see the line `bodyParams.cursor = cursors.next;`)