### PR TITLE
Optimize CPU-bound Task Execution by Replacing Thread Lock with Producer-Consumer Pattern

### DIFF
--- a/python/langsmith/evaluation/_runner.py
+++ b/python/langsmith/evaluation/_runner.py
@@ -377,7 +377,7 @@ class ExperimentResults:
     ):
         self._manager = experiment_manager
         self._results: List[ExperimentResultRow] = []
-        self._queue = queue.Queue()
+        self._queue: queue.Queue[ExperimentResultRow] = queue.Queue()
         self._processing_complete = threading.Event()
         self._thread = threading.Thread(target=self._process_data)
         self._thread.start()

--- a/python/langsmith/evaluation/_runner.py
+++ b/python/langsmith/evaluation/_runner.py
@@ -376,7 +376,7 @@ class ExperimentResults:
         experiment_manager: _ExperimentManager,
     ):
         self._manager = experiment_manager
-        self._results: List[ExperimentResultRow]= []
+        self._results: List[ExperimentResultRow] = []
         self._queue = queue.Queue()
         self._lock = threading.RLock()
         self._processing_complete = threading.Event()

--- a/python/langsmith/evaluation/_runner.py
+++ b/python/langsmith/evaluation/_runner.py
@@ -3,13 +3,13 @@
 from __future__ import annotations
 
 import collections
-import queue
 import concurrent.futures as cf
 import datetime
 import functools
 import itertools
 import logging
 import pathlib
+import queue
 import random
 import threading
 import uuid
@@ -405,11 +405,11 @@ class ExperimentResults:
             self._queue.put(item)
             with self._lock:
                 self._results.append(item)
-        
+
         summary_scores = self._manager.get_summary_scores()
         with self._lock:
             self._summary_results = summary_scores
-        
+
         self._queue.put(None)  # Sentinel value to indicate completion
         self._processing_complete.set()
 

--- a/python/langsmith/evaluation/_runner.py
+++ b/python/langsmith/evaluation/_runner.py
@@ -376,9 +376,9 @@ class ExperimentResults:
         experiment_manager: _ExperimentManager,
     ):
         self._manager = experiment_manager
-        self._results = []
+        self._results: List[ExperimentResultRow]= []
         self._queue = queue.Queue()
-        self._lock = threading.Lock()
+        self._lock = threading.RLock()
         self._processing_complete = threading.Event()
         self._thread = threading.Thread(target=self._process_data)
         self._thread.start()

--- a/python/tests/unit_tests/evaluation/test_runner.py
+++ b/python/tests/unit_tests/evaluation/test_runner.py
@@ -1,6 +1,7 @@
 """Test the eval runner."""
 
 import asyncio
+import itertools
 import json
 import random
 import sys
@@ -232,7 +233,13 @@ def test_evaluate_results(blocking: bool) -> None:
     ex_results = evaluate_existing(
         fake_request.created_session["name"], evaluators=[score_value], client=client
     )
-    assert len(list(ex_results)) == SPLIT_SIZE * NUM_REPETITIONS
+    second_item = next(itertools.islice(iter(ex_results), 1, 2))
+    first_list = list(ex_results)
+    second_list = list(ex_results)
+    second_item_after = next(itertools.islice(iter(ex_results), 1, 2))
+    assert len(first_list) == len(second_list) == SPLIT_SIZE * NUM_REPETITIONS
+    assert first_list == second_list
+    assert second_item == second_item_after
     dev_xample_ids = [e.id for e in dev_split]
     for r in ex_results:
         assert r["example"].id in dev_xample_ids


### PR DESCRIPTION
## Issue
Seeing large slowdowns when using `evaluate()` compared to naive `ThreadPoolExecutor`. The specific slowdown happens on a cpu-bound call to BeautifulSoup, which balloons from 0.1s -> 5 seconds (and sometimes up to 60+ seconds based on concurrency).

## Profiling Investigation
First, I noticed that the majority of the time in bs4 init was actually empty space, which made me think that: (1) there was GIL contention, or (2) there was some lock being placed on the thread.
![CleanShot 2024-08-28 at 13 09 14](https://github.com/user-attachments/assets/85f9b9a6-a401-405c-a428-d573e31c14b5)

I took a look at the `ExperimentResults` implementation, and noted that in the infinite while loop, there was an `is_active` call inside of the thread lock, and since `is_active` has nontrivial overhead, and this loop was running even if there were no results, we were incurring this overhead over and over.
![CleanShot 2024-08-28 at 13 10 33](https://github.com/user-attachments/assets/3525a57d-10d2-4ab6-9801-7b852543b4c2)

To confirm, I noticed that in the main thread profile, about half the time is spent in `is_alive` in aggregate.
![CleanShot 2024-08-28 at 13 13 04](https://github.com/user-attachments/assets/45b84f28-e3d2-4e51-b565-dc168220af7b)

## Fix
To improve the implementation without blocking CPU-bound operations, we can use a producer-consumer pattern with a queue. This will allow the main thread to continue processing while the data is being fetched and processed in the background.