### PR TITLE
fix(js): Use absolute links

### DIFF
--- a/js/typedoc.json
+++ b/js/typedoc.json
@@ -24,4 +24,5 @@
   "skipErrorChecking": false,
   "exclude": ["dist"],
   "hostedBaseUrl": "https://docs.smith.langchain.com/reference/js/",
+  "useHostedBaseUrlForAbsoluteLinks": true
 }


### PR DESCRIPTION
Needed because LangSmith docs enforce NO trailing slash

CC @agola11 