### PR TITLE
nit: stop calling importlib on every api req

### DIFF
--- a/python/langsmith/__init__.py
+++ b/python/langsmith/__init__.py
@@ -1,8 +1,7 @@
 """LangSmith Client."""
 
-from typing import TYPE_CHECKING, Any
-
 from importlib import metadata
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from langsmith._expect import expect

--- a/python/langsmith/__init__.py
+++ b/python/langsmith/__init__.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
 # Avoid calling into importlib on every call to __version__
 version = ""
 try:
-    metadata.version(__package__)
+    version = metadata.version(__package__)
 except metadata.PackageNotFoundError:
     pass
 

--- a/python/langsmith/__init__.py
+++ b/python/langsmith/__init__.py
@@ -2,6 +2,8 @@
 
 from typing import TYPE_CHECKING, Any
 
+from importlib import metadata
+
 if TYPE_CHECKING:
     from langsmith._expect import expect
     from langsmith._testing import test, unit
@@ -21,15 +23,17 @@ if TYPE_CHECKING:
         ContextThreadPoolExecutor,
     )
 
+# Avoid calling into importlib on every call to __version__
+version = ""
+try:
+    metadata.version(__package__)
+except metadata.PackageNotFoundError:
+    pass
+
 
 def __getattr__(name: str) -> Any:
     if name == "__version__":
-        try:
-            from importlib import metadata
-
-            return metadata.version(__package__)
-        except metadata.PackageNotFoundError:
-            return ""
+        return version
     elif name == "Client":
         from langsmith.client import Client
 


### PR DESCRIPTION
Each call is like 1-3ms, and we call to get the version as part of every client request's headers. If you're running an eval over a lot of traces (say 10 evaluators on 1k examples), that's slow. Esp if just doing custom code evaluators which should run fast. 

### Flame Graphs before and after
(ran on 2k smallish examples w 10 evaluators)
<img width="1510" alt="Screenshot 2024-11-14 at 5 25 43 PM" src="https://github.com/user-attachments/assets/2366b357-f3de-4f18-b7a8-5b362c992119">

<img width="1507" alt="Screenshot 2024-11-14 at 5 25 53 PM" src="https://github.com/user-attachments/assets/3311e686-373c-4fd7-80e1-d6939a3c4632">