### PR TITLE
Update exports of eval types

### DIFF
--- a/python/langsmith/evaluation/__init__.py
+++ b/python/langsmith/evaluation/__init__.py
@@ -1,6 +1,17 @@
 """Evaluation Helpers."""
 
-from langsmith.evaluation.evaluator import EvaluationResult, RunEvaluator, run_evaluator
+from langsmith.evaluation.evaluator import (
+    EvaluationResult,
+    EvaluationResults,
+    RunEvaluator,
+    run_evaluator,
+)
 from langsmith.evaluation.string_evaluator import StringEvaluator
 
-__all__ = ["run_evaluator", "EvaluationResult", "RunEvaluator", "StringEvaluator"]
+__all__ = [
+    "run_evaluator",
+    "EvaluationResult",
+    "EvaluationResults",
+    "RunEvaluator",
+    "StringEvaluator",
+]


### PR DESCRIPTION
Also auto-trace in the runevaluator if possible

Related to: https://github.com/langchain-ai/langsmith-sdk/pull/542
