### PR TITLE
[Python] Deeper Copy

### DIFF
--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -1088,8 +1088,11 @@ class Client:
         elif isinstance(run_create["id"], str):
             run_create["id"] = uuid.UUID(run_create["id"])
         if "inputs" in run_create and run_create["inputs"] is not None:
+            # Copy the inputs to avoid modifying the original
+            run_create["inputs"] = ls_utils.deepish_copy(run_create["inputs"])
             run_create["inputs"] = self._hide_run_inputs(run_create["inputs"])
         if "outputs" in run_create and run_create["outputs"] is not None:
+            run_create["outputs"] = ls_utils.deepish_copy(run_create["outputs"])
             run_create["outputs"] = self._hide_run_outputs(run_create["outputs"])
         if not update and not run_create.get("start_time"):
             run_create["start_time"] = datetime.datetime.now(datetime.timezone.utc)
@@ -1179,7 +1182,6 @@ class Client:
             return
         run_create = self._run_transform(run_create)
         self._insert_runtime_env([run_create])
-
         if revision_id is not None:
             run_create["extra"]["metadata"]["revision_id"] = revision_id
         if (

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -1088,7 +1088,6 @@ class Client:
         elif isinstance(run_create["id"], str):
             run_create["id"] = uuid.UUID(run_create["id"])
         if "inputs" in run_create and run_create["inputs"] is not None:
-            # Copy the inputs to avoid modifying the original
             run_create["inputs"] = ls_utils.deepish_copy(run_create["inputs"])
             run_create["inputs"] = self._hide_run_inputs(run_create["inputs"])
         if "outputs" in run_create and run_create["outputs"] is not None:

--- a/python/langsmith/run_trees.py
+++ b/python/langsmith/run_trees.py
@@ -225,11 +225,11 @@ class RunTree(ls_schemas.RunBase):
         self_dict = self.dict(
             exclude={"child_runs", "inputs", "outputs"}, exclude_none=True
         )
-        if self.inputs:
-            # shallow copy
+        if self.inputs is not None:
+            # shallow copy. deep copying will occur in the client
             self_dict["inputs"] = self.inputs.copy()
-        if self.outputs:
-            # shallow copy
+        if self.outputs is not None:
+            # shallow copy; deep copying will occur in the client
             self_dict["outputs"] = self.outputs.copy()
         return self_dict
 

--- a/python/langsmith/run_trees.py
+++ b/python/langsmith/run_trees.py
@@ -221,20 +221,17 @@ class RunTree(ls_schemas.RunBase):
         return run
 
     def _get_dicts_safe(self):
-        try:
-            return self.dict(exclude={"child_runs"}, exclude_none=True)
-        except TypeError:
-            # Things like generators cannot be copied
-            self_dict = self.dict(
-                exclude={"child_runs", "inputs", "outputs"}, exclude_none=True
-            )
-            if self.inputs:
-                # shallow copy
-                self_dict["inputs"] = self.inputs.copy()
-            if self.outputs:
-                # shallow copy
-                self_dict["outputs"] = self.outputs.copy()
-            return self_dict
+        # Things like generators cannot be copied
+        self_dict = self.dict(
+            exclude={"child_runs", "inputs", "outputs"}, exclude_none=True
+        )
+        if self.inputs:
+            # shallow copy
+            self_dict["inputs"] = self.inputs.copy()
+        if self.outputs:
+            # shallow copy
+            self_dict["outputs"] = self.outputs.copy()
+        return self_dict
 
     def post(self, exclude_child_runs: bool = True) -> None:
         """Post the run tree to the API asynchronously."""

--- a/python/langsmith/utils.py
+++ b/python/langsmith/utils.py
@@ -543,7 +543,7 @@ def deepish_copy(val: T) -> T:
     Returns:
         The deep copied value.
     """
-    memo = {}
+    memo: dict[int, Any] = {}
     try:
         return copy.deepcopy(val, memo)
     except (TypeError, ValueError, RecursionError) as e:

--- a/python/langsmith/utils.py
+++ b/python/langsmith/utils.py
@@ -543,7 +543,7 @@ def deepish_copy(val: T) -> T:
     Returns:
         The deep copied value.
     """
-    memo: dict[int, Any] = {}
+    memo: Dict[int, Any] = {}
     try:
         return copy.deepcopy(val, memo)
     except (TypeError, ValueError, RecursionError) as e:

--- a/python/langsmith/wrappers/_openai.py
+++ b/python/langsmith/wrappers/_openai.py
@@ -114,13 +114,13 @@ def _reduce_choices(choices: List[Choice]) -> dict:
                             "arguments": "",
                         }
                     if chunk.function.name:
-                        message["tool_calls"][index]["function"]["name"] += (
-                            chunk.function.name
-                        )
+                        message["tool_calls"][index]["function"][
+                            "name"
+                        ] += chunk.function.name
                     if chunk.function.arguments:
-                        message["tool_calls"][index]["function"]["arguments"] += (
-                            chunk.function.arguments
-                        )
+                        message["tool_calls"][index]["function"][
+                            "arguments"
+                        ] += chunk.function.arguments
     return {
         "index": choices[0].index,
         "finish_reason": next(

--- a/python/langsmith/wrappers/_openai.py
+++ b/python/langsmith/wrappers/_openai.py
@@ -114,13 +114,13 @@ def _reduce_choices(choices: List[Choice]) -> dict:
                             "arguments": "",
                         }
                     if chunk.function.name:
-                        message["tool_calls"][index]["function"][
-                            "name"
-                        ] += chunk.function.name
+                        message["tool_calls"][index]["function"]["name"] += (
+                            chunk.function.name
+                        )
                     if chunk.function.arguments:
-                        message["tool_calls"][index]["function"][
-                            "arguments"
-                        ] += chunk.function.arguments
+                        message["tool_calls"][index]["function"]["arguments"] += (
+                            chunk.function.arguments
+                        )
     return {
         "index": choices[0].index,
         "finish_reason": next(

--- a/python/tests/unit_tests/test_client.py
+++ b/python/tests/unit_tests/test_client.py
@@ -305,7 +305,7 @@ def test_create_run_unicode() -> None:
 
 
 def test_create_run_mutate() -> None:
-    inputs = {"messages": ["hi"]}
+    inputs = {"messages": ["hi"], "mygen": (i for i in range(10))}
     session = mock.Mock()
     session.request = mock.Mock()
     client = Client(
@@ -334,7 +334,7 @@ def test_create_run_mutate() -> None:
         ),
     )
     client.create_run(**run_dict)  # type: ignore
-    inputs["messages"].append("there")
+    inputs["messages"].append("there")  # type: ignore
     outputs = {"messages": ["hi", "there"]}
     client.update_run(
         id_,
@@ -343,7 +343,7 @@ def test_create_run_mutate() -> None:
         trace_id=id_,
         dotted_order=run_dict["dotted_order"],
     )
-    time.sleep(0.2)
+    time.sleep(0.3)  # Give the background thread time to stop
     request_calls = [call for call in session.request.mock_calls if call.args]
     batch_requests = [
         call for call in request_calls if call.args[1].endswith("runs/batch")
@@ -360,7 +360,11 @@ def test_create_run_mutate() -> None:
         {},
     )
     # Check that the mutated value wasn't posted
-    assert inputs == {"messages": ["hi"]}
+    assert inputs["messages"] == ["hi"]
+    assert "mygen" in inputs
+    assert inputs["mygen"].startswith(  # type: ignore
+        "<generator object test_create_run_mutate.<locals>."
+    )
     assert outputs == {"messages": ["hi", "there"]}
 
 

--- a/python/tests/unit_tests/test_client.py
+++ b/python/tests/unit_tests/test_client.py
@@ -360,6 +360,7 @@ def test_create_run_mutate() -> None:
         {},
     )
     # Check that the mutated value wasn't posted
+    assert "messages" in inputs
     assert inputs["messages"] == ["hi"]
     assert "mygen" in inputs
     assert inputs["mygen"].startswith(  # type: ignore

--- a/python/tests/unit_tests/test_client.py
+++ b/python/tests/unit_tests/test_client.py
@@ -333,7 +333,7 @@ def test_create_run_mutate() -> None:
             datetime.now(timezone.utc), id_
         ),
     )
-    client.create_run(**run_dict)
+    client.create_run(**run_dict)  # type: ignore
     inputs["messages"].append("there")
     outputs = {"messages": ["hi", "there"]}
     client.update_run(
@@ -353,11 +353,11 @@ def test_create_run_mutate() -> None:
     patches = [pr for payload in payloads for pr in payload.get("patch", [])]
     inputs = next(
         (pr["inputs"] for pr in itertools.chain(posts, patches) if pr.get("inputs")),
-        None,
+        {},
     )
     outputs = next(
         (pr["outputs"] for pr in itertools.chain(posts, patches) if pr.get("outputs")),
-        None,
+        {},
     )
     # Check that the mutated value wasn't posted
     assert inputs == {"messages": ["hi"]}

--- a/python/tests/unit_tests/test_client.py
+++ b/python/tests/unit_tests/test_client.py
@@ -11,7 +11,7 @@ import threading
 import time
 import uuid
 import weakref
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum
 from io import BytesIO
 from typing import Any, NamedTuple, Optional
@@ -28,6 +28,8 @@ from requests import HTTPError
 
 import langsmith.env as ls_env
 import langsmith.utils as ls_utils
+from langsmith import run_trees
+from langsmith import schemas as ls_schemas
 from langsmith.client import (
     Client,
     _dumps_json,
@@ -37,7 +39,6 @@ from langsmith.client import (
     _is_localhost,
     _serialize_json,
 )
-from langsmith.schemas import Example
 
 _CREATED_AT = datetime(2015, 1, 1, 0, 0, 0)
 
@@ -173,14 +174,14 @@ def test_headers(monkeypatch: pytest.MonkeyPatch) -> None:
 @mock.patch("langsmith.client.requests.Session")
 def test_upload_csv(mock_session_cls: mock.Mock) -> None:
     dataset_id = str(uuid.uuid4())
-    example_1 = Example(
+    example_1 = ls_schemas.Example(
         id=str(uuid.uuid4()),
         created_at=_CREATED_AT,
         inputs={"input": "1"},
         outputs={"output": "2"},
         dataset_id=dataset_id,
     )
-    example_2 = Example(
+    example_2 = ls_schemas.Example(
         id=str(uuid.uuid4()),
         created_at=_CREATED_AT,
         inputs={"input": "3"},
@@ -301,6 +302,66 @@ def test_create_run_unicode() -> None:
     id_ = uuid.uuid4()
     client.create_run("my_run", inputs=inputs, run_type="llm", id=id_)
     client.update_run(id_, status="completed")
+
+
+def test_create_run_mutate() -> None:
+    inputs = {"messages": ["hi"]}
+    session = mock.Mock()
+    session.request = mock.Mock()
+    client = Client(
+        api_url="http://localhost:1984",
+        api_key="123",
+        session=session,
+        info=ls_schemas.LangSmithInfo(
+            batch_ingest_config=ls_schemas.BatchIngestConfig(
+                size_limit_bytes=None,  # Note this field is not used here
+                size_limit=100,
+                scale_up_nthreads_limit=16,
+                scale_up_qsize_trigger=1000,
+                scale_down_nempty_trigger=4,
+            )
+        ),
+    )
+    id_ = uuid.uuid4()
+    run_dict = dict(
+        id=id_,
+        name="my_run",
+        inputs=inputs,
+        run_type="llm",
+        trace_id=id_,
+        dotted_order=run_trees._create_current_dotted_order(
+            datetime.now(timezone.utc), id_
+        ),
+    )
+    client.create_run(**run_dict)
+    inputs["messages"].append("there")
+    outputs = {"messages": ["hi", "there"]}
+    client.update_run(
+        id_,
+        outputs=outputs,
+        end_time=datetime.now(timezone.utc),
+        trace_id=id_,
+        dotted_order=run_dict["dotted_order"],
+    )
+    time.sleep(0.2)
+    request_calls = [call for call in session.request.mock_calls if call.args]
+    batch_requests = [
+        call for call in request_calls if call.args[1].endswith("runs/batch")
+    ]
+    payloads = [json.loads(req[2]["data"]) for req in batch_requests]
+    posts = [pr for payload in payloads for pr in payload.get("post", [])]
+    patches = [pr for payload in payloads for pr in payload.get("patch", [])]
+    inputs = next(
+        (pr["inputs"] for pr in itertools.chain(posts, patches) if pr.get("inputs")),
+        None,
+    )
+    outputs = next(
+        (pr["outputs"] for pr in itertools.chain(posts, patches) if pr.get("outputs")),
+        None,
+    )
+    # Check that the mutated value wasn't posted
+    assert inputs == {"messages": ["hi"]}
+    assert outputs == {"messages": ["hi", "there"]}
 
 
 class CallTracker:

--- a/python/tests/unit_tests/test_client.py
+++ b/python/tests/unit_tests/test_client.py
@@ -343,12 +343,15 @@ def test_create_run_mutate() -> None:
         trace_id=id_,
         dotted_order=run_dict["dotted_order"],
     )
-    time.sleep(0.3)  # Give the background thread time to stop
-    request_calls = [call for call in session.request.mock_calls if call.args]
-    batch_requests = [
-        call for call in request_calls if call.args[1].endswith("runs/batch")
-    ]
-    payloads = [json.loads(req[2]["data"]) for req in batch_requests]
+    for _ in range(7):
+        time.sleep(0.1)  # Give the background thread time to stop
+        payloads = [
+            json.loads(call[2]["data"])
+            for call in session.request.mock_calls
+            if call.args and call.args[1].endswith("runs/batch")
+        ]
+        if payloads:
+            break
     posts = [pr for payload in payloads for pr in payload.get("post", [])]
     patches = [pr for payload in payloads for pr in payload.get("patch", [])]
     inputs = next(


### PR DESCRIPTION
For some code paths currently, if you mutate inputs/outputs within Xs of invocation, langsmith will log the mutated value, which is confusing and the wrong behavior.

We can't naively use deepcopy, as many valid python objects cannot be copied.

This PR creates a compromise solution that attempts to deepcopy and then falls back to copying up to depth 4 while handling errors.

Will hopefully resolve #706 . Placed before the `hide_*` as well so that if people want to mutate the dict when filtering it doesn't impact the execution flow.