### PR TITLE
support overridding name in langsmith_extra

### DIFF
--- a/python/langsmith/run_helpers.py
+++ b/python/langsmith/run_helpers.py
@@ -174,6 +174,7 @@ def is_async(func: Callable) -> bool:
 class LangSmithExtra(TypedDict, total=False):
     """Any additional info to be injected into the run dynamically."""
 
+    name: Optional[str]
     reference_example_id: Optional[ls_client.ID_TYPE]
     run_extra: Optional[Dict]
     parent: Optional[Union[run_trees.RunTree, str, Mapping]]
@@ -1006,13 +1007,13 @@ def _setup_run(
 ) -> _TraceableContainer:
     """Create a new run or create_child() if run is passed in kwargs."""
     extra_outer = container_input.get("extra_outer") or {}
-    name = container_input.get("name")
     metadata = container_input.get("metadata")
     tags = container_input.get("tags")
     client = container_input.get("client")
     run_type = container_input.get("run_type") or "chain"
     outer_project = _PROJECT_NAME.get()
     langsmith_extra = langsmith_extra or LangSmithExtra()
+    name = langsmith_extra.get("name") or container_input.get("name")
     client_ = langsmith_extra.get("client", client)
     parent_run_ = _get_parent_run(
         {**langsmith_extra, "client": client_}, kwargs.get("config")

--- a/python/tests/unit_tests/test_run_helpers.py
+++ b/python/tests/unit_tests/test_run_helpers.py
@@ -726,7 +726,12 @@ def test_generator():
 
     with tracing_context(enabled=True):
         chunks = my_answer(
-            "some_query", langsmith_extra={"on_end": _get_run, "client": mock_client_}
+            "some_query",
+            langsmith_extra={
+                "name": "test_overridding_name",
+                "on_end": _get_run,
+                "client": mock_client_,
+            },
         )
         all_chunks = []
         for chunk in chunks:
@@ -741,7 +746,7 @@ def test_generator():
     ]
     assert run is not None
     run = cast(RunTree, run)
-    assert run.name == "expand_and_answer_questions"
+    assert run.name == "test_overridding_name"
     child_runs = run.child_runs
     assert child_runs and len(child_runs) == 5
     names = [run.name for run in child_runs]


### PR DESCRIPTION
currently there is no way to dynamically override the `name` argument that could be passed into `traceable`. This allows the run name to be overridden by `langsmith_extra`