### PR TITLE
Add Rust implementation for Python client's `update_run()` method.

### DIFF
--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -1752,7 +1752,10 @@ class Client:
             data["events"] = events
         if data["extra"]:
             self._insert_runtime_env([data])
-        if use_multipart and self.tracing_queue is not None:
+
+        if self._pyo3_client is not None:
+            self._pyo3_client.update_run(data)
+        elif use_multipart and self.tracing_queue is not None:
             # not collecting attachments currently, use empty dict
             serialized_op = serialize_run_dict(operation="patch", payload=data)
             self.tracing_queue.put(

--- a/rust/crates/langsmith-pyo3/src/blocking_tracing_client.rs
+++ b/rust/crates/langsmith-pyo3/src/blocking_tracing_client.rs
@@ -47,8 +47,7 @@ impl BlockingTracingClient {
         Ok(Self { client: Arc::from(client) })
     }
 
-    // N.B.: We use `Py<Self>` so that we don't hold the GIL while running this method.
-    //       `slf.get()` below is only valid if the `Self` type is `Sync` and `pyclass(frozen)`,
+    // N.B.: `slf.get()` below is only valid if the `Self` type is `Sync` and `pyclass(frozen)`,
     //       which is enforced at compile-time.
     pub fn create_run(
         slf: &Bound<'_, Self>,
@@ -56,6 +55,17 @@ impl BlockingTracingClient {
     ) -> PyResult<()> {
         let unpacked = slf.get();
         Python::allow_threads(slf.py(), || unpacked.client.submit_run_create(run.into_inner()))
+            .map_err(|e| into_py_err(slf.py(), e))
+    }
+
+    // N.B.: `slf.get()` below is only valid if the `Self` type is `Sync` and `pyclass(frozen)`,
+    //       which is enforced at compile-time.
+    pub fn update_run(
+        slf: &Bound<'_, Self>,
+        run: super::py_run::RunUpdateExtended,
+    ) -> PyResult<()> {
+        let unpacked = slf.get();
+        Python::allow_threads(slf.py(), || unpacked.client.submit_run_update(run.into_inner()))
             .map_err(|e| into_py_err(slf.py(), e))
     }
 

--- a/rust/crates/langsmith-pyo3/src/py_run.rs
+++ b/rust/crates/langsmith-pyo3/src/py_run.rs
@@ -60,14 +60,17 @@ impl FromPyObject<'_> for RunUpdateExtended {
     fn extract_bound(value: &Bound<'_, PyAny>) -> PyResult<Self> {
         let run_update = value.extract::<RunUpdate>()?.into_inner();
 
-        let attachments = {
-            if let Ok(attachments_value) = value.get_item(pyo3::intern!(value.py(), "attachments"))
-            {
-                extract_attachments(&attachments_value)?
-            } else {
-                None
-            }
-        };
+        // TODO: attachments are WIP at the moment, ignore them here for now.
+        //
+        // let attachments = {
+        //     if let Ok(attachments_value) = value.get_item(pyo3::intern!(value.py(), "attachments"))
+        //     {
+        //         extract_attachments(&attachments_value)?
+        //     } else {
+        //         None
+        //     }
+        // };
+        let attachments = None;
 
         let io = RunIO {
             inputs: serialize_optional_dict_value(value, pyo3::intern!(value.py(), "inputs"))?,


### PR DESCRIPTION
Implement the `update_run()` client method in the Rust PyO3 bindings, and call it from the Python client if the Rust bindings are enabled.
