### PR TITLE
feat: allow multiple write URLS for runs in SDK (python)

### DIFF
--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -288,19 +288,21 @@ def _get_tracing_sampling_rate() -> float | None:
 
 
 def _get_api_key(api_key: Optional[str]) -> Optional[str]:
-    api_key = api_key if api_key is not None else os.getenv("LANGCHAIN_API_KEY")
+    api_key = api_key or os.getenv("LANGSMITH_API_KEY", os.getenv("LANGCHAIN_API_KEY"))
     if api_key is None or not api_key.strip():
         return None
     return api_key.strip().strip('"').strip("'")
 
 
-def _get_api_url(api_url: Optional[str], api_key: Optional[str]) -> str:
+def _get_api_url(api_url: Optional[str]) -> str:
     _api_url = (
         api_url
-        if api_url is not None
-        else os.getenv(
-            "LANGCHAIN_ENDPOINT",
-            "https://api.smith.langchain.com",
+        or os.getenv(
+            "LANGSMITH_ENDPOINT",
+            os.getenv(
+                "LANGCHAIN_ENDPOINT",
+                "https://api.smith.langchain.com",
+            )
         )
     )
     if not _api_url.strip():
@@ -413,7 +415,7 @@ class Client:
         self.tracing_sample_rate = _get_tracing_sampling_rate()
         self._sampled_post_uuids: set[uuid.UUID] = set()
         self.api_key = _get_api_key(api_key)
-        self.api_url = _get_api_url(api_url, self.api_key)
+        self.api_url = _get_api_url(api_url)
         _validate_api_key_if_hosted(self.api_url, self.api_key)
         self.retry_config = retry_config or _default_retry_config()
         self.timeout_ms = timeout_ms or 10000

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -289,11 +289,19 @@ def _get_tracing_sampling_rate() -> float | None:
     return sampling_rate
 
 
+def _get_env(var_names: Sequence[str], default: Optional[str] = None) -> Optional[str]:
+    for var_name in var_names:
+        var = os.getenv(var_name)
+        if var is not None:
+            return var
+    return default
+
+
 def _get_api_key(api_key: Optional[str]) -> Optional[str]:
     api_key_ = (
         api_key
         if api_key is not None
-        else os.getenv("LANGSMITH_API_KEY", os.getenv("LANGCHAIN_API_KEY"))
+        else _get_env(("LANGSMITH_API_KEY", "LANGCHAIN_API_KEY"))
     )
     if api_key_ is None or not api_key_.strip():
         return None
@@ -301,15 +309,12 @@ def _get_api_key(api_key: Optional[str]) -> Optional[str]:
 
 
 def _get_api_url(api_url: Optional[str]) -> str:
-    _api_url = (
-        api_url
-        or os.getenv(
-            "LANGSMITH_ENDPOINT",
-            os.getenv(
-                "LANGCHAIN_ENDPOINT",
-            ),
-        )
-        or "https://api.smith.langchain.com"
+    _api_url = api_url or cast(
+        str,
+        _get_env(
+            ("LANGSMITH_ENDPOINT", "LANGCHAIN_ENDPOINT"),
+            "https://api.smith.langchain.com",
+        ),
     )
     if not _api_url.strip():
         raise ls_utils.LangSmithUserError("LangSmith API URL cannot be empty")

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -290,10 +290,14 @@ def _get_tracing_sampling_rate() -> float | None:
 
 
 def _get_api_key(api_key: Optional[str]) -> Optional[str]:
-    api_key = api_key or os.getenv("LANGSMITH_API_KEY", os.getenv("LANGCHAIN_API_KEY"))
-    if api_key is None or not api_key.strip():
+    api_key_ = (
+        api_key
+        if api_key is not None
+        else os.getenv("LANGSMITH_API_KEY", os.getenv("LANGCHAIN_API_KEY"))
+    )
+    if api_key_ is None or not api_key_.strip():
         return None
-    return api_key.strip().strip('"').strip("'")
+    return api_key_.strip().strip('"').strip("'")
 
 
 def _get_api_url(api_url: Optional[str]) -> str:
@@ -452,7 +456,7 @@ class Client:
         ) and os.getenv("LANGSMITH_RUNS_ENDPOINTS"):
             raise ls_utils.LangSmithUserError(
                 "You cannot provide both LANGSMITH_ENDPOINT / LANGCHAIN_ENDPOINT "
-                "and LANGSMITH_ENDPOINTS."
+                "and LANGSMITH_RUNS_ENDPOINTS."
             )
 
         self.tracing_sample_rate = _get_tracing_sampling_rate()

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -457,7 +457,9 @@ class Client:
 
         self.tracing_sample_rate = _get_tracing_sampling_rate()
         self._sampled_post_uuids: set[uuid.UUID] = set()
-        self._write_api_urls = _get_write_api_urls(api_urls)
+        self._write_api_urls: Mapping[str, Optional[str]] = _get_write_api_urls(
+            api_urls
+        )
         if self._write_api_urls:
             self.api_url = next(iter(self._write_api_urls))
             self.api_key: Optional[str] = self._write_api_urls[self.api_url]

--- a/python/langsmith/schemas.py
+++ b/python/langsmith/schemas.py
@@ -221,7 +221,7 @@ class RunBase(BaseModel):
     """List of events associated with the run, like
     start and end events."""
 
-    inputs: Optional[dict] = Field(default_factory=dict)
+    inputs: dict = Field(default_factory=dict)
     """Inputs used for the run."""
 
     outputs: Optional[dict] = None

--- a/python/langsmith/schemas.py
+++ b/python/langsmith/schemas.py
@@ -221,7 +221,7 @@ class RunBase(BaseModel):
     """List of events associated with the run, like
     start and end events."""
 
-    inputs: dict
+    inputs: Optional[dict] = Field(default_factory=dict)
     """Inputs used for the run."""
 
     outputs: Optional[dict] = None
@@ -301,7 +301,8 @@ class Run(RunBase):
         """Initialize a Run object."""
         if not kwargs.get("trace_id"):
             kwargs = {"trace_id": kwargs.get("id"), **kwargs}
-        super().__init__(**kwargs)
+        inputs = kwargs.pop("inputs", None) or {}
+        super().__init__(**kwargs, inputs=inputs)
         self._host_url = _host_url
         if not self.dotted_order.strip() and not self.parent_run_id:
             self.dotted_order = f"{self.start_time.isoformat()}{self.id}"

--- a/python/tests/unit_tests/test_client.py
+++ b/python/tests/unit_tests/test_client.py
@@ -150,6 +150,8 @@ def test_validate_multiple_urls(monkeypatch: pytest.MonkeyPatch) -> None:
         "https://api.smith.langsmith-endpoint_2.com": "456",
         "https://api.smith.langsmith-endpoint_3.com": "789",
     }
+    monkeypatch.delenv("LANGCHAIN_ENDPOINT")
+    monkeypatch.delenv("LANGSMITH_ENDPOINT", raising=False)
     monkeypatch.setenv("LANGSMITH_RUNS_ENDPOINTS", json.dumps(data))
     client = Client()
     assert client._write_api_urls == data

--- a/python/tests/unit_tests/test_client.py
+++ b/python/tests/unit_tests/test_client.py
@@ -66,14 +66,14 @@ def test_validate_api_key_if_hosted(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_validate_api_url(monkeypatch: pytest.MonkeyPatch) -> None:
-    # Scenario 1: Both LANGCHAIN_ENDPOINT and LANGSMITH_ENDPOINT are set, but api_url is not
+    # Scenario 1: Both LANGCHAIN_ENDPOINT and LANGSMITH_ENDPOINT set, api_url is not
     monkeypatch.setenv("LANGCHAIN_ENDPOINT", "https://api.smith.langchain-endpoint.com")
     monkeypatch.setenv("LANGSMITH_ENDPOINT", "https://api.smith.langsmith-endpoint.com")
 
     client = Client()
     assert client.api_url == "https://api.smith.langsmith-endpoint.com"
 
-    # Scenario 2: Both LANGCHAIN_ENDPOINT and LANGSMITH_ENDPOINT are set, and api_url is set
+    # Scenario 2: Both LANGCHAIN_ENDPOINT and LANGSMITH_ENDPOINT set, api_url is set
     monkeypatch.setenv("LANGCHAIN_ENDPOINT", "https://api.smith.langchain-endpoint.com")
     monkeypatch.setenv("LANGSMITH_ENDPOINT", "https://api.smith.langsmith-endpoint.com")
 
@@ -96,14 +96,14 @@ def test_validate_api_url(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_validate_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
-    # Scenario 1: Both LANGCHAIN_API_KEY and LANGSMITH_API_KEY are set, but api_key is not
+    # Scenario 1: Both LANGCHAIN_API_KEY and LANGSMITH_API_KEY set, api_key is not
     monkeypatch.setenv("LANGCHAIN_API_KEY", "env_langchain_api_key")
     monkeypatch.setenv("LANGSMITH_API_KEY", "env_langsmith_api_key")
 
     client = Client()
     assert client.api_key == "env_langsmith_api_key"
 
-    # Scenario 2: Both LANGCHAIN_API_KEY and LANGSMITH_API_KEY are set, and api_key is set
+    # Scenario 2: Both LANGCHAIN_API_KEY and LANGSMITH_API_KEY set, api_key is set
     monkeypatch.setenv("LANGCHAIN_API_KEY", "env_langchain_api_key")
     monkeypatch.setenv("LANGSMITH_API_KEY", "env_langsmith_api_key")
 
@@ -123,6 +123,34 @@ def test_validate_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
 
     client = Client()
     assert client.api_key == "env_langsmith_api_key"
+
+
+def test_validate_multiple_urls(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LANGCHAIN_ENDPOINT", "https://api.smith.langchain-endpoint.com")
+    monkeypatch.setenv("LANGSMITH_ENDPOINT", "https://api.smith.langsmith-endpoint.com")
+    monkeypatch.setenv("LANGSMITH_RUNS_ENDPOINTS", "{}")
+
+    with pytest.raises(ls_utils.LangSmithUserError):
+        Client()
+
+    monkeypatch.undo()
+    with pytest.raises(ls_utils.LangSmithUserError):
+        Client(
+            api_url="https://api.smith.langchain.com",
+            api_key="123",
+            api_urls={"https://api.smith.langchain.com": "123"},
+        )
+
+    data = {
+        "https://api.smith.langsmith-endpoint_1.com": "123",
+        "https://api.smith.langsmith-endpoint_2.com": "456",
+        "https://api.smith.langsmith-endpoint_3.com": "789",
+    }
+    monkeypatch.setenv("LANGSMITH_RUNS_ENDPOINTS", json.dumps(data))
+    client = Client()
+    assert client.write_api_urls == data
+    assert client.api_url == "https://api.smith.langsmith-endpoint_1.com"
+    assert client.api_key == "123"
 
 
 def test_headers(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -234,22 +262,22 @@ def test_get_api_key() -> None:
 
 
 def test_get_api_url() -> None:
-    assert _get_api_url("http://provided.url", "api_key") == "http://provided.url"
+    assert _get_api_url("http://provided.url") == "http://provided.url"
 
     with patch.dict(os.environ, {"LANGCHAIN_ENDPOINT": "http://env.url"}):
-        assert _get_api_url(None, "api_key") == "http://env.url"
+        assert _get_api_url(None) == "http://env.url"
 
     with patch.dict(os.environ, {}, clear=True):
-        assert _get_api_url(None, "api_key") == "https://api.smith.langchain.com"
+        assert _get_api_url(None) == "https://api.smith.langchain.com"
 
     with patch.dict(os.environ, {}, clear=True):
-        assert _get_api_url(None, None) == "https://api.smith.langchain.com"
+        assert _get_api_url(None) == "https://api.smith.langchain.com"
 
     with patch.dict(os.environ, {"LANGCHAIN_ENDPOINT": "http://env.url"}):
-        assert _get_api_url(None, None) == "http://env.url"
+        assert _get_api_url(None) == "http://env.url"
 
     with pytest.raises(ls_utils.LangSmithUserError):
-        _get_api_url(" ", "api_key")
+        _get_api_url(" ")
 
 
 def test_create_run_unicode() -> None:

--- a/python/tests/unit_tests/test_client.py
+++ b/python/tests/unit_tests/test_client.py
@@ -152,7 +152,7 @@ def test_validate_multiple_urls(monkeypatch: pytest.MonkeyPatch) -> None:
     }
     monkeypatch.setenv("LANGSMITH_RUNS_ENDPOINTS", json.dumps(data))
     client = Client()
-    assert client.write_api_urls == data
+    assert client._write_api_urls == data
     assert client.api_url == "https://api.smith.langsmith-endpoint_1.com"
     assert client.api_key == "123"
 

--- a/python/tests/unit_tests/test_client.py
+++ b/python/tests/unit_tests/test_client.py
@@ -150,7 +150,7 @@ def test_validate_multiple_urls(monkeypatch: pytest.MonkeyPatch) -> None:
         "https://api.smith.langsmith-endpoint_2.com": "456",
         "https://api.smith.langsmith-endpoint_3.com": "789",
     }
-    monkeypatch.delenv("LANGCHAIN_ENDPOINT")
+    monkeypatch.delenv("LANGCHAIN_ENDPOINT", raising=False)
     monkeypatch.delenv("LANGSMITH_ENDPOINT", raising=False)
     monkeypatch.setenv("LANGSMITH_RUNS_ENDPOINTS", json.dumps(data))
     client = Client()


### PR DESCRIPTION
* Allow user to set `LANGSMITH_ENDPOINT` and `LANGSMITH_API_KEY` (in addition to `LANGCHAIN_ENDPOINT` and `LANGCHAIN_API_KEY`). This priority will be former > latter > passed-in parameter.
* Allow user to set `LANGSMITH_RUNS_ENDPOINTS` environment variable or pass in `api_urls` which are a map of api urls to api keys. The first element will be used for all requests, whereas all elements will be used for writing (Runs only)