### PR TITLE
Remove links in vendored code that point outside the sdist source code.

### DIFF
--- a/vendor/pyo3/pyo3-ffi/src/lib.rs
+++ b/vendor/pyo3/pyo3-ffi/src/lib.rs
@@ -129,9 +129,7 @@
 //! ```
 //!
 //! **`src/lib.rs`**
-//! ```rust
-#![doc = include_str!("../examples/string-sum/src/lib.rs")]
-//! ```
+//! see: `../examples/string-sum/src/lib.rs`
 //!
 //! With those two files in place, now `maturin` needs to be installed. This can be done using
 //! Python's package manager `pip`. First, load up a new Python `virtualenv`, and install `maturin`

--- a/vendor/pyo3/src/lib.rs
+++ b/vendor/pyo3/src/lib.rs
@@ -463,7 +463,7 @@ pub use pyo3_macros::{
 
 /// A proc macro used to expose Rust structs and fieldless enums as Python objects.
 ///
-#[doc = include_str!("../guide/pyclass-parameters.md")]
+/// see: `../guide/pyclass-parameters.md`
 ///
 /// For more on creating Python classes,
 /// see the [class section of the guide][1].


### PR DESCRIPTION
We vendor `pyo3` and its related libraries, but we depend on users' build tools to build wheels when a suitable wheel is not found on PyPI. The source distribution only includes the actual source code of `pyo3` et al, but their source code indirectly depends on non-source artifacts, such as files in their `guide/` or `examples/` directories. Those directories are not part of the source distribution, so locally building the wheel fails.

This PR removes those links, since they are only used for doc comments and aren't relevant to the actual operation of our library.
