### PR TITLE
feat(python): AsyncClient background run compression

### DIFF
--- a/python/langsmith/_internal/_compressed_runs.py
+++ b/python/langsmith/_internal/_compressed_runs.py
@@ -1,3 +1,4 @@
+import asyncio
 import io
 import threading
 
@@ -17,7 +18,6 @@ class CompressedRuns:
     def __init__(self):
         self.buffer = io.BytesIO()
         self.run_count = 0
-        self.lock = threading.Lock()
         self.uncompressed_size = 0
 
         if not HAVE_ZSTD:

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -384,6 +384,7 @@ class Client:
         "_manual_cleanup",
         "_pyo3_client",
         "compressed_runs",
+        "_compressed_runs_lock",
         "_data_available_event",
         "_futures",
     ]
@@ -479,6 +480,7 @@ class Client:
         if ls_utils.get_env_var("USE_RUN_COMPRESSION"):
             self._futures: set[cf.Future] = set()
             self.compressed_runs: Optional[CompressedRuns] = CompressedRuns()
+            self._compressed_runs_lock = threading.Lock()
             self._data_available_event = threading.Event()
         else:
             self.compressed_runs = None
@@ -1299,7 +1301,7 @@ class Client:
                         serialized_op
                     )
                 )
-                with self.compressed_runs.lock:
+                with self._compressed_runs_lock:
                     compress_multipart_parts_and_context(
                         multipart_form,
                         self.compressed_runs,
@@ -1994,7 +1996,7 @@ class Client:
                         serialized_op
                     )
                 )
-                with self.compressed_runs.lock:
+                with self._compressed_runs_lock:
                     compress_multipart_parts_and_context(
                         multipart_form,
                         self.compressed_runs,


### PR DESCRIPTION
- Updates AsyncClient with a background async task to compress runs and send them as multipart/form-data to backend
- Updates AsyncClient.create_run to handle batched submission similar to Client.create_run
- Reuses (some) code handling compression (headers and content)
- Adds a basic integration test to ensure ingest happens in this path