### PR TITLE
Compress create feedback

### DIFF
--- a/python/langsmith/_internal/_background_thread.py
+++ b/python/langsmith/_internal/_background_thread.py
@@ -123,7 +123,9 @@ def _tracing_thread_drain_compressed_buffer(
             return None, None
 
         # Write final boundary and close compression stream
-        client.compressed_traces.compressor_writer.write(f"--{_BOUNDARY}--\r\n".encode())
+        client.compressed_traces.compressor_writer.write(
+            f"--{_BOUNDARY}--\r\n".encode()
+        )
         client.compressed_traces.compressor_writer.close()
 
         filled_buffer = client.compressed_traces.buffer
@@ -343,9 +345,9 @@ def tracing_control_thread_func_compress_parallel(
         if triggered:
             client._data_available_event.clear()
 
-            data_stream, compressed_traces_info = _tracing_thread_drain_compressed_buffer(
-                client, size_limit, size_limit_bytes
-            )
+            data_stream, compressed_traces_info = (
+                _tracing_thread_drain_compressed_buffer
+            )(client, size_limit, size_limit_bytes)
             # If we have data, submit the send request
             if data_stream is not None:
                 try:

--- a/python/langsmith/_internal/_compressed_traces.py
+++ b/python/langsmith/_internal/_compressed_traces.py
@@ -8,10 +8,10 @@ from langsmith import utils as ls_utils
 compression_level = ls_utils.get_env_var("RUN_COMPRESSION_LEVEL", 3)
 
 
-class CompressedRuns:
+class CompressedTraces:
     def __init__(self):
         self.buffer = io.BytesIO()
-        self.run_count = 0
+        self.trace_count = 0
         self.lock = threading.Lock()
         self.uncompressed_size = 0
 
@@ -21,7 +21,7 @@ class CompressedRuns:
 
     def reset(self):
         self.buffer = io.BytesIO()
-        self.run_count = 0
+        self.trace_count = 0
         self.uncompressed_size = 0
 
         self.compressor_writer = ZstdCompressor(

--- a/python/langsmith/_internal/_operations.py
+++ b/python/langsmith/_internal/_operations.py
@@ -9,7 +9,7 @@ from typing import Dict, Literal, Optional, Union, cast
 
 from langsmith import schemas as ls_schemas
 from langsmith._internal import _orjson
-from langsmith._internal._compressed_runs import CompressedRuns
+from langsmith._internal._compressed_traces import CompressedTraces
 from langsmith._internal._multipart import MultipartPart, MultipartPartsAndContext
 from langsmith._internal._serde import dumps_json as _dumps_json
 
@@ -294,7 +294,7 @@ def serialized_run_operation_to_multipart_parts_and_context(
 
 def compress_multipart_parts_and_context(
     parts_and_context: MultipartPartsAndContext,
-    compressed_runs: CompressedRuns,
+    compressed_traces: CompressedTraces,
     boundary: str,
 ) -> None:
     for part_name, (filename, data, content_type, headers) in parts_and_context.parts:
@@ -314,18 +314,18 @@ def compress_multipart_parts_and_context(
             ]
         )
 
-        compressed_runs.compressor_writer.write("".join(header_parts).encode())
+        compressed_traces.compressor_writer.write("".join(header_parts).encode())
 
         if isinstance(data, (bytes, bytearray)):
-            compressed_runs.uncompressed_size += len(data)
-            compressed_runs.compressor_writer.write(data)
+            compressed_traces.uncompressed_size += len(data)
+            compressed_traces.compressor_writer.write(data)
         else:
             if isinstance(data, BufferedReader):
                 encoded_data = data.read()
             else:
                 encoded_data = str(data).encode()
-            compressed_runs.uncompressed_size += len(encoded_data)
-            compressed_runs.compressor_writer.write(encoded_data)
+            compressed_traces.uncompressed_size += len(encoded_data)
+            compressed_traces.compressor_writer.write(encoded_data)
 
         # Write part terminator
-        compressed_runs.compressor_writer.write(b"\r\n")
+        compressed_traces.compressor_writer.write(b"\r\n")

--- a/python/langsmith/_internal/_operations.py
+++ b/python/langsmith/_internal/_operations.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 import itertools
 import logging
 import os
@@ -292,6 +291,7 @@ def serialized_run_operation_to_multipart_parts_and_context(
         opened_files_dict,
     )
 
+
 def encode_multipart_parts_and_context(
     parts_and_context: MultipartPartsAndContext,
     boundary: str,
@@ -314,6 +314,7 @@ def encode_multipart_parts_and_context(
         )
 
         yield ("".join(header_parts).encode(), data)
+
 
 def compress_multipart_parts_and_context(
     parts_and_context: MultipartPartsAndContext,

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -1850,10 +1850,14 @@ class Client:
                         "Content-Type": f"multipart/form-data; boundary={_BOUNDARY}",
                         "Content-Encoding": "zstd",
                         "X-Pre-Compressed-Size": (
-                            str(compressed_traces_info[0]) if compressed_traces_info else ""
+                            str(compressed_traces_info[0])
+                            if compressed_traces_info
+                            else ""
                         ),
                         "X-Post-Compressed-Size": (
-                            str(compressed_traces_info[1]) if compressed_traces_info else ""
+                            str(compressed_traces_info[1])
+                            if compressed_traces_info
+                            else ""
                         ),
                     }
 
@@ -5295,13 +5299,17 @@ class Client:
                 use_multipart
                 and self.info.version  # TODO: Remove version check once versions have updated
                 and ls_utils.is_version_greater_or_equal(self.info.version, "0.8.10")
-                and (self.tracing_queue is not None or self.compressed_traces is not None)
+                and (
+                    self.tracing_queue is not None or self.compressed_traces is not None
+                )
                 and feedback.trace_id is not None
             ):
                 serialized_op = serialize_feedback_dict(feedback)
                 if self.compressed_traces is not None:
-                    multipart_form = serialized_feedback_operation_to_multipart_parts_and_context(
-                        serialized_op
+                    multipart_form = (
+                        serialized_feedback_operation_to_multipart_parts_and_context(
+                            serialized_op
+                        )
                     )
                     with self.compressed_traces.lock:
                         compress_multipart_parts_and_context(

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -5295,7 +5295,7 @@ class Client:
                 use_multipart
                 and self.info.version  # TODO: Remove version check once versions have updated
                 and ls_utils.is_version_greater_or_equal(self.info.version, "0.8.10")
-                and self.tracing_queue is not None
+                and (self.tracing_queue is not None or self.compressed_traces is not None)
                 and feedback.trace_id is not None
             ):
                 serialized_op = serialize_feedback_dict(feedback)
@@ -5310,7 +5310,8 @@ class Client:
                             _BOUNDARY,
                         )
                         self.compressed_traces.trace_count += 1
-                        self._data_available_event.set()
+                        if self._data_available_event:
+                            self._data_available_event.set()
                 elif self.tracing_queue is not None:
                     self.tracing_queue.put(
                         TracingQueueItem(str(feedback.id), serialized_op)

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -5299,9 +5299,22 @@ class Client:
                 and feedback.trace_id is not None
             ):
                 serialized_op = serialize_feedback_dict(feedback)
-                self.tracing_queue.put(
-                    TracingQueueItem(str(feedback.id), serialized_op)
-                )
+                if self.compressed_traces is not None:
+                    multipart_form = serialized_feedback_operation_to_multipart_parts_and_context(
+                        serialized_op
+                    )
+                    with self.compressed_traces.lock:
+                        compress_multipart_parts_and_context(
+                            multipart_form,
+                            self.compressed_traces,
+                            _BOUNDARY,
+                        )
+                        self.compressed_traces.trace_count += 1
+                        self._data_available_event.set()
+                elif self.tracing_queue is not None:
+                    self.tracing_queue.put(
+                        TracingQueueItem(str(feedback.id), serialized_op)
+                    )
             else:
                 feedback_block = _dumps_json(feedback.dict(exclude_none=True))
                 self.request_with_retries(

--- a/python/tests/unit_tests/test_client.py
+++ b/python/tests/unit_tests/test_client.py
@@ -2145,6 +2145,83 @@ def test_create_run_with_zstd_compression(mock_session_cls: mock.Mock) -> None:
 
 
 @patch("langsmith.client.requests.Session")
+def test_create_feedback_with_zstd_compression(mock_session_cls: mock.Mock) -> None:
+    """Test that feedback is sent using zstd compression when compression is enabled."""
+    # Prepare a mocked session
+    mock_session = MagicMock()
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_session.request.return_value = mock_response
+    mock_session_cls.return_value = mock_session
+
+    with patch.dict("os.environ", {}, clear=True):
+        info = ls_schemas.LangSmithInfo(
+            version="0.8.11",
+            instance_flags={"zstd_compression_enabled": True},
+            batch_ingest_config=ls_schemas.BatchIngestConfig(
+                use_multipart_endpoint=True,
+                size_limit=1,
+                size_limit_bytes=128,
+                scale_up_nthreads_limit=4,
+                scale_up_qsize_trigger=3,
+                scale_down_nempty_trigger=1,
+            ),
+        )
+        client = Client(
+            api_url="http://localhost:1984",
+            api_key="123",
+            auto_batch_tracing=True,
+            session=mock_session,
+            info=info,
+        )
+
+        # Create a few runs with larger payloads so there's something to compress
+        run_id = uuid.uuid4()
+
+        feedback_data = {
+            "comment": "test comment",
+            "score": 0.95,
+        }
+        client.create_feedback(
+            run_id=run_id, key="test_key", trace_id=run_id, **feedback_data
+        )
+
+        # Let the background threads flush
+        if client.tracing_queue:
+            client.tracing_queue.join()
+        if client._futures is not None:
+            for fut in client._futures:
+                fut.result()
+
+        time.sleep(0.1)
+
+    # Inspect the calls
+    post_calls = [
+        call_obj
+        for call_obj in mock_session.request.mock_calls
+        if call_obj.args and call_obj.args[0] == "POST"
+    ]
+    assert len(post_calls) == 1, "Expected exactly one POST request"
+
+    call_data = post_calls[0][2]["data"]
+    if hasattr(call_data, "read"):
+        call_data = call_data.read()
+
+    # Check for zstd magic bytes
+    zstd_magic = b"\x28\xb5\x2f\xfd"
+    assert call_data.startswith(zstd_magic), (
+        "Expected the request body to start with zstd magic bytes; "
+        "it appears feedback was not compressed."
+    )
+
+    # Verify Content-Encoding header
+    headers = post_calls[0][2]["headers"]
+    assert (
+        headers.get("Content-Encoding") == "zstd"
+    ), "Expected Content-Encoding header to be 'zstd'"
+
+
+@patch("langsmith.client.requests.Session")
 def test_create_run_without_compression_support(mock_session_cls: mock.Mock) -> None:
     """Test that runs use regular multipart when server doesn't support compression."""
     mock_session = MagicMock()
@@ -2348,80 +2425,3 @@ def test_create_run_with_disabled_compression(mock_session_cls: mock.Mock) -> No
     run_parsed = json.loads(parts[0].value)
     assert run_parsed["trace_id"] == str(run_id)
     assert run_parsed["dotted_order"] == str(run_id)
-
-
-@patch("langsmith.client.requests.Session")
-def test_create_feedback_with_zstd_compression(mock_session_cls: mock.Mock) -> None:
-    """Test that feedback is sent using zstd compression when compression is enabled."""
-    # Prepare a mocked session
-    mock_session = MagicMock()
-    mock_response = MagicMock()
-    mock_response.status_code = 200
-    mock_session.request.return_value = mock_response
-    mock_session_cls.return_value = mock_session
-
-    with patch.dict("os.environ", {}, clear=True):
-        info = ls_schemas.LangSmithInfo(
-            version="0.8.11",
-            instance_flags={"zstd_compression_enabled": True},
-            batch_ingest_config=ls_schemas.BatchIngestConfig(
-                use_multipart_endpoint=True,
-                size_limit=1,
-                size_limit_bytes=128,
-                scale_up_nthreads_limit=4,
-                scale_up_qsize_trigger=3,
-                scale_down_nempty_trigger=1,
-            ),
-        )
-        client = Client(
-            api_url="http://localhost:1984",
-            api_key="123",
-            auto_batch_tracing=True,
-            session=mock_session,
-            info=info,
-        )
-
-        # Create a few runs with larger payloads so there's something to compress
-        run_id = uuid.uuid4()
-
-        feedback_data = {
-            "comment": "test comment",
-            "score": 0.95,
-        }
-        client.create_feedback(
-            run_id=run_id, key="test_key", trace_id=run_id, **feedback_data
-        )
-
-        # Let the background threads flush
-        if client.tracing_queue:
-            client.tracing_queue.join()
-        if client._futures is not None:
-            for fut in client._futures:
-                fut.result()
-
-        time.sleep(0.1)
-
-    # Inspect the calls
-    post_calls = [
-        call_obj
-        for call_obj in mock_session.request.mock_calls
-        if call_obj.args and call_obj.args[0] == "POST"
-    ]
-    assert len(post_calls) == 1, "Expected exactly one POST request"
-
-    call_data = post_calls[0][2]["data"]
-    if hasattr(call_data, "read"):
-        call_data = call_data.read()
-
-    # Check for zstd magic bytes
-    zstd_magic = b"\x28\xb5\x2f\xfd"
-    assert call_data.startswith(zstd_magic), (
-        "Expected the request body to start with zstd magic bytes; "
-        "it appears feedback was not compressed."
-    )
-
-    # Verify Content-Encoding header
-    headers = post_calls[0][2]["headers"]
-    assert (
-        headers.get("Content-Encoding") == "zstd"
-    ), "Expected Content-Encoding header to be 'zstd'"

--- a/python/tests/unit_tests/test_client.py
+++ b/python/tests/unit_tests/test_client.py
@@ -15,7 +15,6 @@ import time
 import uuid
 import warnings
 import weakref
-import zstandard as zstd
 from datetime import datetime, timezone
 from enum import Enum
 from io import BytesIO
@@ -2390,10 +2389,7 @@ def test_create_feedback_with_zstd_compression(mock_session_cls: mock.Mock) -> N
             "score": 0.95,
         }
         client.create_feedback(
-            run_id=run_id,
-            key="test_key",
-            trace_id=run_id,
-            **feedback_data
+            run_id=run_id, key="test_key", trace_id=run_id, **feedback_data
         )
 
         # Let the background threads flush
@@ -2407,13 +2403,11 @@ def test_create_feedback_with_zstd_compression(mock_session_cls: mock.Mock) -> N
 
     # Inspect the calls
     post_calls = [
-        call_obj 
+        call_obj
         for call_obj in mock_session.request.mock_calls
         if call_obj.args and call_obj.args[0] == "POST"
     ]
     assert len(post_calls) == 1, "Expected exactly one POST request"
-
-    print(post_calls)
 
     call_data = post_calls[0][2]["data"]
     if hasattr(call_data, "read"):
@@ -2428,6 +2422,6 @@ def test_create_feedback_with_zstd_compression(mock_session_cls: mock.Mock) -> N
 
     # Verify Content-Encoding header
     headers = post_calls[0][2]["headers"]
-    assert headers.get("Content-Encoding") == "zstd", (
-        "Expected Content-Encoding header to be 'zstd'"
-    )
+    assert (
+        headers.get("Content-Encoding") == "zstd"
+    ), "Expected Content-Encoding header to be 'zstd'"


### PR DESCRIPTION
### Purpose
Compress feedback along with runs using the same compression buffer and background thread

### Changes
* Renamed compressed runs variables to compressed traces
* Compress feedback along with runs
* Added additional client ref to `num_refs` to account for compression bg thread.

### Tests
Tested locally to ensure feedback ingest works with and without compression
Added unit tests for feedback ingest with compression