### PR TITLE
js[patch]: Store local storage instance on globalThis

### DIFF
--- a/js/src/singletons/traceable.ts
+++ b/js/src/singletons/traceable.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { RunTree } from "../run_trees.js";
 import { TraceableFunction } from "./types.js";
 
@@ -17,20 +18,19 @@ class MockAsyncLocalStorage implements AsyncLocalStorageInterface {
   }
 }
 
+const mockAsyncLocalStorage = new MockAsyncLocalStorage();
+
 class AsyncLocalStorageProvider {
-  private asyncLocalStorage: AsyncLocalStorageInterface =
-    new MockAsyncLocalStorage();
-
-  private hasBeenInitialized = false;
-
   getInstance(): AsyncLocalStorageInterface {
-    return this.asyncLocalStorage;
+    return (
+      (globalThis as any).__lc_tracing_async_local_storage ??
+      mockAsyncLocalStorage
+    );
   }
 
   initializeGlobalInstance(instance: AsyncLocalStorageInterface) {
-    if (!this.hasBeenInitialized) {
-      this.hasBeenInitialized = true;
-      this.asyncLocalStorage = instance;
+    if ((globalThis as any).__lc_tracing_async_local_storage === undefined) {
+      (globalThis as any).__lc_tracing_async_local_storage = instance;
     }
   }
 }


### PR DESCRIPTION
Matches LangChain.js, lays groundwork for easier trace handoffs since both can now reference the same `AsyncLocalStorage` instance.

https://github.com/langchain-ai/langchainjs/blob/main/langchain-core/src/singletons/index.ts#L24