### PR TITLE
fix url hosting url parse

### DIFF
--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -227,7 +227,10 @@ export class Client {
     } else if (isLocalhost(this.apiUrl)) {
       this.webUrl = "http://localhost";
       return "http://localhost";
-    } else if (this.apiUrl.includes("/api")) {
+    } else if (
+      this.apiUrl.includes("/api") &&
+      !this.apiUrl.split(".", 1)[0].endsWith("api")
+    ) {
       this.webUrl = this.apiUrl.replace("/api", "");
       return this.webUrl;
     } else if (this.apiUrl.split(".", 1)[0].includes("dev")) {


### PR DESCRIPTION
The current logic to fetch the langsmith host url unintentionally turns the default langsmith url of `https://api.smith.langchain.com` into an invalid url of `https:/.smith.langchain.com` because it matches on the /api portion.

This PR changes the logic to exempt those cases where the subdomain begins with `api` so that the correct host url is returned.