### PR TITLE
feat(js): trace deferred values in input

### DIFF
--- a/js/src/run_trees.ts
+++ b/js/src/run_trees.ts
@@ -326,6 +326,7 @@ export class RunTree implements BaseRun {
     const runUpdate: RunUpdate = {
       end_time: this.end_time,
       error: this.error,
+      inputs: this.inputs,
       outputs: this.outputs,
       parent_run_id: this.parent_run?.id,
       reference_example_id: this.reference_example_id,

--- a/js/src/traceable.ts
+++ b/js/src/traceable.ts
@@ -204,7 +204,7 @@ const getSerializablePromise = <T = unknown>(arg: Promise<T>) => {
             },
             (error) => {
               proxyState.current = ["reject", error];
-              return reject?.(error);
+              return reject(error);
             }
           );
         };

--- a/js/src/traceable.ts
+++ b/js/src/traceable.ts
@@ -193,7 +193,9 @@ const getSerializablePromise = <T = unknown>(arg: Promise<T>) => {
         const boundThen = arg[prop].bind(arg);
         return (
           resolve: (value: unknown) => unknown,
-          reject?: (error: unknown) => unknown
+          reject: (error: unknown) => unknown = (x) => {
+            throw x;
+          }
         ) => {
           return boundThen(
             (value) => {


### PR DESCRIPTION
- **Send inputs even when patching run**
- **Collect deferred values during invocation via proxy**
- **Handle ReadableStream in input**
