### PR TITLE
Enable no args decorator

### DIFF
--- a/python/langsmith/run_helpers.py
+++ b/python/langsmith/run_helpers.py
@@ -25,6 +25,7 @@ from typing import (
     TypedDict,
     TypeVar,
     cast,
+    overload,
     runtime_checkable,
 )
 
@@ -241,6 +242,14 @@ class SupportsLangsmithExtra(Protocol, Generic[R]):
         ...
 
 
+@overload
+def traceable(
+    func: Callable[..., R],
+) -> Callable[..., R]:
+    ...
+
+
+@overload
 def traceable(
     run_type: str = "chain",
     *,
@@ -251,6 +260,13 @@ def traceable(
     client: Optional[client.Client] = None,
     extra: Optional[Dict] = None,
     reduce_fn: Optional[Callable] = None,
+) -> Callable[[Callable[..., R]], SupportsLangsmithExtra[R]]:
+    ...
+
+
+def traceable(
+    *args: Any,
+    **kwargs: Any,
 ) -> Callable[[Callable[..., R]], SupportsLangsmithExtra[R]]:
     """Decorator for creating or adding a run to a run tree.
 
@@ -264,8 +280,6 @@ def traceable(
         tags: The tags to add to the run. Defaults to None.
         client: The client to use for logging the run to LangSmith. Defaults to
             None, which will use the default client.
-        extra: Any additional info to be injected into the run's 'extra' field.
-            Metadata are stored in a field within the extra dict. Defaults to None.
         reduce_fn: A function to reduce the output of the function if the function
             returns a generator. Defaults to None, which means the values will be
                 logged as a list. Note: if the iterator is never exhausted (e.g.
@@ -273,7 +287,18 @@ def traceable(
                 called, and the run itself will be stuck in a pending state.
 
     """
-    extra_outer = extra or {}
+    run_type = (
+        args[0]
+        if args and isinstance(args[0], str)
+        else (kwargs.get("run_type") or "chain")
+    )
+    extra_outer = kwargs.get("extra") or {}
+    name = kwargs.get("name")
+    executor = kwargs.get("executor")
+    metadata = kwargs.get("metadata")
+    tags = kwargs.get("tags")
+    client = kwargs.get("client")
+    reduce_fn = kwargs.get("reduce_fn")
 
     def decorator(func: Callable):
         @functools.wraps(func)
@@ -492,6 +517,11 @@ def traceable(
         setattr(selected_wrapper, "__langsmith_traceable__", True)
         return selected_wrapper
 
+    # If the decorator is called with no arguments, then it's being used as a
+    # decorator, so we return the decorator function
+    if len(args) == 1 and callable(args[0]) and not kwargs:
+        return decorator(args[0])
+    # Else it's being used as a decorator factory, so we return the decorator
     return decorator
 
 

--- a/python/langsmith/run_helpers.py
+++ b/python/langsmith/run_helpers.py
@@ -24,6 +24,7 @@ from typing import (
     Protocol,
     TypedDict,
     TypeVar,
+    Union,
     cast,
     overload,
     runtime_checkable,
@@ -267,7 +268,7 @@ def traceable(
 def traceable(
     *args: Any,
     **kwargs: Any,
-) -> Callable[[Callable[..., R]], SupportsLangsmithExtra[R]]:
+) -> Union[Callable, Callable[[Callable], Callable]]:
     """Decorator for creating or adding a run to a run tree.
 
     Args:

--- a/python/tests/unit_tests/test_run_helpers.py
+++ b/python/tests/unit_tests/test_run_helpers.py
@@ -167,6 +167,26 @@ async def test_traceable_async_iterator() -> None:
     assert [i async for i in my_iterator_fn(1, 2, 3)] == [0, 1, 2, 3, 4, 5]
 
 
+def test_traceable_iterator_noargs() -> None:
+    # Check that it's callable without the parens
+    @traceable
+    def my_iterator_fn(a, b, d):
+        for i in range(a + b + d):
+            yield i
+
+    assert list(my_iterator_fn(1, 2, 3)) == [0, 1, 2, 3, 4, 5]
+
+
+async def test_traceable_async_iterator_noargs() -> None:
+    # Check that it's callable without the parens
+    @traceable
+    async def my_iterator_fn(a, b, d):
+        for i in range(a + b + d):
+            yield i
+
+    assert [i async for i in my_iterator_fn(1, 2, 3)] == [0, 1, 2, 3, 4, 5]
+
+
 def test_as_runnable() -> None:
     @traceable()
     def my_function(a, b, d):


### PR DESCRIPTION
Change to let you do this:
```
from langsmith import traceable

@traceable
def foo():
    return "bar"
```

Rather than ONLY this:
```
from langsmith import traceable

@traceable() # <- need to call the function
def foo():
    return "bar"
```