### PR TITLE
js[patch]: Inline lodash.set functionality to patch vulnerability

### DIFF
--- a/js/.eslintrc.cjs
+++ b/js/.eslintrc.cjs
@@ -14,6 +14,7 @@ module.exports = {
   ignorePatterns: [
     ".eslintrc.cjs",
     "scripts",
+    "src/utils/lodash/*",
     "node_modules",
     "dist",
     "dist-cjs",

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langsmith",
-  "version": "0.1.35",
+  "version": "0.1.36",
   "description": "Client library to connect to the LangSmith LLM Tracing and Evaluation Platform.",
   "packageManager": "yarn@1.22.19",
   "files": [

--- a/js/package.json
+++ b/js/package.json
@@ -95,7 +95,6 @@
   "dependencies": {
     "@types/uuid": "^9.0.1",
     "commander": "^10.0.1",
-    "lodash.set": "^4.3.2",
     "p-queue": "^6.6.2",
     "p-retry": "4",
     "uuid": "^9.0.0"
@@ -109,7 +108,6 @@
     "@langchain/langgraph": "^0.0.19",
     "@tsconfig/recommended": "^1.0.2",
     "@types/jest": "^29.5.1",
-    "@types/lodash.set": "^4.3.9",
     "@typescript-eslint/eslint-plugin": "^5.59.8",
     "@typescript-eslint/parser": "^5.59.8",
     "babel-jest": "^29.5.0",

--- a/js/src/anonymizer/index.ts
+++ b/js/src/anonymizer/index.ts
@@ -1,4 +1,4 @@
-import set from "lodash.set";
+import set from "../utils/lodash/set.js";
 
 export interface StringNode {
   value: string;

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -12,4 +12,4 @@ export type {
 export { RunTree, type RunTreeConfig } from "./run_trees.js";
 
 // Update using yarn bump-version
-export const __version__ = "0.1.35";
+export const __version__ = "0.1.36";

--- a/js/src/utils/lodash/LICENSE
+++ b/js/src/utils/lodash/LICENSE
@@ -1,0 +1,49 @@
+The MIT License
+
+Copyright JS Foundation and other contributors <https://js.foundation/>
+
+Based on Underscore.js, copyright Jeremy Ashkenas,
+DocumentCloud and Investigative Reporters & Editors <http://underscorejs.org/>
+
+This software consists of voluntary contributions made by many
+individuals. For exact contribution history, see the revision history
+available at https://github.com/lodash/lodash
+
+The following license applies to all parts of this software except as
+documented below:
+
+====
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+====
+
+Copyright and related rights for sample code are waived via CC0. Sample
+code is defined as all source code displayed within the prose of the
+documentation.
+
+CC0: http://creativecommons.org/publicdomain/zero/1.0/
+
+====
+
+Files located in the node_modules and vendor directories are externally
+maintained libraries used by this software which have their own
+licenses; we recommend you read them, as their terms may differ from the
+terms above.

--- a/js/src/utils/lodash/assignValue.ts
+++ b/js/src/utils/lodash/assignValue.ts
@@ -1,0 +1,27 @@
+import baseAssignValue from "./baseAssignValue.js";
+import eq from "./eq.js";
+
+/** Used to check objects for own properties. */
+const hasOwnProperty = Object.prototype.hasOwnProperty;
+
+/**
+ * Assigns `value` to `key` of `object` if the existing value is not equivalent.
+ *
+ * @private
+ * @param {Object} object The object to modify.
+ * @param {string} key The key of the property to assign.
+ * @param {*} value The value to assign.
+ */
+function assignValue(object: Record<string, any>, key: string, value: any) {
+  const objValue = object[key];
+
+  if (!(hasOwnProperty.call(object, key) && eq(objValue, value))) {
+    if (value !== 0 || 1 / value === 1 / objValue) {
+      baseAssignValue(object, key, value);
+    }
+  } else if (value === undefined && !(key in object)) {
+    baseAssignValue(object, key, value);
+  }
+}
+
+export default assignValue;

--- a/js/src/utils/lodash/baseAssignValue.ts
+++ b/js/src/utils/lodash/baseAssignValue.ts
@@ -1,0 +1,23 @@
+/**
+ * The base implementation of `assignValue` and `assignMergeValue` without
+ * value checks.
+ *
+ * @private
+ * @param {Object} object The object to modify.
+ * @param {string} key The key of the property to assign.
+ * @param {*} value The value to assign.
+ */
+function baseAssignValue(object: Record<string, any>, key: string, value: any) {
+  if (key === "__proto__") {
+    Object.defineProperty(object, key, {
+      configurable: true,
+      enumerable: true,
+      value: value,
+      writable: true,
+    });
+  } else {
+    object[key] = value;
+  }
+}
+
+export default baseAssignValue;

--- a/js/src/utils/lodash/baseSet.ts
+++ b/js/src/utils/lodash/baseSet.ts
@@ -1,0 +1,52 @@
+// @ts-nocheck
+
+import assignValue from "./assignValue.js";
+import castPath from "./castPath.js";
+import isIndex from "./isIndex.js";
+import isObject from "./isObject.js";
+import toKey from "./toKey.js";
+
+/**
+ * The base implementation of `set`.
+ *
+ * @private
+ * @param {Object} object The object to modify.
+ * @param {Array|string} path The path of the property to set.
+ * @param {*} value The value to set.
+ * @param {Function} [customizer] The function to customize path creation.
+ * @returns {Object} Returns `object`.
+ */
+function baseSet(object, path, value, customizer) {
+  if (!isObject(object)) {
+    return object;
+  }
+  path = castPath(path, object);
+
+  const length = path.length;
+  const lastIndex = length - 1;
+
+  let index = -1;
+  let nested = object;
+
+  while (nested != null && ++index < length) {
+    const key = toKey(path[index]);
+    let newValue = value;
+
+    if (index !== lastIndex) {
+      const objValue = nested[key];
+      newValue = customizer ? customizer(objValue, key, nested) : undefined;
+      if (newValue === undefined) {
+        newValue = isObject(objValue)
+          ? objValue
+          : isIndex(path[index + 1])
+          ? []
+          : {};
+      }
+    }
+    assignValue(nested, key, newValue);
+    nested = nested[key];
+  }
+  return object;
+}
+
+export default baseSet;

--- a/js/src/utils/lodash/castPath.ts
+++ b/js/src/utils/lodash/castPath.ts
@@ -1,0 +1,19 @@
+import isKey from "./isKey.js";
+import stringToPath from "./stringToPath.js";
+
+/**
+ * Casts `value` to a path array if it's not one.
+ *
+ * @private
+ * @param {*} value The value to inspect.
+ * @param {Object} [object] The object to query keys on.
+ * @returns {Array} Returns the cast property path array.
+ */
+function castPath(value: any, object: Record<string, any>) {
+  if (Array.isArray(value)) {
+    return value;
+  }
+  return isKey(value, object) ? [value] : stringToPath(value);
+}
+
+export default castPath;

--- a/js/src/utils/lodash/eq.ts
+++ b/js/src/utils/lodash/eq.ts
@@ -1,0 +1,35 @@
+/**
+ * Performs a
+ * [`SameValueZero`](http://ecma-international.org/ecma-262/7.0/#sec-samevaluezero)
+ * comparison between two values to determine if they are equivalent.
+ *
+ * @since 4.0.0
+ * @category Lang
+ * @param {*} value The value to compare.
+ * @param {*} other The other value to compare.
+ * @returns {boolean} Returns `true` if the values are equivalent, else `false`.
+ * @example
+ *
+ * const object = { 'a': 1 }
+ * const other = { 'a': 1 }
+ *
+ * eq(object, object)
+ * // => true
+ *
+ * eq(object, other)
+ * // => false
+ *
+ * eq('a', 'a')
+ * // => true
+ *
+ * eq('a', Object('a'))
+ * // => false
+ *
+ * eq(NaN, NaN)
+ * // => true
+ */
+function eq(value: any, other: any) {
+  return value === other || (value !== value && other !== other);
+}
+
+export default eq;

--- a/js/src/utils/lodash/getTag.ts
+++ b/js/src/utils/lodash/getTag.ts
@@ -1,0 +1,19 @@
+// @ts-nocheck
+
+const toString = Object.prototype.toString;
+
+/**
+ * Gets the `toStringTag` of `value`.
+ *
+ * @private
+ * @param {*} value The value to query.
+ * @returns {string} Returns the `toStringTag`.
+ */
+function getTag(value) {
+  if (value == null) {
+    return value === undefined ? "[object Undefined]" : "[object Null]";
+  }
+  return toString.call(value);
+}
+
+export default getTag;

--- a/js/src/utils/lodash/isIndex.ts
+++ b/js/src/utils/lodash/isIndex.ts
@@ -1,0 +1,30 @@
+// @ts-nocheck
+
+/** Used as references for various `Number` constants. */
+const MAX_SAFE_INTEGER = 9007199254740991;
+
+/** Used to detect unsigned integer values. */
+const reIsUint = /^(?:0|[1-9]\d*)$/;
+
+/**
+ * Checks if `value` is a valid array-like index.
+ *
+ * @private
+ * @param {*} value The value to check.
+ * @param {number} [length=MAX_SAFE_INTEGER] The upper bounds of a valid index.
+ * @returns {boolean} Returns `true` if `value` is a valid index, else `false`.
+ */
+function isIndex(value, length) {
+  const type = typeof value;
+  length = length == null ? MAX_SAFE_INTEGER : length;
+
+  return (
+    !!length &&
+    (type === "number" || (type !== "symbol" && reIsUint.test(value))) &&
+    value > -1 &&
+    value % 1 === 0 &&
+    value < length
+  );
+}
+
+export default isIndex;

--- a/js/src/utils/lodash/isKey.ts
+++ b/js/src/utils/lodash/isKey.ts
@@ -1,0 +1,36 @@
+// @ts-nocheck
+import isSymbol from "./isSymbol.js";
+
+/** Used to match property names within property paths. */
+const reIsDeepProp = /\.|\[(?:[^[\]]*|(["'])(?:(?!\1)[^\\]|\\.)*?\1)\]/;
+const reIsPlainProp = /^\w*$/;
+
+/**
+ * Checks if `value` is a property name and not a property path.
+ *
+ * @private
+ * @param {*} value The value to check.
+ * @param {Object} [object] The object to query keys on.
+ * @returns {boolean} Returns `true` if `value` is a property name, else `false`.
+ */
+function isKey(value, object) {
+  if (Array.isArray(value)) {
+    return false;
+  }
+  const type = typeof value;
+  if (
+    type === "number" ||
+    type === "boolean" ||
+    value == null ||
+    isSymbol(value)
+  ) {
+    return true;
+  }
+  return (
+    reIsPlainProp.test(value) ||
+    !reIsDeepProp.test(value) ||
+    (object != null && value in Object(object))
+  );
+}
+
+export default isKey;

--- a/js/src/utils/lodash/isObject.ts
+++ b/js/src/utils/lodash/isObject.ts
@@ -1,0 +1,31 @@
+// @ts-nocheck
+
+/**
+ * Checks if `value` is the
+ * [language type](http://www.ecma-international.org/ecma-262/7.0/#sec-ecmascript-language-types)
+ * of `Object`. (e.g. arrays, functions, objects, regexes, `new Number(0)`, and `new String('')`)
+ *
+ * @since 0.1.0
+ * @category Lang
+ * @param {*} value The value to check.
+ * @returns {boolean} Returns `true` if `value` is an object, else `false`.
+ * @example
+ *
+ * isObject({})
+ * // => true
+ *
+ * isObject([1, 2, 3])
+ * // => true
+ *
+ * isObject(Function)
+ * // => true
+ *
+ * isObject(null)
+ * // => false
+ */
+function isObject(value) {
+  const type = typeof value;
+  return value != null && (type === "object" || type === "function");
+}
+
+export default isObject;

--- a/js/src/utils/lodash/isSymbol.ts
+++ b/js/src/utils/lodash/isSymbol.ts
@@ -1,0 +1,28 @@
+// @ts-nocheck
+
+import getTag from "./getTag.js";
+
+/**
+ * Checks if `value` is classified as a `Symbol` primitive or object.
+ *
+ * @since 4.0.0
+ * @category Lang
+ * @param {*} value The value to check.
+ * @returns {boolean} Returns `true` if `value` is a symbol, else `false`.
+ * @example
+ *
+ * isSymbol(Symbol.iterator)
+ * // => true
+ *
+ * isSymbol('abc')
+ * // => false
+ */
+function isSymbol(value) {
+  const type = typeof value;
+  return (
+    type === "symbol" ||
+    (type === "object" && value != null && getTag(value) === "[object Symbol]")
+  );
+}
+
+export default isSymbol;

--- a/js/src/utils/lodash/memoizeCapped.ts
+++ b/js/src/utils/lodash/memoizeCapped.ts
@@ -1,0 +1,69 @@
+// @ts-nocheck
+
+/**
+ * Creates a function that memoizes the result of `func`. If `resolver` is
+ * provided, it determines the cache key for storing the result based on the
+ * arguments provided to the memoized function. By default, the first argument
+ * provided to the memoized function is used as the map cache key. The `func`
+ * is invoked with the `this` binding of the memoized function.
+ *
+ * **Note:** The cache is exposed as the `cache` property on the memoized
+ * function. Its creation may be customized by replacing the `memoize.Cache`
+ * constructor with one whose instances implement the
+ * [`Map`](http://ecma-international.org/ecma-262/7.0/#sec-properties-of-the-map-prototype-object)
+ * method interface of `clear`, `delete`, `get`, `has`, and `set`.
+ *
+ * @since 0.1.0
+ * @category Function
+ * @param {Function} func The function to have its output memoized.
+ * @param {Function} [resolver] The function to resolve the cache key.
+ * @returns {Function} Returns the new memoized function.
+ * @example
+ *
+ * const object = { 'a': 1, 'b': 2 }
+ * const other = { 'c': 3, 'd': 4 }
+ *
+ * const values = memoize(values)
+ * values(object)
+ * // => [1, 2]
+ *
+ * values(other)
+ * // => [3, 4]
+ *
+ * object.a = 2
+ * values(object)
+ * // => [1, 2]
+ *
+ * // Modify the result cache.
+ * values.cache.set(object, ['a', 'b'])
+ * values(object)
+ * // => ['a', 'b']
+ *
+ * // Replace `memoize.Cache`.
+ * memoize.Cache = WeakMap
+ */
+function memoize(func, resolver) {
+  if (
+    typeof func !== "function" ||
+    (resolver != null && typeof resolver !== "function")
+  ) {
+    throw new TypeError("Expected a function");
+  }
+  const memoized = function (...args) {
+    const key = resolver ? resolver.apply(this, args) : args[0];
+    const cache = memoized.cache;
+
+    if (cache.has(key)) {
+      return cache.get(key);
+    }
+    const result = func.apply(this, args);
+    memoized.cache = cache.set(key, result) || cache;
+    return result;
+  };
+  memoized.cache = new (memoize.Cache || Map)();
+  return memoized;
+}
+
+memoize.Cache = Map;
+
+export default memoize;

--- a/js/src/utils/lodash/set.ts
+++ b/js/src/utils/lodash/set.ts
@@ -1,0 +1,39 @@
+// @ts-nocheck
+
+import baseSet from "./baseSet.js";
+
+/**
+ * Sets the value at `path` of `object`. If a portion of `path` doesn't exist,
+ * it's created. Arrays are created for missing index properties while objects
+ * are created for all other missing properties. Use `setWith` to customize
+ * `path` creation.
+ *
+ * **Note:** This method mutates `object`.
+ *
+ * Inlined to just use set functionality and patch vulnerabilities
+ * on existing isolated "lodash.set" package.
+ *
+ * @since 3.7.0
+ * @category Object
+ * @param {Object} object The object to modify.
+ * @param {Array|string} path The path of the property to set.
+ * @param {*} value The value to set.
+ * @returns {Object} Returns `object`.
+ * @see has, hasIn, get, unset
+ * @example
+ *
+ * const object = { 'a': [{ 'b': { 'c': 3 } }] }
+ *
+ * set(object, 'a[0].b.c', 4)
+ * console.log(object.a[0].b.c)
+ * // => 4
+ *
+ * set(object, ['x', '0', 'y', 'z'], 5)
+ * console.log(object.x[0].y.z)
+ * // => 5
+ */
+function set(object, path, value) {
+  return object == null ? object : baseSet(object, path, value);
+}
+
+export default set;

--- a/js/src/utils/lodash/stringToPath.ts
+++ b/js/src/utils/lodash/stringToPath.ts
@@ -1,0 +1,49 @@
+// @ts-nocheck
+
+import memoizeCapped from "./memoizeCapped.js";
+
+const charCodeOfDot = ".".charCodeAt(0);
+const reEscapeChar = /\\(\\)?/g;
+const rePropName = RegExp(
+  // Match anything that isn't a dot or bracket.
+  "[^.[\\]]+" +
+    "|" +
+    // Or match property names within brackets.
+    "\\[(?:" +
+    // Match a non-string expression.
+    "([^\"'][^[]*)" +
+    "|" +
+    // Or match strings (supports escaping characters).
+    "([\"'])((?:(?!\\2)[^\\\\]|\\\\.)*?)\\2" +
+    ")\\]" +
+    "|" +
+    // Or match "" as the space between consecutive dots or empty brackets.
+    "(?=(?:\\.|\\[\\])(?:\\.|\\[\\]|$))",
+  "g"
+);
+
+/**
+ * Converts `string` to a property path array.
+ *
+ * @private
+ * @param {string} string The string to convert.
+ * @returns {Array} Returns the property path array.
+ */
+const stringToPath = memoizeCapped((string: string) => {
+  const result = [];
+  if (string.charCodeAt(0) === charCodeOfDot) {
+    result.push("");
+  }
+  string.replace(rePropName, (match, expression, quote, subString) => {
+    let key = match;
+    if (quote) {
+      key = subString.replace(reEscapeChar, "$1");
+    } else if (expression) {
+      key = expression.trim();
+    }
+    result.push(key);
+  });
+  return result;
+});
+
+export default stringToPath;

--- a/js/src/utils/lodash/toKey.ts
+++ b/js/src/utils/lodash/toKey.ts
@@ -1,0 +1,23 @@
+// @ts-nocheck
+
+import isSymbol from "./isSymbol.js";
+
+/** Used as references for various `Number` constants. */
+const INFINITY = 1 / 0;
+
+/**
+ * Converts `value` to a string key if it's not a string or symbol.
+ *
+ * @private
+ * @param {*} value The value to inspect.
+ * @returns {string|symbol} Returns the key.
+ */
+function toKey(value) {
+  if (typeof value === "string" || isSymbol(value)) {
+    return value;
+  }
+  const result = `${value}`;
+  return result === "0" && 1 / value === -INFINITY ? "-0" : result;
+}
+
+export default toKey;

--- a/js/yarn.lock
+++ b/js/yarn.lock
@@ -1487,18 +1487,6 @@
   resolved "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz"
   integrity sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==
 
-"@types/lodash.set@^4.3.9":
-  version "4.3.9"
-  resolved "https://registry.yarnpkg.com/@types/lodash.set/-/lodash.set-4.3.9.tgz#55d95bce407b42c6655f29b2d0811fd428e698f0"
-  integrity sha512-KOxyNkZpbaggVmqbpr82N2tDVTx05/3/j0f50Es1prxrWB0XYf9p3QNxqcbWb7P1Q9wlvsUSlCFnwlPCIJ46PQ==
-  dependencies:
-    "@types/lodash" "*"
-
-"@types/lodash@*":
-  version "4.17.4"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.17.4.tgz#0303b64958ee070059e3a7184048a55159fe20b7"
-  integrity sha512-wYCP26ZLxaT3R39kiN2+HcJ4kTd3U1waI/cY7ivWYqFP6pW3ZNpvi6Wd6PHZx7T/t8z0vlkXMg3QYLa7DZ/IJQ==
-
 "@types/node-fetch@^2.6.4":
   version "2.6.11"
   resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.6.11.tgz#9b39b78665dae0e82a08f02f4967d62c66f95d24"
@@ -3584,11 +3572,6 @@ lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
-
-lodash.set@^4.3.2:
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/lodash.set/-/lodash.set-4.3.2.tgz#d8757b1da807dde24816b0d6a84bea1a76230b23"
-  integrity sha512-4hNPN5jlm/N/HLMCO43v8BXKq9Z7QdAGc/VGrRD61w8gN9g/6jF9A4L1pbUgBLCffi0w9VsXfTOij5x8iTyFvg==
 
 lru-cache@^5.1.1:
   version "5.1.1"


### PR DESCRIPTION
The `lodash.set` package is unmaintained and has a CVE: https://security.snyk.io/package/npm/lodash.set

The current `lodash` version has no CVEs: https://security.snyk.io/package/npm/lodash

I've inlined the relevant set functionality from the current version of `lodash`.

Let's be more careful with adding deps in the future!

@dqbd @nfcampos @agola11 