### PR TITLE
py: Stop sending serialized as a separate part

### DIFF
--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -1650,7 +1650,6 @@ class Client:
                 fields = [
                     ("inputs", payload.pop("inputs", None)),
                     ("outputs", payload.pop("outputs", None)),
-                    ("serialized", payload.pop("serialized", None)),
                     ("events", payload.pop("events", None)),
                 ]
                 # encode the main run payload


### PR DESCRIPTION
- This is harder to get to work correctly in api, and not useful given we mostly don't send these anymore