### PR TITLE
ensure executor is not shutdown prior to task submisssion

### DIFF
--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -3956,7 +3956,7 @@ class Client:
         results = self._select_eval_results(evaluator_response)
 
         def _submit_feedback(**kwargs):
-            if _executor:
+            if _executor and not _executor._shutdown:
                 _executor.submit(self.create_feedback, **kwargs)
             else:
                 self.create_feedback(**kwargs)


### PR DESCRIPTION
There is a recent issue that has emerged during async evaluations. To repro, you can create a simple custom evaluator whose `aevaluate_run` implementation contains an inference. 

Under these conditions, the `_log_evaluation_feedback` method will throw because it's trying to submit tasks to a shutdown executor. Specifically we see: 

```
Error running evaluator <wordsmith.evaluation.langsmith.scorers.session_chat_scorer.SessionChatScorer object at 0x122485e10> on run a1247822-b895-45aa-9a15-dcae2a958d7c: RuntimeError('cannot schedule new futures after shutdown')
Traceback (most recent call last):
  File "/Users/rossmcnairn/Library/Application Support/pdm/venvs/wordsmith-8JUPZepZ-wordsmith/lib/python3.11/site-packages/langsmith/evaluation/_arunner.py", line 649, in _arun_evaluators
    self.client._log_evaluation_feedback(
  File "/Users/rossmcnairn/Library/Application Support/pdm/venvs/wordsmith-8JUPZepZ-wordsmith/lib/python3.11/site-packages/langsmith/client.py", line 3983, in _log_evaluation_feedback
    _submit_feedback(
  File "/Users/rossmcnairn/Library/Application Support/pdm/venvs/wordsmith-8JUPZepZ-wordsmith/lib/python3.11/site-packages/langsmith/client.py", line 3969, in _submit_feedback
    _executor.submit(self.create_feedback, **kwargs)
  File "/Users/rossmcnairn/Library/Application Support/pdm/python/cpython@3.11.9/lib/python3.11/concurrent/futures/thread.py", line 167, in submit
    raise RuntimeError('cannot schedule new futures after shutdown')
RuntimeError: cannot schedule new futures after shutdown
```

I will openly admit I don't understand why this is happening, but the fix is just to make sure we don't submit tasks to a shutdown executor. 

With the minor change, the other path is followed and the code completes successfully. 