### PR TITLE
fix sig.replace to account for kwargs

### DIFF
--- a/python/langsmith/run_helpers.py
+++ b/python/langsmith/run_helpers.py
@@ -647,10 +647,11 @@ def traceable(
         if not sig.parameters.get("config"):
             sig = sig.replace(
                 parameters=[
-                    *sig.parameters.values(),
+                    *(param for param in sig.parameters.values() if param.kind != inspect.Parameter.VAR_KEYWORD),
                     inspect.Parameter(
                         "config", inspect.Parameter.KEYWORD_ONLY, default=None
                     ),
+                    *(param for param in sig.parameters.values() if param.kind == inspect.Parameter.VAR_KEYWORD),
                 ]
             )
             selected_wrapper.__signature__ = sig  # type: ignore[attr-defined]


### PR DESCRIPTION
If the `selected_wrapper` function contains a `**kwargs` parameters, `sig.replace(...)` breaks because of the following error:
```
ValueError: wrong parameter order: variadic keyword parameter before keyword-only parameter
```

This PR fixes the above error.