### PR TITLE
feat: Make size_limit (max run count per batch) globally configurable via env var

### DIFF
--- a/python/langsmith/_internal/_background_thread.py
+++ b/python/langsmith/_internal/_background_thread.py
@@ -19,7 +19,6 @@ from typing import (
 
 from langsmith import schemas as ls_schemas
 from langsmith import utils as ls_utils
-
 from langsmith._internal._constants import (
     _AUTO_SCALE_DOWN_NEMPTY_TRIGGER,
     _AUTO_SCALE_UP_NTHREADS_LIMIT,
@@ -157,6 +156,7 @@ def _tracing_thread_handle_batch(
         for _ in batch:
             tracing_queue.task_done()
 
+
 def get_size_limit_from_env() -> Optional[int]:
     size_limit_str = ls_utils.get_env_var(
         "BATCH_INGEST_SIZE_LIMIT",
@@ -165,8 +165,12 @@ def get_size_limit_from_env() -> Optional[int]:
         try:
             return int(size_limit_str)
         except ValueError:
-            logger.warning("Invalid value for BATCH_INGEST_SIZE_LIMIT: %s, continuing with default", size_limit_str)
+            logger.warning(
+                f"Invalid value for BATCH_INGEST_SIZE_LIMIT: {size_limit_str}, "
+                "continuing with default"
+            )
     return None
+
 
 def _ensure_ingest_config(
     info: ls_schemas.LangSmithInfo,


### PR DESCRIPTION
### Purpose
Compression improves run throughput and memory usage, but performance is still slower than expected for power users due to excessive threads and small payloads. SDK users can improve the throughput for larger payloads and higher trace counts by making the run count batch ingest config globally configurable.

### Changes
* Created an environment variable `LANGSMITH_BATCH_INGEST_SIZE_LIMIT` to configure run count.

* This takes precedence over the `/info` api response and any value passed directly to the client batch ingest config.

### Tests / Benchmarks
Setting a higher run count increased compressed runs throughput by **~80-100%** depending on run count and payload size.