### PR TITLE
fix time for runs in convert_runs_test

### DIFF
--- a/python/langsmith/beta/_evals.py
+++ b/python/langsmith/beta/_evals.py
@@ -163,6 +163,9 @@ def convert_runs_to_test(
     )
 
     for new_run in to_create:
+        latency = new_run["end_time"] - new_run["start_time"]
+        new_run["start_time"] = datetime.datetime.now(tz=datetime.timezone.utc)
+        new_run["end_time"] = new_run["start_time"] + latency
         client.create_run(**new_run, project_name=test_project_name)
 
     _ = client.update_project(


### PR DESCRIPTION
This error occurs because the dataset examples were created AFTER the runs (which we copy to the experiment), thus the experiment cannot determine which examples to associate the experiment with which leads to the experiment view not loading.