### PR TITLE
chore: update docker-compose for new OAuth mode

### DIFF
--- a/python/langsmith/cli/docker-compose.yaml
+++ b/python/langsmith/cli/docker-compose.yaml
@@ -1,11 +1,11 @@
 version: "4"
 services:
   langchain-playground:
-    image: langchain/langsmith-playground:${_LANGSMITH_IMAGE_VERSION:-0.7.44}
+    image: langchain/langsmith-playground:${_LANGSMITH_IMAGE_VERSION:-0.7.45}
     ports:
       - 3001:3001
   langchain-frontend:
-    image: langchain/langsmith-frontend:${_LANGSMITH_IMAGE_VERSION:-0.7.44}
+    image: langchain/langsmith-frontend:${_LANGSMITH_IMAGE_VERSION:-0.7.45}
     environment:
       - VITE_BACKEND_AUTH_TYPE=${AUTH_TYPE:-none}
       - VITE_OAUTH_CLIENT_ID=${OAUTH_CLIENT_ID}
@@ -16,7 +16,7 @@ services:
       - langchain-backend
       - langchain-playground
   langchain-backend:
-    image: langchain/langsmith-backend:${_LANGSMITH_IMAGE_VERSION:-0.7.44}
+    image: langchain/langsmith-backend:${_LANGSMITH_IMAGE_VERSION:-0.7.45}
     environment:
       - PORT=1984
       - LANGCHAIN_ENV=local_docker
@@ -66,7 +66,7 @@ services:
         condition: service_completed_successfully
     restart: always
   langchain-platform-backend:
-    image: langchain/langsmith-go-backend:${_LANGSMITH_IMAGE_VERSION:-0.7.44}
+    image: langchain/langsmith-go-backend:${_LANGSMITH_IMAGE_VERSION:-0.7.45}
     environment:
       - PORT=1986
       - LANGCHAIN_ENV=local_docker
@@ -99,7 +99,7 @@ services:
         condition: service_completed_successfully
     restart: always
   langchain-queue:
-    image: langchain/langsmith-backend:${_LANGSMITH_IMAGE_VERSION:-0.7.44}
+    image: langchain/langsmith-backend:${_LANGSMITH_IMAGE_VERSION:-0.7.45}
     environment:
       - LANGCHAIN_ENV=local_docker
       - GO_ENDPOINT=http://langchain-platform-backend:1986
@@ -199,7 +199,7 @@ services:
       timeout: 2s
       retries: 30
   clickhouse-setup:
-    image: langchain/langsmith-backend:${_LANGSMITH_IMAGE_VERSION:-0.7.44}
+    image: langchain/langsmith-backend:${_LANGSMITH_IMAGE_VERSION:-0.7.45}
     depends_on:
       langchain-clickhouse:
         condition: service_healthy
@@ -218,7 +218,7 @@ services:
         "scripts/wait_for_clickhouse_and_migrate.sh"
       ]
   postgres-setup:
-    image: langchain/langsmith-backend:${_LANGSMITH_IMAGE_VERSION:-0.7.44}
+    image: langchain/langsmith-backend:${_LANGSMITH_IMAGE_VERSION:-0.7.45}
     depends_on:
       langchain-db:
         condition: service_healthy

--- a/python/langsmith/cli/docker-compose.yaml
+++ b/python/langsmith/cli/docker-compose.yaml
@@ -66,7 +66,7 @@ services:
         condition: service_completed_successfully
     restart: always
   langchain-platform-backend:
-    image: smith-go:test
+    image: langchain/langsmith-go-backend:${_LANGSMITH_IMAGE_VERSION:-0.7.44}
     environment:
       - PORT=1986
       - LANGCHAIN_ENV=local_docker

--- a/python/langsmith/cli/docker-compose.yaml
+++ b/python/langsmith/cli/docker-compose.yaml
@@ -1,11 +1,11 @@
 version: "4"
 services:
   langchain-playground:
-    image: langchain/langsmith-playground:${_LANGSMITH_IMAGE_VERSION:-0.7.39}
+    image: langchain/langsmith-playground:${_LANGSMITH_IMAGE_VERSION:-0.7.44}
     ports:
       - 3001:3001
   langchain-frontend:
-    image: langchain/langsmith-frontend:${_LANGSMITH_IMAGE_VERSION:-0.7.39}
+    image: langchain/langsmith-frontend:${_LANGSMITH_IMAGE_VERSION:-0.7.44}
     environment:
       - VITE_BACKEND_AUTH_TYPE=${AUTH_TYPE:-none}
       - VITE_OAUTH_CLIENT_ID=${OAUTH_CLIENT_ID}
@@ -16,16 +16,18 @@ services:
       - langchain-backend
       - langchain-playground
   langchain-backend:
-    image: langchain/langsmith-backend:${_LANGSMITH_IMAGE_VERSION:-0.7.39}
+    image: langchain/langsmith-backend:${_LANGSMITH_IMAGE_VERSION:-0.7.44}
     environment:
       - PORT=1984
       - LANGCHAIN_ENV=local_docker
+      - LANGSMITH_URL=${LANGSMITH_URL:-http://langchain-frontend:1980}
       - GO_ENDPOINT=http://langchain-platform-backend:1986
-      - SMITH_BACKEND_ENDPOINT=http://langchain-backend:1984
+      - SMITH_BACKEND_ENDPOINT=${SMITH_BACKEND_ENDPOINT:-http://langchain-backend:1984}
       - LANGSMITH_LICENSE_KEY=${LANGSMITH_LICENSE_KEY}
       - LOG_LEVEL=${LOG_LEVEL:-info}
       - AUTH_TYPE=${AUTH_TYPE:-none}
       - OAUTH_CLIENT_ID=${OAUTH_CLIENT_ID}
+      - OAUTH_CLIENT_SECRET=${OAUTH_CLIENT_SECRET}
       - OAUTH_ISSUER_URL=${OAUTH_ISSUER_URL}
       - API_KEY_SALT=${API_KEY_SALT}
       - X_SERVICE_AUTH_JWT_SECRET=${API_KEY_SALT}
@@ -64,15 +66,19 @@ services:
         condition: service_completed_successfully
     restart: always
   langchain-platform-backend:
-    image: langchain/langsmith-go-backend:${_LANGSMITH_IMAGE_VERSION:-0.7.39}
+    image: smith-go:test
     environment:
       - PORT=1986
       - LANGCHAIN_ENV=local_docker
+      - LANGSMITH_URL=${LANGSMITH_URL:-http://langchain-frontend:1980}
+      - SMITH_BACKEND_ENDPOINT=${SMITH_BACKEND_ENDPOINT:-http://langchain-backend:1984}
       - LANGSMITH_LICENSE_KEY=${LANGSMITH_LICENSE_KEY}
       - OPENAI_API_KEY=${OPENAI_API_KEY}
       - LOG_LEVEL=${LOG_LEVEL:-warning}
       - AUTH_TYPE=${AUTH_TYPE:-none}
       - OAUTH_CLIENT_ID=${OAUTH_CLIENT_ID}
+      - OAUTH_CLIENT_SECRET=${OAUTH_CLIENT_SECRET}
+      - OAUTH_CALLBACK_URL=${OAUTH_CALLBACK_URL}
       - OAUTH_ISSUER_URL=${OAUTH_ISSUER_URL}
       - API_KEY_SALT=${API_KEY_SALT}
       - X_SERVICE_AUTH_JWT_SECRET=${API_KEY_SALT}
@@ -93,7 +99,7 @@ services:
         condition: service_completed_successfully
     restart: always
   langchain-queue:
-    image: langchain/langsmith-backend:${_LANGSMITH_IMAGE_VERSION:-0.7.39}
+    image: langchain/langsmith-backend:${_LANGSMITH_IMAGE_VERSION:-0.7.44}
     environment:
       - LANGCHAIN_ENV=local_docker
       - GO_ENDPOINT=http://langchain-platform-backend:1986
@@ -193,7 +199,7 @@ services:
       timeout: 2s
       retries: 30
   clickhouse-setup:
-    image: langchain/langsmith-backend:${_LANGSMITH_IMAGE_VERSION:-0.7.39}
+    image: langchain/langsmith-backend:${_LANGSMITH_IMAGE_VERSION:-0.7.44}
     depends_on:
       langchain-clickhouse:
         condition: service_healthy
@@ -212,7 +218,7 @@ services:
         "scripts/wait_for_clickhouse_and_migrate.sh"
       ]
   postgres-setup:
-    image: langchain/langsmith-backend:${_LANGSMITH_IMAGE_VERSION:-0.7.39}
+    image: langchain/langsmith-backend:${_LANGSMITH_IMAGE_VERSION:-0.7.44}
     depends_on:
       langchain-db:
         condition: service_healthy


### PR DESCRIPTION
this adds environment variables to support the new self-hosted SSO auth mode: https://docs.smith.langchain.com/self_hosting/configuration/sso#oauth20-and-oidc-without-pkce