### PR TITLE
fix(py): Relax integration tests

### DIFF
--- a/python/tests/integration_tests/test_client.py
+++ b/python/tests/integration_tests/test_client.py
@@ -961,7 +961,7 @@ def test_multipart_ingest_create_with_attachments(
         assert not caplog.records
         wait_for(lambda: _get_run(str(trace_a_id), langchain_client))
         created_run = langchain_client.read_run(run_id=str(trace_a_id))
-        assert sorted(created_run.attachments.keys()) == sorted(["foo", "bar"])
+        assert all(key in created_run.attachments.keys() for key in ["foo", "bar"])
         assert created_run.attachments["foo"]["reader"].read() == b"bar"
         assert (
             created_run.attachments["bar"]["reader"].read()

--- a/python/tests/integration_tests/test_client.py
+++ b/python/tests/integration_tests/test_client.py
@@ -1000,7 +1000,7 @@ def test_multipart_ingest_update_with_attachments_no_paths(
         wait_for(lambda: _get_run(str(trace_a_id), langchain_client))
         created_run = langchain_client.read_run(run_id=str(trace_a_id))
         assert created_run.attachments
-        assert sorted(created_run.attachments.keys()) == sorted(["foo", "bar"])
+        assert all(key in created_run.attachments.keys() for key in ["foo", "bar"])
         assert created_run.attachments["foo"]["reader"].read() == b"bar"
         assert created_run.attachments["bar"]["reader"].read() == b"bar"
 

--- a/python/tests/integration_tests/test_runs.py
+++ b/python/tests/integration_tests/test_runs.py
@@ -261,7 +261,10 @@ async def test_nested_async_runs_with_threadpool(langchain_client: Client):
     # sort by dotted_order
     runs = sorted(runs, key=lambda run: run.dotted_order)
     trace_runs = sorted(trace_runs, key=lambda run: run.dotted_order)
-    assert runs == trace_runs
+    assert len(runs) == len(trace_runs)
+    assert all(
+        run.dict() == trace_run.dict() for run, trace_run in zip(runs, trace_runs)
+    )
     # Check that all instances of async_llm have a parent with
     # the same name (my_tool_run)
     name_to_ids_map = defaultdict(list)

--- a/python/tests/integration_tests/test_runs.py
+++ b/python/tests/integration_tests/test_runs.py
@@ -262,9 +262,13 @@ async def test_nested_async_runs_with_threadpool(langchain_client: Client):
     runs = sorted(runs, key=lambda run: run.dotted_order)
     trace_runs = sorted(trace_runs, key=lambda run: run.dotted_order)
     assert len(runs) == len(trace_runs)
-    assert all(
-        run.dict() == trace_run.dict() for run, trace_run in zip(runs, trace_runs)
-    )
+    for run, trace_run in zip(runs, trace_runs):
+        assert run.id == trace_run.id
+        assert run.name == trace_run.name
+        assert run.run_type == trace_run.run_type
+        assert run.inputs == trace_run.inputs
+        assert run.outputs == trace_run.outputs
+
     # Check that all instances of async_llm have a parent with
     # the same name (my_tool_run)
     name_to_ids_map = defaultdict(list)


### PR DESCRIPTION
Some extra field got added, currently broken here:

https://github.com/langchain-ai/langsmith-sdk/actions/runs/14135241769/job/39620024048?pr=1613