### PR TITLE
fix(js): throw when wrapping same client twice, allow passing name in argsConfigExtra

### DIFF
--- a/js/src/run_trees.ts
+++ b/js/src/run_trees.ts
@@ -62,11 +62,6 @@ export interface RunTreeConfig {
 
 export interface RunnableConfigLike {
   /**
-   * Name of the traced run, overriding the name provided by the traceable
-   * function.
-   */
-  name?: string;
-  /**
    * Tags for this call and any sub-calls (eg. a Chain calling an LLM).
    * You can use these to filter calls.
    */

--- a/js/src/run_trees.ts
+++ b/js/src/run_trees.ts
@@ -62,6 +62,11 @@ export interface RunTreeConfig {
 
 export interface RunnableConfigLike {
   /**
+   * Name of the traced run, overriding the name provided by the traceable
+   * function.
+   */
+  name?: string;
+  /**
    * Tags for this call and any sub-calls (eg. a Chain calling an LLM).
    * You can use these to filter calls.
    */

--- a/js/src/tests/traceable.test.ts
+++ b/js/src/tests/traceable.test.ts
@@ -1,5 +1,5 @@
-import type { RunTree, RunnableConfigLike } from "../run_trees.js";
-import { ROOT, RunTreeLike, traceable } from "../traceable.js";
+import type { RunTree, RunTreeConfig } from "../run_trees.js";
+import { ROOT, traceable } from "../traceable.js";
 import { getAssumedTreeFromCalls } from "./utils/tree.js";
 import { mockClient } from "./utils/mock_client.js";
 import { FakeChatModel } from "@langchain/core/utils/testing";
@@ -472,7 +472,7 @@ test("argsConfigPath", async () => {
       value: number,
       options: {
         suffix: string;
-        langsmithExtra?: RunTreeLike | RunnableConfigLike;
+        langsmithExtra?: Partial<RunTreeConfig>;
       }
     ): Promise<string> => `${value}${options.suffix}`,
     {

--- a/js/src/tests/traceable.test.ts
+++ b/js/src/tests/traceable.test.ts
@@ -1,5 +1,5 @@
-import type { RunTree } from "../run_trees.js";
-import { ROOT, traceable } from "../traceable.js";
+import type { RunTree, RunnableConfigLike } from "../run_trees.js";
+import { ROOT, RunTreeLike, traceable } from "../traceable.js";
 import { getAssumedTreeFromCalls } from "./utils/tree.js";
 import { mockClient } from "./utils/mock_client.js";
 import { FakeChatModel } from "@langchain/core/utils/testing";
@@ -439,5 +439,71 @@ describe("langchain", () => {
         ["FakeChatModel:2", "StringOutputParser:3"],
       ],
     });
+  });
+});
+
+test("metadata", async () => {
+  const { client, callSpy } = mockClient();
+  const main = traceable(async (): Promise<number> => 42, {
+    client,
+    name: "main",
+    metadata: { customValue: "hello" },
+    tracingEnabled: true,
+  });
+
+  await main();
+
+  expect(getAssumedTreeFromCalls(callSpy.mock.calls)).toMatchObject({
+    nodes: ["main:0"],
+    edges: [],
+    data: {
+      "main:0": {
+        extra: { metadata: { customValue: "hello" } },
+        outputs: { outputs: 42 },
+      },
+    },
+  });
+});
+
+test("argsConfigPath", async () => {
+  const { client, callSpy } = mockClient();
+  const main = traceable(
+    async (
+      value: number,
+      options: {
+        suffix: string;
+        langsmithExtra?: RunTreeLike | RunnableConfigLike;
+      }
+    ): Promise<string> => `${value}${options.suffix}`,
+    {
+      client,
+      name: "main",
+      argsConfigPath: [1, "langsmithExtra"],
+      tracingEnabled: true,
+    }
+  );
+
+  await main(1, {
+    suffix: "hello",
+    langsmithExtra: {
+      name: "renamed",
+      tags: ["tag1", "tag2"],
+      metadata: { customValue: "hello" },
+    },
+  });
+
+  expect(getAssumedTreeFromCalls(callSpy.mock.calls)).toMatchObject({
+    nodes: ["renamed:0"],
+    edges: [],
+    data: {
+      "renamed:0": {
+        extra: { metadata: { customValue: "hello" } },
+        tags: ["tag1", "tag2"],
+        inputs: {
+          args: [1, { suffix: "hello" }],
+        },
+        outputs: { outputs: "1hello" },
+      },
+    },
   });
 });

--- a/js/src/tests/wrapped_openai.int.test.ts
+++ b/js/src/tests/wrapped_openai.int.test.ts
@@ -462,3 +462,10 @@ test.skip("no tracing with env var unset", async () => {
   expect(patched).toBeDefined();
   console.log(patched);
 });
+
+test("wrapping same instance", async () => {
+  const wrapped = wrapOpenAI(new OpenAI());
+  expect(() => wrapOpenAI(wrapped)).toThrowError(
+    "This instance of OpenAI client has been already wrapped once."
+  );
+});

--- a/js/src/wrappers/openai.ts
+++ b/js/src/wrappers/openai.ts
@@ -1,12 +1,7 @@
 import { OpenAI } from "openai";
 import type { APIPromise } from "openai/core";
 import type { Client, RunTreeConfig } from "../index.js";
-import { type RunnableConfigLike } from "../run_trees.js";
-import {
-  isTraceableFunction,
-  traceable,
-  type RunTreeLike,
-} from "../traceable.js";
+import { isTraceableFunction, traceable } from "../traceable.js";
 
 // Extra leniency around types in case multiple OpenAI SDK versions get installed
 type OpenAIType = {
@@ -22,22 +17,23 @@ type OpenAIType = {
   };
 };
 
+type ExtraRunTreeConfig = Pick<
+  Partial<RunTreeConfig>,
+  "name" | "metadata" | "tags"
+>;
+
 type PatchedOpenAIClient<T extends OpenAIType> = T & {
   chat: T["chat"] & {
     completions: T["chat"]["completions"] & {
       create: {
         (
           arg: OpenAI.ChatCompletionCreateParamsStreaming,
-          arg2?: OpenAI.RequestOptions & {
-            langsmithExtra?: RunnableConfigLike | RunTreeLike;
-          }
+          arg2?: OpenAI.RequestOptions & { langsmithExtra?: ExtraRunTreeConfig }
         ): APIPromise<AsyncGenerator<OpenAI.ChatCompletionChunk>>;
       } & {
         (
           arg: OpenAI.ChatCompletionCreateParamsNonStreaming,
-          arg2?: OpenAI.RequestOptions & {
-            langsmithExtra?: RunnableConfigLike | RunTreeLike;
-          }
+          arg2?: OpenAI.RequestOptions & { langsmithExtra?: ExtraRunTreeConfig }
         ): APIPromise<OpenAI.ChatCompletionChunk>;
       };
     };
@@ -46,16 +42,12 @@ type PatchedOpenAIClient<T extends OpenAIType> = T & {
     create: {
       (
         arg: OpenAI.CompletionCreateParamsStreaming,
-        arg2?: OpenAI.RequestOptions & {
-          langsmithExtra?: RunnableConfigLike | RunTreeLike;
-        }
+        arg2?: OpenAI.RequestOptions & { langsmithExtra?: ExtraRunTreeConfig }
       ): APIPromise<AsyncGenerator<OpenAI.Completion>>;
     } & {
       (
         arg: OpenAI.CompletionCreateParamsNonStreaming,
-        arg2?: OpenAI.RequestOptions & {
-          langsmithExtra?: RunnableConfigLike | RunTreeLike;
-        }
+        arg2?: OpenAI.RequestOptions & { langsmithExtra?: ExtraRunTreeConfig }
       ): APIPromise<OpenAI.Completion>;
     };
   };

--- a/js/src/wrappers/openai.ts
+++ b/js/src/wrappers/openai.ts
@@ -220,7 +220,7 @@ export const wrapOpenAI = <T extends OpenAIType>(
     isTraceableFunction(openai.completions.create)
   ) {
     throw new Error(
-      "This instance of OpenAI client has already been wrapped once."
+      "This instance of OpenAI client has been already wrapped once."
     );
   }
 


### PR DESCRIPTION
- **Make sure we're only allowing wrapping once**
- **Allow passing name to runnable config like**
