### PR TITLE
patch[python]: Accept langsmith_extras for OpenAI Agents tracing

### DIFF
--- a/python/langsmith/wrappers/_openai_agents.py
+++ b/python/langsmith/wrappers/_openai_agents.py
@@ -1,9 +1,11 @@
 import datetime
 import logging
 import uuid
-from typing import Dict, Optional
+import warnings
+from typing import Any, Dict, Optional, cast
 
 from langsmith import run_trees as rt
+from langsmith.run_helpers import _VALID_RUN_TYPES
 
 try:
     from agents import tracing  # type: ignore[import]
@@ -133,9 +135,54 @@ if HAVE_AGENTS:
                 print(result.final_output)
         """  # noqa: E501
 
-        def __init__(self, client: Optional[ls_client.Client] = None):
+        def __init__(
+            self,
+            client: Optional[ls_client.Client] = None,
+            langsmith_extra: Optional[Dict[str, Any]] = None,
+        ):
             self.client = client or rt.get_cached_client()
             self._runs: Dict[str, str] = {}
+            self._langsmith_extra = (
+                self._validate_langsmith_extra(langsmith_extra)
+                if langsmith_extra
+                else {}
+            )
+
+        def _validate_langsmith_extra(self, extra: Dict[str, Any]) -> Dict[str, Any]:
+            allowed_keys = {
+                "name",
+                "metadata",
+                "tags",
+                "project_name",
+                "client",
+                "run_type",
+            }
+            filtered_extra = {k: v for k, v in extra.items() if k in allowed_keys}
+            invalid_keys = set(extra.keys()) - allowed_keys
+            if invalid_keys:
+                logger.warning(
+                    f"Invalid keys in langsmith_extra will be ignored: {invalid_keys}. "
+                    f"Allowed keys are: {allowed_keys}"
+                )
+            if "run_type" in filtered_extra:
+                run_type = cast(ls_client.RUN_TYPE_T, filtered_extra["run_type"])
+                if run_type not in _VALID_RUN_TYPES:
+                    warnings.warn(
+                        f"Unrecognized run_type: {run_type}. "
+                        f"Must be one of: {_VALID_RUN_TYPES}."
+                        f" Did you mean to use a different name instead?"
+                    )
+                    filtered_extra.pop("run_type")
+            if "metadata" in filtered_extra:
+                metadata = filtered_extra.pop("metadata")
+                if not isinstance(metadata, dict):
+                    warnings.warn(
+                        f"metadata must be a dictionary, got {type(metadata)}. "
+                    )
+                    metadata = {}
+                filtered_extra["extra"] = {"metadata": metadata}
+
+            return filtered_extra
 
         def on_trace_start(self, trace: tracing.Trace) -> None:
             run_name = trace.name if trace.name else "Agent workflow"
@@ -144,13 +191,15 @@ if HAVE_AGENTS:
 
             try:
                 run_data: dict = dict(
-                    name=run_name,
                     inputs={},
-                    run_type="chain",
                     id=trace_run_id,
                     revision_id=None,
                 )
-                self.client.create_run(**run_data)
+                if "name" not in self._langsmith_extra:
+                    run_data["name"] = run_name
+                if "run_type" not in self._langsmith_extra:
+                    run_data["run_type"] = "chain"
+                self.client.create_run(**run_data, **self._langsmith_extra)
             except Exception as e:
                 logger.exception(f"Error creating trace run: {e}")
 
@@ -160,6 +209,13 @@ if HAVE_AGENTS:
             metadata = trace_dict.get("metadata") or {}
             if run_id:
                 try:
+                    # Merge with existing metadata if present
+                    if (
+                        "extra" in self._langsmith_extra
+                        and "metadata" in self._langsmith_extra["extra"]
+                    ):
+                        user_metadata = self._langsmith_extra["extra"]["metadata"]
+                        metadata.update(user_metadata)
                     self.client.update_run(run_id=run_id, extra={"metadata": metadata})
                 except Exception as e:
                     logger.exception(f"Error updating trace run: {e}")
@@ -175,17 +231,19 @@ if HAVE_AGENTS:
 
             try:
                 run_data: dict = dict(
-                    name=run_name,
-                    run_type=run_type,
                     id=span_run_id,
                     parent_run_id=parent_run_id,
                     inputs=extracted.get("inputs", {}),
                 )
+                if "name" not in self._langsmith_extra:
+                    run_data["name"] = run_name
+                if "run_type" not in self._langsmith_extra:
+                    run_data["run_type"] = run_type
                 if span.started_at:
                     run_data["start_time"] = datetime.datetime.fromisoformat(
                         span.started_at
                     )
-                self.client.create_run(**run_data)
+                self.client.create_run(**run_data, **self._langsmith_extra)
             except Exception as e:
                 logger.exception(f"Error creating span run: {e}")
 
@@ -194,9 +252,19 @@ if HAVE_AGENTS:
             if run_id:
                 extracted = agent_utils.extract_span_data(span)
                 metadata = extracted.get("metadata", {})
+
+                # Add OpenAI span IDs to metadata
                 metadata["openai_parent_id"] = span.parent_id
                 metadata["openai_trace_id"] = span.trace_id
                 metadata["openai_span_id"] = span.span_id
+
+                # Merge with existing metadata from langsmith_extra if it exists
+                if (
+                    "extra" in self._langsmith_extra
+                    and "metadata" in self._langsmith_extra["extra"]
+                ):
+                    user_metadata = self._langsmith_extra["extra"]["metadata"]
+                    metadata.update(user_metadata)
                 extracted["metadata"] = metadata
                 run_data: dict = dict(
                     run_id=run_id,

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "langsmith"
-version = "0.3.22"
+version = "0.3.23"
 description = "Client library to connect to the LangSmith LLM Tracing and Evaluation Platform."
 authors = ["LangChain <support@langchain.dev>"]
 license = "MIT"


### PR DESCRIPTION
### Purpose
Allow users to customize run parameters when tracing OpenAI Agents, similar to `with tracing_context`

### Changes
Adds ability to pass in additional run params to the tracing processor which allows customizing the following run creation parameters: `client`, `project_name`, `name`, `tags`, and `metadata`when tracing OpenAI Agents. 

Validates the input parameters, merge metadata with existing trace metadata, and propagate the extras to parent trace.