### PR TITLE
patch[python]: Don't set metadata values if the value is None

### DIFF
--- a/python/langsmith/_internal/otel/_otel_exporter.py
+++ b/python/langsmith/_internal/otel/_otel_exporter.py
@@ -346,7 +346,8 @@ class OTELExporter:
         extra = run_info.get("extra", {})
         metadata = extra.get("metadata", {})
         for key, value in metadata.items():
-            span.set_attribute(f"{LANGSMITH_METADATA}.{key}", value)
+            if value is not None:
+                span.set_attribute(f"{LANGSMITH_METADATA}.{key}", value)
 
         tags = run_info.get("tags")
         if tags:

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "langsmith"
-version = "0.3.24"
+version = "0.3.25"
 description = "Client library to connect to the LangSmith LLM Tracing and Evaluation Platform."
 authors = ["LangChain <support@langchain.dev>"]
 license = "MIT"


### PR DESCRIPTION
This change fixes an issue in the LangSmith OTEL integration where metadata attributes with a value of None were being set on spans, causing errors like:

Invalid type NoneType for attribute 'langsmith.metadata.ls_temperature' value.

Changes:

Added a check to ensure that metadata values are only set if they are not None.

Bumped the package version from 0.3.24 to 0.3.25.

Resolves: https://github.com/langchain-ai/langsmith-sdk/issues/1640