### PR TITLE
patch[python]: Add debug logging for batch requests to LangSmith

### DIFF
--- a/python/langsmith/_internal/_background_thread.py
+++ b/python/langsmith/_internal/_background_thread.py
@@ -328,6 +328,7 @@ def tracing_control_thread_func(client_ref: weakref.ref[Client]) -> None:
             _tracing_thread_handle_batch(
                 client, tracing_queue, next_batch, use_multipart
             )
+        logger.debug("Tracing control thread is shutting down")
 
 
 def tracing_control_thread_func_compress_parallel(
@@ -456,6 +457,7 @@ def tracing_control_thread_func_compress_parallel(
 
     except Exception:
         logger.error("Error in final cleanup", exc_info=True)
+    logger.debug("Compressed traces control thread is shutting down")
 
 
 def _tracing_sub_thread_func(
@@ -506,3 +508,4 @@ def _tracing_sub_thread_func(
             _tracing_thread_handle_batch(
                 client, tracing_queue, next_batch, use_multipart
             )
+        logger.debug("Tracing control sub-thread is shutting down")

--- a/python/langsmith/_internal/_background_thread.py
+++ b/python/langsmith/_internal/_background_thread.py
@@ -129,6 +129,7 @@ def _tracing_thread_drain_compressed_buffer(
         client.compressed_traces.compressor_writer.close()
 
         filled_buffer = client.compressed_traces.buffer
+        filled_buffer.context = client.compressed_traces._context
 
         compressed_traces_info = (pre_compressed_size, current_size)
 

--- a/python/langsmith/_internal/_compressed_traces.py
+++ b/python/langsmith/_internal/_compressed_traces.py
@@ -14,6 +14,7 @@ class CompressedTraces:
         self.trace_count = 0
         self.lock = threading.Lock()
         self.uncompressed_size = 0
+        self._context = []
 
         self.compressor_writer = ZstdCompressor(
             level=compression_level, threads=-1
@@ -23,7 +24,7 @@ class CompressedTraces:
         self.buffer = io.BytesIO()
         self.trace_count = 0
         self.uncompressed_size = 0
-
+        self._context = []
         self.compressor_writer = ZstdCompressor(
             level=compression_level, threads=-1
         ).stream_writer(self.buffer, closefd=False)

--- a/python/langsmith/_internal/_operations.py
+++ b/python/langsmith/_internal/_operations.py
@@ -339,3 +339,4 @@ def compress_multipart_parts_and_context(
 
         # Write part terminator
         compressed_traces.compressor_writer.write(b"\r\n")
+    compressed_traces._context.append(parts_and_context.context)

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -822,6 +822,7 @@ class Client:
                             **request_kwargs,
                         )
                     ls_utils.raise_for_status_with_text(response)
+                    logger.debug("Request succeeded for %s %s. Context: %s", method, pathname, _context)
                     return response
                 except requests.exceptions.ReadTimeout as e:
                     logger.debug("Passing on exception %s", e)

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -1386,11 +1386,11 @@ class Client:
                         serialized_op
                     )
                 )
-                if ls_utils.is_truish(ls_utils.get_env_var("DEBUG_TRACING_QUEUE")):
-                    logger.debug(
-                        "Adding compressed multipart to queue with context: %s",
-                        multipart_form.context,
-                    )
+                logger.log(
+                    5,
+                    "Adding compressed multipart to queue with context: %s",
+                    multipart_form.context,
+                )
                 with self.compressed_traces.lock:
                     compress_multipart_parts_and_context(
                         multipart_form,
@@ -1403,12 +1403,12 @@ class Client:
                 _close_files(list(opened_files.values()))
             elif self.tracing_queue is not None:
                 serialized_op = serialize_run_dict("post", run_create)
-                if ls_utils.is_truish(ls_utils.get_env_var("DEBUG_TRACING_QUEUE")):
-                    logger.debug(
-                        "Adding to tracing queue: trace_id=%s, run_id=%s",
-                        serialized_op.trace_id,
-                        serialized_op.id,
-                    )
+                logger.log(
+                    5,
+                    "Adding to tracing queue: trace_id=%s, run_id=%s",
+                    serialized_op.trace_id,
+                    serialized_op.id,
+                )
                 self.tracing_queue.put(
                     TracingQueueItem(run_create["dotted_order"], serialized_op)
                 )
@@ -2137,11 +2137,11 @@ class Client:
                         serialized_op
                     )
                 )
-                if ls_utils.is_truish(ls_utils.get_env_var("DEBUG_TRACING_QUEUE")):
-                    logger.debug(
-                        "Adding compressed multipart to queue with context: %s",
-                        multipart_form.context,
-                    )
+                logger.log(
+                    5,
+                    "Adding compressed multipart to queue with context: %s",
+                    multipart_form.context,
+                )
                 with self.compressed_traces.lock:
                     if self._data_available_event is None:
                         raise ValueError(
@@ -2156,12 +2156,12 @@ class Client:
                     self._data_available_event.set()
                 _close_files(list(opened_files.values()))
             elif self.tracing_queue is not None:
-                if ls_utils.is_truish(ls_utils.get_env_var("DEBUG_TRACING_QUEUE")):
-                    logger.debug(
-                        "Adding to tracing queue: trace_id=%s, run_id=%s",
-                        serialized_op.trace_id,
-                        serialized_op.id,
-                    )
+                logger.log(
+                    5,
+                    "Adding to tracing queue: trace_id=%s, run_id=%s",
+                    serialized_op.trace_id,
+                    serialized_op.id,
+                )
                 self.tracing_queue.put(
                     TracingQueueItem(data["dotted_order"], serialized_op)
                 )

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -867,7 +867,7 @@ class Client:
                             )
                         elif response.status_code == 409:
                             raise ls_utils.LangSmithConflictError(
-                                f"Conflict for {pathname}. {repr(e)}" f"{_context}"
+                                f"Conflict for {pathname}. {repr(e)}{_context}"
                             )
                         else:
                             raise ls_utils.LangSmithError(
@@ -877,8 +877,7 @@ class Client:
 
                     else:
                         raise ls_utils.LangSmithUserError(
-                            f"Failed to {method} {pathname} in LangSmith API."
-                            f" {repr(e)}"
+                            f"Failed to {method} {pathname} in LangSmith API. {repr(e)}"
                         )
                 except requests.ConnectionError as e:
                     recommendation = (
@@ -1387,6 +1386,11 @@ class Client:
                         serialized_op
                     )
                 )
+                if ls_utils.is_truish(ls_utils.get_env_var("DEBUG_TRACING_QUEUE")):
+                    logger.debug(
+                        "Adding compressed multipart to queue with context: %s",
+                        multipart_form.context,
+                    )
                 with self.compressed_traces.lock:
                     compress_multipart_parts_and_context(
                         multipart_form,
@@ -1399,6 +1403,12 @@ class Client:
                 _close_files(list(opened_files.values()))
             elif self.tracing_queue is not None:
                 serialized_op = serialize_run_dict("post", run_create)
+                if ls_utils.is_truish(ls_utils.get_env_var("DEBUG_TRACING_QUEUE")):
+                    logger.debug(
+                        "Adding to tracing queue: trace_id=%s, run_id=%s",
+                        serialized_op.trace_id,
+                        serialized_op.id,
+                    )
                 self.tracing_queue.put(
                     TracingQueueItem(run_create["dotted_order"], serialized_op)
                 )
@@ -2127,6 +2137,11 @@ class Client:
                         serialized_op
                     )
                 )
+                if ls_utils.is_truish(ls_utils.get_env_var("DEBUG_TRACING_QUEUE")):
+                    logger.debug(
+                        "Adding compressed multipart to queue with context: %s",
+                        multipart_form.context,
+                    )
                 with self.compressed_traces.lock:
                     if self._data_available_event is None:
                         raise ValueError(
@@ -2141,6 +2156,12 @@ class Client:
                     self._data_available_event.set()
                 _close_files(list(opened_files.values()))
             elif self.tracing_queue is not None:
+                if ls_utils.is_truish(ls_utils.get_env_var("DEBUG_TRACING_QUEUE")):
+                    logger.debug(
+                        "Adding to tracing queue: trace_id=%s, run_id=%s",
+                        serialized_op.trace_id,
+                        serialized_op.id,
+                    )
                 self.tracing_queue.put(
                     TracingQueueItem(data["dotted_order"], serialized_op)
                 )

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "langsmith"
-version = "0.3.25rc0"
+version = "0.3.25rc2"
 description = "Client library to connect to the LangSmith LLM Tracing and Evaluation Platform."
 authors = ["LangChain <support@langchain.dev>"]
 license = "MIT"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "langsmith"
-version = "0.3.24"
+version = "0.3.25rc0"
 description = "Client library to connect to the LangSmith LLM Tracing and Evaluation Platform."
 authors = ["LangChain <support@langchain.dev>"]
 license = "MIT"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "langsmith"
-version = "0.3.27rc1"
+version = "0.3.27"
 description = "Client library to connect to the LangSmith LLM Tracing and Evaluation Platform."
 authors = ["LangChain <support@langchain.dev>"]
 license = "MIT"


### PR DESCRIPTION
### Purpose

Enabling this logging is useful for pinpointing where traces are being lost. Right now it's difficult to tell if they are making it from the sdk into LangSmith or not