### PR TITLE
safer exception

### DIFF
--- a/python/langsmith/utils.py
+++ b/python/langsmith/utils.py
@@ -546,7 +546,7 @@ def deepish_copy(val: T) -> T:
     memo: Dict[int, Any] = {}
     try:
         return copy.deepcopy(val, memo)
-    except (TypeError, ValueError, RecursionError) as e:
+    except Exception as e:
         # Generators, locks, etc. cannot be copied
         # and raise a TypeError (mentioning pickling, since the dunder methods)
         # are re-used for copying. We'll try to do a compromise and copy

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "langsmith"
-version = "0.1.67"
+version = "0.1.68"
 description = "Client library to connect to the LangSmith LLM Tracing and Evaluation Platform."
 authors = ["LangChain <support@langchain.dev>"]
 license = "MIT"


### PR DESCRIPTION
Catch all exceptions. This was failing when deepcopy raised an error like SparkRuntime.. or the like