### PR TITLE
feat(js): Expose light interface for tracing client

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langsmith",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "Client library to connect to the LangSmith LLM Tracing and Evaluation Platform.",
   "packageManager": "yarn@1.22.19",
   "files": [

--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -437,7 +437,7 @@ export const DEFAULT_BATCH_SIZE_LIMIT_BYTES = 20_971_520;
 
 const SERVER_INFO_REQUEST_TIMEOUT = 1000;
 
-export class Client {
+export class Client implements LangSmithTracingClientInterface {
   private apiKey?: string;
 
   private apiUrl: string;
@@ -4170,4 +4170,12 @@ export class Client {
       this.batchIngestCaller.queue.onIdle(),
     ]);
   }
+}
+
+export interface LangSmithTracingClientInterface {
+  createRun: (run: CreateRunParams) => Promise<void>;
+
+  updateRun: (runId: string, run: RunUpdate) => Promise<void>;
+
+  awaitPendingTraceBatches: () => Promise<any>;
 }

--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -4176,6 +4176,4 @@ export interface LangSmithTracingClientInterface {
   createRun: (run: CreateRunParams) => Promise<void>;
 
   updateRun: (runId: string, run: RunUpdate) => Promise<void>;
-
-  awaitPendingTraceBatches: () => Promise<any>;
 }

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -1,4 +1,8 @@
-export { Client, type ClientConfig } from "./client.js";
+export {
+  Client,
+  type ClientConfig,
+  LangSmithTracingClientInterface,
+} from "./client.js";
 
 export type {
   Dataset,

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -14,4 +14,4 @@ export { RunTree, type RunTreeConfig } from "./run_trees.js";
 export { overrideFetchImplementation } from "./singletons/fetch.js";
 
 // Update using yarn bump-version
-export const __version__ = "0.2.7";
+export const __version__ = "0.2.8";

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -1,7 +1,7 @@
 export {
   Client,
   type ClientConfig,
-  LangSmithTracingClientInterface,
+  type LangSmithTracingClientInterface,
 } from "./client.js";
 
 export type {


### PR DESCRIPTION
Allows for interoperability in LangChain when initializing tracer with clients if different LangSmith versions are resolved:

```ts
import { Client } from "langsmith";
// `@langchain/core` may have a different internal version of `langsmith`
import { LangChainTracer } from "@langchain/core/tracers";

const client = new Client();

const tracer = new LangChainTracer({
  client, // Will type error if resolutions are bad
});
```