### PR TITLE
fix: Flush zstd and correctly get buffer size

### DIFF
--- a/python/langsmith/_internal/_background_thread.py
+++ b/python/langsmith/_internal/_background_thread.py
@@ -101,7 +101,7 @@ def _tracing_thread_drain_compressed_buffer(
     assert client.compressed_runs is not None
     with client.compressed_runs.lock:
         client.compressed_runs.compressor_writer.flush()
-        current_size = client.compressed_runs.buffer.getbuffer().nbytes
+        current_size = client.compressed_runs.buffer.tell()
 
         if size_limit is not None and size_limit <= 0:
             raise ValueError(f"size_limit must be positive; got {size_limit}")

--- a/python/langsmith/_internal/_background_thread.py
+++ b/python/langsmith/_internal/_background_thread.py
@@ -100,7 +100,8 @@ def _tracing_thread_drain_compressed_buffer(
 ) -> Optional[io.BytesIO]:
     assert client.compressed_runs is not None
     with client.compressed_runs.lock:
-        current_size = client.compressed_runs.buffer.tell()
+        client.compressed_runs.compressor_writer.flush()
+        current_size = client.compressed_runs.buffer.getbuffer().nbytes
 
         if size_limit is not None and size_limit <= 0:
             raise ValueError(f"size_limit must be positive; got {size_limit}")


### PR DESCRIPTION
### Purpose 
Correctly determine the size of compressed runs buffer before checking if we should flush it.

### Changes
Periodically flush zstd buffer and get the correct size.