### PR TITLE
fix(js): Fix traceable behavior when passing RunTree directly as first arg

### DIFF
--- a/js/src/traceable.ts
+++ b/js/src/traceable.ts
@@ -491,16 +491,14 @@ export function traceable<Func extends (...args: any[]) => any>(
       // pass in the run tree
       if (firstArg === ROOT || isRunTree(firstArg)) {
         const currentRunTree = getTracingRunTree(
-          firstArg === ROOT
-            ? new RunTree(ensuredConfig)
-            : firstArg.createChild(ensuredConfig),
+          firstArg === ROOT ? new RunTree(ensuredConfig) : firstArg,
           restArgs as Inputs,
           config?.getInvocationParams,
           processInputsFn,
           extractAttachmentsFn
         );
 
-        return [currentRunTree, [currentRunTree, ...restArgs] as Inputs];
+        return [currentRunTree, restArgs as Inputs];
       }
 
       // Node.JS uses AsyncLocalStorage (ALS) and AsyncResource


### PR DESCRIPTION
Behavior was broken - the `RunTree` should be removed from the arg list

Also uses the RunTree directly rather than creating a child run