### PR TITLE
Add optional tracing sampling rate to langsmith sdk

### DIFF
--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -318,7 +318,7 @@ class Client:
             If the API key is not provided when using the hosted service.
         """
         self.tracing_sample_rate = _get_tracing_sampling_rate()
-        self._sampled_post_uuids = set()
+        self._sampled_post_uuids: set[uuid.UUID] = set()
         self.api_key = _get_api_key(api_key)
         self.api_url = _get_api_url(api_url, self.api_key)
         _validate_api_key_if_hosted(self.api_url, self.api_key)
@@ -737,7 +737,7 @@ class Client:
         self, runs: Iterable[dict], *, patch: bool = False
     ) -> list[dict]:
         if self.tracing_sample_rate is None:
-            return runs
+            return list(runs)
 
         if patch:
             sampled = []

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -217,7 +217,8 @@ def _get_tracing_sampling_rate() -> float | None:
     sampling_rate = float(sampling_rate_str)
     if sampling_rate < 0 or sampling_rate > 1:
         raise ls_utils.LangSmithUserError(
-            "LANGCHAIN_TRACING_SAMPLING_RATE must be between 0 and 1 if set"
+            "LANGCHAIN_TRACING_SAMPLING_RATE must be between 0 and 1 if set."
+            f" Got: {sampling_rate}"
         )
     return sampling_rate
 

--- a/python/tests/integration_tests/test_runs.py
+++ b/python/tests/integration_tests/test_runs.py
@@ -72,13 +72,15 @@ def test_nested_runs(
 
     my_chain_run("foo", langsmith_extra=dict(project_name=project_name))
     executor.shutdown(wait=True)
-    for _ in range(5):
+    for _ in range(15):
         try:
             runs = list(langchain_client.list_runs(project_name=project_name))
             assert len(runs) == 3
             break
         except (ls_utils.LangSmithError, AssertionError):
             time.sleep(1)
+    else:
+        raise AssertionError("Failed to get runs after 5 attempts.")
     assert len(runs) == 3
     runs_dict = {run.name: run for run in runs}
     assert runs_dict["my_chain_run"].parent_run_id is None

--- a/python/tests/integration_tests/test_runs.py
+++ b/python/tests/integration_tests/test_runs.py
@@ -80,7 +80,7 @@ def test_nested_runs(
         except (ls_utils.LangSmithError, AssertionError):
             time.sleep(1)
     else:
-        raise AssertionError("Failed to get runs after 5 attempts.")
+        raise AssertionError("Failed to get runs after 15 attempts.")
     assert len(runs) == 3
     runs_dict = {run.name: run for run in runs}
     assert runs_dict["my_chain_run"].parent_run_id is None


### PR DESCRIPTION
- controlled by LANGCHAIN_TRACING_SAMPLING_RATE
- if a POST was allowed then the matching PATCH is allowed too
- applied on both single and batch tracing endpoints