### PR TITLE
add inputs/outputs to root trace

### DIFF
--- a/python/langsmith/wrappers/_openai_agents.py
+++ b/python/langsmith/wrappers/_openai_agents.py
@@ -166,7 +166,11 @@ if HAVE_AGENTS:
             run_id = self._runs.pop(trace.trace_id, None)
             if run_id:
                 try:
-                    self.client.update_run(run_id=run_id, inputs=self._first_response_inputs.pop(trace.trace_id, {}), outputs=self._last_response_outputs.pop(trace.trace_id, {}))
+                    self.client.update_run(
+                        run_id=run_id,
+                        inputs=self._first_response_inputs.pop(trace.trace_id, {}),
+                        outputs=self._last_response_outputs.pop(trace.trace_id, {}),
+                    )
                 except Exception as e:
                     logger.exception(f"Error updating trace run: {e}")
 
@@ -204,8 +208,8 @@ if HAVE_AGENTS:
                 metadata["openai_trace_id"] = span.trace_id
                 metadata["openai_span_id"] = span.span_id
                 extracted["metadata"] = metadata
-                outputs=extracted.pop("outputs", {})
-                inputs=extracted.pop("inputs", {})
+                outputs = extracted.pop("outputs", {})
+                inputs = extracted.pop("inputs", {})
                 run_data: dict = dict(
                     run_id=run_id,
                     error=str(span.error) if span.error else None,
@@ -218,7 +222,9 @@ if HAVE_AGENTS:
                         span.ended_at
                     )
                 if isinstance(span.span_data, tracing.ResponseSpanData):
-                    self._first_response_inputs[span.trace_id] = self._first_response_inputs.get(span.trace_id) or inputs
+                    self._first_response_inputs[span.trace_id] = (
+                        self._first_response_inputs.get(span.trace_id) or inputs
+                    )
                     self._last_response_outputs[span.trace_id] = outputs
                 self.client.update_run(**run_data)
 

--- a/python/langsmith/wrappers/_openai_agents.py
+++ b/python/langsmith/wrappers/_openai_agents.py
@@ -136,8 +136,8 @@ if HAVE_AGENTS:
         def __init__(self, client: Optional[ls_client.Client] = None):
             self.client = client or rt.get_cached_client()
             self._runs: Dict[str, str] = {}
-            self._first_response_inputs = {}
-            self._last_response_outputs = {}
+            self._first_response_inputs: dict = {}
+            self._last_response_outputs: dict = {}
 
         def on_trace_start(self, trace: tracing.Trace) -> None:
             run_name = trace.name if trace.name else "Agent workflow"


### PR DESCRIPTION
questions i haven't really thought through yet:
- do we really only want to bubble up responses spans? could a tool be the last span (if theres a handoff?)
- should we bubble up response/tool spans to agent spans as well, not just the root trace?
- could this accidentally lead to large memory usage?
![Screenshot 2025-03-17 at 1 31 14 PM](https://github.com/user-attachments/assets/45271d59-c5d2-49c1-9842-5b544e704bfe)
