### PR TITLE
[Python] Infer parent_run_id in from_dotted_order

### DIFF
--- a/python/langsmith/run_trees.py
+++ b/python/langsmith/run_trees.py
@@ -374,6 +374,9 @@ class RunTree(ls_schemas.RunBase):
         init_args["trace_id"] = trace_id
         init_args["id"] = parsed_dotted_order[-1][1]
         init_args["dotted_order"] = parent_dotted_order
+        if len(parsed_dotted_order) >= 2:
+            # Has a parent
+            init_args["parent_run_id"] = parsed_dotted_order[-2][1]
         # All placeholders. We assume the source process
         # handles the life-cycle of the run.
         init_args["start_time"] = init_args.get("start_time") or datetime.now(

--- a/python/langsmith/run_trees.py
+++ b/python/langsmith/run_trees.py
@@ -92,6 +92,8 @@ class RunTree(ls_schemas.RunBase):
         cast(dict, values.setdefault("extra", {}))
         if values.get("events") is None:
             values["events"] = []
+        if values.get("tags") is None:
+            values["tags"] = []
         return values
 
     @root_validator(pre=False)

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "langsmith"
-version = "0.1.66"
+version = "0.1.67"
 description = "Client library to connect to the LangSmith LLM Tracing and Evaluation Platform."
 authors = ["LangChain <support@langchain.dev>"]
 license = "MIT"

--- a/python/tests/unit_tests/test_run_trees.py
+++ b/python/tests/unit_tests/test_run_trees.py
@@ -71,3 +71,43 @@ def test_run_tree_events_not_null():
         events=None,
     )
     assert run_tree.events == []
+
+
+def test_nested_run_trees_from_dotted_order():
+    grandparent = run_trees.RunTree(
+        name="Grandparent",
+        inputs={"text": "Summarize this morning's meetings."},
+    )
+    parent = grandparent.create_child(
+        name="Parent",
+    )
+    child = parent.create_child(
+        name="Child",
+    )
+    # Check child
+    clone = run_trees.RunTree.from_dotted_order(
+        dotted_order=child.dotted_order,
+        name="Clone",
+    )
+
+    assert clone.id == child.id
+    assert clone.parent_run_id == child.parent_run_id
+    assert clone.dotted_order == child.dotted_order
+
+    # Check parent
+    parent_clone = run_trees.RunTree.from_dotted_order(
+        dotted_order=parent.dotted_order,
+        name="Parent Clone",
+    )
+    assert parent_clone.id == parent.id
+    assert parent_clone.parent_run_id == parent.parent_run_id
+    assert parent_clone.dotted_order == parent.dotted_order
+
+    # Check grandparent
+    grandparent_clone = run_trees.RunTree.from_dotted_order(
+        dotted_order=grandparent.dotted_order,
+        name="Grandparent Clone",
+    )
+    assert grandparent_clone.id == grandparent.id
+    assert grandparent_clone.parent_run_id is None
+    assert grandparent_clone.dotted_order == grandparent.dotted_order

--- a/python/tests/unit_tests/test_run_trees.py
+++ b/python/tests/unit_tests/test_run_trees.py
@@ -88,6 +88,7 @@ def test_nested_run_trees_from_dotted_order():
     clone = run_trees.RunTree.from_dotted_order(
         dotted_order=child.dotted_order,
         name="Clone",
+        client=MagicMock(spec=Client),
     )
 
     assert clone.id == child.id
@@ -98,6 +99,7 @@ def test_nested_run_trees_from_dotted_order():
     parent_clone = run_trees.RunTree.from_dotted_order(
         dotted_order=parent.dotted_order,
         name="Parent Clone",
+        client=MagicMock(spec=Client),
     )
     assert parent_clone.id == parent.id
     assert parent_clone.parent_run_id == parent.parent_run_id
@@ -107,6 +109,7 @@ def test_nested_run_trees_from_dotted_order():
     grandparent_clone = run_trees.RunTree.from_dotted_order(
         dotted_order=grandparent.dotted_order,
         name="Grandparent Clone",
+        client=MagicMock(spec=Client),
     )
     assert grandparent_clone.id == grandparent.id
     assert grandparent_clone.parent_run_id is None

--- a/python/tests/unit_tests/test_run_trees.py
+++ b/python/tests/unit_tests/test_run_trees.py
@@ -67,7 +67,6 @@ def test_run_tree_events_not_null():
         name="My Chat Bot",
         inputs={"text": "Summarize this morning's meetings."},
         client=mock_client,
-        executor=ThreadPoolExecutor(),
         events=None,
     )
     assert run_tree.events == []
@@ -77,6 +76,7 @@ def test_nested_run_trees_from_dotted_order():
     grandparent = run_trees.RunTree(
         name="Grandparent",
         inputs={"text": "Summarize this morning's meetings."},
+        client=MagicMock(spec=Client),
     )
     parent = grandparent.create_child(
         name="Parent",


### PR DESCRIPTION
Also needed for the handoff. I had neglected to see that some batch ingestion operations depend on it.

Closes https://github.com/langchain-ai/langsmith-sdk/issues/751
Closes https://github.com/langchain-ai/langchain/issues/22353
Closes https://github.com/langchain-ai/langsmith-sdk/issues/752