### PR TITLE
langsmith no longer supports Python 3.8, so neither should our PyO3 code

### DIFF
--- a/.github/workflows/build_langsmith_pyo3_wheels.yml
+++ b/.github/workflows/build_langsmith_pyo3_wheels.yml
@@ -40,7 +40,7 @@ env:
   # Building wheels for Python 3.13 on Windows is broken at the moment with a linking error,
   # so we build 3.13 wheels for other platforms explicitly instead of adding 3.13 here.
   # https://github.com/PyO3/maturin-action/issues/292
-  SUPPORTED_PYTHON_VERSIONS: 'python3.8 python3.9 python3.10 python3.11 python3.12'
+  SUPPORTED_PYTHON_VERSIONS: 'python3.9 python3.10 python3.11 python3.12'
   WORKING_DIRECTORY: rust/crates/langsmith-pyo3
 
 jobs:

--- a/rust/crates/langsmith-pyo3/pyproject.toml
+++ b/rust/crates/langsmith-pyo3/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "langsmith-pyo3"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 classifiers = [
     "Programming Language :: Rust",
     "Programming Language :: Python :: Implementation :: CPython",


### PR DESCRIPTION
Drop support for Python 3.8 from the PyO3 bindings, and don't build Python 3.8 wheels when publishing.
