### PR TITLE
Make start_time type mandatory in create run params

### DIFF
--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -93,7 +93,7 @@ interface CreateRunParams {
   run_type: string;
   execution_order?: number;
   id?: string;
-  start_time?: number;
+  start_time: number;
   end_time?: number;
   extra?: KVMap;
   error?: string;

--- a/js/src/schemas.ts
+++ b/js/src/schemas.ts
@@ -175,6 +175,7 @@ export interface Run extends BaseRun {
 }
 
 export interface RunCreate extends BaseRun {
+  start_time: number;
   child_runs?: this[];
   session_name?: string;
 }


### PR DESCRIPTION
CC @nfcampos @hinthornw 