### PR TITLE
feat: support `name` parameter to `update_run`

### DIFF
--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -1434,6 +1434,7 @@ class Client:
         self,
         run_id: ID_TYPE,
         *,
+        name: Optional[str] = None,
         end_time: Optional[datetime.datetime] = None,
         error: Optional[str] = None,
         inputs: Optional[Dict] = None,
@@ -1449,6 +1450,8 @@ class Client:
         ----------
         run_id : str or UUID
             The ID of the run to update.
+        name : str or None, default=None
+            The name of the run.
         end_time : datetime or None
             The end time of the run.
         error : str or None, default=None
@@ -1468,6 +1471,7 @@ class Client:
         """
         data: Dict[str, Any] = {
             "id": _as_uuid(run_id, "run_id"),
+            "name": name,
             "trace_id": kwargs.pop("trace_id", None),
             "parent_run_id": kwargs.pop("parent_run_id", None),
             "dotted_order": kwargs.pop("dotted_order", None),

--- a/python/langsmith/run_trees.py
+++ b/python/langsmith/run_trees.py
@@ -268,6 +268,7 @@ class RunTree(ls_schemas.RunBase):
         if not self.end_time:
             self.end()
         self.client.update_run(
+            name=self.name,
             run_id=self.id,
             outputs=self.outputs.copy() if self.outputs else None,
             error=self.error,

--- a/python/tests/integration_tests/test_client.py
+++ b/python/tests/integration_tests/test_client.py
@@ -292,9 +292,11 @@ def test_persist_update_run(langchain_client: Client) -> None:
         langchain_client.create_run(**run)
         run["outputs"] = {"output": ["Hi"]}
         run["extra"]["foo"] = "bar"
+        run["name"] = "test_run_updated"
         langchain_client.update_run(run["id"], **run)
         wait_for(lambda: langchain_client.read_run(run["id"]).end_time is not None)
         stored_run = langchain_client.read_run(run["id"])
+        assert stored_run.name == run["name"]
         assert stored_run.id == run["id"]
         assert stored_run.outputs == run["outputs"]
         assert stored_run.start_time == run["start_time"]


### PR DESCRIPTION
This change makes it possible to update the name of a run after it has been created. Previously, run names could not be modified once set.