### PR TITLE
Fix serialization of `pydantic.BaseModel` fields with `pathlib.Path` dict keys

### DIFF
--- a/python/langsmith/_internal/_serde.py
+++ b/python/langsmith/_internal/_serde.py
@@ -37,6 +37,8 @@ def _simple_default(obj):
             return obj.isoformat()
         if isinstance(obj, uuid.UUID):
             return str(obj)
+        if isinstance(obj, dict):
+            return {_simple_default(key): value for key, value in obj.items()}
         if hasattr(obj, "model_dump") and callable(obj.model_dump):
             return obj.model_dump()
         elif hasattr(obj, "dict") and callable(obj.dict):

--- a/python/langsmith/_internal/_serde.py
+++ b/python/langsmith/_internal/_serde.py
@@ -31,16 +31,8 @@ def _simple_default(obj):
         # https://github.com/ijl/orjson#serialize
         if isinstance(obj, datetime.datetime):
             return obj.isoformat()
-        if isinstance(obj, uuid.UUID):
+        elif isinstance(obj, uuid.UUID):
             return str(obj)
-        if isinstance(obj, dict):
-            return {_simple_default(key): value for key, value in obj.items()}
-        if hasattr(obj, "model_dump") and callable(obj.model_dump):
-            return obj.model_dump(mode="json")
-        elif hasattr(obj, "dict") and callable(obj.dict):
-            return obj.dict()
-        elif hasattr(obj, "_asdict") and callable(obj._asdict):
-            return obj._asdict()
         elif isinstance(obj, BaseException):
             return {"error": type(obj).__name__, "message": str(obj)}
         elif isinstance(obj, (set, frozenset, collections.deque)):
@@ -90,8 +82,8 @@ def _serialize_json(obj: Any) -> Any:
                 "model_dump",
                 {"exclude_none": True, "mode": "json"},
             ),  # Pydantic V2 with non-serializable fields
-            ("to_dict", {}),  # dataclasses-json
             ("dict", {}),  # Pydantic V1 with non-serializable field
+            ("to_dict", {}),  # dataclasses-json
         ]
         for attr, kwargs in serialization_methods:
             if (

--- a/python/langsmith/_internal/_serde.py
+++ b/python/langsmith/_internal/_serde.py
@@ -40,7 +40,7 @@ def _simple_default(obj):
         if isinstance(obj, dict):
             return {_simple_default(key): value for key, value in obj.items()}
         if hasattr(obj, "model_dump") and callable(obj.model_dump):
-            return obj.model_dump()
+            return obj.model_dump(mode="json")
         elif hasattr(obj, "dict") and callable(obj.dict):
             return obj.dict()
         elif hasattr(obj, "_asdict") and callable(obj._asdict):

--- a/python/tests/unit_tests/test_client.py
+++ b/python/tests/unit_tests/test_client.py
@@ -858,7 +858,12 @@ def test_serialize_json(caplog) -> None:
         "class_with_tee": "tee_a, tee_b",
         "my_dataclass": {"foo": "foo", "bar": 1},
         "my_enum": "foo",
-        "my_pydantic": {"foo": "foo", "bar": 1},
+        "my_pydantic": {
+            "foo": "foo",
+            "bar": 1,
+            "path_keys": {"foo": {"foo": "foo", "bar": 1, "path_keys": {}}},
+        },
+        "my_pydantic_class": lambda x: "MyPydantic" in x,
         "person": {"name": "foo_person"},
         "a_bool": True,
         "a_none": None,

--- a/python/tests/unit_tests/test_client.py
+++ b/python/tests/unit_tests/test_client.py
@@ -7,6 +7,7 @@ import itertools
 import json
 import logging
 import math
+import pathlib
 import sys
 import time
 import uuid
@@ -723,6 +724,7 @@ def test_pydantic_serialize() -> None:
 
     class ChildPydantic(BaseModel):
         uid: uuid.UUID
+        child_path_keys: Dict[pathlib.Path, pathlib.Path]
 
     class MyPydantic(BaseModel):
         foo: str
@@ -730,9 +732,16 @@ def test_pydantic_serialize() -> None:
         tim: datetime
         ex: Optional[str] = None
         child: Optional[ChildPydantic] = None
+        path_keys: Dict[pathlib.Path, pathlib.Path]
 
     obj = MyPydantic(
-        foo="bar", uid=test_uuid, tim=test_time, child=ChildPydantic(uid=test_uuid)
+        foo="bar",
+        uid=test_uuid,
+        tim=test_time,
+        child=ChildPydantic(
+            uid=test_uuid, child_path_keys={pathlib.Path("foo"): pathlib.Path("bar")}
+        ),
+        path_keys={pathlib.Path("foo"): pathlib.Path("bar")},
     )
     res = json.loads(json.dumps(obj, default=_serialize_json))
     expected = {
@@ -741,7 +750,9 @@ def test_pydantic_serialize() -> None:
         "tim": test_time.isoformat(),
         "child": {
             "uid": str(test_uuid),
+            "child_path_keys": {"foo": "bar"},
         },
+        "path_keys": {"foo": "bar"},
     }
     assert res == expected
 
@@ -781,6 +792,7 @@ def test_serialize_json(caplog) -> None:
     class MyPydantic(BaseModel):
         foo: str
         bar: int
+        path_keys: Dict[pathlib.Path, "MyPydantic"]
 
     @dataclasses.dataclass
     class MyDataclass:
@@ -820,7 +832,11 @@ def test_serialize_json(caplog) -> None:
         "class_with_tee": ClassWithTee(),
         "my_dataclass": MyDataclass("foo", 1),
         "my_enum": MyEnum.FOO,
-        "my_pydantic": MyPydantic(foo="foo", bar=1),
+        "my_pydantic": MyPydantic(
+            foo="foo",
+            bar=1,
+            path_keys={pathlib.Path("foo"): MyPydantic(foo="foo", bar=1, path_keys={})},
+        ),
         "my_pydantic_class": MyPydantic,
         "person": Person(name="foo_person"),
         "a_bool": True,
@@ -847,7 +863,6 @@ def test_serialize_json(caplog) -> None:
         "my_dataclass": {"foo": "foo", "bar": 1},
         "my_enum": "foo",
         "my_pydantic": {"foo": "foo", "bar": 1},
-        "my_pydantic_class": lambda x: "MyPydantic" in x,
         "person": {"name": "foo_person"},
         "a_bool": True,
         "a_none": None,


### PR DESCRIPTION
Apply `_simple_default` serialization on dict keys to resolve this exception

```python
Traceback (most recent call last):
  File "/Users/brendan/.local/share/virtualenvs/core-bRkH1-KB/lib/python3.11/site-packages/langsmith/client.py", line 281, in _dumps_json_single
    return orjson.dumps(
           ^^^^^^^^^^^^^
TypeError: Dict key must a type serializable with OPT_NON_STR_KEYS

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/brendan/.local/share/virtualenvs/core-bRkH1-KB/lib/python3.11/site-packages/langsmith/client.py", line 5802, in _tracing_thread_handle_batch
    client.multipart_ingest_runs(create=create, update=update, pre_sampled=True)
  File "/Users/brendan/.local/share/virtualenvs/core-bRkH1-KB/lib/python3.11/site-packages/langsmith/client.py", line 1675, in multipart_ingest_runs
    valb = _dumps_json(value)
           ^^^^^^^^^^^^^^^^^^
  File "/Users/brendan/.local/share/virtualenvs/core-bRkH1-KB/lib/python3.11/site-packages/langsmith/client.py", line 321, in _dumps_json
    return _dumps_json_single(obj, _serialize_json)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/brendan/.local/share/virtualenvs/core-bRkH1-KB/lib/python3.11/site-packages/langsmith/client.py", line 292, in _dumps_json_single
    result = json.dumps(
             ^^^^^^^^^^^
  File "/usr/local/Cellar/python@3.11/3.11.10/Frameworks/Python.framework/Versions/3.11/lib/python3.11/json/__init__.py", line 238, in dumps
    **kw).encode(obj)
          ^^^^^^^^^^^
  File "/usr/local/Cellar/python@3.11/3.11.10/Frameworks/Python.framework/Versions/3.11/lib/python3.11/json/encoder.py", line 200, in encode
    chunks = self.iterencode(o, _one_shot=True)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/Cellar/python@3.11/3.11.10/Frameworks/Python.framework/Versions/3.11/lib/python3.11/json/encoder.py", line 258, in iterencode
    return _iterencode(o, 0)
           ^^^^^^^^^^^^^^^^^
TypeError: keys must be str, int, float, bool or None, not PosixPath
```