### PR TITLE
Add support for bedrock models in embedding_distance function

### DIFF
--- a/python/tests/unit_tests/test_expect.py
+++ b/python/tests/unit_tests/test_expect.py
@@ -18,3 +18,25 @@ def test_expect_explicit_none(mock_client: mock.Mock) -> None:
     expect.score(1).to_be_between(0, 2)
     expect.score(1).to_be_approximately(1, 2)
     expect({1, 2}).to_contain(1)
+
+
+@mock.patch.object(ls_client, "Client", autospec=True)
+def test_embedding_distance_with_bedrock(mock_client: mock.Mock) -> None:
+    # Mock the bedrock encoder function
+    def mock_bedrock_encoder(texts):
+        return [[0.1, 0.2, 0.3] for _ in texts]
+
+    # Test with bedrock encoder
+    config = {"encoder": mock_bedrock_encoder, "metric": "cosine"}
+    matcher = expect.embedding_distance(
+        prediction="hello",
+        reference="hi",
+        config=config,
+    )
+    matcher.to_be_less_than(1.0)
+    matcher.to_be_greater_than(0.0)
+    matcher.to_be_between(0.0, 1.0)
+    matcher.to_be_approximately(0.5, precision=1)
+    matcher.to_equal(0.5)
+    matcher.to_be_none()
+    matcher.to_contain(0.5)


### PR DESCRIPTION
Related to #1152

Add unit test for embedding_distance function with bedrock model encoder.

* Mock the bedrock encoder function.
* Test embedding_distance function with bedrock encoder.
* Verify functionality with various assertions.
