### PR TITLE
[Python] Fix nesting in async trace context manager

### DIFF
--- a/python/langsmith/_internal/_aiter.py
+++ b/python/langsmith/_internal/_aiter.py
@@ -310,7 +310,9 @@ def accepts_context(callable: Callable[..., Any]) -> bool:
 
 
 # Ported from Python 3.9+ to support Python 3.8
-async def aio_to_thread(func, /, *args, **kwargs):
+async def aio_to_thread(
+    func, /, *args, __ctx: Optional[contextvars.Context] = None, **kwargs
+):
     """Asynchronously run function *func* in a separate thread.
 
     Any *args and **kwargs supplied for this function are directly passed
@@ -321,7 +323,7 @@ async def aio_to_thread(func, /, *args, **kwargs):
     Return a coroutine that can be awaited to get the eventual result of *func*.
     """
     loop = asyncio.get_running_loop()
-    ctx = contextvars.copy_context()
+    ctx = __ctx or contextvars.copy_context()
     func_call = functools.partial(ctx.run, func, *args, **kwargs)
     return await loop.run_in_executor(None, func_call)
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "langsmith"
-version = "0.1.93"
+version = "0.1.94"
 description = "Client library to connect to the LangSmith LLM Tracing and Evaluation Platform."
 authors = ["LangChain <support@langchain.dev>"]
 license = "MIT"


### PR DESCRIPTION
We were previously setting the context vars in a separate context and then letting it be gc'd.

Fixes https://github.com/langchain-ai/langsmith-sdk/issues/892