### PR TITLE
Allow aggregator for streamed chunks to be passed to traceable in TS

### DIFF
--- a/js/src/traceable.ts
+++ b/js/src/traceable.ts
@@ -95,10 +95,14 @@ const isAsyncIterable = (x: unknown): x is AsyncIterable<unknown> =>
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function traceable<Func extends (...args: any[]) => any>(
   wrappedFunc: Func,
-  config?: Partial<RunTreeConfig>
+  config?: Partial<RunTreeConfig> & {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    aggregator?: (args: any[]) => any;
+  }
 ) {
   type Inputs = Parameters<Func>;
   type Output = ReturnType<Func>;
+  const { aggregator, ...runTreeConfig } = config ?? {};
 
   const traceableFunc = async (
     ...args: Inputs | [RunTreeLike, ...Inputs] | [RunnableConfigLike, ...Inputs]
@@ -108,7 +112,7 @@ export function traceable<Func extends (...args: any[]) => any>(
 
     const ensuredConfig: RunTreeConfig = {
       name: wrappedFunc.name || "<lambda>",
-      ...config,
+      ...runTreeConfig,
     };
 
     const previousRunTree = asyncLocalStorage.getStore();
@@ -157,7 +161,9 @@ export function traceable<Func extends (...args: any[]) => any>(
                 chunks.push(chunk);
                 yield chunk;
               }
-              await currentRunTree.end({ outputs: chunks });
+              const finalOutputs =
+                aggregator === undefined ? chunks : aggregator(chunks);
+              await currentRunTree.end({ outputs: finalOutputs });
               await currentRunTree.patchRun();
             }
             return resolve(wrapOutputForTracing() as Output);
@@ -190,7 +196,7 @@ export function traceable<Func extends (...args: any[]) => any>(
   };
 
   Object.defineProperty(traceableFunc, "langsmith:traceable", {
-    value: config,
+    value: runTreeConfig,
   });
 
   return traceableFunc as TraceableFunction<Func>;


### PR DESCRIPTION
We'll automatically create and pass one of these for `wrapOpenAI`. Will do that in a third PR as I didn't want to create conflicts with #628.

@agola11 @hinthornw 