### PR TITLE
fix: push existing prompt without specifying any other options

### DIFF
--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -3417,12 +3417,14 @@ export class Client {
   ): Promise<string> {
     // Create or update prompt metadata
     if (await this.promptExists(promptIdentifier)) {
-      await this.updatePrompt(promptIdentifier, {
-        description: options?.description,
-        readme: options?.readme,
-        tags: options?.tags,
-        isPublic: options?.isPublic,
-      });
+      if (options && Object.keys(options).some((key) => key !== "object")) {
+        await this.updatePrompt(promptIdentifier, {
+          description: options?.description,
+          readme: options?.readme,
+          tags: options?.tags,
+          isPublic: options?.isPublic,
+        });
+      }
     } else {
       await this.createPrompt(promptIdentifier, {
         description: options?.description,

--- a/js/src/tests/client.int.test.ts
+++ b/js/src/tests/client.int.test.ts
@@ -997,12 +997,24 @@ test("Test push and pull prompt", async () => {
     ],
     { templateFormat: "mustache" }
   );
+  const template2 = ChatPromptTemplate.fromMessages(
+    [
+      new SystemMessage({ content: "System message" }),
+      new HumanMessage({ content: "My question is: {{question}}" }),
+    ],
+    { templateFormat: "mustache" }
+  );
 
   await client.pushPrompt(promptName, {
     object: template,
     description: "Test description",
     readme: "Test readme",
     tags: ["test", "tag"],
+  });
+
+  // test you can push an updated manifest
+  await client.pushPrompt(promptName, {
+    object: template2,
   });
 
   const pulledPrompt = await client._pullPrompt(promptName);

--- a/js/src/tests/client.int.test.ts
+++ b/js/src/tests/client.int.test.ts
@@ -1012,7 +1012,7 @@ test("Test push and pull prompt", async () => {
     tags: ["test", "tag"],
   });
 
-  // test you can push an updated manifest
+  // test you can push an updated manifest without any other options
   await client.pushPrompt(promptName, {
     object: template2,
   });


### PR DESCRIPTION
When pushing an updated manifest to an existing prompt and not specifying any other options, updatePrompt threw an error that we need to be updating something, but we're updating the manifest. This fixes.