### PR TITLE
fix: Create new multipart encoder for each retry attempt

### DIFF
--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -1721,15 +1721,16 @@ class Client:
                         stop_after_attempt=1,
                         _context=_context,
                     )
+                    break
                 except ls_utils.LangSmithConflictError:
                     break
                 except (
                     ls_utils.LangSmithConnectionError,
                     ls_utils.LangSmithRequestTimeout,
                     ls_utils.LangSmithAPIError,
-                ):
+                ) as exc:
                     if idx == attempts:
-                        raise
+                        logger.warning(f"Failed to multipart ingest runs: {exc}")
                     else:
                         continue
                 except Exception as e:

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "langsmith"
-version = "0.1.136"
+version = "0.1.137"
 description = "Client library to connect to the LangSmith LLM Tracing and Evaluation Platform."
 authors = ["LangChain <support@langchain.dev>"]
 license = "MIT"


### PR DESCRIPTION
- requests doesn't seek the encoder object to the start when starting a new retry, so we need to create a new encoder instead