### PR TITLE
skip flaky js integration test

### DIFF
--- a/js/src/tests/evaluate_comparative.int.test.ts
+++ b/js/src/tests/evaluate_comparative.int.test.ts
@@ -28,7 +28,7 @@ afterAll(async () => {
 });
 
 describe("evaluate comparative", () => {
-  test.skip("basic", async () => {
+  test("basic", async () => {
     const client = new Client();
 
     const firstEval = await evaluate(
@@ -62,7 +62,7 @@ describe("evaluate comparative", () => {
     expect(pairwise.results.length).toEqual(2);
   });
 
-  test.skip("pass directly", async () => {
+  test("pass directly", async () => {
     const pairwise = await evaluateComparative(
       [
         evaluate((input) => ({ foo: `first:${input.input}` }), {

--- a/js/src/tests/evaluate_comparative.int.test.ts
+++ b/js/src/tests/evaluate_comparative.int.test.ts
@@ -28,7 +28,7 @@ afterAll(async () => {
 });
 
 describe("evaluate comparative", () => {
-  test("basic", async () => {
+  test.skip("basic", async () => {
     const client = new Client();
 
     const firstEval = await evaluate(
@@ -62,7 +62,7 @@ describe("evaluate comparative", () => {
     expect(pairwise.results.length).toEqual(2);
   });
 
-  test("pass directly", async () => {
+  test.skip("pass directly", async () => {
     const pairwise = await evaluateComparative(
       [
         evaluate((input) => ({ foo: `first:${input.input}` }), {

--- a/js/src/tests/vercel.int.test.ts
+++ b/js/src/tests/vercel.int.test.ts
@@ -102,7 +102,7 @@ test("generateText with image", async () => {
   expect(storedRun.id).toEqual(runId);
 });
 
-test("streamText", async () => {
+test.skip("streamText", async () => {
   const runId = uuid();
   const result = await streamText({
     model: openai("gpt-4o-mini"),


### PR DESCRIPTION
saw some flakiness in comparative evals stuff too, but not skipping those because seems less common

if we do want to remove comparative evals: https://github.com/langchain-ai/langsmith-sdk/pull/1232/commits/c07164a846d9cd131e7bb737c68e40dfe103c27b