### PR TITLE
Accept EvaluationResults with dict

### DIFF
--- a/js/src/tests/client.int.test.ts
+++ b/js/src/tests/client.int.test.ts
@@ -759,10 +759,11 @@ test.concurrent("Test run stats", async () => {
 
 test("Test list prompts", async () => {
   const client = new Client();
+  const uid = uuidv4();
   // push 3 prompts
-  const promptName1 = `test_prompt_${uuidv4().slice(0, 8)}`;
-  const promptName2 = `test_prompt_${uuidv4().slice(0, 8)}`;
-  const promptName3 = `test_prompt_${uuidv4().slice(0, 8)}`;
+  const promptName1 = `test_prompt_${uid}__0`;
+  const promptName2 = `test_prompt_${uid}__1`;
+  const promptName3 = `test_prompt_${uid}__2`;
 
   await client.pushPrompt(promptName1, {
     object: ChatPromptTemplate.fromMessages(
@@ -794,7 +795,7 @@ test("Test list prompts", async () => {
   });
 
   // expect at least one of the prompts to have promptName1
-  const response = await client.listPrompts({ isPublic: true });
+  const response = client.listPrompts({ isPublic: true, query: uid });
   let found = false;
   expect(response).toBeDefined();
   for await (const prompt of response) {
@@ -806,7 +807,7 @@ test("Test list prompts", async () => {
   expect(found).toBe(true);
 
   // expect the prompts to be sorted by updated_at
-  const response2 = client.listPrompts({ sortField: "updated_at" });
+  const response2 = client.listPrompts({ sortField: "updated_at", query: uid });
   expect(response2).toBeDefined();
   let lastUpdatedAt: number | undefined;
   for await (const prompt of response2) {

--- a/js/src/tests/client.int.test.ts
+++ b/js/src/tests/client.int.test.ts
@@ -915,23 +915,26 @@ test("Test delete prompt", async () => {
 
 test("test listing projects by metadata", async () => {
   const client = new Client();
+  const uid = uuidv4();
+  const projectName = `my_metadata_project_${uid}`;
+
   await client.createProject({
-    projectName: "my_metadata_project",
+    projectName: projectName,
     metadata: {
-      foobar: "bar",
+      foobar: uid,
       baz: "barfooqux",
     },
   });
 
-  const projects = await client.listProjects({ metadata: { foobar: "bar" } });
+  const projects = await client.listProjects({ metadata: { foobar: uid } });
 
   let myProject: TracerSession | null = null;
   for await (const project of projects) {
     myProject = project;
   }
-  expect(myProject?.name).toEqual("my_metadata_project");
+  expect(myProject?.name).toEqual(projectName);
 
-  await client.deleteProject({ projectName: "my_metadata_project" });
+  await client.deleteProject({ projectName: projectName });
 });
 
 test("Test create commit", async () => {


### PR DESCRIPTION
Previously required {"results": [EvaluationResult]}
Now can be: {"results": [EvaluationResultLike]}