### PR TITLE
Skip model_dump for classes

### DIFF
--- a/python/langsmith/_internal/_serde.py
+++ b/python/langsmith/_internal/_serde.py
@@ -93,7 +93,11 @@ def _serialize_json(obj: Any) -> Any:
             ("to_dict", False),  # dataclasses-json
         ]
         for attr, exclude_none in serialization_methods:
-            if hasattr(obj, attr) and callable(getattr(obj, attr)):
+            if (
+                hasattr(obj, attr)
+                and callable(getattr(obj, attr))
+                and not isinstance(obj, type)
+            ):
                 try:
                     method = getattr(obj, attr)
                     response = (


### PR DESCRIPTION
Avoid running into the error for "missing self" when serializing

Fixes #1116