### PR TITLE
py: Retry on 408

### DIFF
--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -827,6 +827,7 @@ class Client:
             *(retry_on or ()),
             *(
                 ls_utils.LangSmithConnectionError,
+                ls_utils.LangSmithRequestTimeout,
                 ls_utils.LangSmithAPIError,
             ),
         )
@@ -869,6 +870,11 @@ class Client:
                                 f" {pathname} in"
                                 f" LangSmith API. {repr(e)}"
                                 f"{_context}"
+                            )
+                        elif response.status_code == 408:
+                            raise ls_utils.LangSmithRequestTimeout(
+                                f"Client took too long to send request to {method}"
+                                f"{pathname} {_context}"
                             )
                         elif response.status_code == 429:
                             raise ls_utils.LangSmithRateLimitError(

--- a/python/langsmith/utils.py
+++ b/python/langsmith/utils.py
@@ -52,6 +52,10 @@ class LangSmithAPIError(LangSmithError):
     """Internal server error while communicating with LangSmith."""
 
 
+class LangSmithRequestTimeout(LangSmithError):
+    """Client took too long to send request body."""
+
+
 class LangSmithUserError(LangSmithError):
     """User error caused an exception when communicating with LangSmith."""
 


### PR DESCRIPTION
- 408 is "client took too long to send request body"