### PR TITLE
fix: Reset buffer after sending to server

### DIFF
--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -1821,6 +1821,8 @@ class Client:
         _context: str = ""
 
         for api_url, api_key in self._write_api_urls.items():
+            data_stream.seek(0)
+
             for idx in range(1, attempts + 1):
                 try:
                     headers = {


### PR DESCRIPTION
### Purpose
Need to rewind the buffer back to the start for the next endpoint, so we send the entire data stream