### PR TITLE
Unset parent_run in run_tree

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "langsmith"
-version = "0.3.16"
+version = "0.3.17"
 description = "Client library to connect to the LangSmith LLM Tracing and Evaluation Platform."
 authors = ["LangChain <support@langchain.dev>"]
 license = "MIT"

--- a/python/tests/integration_tests/fake_server.py
+++ b/python/tests/integration_tests/fake_server.py
@@ -12,8 +12,7 @@ fake_app.add_middleware(TracingMiddleware)
 def fake_function():
     span = get_current_run_tree()
     assert span is not None
-    parent_run = span.parent_run
-    assert parent_run is not None
+    assert span.parent_dotted_order
     assert "did-propagate" in span.tags or []
     assert span.metadata["some-cool-value"] == 42
     assert span.session_name == "distributed-tracing"
@@ -24,8 +23,7 @@ def fake_function():
 def fake_function_two(foo: str):
     span = get_current_run_tree()
     assert span is not None
-    parent_run = span.parent_run
-    assert parent_run is not None
+    assert span.parent_dotted_order
     assert "did-propagate" in (span.tags or [])
     assert span.metadata["some-cool-value"] == 42
     assert span.session_name == "distributed-tracing"
@@ -36,8 +34,7 @@ def fake_function_two(foo: str):
 def fake_function_three(foo: str):
     span = get_current_run_tree()
     assert span is not None
-    parent_run = span.parent_run
-    assert parent_run is not None
+    assert span.parent_dotted_order
     assert "did-propagate" in (span.tags or [])
     assert span.metadata["some-cool-value"] == 42
     assert span.session_name == "distributed-tracing"

--- a/python/tests/unit_tests/test_run_helpers.py
+++ b/python/tests/unit_tests/test_run_helpers.py
@@ -1296,8 +1296,7 @@ def test_from_runnable_config():
         assert rt
         assert rt.run_type == "retriever"
         assert rt.parent_run_id
-        assert rt.parent_run
-        assert rt.parent_run.run_type == "tool"
+        assert rt.parent_dotted_order
         assert rt.session_name == "foo"
         return my_grandchild_tool.invoke({"text": text}, {"run_id": gc_run_id})
 

--- a/python/tests/unit_tests/test_utils.py
+++ b/python/tests/unit_tests/test_utils.py
@@ -113,7 +113,7 @@ def test_tracing_enabled():
         assert rt
         assert rt.parent_run_id is None
         assert "." not in rt.dotted_order
-        assert rt.parent_run is None
+        assert rt.parent_dotted_order is None
         return 1
 
     @traceable


### PR DESCRIPTION
It creates a cyclic reference which slows down garbage collection and makes it easy to introduce memory leaks