### PR TITLE
[Python] Improve @traceable typing

### DIFF
--- a/python/langsmith/evaluation/_arunner.py
+++ b/python/langsmith/evaluation/_arunner.py
@@ -801,7 +801,7 @@ class AsyncExperimentResults:
 
 
 async def _aforward(
-    fn: rh.SupportsLangsmithExtra[Awaitable],
+    fn: rh.SupportsLangsmithExtra[[dict], Awaitable],
     example: schemas.Example,
     experiment_name: str,
     metadata: dict,
@@ -839,7 +839,9 @@ async def _aforward(
     )
 
 
-def _ensure_async_traceable(target: ATARGET_T) -> rh.SupportsLangsmithExtra[Awaitable]:
+def _ensure_async_traceable(
+    target: ATARGET_T,
+) -> rh.SupportsLangsmithExtra[[dict], Awaitable]:
     if not asyncio.iscoroutinefunction(target):
         raise ValueError(
             "Target must be an async function. For sync functions, use evaluate."

--- a/python/langsmith/evaluation/_runner.py
+++ b/python/langsmith/evaluation/_runner.py
@@ -1466,14 +1466,16 @@ def _resolve_data(
     return data
 
 
-def _ensure_traceable(target: TARGET_T) -> rh.SupportsLangsmithExtra:
+def _ensure_traceable(target: TARGET_T) -> rh.SupportsLangsmithExtra[[dict], dict]:
     """Ensure the target function is traceable."""
     if not callable(target):
         raise ValueError("Target must be a callable function.")
     if rh.is_traceable_function(target):
-        fn = cast(rh.SupportsLangsmithExtra, target)
+        fn = target  # type: ignore
     else:
-        fn = rh.traceable(name="Target")(target)
+        dc = rh.traceable(name="Target")
+        fn_ = dc(target)
+        fn = fn_
     return fn
 
 

--- a/python/langsmith/evaluation/_runner.py
+++ b/python/langsmith/evaluation/_runner.py
@@ -1466,14 +1466,16 @@ def _resolve_data(
     return data
 
 
-def _ensure_traceable(target: TARGET_T) -> rh.SupportsLangsmithExtra[[dict], dict]:
+def _ensure_traceable(
+    target: TARGET_T | rh.SupportsLangsmithExtra[[dict], dict],
+) -> rh.SupportsLangsmithExtra[[dict], dict]:
     """Ensure the target function is traceable."""
     if not callable(target):
         raise ValueError("Target must be a callable function.")
     if rh.is_traceable_function(target):
-        fn = target  # type: ignore
+        fn = target
     else:
-        fn = rh.traceable(name="Target")
+        fn = rh.traceable(name="Target")(target)
     return fn
 
 

--- a/python/langsmith/evaluation/_runner.py
+++ b/python/langsmith/evaluation/_runner.py
@@ -1473,9 +1473,7 @@ def _ensure_traceable(target: TARGET_T) -> rh.SupportsLangsmithExtra[[dict], dic
     if rh.is_traceable_function(target):
         fn = target  # type: ignore
     else:
-        dc = rh.traceable(name="Target")
-        fn_ = dc(target)
-        fn = fn_
+        fn = rh.traceable(name="Target")
     return fn
 
 

--- a/python/langsmith/evaluation/evaluator.py
+++ b/python/langsmith/evaluation/evaluator.py
@@ -181,9 +181,8 @@ class DynamicRunEvaluator(RunEvaluator):
             self.afunc = run_helpers.ensure_traceable(func)
             self._name = getattr(func, "__name__", "DynamicRunEvaluator")
         else:
-            self.func = cast(
-                run_helpers.SupportsLangsmithExtra[_RUNNABLE_OUTPUT],
-                run_helpers.ensure_traceable(func),
+            self.func = run_helpers.ensure_traceable(
+                cast(Callable[[Run, Optional[Example]], _RUNNABLE_OUTPUT], func)
             )
             self._name = getattr(func, "__name__", "DynamicRunEvaluator")
 
@@ -383,9 +382,14 @@ class DynamicComparisonRunEvaluator:
             self.afunc = run_helpers.ensure_traceable(func)
             self._name = getattr(func, "__name__", "DynamicRunEvaluator")
         else:
-            self.func = cast(
-                run_helpers.SupportsLangsmithExtra[_COMPARISON_OUTPUT],
-                run_helpers.ensure_traceable(func),
+            self.func = run_helpers.ensure_traceable(
+                cast(
+                    Callable[
+                        [Sequence[Run], Optional[Example]],
+                        _COMPARISON_OUTPUT,
+                    ],
+                    func,
+                )
             )
             self._name = getattr(func, "__name__", "DynamicRunEvaluator")
 

--- a/python/langsmith/run_helpers.py
+++ b/python/langsmith/run_helpers.py
@@ -35,6 +35,8 @@ from typing import (
     runtime_checkable,
 )
 
+from typing_extensions import ParamSpec, TypeGuard
+
 from langsmith import client as ls_client
 from langsmith import run_trees, utils
 from langsmith._internal import _aiter as aitertools
@@ -143,7 +145,9 @@ def tracing_context(
 get_run_tree_context = get_current_run_tree
 
 
-def is_traceable_function(func: Callable) -> bool:
+def is_traceable_function(
+    func: Callable[P, R],
+) -> TypeGuard[SupportsLangsmithExtra[P, R]]:
     """Check if a function is @traceable decorated."""
     return (
         _is_traceable_function(func)
@@ -152,12 +156,11 @@ def is_traceable_function(func: Callable) -> bool:
     )
 
 
-def ensure_traceable(func: Callable[..., R]) -> Callable[..., R]:
+def ensure_traceable(func: Callable[P, R]) -> SupportsLangsmithExtra[P, R]:
     """Ensure that a function is traceable."""
-    return cast(
-        SupportsLangsmithExtra,
-        (func if is_traceable_function(func) else traceable()(func)),
-    )
+    if is_traceable_function(func):
+        return func
+    return traceable()(func)
 
 
 def is_async(func: Callable) -> bool:
@@ -183,10 +186,11 @@ class LangSmithExtra(TypedDict, total=False):
 
 
 R = TypeVar("R", covariant=True)
+P = ParamSpec("P")
 
 
 @runtime_checkable
-class SupportsLangsmithExtra(Protocol, Generic[R]):
+class SupportsLangsmithExtra(Protocol, Generic[P, R]):
     """Implementations of this Protoc accept an optional langsmith_extra parameter.
 
     Args:
@@ -201,9 +205,9 @@ class SupportsLangsmithExtra(Protocol, Generic[R]):
 
     def __call__(
         self,
-        *args: Any,
+        *args: P.args,
         langsmith_extra: Optional[LangSmithExtra] = None,
-        **kwargs: Any,
+        **kwargs: P.kwargs,
     ) -> R:
         """Call the instance when it is called as a function.
 
@@ -222,8 +226,8 @@ class SupportsLangsmithExtra(Protocol, Generic[R]):
 
 @overload
 def traceable(
-    func: Callable[..., R],
-) -> Callable[..., R]: ...
+    func: Callable[P, R],
+) -> SupportsLangsmithExtra[P, R]: ...
 
 
 @overload
@@ -238,7 +242,7 @@ def traceable(
     project_name: Optional[str] = None,
     process_inputs: Optional[Callable[[dict], dict]] = None,
     _invocation_params_fn: Optional[Callable[[dict], dict]] = None,
-) -> Callable[[Callable[..., R]], SupportsLangsmithExtra[R]]: ...
+) -> Callable[[Callable[P, R]], SupportsLangsmithExtra[P, R]]: ...
 
 
 def traceable(

--- a/python/tests/unit_tests/test_run_helpers.py
+++ b/python/tests/unit_tests/test_run_helpers.py
@@ -350,7 +350,7 @@ def test_traceable_project_name() -> None:
         def my_other_function(run_tree) -> int:
             return my_function(1, 2, 3)
 
-        my_other_function()
+        my_other_function()  # type: ignore
         time.sleep(0.25)
         # Inspect the mock_calls and assert that "my bar project" is in
         # both all POST runs in the single request. We want to ensure


### PR DESCRIPTION
Improves for python >= 3.10. Should in theory not change anything for users of 3.8 and 3.9 (at least, things pass in our 3.8 linting here... Apologies in advance to any mypy acolytes on 3.{8,9} who gain undesired linting errors after this change)

Uses:
1. ParamSpec (available in 3.10 and onwards)
2. Protocols (already used)

Even though python doesn't naturally support keyword-only concatenation, we can work around this with protocols and duck typing to communicate the actual returned type of "the same function signature + a keyword only langsmith_extra arg"

Python's typing situation makes it hard to make everyone happy, but hopefully this strikes a better compromise than before (typing kwargs as Any in the wrapped function; too lenient)

Closes #551 

