### PR TITLE
js[patch]: make evaluate,traceable importable from top-level

### DIFF
--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -11,6 +11,10 @@ export type {
 
 export { RunTree, type RunTreeConfig } from "./run_trees.js";
 
+export { evaluate, EvaluationResult } from "./evaluation/index.js";
+
+export { traceable } from "./traceable.js";
+
 export { overrideFetchImplementation } from "./singletons/fetch.js";
 
 // Update using yarn bump-version


### PR DESCRIPTION
- match python sdk
- make our most-used classes and functions more easily accessible