### PR TITLE
Python wheels don't distinguish between macOS versions.

### DIFF
--- a/.github/workflows/build_langsmith_pyo3_wheels.yml
+++ b/.github/workflows/build_langsmith_pyo3_wheels.yml
@@ -140,8 +140,6 @@ jobs:
     strategy:
       matrix:
         platform:
-          - runner: macos-14
-            target: aarch64
           - runner: macos-15
             target: aarch64
     steps:


### PR DESCRIPTION
Due to the above, we should just build on the newer macOS. Those wheels *should* work on any reasonably-new macOS version, or else Python would have made the wheels different across versions like they are for `musllinux` vs regular linux.
