### PR TITLE
[Py] Warn if api key not provided

### DIFF
--- a/python/langsmith/async_client.py
+++ b/python/langsmith/async_client.py
@@ -52,8 +52,10 @@ class AsyncClient:
             "Content-Type": "application/json",
         }
         api_key = ls_utils.get_api_key(api_key)
+        api_url = ls_utils.get_api_url(api_url)
         if api_key:
             _headers[ls_client.X_API_KEY] = api_key
+        ls_client._validate_api_key_if_hosted(api_url, api_key)
 
         if isinstance(timeout_ms, int):
             timeout_: Union[Tuple, float] = (timeout_ms / 1000, None, None, None)
@@ -62,7 +64,7 @@ class AsyncClient:
         else:
             timeout_ = 10
         self._client = httpx.AsyncClient(
-            base_url=ls_utils.get_api_url(api_url), headers=_headers, timeout=timeout_
+            base_url=api_url, headers=_headers, timeout=timeout_
         )
 
     async def __aenter__(self) -> "AsyncClient":

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -330,8 +330,9 @@ def _validate_api_key_if_hosted(api_url: str, api_key: Optional[str]) -> None:
     # If the domain is langchain.com, raise error if no api_key
     if not api_key:
         if _is_langchain_hosted(api_url):
-            raise ls_utils.LangSmithUserError(
-                "API key must be provided when using hosted LangSmith API"
+            warnings.warn(
+                "API key must be provided when using hosted LangSmith API",
+                ls_utils.LangSmithMissingAPIKeyWarning,
             )
 
 

--- a/python/langsmith/utils.py
+++ b/python/langsmith/utils.py
@@ -74,6 +74,17 @@ class LangSmithConnectionError(LangSmithError):
     """Couldn't connect to the LangSmith API."""
 
 
+## Warning classes
+
+
+class LangSmithWarning(UserWarning):
+    """Base class for warnings."""
+
+
+class LangSmithMissingAPIKeyWarning(LangSmithWarning):
+    """Warning for missing API key."""
+
+
 def tracing_is_enabled(ctx: Optional[dict] = None) -> bool:
     """Return True if tracing is enabled."""
     from langsmith.run_helpers import get_current_run_tree, get_tracing_context

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "langsmith"
-version = "0.1.105"
+version = "0.1.106"
 description = "Client library to connect to the LangSmith LLM Tracing and Evaluation Platform."
 authors = ["LangChain <support@langchain.dev>"]
 license = "MIT"


### PR DESCRIPTION
For a long time we have been raising an error if you create a client that connects to the public endpoint without specifying an api key.

This makes it possible for someone with inadequate testing to push code into prod leaving the LANGSMITH_TRACING=true on but without setting an api key.

This would raise a lot of error logs in the best case and crash a deployment in the worst case.

Would prefer to just warn and not have tracing rather than impact the actual runtime.