### PR TITLE
Ensure the wheel-building workflow runs if it's changed.

### DIFF
--- a/.github/workflows/build_langsmith_pyo3_wheels.yml
+++ b/.github/workflows/build_langsmith_pyo3_wheels.yml
@@ -23,11 +23,13 @@ on:
       - "rust/**"
       - "vendor/orjson/**"
       - "vendor/pyo3/**"
+      - ".github/workflows/build_langsmith_pyo3_wheels.yml"
   pull_request:
     paths:
       - "rust/**"
       - "vendor/orjson/**"
       - "vendor/pyo3/**"
+      - ".github/workflows/build_langsmith_pyo3_wheels.yml"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Otherwise, PRs that touch *only* the workflow file aren't tested on the workflow, and might break it.
