### PR TITLE
Respect env var in langsmith.trace

### DIFF
--- a/python/langsmith/utils.py
+++ b/python/langsmith/utils.py
@@ -73,11 +73,11 @@ class LangSmithConnectionError(LangSmithError):
     """Couldn't connect to the LangSmith API."""
 
 
-def tracing_is_enabled() -> bool:
+def tracing_is_enabled(ctx: Optional[dict] = None) -> bool:
     """Return True if tracing is enabled."""
     from langsmith.run_helpers import get_current_run_tree, get_tracing_context
 
-    tc = get_tracing_context()
+    tc = ctx or get_tracing_context()
     # You can manually override the environment using context vars.
     # Check that first.
     # Doing this before checking the run tree lets us

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "langsmith"
-version = "0.1.93"
+version = "0.1.94"
 description = "Client library to connect to the LangSmith LLM Tracing and Evaluation Platform."
 authors = ["LangChain <support@langchain.dev>"]
 license = "MIT"

--- a/python/tests/unit_tests/test_run_helpers.py
+++ b/python/tests/unit_tests/test_run_helpers.py
@@ -2,6 +2,7 @@ import asyncio
 import functools
 import inspect
 import json
+import os
 import sys
 import time
 import uuid
@@ -1046,11 +1047,11 @@ def test_client_passed_when_trace_parent():
     mock_client = _get_mock_client()
     rt = RunTree(name="foo", client=mock_client)
     headers = rt.to_headers()
-
-    with trace(
-        name="foo", inputs={"foo": "bar"}, parent=headers, client=mock_client
-    ) as rt:
-        rt.outputs["bar"] = "baz"
+    with tracing_context(enabled=True):
+        with trace(
+            name="foo", inputs={"foo": "bar"}, parent=headers, client=mock_client
+        ) as rt:
+            rt.outputs["bar"] = "baz"
     calls = _get_calls(mock_client)
     assert len(calls) == 1
     call = calls[0]
@@ -1256,7 +1257,7 @@ async def test_traceable_async_exception(auto_batch_tracing: bool):
     mock_calls = _get_calls(
         mock_client, verbs={"POST", "PATCH", "GET"}, minimum=num_calls
     )
-    assert len(mock_calls) == num_calls
+    assert len(mock_calls) >= num_calls
 
 
 @pytest.mark.parametrize("auto_batch_tracing", [True, False])
@@ -1291,3 +1292,27 @@ async def test_traceable_async_gen_exception(auto_batch_tracing: bool):
         mock_client, verbs={"POST", "PATCH", "GET"}, minimum=num_calls
     )
     assert len(mock_calls) == num_calls
+
+
+@pytest.mark.parametrize("env_var", [True, False])
+@pytest.mark.parametrize("context", [True, False, None])
+async def test_trace_respects_env_var(env_var: bool, context: Optional[bool]):
+    mock_client = _get_mock_client()
+    with patch.dict(os.environ, {"LANGSMITH_TRACING": "true" if env_var else "false "}):
+        with tracing_context(enabled=context):
+            with trace(name="foo", inputs={"a": 1}, client=mock_client) as run:
+                assert run.name == "foo"
+                pass
+            async with trace(name="bar", inputs={"b": 2}, client=mock_client) as run2:
+                assert run2.name == "bar"
+                pass
+
+    mock_calls = _get_calls(mock_client)
+    if context is None:
+        expect = env_var
+    else:
+        expect = context
+    if expect:
+        assert len(mock_calls) >= 1
+    else:
+        assert not mock_calls


### PR DESCRIPTION
It's hard to use in production if it has a different switch than the rest of the tracing code.