### PR TITLE
feat(js): traceable types for processInputs and processOutputs

### DIFF
--- a/js/src/traceable.ts
+++ b/js/src/traceable.ts
@@ -849,6 +849,7 @@ export {
 
 export type { RunTreeLike, TraceableFunction } from "./singletons/types.js";
 
+// TEST CODE - MUST BE REMOVED BEFORE MERGING
 const singlePrimitiveArg = traceable((a: string) => a, {
   processInputs: (inputs) => ({ a: inputs.input }),
   //                ^? Readonly<{ input: string; }>


### PR DESCRIPTION
Hi,

I added some types for `processInputs` and `processOutputs` of `traceable()`.

The input types are inferred by the same logic as `runInputsToMap()`:
https://github.com/langchain-ai/langsmith-sdk/blob/0af18d33d8364767482fcd49562e0f3f6a2e3f85/js/src/traceable.ts#L32-L46

The output types follow the logic of `handleRunOutputs`:
https://github.com/langchain-ai/langsmith-sdk/blob/0af18d33d8364767482fcd49562e0f3f6a2e3f85/js/src/traceable.ts#L63-L84

I left some test code at the end of the function, so you can easily verify the type inference:

```ts
const singlePrimitiveArg = traceable((a: string) => a, {
  processInputs: (inputs) => ({ a: inputs.input }),
  //                ^? Readonly<{ input: string; }>
  processOutputs: (outputs) => ({ a: outputs.outputs }),
  //                ^? Readonly<{ outputs: string; }>
});
const singleRecordArg = traceable((a: { a: number }) => a, {
  processInputs: (inputs) => ({ a: inputs.a }),
  //                ^? Readonly<{ a: number }>
  processOutputs: (outputs) => ({ a: outputs.a }),
  //                ^? Readonly<{ a: number }>
});
const multiplePrimitiveArgs = traceable((a: string, b: number) => ({ a, b }), {
  processInputs: (inputs) => ({ a: inputs.args[0], b: inputs.args[1] }),
  //                ^? Readonly<{ args: [a: string, b: number]; }>
  processOutputs: (outputs) => ({ a: outputs.a, b: outputs.b }),
  //                ^? Readonly<{ a: string; b: number; }>
});
const multipleRecordArgs = traceable(
  (a: { a: number }, b: { b: string }) => ({ a: a.a, b: b.b }),
  {
    processInputs: (inputs) => ({ a: inputs.args[0].a, b: inputs.args[1].b }),
    //                ^? Readonly<{ args: [{ a: number }, { b: string }]; }>
    processOutputs: (outputs) => ({ a: outputs.a, b: outputs.b }),
    //                ^? Readonly<{ a: number; b: string; }>
  }
);
const noArgs = traceable(() => undefined, {
  processInputs: (inputs) => inputs,
  //                ^? Readonly<Record<string, never>>
  processOutputs: (outputs) => outputs,
  //                ^? Readonly<{ outputs: undefined; }>
});
```

If it's all good, I can remove this section before merging.