### PR TITLE
Fix Example Serialization

### DIFF
--- a/.github/actions/python-integration-tests/action.yml
+++ b/.github/actions/python-integration-tests/action.yml
@@ -63,7 +63,6 @@ runs:
           LANGCHAIN_API_KEY: ${{ inputs.langchain-api-key }}
           OPENAI_API_KEY: ${{ inputs.openai-api-key }}
           ANTHROPIC_API_KEY: ${{ inputs.anthropic-api-key }}
-          LANGCHAIN_TEST_CACHE: "tests/cassettes"
       run: make evals
       shell: bash
       working-directory: python

--- a/.github/workflows/python_test.yml
+++ b/.github/workflows/python_test.yml
@@ -21,6 +21,7 @@ jobs:
         python-version:
           - "3.8"
           - "3.11"
+          - "3.12"
     defaults:
       run:
         working-directory: python
@@ -61,6 +62,12 @@ jobs:
   test:
     needs: build
     runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        python-version:
+          - "3.8"
+          - "3.11"
+          - "3.12"
     defaults:
       run:
         working-directory: python

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langsmith",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "description": "Client library to connect to the LangSmith LLM Tracing and Evaluation Platform.",
   "packageManager": "yarn@1.22.19",
   "files": [

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -11,4 +11,4 @@ export type {
 export { RunTree, type RunTreeConfig } from "./run_trees.js";
 
 // Update using yarn bump-version
-export const __version__ = "0.1.17";
+export const __version__ = "0.1.18";

--- a/python/langsmith/_internal/_aiter.py
+++ b/python/langsmith/_internal/_aiter.py
@@ -6,6 +6,7 @@ MIT License
 """
 
 import asyncio
+import inspect
 from collections import deque
 from typing import (
     Any,
@@ -291,3 +292,11 @@ def aiter_with_concurrency(
             yield await task
 
     return process_generator()
+
+
+def accepts_context(callable: Callable[..., Any]) -> bool:
+    """Check if a callable accepts a context argument."""
+    try:
+        return inspect.signature(callable).parameters.get("context") is not None
+    except ValueError:
+        return False

--- a/python/langsmith/_testing.py
+++ b/python/langsmith/_testing.py
@@ -320,7 +320,7 @@ def _start_experiment(
 # Track the number of times a parameter has been used in a test
 # This is to ensure that we can uniquely identify each test case
 # defined using pytest.mark.parametrize
-_param_dict = defaultdict(lambda: defaultdict(int))
+_param_dict: dict = defaultdict(lambda: defaultdict(int))
 
 
 def _get_id(func: Callable, inputs: dict, suite_id: uuid.UUID) -> Tuple[uuid.UUID, str]:

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -421,7 +421,7 @@ class Client:
         *,
         api_key: Optional[str] = None,
         retry_config: Optional[Retry] = None,
-        timeout_ms: Optional[int] = None,
+        timeout_ms: Optional[Union[int, Tuple[int, int]]] = None,
         web_url: Optional[str] = None,
         session: Optional[requests.Session] = None,
         auto_batch_tracing: bool = True,
@@ -499,7 +499,11 @@ class Client:
             _validate_api_key_if_hosted(self.api_url, self.api_key)
             self._write_api_urls = {self.api_url: self.api_key}
         self.retry_config = retry_config or _default_retry_config()
-        self.timeout_ms = timeout_ms or 10000
+        self.timeout_ms = (
+            (timeout_ms, timeout_ms)
+            if isinstance(timeout_ms, int)
+            else (timeout_ms or (10_000, 90_001))
+        )
         self._web_url = web_url
         self._tenant_id: Optional[uuid.UUID] = None
         # Create a session and register a finalizer to close it
@@ -619,7 +623,7 @@ class Client:
                 response = self.session.get(
                     self.api_url + "/info",
                     headers={"Accept": "application/json"},
-                    timeout=self.timeout_ms / 1000,
+                    timeout=(self.timeout_ms[0] / 1000, self.timeout_ms[1] / 1000),
                 )
                 ls_utils.raise_for_status_with_text(response)
                 self._info = ls_schemas.LangSmithInfo(**response.json())
@@ -689,7 +693,7 @@ class Client:
                 **request_kwargs.get("headers", {}),
                 **kwargs.get("headers", {}),
             },
-            "timeout": self.timeout_ms / 1000,
+            "timeout": (self.timeout_ms[0] / 1000, self.timeout_ms[1] / 1000),
             **request_kwargs,
             **kwargs,
         }
@@ -726,6 +730,14 @@ class Client:
                         )
                     ls_utils.raise_for_status_with_text(response)
                     return response
+                except requests.exceptions.ReadTimeout as e:
+                    logger.debug("Passing on exception %s", e)
+                    if idx + 1 == stop_after_attempt:
+                        raise
+                    sleep_time = 2**idx + (random.random() * 0.5)
+                    time.sleep(sleep_time)
+                    continue
+
                 except requests.HTTPError as e:
                     if response is not None:
                         if handle_response is not None:

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "langsmith"
-version = "0.1.48"
+version = "0.1.49"
 description = "Client library to connect to the LangSmith LLM Tracing and Evaluation Platform."
 authors = ["LangChain <support@langchain.dev>"]
 license = "MIT"

--- a/python/tests/unit_tests/test_client.py
+++ b/python/tests/unit_tests/test_client.py
@@ -7,6 +7,7 @@ import itertools
 import json
 import math
 import os
+import sys
 import threading
 import time
 import uuid
@@ -764,6 +765,18 @@ def test_serialize_json() -> None:
                 assert res[k] == v, f"Failed for {k}"
         except AssertionError:
             raise
+
+
+def test__dumps_json():
+    chars = "".join(chr(cp) for cp in range(0, sys.maxunicode + 1))
+    trans_table = str.maketrans("", "", "")
+    all_chars = chars.translate(trans_table)
+    serialized_json = _dumps_json({"chars": all_chars})
+    assert isinstance(serialized_json, bytes)
+    serialized_str = serialized_json.decode("utf-8")
+    assert '"chars"' in serialized_str
+    assert "\\uD800" not in serialized_str
+    assert "\\uDC00" not in serialized_str
 
 
 @patch("langsmith.client.requests.Session", autospec=True)

--- a/python/tests/unit_tests/test_run_helpers.py
+++ b/python/tests/unit_tests/test_run_helpers.py
@@ -3,13 +3,15 @@ import functools
 import inspect
 import json
 import os
+import sys
 import time
 import warnings
-from typing import Any
+from typing import Any, AsyncGenerator, Optional, cast
 from unittest.mock import MagicMock, patch
 
 import pytest
 
+import langsmith
 from langsmith import Client
 from langsmith.run_helpers import (
     _get_inputs,
@@ -17,6 +19,7 @@ from langsmith.run_helpers import (
     is_traceable_function,
     traceable,
 )
+from langsmith.run_trees import RunTree
 
 
 def test__get_inputs_with_no_args() -> None:
@@ -449,3 +452,106 @@ def test_traceable_too_many_pos_args() -> None:
         assert len(warning_records) == 1
         assert issubclass(warning_records[0].category, UserWarning)
         assert "only accepts one positional argument" in str(warning_records[0].message)
+
+
+# Really hard to get contextvar propagation right for async generators
+# prior to Python 3.10
+@pytest.mark.skipif(
+    sys.version_info < (3, 9),
+    reason="Skipping for Python 3.8 or earlier",
+)
+async def test_async_generator():
+    @traceable
+    def some_sync_func(query: str) -> list:
+        return [query, query]
+
+    @traceable
+    async def some_async_func(queries: list) -> AsyncGenerator[list, None]:
+        await asyncio.sleep(0.01)
+        for query in queries:
+            yield query
+
+    @traceable
+    async def another_async_func(query: str) -> str:
+        with langsmith.trace(name="zee-cm", inputs={"query": query}) as run_tree:
+            run_tree.end(outputs={"query": query})
+        return query
+
+    @traceable
+    async def create_document_context(documents: list) -> str:
+        await asyncio.sleep(0.01)
+        return "\n".join(documents)
+
+    @traceable
+    async def summarize_answers(
+        query: str, document_context: str
+    ) -> AsyncGenerator[str, None]:
+        await asyncio.sleep(0.01)
+        for i in range(3):
+            yield f"Answer {i}"
+
+    @traceable(run_type="chain", name="expand_and_answer_questions")
+    async def my_answer(
+        query: str,
+    ) -> AsyncGenerator[Any, None]:
+        expanded_terms = some_sync_func(query=query)
+        docs_gen = some_async_func(
+            queries=expanded_terms,
+        )
+        documents = []
+        async for document in docs_gen:
+            documents.append(document)
+            break
+
+        await another_async_func(query=query)
+
+        for document in documents:
+            yield document
+        async for document in docs_gen:
+            documents.append(document)
+            yield document
+
+        document_context = await create_document_context(
+            documents=documents,
+        )
+
+        final_answer = summarize_answers(query=query, document_context=document_context)
+        async for chunk in final_answer:
+            yield chunk
+
+    run: Optional[RunTree] = None  # type: ignore
+
+    def _get_run(r: RunTree) -> None:
+        nonlocal run
+        run = r
+
+    mock_client_ = _get_mock_client()
+
+    chunks = my_answer(
+        "some_query", langsmith_extra={"on_end": _get_run, "client": mock_client_}
+    )
+    all_chunks = []
+    async for chunk in chunks:
+        all_chunks.append(chunk)
+
+    assert all_chunks == [
+        "some_query",
+        "some_query",
+        "Answer 0",
+        "Answer 1",
+        "Answer 2",
+    ]
+    assert run is not None
+    run = cast(RunTree, run)
+    assert run.name == "expand_and_answer_questions"
+    child_runs = run.child_runs
+    assert child_runs and len(child_runs) == 5
+    names = [run.name for run in child_runs]
+    assert names == [
+        "some_sync_func",
+        "some_async_func",
+        "another_async_func",
+        "create_document_context",
+        "summarize_answers",
+    ]
+    assert len(child_runs[2].child_runs) == 1  # type: ignore

--- a/python/tests/unit_tests/test_testing.py
+++ b/python/tests/unit_tests/test_testing.py
@@ -1,0 +1,12 @@
+from langsmith._testing import _serde_example_values
+
+
+def test__serde_example_values():
+    class Foo:
+        def __init__(self, a, b):
+            self.a = a
+            self.b = b
+
+    results = _serde_example_values({"foo": Foo(1, 2)})
+    assert "foo" in results
+    assert isinstance(results["foo"], str)

--- a/python/tests/unit_tests/test_testing.py
+++ b/python/tests/unit_tests/test_testing.py
@@ -1,4 +1,5 @@
-from langsmith._testing import _serde_example_values
+from langsmith._testing import _serde_example_values, _get_id
+import uuid
 
 
 def test__serde_example_values():
@@ -10,3 +11,19 @@ def test__serde_example_values():
     results = _serde_example_values({"foo": Foo(1, 2)})
     assert "foo" in results
     assert isinstance(results["foo"], str)
+
+
+def test__get_id():
+    class Foo:
+        bar: str = "baz"
+
+        def __init__(self, a: int, b: int):
+            self.a = a
+            self.b = b
+
+    def foo(x: Foo):
+        return x
+
+    suite_id = uuid.UUID("4e32bff6-5762-4906-8d74-ee2bd0f1d234")
+
+    _get_id(foo, {"x": Foo(1, 2)}, suite_id)

--- a/python/tests/unit_tests/test_testing.py
+++ b/python/tests/unit_tests/test_testing.py
@@ -16,7 +16,7 @@ def test__serde_example_values():
 
 def test__get_id():
     class Foo:
-        bar: str = "baz"
+        bar: str = "baz"  # type: ignore
 
         def __init__(self, a: int, b: int):
             self.a = a

--- a/python/tests/unit_tests/test_testing.py
+++ b/python/tests/unit_tests/test_testing.py
@@ -1,5 +1,6 @@
-from langsmith._testing import _serde_example_values, _get_id
 import uuid
+
+from langsmith._testing import _get_id, _serde_example_values
 
 
 def test__serde_example_values():


### PR DESCRIPTION
(slightly breaking for comparison flows for unit testing)
1.  Update the ID representation to mostly match the pytest format of `path/to/test_file.py::test_function[arg#-arg#-arg#]` instead of 
2. Fallback to `repr` of object fo rexample inputs/outputs

Why?

- In unit testing, the example inputs/outputs are less important. Want to permit non-serializable objects.
- Don't want to keep creating populating new examples with new IDs just because the non-serializable object includes its memory ID in its repr
