### PR TITLE
python[patch]: client.evaluate, client.aevaluate

### DIFF
--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -5898,8 +5898,6 @@ class Client:
             description (str | None): A free-form text description for the experiment.
             max_concurrency (int | None): The maximum number of concurrent
                 evaluations to run. Defaults to None (max number of workers).
-            client (langsmith.Client | None): The LangSmith client to use.
-                Defaults to None.
             blocking (bool): Whether to block until the evaluation is complete.
                 Defaults to True.
             num_repetitions (int): The number of times to run the evaluation.
@@ -6084,7 +6082,6 @@ class Client:
         description: Optional[str] = None,
         max_concurrency: Optional[int] = None,
         num_repetitions: int = 1,
-        client: Optional[langsmith.Client] = None,
         blocking: bool = True,
         experiment: Optional[Union[schemas.TracerSession, str, uuid.UUID]] = None,
         upload_results: bool = True,
@@ -6113,8 +6110,6 @@ class Client:
             num_repetitions (int): The number of times to run the evaluation.
                 Each item in the dataset will be run and evaluated this many times.
                 Defaults to 1.
-            client (Optional[langsmith.Client]): The LangSmith client to use.
-                Defaults to None.
             blocking (bool): Whether to block until the evaluation is complete.
                 Defaults to True.
             experiment (Optional[schemas.TracerSession]): An existing experiment to

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -6262,6 +6262,7 @@ class Client:
             blocking=blocking,
             experiment=experiment,
             upload_results=upload_results,
+            *kwargs,
         )
 
 

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -38,6 +38,7 @@ from queue import PriorityQueue
 from typing import (
     TYPE_CHECKING,
     Any,
+    AsyncIterable,
     Callable,
     DefaultDict,
     Dict,
@@ -106,8 +107,22 @@ except ImportError:
 
 if TYPE_CHECKING:
     import pandas as pd  # type: ignore
+    from langchain_core.runnables import Runnable
 
+    from langsmith import schemas
     from langsmith.evaluation import evaluator as ls_evaluator
+    from langsmith.evaluation._arunner import (
+        AEVALUATOR_T,
+        ATARGET_T,
+        AsyncExperimentResults,
+    )
+    from langsmith.evaluation._runner import (
+        DATA_T,
+        EVALUATOR_T,
+        SUMMARY_EVALUATOR_T,
+        TARGET_T,
+        ExperimentResults,
+    )
 
 
 logger = logging.getLogger(__name__)
@@ -5798,6 +5813,379 @@ class Client:
     def cleanup(self) -> None:
         """Manually trigger cleanup of the background thread."""
         self._manual_cleanup = True
+
+    def evaluate(
+        self,
+        target: Union[TARGET_T, Runnable],
+        /,
+        data: DATA_T,
+        evaluators: Optional[Sequence[EVALUATOR_T]] = None,
+        summary_evaluators: Optional[Sequence[SUMMARY_EVALUATOR_T]] = None,
+        metadata: Optional[dict] = None,
+        experiment_prefix: Optional[str] = None,
+        description: Optional[str] = None,
+        max_concurrency: Optional[int] = None,
+        num_repetitions: int = 1,
+        blocking: bool = True,
+        experiment: Optional[Union[schemas.TracerSession, str, uuid.UUID]] = None,
+        upload_results: bool = True,
+    ) -> ExperimentResults:
+        r"""Evaluate a target system or function on a given dataset.
+
+        Args:
+            target (TARGET_T): The target system or function to evaluate.
+            data (DATA_T): The dataset to evaluate on. Can be a dataset name, a list of
+                examples, or a generator of examples.
+            evaluators (Optional[Sequence[EVALUATOR_T]]): A list of evaluators to run
+                on each example. Defaults to None.
+            summary_evaluators (Optional[Sequence[SUMMARY_EVALUATOR_T]]): A list of summary
+                evaluators to run on the entire dataset. Defaults to None.
+            metadata (Optional[dict]): Metadata to attach to the experiment.
+                Defaults to None.
+            experiment_prefix (Optional[str]): A prefix to provide for your experiment name.
+                Defaults to None.
+            description (Optional[str]): A free-form text description for the experiment.
+            max_concurrency (Optional[int]): The maximum number of concurrent
+                evaluations to run. Defaults to None (max number of workers).
+            blocking (bool): Whether to block until the evaluation is complete.
+                Defaults to True.
+            num_repetitions (int): The number of times to run the evaluation.
+                Each item in the dataset will be run and evaluated this many times.
+                Defaults to 1.
+            experiment (Optional[schemas.TracerSession]): An existing experiment to
+                extend. If provided, experiment_prefix is ignored. For advanced
+                usage only.
+
+        Returns:
+            ExperimentResults: The results of the evaluation.
+
+        Examples:
+            Prepare the dataset:
+
+            >>> from langsmith import Client
+            >>> client = Client()
+            >>> dataset = client.clone_public_dataset(
+            ...     "https://smith.langchain.com/public/419dcab2-1d66-4b94-8901-0357ead390df/d"
+            ... )
+            >>> dataset_name = "Evaluate Examples"
+
+            Basic usage:
+
+            >>> def accuracy(outputs: dict, reference_outputs: dict) -> dict:
+            ...     # Row-level evaluator for accuracy.
+            ...     pred = outputs["response"]
+            ...     expected = reference_outputs["answer"]
+            ...     return {"score": expected.lower() == pred.lower()}
+
+            >>> def precision(outputs: list[dict], reference_outputs: list[dict]) -> dict:
+            ...     # Experiment-level evaluator for precision.
+            ...     # TP / (TP + FP)
+            ...     predictions = [out["response"].lower() for out in outputs]
+            ...     expected = [ref["answer"].lower() for ref in reference_outputs]
+            ...     # yes and no are the only possible answers
+            ...     tp = sum([p == e for p, e in zip(predictions, expected) if p == "yes"])
+            ...     fp = sum([p == "yes" and e == "no" for p, e in zip(predictions, expected)])
+            ...     return {"score": tp / (tp + fp)}
+            >>> def predict(inputs: dict) -> dict:
+            ...     # This can be any function or just an API call to your app.
+            ...     return {"response": "Yes"}
+            >>> results = client.evaluate(
+            ...     predict,
+            ...     data=dataset_name,
+            ...     evaluators=[accuracy],
+            ...     summary_evaluators=[precision],
+            ...     experiment_prefix="My Experiment",
+            ...     description="Evaluating the accuracy of a simple prediction model.",
+            ...     metadata={
+            ...         "my-prompt-version": "abcd-1234",
+            ...     },
+            ... )  # doctest: +ELLIPSIS
+            View the evaluation results for experiment:...
+
+            Evaluating over only a subset of the examples
+
+            >>> experiment_name = results.experiment_name
+            >>> examples = client.list_examples(dataset_name=dataset_name, limit=5)
+            >>> results = client.evaluate(
+            ...     predict,
+            ...     data=examples,
+            ...     evaluators=[accuracy],
+            ...     summary_evaluators=[precision],
+            ...     experiment_prefix="My Experiment",
+            ...     description="Just testing a subset synchronously.",
+            ... )  # doctest: +ELLIPSIS
+            View the evaluation results for experiment:...
+
+            Streaming each prediction to more easily + eagerly debug.
+
+            >>> results = client.evaluate(
+            ...     predict,
+            ...     data=dataset_name,
+            ...     evaluators=[accuracy],
+            ...     summary_evaluators=[precision],
+            ...     description="I don't even have to block!",
+            ...     blocking=False,
+            ... )  # doctest: +ELLIPSIS
+            View the evaluation results for experiment:...
+            >>> for i, result in enumerate(results):  # doctest: +ELLIPSIS
+            ...     pass
+
+            Using the `evaluate` API with an off-the-shelf LangChain evaluator:
+
+            >>> from langsmith.evaluation import LangChainStringEvaluator
+            >>> from langchain.chat_models import init_chat_model
+            >>> def prepare_criteria_data(run: Run, example: Example):
+            ...     return {
+            ...         "prediction": run.outputs["output"],
+            ...         "reference": example.outputs["answer"],
+            ...         "input": str(example.inputs),
+            ...     }
+            >>> results = client.evaluate(
+            ...     predict,
+            ...     data=dataset_name,
+            ...     evaluators=[
+            ...         accuracy,
+            ...         LangChainStringEvaluator("embedding_distance"),
+            ...         LangChainStringEvaluator(
+            ...             "labeled_criteria",
+            ...             config={
+            ...                 "criteria": {
+            ...                     "usefulness": "The prediction is useful if it is correct"
+                                                      ...                     " and/or asks a useful followup question."
+            ...                 },
+            ...                 "llm": init_chat_model("gpt-4o"),
+            ...             },
+            ...             prepare_data=prepare_criteria_data,
+            ...         ),
+            ...     ],
+            ...     description="Evaluating with off-the-shelf LangChain evaluators.",
+            ...     summary_evaluators=[precision],
+            ... )  # doctest: +ELLIPSIS
+            View the evaluation results for experiment:...
+
+            Evaluating a LangChain object:
+
+            >>> from langchain_core.runnables import chain as as_runnable
+            >>> @as_runnable
+            ... def nested_predict(inputs):
+            ...     return {"response": "Yes"}
+            >>> @as_runnable
+            ... def lc_predict(inputs):
+            ...     return nested_predict.invoke(inputs)
+            >>> results = client.evaluate(
+            ...     lc_predict,
+            ...     data=dataset_name,
+            ...     evaluators=[accuracy],
+            ...     description="This time we're evaluating a LangChain object.",
+            ...     summary_evaluators=[precision],
+            ... )  # doctest: +ELLIPSIS
+            View the evaluation results for experiment:...
+        """  # noqa: E501
+        from langsmith.evaluation._runner import evaluate as evaluate_
+
+        return evaluate_(
+            target,
+            data=data,
+            evaluators=evaluators,
+            summary_evaluators=summary_evaluators,
+            metadata=metadata,
+            experiment_prefix=experiment_prefix,
+            description=description,
+            max_concurrency=max_concurrency,
+            num_repetitions=num_repetitions,
+            client=self,
+            blocking=blocking,
+            experiment=experiment,
+            upload_results=upload_results,
+        )
+
+    async def aevaluate(
+        self,
+        target: Union[ATARGET_T, AsyncIterable[dict]],
+        /,
+        data: Union[DATA_T, AsyncIterable[schemas.Example], Iterable[schemas.Example]],
+        evaluators: Optional[Sequence[Union[EVALUATOR_T, AEVALUATOR_T]]] = None,
+        summary_evaluators: Optional[Sequence[SUMMARY_EVALUATOR_T]] = None,
+        metadata: Optional[dict] = None,
+        experiment_prefix: Optional[str] = None,
+        description: Optional[str] = None,
+        max_concurrency: Optional[int] = None,
+        num_repetitions: int = 1,
+        client: Optional[langsmith.Client] = None,
+        blocking: bool = True,
+        experiment: Optional[Union[schemas.TracerSession, str, uuid.UUID]] = None,
+        upload_results: bool = True,
+    ) -> AsyncExperimentResults:
+        r"""Evaluate an async target system or function on a given dataset.
+
+        Args:
+            target (Union[AsyncCallable[[dict], dict], AsyncIterable[dict]]): The async target system or function to evaluate.
+            data (Union[DATA_T, AsyncIterable[schemas.Example]]): The dataset to evaluate on. Can be a dataset name, a list of
+                examples, an async generator of examples, or an async iterable of examples.
+            evaluators (Optional[Sequence[EVALUATOR_T]]): A list of evaluators to run
+                on each example. Defaults to None.
+            summary_evaluators (Optional[Sequence[SUMMARY_EVALUATOR_T]]): A list of summary
+                evaluators to run on the entire dataset. Defaults to None.
+            metadata (Optional[dict]): Metadata to attach to the experiment.
+                Defaults to None.
+            experiment_prefix (Optional[str]): A prefix to provide for your experiment name.
+                Defaults to None.
+            description (Optional[str]): A description of the experiment.
+            max_concurrency (Optional[int]): The maximum number of concurrent
+                evaluations to run. Defaults to None.
+            num_repetitions (int): The number of times to run the evaluation.
+                Each item in the dataset will be run and evaluated this many times.
+                Defaults to 1.
+            blocking (bool): Whether to block until the evaluation is complete.
+                Defaults to True.
+            experiment (Optional[schemas.TracerSession]): An existing experiment to
+                extend. If provided, experiment_prefix is ignored. For advanced
+                usage only.
+
+        Returns:
+            AsyncIterator[ExperimentResultRow]: An async iterator over the experiment results.
+
+        Environment:
+            - LANGSMITH_TEST_CACHE: If set, API calls will be cached to disk to save time and
+                cost during testing. Recommended to commit the cache files to your repository
+                for faster CI/CD runs.
+                Requires the 'langsmith[vcr]' package to be installed.
+
+        Examples:
+            >>> import asyncio
+            >>> from langsmith import Client
+            >>> client = Client()
+            >>> dataset = client.clone_public_dataset(
+            ...     "https://smith.langchain.com/public/419dcab2-1d66-4b94-8901-0357ead390df/d"
+            ... )
+            >>> dataset_name = "Evaluate Examples"
+
+            Basic usage:
+
+            >>> def accuracy(outputs: dict, reference_outputs: dict) -> dict:
+            ...     # Row-level evaluator for accuracy.
+            ...     pred = outputs["resposen"]
+            ...     expected = reference_outputs["answer"]
+            ...     return {"score": expected.lower() == pred.lower()}
+
+            >>> def precision(outputs: list[dict], reference_outputs: list[dict]) -> dict:
+            ...     # Experiment-level evaluator for precision.
+            ...     # TP / (TP + FP)
+            ...     predictions = [out["response"].lower() for out in outputs]
+            ...     expected = [ref["answer"].lower() for ref in reference_outputs]
+            ...     # yes and no are the only possible answers
+            ...     tp = sum([p == e for p, e in zip(predictions, expected) if p == "yes"])
+            ...     fp = sum([p == "yes" and e == "no" for p, e in zip(predictions, expected)])
+            ...     return {"score": tp / (tp + fp)}
+
+            >>> async def apredict(inputs: dict) -> dict:
+            ...     # This can be any async function or just an API call to your app.
+            ...     await asyncio.sleep(0.1)
+            ...     return {"response": "Yes"}
+            >>> results = asyncio.run(
+            ...     client.aevaluate(
+            ...         apredict,
+            ...         data=dataset_name,
+            ...         evaluators=[accuracy],
+            ...         summary_evaluators=[precision],
+            ...         experiment_prefix="My Experiment",
+            ...         description="Evaluate the accuracy of the model asynchronously.",
+            ...         metadata={
+            ...             "my-prompt-version": "abcd-1234",
+            ...         },
+            ...     )
+            ... )  # doctest: +ELLIPSIS
+            View the evaluation results for experiment:...
+
+            Evaluating over only a subset of the examples using an async generator:
+
+            >>> async def example_generator():
+            ...     examples = client.list_examples(dataset_name=dataset_name, limit=5)
+            ...     for example in examples:
+            ...         yield example
+            >>> results = asyncio.run(
+            ...     client.aevaluate(
+            ...         apredict,
+            ...         data=example_generator(),
+            ...         evaluators=[accuracy],
+            ...         summary_evaluators=[precision],
+            ...         experiment_prefix="My Subset Experiment",
+            ...         description="Evaluate a subset of examples asynchronously.",
+            ...     )
+            ... )  # doctest: +ELLIPSIS
+            View the evaluation results for experiment:...
+
+            Streaming each prediction to more easily + eagerly debug.
+
+            >>> results = asyncio.run(
+            ...     client.aevaluate(
+            ...         apredict,
+            ...         data=dataset_name,
+            ...         evaluators=[accuracy],
+            ...         summary_evaluators=[precision],
+            ...         experiment_prefix="My Streaming Experiment",
+            ...         description="Streaming predictions for debugging.",
+            ...         blocking=False,
+            ...     )
+            ... )  # doctest: +ELLIPSIS
+            View the evaluation results for experiment:...
+
+            >>> async def aenumerate(iterable):
+            ...     async for elem in iterable:
+            ...         print(elem)
+            >>> asyncio.run(aenumerate(results))
+
+            Running without concurrency:
+
+            >>> results = asyncio.run(
+            ...     client.aevaluate(
+            ...         apredict,
+            ...         data=dataset_name,
+            ...         evaluators=[accuracy],
+            ...         summary_evaluators=[precision],
+            ...         experiment_prefix="My Experiment Without Concurrency",
+            ...         description="This was run without concurrency.",
+            ...         max_concurrency=0,
+            ...     )
+            ... )  # doctest: +ELLIPSIS
+            View the evaluation results for experiment:...
+
+            Using Async evaluators:
+
+            >>> async def helpfulness(outputs: dict) -> dict:
+            ...     # Row-level evaluator for helpfulness.
+            ...     await asyncio.sleep(5)  # Replace with your LLM API call
+            ...     return {"score": outputs["output"] == "Yes"}
+
+            >>> results = asyncio.run(
+            ...     client.aevaluate(
+            ...         apredict,
+            ...         data=dataset_name,
+            ...         evaluators=[helpfulness],
+            ...         summary_evaluators=[precision],
+            ...         experiment_prefix="My Helpful Experiment",
+            ...         description="Applying async evaluators example.",
+            ...     )
+            ... )  # doctest: +ELLIPSIS
+            View the evaluation results for experiment:...
+        """  # noqa: E501
+        from langsmith.evaluation._arunner import aevaluate as aevaluate_
+
+        return await aevaluate_(
+            target,
+            data=data,
+            evaluators=evaluators,
+            summary_evaluators=summary_evaluators,
+            metadata=metadata,
+            experiment_prefix=experiment_prefix,
+            description=description,
+            max_concurrency=max_concurrency,
+            num_repetitions=num_repetitions,
+            client=self,
+            blocking=blocking,
+            experiment=experiment,
+            upload_results=upload_results,
+        )
 
 
 def convert_prompt_to_openai_format(

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -6262,7 +6262,7 @@ class Client:
             blocking=blocking,
             experiment=experiment,
             upload_results=upload_results,
-            *kwargs,
+            **kwargs,
         )
 
 

--- a/python/langsmith/evaluation/_runner.py
+++ b/python/langsmith/evaluation/_runner.py
@@ -95,7 +95,7 @@ EXPERIMENT_T = Union[str, uuid.UUID, schemas.TracerSession]
 def evaluate(
     target: Union[TARGET_T, Runnable, EXPERIMENT_T],
     /,
-    data: DATA_T,
+    data: Optional[DATA_T] = None,
     evaluators: Optional[Sequence[EVALUATOR_T]] = None,
     summary_evaluators: Optional[Sequence[SUMMARY_EVALUATOR_T]] = None,
     metadata: Optional[dict] = None,
@@ -115,7 +115,7 @@ def evaluate(
 def evaluate(
     target: Union[Tuple[EXPERIMENT_T, EXPERIMENT_T]],
     /,
-    data: DATA_T,
+    data: Optional[DATA_T] = None,
     evaluators: Optional[Sequence[COMPARATIVE_EVALUATOR_T]] = None,
     summary_evaluators: Optional[Sequence[SUMMARY_EVALUATOR_T]] = None,
     metadata: Optional[dict] = None,

--- a/python/tests/unit_tests/test_client.py
+++ b/python/tests/unit_tests/test_client.py
@@ -1966,11 +1966,6 @@ def test_pull_prompt(
 
 
 def test_evaluate_methods() -> None:
-    """For every method defined on the Client, if there is a
-
-    corresponding async method, then the async method args should be a
-    superset of the sync method args.
-    """
     client_args = set(inspect.signature(Client.evaluate).parameters).difference(
         {"self"}
     )

--- a/python/tests/unit_tests/test_client.py
+++ b/python/tests/unit_tests/test_client.py
@@ -3,6 +3,7 @@
 import asyncio
 import dataclasses
 import gc
+import inspect
 import io
 import itertools
 import json
@@ -262,8 +263,8 @@ def test_async_methods() -> None:
     for async_method in async_methods:
         sync_method = async_method[1:]  # Remove the "a" from the beginning
         assert sync_method in sync_methods
-        sync_args = set(Client.__dict__[sync_method].__code__.co_varnames)
-        async_args = set(Client.__dict__[async_method].__code__.co_varnames)
+        sync_args = set(inspect.signature(Client.__dict__[sync_method]).parameters)
+        async_args = set(inspect.signature(Client.__dict__[async_method]).parameters)
         extra_args = sync_args - async_args
         assert not extra_args, (
             f"Extra args for {async_method} "

--- a/python/tests/unit_tests/test_client.py
+++ b/python/tests/unit_tests/test_client.py
@@ -31,7 +31,7 @@ from requests import HTTPError
 
 import langsmith.env as ls_env
 import langsmith.utils as ls_utils
-from langsmith import AsyncClient, EvaluationResult, run_trees
+from langsmith import AsyncClient, EvaluationResult, aevaluate, evaluate, run_trees
 from langsmith import schemas as ls_schemas
 from langsmith._internal import _orjson
 from langsmith._internal._serde import _serialize_json
@@ -1963,3 +1963,23 @@ def test_pull_prompt(
         assert isinstance(result, expected_prompt_type)
         if manifest_type != "structured":
             assert not isinstance(result, StructuredPrompt)
+
+
+def test_evaluate_methods() -> None:
+    """For every method defined on the Client, if there is a
+
+    corresponding async method, then the async method args should be a
+    superset of the sync method args.
+    """
+    client_args = set(inspect.signature(Client.evaluate).parameters).difference(
+        {"self"}
+    )
+    eval_args = set(inspect.signature(evaluate).parameters).difference({"client"})
+    assert client_args == eval_args
+
+    client_args = set(inspect.signature(Client.aevaluate).parameters).difference(
+        {"self"}
+    )
+    eval_args = set(inspect.signature(aevaluate).parameters).difference({"client"})
+    extra_args = client_args - eval_args
+    assert not extra_args


### PR DESCRIPTION
take: we should aim for users to not have to import/instantiate anything other than Client