### PR TITLE
fix(js): upgrade to uuid@10 for UUIDv6 support

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -97,12 +97,12 @@
   },
   "homepage": "https://github.com/langchain-ai/langsmith-sdk#readme",
   "dependencies": {
-    "@types/uuid": "^9.0.1",
+    "@types/uuid": "^10.0.0",
     "commander": "^10.0.1",
     "p-queue": "^6.6.2",
     "p-retry": "4",
     "semver": "^7.6.3",
-    "uuid": "^9.0.0"
+    "uuid": "^10.0.0"
   },
   "devDependencies": {
     "@ai-sdk/openai": "^0.0.40",

--- a/js/yarn.lock
+++ b/js/yarn.lock
@@ -1617,6 +1617,11 @@
   resolved "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz"
   integrity sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==
 
+"@types/uuid@^10.0.0":
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-10.0.0.tgz#e9c07fe50da0f53dc24970cca94d619ff03f6f6d"
+  integrity sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==
+
 "@types/uuid@^9.0.1":
   version "9.0.1"
   resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-9.0.1.tgz#98586dc36aee8dacc98cc396dbca8d0429647aa6"


### PR DESCRIPTION
This PR addresses `uuid.validate` rejecting UUIDv6. Alternatively we can inline the regex used 