### PR TITLE
[Py] Ignore optional numpy import

### DIFF
--- a/python/langsmith/_internal/_embedding_distance.py
+++ b/python/langsmith/_internal/_embedding_distance.py
@@ -15,7 +15,7 @@ from typing import (
 from typing_extensions import TypedDict
 
 if TYPE_CHECKING:
-    import numpy as np
+    import numpy as np  # type: ignore
 
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
In the type_checking section.