### PR TITLE
Implement streaming multipart zstd compression.

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -153,6 +153,8 @@ version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f34d93e62b03caf570cccc334cbc6c2fceca82f39211051345108adcba3eebdc"
 dependencies = [
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -323,6 +325,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06ba6d68e24814cb8de6bb986db8222d3a027d15872cabc0d18817bc3c0e4471"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -397,9 +408,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "486f806e73c5707928240ddc295403b1b93c96a02038563881c4a2fd84b81ac4"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "flate2"
@@ -908,6 +919,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db69f08d4fb10524cacdb074c10b296299d71274ddbc830a8ee65666867002e9"
 
 [[package]]
+name = "jobserver"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -935,8 +955,11 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "criterion",
+ "crossbeam-channel",
+ "fastrand",
  "flate2",
  "futures",
+ "http",
  "mockito",
  "multer",
  "rayon",
@@ -949,6 +972,7 @@ dependencies = [
  "tokio-util",
  "ureq",
  "uuid",
+ "zstd",
 ]
 
 [[package]]
@@ -1179,6 +1203,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
 name = "plotters"
@@ -2443,4 +2473,32 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcf2b778a664581e31e389454a7072dab1647606d44f7feea22cd5abb9c9f3f9"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54a3ab4db68cea366acc5c897c7b4d4d1b8994a9cd6e6f841f8964566a419059"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.13+zstd.1.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38ff0f21cfee8f97d94cef41359e0c89aa6113028ab0291aa8ca0038995a95aa"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -9,8 +9,11 @@ resolver = "2"
 
 [workspace.dependencies]
 chrono = "0.4.38"
+crossbeam-channel = "0.5.14"
+fastrand = "2.3.0"
 flate2 = "1.0.34"
 futures = "0.3.31"
+http = "1.2.0"
 rayon = "1.10.0"
 serde = { version = "1.0.210", features = ["derive"] }
 serde_json = "1.0.128"
@@ -20,6 +23,7 @@ tokio = { version = "1", features = ["full"] }
 tokio-util = "0.7.12"
 ureq = "2.10.1"
 uuid = { version = "1.11.0", features = ["v4"] }
+zstd = { version = "0.13.2", features = ["zstdmt"] }
 
 # Use rustls instead of OpenSSL, because OpenSSL is a nightmare when compiling across platforms.
 # OpenSSL is a default feature, so we have to disable all default features, then re-add

--- a/rust/crates/langsmith-tracing-client/Cargo.toml
+++ b/rust/crates/langsmith-tracing-client/Cargo.toml
@@ -17,6 +17,10 @@ futures = { workspace = true }
 rayon = { workspace = true }
 ureq = { workspace = true }
 flate2 = { workspace = true }
+fastrand = { workspace = true }
+crossbeam-channel = { workspace = true }
+http = { workspace = true }
+zstd = { workspace = true }
 
 [dev-dependencies]
 multer = "3.1.0"

--- a/rust/crates/langsmith-tracing-client/src/client/errors.rs
+++ b/rust/crates/langsmith-tracing-client/src/client/errors.rs
@@ -23,3 +23,9 @@ pub enum TracingClientError {
     #[error("IO error")]
     IoError(String),
 }
+
+impl From<std::io::Error> for TracingClientError {
+    fn from(value: std::io::Error) -> Self {
+        Self::IoError(value.to_string())
+    }
+}

--- a/rust/crates/langsmith-tracing-client/src/client/mod.rs
+++ b/rust/crates/langsmith-tracing-client/src/client/mod.rs
@@ -3,6 +3,7 @@ mod run;
 
 pub mod async_enabled;
 pub mod blocking;
+pub mod streaming;
 
 pub use errors::TracingClientError;
 pub use run::{

--- a/rust/crates/langsmith-tracing-client/src/client/streaming/mod.rs
+++ b/rust/crates/langsmith-tracing-client/src/client/streaming/mod.rs
@@ -1,0 +1,6 @@
+mod multipart_writer;
+mod processor;
+mod tracing_client;
+
+pub use processor::RunProcessor;
+pub use tracing_client::{ClientConfig, TracingClient};

--- a/rust/crates/langsmith-tracing-client/src/client/streaming/multipart_writer.rs
+++ b/rust/crates/langsmith-tracing-client/src/client/streaming/multipart_writer.rs
@@ -1,0 +1,163 @@
+use std::{borrow::Cow, io::Write, path::Path};
+
+pub struct StreamingMultipart<W: Write> {
+    writer: W,
+    boundary: String,
+    empty: bool,
+}
+
+impl<W: Write> StreamingMultipart<W> {
+    pub(super) fn new(writer: W) -> Self {
+        let boundary = generate_boundary();
+        Self { writer, boundary, empty: true }
+    }
+
+    #[inline(always)]
+    pub(super) fn get_ref(&self) -> &W {
+        &self.writer
+    }
+
+    #[inline(always)]
+    pub(super) fn is_empty(&self) -> bool {
+        self.empty
+    }
+
+    #[inline(always)]
+    pub(super) fn boundary(&self) -> &str {
+        &self.boundary
+    }
+
+    /// Implement field value escaping as specified in the HTTP5 standard:
+    /// <https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#multipart-form-data>
+    ///
+    /// > - Field names, field values for non-file fields, and filenames for file fields,
+    /// >   in the generated multipart/form-data resource must be set to the result of encoding
+    /// >   the corresponding entry's name or value with encoding, converted to a byte sequence.
+    /// >
+    /// > - For field names and filenames for file fields, the result of the encoding in the
+    /// >   previous bullet point must be escaped by replacing any 0x0A (LF) bytes with
+    /// >   the byte sequence `%0A`, 0x0D (CR) with `%0D` and 0x22 (") with `%22`.
+    /// >   The user agent must not perform any other escapes.
+    fn escape_field_value(value: &str) -> Cow<'_, str> {
+        if value.contains(['"', '\n', '\r']) {
+            value.replace('"', "%22").replace('\n', "%0A").replace('\r', "%0D").into()
+        } else {
+            Cow::Borrowed(value)
+        }
+    }
+
+    pub(super) fn json_part(
+        &mut self,
+        name: &str,
+        serialized: &[u8],
+    ) -> Result<(), std::io::Error> {
+        self.empty = false;
+        let boundary = self.boundary.as_str();
+        let length = serialized.len();
+        let name = Self::escape_field_value(name);
+
+        // The HTTP5 standard prohibits the `Content-Type` header on multipart form parts
+        // that do not correspond to a file upload:
+        //   https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#multipart-form-data
+        //
+        // However, the current server-side implementation *requires* this header,
+        // so we add it anyway.
+        //
+        // `Content-Length` is explicitly prohibited in multipart parts by RFC 7578:
+        //   https://datatracker.ietf.org/doc/html/rfc7578#section-4.8
+        //
+        // However, the server-side implementation *requires* that the length is specified,
+        // so we add it anyway.
+        write!(
+            self.writer,
+            "--{boundary}\r\n\
+Content-Disposition: form-data; name=\"{name}\"\r\n\
+Content-Type: application/json\r\n\
+Content-Length: {length}\r\n\
+\r\n"
+        )?;
+
+        self.writer.write_all(serialized)?;
+        write!(self.writer, "\r\n")
+    }
+
+    pub(super) fn file_part_from_bytes(
+        &mut self,
+        name: &str,
+        file_name: &str,
+        content_type: &str,
+        contents: &[u8],
+    ) -> Result<(), std::io::Error> {
+        self.empty = false;
+        let boundary = self.boundary.as_str();
+        let length = contents.len();
+        let name = Self::escape_field_value(name);
+        let file_name = Self::escape_field_value(file_name);
+
+        // `Content-Length` is explicitly prohibited in multipart parts by RFC 7578:
+        //   https://datatracker.ietf.org/doc/html/rfc7578#section-4.8
+        //
+        // However, the server-side implementation *requires* that the length is specified,
+        // so we add it anyway.
+        write!(
+            self.writer,
+            "--{boundary}\r\n\
+Content-Disposition: form-data; name=\"{name}\"; filename=\"{file_name}\"\r\n\
+Content-Type: {content_type}\r\n\
+Content-Length: {length}\r\n\
+\r\n"
+        )?;
+
+        self.writer.write_all(contents)?;
+
+        write!(self.writer, "\r\n")
+    }
+
+    pub(super) fn file_part_from_path(
+        &mut self,
+        name: &str,
+        file_name: &str,
+        content_type: &str,
+        path: &Path,
+    ) -> Result<(), std::io::Error> {
+        self.empty = false;
+        let boundary = self.boundary.as_str();
+        let name = Self::escape_field_value(name);
+        let file_name = Self::escape_field_value(file_name);
+
+        let mut file = std::fs::File::open(path)?;
+        let metadata = file.metadata()?;
+        let file_size = metadata.len();
+
+        // `Content-Length` is explicitly prohibited in multipart parts by RFC 7578:
+        //   https://datatracker.ietf.org/doc/html/rfc7578#section-4.8
+        //
+        // However, the server-side implementation *requires* that the length is specified,
+        // so we add it anyway.
+        write!(
+            self.writer,
+            "--{boundary}\r\n\
+Content-Disposition: form-data; name=\"{name}\"; filename=\"{file_name}\"\r\n\
+Content-Type: {content_type}\r\n\
+Content-Length: {file_size}\r\n\
+\r\n"
+        )?;
+
+        std::io::copy(&mut file, &mut self.writer)?;
+
+        write!(self.writer, "\r\n")
+    }
+
+    pub(super) fn finish(mut self) -> Result<W, std::io::Error> {
+        let boundary = self.boundary.as_str();
+        write!(&mut self.writer, "--{boundary}--\r\n")?;
+        Ok(self.writer)
+    }
+}
+
+fn generate_boundary() -> String {
+    let chars: [char; 16] = std::array::from_fn(|_| fastrand::alphanumeric());
+    let mut boundary = String::with_capacity(16);
+    boundary.extend(chars);
+    boundary
+}

--- a/rust/crates/langsmith-tracing-client/src/client/streaming/processor.rs
+++ b/rust/crates/langsmith-tracing-client/src/client/streaming/processor.rs
@@ -1,0 +1,252 @@
+use std::{
+    path::Path,
+    sync::Arc,
+    time::{Duration, Instant},
+};
+
+use crate::client::{run::QueuedRun, RunCreateExtended, RunUpdateExtended, TracingClientError};
+
+use super::{multipart_writer::StreamingMultipart, ClientConfig};
+
+pub struct RunProcessor {
+    receiver: crossbeam_channel::Receiver<QueuedRun>,
+    drain_sender: crossbeam_channel::Sender<()>,
+    http_client: reqwest::blocking::Client,
+    config: Arc<ClientConfig>,
+    compression_workers: u32,
+    multipart_stream: StreamingMultipart<zstd::stream::write::Encoder<'static, Vec<u8>>>,
+}
+
+impl RunProcessor {
+    fn make_stream(
+        compression_level: i32,
+        n_workers: u32,
+    ) -> StreamingMultipart<zstd::stream::write::Encoder<'static, Vec<u8>>> {
+        // Unfortunately, the `reqwest` API doesn't seem to allow reusing this buffer
+        // since `Into<Body>` requires `&'static [u8]` and can't take an arbitrary lifetime.
+        let buffer = Vec::with_capacity(8192);
+
+        let mut compressor = zstd::stream::write::Encoder::new(buffer, compression_level)
+            .expect("failed to construct compressor");
+        compressor.multithread(n_workers).expect("failed to enable multithreading in compressor");
+
+        StreamingMultipart::new(compressor)
+    }
+
+    pub(crate) fn new(
+        receiver: crossbeam_channel::Receiver<QueuedRun>,
+        drain_sender: crossbeam_channel::Sender<()>,
+        config: Arc<ClientConfig>,
+    ) -> Self {
+        let http_client = reqwest::blocking::Client::new();
+
+        // We want to use as many threads as available cores to compress data.
+        // However, we have to be mindful of special values in the zstd library:
+        // - A setting of `0` here means "use the current thread only."
+        // - A setting of `1` means "use a separate thread, but only one."
+        //
+        // `1` isn't a useful setting for us, so turn `1` into `0` while
+        // keeping higher numbers the same.
+        let compression_workers = match std::thread::available_parallelism() {
+            Ok(num) => {
+                if num.get() == 1 {
+                    0
+                } else {
+                    num.get() as u32
+                }
+            }
+            Err(_) => {
+                // We failed to query the available number of cores.
+                // Use only the current single thread, to be safe.
+                0
+            }
+        };
+
+        let multipart_stream = Self::make_stream(config.compression_level, compression_workers);
+
+        Self { receiver, drain_sender, http_client, config, compression_workers, multipart_stream }
+    }
+
+    pub(crate) fn run(&mut self) -> Result<(), TracingClientError> {
+        let mut last_send_time = Instant::now();
+
+        loop {
+            let queued_run = { self.receiver.recv_timeout(Duration::from_millis(100)) };
+
+            match queued_run {
+                Ok(queued_run) => match queued_run {
+                    QueuedRun::Shutdown => {
+                        self.send_pending_data()?;
+                        break;
+                    }
+                    QueuedRun::Drain => {
+                        self.send_pending_data()?;
+                        self.drain_sender.send(()).expect("drain_sender should never fail");
+                        break;
+                    }
+                    _ => {
+                        self.process_new_data(queued_run)?;
+                        if self.multipart_stream.get_ref().get_ref().len()
+                            >= self.config.send_at_batch_size
+                        {
+                            self.send_pending_data()?;
+                            last_send_time = Instant::now();
+                        }
+                    }
+                },
+                Err(crossbeam_channel::RecvTimeoutError::Timeout) => {
+                    if self.multipart_stream.is_empty()
+                        && last_send_time.elapsed() >= self.config.send_at_batch_time
+                    {
+                        self.send_pending_data()?;
+                        last_send_time = Instant::now();
+                    }
+                }
+                Err(crossbeam_channel::RecvTimeoutError::Disconnected) => {
+                    // The sending part of the channel was dropped, so no further data is incoming.
+                    self.send_pending_data()?;
+                    break;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn send_pending_data(&mut self) -> Result<(), TracingClientError> {
+        if self.multipart_stream.is_empty() {
+            return Ok(());
+        }
+
+        // Start a new compression stream for future payload data, and replace the current one.
+        let next_stream =
+            Self::make_stream(self.config.compression_level, self.compression_workers);
+        let compressed_stream = std::mem::replace(&mut self.multipart_stream, next_stream);
+
+        let content_type =
+            format!("multipart/form-data; boundary={}", compressed_stream.boundary());
+        let compressed_payload = compressed_stream.finish()?.finish()?;
+
+        let response = self
+            .http_client
+            .post(format!("{}/runs/multipart", self.config.endpoint))
+            .headers(self.config.headers.as_ref().cloned().unwrap_or_default())
+            .header(http::header::CONTENT_TYPE, content_type)
+            .header(http::header::CONTENT_ENCODING, "zstd")
+            .body(compressed_payload)
+            .send()?;
+
+        if response.status().is_success() {
+            Ok(())
+        } else {
+            let status = response.status();
+            Err(TracingClientError::HttpError(status))
+        }
+    }
+
+    fn process_new_data(&mut self, queued_run: QueuedRun) -> Result<(), TracingClientError> {
+        match queued_run {
+            QueuedRun::Create(run_create_extended) => {
+                let RunCreateExtended { run_create, io, attachments } = run_create_extended;
+                let run_id = run_create.common.id.clone();
+
+                // Collect JSON data.
+                let part_name = format!("post.{}", run_id);
+                let serialized = serde_json::to_vec(&run_create).expect("serialization_failed");
+                self.multipart_stream.json_part(&part_name, &serialized)?;
+
+                // Ensure that pre-formatted JSON data represented as bytes
+                // doesn't end in trailing null bytes, since they are unnecessary
+                // in HTTP multipart requests.
+                if let Some(mut inputs) = io.inputs {
+                    if inputs.last() == Some(&0) {
+                        inputs.pop().expect("popping trailing null byte failed");
+                    }
+                    let part_name = format!("post.{}.inputs", run_id);
+                    self.multipart_stream.json_part(&part_name, &inputs)?;
+                }
+                if let Some(mut outputs) = io.outputs {
+                    if outputs.last() == Some(&0) {
+                        outputs.pop().expect("popping trailing null byte failed");
+                    }
+                    let part_name = format!("post.{}.outputs", run_id);
+                    self.multipart_stream.json_part(&part_name, &outputs)?;
+                }
+
+                if let Some(attachments) = attachments {
+                    for attachment in attachments {
+                        let part_name = format!("attachment.{}.{}", run_id, attachment.ref_name);
+                        if let Some(data) = attachment.data {
+                            self.multipart_stream.file_part_from_bytes(
+                                &part_name,
+                                &attachment.ref_name,
+                                &attachment.content_type,
+                                &data,
+                            )?;
+                        } else {
+                            self.multipart_stream.file_part_from_path(
+                                &part_name,
+                                &attachment.ref_name,
+                                &attachment.content_type,
+                                Path::new(&attachment.filename),
+                            )?;
+                        }
+                    }
+                }
+
+                Ok(())
+            }
+            QueuedRun::Update(run_update_extended) => {
+                let RunUpdateExtended { run_update, io, attachments } = run_update_extended;
+                let run_id = run_update.common.id.clone();
+
+                // Collect JSON data.
+                let part_name = format!("patch.{}", run_id);
+                let serialized = serde_json::to_vec(&run_update).expect("serialization_failed");
+                self.multipart_stream.json_part(&part_name, &serialized)?;
+
+                // Ensure that pre-formatted JSON data represented as bytes
+                // doesn't end in trailing null bytes, since they are unnecessary
+                // in HTTP multipart requests.
+                if let Some(mut outputs) = io.outputs {
+                    if outputs.last() == Some(&0) {
+                        outputs.pop().expect("popping trailing null byte failed");
+                    }
+
+                    let part_name = format!("patch.{}.outputs", run_id);
+                    self.multipart_stream.json_part(&part_name, &outputs)?;
+                }
+
+                if let Some(attachments) = attachments {
+                    for attachment in attachments {
+                        let part_name = format!("attachment.{}.{}", run_id, attachment.ref_name);
+                        if let Some(data) = attachment.data {
+                            self.multipart_stream.file_part_from_bytes(
+                                &part_name,
+                                &attachment.ref_name,
+                                &attachment.content_type,
+                                &data,
+                            )?;
+                        } else {
+                            self.multipart_stream.file_part_from_path(
+                                &part_name,
+                                &attachment.ref_name,
+                                &attachment.content_type,
+                                Path::new(&attachment.filename),
+                            )?;
+                        }
+                    }
+                }
+
+                Ok(())
+            }
+            QueuedRun::RunBytes(_) => {
+                unimplemented!("RunBytes is not supported")
+            }
+            QueuedRun::Drain => {
+                unreachable!("drain message that wasn't handled earlier");
+            }
+            QueuedRun::Shutdown => Err(TracingClientError::UnexpectedShutdown),
+        }
+    }
+}

--- a/rust/crates/langsmith-tracing-client/src/client/streaming/tracing_client.rs
+++ b/rust/crates/langsmith-tracing-client/src/client/streaming/tracing_client.rs
@@ -1,0 +1,83 @@
+use std::{sync::Arc, thread, time::Duration};
+
+use reqwest::header::{HeaderMap, HeaderValue};
+
+use crate::client::{run::QueuedRun, RunCreateExtended, RunUpdateExtended, TracingClientError};
+
+#[derive(Clone)]
+pub struct ClientConfig {
+    pub endpoint: String,
+    pub api_key: String,
+    pub send_at_batch_size: usize,
+    pub send_at_batch_time: Duration,
+    pub headers: Option<HeaderMap>,
+    pub compression_level: i32,
+}
+
+pub struct TracingClient {
+    sender: crossbeam_channel::Sender<QueuedRun>,
+    drain: crossbeam_channel::Receiver<()>,
+    worker: thread::JoinHandle<()>,
+}
+
+impl TracingClient {
+    pub fn new(mut config: ClientConfig) -> Result<Self, TracingClientError> {
+        let (sender, receiver) = crossbeam_channel::unbounded();
+        let (drain_sender, drain_receiver) = crossbeam_channel::bounded(1);
+
+        // Ensure our headers include the API key.
+        config.headers.get_or_insert_with(Default::default).append(
+            "X-API-KEY",
+            HeaderValue::from_str(&config.api_key).expect("failed to convert API key into header"),
+        );
+
+        // We're going to share the config across threads.
+        // It's immutable from this point onward, so Arc it for efficiency.
+        let config = Arc::from(config);
+
+        let worker = thread::spawn(move || {
+            let mut processor = super::RunProcessor::new(receiver, drain_sender, config);
+            processor.run().expect("run failed")
+        });
+
+        Ok(Self { sender, drain: drain_receiver, worker })
+    }
+
+    pub fn submit_run_create(&self, run: RunCreateExtended) -> Result<(), TracingClientError> {
+        let queued_run = QueuedRun::Create(run);
+
+        self.sender.send(queued_run).map_err(|_| TracingClientError::QueueFull)
+    }
+
+    pub fn submit_run_update(&self, run: RunUpdateExtended) -> Result<(), TracingClientError> {
+        let queued_run = QueuedRun::Update(run);
+
+        self.sender.send(queued_run).map_err(|_| TracingClientError::QueueFull)
+    }
+
+    /// Complete all in-progress requests, then allow the worker threads to exit.
+    ///
+    /// Convenience function for the PyO3 bindings, which cannot use [`Self::shutdown`]
+    /// due to its by-value `self`. This means we cannot `.join()` the threads,
+    /// but the client is nevertheless unusable after this call.
+    ///
+    /// Sending further data after a [`Self::drain()`] call has unspecified behavior.
+    /// It will not cause *undefined behavior* in the programming language sense,
+    /// but it may e.g. cause errors, panics, or even silently fail, with no guarantees.
+    pub fn drain(&self) -> Result<(), TracingClientError> {
+        self.sender.send(QueuedRun::Drain).map_err(|_| TracingClientError::QueueFull)?;
+        self.drain.recv().expect("failed to receive drained message");
+
+        Ok(())
+    }
+
+    pub fn shutdown(self) -> Result<(), TracingClientError> {
+        // Send a Shutdown message to worker thread
+        self.sender.send(QueuedRun::Shutdown).map_err(|_| TracingClientError::QueueFull)?;
+
+        // Wait for worker thread to finish
+        self.worker.join().unwrap();
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
Uses a hand-written streaming multipart writer that can wrap a zstd compressor, so that we try to not keep `QueuedRun` values in memory any longer than strictly necessary.

A "TODO" for tomorrow's revamp of the error types is to switch from unbounded to bounded channels and either use the `QueueFull` error variant or just block until the channel frees up. @agola11 do you have a preference one way or the other? This governs what happens in the rare instance if e.g. the server is much too slow at ingesting data and traces are piling up on the client. We can either drop data, or force the client to slow down, and this is a product-level decision.

It's a good idea to use bounded channels over unbounded ones, even if the bound is huge and shouldn't ever be hit. Bounded channels are both more efficient *and* can more gracefully handle excessive load. Unbounded channels grow until OOM and then kill the program, which is a worse experience.