### PR TITLE
python[patch]: evaluators can return primitives

### DIFF
--- a/python/langsmith/evaluation/_runner.py
+++ b/python/langsmith/evaluation/_runner.py
@@ -7,6 +7,7 @@ import collections
 import concurrent.futures as cf
 import datetime
 import functools
+import importlib
 import inspect
 import itertools
 import logging
@@ -277,6 +278,17 @@ def evaluate(
             "    # ... other parameters\n"
             ")"
         )
+    if not callable(target):
+        if importlib.util.find_spec("langchain_core"):
+            from langchain_core.runnables import Runnable
+
+            if isinstance(target, Runnable):
+                target = target.invoke
+
+    if not callable(target):
+        msg = ""
+        raise ValueError(msg)
+
     if experiment and experiment_prefix:
         raise ValueError(
             "Expected at most one of 'experiment' or 'experiment_prefix',"

--- a/python/langsmith/evaluation/_runner.py
+++ b/python/langsmith/evaluation/_runner.py
@@ -7,7 +7,6 @@ import collections
 import concurrent.futures as cf
 import datetime
 import functools
-import importlib
 import inspect
 import itertools
 import logging
@@ -278,17 +277,6 @@ def evaluate(
             "    # ... other parameters\n"
             ")"
         )
-    if not callable(target):
-        if importlib.util.find_spec("langchain_core"):
-            from langchain_core.runnables import Runnable
-
-            if isinstance(target, Runnable):
-                target = target.invoke
-
-    if not callable(target):
-        msg = ""
-        raise ValueError(msg)
-
     if experiment and experiment_prefix:
         raise ValueError(
             "Expected at most one of 'experiment' or 'experiment_prefix',"

--- a/python/langsmith/evaluation/_runner.py
+++ b/python/langsmith/evaluation/_runner.py
@@ -1848,7 +1848,7 @@ def _extract_code_evaluator_feedback_keys(func: Callable) -> list[str]:
     try:
         tree = ast.parse(python_code)
         function_def = tree.body[0]
-        if not isinstance(function_def, ast.FunctionDef):
+        if not isinstance(function_def, (ast.FunctionDef, ast.AsyncFunctionDef)):
             return []
 
         variables = {}

--- a/python/langsmith/evaluation/evaluator.py
+++ b/python/langsmith/evaluation/evaluator.py
@@ -224,7 +224,7 @@ class DynamicRunEvaluator(RunEvaluator):
         self,
         result: Union[EvaluationResult, dict],
         source_run_id: uuid.UUID,
-        default_name: str = "",
+        allow_no_key: bool = False,
     ) -> EvaluationResult:
         if isinstance(result, EvaluationResult):
             if not result.source_run_id:
@@ -236,8 +236,8 @@ class DynamicRunEvaluator(RunEvaluator):
                     "Expected an EvaluationResult object, or dict with a metric"
                     f" 'key' and optional 'score'; got empty result: {result}"
                 )
-            if "key" not in result:
-                result["key"] = default_name
+            if "key" not in result and allow_no_key:
+                result["key"] = self._name
             if all(k not in result for k in ("score", "value", "comment")):
                 raise ValueError(
                     "Expected an EvaluationResult object, or dict with a metric"
@@ -258,15 +258,13 @@ class DynamicRunEvaluator(RunEvaluator):
         if "results" in results:
             cp = results.copy()
             cp["results"] = [
-                self._coerce_evaluation_result(
-                    r, source_run_id=source_run_id, default_name=f"{self._name}_{i+1}"
-                )
+                self._coerce_evaluation_result(r, source_run_id=source_run_id)
                 for i, r in enumerate(results["results"])
             ]
             return EvaluationResults(**cp)
 
         return self._coerce_evaluation_result(
-            cast(dict, results), source_run_id=source_run_id, default_name=self._name
+            cast(dict, results), source_run_id=source_run_id, allow_no_key=True
         )
 
     def _format_result(
@@ -276,23 +274,27 @@ class DynamicRunEvaluator(RunEvaluator):
         ],
         source_run_id: uuid.UUID,
     ) -> Union[EvaluationResult, EvaluationResults]:
-        if not result and not isinstance(result, (int, float, bool)):
+        if isinstance(result, (bool, float, int)):
+            result = {"score": result}
+        elif not result:
             raise ValueError(
-                "Expected an EvaluationResult or EvaluationResults object, or a"
-                " dict with key and one of score or value, EvaluationResults,"
-                f" got {result}"
+                f"Expected a non-empty dict, str, bool, int, float, list, "
+                f"EvaluationResult, or EvaluationResults. Got {result}"
             )
-
-        if isinstance(result, EvaluationResult):
+        elif isinstance(result, EvaluationResult):
             if not result.source_run_id:
                 result.source_run_id = source_run_id
             return result
         elif isinstance(result, list):
-            result = {"results": [_primitive_to_result_dict(r) for r in result]}  # type: ignore[misc]
-        elif isinstance(result, (bool, int, float, str, dict)):
-            result = _primitive_to_result_dict(
-                cast(Union[bool, int, float, str, dict], result)
-            )
+            if not all(isinstance(x, dict) for x in result):
+                raise ValueError(
+                    f"Expected a list of dicts or EvaluationResult. Received {result}."
+                )
+            result = {"results": result}  # type: ignore[misc]
+        elif isinstance(result, str):
+            result = {"value": result}
+        elif isinstance(result, dict):
+            pass
         else:
             raise ValueError(
                 f"Expected a dict, str, bool, int, float, list, EvaluationResult, or "
@@ -643,17 +645,3 @@ def comparison_evaluator(
 ) -> DynamicComparisonRunEvaluator:
     """Create a comaprison evaluator from a function."""
     return DynamicComparisonRunEvaluator(func)
-
-
-def _primitive_to_result_dict(result: Union[float, str, int, bool, dict]) -> dict:
-    if isinstance(result, (bool, float, int)):
-        return {"score": result}
-    elif isinstance(result, str):
-        return {"value": result}
-    elif isinstance(result, dict):
-        return result
-    else:
-        raise ValueError(
-            f"Expected evaluation result to be int, float, str, bool, or dict. "
-            f"Received: {result}"
-        )

--- a/python/langsmith/evaluation/evaluator.py
+++ b/python/langsmith/evaluation/evaluator.py
@@ -259,7 +259,7 @@ class DynamicRunEvaluator(RunEvaluator):
             cp = results.copy()
             cp["results"] = [
                 self._coerce_evaluation_result(r, source_run_id=source_run_id)
-                for i, r in enumerate(results["results"])
+                for r in results["results"]
             ]
             return EvaluationResults(**cp)
 

--- a/python/tests/unit_tests/evaluation/test_evaluator.py
+++ b/python/tests/unit_tests/evaluation/test_evaluator.py
@@ -321,8 +321,8 @@ async def test_run_evaluator_decorator_return_multi_evaluation_result_async(
     assert result["results"][1].score == 2.0
 
 
-@pytest.mark.parametrize("response", [None, {}, {"accuracy": 5}])
-async def test_evaluator_raises_for_null_ouput(response: Any):
+@pytest.mark.parametrize("response", [None, {}, []])
+async def test_evaluator_raises_for_null_output(response: Any):
     @run_evaluator  # type: ignore
     def bad_evaluator(run: schemas.Run, example: schemas.Example):
         return response
@@ -334,13 +334,36 @@ async def test_evaluator_raises_for_null_ouput(response: Any):
     fake_run = MagicMock()
     fake_example = MagicMock()
 
-    with pytest.raises(ValueError, match="Expected an EvaluationResult "):
+    with pytest.raises(ValueError, match="Expected a non-empty "):
         bad_evaluator.evaluate_run(fake_run, fake_example)
 
-    with pytest.raises(ValueError, match="Expected an EvaluationResult "):
+    with pytest.raises(ValueError, match="Expected a non-empty "):
         await bad_evaluator.aevaluate_run(fake_run, fake_example)
 
-    with pytest.raises(ValueError, match="Expected an EvaluationResult "):
+    with pytest.raises(ValueError, match="Expected a non-empty "):
+        await abad_evaluator.aevaluate_run(fake_run, fake_example)
+
+
+@pytest.mark.parametrize("response", [[5], {"accuracy": 5}])
+async def test_evaluator_raises_for_bad_output(response: Any):
+    @run_evaluator  # type: ignore
+    def bad_evaluator(run: schemas.Run, example: schemas.Example):
+        return response
+
+    @run_evaluator  # type: ignore
+    async def abad_evaluator(run: schemas.Run, example: schemas.Example):
+        return response
+
+    fake_run = MagicMock()
+    fake_example = MagicMock()
+
+    with pytest.raises(ValueError, match="Expected"):
+        bad_evaluator.evaluate_run(fake_run, fake_example)
+
+    with pytest.raises(ValueError, match="Expected"):
+        await bad_evaluator.aevaluate_run(fake_run, fake_example)
+
+    with pytest.raises(ValueError, match="Expected"):
         await abad_evaluator.aevaluate_run(fake_run, fake_example)
 
 

--- a/python/tests/unit_tests/evaluation/test_runner.py
+++ b/python/tests/unit_tests/evaluation/test_runner.py
@@ -275,6 +275,22 @@ def test_evaluate_results(blocking: bool, as_runnable: bool) -> None:
         assert r["run"].reference_example_id in dev_xample_ids
     assert not fake_request.should_fail
 
+    # Returning list of non-dicts not supported.
+    def bad_eval_list(run, example):
+        ordering_of_stuff.append("evaluate")
+        return ["foo", 1]
+
+    results = evaluate(
+        predict,
+        client=client,
+        data=dev_split,
+        evaluators=[bad_eval_list],
+        num_repetitions=NUM_REPETITIONS,
+        blocking=blocking,
+    )
+    for r in results:
+        assert r["evaluation_results"]["results"][0].extra == {"error": True}
+
 
 def test_evaluate_raises_for_async():
     async def my_func(inputs: dict):
@@ -461,3 +477,19 @@ async def test_aevaluate_results(blocking: bool, as_runnable: bool) -> None:
         assert r["evaluation_results"]["results"][0].score == 0.7
         assert r["run"].reference_example_id in dev_xample_ids
     assert not fake_request.should_fail
+    # Returning list of non-dicts not supported.
+
+    async def bad_eval_list(run, example):
+        ordering_of_stuff.append("evaluate")
+        return ["foo", 1]
+
+    results = await aevaluate(
+        predict,
+        client=client,
+        data=dev_split,
+        evaluators=[bad_eval_list],
+        num_repetitions=NUM_REPETITIONS,
+        blocking=blocking,
+    )
+    async for r in results:
+        assert r["evaluation_results"]["results"][0].extra == {"error": True}


### PR DESCRIPTION
```python
from langsmith import evaluate

def foo(run, example):
    return 0

def bar(run, example):
    return "long"

# removed, needs to be list of dict
# def baz(run, example):
#     return [0, 0.2, "how are ya"]

def app(inputs):
    return inputs

evaluate(app, data="Sample Dataset 3", evaluators=[foo, bar, baz])
```