### PR TITLE
feat: verbose mode for evaluate and client

### DIFF
--- a/python/langsmith/_internal/_background_thread.py
+++ b/python/langsmith/_internal/_background_thread.py
@@ -14,6 +14,7 @@ from typing import (
 )
 
 from langsmith import schemas as ls_schemas
+from langsmith import utils as ls_utils
 from langsmith._internal._constants import (
     _AUTO_SCALE_DOWN_NEMPTY_TRIGGER,
     _AUTO_SCALE_UP_NTHREADS_LIMIT,
@@ -185,7 +186,7 @@ def tracing_control_thread_func(client_ref: weakref.ref[Client]) -> None:
         ):
             new_thread = threading.Thread(
                 target=_tracing_sub_thread_func,
-                args=(weakref.ref(client), use_multipart),
+                args=(weakref.ref(client), use_multipart, client.verbose),
             )
             sub_threads.append(new_thread)
             new_thread.start()
@@ -203,6 +204,7 @@ def tracing_control_thread_func(client_ref: weakref.ref[Client]) -> None:
 def _tracing_sub_thread_func(
     client_ref: weakref.ref[Client],
     use_multipart: bool,
+    verbose: bool,
 ) -> None:
     client = client_ref()
     if client is None:
@@ -211,7 +213,7 @@ def _tracing_sub_thread_func(
         if not client.info:
             return
     except BaseException as e:
-        logger.debug("Error in tracing control thread: %s", e)
+        ls_utils.debug(verbose, "Error in tracing control thread: %s", e)
         return
     tracing_queue = client.tracing_queue
     assert tracing_queue is not None

--- a/python/langsmith/_internal/_serde.py
+++ b/python/langsmith/_internal/_serde.py
@@ -108,7 +108,7 @@ def _serialize_json(obj: Any, verbose: bool = False) -> Any:
                     pass
         return _simple_default(obj, verbose=verbose)
     except BaseException as e:
-        debug(f"Failed to serialize {type(obj)} to JSON: {e}")
+        debug(verbose, f"Failed to serialize {type(obj)} to JSON: {e}")
         return str(obj)
 
 

--- a/python/langsmith/_internal/_serde.py
+++ b/python/langsmith/_internal/_serde.py
@@ -43,7 +43,8 @@ def _simple_default(obj, verbose: bool = False) -> Any:
         elif isinstance(obj, datetime.timedelta):
             return obj.total_seconds()
         elif isinstance(obj, decimal.Decimal):
-            if obj.as_tuple().exponent >= 0:
+            exponent = obj.as_tuple().exponent
+            if isinstance(exponent, int) and exponent >= 0:
                 return int(obj)
             else:
                 return float(obj)

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -6071,6 +6071,7 @@ class Client:
             blocking=blocking,
             experiment=experiment,
             upload_results=upload_results,
+            verbose=self.verbose,
             **kwargs,
         )
 
@@ -6275,6 +6276,7 @@ class Client:
             blocking=blocking,
             experiment=experiment,
             upload_results=upload_results,
+            verbose=self.verbose,
             **kwargs,
         )
 

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -388,6 +388,7 @@ class Client:
         "_settings",
         "_manual_cleanup",
         "_pyo3_client",
+        "verbose",
     ]
 
     def __init__(

--- a/python/langsmith/env/_runtime_env.py
+++ b/python/langsmith/env/_runtime_env.py
@@ -7,7 +7,7 @@ import platform
 import subprocess
 from typing import Dict, List, Optional, Union
 
-from langsmith.utils import get_docker_compose_command
+from langsmith.utils import get_docker_compose_command, debug
 from langsmith.env._git import exec_git
 
 try:
@@ -58,7 +58,7 @@ def get_system_metrics() -> Dict[str, Union[float, dict]]:
         # If psutil is installed but not compatible with the build,
         # we'll just cease further attempts to use it.
         _PSUTIL_AVAILABLE = False
-        logger.debug("Failed to get system metrics: %s", e)
+        debug(False, "Failed to get system metrics: %s", e)
         return {}
 
 

--- a/python/langsmith/run_helpers.py
+++ b/python/langsmith/run_helpers.py
@@ -1480,7 +1480,7 @@ def _get_inputs_safe(
     try:
         return _get_inputs(signature, *args, **kwargs)
     except BaseException as e:
-        LOGGER.debug(f"Failed to get inputs for {signature}: {e}")
+        utils.debug(False, f"Failed to get inputs for {signature}: {e}")
         return {"args": args, "kwargs": kwargs}
 
 
@@ -1515,7 +1515,7 @@ def _get_inputs_and_attachments_safe(
             return inputs, attachments
         return inferred, {}
     except BaseException as e:
-        LOGGER.debug(f"Failed to get inputs for {signature}: {e}")
+        utils.debug(False, f"Failed to get inputs for {signature}: {e}")
         return {"args": args, "kwargs": kwargs}, {}
 
 

--- a/python/langsmith/run_trees.py
+++ b/python/langsmith/run_trees.py
@@ -44,6 +44,14 @@ def get_cached_client(**init_kwargs: Any) -> Client:
     if _CLIENT is None:
         if _CLIENT is None:
             _CLIENT = Client(**init_kwargs)
+    elif init_kwargs.get("verbose", False) != _CLIENT.verbose:
+        desired_verbosity = init_kwargs.get("verbose", False)
+        logger.warning(
+            "A LangSmith client has already been initialized on your process with "
+            + f"verbose={desired_verbosity}, which mismatches desired value of "
+            + f"verbose={_CLIENT.verbose}. Please explicitly create a client to avoid "
+            + "this warning."
+        )
     return _CLIENT
 
 

--- a/python/langsmith/run_trees.py
+++ b/python/langsmith/run_trees.py
@@ -48,9 +48,9 @@ def get_cached_client(**init_kwargs: Any) -> Client:
         desired_verbosity = init_kwargs.get("verbose", False)
         logger.warning(
             "A LangSmith client has already been initialized on your process with "
-            + f"verbose={desired_verbosity}, which mismatches desired value of "
-            + f"verbose={_CLIENT.verbose}. Please explicitly create a client to avoid "
-            + "this warning."
+            + f"verbose={_CLIENT.verbose}, which mismatches desired value of "
+            + f"verbose={desired_verbosity}. Please explicitly create a client "
+            + "to avoid this warning."
         )
     return _CLIENT
 

--- a/python/langsmith/utils.py
+++ b/python/langsmith/utils.py
@@ -577,7 +577,7 @@ def _middle_copy(
     return val
 
 
-def deepish_copy(val: T) -> T:
+def deepish_copy(val: T, verbose: bool = False) -> T:
     """Deep copy a value with a compromise for uncopyable objects.
 
     Args:
@@ -594,7 +594,7 @@ def deepish_copy(val: T) -> T:
         # and raise a TypeError (mentioning pickling, since the dunder methods)
         # are re-used for copying. We'll try to do a compromise and copy
         # what we can
-        _LOGGER.debug("Failed to deepcopy input: %s", repr(e))
+        debug(verbose, "Failed to deepcopy input: %s", repr(e))
         return _middle_copy(val, memo)
 
 
@@ -777,6 +777,14 @@ def get_host_url(web_url: Optional[str], api_url: str):
     else:
         link = "https://smith.langchain.com"
     return link
+
+
+def debug(verbose: bool, *args, **kwargs):
+    """Set the logger level to DEBUG if verbose is True."""
+    if verbose:
+        _LOGGER.info(*args, **kwargs)
+    else:
+        _LOGGER.debug(*args, **kwargs)
 
 
 def _get_function_name(fn: Callable, depth: int = 0) -> str:

--- a/python/langsmith/wrappers/_openai.py
+++ b/python/langsmith/wrappers/_openai.py
@@ -21,6 +21,7 @@ from typing_extensions import TypedDict
 
 from langsmith import client as ls_client
 from langsmith import run_helpers
+from langsmith import utils as ls_utils
 from langsmith.schemas import InputTokenDetails, OutputTokenDetails, UsageMetadata
 
 if TYPE_CHECKING:
@@ -209,7 +210,7 @@ def _process_chat_completion(outputs: Any):
         )
         return rdict
     except BaseException as e:
-        logger.debug(f"Error processing chat completion: {e}")
+        ls_utils.debug(False, f"Error processing chat completion: {e}")
         return {"output": outputs}
 
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "langsmith"
-version = "0.1.147"
+version = "0.1.148"
 description = "Client library to connect to the LangSmith LLM Tracing and Evaluation Platform."
 authors = ["LangChain <support@langchain.dev>"]
 license = "MIT"

--- a/python/tests/unit_tests/test_client.py
+++ b/python/tests/unit_tests/test_client.py
@@ -1966,15 +1966,21 @@ def test_pull_prompt(
 
 
 def test_evaluate_methods() -> None:
+    # Non Async
     client_args = set(inspect.signature(Client.evaluate).parameters).difference(
         {"self"}
     )
-    eval_args = set(inspect.signature(evaluate).parameters).difference({"client"})
+    eval_args = set(inspect.signature(evaluate).parameters).difference(
+        {"client", "verbose"}
+    )
     assert client_args == eval_args
 
+    # Async
     client_args = set(inspect.signature(Client.aevaluate).parameters).difference(
         {"self"}
     )
-    eval_args = set(inspect.signature(aevaluate).parameters).difference({"client"})
+    eval_args = set(inspect.signature(aevaluate).parameters).difference(
+        {"client", "verbose"}
+    )
     extra_args = client_args - eval_args
     assert not extra_args


### PR DESCRIPTION
Have you ever wanted to set your log level to debug for just the `evaluate` SDK or LangSmith `client`, but not for the entire python application you're using? Now you can, with the all-new `verbose` flag from LangSmith. 

Rejoice in a sea of error logs! 