### PR TITLE
[Python] Add Null Sentry

### DIFF
--- a/python/langsmith/_expect.py
+++ b/python/langsmith/_expect.py
@@ -56,7 +56,6 @@ from typing import (
     Optional,
     Union,
     overload,
-    override,
 )
 
 from langsmith import client as ls_client
@@ -77,7 +76,6 @@ class _NULL_SENTRY:
     def __bool__(self) -> Literal[False]:
         return False
 
-    @override
     def __repr__(self) -> str:
         return "NOT_GIVEN"
 

--- a/python/langsmith/_expect.py
+++ b/python/langsmith/_expect.py
@@ -88,13 +88,13 @@ class _Matcher:
 
     def __init__(
         self,
-        client: ls_client.Client,
+        client: Optional[ls_client.Client],
         key: str,
         value: Any,
         _executor: Optional[concurrent.futures.ThreadPoolExecutor] = None,
         run_id: Optional[str] = None,
     ):
-        self.client = client
+        self._client = client
         self.key = key
         self.value = value
         self._executor = _executor or concurrent.futures.ThreadPoolExecutor(
@@ -105,8 +105,10 @@ class _Matcher:
 
     def _submit_feedback(self, score: int, message: Optional[str] = None) -> None:
         if not ls_utils.test_tracking_is_disabled():
+            if not self._client:
+                self._client = ls_client.Client()
             self._executor.submit(
-                self.client.create_feedback,
+                self._client.create_feedback,
                 run_id=self._run_id,
                 key="expectation",
                 score=score,
@@ -252,7 +254,7 @@ class _Expect:
     """A class for setting expectations on test results."""
 
     def __init__(self, *, client: Optional[ls_client.Client] = None):
-        self.client = client or ls_client.Client()
+        self._client = client
         self.executor = concurrent.futures.ThreadPoolExecutor(max_workers=3)
         atexit.register(self.executor.shutdown, wait=True)
 
@@ -307,7 +309,7 @@ class _Expect:
             },
         )
         return _Matcher(
-            self.client, "embedding_distance", score, _executor=self.executor
+            self._client, "embedding_distance", score, _executor=self.executor
         )
 
     def edit_distance(
@@ -357,7 +359,7 @@ class _Expect:
             },
         )
         return _Matcher(
-            self.client,
+            self._client,
             "edit_distance",
             score,
             _executor=self.executor,
@@ -375,7 +377,7 @@ class _Expect:
         Examples:
            >>> expect.value(10).to_be_less_than(20)
         """
-        return _Matcher(self.client, "value", value, _executor=self.executor)
+        return _Matcher(self._client, "value", value, _executor=self.executor)
 
     def score(
         self,
@@ -406,7 +408,7 @@ class _Expect:
                 "comment": comment,
             },
         )
-        return _Matcher(self.client, key, score, _executor=self.executor)
+        return _Matcher(self._client, key, score, _executor=self.executor)
 
     ## Private Methods
 
@@ -431,8 +433,10 @@ class _Expect:
         current_run = rh.get_current_run_tree()
         run_id = current_run.trace_id if current_run else None
         if not ls_utils.test_tracking_is_disabled():
+            if not self._client:
+                self._client = ls_client.Client()
             self.executor.submit(
-                self.client.create_feedback, run_id=run_id, key=key, **results
+                self._client.create_feedback, run_id=run_id, key=key, **results
             )
 
 

--- a/python/langsmith/wrappers/_openai.py
+++ b/python/langsmith/wrappers/_openai.py
@@ -114,13 +114,13 @@ def _reduce_choices(choices: List[Choice]) -> dict:
                             "arguments": "",
                         }
                     if chunk.function.name:
-                        message["tool_calls"][index]["function"]["name"] += (
-                            chunk.function.name
-                        )
+                        message["tool_calls"][index]["function"][
+                            "name"
+                        ] += chunk.function.name
                     if chunk.function.arguments:
-                        message["tool_calls"][index]["function"]["arguments"] += (
-                            chunk.function.arguments
-                        )
+                        message["tool_calls"][index]["function"][
+                            "arguments"
+                        ] += chunk.function.arguments
     return {
         "index": choices[0].index,
         "finish_reason": next(

--- a/python/langsmith/wrappers/_openai.py
+++ b/python/langsmith/wrappers/_openai.py
@@ -114,13 +114,13 @@ def _reduce_choices(choices: List[Choice]) -> dict:
                             "arguments": "",
                         }
                     if chunk.function.name:
-                        message["tool_calls"][index]["function"][
-                            "name"
-                        ] += chunk.function.name
+                        message["tool_calls"][index]["function"]["name"] += (
+                            chunk.function.name
+                        )
                     if chunk.function.arguments:
-                        message["tool_calls"][index]["function"][
-                            "arguments"
-                        ] += chunk.function.arguments
+                        message["tool_calls"][index]["function"]["arguments"] += (
+                            chunk.function.arguments
+                        )
     return {
         "index": choices[0].index,
         "finish_reason": next(

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "langsmith"
-version = "0.1.60"
+version = "0.1.61"
 description = "Client library to connect to the LangSmith LLM Tracing and Evaluation Platform."
 authors = ["LangChain <support@langchain.dev>"]
 license = "MIT"

--- a/python/tests/unit_tests/test_expect.py
+++ b/python/tests/unit_tests/test_expect.py
@@ -1,14 +1,15 @@
 from unittest import mock
 
 from langsmith import expect
+from langsmith._expect import ls_client
 
 
 def _is_none(x: object) -> bool:
     return x is None
 
 
-@mock.patch("langsmith.client.requests.Session")
-def test_expect_explicit_none(mock_session_cls: mock.Mock) -> None:
+@mock.patch.object(ls_client, "Client", autospec=True)
+def test_expect_explicit_none(mock_client: mock.Mock) -> None:
     expect(None).against(_is_none)
     expect(None).to_be_none()
     expect.score(1).to_equal(1)

--- a/python/tests/unit_tests/test_expect.py
+++ b/python/tests/unit_tests/test_expect.py
@@ -1,0 +1,19 @@
+from unittest import mock
+
+from langsmith import expect
+
+
+def _is_none(x: object) -> bool:
+    return x is None
+
+
+@mock.patch("langsmith.client.requests.Session")
+def test_expect_explicit_none(mock_session_cls: mock.Mock) -> None:
+    expect(None).against(_is_none)
+    expect(None).to_be_none()
+    expect.score(1).to_equal(1)
+    expect.score(1).to_be_less_than(2)
+    expect.score(1).to_be_greater_than(0)
+    expect.score(1).to_be_between(0, 2)
+    expect.score(1).to_be_approximately(1, 2)
+    expect.score({1, 2}).to_contain(1)

--- a/python/tests/unit_tests/test_expect.py
+++ b/python/tests/unit_tests/test_expect.py
@@ -16,4 +16,4 @@ def test_expect_explicit_none(mock_session_cls: mock.Mock) -> None:
     expect.score(1).to_be_greater_than(0)
     expect.score(1).to_be_between(0, 2)
     expect.score(1).to_be_approximately(1, 2)
-    expect.score({1, 2}).to_contain(1)
+    expect({1, 2}).to_contain(1)


### PR DESCRIPTION
Previously, you couldn't write `expect(None).to_*`