### PR TITLE
chore(js): reexport TraceableFunction type from singleton

### DIFF
--- a/js/src/singletons/traceable.ts
+++ b/js/src/singletons/traceable.ts
@@ -67,3 +67,5 @@ export function isTraceableFunction(
 ): x is TraceableFunction<any> {
   return typeof x === "function" && "langsmith:traceable" in x;
 }
+
+export type { TraceableFunction } from "./types.js";


### PR DESCRIPTION
As `langsmith/singletons/traceable` is an entrypoint from langchain as well, we need to reexport the type