### PR TITLE
py: Fix traceable decorator blocking asyncio event loop

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "langsmith"
-version = "0.1.83"
+version = "0.1.84"
 description = "Client library to connect to the LangSmith LLM Tracing and Evaluation Platform."
 authors = ["LangChain <support@langchain.dev>"]
 license = "MIT"

--- a/python/tests/integration_tests/test_runs.py
+++ b/python/tests/integration_tests/test_runs.py
@@ -132,8 +132,6 @@ async def test_list_runs_multi_project(langchain_client: Client):
 async def test_nested_async_runs(langchain_client: Client):
     """Test nested runs with a mix of async and sync functions."""
     project_name = "__My Tracer Project - test_nested_async_runs"
-    if langchain_client.has_project(project_name):
-        langchain_client.delete_project(project_name=project_name)
     executor = ThreadPoolExecutor(max_workers=1)
 
     @traceable(run_type="chain")
@@ -156,10 +154,15 @@ async def test_nested_async_runs(langchain_client: Client):
     async def my_chain_run(text: str):
         return await my_run(text)
 
-    await my_chain_run("foo", langsmith_extra=dict(project_name=project_name))
+    meta = uuid.uuid4().hex
+    await my_chain_run(
+        "foo",
+        langsmith_extra=dict(project_name=project_name, metadata={"test_run": meta}),
+    )
     executor.shutdown(wait=True)
-    poll_runs_until_count(langchain_client, project_name, 4)
-    runs = list(langchain_client.list_runs(project_name=project_name))
+    _filter = f'and(eq(metadata_key, "test_run"), eq(metadata_value, "{meta}")'
+    poll_runs_until_count(langchain_client, project_name, 4, filter_=_filter)
+    runs = list(langchain_client.list_runs(project_name=project_name, filter=_filter))
     assert len(runs) == 4
     runs_dict = {run.name: run for run in runs}
     assert runs_dict["my_chain_run"].parent_run_id is None
@@ -175,14 +178,11 @@ async def test_nested_async_runs(langchain_client: Client):
         "text": "foo",
         "my_arg": 20,
     }
-    langchain_client.delete_project(project_name=project_name)
 
 
 async def test_nested_async_runs_with_threadpool(langchain_client: Client):
     """Test nested runs with a mix of async and sync functions."""
     project_name = "__My Tracer Project - test_nested_async_runs_with_threadpol"
-    if langchain_client.has_project(project_name):
-        langchain_client.delete_project(project_name=project_name)
 
     @traceable(run_type="llm")
     async def async_llm(text: str):
@@ -221,11 +221,18 @@ async def test_nested_async_runs_with_threadpool(langchain_client: Client):
         thread_pool.shutdown(wait=True)
         return text
 
-    await my_chain_run("foo", langsmith_extra=dict(project_name=project_name))
+    meta = uuid.uuid4().hex
+    await my_chain_run(
+        "foo",
+        langsmith_extra=dict(project_name=project_name, metadata={"test_run": meta}),
+    )
     executor.shutdown(wait=True)
-    poll_runs_until_count(langchain_client, project_name, 17)
-    runs = list(langchain_client.list_runs(project_name=project_name))
-    trace_runs = list(langchain_client.list_runs(trace_id=runs[0].trace_id))
+    filter_ = f'and(eq(metadata_key, "test_run"), eq(metadata_value, "{meta}")'
+    poll_runs_until_count(langchain_client, project_name, 17, filter_=filter_)
+    runs = list(langchain_client.list_runs(project_name=project_name, filter=filter_))
+    trace_runs = list(
+        langchain_client.list_runs(trace_id=runs[0].trace_id, project_name=project_name)
+    )
     assert len(trace_runs) == 17
     assert len(runs) == 17
     assert sum([run.run_type == "llm" for run in runs]) == 8
@@ -257,14 +264,15 @@ async def test_nested_async_runs_with_threadpool(langchain_client: Client):
 
 async def test_context_manager(langchain_client: Client) -> None:
     project_name = "__My Tracer Project - test_context_manager"
-    if langchain_client.has_project(project_name):
-        langchain_client.delete_project(project_name=project_name)
 
     @traceable(run_type="llm")
     async def my_llm(prompt: str) -> str:
         return f"LLM {prompt}"
 
-    with trace("my_context", "chain", project_name=project_name) as run_tree:
+    meta = uuid.uuid4().hex
+    with trace(
+        "my_context", "chain", project_name=project_name, metadata={"test_run": meta}
+    ) as run_tree:
         await my_llm("foo")
         with trace("my_context2", "chain", run_tree=run_tree) as run_tree2:
             runs = [my_llm("baz"), my_llm("qux")]
@@ -273,8 +281,9 @@ async def test_context_manager(langchain_client: Client) -> None:
                 await my_llm("corge")
             await asyncio.gather(*runs)
         run_tree.end(outputs={"End val": "my_context2"})
-    poll_runs_until_count(langchain_client, project_name, 8)
-    runs_ = list(langchain_client.list_runs(project_name=project_name))
+    _filter = f'and(eq(metadata_key, "test_run"), eq(metadata_value, "{meta}")'
+    poll_runs_until_count(langchain_client, project_name, 8, filter_=_filter)
+    runs_ = list(langchain_client.list_runs(project_name=project_name, filter=_filter))
     assert len(runs_) == 8
 
 

--- a/python/tests/unit_tests/test_run_helpers.py
+++ b/python/tests/unit_tests/test_run_helpers.py
@@ -264,7 +264,9 @@ async def test_traceable_async_iterator(use_next: bool, mock_client: Client) -> 
         assert call.args[1].startswith("https://api.smith.langchain.com")
         body = json.loads(call.kwargs["data"])
         assert body["post"]
-        assert body["post"][0]["outputs"]["output"] == expected
+        outputs_ = body["post"][0]["outputs"]
+        assert "output" in outputs_
+        assert outputs_["output"] == expected
         # Assert the inputs are filtered as expected
         assert body["post"][0]["inputs"] == {"a": "FOOOOOO", "b": 2, "d": 3}
 

--- a/python/tests/unit_tests/test_run_helpers.py
+++ b/python/tests/unit_tests/test_run_helpers.py
@@ -264,11 +264,17 @@ async def test_traceable_async_iterator(use_next: bool, mock_client: Client) -> 
         assert call.args[1].startswith("https://api.smith.langchain.com")
         body = json.loads(call.kwargs["data"])
         assert body["post"]
-        outputs_ = body["post"][0]["outputs"]
-        assert "output" in outputs_
-        assert outputs_["output"] == expected
-        # Assert the inputs are filtered as expected
         assert body["post"][0]["inputs"] == {"a": "FOOOOOO", "b": 2, "d": 3}
+        outputs_ = body["post"][0]["outputs"]
+        if "output" in outputs_:
+            assert outputs_["output"] == expected
+            # Assert the inputs are filtered as expected
+        else:
+            # It was put in the second batch
+            assert len(mock_calls) == 2
+            body_2 = json.loads(mock_calls[1].kwargs["data"])
+            assert body_2["patch"]
+            assert body_2["patch"][0]["outputs"]["output"] == expected
 
 
 @patch("langsmith.run_trees.Client", autospec=True)


### PR DESCRIPTION
- currently happens in two situations
  - for errored runs, when fetching the langsmith run url for a debug print statement (which most people won't  even want in production, but thats a separate issue)
  - for all runs, when batch tracing is turned off