### PR TITLE
[Python] 0.1.16

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "langsmith"
-version = "0.1.15"
+version = "0.1.16"
 description = "Client library to connect to the LangSmith LLM Tracing and Evaluation Platform."
 authors = ["LangChain <support@langchain.dev>"]
 license = "MIT"


### PR DESCRIPTION
Fix a bug that occurs when using Datadog (they patch threading.lock, making it non-deep-copyable)