### PR TITLE
Use zstd compression in PyO3 client bindings.

### DIFF
--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -556,6 +556,9 @@ class Client:
                 batch_size = 100
                 batch_timeout_millis = 1000
                 worker_threads = 1
+                compression_level = int(
+                    ls_utils.get_env_var("RUN_COMPRESSION_LEVEL", 3)
+                )
 
                 try:
                     self._pyo3_client = langsmith_pyo3.BlockingTracingClient(
@@ -565,6 +568,7 @@ class Client:
                         batch_size,
                         batch_timeout_millis,
                         worker_threads,
+                        compression_level,
                     )
                 except Exception as e:
                     logger.warning(

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -36,7 +36,7 @@ httpx = ">=0.23.0,<1"
 requests-toolbelt = "^1.0.0"
 
 # Enabled via `langsmith_pyo3` extra: `pip install langsmith[langsmith_pyo3]`.
-langsmith-pyo3 = { version = "^0.1.0rc2", optional = true }
+langsmith-pyo3 = { version = "^0.2.0rc1", optional = true }
 # Enabled via `compression` extra: `pip install langsmith[compression]`.
 zstandard = { version = "^0.23.0", optional = true }
 


### PR DESCRIPTION
Requires #1401 to merge first, and will need a re-lock of poetry dependencies when that happens.

Tested end-to-end by sending zstd-compressed traces to LangSmith servers.
