### PR TITLE
Add UUID to project name in integration test

### DIFF
--- a/js/src/tests/run_trees.int.test.ts
+++ b/js/src/tests/run_trees.int.test.ts
@@ -219,7 +219,7 @@ test.concurrent(
   "Test end() write to metadata",
   async () => {
     const runId = uuid.v4();
-    const projectName = `__test_end_metadata_run_tree_js`;
+    const projectName = `__test_end_metadata_run_tree_js ${runId}`;
     const langchainClient = new Client({ timeout_ms: 30_000 });
     const parentRunConfig: RunTreeConfig = {
       name: "parent_run",


### PR DESCRIPTION
There were some issues with creating and deleting a project of the same name in an integration test - I added a uuid in project name and we still cleanup by deleting the now unique project name.