### PR TITLE
Switch PyO3 to streaming zstd-compressed multipart Rust client.

### DIFF
--- a/rust/crates/langsmith-pyo3/src/blocking_tracing_client.rs
+++ b/rust/crates/langsmith-pyo3/src/blocking_tracing_client.rs
@@ -2,7 +2,9 @@ use std::{sync::Arc, time::Duration};
 
 use pyo3::prelude::*;
 
-use langsmith_tracing_client::client::blocking::TracingClient as RustTracingClient;
+use langsmith_tracing_client::client::streaming::{
+    ClientConfig as RustClientConfig, TracingClient as RustTracingClient,
+};
 
 pub(super) fn register(_py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<BlockingTracingClient>()?;
@@ -23,22 +25,17 @@ impl BlockingTracingClient {
     pub fn new(
         endpoint: String,
         api_key: String,
-        queue_capacity: usize,
         batch_size: usize,
         batch_timeout_millis: u64,
-        worker_threads: usize,
+        compression_level: i32,
     ) -> PyResult<Self> {
-        let config = langsmith_tracing_client::client::blocking::ClientConfig {
+        let config = RustClientConfig {
             endpoint,
             api_key,
-            queue_capacity,
-            batch_size,
-
-            // TODO: check if this is fine
-            batch_timeout: Duration::from_millis(batch_timeout_millis),
-
+            send_at_batch_size: batch_size,
+            send_at_batch_time: Duration::from_millis(batch_timeout_millis),
+            compression_level,
             headers: None, // TODO: support custom headers
-            num_worker_threads: worker_threads,
         };
 
         let client = RustTracingClient::new(config)

--- a/rust/crates/langsmith-pyo3/src/blocking_tracing_client.rs
+++ b/rust/crates/langsmith-pyo3/src/blocking_tracing_client.rs
@@ -25,6 +25,7 @@ impl BlockingTracingClient {
     pub fn new(
         endpoint: String,
         api_key: String,
+        queue_capacity: usize,
         batch_size: usize,
         batch_timeout_millis: u64,
         compression_level: i32,
@@ -32,6 +33,7 @@ impl BlockingTracingClient {
         let config = RustClientConfig {
             endpoint,
             api_key,
+            queue_capacity,
             send_at_batch_size: batch_size,
             send_at_batch_time: Duration::from_millis(batch_timeout_millis),
             compression_level,

--- a/rust/crates/langsmith-tracing-client/src/client/streaming/tracing_client.rs
+++ b/rust/crates/langsmith-tracing-client/src/client/streaming/tracing_client.rs
@@ -8,6 +8,7 @@ use crate::client::{run::QueuedRun, RunCreateExtended, RunUpdateExtended, Tracin
 pub struct ClientConfig {
     pub endpoint: String,
     pub api_key: String,
+    pub queue_capacity: usize,
     pub send_at_batch_size: usize,
     pub send_at_batch_time: Duration,
     pub headers: Option<HeaderMap>,
@@ -22,7 +23,7 @@ pub struct TracingClient {
 
 impl TracingClient {
     pub fn new(mut config: ClientConfig) -> Result<Self, TracingClientError> {
-        let (sender, receiver) = crossbeam_channel::unbounded();
+        let (sender, receiver) = crossbeam_channel::bounded(config.queue_capacity);
         let (drain_sender, drain_receiver) = crossbeam_channel::bounded(1);
 
         // Ensure our headers include the API key.


### PR DESCRIPTION
Builds upon #1413 and uses that functionality in the PyO3 crate.

This is a major breaking change in the API, so make it be part of a v0.2.0-rc1 release.
