### PR TITLE
fix depracation warning of .utcnow()

### DIFF
--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -864,7 +864,7 @@ class Client:
         if "outputs" in run_create:
             run_create["outputs"] = _hide_outputs(run_create["outputs"])
         if not run_create.get("start_time"):
-            run_create["start_time"] = datetime.datetime.now(datetime.UTC)
+            run_create["start_time"] = datetime.datetime.now(datetime.timezone.utc)
         return run_create
 
     @staticmethod
@@ -1132,7 +1132,7 @@ class Client:
         if end_time is not None:
             data["end_time"] = end_time.isoformat()
         else:
-            data["end_time"] = datetime.datetime.now(datetime.UTC).isoformat()
+            data["end_time"] = datetime.datetime.now(datetime.timezone.utc).isoformat()
         if error is not None:
             data["error"] = error
         if inputs is not None:

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -864,7 +864,7 @@ class Client:
         if "outputs" in run_create:
             run_create["outputs"] = _hide_outputs(run_create["outputs"])
         if not run_create.get("start_time"):
-            run_create["start_time"] = datetime.datetime.utcnow()
+            run_create["start_time"] = datetime.datetime.now(datetime.UTC)
         return run_create
 
     @staticmethod
@@ -1132,7 +1132,7 @@ class Client:
         if end_time is not None:
             data["end_time"] = end_time.isoformat()
         else:
-            data["end_time"] = datetime.datetime.utcnow().isoformat()
+            data["end_time"] = datetime.datetime.now(datetime.UTC).isoformat()
         if error is not None:
             data["error"] = error
         if inputs is not None:

--- a/python/langsmith/run_trees.py
+++ b/python/langsmith/run_trees.py
@@ -29,7 +29,7 @@ class RunTree(RunBase):
     name: str
     id: UUID = Field(default_factory=uuid4)
     run_type: str = Field(default="chain")
-    start_time: datetime = Field(default_factory=datetime.now(timezone.utc))
+    start_time: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     parent_run: Optional[RunTree] = Field(default=None, exclude=True)
     child_runs: List[RunTree] = Field(
         default_factory=list,

--- a/python/langsmith/run_trees.py
+++ b/python/langsmith/run_trees.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Dict, List, Optional, cast
 from uuid import UUID, uuid4
 
@@ -29,7 +29,7 @@ class RunTree(RunBase):
     name: str
     id: UUID = Field(default_factory=uuid4)
     run_type: str = Field(default="chain")
-    start_time: datetime = Field(default_factory=datetime.utcnow)
+    start_time: datetime = Field(default_factory=datetime.now(timezone.utc))
     parent_run: Optional[RunTree] = Field(default=None, exclude=True)
     child_runs: List[RunTree] = Field(
         default_factory=list,
@@ -102,7 +102,7 @@ class RunTree(RunBase):
         end_time: Optional[datetime] = None,
     ) -> None:
         """Set the end time of the run and all child runs."""
-        self.end_time = end_time or datetime.now(datetime.UTC)
+        self.end_time = end_time or datetime.now(timezone.utc)
         if outputs is not None:
             self.outputs = outputs
         if error is not None:
@@ -135,7 +135,7 @@ class RunTree(RunBase):
             error=error,
             run_type=run_type,
             reference_example_id=reference_example_id,
-            start_time=start_time or datetime.now(datetime.UTC),
+            start_time=start_time or datetime.now(timezone.utc),
             end_time=end_time,
             extra=extra or {},
             parent_run=self,

--- a/python/langsmith/run_trees.py
+++ b/python/langsmith/run_trees.py
@@ -102,7 +102,7 @@ class RunTree(RunBase):
         end_time: Optional[datetime] = None,
     ) -> None:
         """Set the end time of the run and all child runs."""
-        self.end_time = end_time or datetime.utcnow()
+        self.end_time = end_time or datetime.now(datetime.UTC)
         if outputs is not None:
             self.outputs = outputs
         if error is not None:
@@ -135,7 +135,7 @@ class RunTree(RunBase):
             error=error,
             run_type=run_type,
             reference_example_id=reference_example_id,
-            start_time=start_time or datetime.utcnow(),
+            start_time=start_time or datetime.now(datetime.UTC),
             end_time=end_time,
             extra=extra or {},
             parent_run=self,

--- a/python/langsmith/schemas.py
+++ b/python/langsmith/schemas.py
@@ -57,7 +57,7 @@ class ExampleCreate(ExampleBase):
     """Example create model."""
 
     id: Optional[UUID]
-    created_at: datetime = Field(default_factory=datetime.now(timezone.utc))
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
 
 class Example(ExampleBase):
@@ -127,7 +127,7 @@ class DatasetCreate(DatasetBase):
     """Dataset create model."""
 
     id: Optional[UUID] = None
-    created_at: datetime = Field(default_factory=datetime.now(timezone.utc))
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
 
 class Dataset(DatasetBase):
@@ -422,7 +422,7 @@ class TracerSession(BaseModel):
 
     id: UUID
     """The ID of the project."""
-    start_time: datetime = Field(default_factory=datetime.now(timezone.utc))
+    start_time: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     """The time the project was created."""
     end_time: Optional[datetime] = None
     """The time the project was ended."""
@@ -514,8 +514,8 @@ class AnnotationQueue(BaseModel):
     id: UUID
     name: str
     description: Optional[str] = None
-    created_at: datetime = Field(default_factory=datetime.now(timezone.utc))
-    updated_at: datetime = Field(default_factory=datetime.now(timezone.utc))
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     tenant_id: UUID
 
 

--- a/python/langsmith/schemas.py
+++ b/python/langsmith/schemas.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from enum import Enum
 from typing import (
     Any,
@@ -57,7 +57,7 @@ class ExampleCreate(ExampleBase):
     """Example create model."""
 
     id: Optional[UUID]
-    created_at: datetime = Field(default_factory=datetime.utcnow)
+    created_at: datetime = Field(default_factory=datetime.now(timezone.utc))
 
 
 class Example(ExampleBase):
@@ -127,7 +127,7 @@ class DatasetCreate(DatasetBase):
     """Dataset create model."""
 
     id: Optional[UUID] = None
-    created_at: datetime = Field(default_factory=datetime.utcnow)
+    created_at: datetime = Field(default_factory=datetime.now(timezone.utc))
 
 
 class Dataset(DatasetBase):
@@ -422,7 +422,7 @@ class TracerSession(BaseModel):
 
     id: UUID
     """The ID of the project."""
-    start_time: datetime = Field(default_factory=datetime.utcnow)
+    start_time: datetime = Field(default_factory=datetime.now(timezone.utc))
     """The time the project was created."""
     end_time: Optional[datetime] = None
     """The time the project was ended."""
@@ -514,8 +514,8 @@ class AnnotationQueue(BaseModel):
     id: UUID
     name: str
     description: Optional[str] = None
-    created_at: datetime = Field(default_factory=datetime.utcnow)
-    updated_at: datetime = Field(default_factory=datetime.utcnow)
+    created_at: datetime = Field(default_factory=datetime.now(timezone.utc))
+    updated_at: datetime = Field(default_factory=datetime.now(timezone.utc))
     tenant_id: UUID
 
 

--- a/python/tests/integration_tests/test_client.py
+++ b/python/tests/integration_tests/test_client.py
@@ -272,8 +272,8 @@ def test_create_run_with_masked_inputs_outputs(
             run_type="llm",
             inputs={"prompt": "hello world"},
             outputs={"generation": "hi there"},
-            start_time=datetime.utcnow(),
-            end_time=datetime.utcnow(),
+            start_time=datetime.now(datetime.UTC),
+            end_time=datetime.now(datetime.UTC),
             hide_inputs=True,
             hide_outputs=True,
         )
@@ -285,14 +285,14 @@ def test_create_run_with_masked_inputs_outputs(
             name="test_run_2",
             run_type="llm",
             inputs={"messages": "hello world 2"},
-            start_time=datetime.utcnow(),
+            start_time=datetime.now(datetime.UTC),
             hide_inputs=True,
         )
 
         langchain_client.update_run(
             run_id2,
             outputs={"generation": "hi there 2"},
-            end_time=datetime.utcnow(),
+            end_time=datetime.now(datetime.UTC),
             hide_outputs=True,
         )
         wait_for(lambda: langchain_client.read_run(run_id).end_time is not None)
@@ -364,8 +364,8 @@ def test_batch_ingest_runs(langchain_client: Client) -> None:
     _session = "__test_batch_ingest_runs"
     trace_id = uuid4()
     run_id_2 = uuid4()
-    current_time = datetime.utcnow().strftime("%Y%m%dT%H%M%S%fZ")
-    later_time = (datetime.utcnow() + timedelta(seconds=1)).strftime("%Y%m%dT%H%M%S%fZ")
+    current_time = datetime.now(datetime.UTC).strftime("%Y%m%dT%H%M%S%fZ")
+    later_time = (datetime.now(datetime.UTC) + timedelta(seconds=1)).strftime("%Y%m%dT%H%M%S%fZ")
     runs_to_create = [
         {
             "id": str(trace_id),
@@ -453,7 +453,7 @@ def test_update_run_extra(add_metadata: bool, do_batching: bool) -> None:
     run: Dict[str, Any] = {
         "id": run_id,
         "name": "run 1",
-        "start_time": datetime.utcnow(),
+        "start_time": datetime.now(datetime.UTC),
         "run_type": "chain",
         "inputs": {"input1": 1, "input2": 2},
         "outputs": {"output1": 3, "output2": 4},

--- a/python/tests/integration_tests/test_client.py
+++ b/python/tests/integration_tests/test_client.py
@@ -1,11 +1,12 @@
 """LangSmith langchain_client Integration Tests."""
 
+import datetime
 import io
 import os
 import random
 import string
 import time
-from datetime import datetime, timedelta
+from datetime import timedelta
 from typing import Any, Callable, Dict, cast
 from uuid import uuid4
 
@@ -142,7 +143,7 @@ def test_persist_update_run(langchain_client: Client) -> None:
     if langchain_client.has_project(project_name):
         langchain_client.delete_project(project_name=project_name)
     try:
-        start_time = datetime.now()
+        start_time = datetime.datetime.now()
         revision_id = uuid4()
         run: dict = dict(
             id=uuid4(),
@@ -272,8 +273,8 @@ def test_create_run_with_masked_inputs_outputs(
             run_type="llm",
             inputs={"prompt": "hello world"},
             outputs={"generation": "hi there"},
-            start_time=datetime.now(datetime.UTC),
-            end_time=datetime.now(datetime.UTC),
+            start_time=datetime.datetime.now(datetime.timezone.utc),
+            end_time=datetime.datetime.now(datetime.timezone.utc),
             hide_inputs=True,
             hide_outputs=True,
         )
@@ -285,14 +286,14 @@ def test_create_run_with_masked_inputs_outputs(
             name="test_run_2",
             run_type="llm",
             inputs={"messages": "hello world 2"},
-            start_time=datetime.now(datetime.UTC),
+            start_time=datetime.datetime.now(datetime.timezone.utc),
             hide_inputs=True,
         )
 
         langchain_client.update_run(
             run_id2,
             outputs={"generation": "hi there 2"},
-            end_time=datetime.now(datetime.UTC),
+            end_time=datetime.datetime.now(datetime.timezone.utc),
             hide_outputs=True,
         )
         wait_for(lambda: langchain_client.read_run(run_id).end_time is not None)
@@ -364,8 +365,12 @@ def test_batch_ingest_runs(langchain_client: Client) -> None:
     _session = "__test_batch_ingest_runs"
     trace_id = uuid4()
     run_id_2 = uuid4()
-    current_time = datetime.now(datetime.UTC).strftime("%Y%m%dT%H%M%S%fZ")
-    later_time = (datetime.now(datetime.UTC) + timedelta(seconds=1)).strftime("%Y%m%dT%H%M%S%fZ")
+    current_time = datetime.datetime.now(datetime.timezone.utc).strftime(
+        "%Y%m%dT%H%M%S%fZ"
+    )
+    later_time = (
+        datetime.datetime.now(datetime.timezone.utc) + timedelta(seconds=1)
+    ).strftime("%Y%m%dT%H%M%S%fZ")
     runs_to_create = [
         {
             "id": str(trace_id),
@@ -453,7 +458,7 @@ def test_update_run_extra(add_metadata: bool, do_batching: bool) -> None:
     run: Dict[str, Any] = {
         "id": run_id,
         "name": "run 1",
-        "start_time": datetime.now(datetime.UTC),
+        "start_time": datetime.datetime.now(datetime.timezone.utc),
         "run_type": "chain",
         "inputs": {"input1": 1, "input2": 2},
         "outputs": {"output1": 3, "output2": 4},


### PR DESCRIPTION
as seen in the [official docs](https://docs.python.org/3/library/datetime.html#datetime.datetime.utcnow) datetime.datetime.utcnow() is being deprecated and the suggested function to use instead is datetime.datetime.now(datetime.UTC) (which also supports the .isoformat() function)