### PR TITLE
Remove initial timeout, the batch timeout is now always 250ms

### DIFF
--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -466,9 +466,7 @@ export class Client {
 
   private autoBatchTimeout: ReturnType<typeof setTimeout> | undefined;
 
-  private autoBatchInitialDelayMs = 250;
-
-  private autoBatchAggregationDelayMs = 50;
+  private autoBatchAggregationDelayMs = 250;
 
   private batchSizeBytesLimit?: number;
 
@@ -802,7 +800,6 @@ export class Client {
   }
 
   private async processRunOperation(item: AutoBatchQueueItem) {
-    const oldTimeout = this.autoBatchTimeout;
     clearTimeout(this.autoBatchTimeout);
     this.autoBatchTimeout = undefined;
     if (item.action === "create") {
@@ -819,9 +816,7 @@ export class Client {
           this.autoBatchTimeout = undefined;
           this.drainAutoBatchQueue(sizeLimitBytes);
         },
-        oldTimeout
-          ? this.autoBatchAggregationDelayMs
-          : this.autoBatchInitialDelayMs
+        this.autoBatchAggregationDelayMs
       );
     }
     return itemPromise;

--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -811,13 +811,10 @@ export class Client {
       this.drainAutoBatchQueue(sizeLimitBytes);
     }
     if (this.autoBatchQueue.items.length > 0) {
-      this.autoBatchTimeout = setTimeout(
-        () => {
-          this.autoBatchTimeout = undefined;
-          this.drainAutoBatchQueue(sizeLimitBytes);
-        },
-        this.autoBatchAggregationDelayMs
-      );
+      this.autoBatchTimeout = setTimeout(() => {
+        this.autoBatchTimeout = undefined;
+        this.drainAutoBatchQueue(sizeLimitBytes);
+      }, this.autoBatchAggregationDelayMs);
     }
     return itemPromise;
   }

--- a/js/src/tests/traceable.int.test.ts
+++ b/js/src/tests/traceable.int.test.ts
@@ -696,8 +696,8 @@ test.concurrent(
           {
             test1bin: ["application/octet-stream", testAttachment1],
             test2bin: ["application/octet-stream", testAttachment2],
-            "input.bin": ["application/octet-stream", attachment],
-            "input2.bin": [
+            inputbin: ["application/octet-stream", attachment],
+            input2bin: [
               "application/octet-stream",
               new Uint8Array(attachment2),
             ],


### PR DESCRIPTION
Standardize with the Python SDK, the delay for batch flushing in multipart JS should also be 250ms