### PR TITLE
[Python] Handoff Bugs

### DIFF
--- a/python/langsmith/run_trees.py
+++ b/python/langsmith/run_trees.py
@@ -90,6 +90,8 @@ class RunTree(ls_schemas.RunBase):
             else:
                 values["trace_id"] = values["id"]
         cast(dict, values.setdefault("extra", {}))
+        if values.get("events") is None:
+            values["events"] = []
         return values
 
     @root_validator(pre=False)

--- a/python/langsmith/run_trees.py
+++ b/python/langsmith/run_trees.py
@@ -335,7 +335,7 @@ class RunTree(ls_schemas.RunBase):
                 )
             )
         ):
-            if hasattr(tracer, "order_map"):
+            if hasattr(tracer, "order_map") and cb.parent_run_id in tracer.order_map:
                 dotted_order = tracer.order_map[cb.parent_run_id][1]
             elif (
                 run := tracer.run_map.get(str(cb.parent_run_id))

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "langsmith"
-version = "0.1.65"
+version = "0.1.66"
 description = "Client library to connect to the LangSmith LLM Tracing and Evaluation Platform."
 authors = ["LangChain <support@langchain.dev>"]
 license = "MIT"

--- a/python/tests/unit_tests/test_run_trees.py
+++ b/python/tests/unit_tests/test_run_trees.py
@@ -59,3 +59,15 @@ def test_run_tree_accepts_tpe() -> None:
 )
 def test_parse_dotted_order(inputs, expected):
     assert run_trees._parse_dotted_order(inputs) == expected
+
+
+def test_run_tree_events_not_null():
+    mock_client = MagicMock(spec=Client)
+    run_tree = run_trees.RunTree(
+        name="My Chat Bot",
+        inputs={"text": "Summarize this morning's meetings."},
+        client=mock_client,
+        executor=ThreadPoolExecutor(),
+        events=None,
+    )
+    assert run_tree.events == []


### PR DESCRIPTION
1. from_runnable_config doesn't lbyl to see if the parent is in the order_map. Should fix
2. events are null by default here but are populated in langchain, meaning run trees cant be treated as interchangeable in the base tracer.