### PR TITLE
feat(python): Add length param to multipart requests

### DIFF
--- a/python/langsmith/_internal/_compressed_runs.py
+++ b/python/langsmith/_internal/_compressed_runs.py
@@ -1,12 +1,7 @@
 import io
 import threading
 
-try:
-    from zstandard import ZstdCompressor  # type: ignore[import]
-
-    HAVE_ZSTD = True
-except ImportError:
-    HAVE_ZSTD = False
+from zstandard import ZstdCompressor  # type: ignore[import]
 
 from langsmith import utils as ls_utils
 
@@ -20,11 +15,6 @@ class CompressedRuns:
         self.lock = threading.Lock()
         self.uncompressed_size = 0
 
-        if not HAVE_ZSTD:
-            raise ImportError(
-                "zstandard package required for compression. "
-                "Install with 'pip install langsmith[compression]'"
-            )
         self.compressor_writer = ZstdCompressor(
             level=compression_level, threads=-1
         ).stream_writer(self.buffer, closefd=False)
@@ -34,11 +24,6 @@ class CompressedRuns:
         self.run_count = 0
         self.uncompressed_size = 0
 
-        if not HAVE_ZSTD:
-            raise ImportError(
-                "zstandard package required for compression. "
-                "Install with 'pip install langsmith[compression]'"
-            )
         self.compressor_writer = ZstdCompressor(
             level=compression_level, threads=-1
         ).stream_writer(self.buffer, closefd=False)

--- a/python/langsmith/_internal/_operations.py
+++ b/python/langsmith/_internal/_operations.py
@@ -201,7 +201,7 @@ def serialized_feedback_operation_to_multipart_parts_and_context(
                 (
                     None,
                     op.feedback,
-                    "application/json",
+                    f"application/json; length={len(op.feedback)}",
                     {"Content-Length": str(len(op.feedback))},
                 ),
             )
@@ -222,7 +222,7 @@ def serialized_run_operation_to_multipart_parts_and_context(
             (
                 None,
                 op._none,
-                "application/json",
+                f"application/json; length={len(op._none)}",
                 {"Content-Length": str(len(op._none))},
             ),
         )
@@ -241,7 +241,7 @@ def serialized_run_operation_to_multipart_parts_and_context(
                 (
                     None,
                     valb,
-                    "application/json",
+                    f"application/json; length={len(valb)}",
                     {"Content-Length": str(len(valb))},
                 ),
             ),
@@ -263,7 +263,7 @@ def serialized_run_operation_to_multipart_parts_and_context(
                     (
                         None,
                         valb,
-                        content_type,
+                        f"{content_type}; length={len(valb)}",
                         {"Content-Length": str(len(valb))},
                     ),
                 )

--- a/python/langsmith/utils.py
+++ b/python/langsmith/utils.py
@@ -795,3 +795,15 @@ def _get_function_name(fn: Callable, depth: int = 0) -> str:
         return _get_function_name(fn.__call__, depth + 1)
 
     return str(fn)
+
+
+def is_truish(val: Any) -> bool:
+    """Check if the value is truish.
+
+    Args:
+        val (Any): The value to check.
+
+    Returns:
+        bool: True if the value is truish, False otherwise.
+    """
+    return val is True or val == "true" or val == "True" or val == "TRUE" or val == "1"

--- a/python/poetry.lock
+++ b/python/poetry.lock
@@ -113,7 +113,7 @@ files = [
 name = "cffi"
 version = "1.17.1"
 description = "Foreign Function Interface for Python calling C code."
-optional = true
+optional = false
 python-versions = ">=3.8"
 files = [
     {file = "cffi-1.17.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:df8b1c11f177bc2313ec4b2d46baec87a5f3e71fc8b45dab2ee7cae86d9aba14"},
@@ -1280,7 +1280,7 @@ files = [
 name = "pycparser"
 version = "2.22"
 description = "C parser in Python"
-optional = true
+optional = false
 python-versions = ">=3.8"
 files = [
     {file = "pycparser-2.22-py3-none-any.whl", hash = "sha256:c3702b6d3dd8c7abc1afa565d7e63d53a1d0bd86cdc24edd75470f4de499cfcc"},
@@ -2200,7 +2200,7 @@ propcache = ">=0.2.0"
 name = "zstandard"
 version = "0.23.0"
 description = "Zstandard bindings for Python"
-optional = true
+optional = false
 python-versions = ">=3.8"
 files = [
     {file = "zstandard-0.23.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:bf0a05b6059c0528477fba9054d09179beb63744355cab9f38059548fedd46a9"},
@@ -2309,11 +2309,10 @@ cffi = {version = ">=1.11", markers = "platform_python_implementation == \"PyPy\
 cffi = ["cffi (>=1.11)"]
 
 [extras]
-compression = ["zstandard"]
 langsmith-pyo3 = ["langsmith-pyo3"]
 vcr = []
 
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<4.0"
-content-hash = "19b288e10f9d6c040798efb74ae2778103abdc87c298b8c3eb21f7685db56642"
+content-hash = "8ea9d9d23cb55e70b8982c4b6d5292cc715b00ee1bd9b0f2cf6bffc59e9bbf54"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -38,7 +38,6 @@ requests-toolbelt = "^1.0.0"
 # Enabled via `langsmith_pyo3` extra: `pip install langsmith[langsmith_pyo3]`.
 langsmith-pyo3 = { version = "^0.1.0rc2", optional = true }
 # Enabled via `compression` extra: `pip install langsmith[compression]`.
-zstandard = { version = "^0.23.0", optional = true }
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.3.1"
@@ -66,6 +65,7 @@ pytest-socket = "^0.7.0"
 pyperf = "^2.7.0"
 py-spy = "^0.3.14"
 multipart = "^1.0.0"
+zstandard = "^0.23.0"
 
 [tool.poetry.group.lint.dependencies]
 openai = "^1.10"
@@ -77,7 +77,6 @@ pytest-socket = "^0.7.0"
 [tool.poetry.extras]
 vcr = ["vcrpy"]
 langsmith_pyo3 = ["langsmith-pyo3"]
-compression = ["zstandard"]
 
 [build-system]
 requires = ["poetry-core"]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "langsmith"
-version = "0.2.10"
+version = "0.3.0"
 description = "Client library to connect to the LangSmith LLM Tracing and Evaluation Platform."
 authors = ["LangChain <support@langchain.dev>"]
 license = "MIT"

--- a/python/tests/unit_tests/test_client.py
+++ b/python/tests/unit_tests/test_client.py
@@ -361,7 +361,7 @@ def test_create_run_mutate(
             f"post.{id_}.outputs",
         ]
         assert [p.headers.get("content-type") for p in parts] == [
-            "application/json; length=705",
+            "application/json; length=703",
             "application/json; length=108",
             "application/json; length=27",
         ]

--- a/python/tests/unit_tests/test_client.py
+++ b/python/tests/unit_tests/test_client.py
@@ -2069,3 +2069,282 @@ def test_evaluate_methods() -> None:
     eval_args = set(inspect.signature(aevaluate).parameters).difference({"client"})
     extra_args = client_args - eval_args
     assert not extra_args
+
+
+@patch("langsmith.client.requests.Session")
+def test_create_run_with_zstd_compression(mock_session_cls: mock.Mock) -> None:
+    """Test that runs are sent using zstd compression when compression is enabled."""
+    # Prepare a mocked session
+    mock_session = MagicMock()
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_session.request.return_value = mock_response
+    mock_session_cls.return_value = mock_session
+
+    with patch.dict("os.environ", {}, clear=True):
+        info = ls_schemas.LangSmithInfo(
+            version="0.6.0",
+            instance_flags={"zstd_compression_enabled": True},
+            batch_ingest_config=ls_schemas.BatchIngestConfig(
+                use_multipart_endpoint=True,
+                size_limit=1,
+                size_limit_bytes=128,
+                scale_up_nthreads_limit=4,
+                scale_up_qsize_trigger=3,
+                scale_down_nempty_trigger=1,
+            ),
+        )
+        client = Client(
+            api_url="http://localhost:1984",
+            api_key="123",
+            auto_batch_tracing=True,
+            session=mock_session,
+            info=info,
+        )
+
+        # Create a few runs with larger payloads so there's something to compress
+        for i in range(2):
+            run_id = uuid.uuid4()
+            client.create_run(
+                name=f"my_test_run_{i}",
+                run_type="llm",
+                inputs={"some_key": "some_val" * 1000},
+                id=run_id,
+                trace_id=run_id,
+                dotted_order=str(run_id),
+            )
+
+        # Let the background threads flush
+        if client.tracing_queue:
+            client.tracing_queue.join()
+        if client._futures is not None:
+            for fut in client._futures:
+                fut.result()
+
+    time.sleep(0.1)
+
+    # Inspect the calls
+    post_calls = []
+    for call_obj in mock_session.request.mock_calls:
+        if call_obj.args and call_obj.args[0] == "POST":
+            post_calls.append(call_obj)
+    assert (
+        len(post_calls) >= 1
+    ), "Expected at least one POST to the compression endpoint"
+
+    call_data = post_calls[0][2]["data"]
+
+    if hasattr(call_data, "read"):
+        call_data = call_data.read()
+
+    zstd_magic = b"\x28\xb5\x2f\xfd"
+    assert call_data.startswith(zstd_magic), (
+        "Expected the request body to start with zstd magic bytes; "
+        "it appears runs were not compressed."
+    )
+
+
+@patch("langsmith.client.requests.Session")
+def test_create_run_without_compression_support(mock_session_cls: mock.Mock) -> None:
+    """Test that runs use regular multipart when server doesn't support compression."""
+    mock_session = MagicMock()
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_session.request.return_value = mock_response
+    mock_session_cls.return_value = mock_session
+
+    with patch.dict("os.environ", {}, clear=True):
+        info = ls_schemas.LangSmithInfo(
+            version="0.6.0",
+            instance_flags={},  # No compression flag
+            batch_ingest_config=ls_schemas.BatchIngestConfig(
+                use_multipart_endpoint=True,
+                size_limit=1,
+                size_limit_bytes=128,
+                scale_up_nthreads_limit=4,
+                scale_up_qsize_trigger=3,
+                scale_down_nempty_trigger=1,
+            ),
+        )
+        client = Client(
+            api_url="http://localhost:1984",
+            api_key="123",
+            auto_batch_tracing=True,
+            session=mock_session,
+            info=info,
+        )
+
+        run_id = uuid.uuid4()
+        inputs = {"key": "there"}
+        client.create_run(
+            name="test_run",
+            run_type="llm",
+            inputs=inputs,
+            id=run_id,
+            trace_id=run_id,
+            dotted_order=str(run_id),
+        )
+
+        outputs = {"key": "hi there"}
+
+        client.update_run(
+            run_id,
+            outputs=outputs,
+            end_time=datetime.now(timezone.utc),
+            trace_id=run_id,
+            dotted_order=str(run_id),
+        )
+
+        if client.tracing_queue:
+            client.tracing_queue.join()
+
+    time.sleep(0.1)
+
+    post_calls = [
+        call_obj
+        for call_obj in mock_session.request.mock_calls
+        if call_obj.args and call_obj.args[0] == "POST"
+    ]
+    assert len(post_calls) >= 1
+
+    payloads = [
+        (call[2]["headers"], call[2]["data"])
+        for call in mock_session.request.mock_calls
+        if call.args and call.args[1].endswith("runs/multipart")
+    ]
+    if not payloads:
+        assert False, "No payloads found"
+
+    parts: List[MultipartPart] = []
+    for payload in payloads:
+        headers, data = payload
+        assert headers["Content-Type"].startswith("multipart/form-data")
+        assert isinstance(data, bytes)
+        boundary = parse_options_header(headers["Content-Type"])[1]["boundary"]
+        parser = MultipartParser(io.BytesIO(data), boundary)
+        parts.extend(parser.parts())
+
+    assert [p.name for p in parts] == [
+        f"post.{run_id}",
+        f"post.{run_id}.inputs",
+        f"post.{run_id}.outputs",
+    ]
+    assert [p.headers.get("content-type") for p in parts] == [
+        "application/json",
+        "application/json",
+        "application/json",
+    ]
+
+    outputs_parsed = json.loads(parts[2].value)
+    assert outputs_parsed == outputs
+    inputs_parsed = json.loads(parts[1].value)
+    assert inputs_parsed == inputs
+    run_parsed = json.loads(parts[0].value)
+    assert run_parsed["trace_id"] == str(run_id)
+    assert run_parsed["dotted_order"] == str(run_id)
+
+
+@patch("langsmith.client.requests.Session")
+def test_create_run_with_disabled_compression(mock_session_cls: mock.Mock) -> None:
+    """Test that runs use regular multipart when compression is explicitly disabled."""
+
+    # Clear the cache to ensure the environment variable is re-evaluated
+    ls_utils.get_env_var.cache_clear()
+
+    mock_session = MagicMock()
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_session.request.return_value = mock_response
+    mock_session_cls.return_value = mock_session
+
+    with patch.dict(
+        "os.environ", {"LANGSMITH_DISABLE_RUN_COMPRESSION": "true"}, clear=True
+    ):
+        info = ls_schemas.LangSmithInfo(
+            version="0.6.0",
+            instance_flags={"zstd_compression_enabled": True},  # Enabled on server
+            batch_ingest_config=ls_schemas.BatchIngestConfig(
+                use_multipart_endpoint=True,
+                size_limit=1,
+                size_limit_bytes=128,
+                scale_up_nthreads_limit=4,
+                scale_up_qsize_trigger=3,
+                scale_down_nempty_trigger=1,
+            ),
+        )
+        client = Client(
+            api_url="http://localhost:1984",
+            api_key="123",
+            auto_batch_tracing=True,
+            session=mock_session,
+            info=info,
+        )
+
+        run_id = uuid.uuid4()
+        inputs = {"key": "there"}
+        client.create_run(
+            name="test_run",
+            run_type="llm",
+            inputs=inputs,
+            id=run_id,
+            trace_id=run_id,
+            dotted_order=str(run_id),
+        )
+
+        outputs = {"key": "hi there"}
+        client.update_run(
+            run_id,
+            outputs=outputs,
+            end_time=datetime.now(timezone.utc),
+            trace_id=run_id,
+            dotted_order=str(run_id),
+        )
+
+        # Let the background threads flush
+        if client.tracing_queue:
+            client.tracing_queue.join()
+
+    time.sleep(0.1)
+
+    post_calls = [
+        call_obj
+        for call_obj in mock_session.request.mock_calls
+        if call_obj.args and call_obj.args[0] == "POST"
+    ]
+    assert len(post_calls) >= 1
+
+    payloads = [
+        (call[2]["headers"], call[2]["data"])
+        for call in mock_session.request.mock_calls
+        if call.args and call.args[1].endswith("runs/multipart")
+    ]
+    if not payloads:
+        assert False, "No payloads found"
+
+    parts: List[MultipartPart] = []
+    for payload in payloads:
+        headers, data = payload
+        assert headers["Content-Type"].startswith("multipart/form-data")
+        assert isinstance(data, bytes)
+        boundary = parse_options_header(headers["Content-Type"])[1]["boundary"]
+        parser = MultipartParser(io.BytesIO(data), boundary)
+        parts.extend(parser.parts())
+
+    assert [p.name for p in parts] == [
+        f"post.{run_id}",
+        f"post.{run_id}.inputs",
+        f"post.{run_id}.outputs",
+    ]
+    assert [p.headers.get("content-type") for p in parts] == [
+        "application/json",
+        "application/json",
+        "application/json",
+    ]
+
+    outputs_parsed = json.loads(parts[2].value)
+    assert outputs_parsed == outputs
+    inputs_parsed = json.loads(parts[1].value)
+    assert inputs_parsed == inputs
+    run_parsed = json.loads(parts[0].value)
+    assert run_parsed["trace_id"] == str(run_id)
+    assert run_parsed["dotted_order"] == str(run_id)

--- a/python/tests/unit_tests/test_client.py
+++ b/python/tests/unit_tests/test_client.py
@@ -361,9 +361,9 @@ def test_create_run_mutate(
             f"post.{id_}.outputs",
         ]
         assert [p.headers.get("content-type") for p in parts] == [
-            "application/json",
-            "application/json",
-            "application/json",
+            "application/json; length=705",
+            "application/json; length=108",
+            "application/json; length=27",
         ]
         outputs_parsed = json.loads(parts[2].value)
         assert outputs_parsed == outputs
@@ -2230,9 +2230,9 @@ def test_create_run_without_compression_support(mock_session_cls: mock.Mock) -> 
         f"post.{run_id}.outputs",
     ]
     assert [p.headers.get("content-type") for p in parts] == [
-        "application/json",
-        "application/json",
-        "application/json",
+        "application/json; length=715",
+        "application/json; length=15",
+        "application/json; length=18",
     ]
 
     outputs_parsed = json.loads(parts[2].value)
@@ -2336,9 +2336,9 @@ def test_create_run_with_disabled_compression(mock_session_cls: mock.Mock) -> No
         f"post.{run_id}.outputs",
     ]
     assert [p.headers.get("content-type") for p in parts] == [
-        "application/json",
-        "application/json",
-        "application/json",
+        "application/json; length=715",
+        "application/json; length=15",
+        "application/json; length=18",
     ]
 
     outputs_parsed = json.loads(parts[2].value)

--- a/python/tests/unit_tests/test_run_helpers.py
+++ b/python/tests/unit_tests/test_run_helpers.py
@@ -1803,7 +1803,7 @@ def test_traceable_input_attachments():
         _, (mime_type1, content1) = next(
             data for data in datas if data[0] == f"attachment.{trace_id}.att1"
         )
-        assert mime_type1 == "text/plain"
+        assert mime_type1 == "text/plain; length=20000000"
         assert content1 == long_content
 
         _, (mime_type2, content2) = next(

--- a/python/tests/unit_tests/test_run_helpers.py
+++ b/python/tests/unit_tests/test_run_helpers.py
@@ -1809,14 +1809,14 @@ def test_traceable_input_attachments():
         _, (mime_type2, content2) = next(
             data for data in datas if data[0] == f"attachment.{trace_id}.att2"
         )
-        assert mime_type2 == "application/octet-stream"
+        assert mime_type2 == "application/octet-stream; length=8"
         assert content2 == b"content2"
 
         # Assert that anoutput is uploaded
         _, (mime_type_output, content_output) = next(
             data for data in datas if data[0] == f"attachment.{trace_id}.anoutput"
         )
-        assert mime_type_output == "text/plain"
+        assert mime_type_output == "text/plain; length=446"
         assert content_output == b"noidea"
 
 

--- a/python/tests/unit_tests/test_run_helpers.py
+++ b/python/tests/unit_tests/test_run_helpers.py
@@ -1816,7 +1816,7 @@ def test_traceable_input_attachments():
         _, (mime_type_output, content_output) = next(
             data for data in datas if data[0] == f"attachment.{trace_id}.anoutput"
         )
-        assert mime_type_output == "text/plain; length=446"
+        assert mime_type_output == "text/plain; length=6"
         assert content_output == b"noidea"
 
 


### PR DESCRIPTION
### Purpose
Go's multipart form parsing implementation differs from Python. It does not handle Content-Length headers for individual form parts. To migrate to our Go ingest service, we need to attach the length of each part in the request.

### Changes
1. Added length parameter for all multipart form parts
1. JS clients already include a length parameter
1. Maintain `Content-Length` header for backwards compatibility with existing python backend service