### PR TITLE
Allow manually specified client in run tree with no env vars

### DIFF
--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -294,7 +294,6 @@ export class Client {
     this.apiUrl = trimQuotes(config.apiUrl ?? defaultConfig.apiUrl) ?? "";
     this.apiKey = trimQuotes(config.apiKey ?? defaultConfig.apiKey);
     this.webUrl = trimQuotes(config.webUrl ?? defaultConfig.webUrl);
-    this.validateApiKeyIfHosted();
     this.timeout_ms = config.timeout_ms ?? 12_000;
     this.caller = new AsyncCaller(config.callerOptions ?? {});
     this.hideInputs = config.hideInputs ?? defaultConfig.hideInputs;
@@ -326,15 +325,6 @@ export class Client {
       hideInputs: hideInputs,
       hideOutputs: hideOutputs,
     };
-  }
-
-  private validateApiKeyIfHosted(): void {
-    const isLocal = isLocalhost(this.apiUrl);
-    if (!isLocal && !this.apiKey) {
-      throw new Error(
-        "API key must be provided when using hosted LangSmith API"
-      );
-    }
   }
 
   private getHostUrl(): string {

--- a/js/src/run_trees.ts
+++ b/js/src/run_trees.ts
@@ -62,7 +62,7 @@ export class RunTree implements BaseRun {
   dotted_order: string;
 
   constructor(config: RunTreeConfig) {
-    const defaultConfig = RunTree.getDefaultConfig();
+    const defaultConfig = RunTree.getDefaultConfig(config.client);
     Object.assign(this, { ...defaultConfig, ...config });
     if (!this.trace_id) {
       if (this.parent_run) {
@@ -84,7 +84,7 @@ export class RunTree implements BaseRun {
       }
     }
   }
-  private static getDefaultConfig(): object {
+  private static getDefaultConfig(client?: Client): object {
     return {
       id: uuid.v4(),
       run_type: "chain",
@@ -101,7 +101,7 @@ export class RunTree implements BaseRun {
       serialized: {},
       inputs: {},
       extra: {},
-      client: new Client({}),
+      client: client ?? new Client({}),
     };
   }
 

--- a/js/src/tests/run_trees.test.ts
+++ b/js/src/tests/run_trees.test.ts
@@ -1,0 +1,34 @@
+import { jest } from "@jest/globals";
+import { Client } from "../client.js";
+import { RunTree } from "../run_trees.js";
+
+test.concurrent(
+  "Should work with manually set API key",
+  async () => {
+    const key = process.env.LANGCHAIN_API_KEY;
+    delete process.env.LANGCHAIN_API_KEY;
+    const langchainClient = new Client({
+      autoBatchTracing: true,
+      callerOptions: { maxRetries: 0 },
+      timeout_ms: 30_000,
+      apiKey: key,
+    });
+    const callSpy = jest
+      .spyOn((langchainClient as any).caller, "call")
+      .mockResolvedValue({
+        ok: true,
+        text: () => "",
+      });
+    const projectName = "__test_persist_update_run_tree";
+    const runTree = new RunTree({
+      name: "Test Run Tree",
+      inputs: { input: "foo1" },
+      client: langchainClient,
+      project_name: projectName,
+    });
+    await runTree.postRun();
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+    expect(callSpy).toHaveBeenCalled();
+  },
+  180_000
+);

--- a/js/src/tests/run_trees.test.ts
+++ b/js/src/tests/run_trees.test.ts
@@ -1,3 +1,5 @@
+/* eslint-disable no-process-env */
+
 import { jest } from "@jest/globals";
 import { Client } from "../client.js";
 import { RunTree } from "../run_trees.js";


### PR DESCRIPTION
We were initializing a client by default every time, which means if you don't have an env var set, you can't use the run tree.

Should we remove the thrown error altogether on client initialization? Why was that added in the first place?

@hinthornw @dqbd 