### PR TITLE
fix(js): remove default created_at from createExample method.

### DIFF
--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -2643,16 +2643,21 @@ export class Client implements LangSmithTracingClientInterface {
       datasetId_ = dataset.id;
     }
 
-    const createdAt_ = createdAt || new Date();
+    // Note: the created at time will be added by the langsmith server when not provided.
+    // This will ensure the timestamp will be of the standard langsmith datetime format.
+    // 2025-01-10T14:43:55.017298+00:00 i.e with 6 digits for fractional seconds.
+    const createdAt_ = createdAt
+      ? new Date(createdAt).toISOString()
+      : undefined;
     const data: ExampleCreate = {
       dataset_id: datasetId_,
       inputs,
       outputs,
-      created_at: createdAt_?.toISOString(),
       id: exampleId,
       metadata,
       split,
       source_run_id: sourceRunId,
+      ...(createdAt_ && { created_at: createdAt_ }),
     };
 
     const response = await this.caller.call(


### PR DESCRIPTION
Fixes issue: [#1399 ](https://github.com/langchain-ai/langsmith-sdk/issues/1399)  

**Issue:**
Examples created from the createExample method of the JS client are created with 3 digits of fractional seconds.

**How Issue Presents:**
The endpoint to get dataset versions ([https://api.smith.langchain.com/api/v1/datasets/{dataset_id}/version](https://api.smith.langchain.com/api/v1/datasets/%7Bdataset_id%7D/version)) always responds with 6 digits of fractional seconds.
When filtering expirements by dataset ID the langsmith frontend will use one of the resuls from the get dataset verions i.e the timestamp with 6 digits.
When a expirement is being tagged with a dataset version it will use the modified_at key of an example which if created from the JS client will only contain 3 digits of precison.

**Fix:**
Hand over the creation of the createExample created_at timestamp to langsmith server.
