### PR TITLE
feat(python, js): add anonymizer API

### DIFF
--- a/js/.gitignore
+++ b/js/.gitignore
@@ -63,6 +63,10 @@ Chinook_Sqlite.sql
 /wrappers.js
 /wrappers.d.ts
 /wrappers.d.cts
+/anonymizer.cjs
+/anonymizer.js
+/anonymizer.d.ts
+/anonymizer.d.cts
 /wrappers/openai.cjs
 /wrappers/openai.js
 /wrappers/openai.d.ts

--- a/js/package.json
+++ b/js/package.json
@@ -37,6 +37,10 @@
     "wrappers.js",
     "wrappers.d.ts",
     "wrappers.d.cts",
+    "anonymizer.cjs",
+    "anonymizer.js",
+    "anonymizer.d.ts",
+    "anonymizer.d.cts",
     "wrappers/openai.cjs",
     "wrappers/openai.js",
     "wrappers/openai.d.ts",
@@ -91,6 +95,7 @@
   "dependencies": {
     "@types/uuid": "^9.0.1",
     "commander": "^10.0.1",
+    "lodash.set": "^4.3.2",
     "p-queue": "^6.6.2",
     "p-retry": "4",
     "uuid": "^9.0.0"
@@ -104,6 +109,7 @@
     "@langchain/langgraph": "^0.0.19",
     "@tsconfig/recommended": "^1.0.2",
     "@types/jest": "^29.5.1",
+    "@types/lodash.set": "^4.3.9",
     "@typescript-eslint/eslint-plugin": "^5.59.8",
     "@typescript-eslint/parser": "^5.59.8",
     "babel-jest": "^29.5.0",
@@ -227,6 +233,15 @@
       },
       "import": "./wrappers.js",
       "require": "./wrappers.cjs"
+    },
+    "./anonymizer": {
+      "types": {
+        "import": "./anonymizer.d.ts",
+        "require": "./anonymizer.d.cts",
+        "default": "./anonymizer.d.ts"
+      },
+      "import": "./anonymizer.js",
+      "require": "./anonymizer.cjs"
     },
     "./wrappers/openai": {
       "types": {

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langsmith",
-  "version": "0.1.32",
+  "version": "0.1.33",
   "description": "Client library to connect to the LangSmith LLM Tracing and Evaluation Platform.",
   "packageManager": "yarn@1.22.19",
   "files": [

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langsmith",
-  "version": "0.1.31",
+  "version": "0.1.32",
   "description": "Client library to connect to the LangSmith LLM Tracing and Evaluation Platform.",
   "packageManager": "yarn@1.22.19",
   "files": [

--- a/js/scripts/create-entrypoints.js
+++ b/js/scripts/create-entrypoints.js
@@ -15,9 +15,11 @@ const entrypoints = {
   schemas: "schemas",
   langchain: "langchain",
   wrappers: "wrappers/index",
+  anonymizer: "anonymizer/index",
   "wrappers/openai": "wrappers/openai",
   "singletons/traceable": "singletons/traceable",
 };
+
 const updateJsonFile = (relativePath, updateFunction) => {
   const contents = fs.readFileSync(relativePath).toString();
   const res = updateFunction(JSON.parse(contents));

--- a/js/src/anonymizer/index.ts
+++ b/js/src/anonymizer/index.ts
@@ -1,0 +1,136 @@
+import set from "lodash.set";
+
+export interface StringNode {
+  value: string;
+  path: string;
+}
+
+function extractStringNodes(data: unknown, options: { maxDepth?: number }) {
+  const parsedOptions = { ...options, maxDepth: options.maxDepth ?? 10 };
+
+  const queue: [value: unknown, depth: number, path: string][] = [
+    [data, 0, ""],
+  ];
+
+  const result: StringNode[] = [];
+  while (queue.length > 0) {
+    const task = queue.shift();
+    if (task == null) continue;
+    const [value, depth, path] = task;
+    if (typeof value === "object" && value != null) {
+      if (depth >= parsedOptions.maxDepth) continue;
+      for (const [key, nestedValue] of Object.entries(value)) {
+        queue.push([nestedValue, depth + 1, path ? `${path}.${key}` : key]);
+      }
+    } else if (Array.isArray(value)) {
+      if (depth >= parsedOptions.maxDepth) continue;
+      for (let i = 0; i < value.length; i++) {
+        queue.push([value[i], depth + 1, `${path}[${i}]`]);
+      }
+    } else if (typeof value === "string") {
+      result.push({ value, path });
+    }
+  }
+
+  return result;
+}
+
+function deepClone<T>(data: T): T {
+  if ("structuredClone" in globalThis) {
+    return globalThis.structuredClone(data);
+  }
+
+  return JSON.parse(JSON.stringify(data));
+}
+
+export interface StringNodeProcessor {
+  maskNodes: (nodes: StringNode[]) => StringNode[];
+}
+
+export interface StringNodeRule {
+  type?: "pattern";
+  pattern: RegExp | string;
+  replace?: string;
+}
+
+export type ReplacerType =
+  | ((value: string, path?: string) => string)
+  | StringNodeRule[]
+  | StringNodeProcessor;
+
+export function replaceSensitiveData<T>(
+  data: T,
+  replacer: ReplacerType,
+  options?: {
+    maxDepth?: number;
+    deepClone?: boolean;
+  }
+): T {
+  const nodes = extractStringNodes(data, {
+    maxDepth: options?.maxDepth,
+  });
+
+  // by default we opt-in to mutate the value directly
+  // to improve performance
+  let mutateValue = options?.deepClone ? deepClone(data) : data;
+
+  const processor: StringNodeProcessor = Array.isArray(replacer)
+    ? (() => {
+        const replacers: [regex: RegExp, replace: string][] = replacer.map(
+          ({ pattern, type, replace }) => {
+            if (type != null && type !== "pattern")
+              throw new Error("Invalid anonymizer type");
+            return [
+              typeof pattern === "string" ? new RegExp(pattern, "g") : pattern,
+              replace ?? "[redacted]",
+            ];
+          }
+        );
+
+        if (replacers.length === 0) throw new Error("No replacers provided");
+        return {
+          maskNodes: (nodes: StringNode[]) => {
+            return nodes.reduce<StringNode[]>((memo, item) => {
+              const newValue = replacers.reduce((value, [regex, replace]) => {
+                const result = value.replace(regex, replace);
+
+                // make sure we reset the state of regex
+                regex.lastIndex = 0;
+
+                return result;
+              }, item.value);
+
+              if (newValue !== item.value) {
+                memo.push({ value: newValue, path: item.path });
+              }
+
+              return memo;
+            }, []);
+          },
+        };
+      })()
+    : typeof replacer === "function"
+    ? {
+        maskNodes: (nodes: StringNode[]) =>
+          nodes.reduce<StringNode[]>((memo, item) => {
+            const newValue = replacer(item.value, item.path);
+            if (newValue !== item.value) {
+              memo.push({ value: newValue, path: item.path });
+            }
+
+            return memo;
+          }, []),
+      }
+    : replacer;
+
+  const toUpdate = processor.maskNodes(nodes);
+  for (const node of toUpdate) {
+    if (node.path === "") {
+      mutateValue = node.value as unknown as T;
+    } else {
+      set(mutateValue as unknown as object, node.path, node.value);
+    }
+  }
+
+  return mutateValue;
+}

--- a/js/src/anonymizer/index.ts
+++ b/js/src/anonymizer/index.ts
@@ -58,14 +58,14 @@ export type ReplacerType =
   | StringNodeRule[]
   | StringNodeProcessor;
 
-export function createAnonymizer<T>(
+export function createAnonymizer(
   replacer: ReplacerType,
   options?: {
     maxDepth?: number;
     deepClone?: boolean;
   }
 ) {
-  return (data: T): T => {
+  return <T>(data: T): T => {
     const nodes = extractStringNodes(data, {
       maxDepth: options?.maxDepth,
     });

--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -49,8 +49,9 @@ interface ClientConfig {
   callerOptions?: AsyncCallerParams;
   timeout_ms?: number;
   webUrl?: string;
-  hideInputs?: boolean;
-  hideOutputs?: boolean;
+  anonymizer?: (values: KVMap) => KVMap;
+  hideInputs?: boolean | ((inputs: KVMap) => KVMap);
+  hideOutputs?: boolean | ((outputs: KVMap) => KVMap);
   autoBatchTracing?: boolean;
   pendingAutoBatchedRunLimit?: number;
   fetchOptions?: RequestInit;
@@ -429,8 +430,12 @@ export class Client {
       ...(config.callerOptions ?? {}),
       onFailedResponseHook: handle429,
     });
-    this.hideInputs = config.hideInputs ?? defaultConfig.hideInputs;
-    this.hideOutputs = config.hideOutputs ?? defaultConfig.hideOutputs;
+
+    this.hideInputs =
+      config.hideInputs ?? config.anonymizer ?? defaultConfig.hideInputs;
+    this.hideOutputs =
+      config.hideOutputs ?? config.anonymizer ?? defaultConfig.hideOutputs;
+
     this.autoBatchTracing = config.autoBatchTracing ?? this.autoBatchTracing;
     this.pendingAutoBatchedRunLimit =
       config.pendingAutoBatchedRunLimit ?? this.pendingAutoBatchedRunLimit;

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -12,4 +12,4 @@ export type {
 export { RunTree, type RunTreeConfig } from "./run_trees.js";
 
 // Update using yarn bump-version
-export const __version__ = "0.1.32";
+export const __version__ = "0.1.33";

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -12,4 +12,4 @@ export type {
 export { RunTree, type RunTreeConfig } from "./run_trees.js";
 
 // Update using yarn bump-version
-export const __version__ = "0.1.31";
+export const __version__ = "0.1.32";

--- a/js/src/tests/anonymizer.test.ts
+++ b/js/src/tests/anonymizer.test.ts
@@ -1,0 +1,72 @@
+import { StringNodeRule, replaceSensitiveData } from "../anonymizer/index.js";
+import { v4 as uuid } from "uuid";
+
+const EMAIL_REGEX = /[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+.[a-zA-Z]{2,}/g;
+const UUID_REGEX =
+  /[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}/g;
+
+describe("replacer", () => {
+  const replacer = (text: string) =>
+    text.replace(EMAIL_REGEX, "[email address]").replace(UUID_REGEX, "[uuid]");
+
+  test("object", () => {
+    expect(
+      replaceSensitiveData(
+        {
+          message: "Hello, this is my email: hello@example.com",
+          metadata: uuid(),
+        },
+        replacer
+      )
+    ).toEqual({
+      message: "Hello, this is my email: [email address]",
+      metadata: "[uuid]",
+    });
+  });
+
+  test("array", () => {
+    expect(
+      replaceSensitiveData(["human", "hello@example.com"], replacer)
+    ).toEqual(["human", "[email address]"]);
+  });
+
+  test("string", () => {
+    expect(replaceSensitiveData("hello@example.com", replacer)).toEqual(
+      "[email address]"
+    );
+  });
+});
+
+describe("declared", () => {
+  const replacers: StringNodeRule[] = [
+    { pattern: EMAIL_REGEX, replace: "[email address]" },
+    { pattern: UUID_REGEX, replace: "[uuid]" },
+  ];
+
+  test("object", () => {
+    expect(
+      replaceSensitiveData(
+        {
+          message: "Hello, this is my email: hello@example.com",
+          metadata: uuid(),
+        },
+        replacers
+      )
+    ).toEqual({
+      message: "Hello, this is my email: [email address]",
+      metadata: "[uuid]",
+    });
+  });
+
+  test("array", () => {
+    expect(
+      replaceSensitiveData(["human", "hello@example.com"], replacers)
+    ).toEqual(["human", "[email address]"]);
+  });
+
+  test("string", () => {
+    expect(replaceSensitiveData("hello@example.com", replacers)).toEqual(
+      "[email address]"
+    );
+  });
+});

--- a/js/src/tests/anonymizer.test.ts
+++ b/js/src/tests/anonymizer.test.ts
@@ -1,4 +1,4 @@
-import { StringNodeRule, replaceSensitiveData } from "../anonymizer/index.js";
+import { StringNodeRule, createAnonymizer } from "../anonymizer/index.js";
 import { v4 as uuid } from "uuid";
 
 const EMAIL_REGEX = /[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+.[a-zA-Z]{2,}/g;
@@ -11,13 +11,10 @@ describe("replacer", () => {
 
   test("object", () => {
     expect(
-      replaceSensitiveData(
-        {
-          message: "Hello, this is my email: hello@example.com",
-          metadata: uuid(),
-        },
-        replacer
-      )
+      createAnonymizer(replacer)({
+        message: "Hello, this is my email: hello@example.com",
+        metadata: uuid(),
+      })
     ).toEqual({
       message: "Hello, this is my email: [email address]",
       metadata: "[uuid]",
@@ -26,12 +23,12 @@ describe("replacer", () => {
 
   test("array", () => {
     expect(
-      replaceSensitiveData(["human", "hello@example.com"], replacer)
+      createAnonymizer(replacer)(["human", "hello@example.com"])
     ).toEqual(["human", "[email address]"]);
   });
 
   test("string", () => {
-    expect(replaceSensitiveData("hello@example.com", replacer)).toEqual(
+    expect(createAnonymizer(replacer)("hello@example.com")).toEqual(
       "[email address]"
     );
   });
@@ -45,13 +42,10 @@ describe("declared", () => {
 
   test("object", () => {
     expect(
-      replaceSensitiveData(
-        {
-          message: "Hello, this is my email: hello@example.com",
-          metadata: uuid(),
-        },
-        replacers
-      )
+      createAnonymizer(replacers)({
+        message: "Hello, this is my email: hello@example.com",
+        metadata: uuid(),
+      })
     ).toEqual({
       message: "Hello, this is my email: [email address]",
       metadata: "[uuid]",
@@ -60,12 +54,12 @@ describe("declared", () => {
 
   test("array", () => {
     expect(
-      replaceSensitiveData(["human", "hello@example.com"], replacers)
+      createAnonymizer(replacers)(["human", "hello@example.com"])
     ).toEqual(["human", "[email address]"]);
   });
 
   test("string", () => {
-    expect(replaceSensitiveData("hello@example.com", replacers)).toEqual(
+    expect(createAnonymizer(replacers)("hello@example.com")).toEqual(
       "[email address]"
     );
   });

--- a/js/src/tests/anonymizer.test.ts
+++ b/js/src/tests/anonymizer.test.ts
@@ -22,9 +22,10 @@ describe("replacer", () => {
   });
 
   test("array", () => {
-    expect(
-      createAnonymizer(replacer)(["human", "hello@example.com"])
-    ).toEqual(["human", "[email address]"]);
+    expect(createAnonymizer(replacer)(["human", "hello@example.com"])).toEqual([
+      "human",
+      "[email address]",
+    ]);
   });
 
   test("string", () => {
@@ -53,9 +54,9 @@ describe("declared", () => {
   });
 
   test("array", () => {
-    expect(
-      createAnonymizer(replacers)(["human", "hello@example.com"])
-    ).toEqual(["human", "[email address]"]);
+    expect(createAnonymizer(replacers)(["human", "hello@example.com"])).toEqual(
+      ["human", "[email address]"]
+    );
   });
 
   test("string", () => {

--- a/js/src/tests/anonymizer.test.ts
+++ b/js/src/tests/anonymizer.test.ts
@@ -1,5 +1,9 @@
 import { StringNodeRule, createAnonymizer } from "../anonymizer/index.js";
 import { v4 as uuid } from "uuid";
+import { traceable } from "../traceable.js";
+import { BaseMessage, SystemMessage } from "@langchain/core/messages";
+import { mockClient } from "./utils/mock_client.js";
+import { getAssumedTreeFromCalls } from "./utils/tree.js";
 
 const EMAIL_REGEX = /[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+.[a-zA-Z]{2,}/g;
 const UUID_REGEX =
@@ -63,5 +67,65 @@ describe("declared", () => {
     expect(createAnonymizer(replacers)("hello@example.com")).toEqual(
       "[email address]"
     );
+  });
+});
+
+describe("client", () => {
+  test("messages", async () => {
+    const anonymizer = createAnonymizer([
+      { pattern: EMAIL_REGEX, replace: "[email]" },
+      { pattern: UUID_REGEX, replace: "[uuid]" },
+    ]);
+
+    const { client, callSpy } = mockClient({ anonymizer });
+
+    const id = uuid();
+    const child = traceable(
+      (value: { messages: BaseMessage[]; values: Record<string, unknown> }) => {
+        return [
+          ...value.messages.map((message) => message.content.toString()),
+          ...Object.entries(value.values).map((lst) => lst.join(": ")),
+        ].join("\n");
+      },
+      { name: "child" }
+    );
+
+    const evaluate = traceable(
+      (values: Record<string, unknown>) => {
+        const messages = [new SystemMessage(`UUID: ${id}`)];
+        return child({ messages, values });
+      },
+      { client, name: "evaluate", tracingEnabled: true }
+    );
+
+    const result = await evaluate({ email: "hello@example.com" });
+
+    expect(result).toEqual(
+      [`UUID: ${id}`, `email: hello@example.com`].join("\n")
+    );
+
+    expect(getAssumedTreeFromCalls(callSpy.mock.calls)).toMatchObject({
+      nodes: ["evaluate:0", "child:1"],
+      data: {
+        "evaluate:0": {
+          inputs: { email: "[email]" },
+          outputs: { outputs: [`UUID: [uuid]`, `email: [email]`].join("\n") },
+        },
+        "child:1": {
+          inputs: {
+            messages: [
+              {
+                lc: 1,
+                type: "constructor",
+                id: ["langchain_core", "messages", "SystemMessage"],
+                kwargs: { content: "UUID: [uuid]" },
+              },
+            ],
+            values: { email: "[email]" },
+          },
+          outputs: { outputs: [`UUID: [uuid]`, `email: [email]`].join("\n") },
+        },
+      },
+    });
   });
 });

--- a/js/src/tests/utils/mock_client.ts
+++ b/js/src/tests/utils/mock_client.ts
@@ -2,8 +2,9 @@
 import { jest } from "@jest/globals";
 import { Client } from "../../index.js";
 
-export const mockClient = () => {
-  const client = new Client({ autoBatchTracing: false });
+type ClientParams = Exclude<ConstructorParameters<typeof Client>[0], undefined>;
+export const mockClient = (config?: Omit<ClientParams, "autoBatchTracing">) => {
+  const client = new Client({ ...config, autoBatchTracing: false });
   const callSpy = jest
     .spyOn((client as any).caller, "call")
     .mockResolvedValue({ ok: true, text: () => "" });

--- a/js/tsconfig.json
+++ b/js/tsconfig.json
@@ -40,6 +40,7 @@
       "src/schemas.ts",
       "src/langchain.ts",
       "src/wrappers/index.ts",
+      "src/anonymizer/index.ts",
       "src/wrappers/openai.ts",
       "src/singletons/traceable.ts"
     ]

--- a/js/yarn.lock
+++ b/js/yarn.lock
@@ -1487,6 +1487,18 @@
   resolved "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz"
   integrity sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==
 
+"@types/lodash.set@^4.3.9":
+  version "4.3.9"
+  resolved "https://registry.yarnpkg.com/@types/lodash.set/-/lodash.set-4.3.9.tgz#55d95bce407b42c6655f29b2d0811fd428e698f0"
+  integrity sha512-KOxyNkZpbaggVmqbpr82N2tDVTx05/3/j0f50Es1prxrWB0XYf9p3QNxqcbWb7P1Q9wlvsUSlCFnwlPCIJ46PQ==
+  dependencies:
+    "@types/lodash" "*"
+
+"@types/lodash@*":
+  version "4.17.4"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.17.4.tgz#0303b64958ee070059e3a7184048a55159fe20b7"
+  integrity sha512-wYCP26ZLxaT3R39kiN2+HcJ4kTd3U1waI/cY7ivWYqFP6pW3ZNpvi6Wd6PHZx7T/t8z0vlkXMg3QYLa7DZ/IJQ==
+
 "@types/node-fetch@^2.6.4":
   version "2.6.11"
   resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.6.11.tgz#9b39b78665dae0e82a08f02f4967d62c66f95d24"
@@ -3572,6 +3584,11 @@ lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
+
+lodash.set@^4.3.2:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/lodash.set/-/lodash.set-4.3.2.tgz#d8757b1da807dde24816b0d6a84bea1a76230b23"
+  integrity sha512-4hNPN5jlm/N/HLMCO43v8BXKq9Z7QdAGc/VGrRD61w8gN9g/6jF9A4L1pbUgBLCffi0w9VsXfTOij5x8iTyFvg==
 
 lru-cache@^5.1.1:
   version "5.1.1"

--- a/python/langsmith/__init__.py
+++ b/python/langsmith/__init__.py
@@ -97,6 +97,7 @@ __all__ = [
     "__version__",
     "EvaluationResult",
     "RunEvaluator",
+    "anonymizer",
     "traceable",
     "trace",
     "unit",

--- a/python/langsmith/anonymizer.py
+++ b/python/langsmith/anonymizer.py
@@ -7,7 +7,7 @@ from typing import Any, Callable, List, Optional, Tuple, TypedDict, Union
 
 
 class _ExtractOptions(TypedDict):
-    maxDepth: Optional[int]
+    max_depth: Optional[int]
     """
     Maximum depth to traverse to to extract string nodes
     """
@@ -26,7 +26,7 @@ class StringNode(TypedDict):
 def _extract_string_nodes(data: Any, options: _ExtractOptions) -> List[StringNode]:
     max_depth = options.get("maxDepth") or 10
 
-    queue: List[Tuple[Any, int, List[Union[str, int]]]] = [(data, 0, list())]
+    queue: List[Tuple[Any, int, List[Union[str, int]]]] = [(data, 0, [])]
     result: List[StringNode] = []
 
     while queue:
@@ -35,7 +35,7 @@ def _extract_string_nodes(data: Any, options: _ExtractOptions) -> List[StringNod
             continue
         value, depth, path = task
 
-        if isinstance(value, dict) or isinstance(value, defaultdict):
+        if isinstance(value, (dict, defaultdict)):
             if depth >= max_depth:
                 continue
             for key, nested_value in value.items():
@@ -62,10 +62,10 @@ class StringNodeProcessor:
 class ReplacerOptions(TypedDict):
     """Configuration options for replacing sensitive data."""
 
-    maxDepth: Optional[int]
+    max_depth: Optional[int]
     """Maximum depth to traverse to to extract string nodes."""
 
-    deepClone: Optional[bool]
+    deep_clone: Optional[bool]
     """Deep clone the data before replacing."""
 
 

--- a/python/langsmith/anonymizer.py
+++ b/python/langsmith/anonymizer.py
@@ -24,7 +24,7 @@ class StringNode(TypedDict):
 
 
 def _extract_string_nodes(data: Any, options: _ExtractOptions) -> List[StringNode]:
-    max_depth = options.get("maxDepth") or 10
+    max_depth = options.get("max_depth") or 10
 
     queue: List[Tuple[Any, int, List[Union[str, int]]]] = [(data, 0, [])]
     result: List[StringNode] = []
@@ -159,9 +159,11 @@ def create_anonymizer(
 
     def anonymizer(data: Any) -> Any:
         nodes = _extract_string_nodes(
-            data, {"maxDepth": (options.get("maxDepth") if options else None) or 10}
+            data, {"max_depth": (options.get("max_depth") if options else None) or 10}
         )
-        mutate_value = copy.deepcopy(data) if options and options["deepClone"] else data
+        mutate_value = (
+            copy.deepcopy(data) if options and options["deep_clone"] else data
+        )
 
         to_update = processor.mask_nodes(nodes)
         for node in to_update:

--- a/python/langsmith/anonymizer.py
+++ b/python/langsmith/anonymizer.py
@@ -110,10 +110,13 @@ class RuleNodeProcessor(StringNodeProcessor):
 class CallableNodeProcessor(StringNodeProcessor):
     """String node processor that uses a callable function to replace sensitive data."""
 
-    func: Callable[[str, List[Union[str, int]]], str]
+    func: Union[Callable[[str], str], Callable[[str, List[Union[str, int]]], str]]
     accepts_path: bool
 
-    def __init__(self, func: Callable[[str, List[Union[str, int]]], str]):
+    def __init__(
+        self,
+        func: Union[Callable[[str], str], Callable[[str, List[Union[str, int]]], str]],
+    ):
         """Initialize the processor with a callable function."""
         self.func = func
         self.accepts_path = len(inspect.signature(func).parameters) == 2
@@ -123,9 +126,9 @@ class CallableNodeProcessor(StringNodeProcessor):
         retval: List[StringNode] = []
         for node in nodes:
             candidate = (
-                self.func(node["value"], node["path"])
+                self.func(node["value"], node["path"])  # type: ignore[call-arg]
                 if self.accepts_path
-                else self.func(node["value"])
+                else self.func(node["value"])  # type: ignore[call-arg]
             )
             if candidate != node["value"]:
                 retval.append(StringNode(value=candidate, path=node["path"]))

--- a/python/langsmith/anonymizer.py
+++ b/python/langsmith/anonymizer.py
@@ -18,14 +18,14 @@ class StringNode(TypedDict):
     value: str
     """String value."""
 
-    path: list[str | int]
+    path: list[Union[str, int]]
     """Path to the string node in the data."""
 
 
 def _extract_string_nodes(data: Any, options: _ExtractOptions) -> List[StringNode]:
     max_depth = options.get("maxDepth") or 10
 
-    queue: List[Tuple[Any, int, list[str | int]]] = [(data, 0, list())]
+    queue: List[Tuple[Any, int, list[Union[str, int]]]] = [(data, 0, list())]
     result: List[StringNode] = []
 
     while queue:
@@ -109,9 +109,9 @@ class RuleNodeProcessor(StringNodeProcessor):
 class CallableNodeProcessor(StringNodeProcessor):
     """String node processor that uses a callable function to replace sensitive data."""
 
-    func: Callable[[str, list[str | int]], str]
+    func: Callable[[str, list[Union[str, int]]], str]
 
-    def __init__(self, func: Callable[[str, list[str | int]], str]):
+    def __init__(self, func: Callable[[str, list[Union[str, int]]], str]):
         """Initialize the processor with a callable function."""
         self.func = func
 
@@ -126,7 +126,9 @@ class CallableNodeProcessor(StringNodeProcessor):
 
 
 ReplacerType = Union[
-    Callable[[str, list[str | int]], str], List[StringNodeRule], StringNodeProcessor
+    Callable[[str, list[Union[str, int]]], str],
+    List[StringNodeRule],
+    StringNodeProcessor,
 ]
 
 

--- a/python/langsmith/anonymizer.py
+++ b/python/langsmith/anonymizer.py
@@ -1,6 +1,5 @@
-import copy  # noqa
-import re
 import inspect
+import re
 from abc import abstractmethod
 from collections import defaultdict
 from typing import Any, Callable, List, Optional, Tuple, TypedDict, Union
@@ -152,18 +151,16 @@ def _get_node_processor(replacer: ReplacerType) -> StringNodeProcessor:
 
 
 def create_anonymizer(
-    replacer: ReplacerType, options: Optional[ReplacerOptions] = None
+    replacer: ReplacerType,
+    *,
+    max_depth: Optional[int] = None,
 ) -> Callable[[Any], Any]:
     """Create an anonymizer function."""
     processor = _get_node_processor(replacer)
 
     def anonymizer(data: Any) -> Any:
-        nodes = _extract_string_nodes(
-            data, {"max_depth": (options.get("max_depth") if options else None) or 10}
-        )
-        mutate_value = (
-            copy.deepcopy(data) if options and options["deep_clone"] else data
-        )
+        nodes = _extract_string_nodes(data, {"max_depth": max_depth or 10})
+        mutate_value = data
 
         to_update = processor.mask_nodes(nodes)
         for node in to_update:

--- a/python/langsmith/anonymizer.py
+++ b/python/langsmith/anonymizer.py
@@ -1,0 +1,115 @@
+import copy
+import re
+from abc import abstractmethod
+from collections import defaultdict
+from typing import Any, Callable, List, Optional, Tuple, TypedDict, Union
+
+
+class ExtractOptions(TypedDict):
+    maxDepth: Optional[int]
+    """
+    Maximum depth to traverse to to extract string nodes
+    """
+
+
+class StringNode(TypedDict):
+    value: str
+    path: tuple[str | int]
+
+
+def _extract_string_nodes(data: Any, options: ExtractOptions) -> List[StringNode]:
+    parsed_options = {**options, "maxDepth": options.get("maxDepth", 10)}
+
+    queue: List[Tuple[Any, int, tuple[str | int]]] = [(data, 0, tuple())]
+    result: List[StringNode] = []
+
+    while queue:
+        task = queue.pop(0)
+        if task is None:
+            continue
+        value, depth, path = task
+
+        if isinstance(value, dict) or isinstance(value, defaultdict):
+            if depth >= parsed_options["maxDepth"]:
+                continue
+            for key, nested_value in value.items():
+                queue.append((nested_value, depth + 1, path + (key,)))
+        elif isinstance(value, list):
+            if depth >= parsed_options["maxDepth"]:
+                continue
+            for i, item in enumerate(value):
+                queue.append((item, depth + 1, path + (i,)))
+        elif isinstance(value, str):
+            result.append(StringNode(value, path))
+
+    return result
+
+
+class StringNodeProcessor:
+    @abstractmethod
+    def mask_nodes(self, nodes: List[StringNode]) -> List[StringNode]:
+        """Mask node."""
+
+
+class ReplacerOptions(TypedDict):
+    maxDepth: Optional[int]
+    deepClone: Optional[bool]
+
+
+class StringNodeRule(TypedDict):
+    pattern: Union[str, re.Pattern]
+    replace: Optional[str] = "[redacted]"
+
+
+ReplacerType = Union[
+    Callable[[str, Optional[str]], str], List[StringNodeRule], StringNodeProcessor
+]
+
+
+def replace_sensitive_data(
+    data: Any, replacer: ReplacerType, options: Optional[ReplacerOptions] = None
+) -> Any:
+    nodes = _extract_string_nodes(data, options)
+    mutate_value = copy.deepcopy(data) if options and options["deepClone"] else data
+
+    if isinstance(replacer, list):
+
+        def mask_nodes(nodes: List[StringNode]) -> List[StringNode]:
+            result = []
+            for item in nodes:
+                new_value = item.value
+                for rule in replacer:
+                    new_value = rule["pattern"].sub(rule["replace"], new_value)
+                if new_value != item.value:
+                    result.append(StringNode(new_value, item.path))
+            return result
+
+        processor = StringNodeProcessor()
+        processor.mask_nodes = mask_nodes
+    elif callable(replacer):
+
+        def mask_nodes(nodes: List[StringNode]) -> List[StringNode]:
+            return [
+                StringNode(replacer(node.value, node.path), node.path)
+                for node in nodes
+                if replacer(node.value, node.path) != node.value
+            ]
+
+        processor = StringNodeProcessor()
+        processor.mask_nodes = mask_nodes
+    else:
+        processor = replacer
+
+    to_update = processor.mask_nodes(nodes)
+    for node in to_update:
+        if not node.path:
+            mutate_value = node.value
+        else:
+            temp = mutate_value
+            for part in node.path[:-1]:
+                temp = temp[part]
+
+            last_part = node.path[-1]
+            temp[last_part] = node.value
+
+    return mutate_value

--- a/python/langsmith/anonymizer.py
+++ b/python/langsmith/anonymizer.py
@@ -1,5 +1,5 @@
+import re  # noqa
 import inspect
-import re
 from abc import abstractmethod
 from collections import defaultdict
 from typing import Any, Callable, List, Optional, Tuple, TypedDict, Union

--- a/python/langsmith/anonymizer.py
+++ b/python/langsmith/anonymizer.py
@@ -155,6 +155,7 @@ def create_anonymizer(
     replacer: ReplacerType, options: Optional[ReplacerOptions] = None
 ) -> Callable[[Any], Any]:
     """Create an anonymizer function."""
+    processor = _get_node_processor(replacer)
 
     def anonymizer(data: Any) -> Any:
         nodes = _extract_string_nodes(
@@ -162,7 +163,7 @@ def create_anonymizer(
         )
         mutate_value = copy.deepcopy(data) if options and options["deepClone"] else data
 
-        to_update = _get_node_processor(replacer).mask_nodes(nodes)
+        to_update = processor.mask_nodes(nodes)
         for node in to_update:
             if not node["path"]:
                 mutate_value = node["value"]

--- a/python/langsmith/anonymizer.py
+++ b/python/langsmith/anonymizer.py
@@ -1,11 +1,11 @@
-import copy
+import copy  # noqa
 import re
 from abc import abstractmethod
 from collections import defaultdict
-from typing import Any, Callable, List, Optional, Tuple, TypedDict, Union
+from typing import Any, Callable, List, Optional, Tuple, TypedDict, TypeVar, Union
 
 
-class ExtractOptions(TypedDict):
+class _ExtractOptions(TypedDict):
     maxDepth: Optional[int]
     """
     Maximum depth to traverse to to extract string nodes
@@ -13,12 +13,17 @@ class ExtractOptions(TypedDict):
 
 
 class StringNode(TypedDict):
+    """String node extracted from the data."""
+
     value: str
+    """String value."""
+
     path: tuple[str | int]
+    """Path to the string node in the data."""
 
 
-def _extract_string_nodes(data: Any, options: ExtractOptions) -> List[StringNode]:
-    parsed_options = {**options, "maxDepth": options.get("maxDepth", 10)}
+def _extract_string_nodes(data: Any, options: _ExtractOptions) -> List[StringNode]:
+    max_depth = options.get("maxDepth", 10)
 
     queue: List[Tuple[Any, int, tuple[str | int]]] = [(data, 0, tuple())]
     result: List[StringNode] = []
@@ -30,46 +35,63 @@ def _extract_string_nodes(data: Any, options: ExtractOptions) -> List[StringNode
         value, depth, path = task
 
         if isinstance(value, dict) or isinstance(value, defaultdict):
-            if depth >= parsed_options["maxDepth"]:
+            if depth >= max_depth:
                 continue
             for key, nested_value in value.items():
                 queue.append((nested_value, depth + 1, path + (key,)))
         elif isinstance(value, list):
-            if depth >= parsed_options["maxDepth"]:
+            if depth >= max_depth:
                 continue
             for i, item in enumerate(value):
                 queue.append((item, depth + 1, path + (i,)))
         elif isinstance(value, str):
-            result.append(StringNode(value, path))
+            result.append(StringNode(value=value, path=path))
 
     return result
 
 
 class StringNodeProcessor:
+    """Processes a list of string nodes for masking."""
+
     @abstractmethod
     def mask_nodes(self, nodes: List[StringNode]) -> List[StringNode]:
-        """Mask node."""
+        """Accept and return a list of string nodes to be masked."""
 
 
 class ReplacerOptions(TypedDict):
+    """Configuration options for replacing sensitive data."""
+
     maxDepth: Optional[int]
+    """Maximum depth to traverse to to extract string nodes."""
+
     deepClone: Optional[bool]
+    """Deep clone the data before replacing."""
 
 
 class StringNodeRule(TypedDict):
+    """Declarative rule used for replacing sensitive data."""
+
     pattern: Union[str, re.Pattern]
+    """Regex pattern to match."""
+
     replace: Optional[str] = "[redacted]"
+    """Replacement value. Defaults to `[redacted]` if not specified."""
 
 
 ReplacerType = Union[
-    Callable[[str, Optional[str]], str], List[StringNodeRule], StringNodeProcessor
+    Callable[[str, tuple[str | int]], str], List[StringNodeRule], StringNodeProcessor
 ]
+
+T = TypeVar("T", str, dict)
 
 
 def replace_sensitive_data(
-    data: Any, replacer: ReplacerType, options: Optional[ReplacerOptions] = None
-) -> Any:
-    nodes = _extract_string_nodes(data, options)
+    data: T, replacer: ReplacerType, options: Optional[ReplacerOptions] = None
+) -> T:
+    """Replace sensitive data."""
+    nodes = _extract_string_nodes(
+        data, {"maxDepth": (options or {}).get("maxDepth", 10)}
+    )
     mutate_value = copy.deepcopy(data) if options and options["deepClone"] else data
 
     if isinstance(replacer, list):
@@ -77,11 +99,11 @@ def replace_sensitive_data(
         def mask_nodes(nodes: List[StringNode]) -> List[StringNode]:
             result = []
             for item in nodes:
-                new_value = item.value
+                new_value = item["value"]
                 for rule in replacer:
                     new_value = rule["pattern"].sub(rule["replace"], new_value)
-                if new_value != item.value:
-                    result.append(StringNode(new_value, item.path))
+                if new_value != item["value"]:
+                    result.append(StringNode(value=new_value, path=item["path"]))
             return result
 
         processor = StringNodeProcessor()
@@ -89,11 +111,12 @@ def replace_sensitive_data(
     elif callable(replacer):
 
         def mask_nodes(nodes: List[StringNode]) -> List[StringNode]:
-            return [
-                StringNode(replacer(node.value, node.path), node.path)
-                for node in nodes
-                if replacer(node.value, node.path) != node.value
-            ]
+            retval: list[StringNode] = []
+            for node in nodes:
+                candidate = replacer(node["value"], node["path"])
+                if candidate != node["value"]:
+                    retval.append(StringNode(value=candidate, path=node["path"]))
+            return retval
 
         processor = StringNodeProcessor()
         processor.mask_nodes = mask_nodes
@@ -102,14 +125,14 @@ def replace_sensitive_data(
 
     to_update = processor.mask_nodes(nodes)
     for node in to_update:
-        if not node.path:
-            mutate_value = node.value
+        if not node["path"]:
+            mutate_value = node["value"]
         else:
             temp = mutate_value
-            for part in node.path[:-1]:
+            for part in node["path"][:-1]:
                 temp = temp[part]
 
-            last_part = node.path[-1]
-            temp[last_part] = node.value
+            last_part = node["path"][-1]
+            temp[last_part] = node["value"]
 
     return mutate_value

--- a/python/langsmith/anonymizer.py
+++ b/python/langsmith/anonymizer.py
@@ -18,14 +18,14 @@ class StringNode(TypedDict):
     value: str
     """String value."""
 
-    path: list[Union[str, int]]
+    path: List[Union[str, int]]
     """Path to the string node in the data."""
 
 
 def _extract_string_nodes(data: Any, options: _ExtractOptions) -> List[StringNode]:
     max_depth = options.get("maxDepth") or 10
 
-    queue: List[Tuple[Any, int, list[Union[str, int]]]] = [(data, 0, list())]
+    queue: List[Tuple[Any, int, List[Union[str, int]]]] = [(data, 0, list())]
     result: List[StringNode] = []
 
     while queue:
@@ -109,15 +109,15 @@ class RuleNodeProcessor(StringNodeProcessor):
 class CallableNodeProcessor(StringNodeProcessor):
     """String node processor that uses a callable function to replace sensitive data."""
 
-    func: Callable[[str, list[Union[str, int]]], str]
+    func: Callable[[str, List[Union[str, int]]], str]
 
-    def __init__(self, func: Callable[[str, list[Union[str, int]]], str]):
+    def __init__(self, func: Callable[[str, List[Union[str, int]]], str]):
         """Initialize the processor with a callable function."""
         self.func = func
 
     def mask_nodes(self, nodes: List[StringNode]) -> List[StringNode]:
         """Mask nodes using the callable function."""
-        retval: list[StringNode] = []
+        retval: List[StringNode] = []
         for node in nodes:
             candidate = self.func(node["value"], node["path"])
             if candidate != node["value"]:
@@ -126,7 +126,7 @@ class CallableNodeProcessor(StringNodeProcessor):
 
 
 ReplacerType = Union[
-    Callable[[str, list[Union[str, int]]], str],
+    Callable[[str, List[Union[str, int]]], str],
     List[StringNodeRule],
     StringNodeProcessor,
 ]

--- a/python/langsmith/anonymizer.py
+++ b/python/langsmith/anonymizer.py
@@ -94,9 +94,11 @@ class RuleNodeProcessor(StringNodeProcessor):
             new_value = item["value"]
             for rule in self.rules:
                 new_value = rule["pattern"].sub(
-                    rule["replace"]
-                    if isinstance(rule["replace"], str)
-                    else "[redacted]",
+                    (
+                        rule["replace"]
+                        if isinstance(rule["replace"], str)
+                        else "[redacted]"
+                    ),
                     new_value,
                 )
             if new_value != item["value"]:

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -461,6 +461,7 @@ class Client:
         web_url: Optional[str] = None,
         session: Optional[requests.Session] = None,
         auto_batch_tracing: bool = True,
+        anonymizer: Optional[Callable[[dict], dict]] = None,
         hide_inputs: Optional[Union[Callable[[dict], dict], bool]] = None,
         hide_outputs: Optional[Union[Callable[[dict], dict], bool]] = None,
         info: Optional[Union[dict, ls_schemas.LangSmithInfo]] = None,
@@ -578,11 +579,15 @@ class Client:
         self._hide_inputs = (
             hide_inputs
             if hide_inputs is not None
+            else anonymizer
+            if anonymizer is not None
             else ls_utils.get_env_var("HIDE_INPUTS") == "true"
         )
         self._hide_outputs = (
             hide_outputs
             if hide_outputs is not None
+            else anonymizer
+            if anonymizer is not None
             else ls_utils.get_env_var("HIDE_OUTPUTS") == "true"
         )
 

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -579,16 +579,20 @@ class Client:
         self._hide_inputs = (
             hide_inputs
             if hide_inputs is not None
-            else anonymizer
-            if anonymizer is not None
-            else ls_utils.get_env_var("HIDE_INPUTS") == "true"
+            else (
+                anonymizer
+                if anonymizer is not None
+                else ls_utils.get_env_var("HIDE_INPUTS") == "true"
+            )
         )
         self._hide_outputs = (
             hide_outputs
             if hide_outputs is not None
-            else anonymizer
-            if anonymizer is not None
-            else ls_utils.get_env_var("HIDE_OUTPUTS") == "true"
+            else (
+                anonymizer
+                if anonymizer is not None
+                else ls_utils.get_env_var("HIDE_OUTPUTS") == "true"
+            )
         )
 
     def _repr_html_(self) -> str:

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "langsmith"
-version = "0.1.80"
+version = "0.1.81"
 description = "Client library to connect to the LangSmith LLM Tracing and Evaluation Platform."
 authors = ["LangChain <support@langchain.dev>"]
 license = "MIT"

--- a/python/tests/unit_tests/test_anonymizer.py
+++ b/python/tests/unit_tests/test_anonymizer.py
@@ -1,5 +1,5 @@
 import re
-from typing import Union
+from typing import List, Union
 from uuid import uuid4
 
 from langsmith.anonymizer import StringNodeRule, replace_sensitive_data
@@ -11,7 +11,7 @@ UUID_REGEX = re.compile(
 
 
 def test_replacer_function():
-    def replacer(text: str, _: list[Union[str, int]]):
+    def replacer(text: str, _: List[Union[str, int]]):
         text = EMAIL_REGEX.sub("[email address]", text)
         text = UUID_REGEX.sub("[uuid]", text)
         return text

--- a/python/tests/unit_tests/test_anonymizer.py
+++ b/python/tests/unit_tests/test_anonymizer.py
@@ -1,0 +1,58 @@
+import re
+from uuid import uuid4
+
+from langsmith.anonymizer import StringNodeRule, replace_sensitive_data
+
+EMAIL_REGEX = re.compile(r"[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}")
+UUID_REGEX = re.compile(
+    r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"
+)
+
+
+def test_replacer_function():
+    def replacer(text: str, _: tuple[str | int]):
+        text = EMAIL_REGEX.sub("[email address]", text)
+        text = UUID_REGEX.sub("[uuid]", text)
+        return text
+
+    assert replace_sensitive_data(
+        {
+            "message": "Hello, this is my email: hello@example.com",
+            "metadata": str(uuid4()),
+        },
+        replacer,
+    ) == {
+        "message": "Hello, this is my email: [email address]",
+        "metadata": "[uuid]",
+    }
+
+    assert replace_sensitive_data(["human", "hello@example.com"], replacer) == [
+        "human",
+        "[email address]",
+    ]
+    assert replace_sensitive_data("hello@example.com", replacer) == "[email address]"
+
+
+def test_replacer_declared():
+    replacers = [
+        StringNodeRule(pattern=EMAIL_REGEX, replace="[email address]"),
+        StringNodeRule(pattern=UUID_REGEX, replace="[uuid]"),
+    ]
+
+    assert replace_sensitive_data(
+        {
+            "message": "Hello, this is my email: hello@example.com",
+            "metadata": str(uuid4()),
+        },
+        replacers,
+    ) == {
+        "message": "Hello, this is my email: [email address]",
+        "metadata": "[uuid]",
+    }
+
+    assert replace_sensitive_data(["human", "hello@example.com"], replacers) == [
+        "human",
+        "[email address]",
+    ]
+
+    assert replace_sensitive_data("hello@example.com", replacers) == "[email address]"

--- a/python/tests/unit_tests/test_anonymizer.py
+++ b/python/tests/unit_tests/test_anonymizer.py
@@ -1,4 +1,5 @@
 import re
+from typing import Union
 from uuid import uuid4
 
 from langsmith.anonymizer import StringNodeRule, replace_sensitive_data
@@ -10,7 +11,7 @@ UUID_REGEX = re.compile(
 
 
 def test_replacer_function():
-    def replacer(text: str, _: list[str | int]):
+    def replacer(text: str, _: list[Union[str, int]]):
         text = EMAIL_REGEX.sub("[email address]", text)
         text = UUID_REGEX.sub("[uuid]", text)
         return text

--- a/python/tests/unit_tests/test_anonymizer.py
+++ b/python/tests/unit_tests/test_anonymizer.py
@@ -33,6 +33,16 @@ def test_replacer_function():
     assert create_anonymizer(replacer)("hello@example.com") == "[email address]"
 
 
+def test_replacer_lambda():
+    assert create_anonymizer(lambda text: EMAIL_REGEX.sub("[email address]", text))(
+        {
+            "message": "Hello, this is my email: hello@example.com",
+        }
+    ) == {
+        "message": "Hello, this is my email: [email address]",
+    }
+
+
 def test_replacer_declared():
     replacers = [
         StringNodeRule(pattern=EMAIL_REGEX, replace="[email address]"),

--- a/python/tests/unit_tests/test_anonymizer.py
+++ b/python/tests/unit_tests/test_anonymizer.py
@@ -10,7 +10,7 @@ UUID_REGEX = re.compile(
 
 
 def test_replacer_function():
-    def replacer(text: str, _: tuple[str | int]):
+    def replacer(text: str, _: list[str | int]):
         text = EMAIL_REGEX.sub("[email address]", text)
         text = UUID_REGEX.sub("[uuid]", text)
         return text


### PR DESCRIPTION
Expected TypeScript usage:
```ts
import { createAnonymizer } from "langsmith/anonymizer"

// provide list of regex and replacement values
const anonymizer = createAnonymizer([
  { pattern: "...", replace: "[value]" }
])

const client = new Client({ anonymizer })

// replace string values
const anonymizer = createAnonymizer((value) => value.replace("...", "[value]"))
```

Expected Python usage:
```python
from langsmith.anonymizer import create_anonymizer

# provide list of regex and replacement values
anonymizer = create_anonymizer([{"pattern": r"...", "replace": "[value]"}])

client = Client(anonymizer=anonymizer)

# replace string values
anonymizer = create_anonymizer(lambda text: r"...".sub("[value]", text))
```
