### PR TITLE
Add six to requirements.txt

### DIFF
--- a/python/docs/requirements.txt
+++ b/python/docs/requirements.txt
@@ -9,4 +9,5 @@ pyyaml
 sphinx-design
 sphinx-copybutton
 beautifulsoup4
+six
 -e python


### PR DESCRIPTION
Six is used at least in this file:
https://github.com/langchain-ai/langsmith-sdk/blob/main/python/langsmith/_internal/_patch.py#L4

So, the library causes errors, if six is not already installed. Better add it to required libs.