### PR TITLE
Drain the Rust client when its last copy in Python is dropped.

### DIFF
--- a/python/bench/tracing_client_via_pyo3.py
+++ b/python/bench/tracing_client_via_pyo3.py
@@ -75,7 +75,7 @@ def benchmark_run_creation(json_size, num_runs) -> None:
 
     if client._pyo3_client:
         # Wait for the queue to drain.
-        client._pyo3_client.drain()
+        del client
     else:
         client.tracing_queue.join()
 

--- a/python/bench/tracing_rust_client_bench.py
+++ b/python/bench/tracing_rust_client_bench.py
@@ -49,7 +49,7 @@ def benchmark_run_creation(num_runs: int, json_size: int, samples: int = 1) -> D
             client.create_run(run)
 
         # wait for client queues to be empty
-        client.drain()
+        del client
         elapsed = time.perf_counter() - start
 
         print(f"runs complete: {elapsed:.3f}s")

--- a/rust/crates/langsmith-tracing-client/src/client/blocking/processor.rs
+++ b/rust/crates/langsmith-tracing-client/src/client/blocking/processor.rs
@@ -55,13 +55,7 @@ impl RunProcessor {
                         }
 
                         self.drain_sender.send(()).expect("drain_sender should never fail");
-
-                        // Put this thread to sleep, so we know the remaining `Drain` messages
-                        // are almost certainly answered by other worker threads.
-                        //
-                        // HACK: This is very hacky!
-                        //       Drain should only be used for benchmarking.
-                        std::thread::sleep(Duration::from_secs(120));
+                        break;
                     }
                     _ => {
                         buffer.push(queued_run);

--- a/rust/crates/langsmith-tracing-client/src/client/run.rs
+++ b/rust/crates/langsmith-tracing-client/src/client/run.rs
@@ -93,6 +93,6 @@ pub(crate) enum QueuedRun {
     Update(RunUpdateExtended),
     #[expect(dead_code)]
     RunBytes(RunEventBytes),
-    Drain,
+    Drain, // Like `Shutdown`, but explicitly sends a message confirming draining is complete.
     Shutdown,
 }


### PR DESCRIPTION
If the Python application wants to exit (or the client just gets garbage collected), we want to finish sending any batched requests before proceeding with the GC or app shutdown.

Normally, Python will make sure to shut down any Python-side threads before allowing the program to exit. But it's completely unaware of Rust's own threads, so it can't shut them down or wait for them. This is why we need to explicitly make sure they complete their work and shut down on their own. The `Drop` trait in Rust runs when the value is dropped, and we ensure we shut down the background threads *only* when we're certain the only `Arc` copy of the Rust client is the one we're holding (and which is about to go out of scope).
