### PR TITLE
chore[python]: Add thread management to main thread

### DIFF
--- a/python/langsmith/_internal/_background_thread.py
+++ b/python/langsmith/_internal/_background_thread.py
@@ -102,41 +102,48 @@ def _tracing_thread_drain_queue(
 def _tracing_thread_drain_compressed_buffer(
     client: Client, size_limit: int = 100, size_limit_bytes: int | None = 20_971_520
 ) -> Tuple[Optional[io.BytesIO], Optional[Tuple[int, int]]]:
-    if client.compressed_traces is None:
-        return None, None
-    with client.compressed_traces.lock:
-        client.compressed_traces.compressor_writer.flush()
-        current_size = client.compressed_traces.buffer.tell()
-
-        pre_compressed_size = client.compressed_traces.uncompressed_size
-
-        if size_limit is not None and size_limit <= 0:
-            raise ValueError(f"size_limit must be positive; got {size_limit}")
-        if size_limit_bytes is not None and size_limit_bytes < 0:
-            raise ValueError(
-                f"size_limit_bytes must be nonnegative; got {size_limit_bytes}"
-            )
-
-        if (size_limit_bytes is None or current_size < size_limit_bytes) and (
-            size_limit is None or client.compressed_traces.trace_count < size_limit
-        ):
+    try:
+        if client.compressed_traces is None:
             return None, None
+        with client.compressed_traces.lock:
+            client.compressed_traces.compressor_writer.flush()
+            current_size = client.compressed_traces.buffer.tell()
 
-        # Write final boundary and close compression stream
-        client.compressed_traces.compressor_writer.write(
-            f"--{_BOUNDARY}--\r\n".encode()
-        )
-        client.compressed_traces.compressor_writer.close()
+            pre_compressed_size = client.compressed_traces.uncompressed_size
 
-        filled_buffer = client.compressed_traces.buffer
-        filled_buffer.context = client.compressed_traces._context
+            if size_limit is not None and size_limit <= 0:
+                raise ValueError(f"size_limit must be positive; got {size_limit}")
+            if size_limit_bytes is not None and size_limit_bytes < 0:
+                raise ValueError(
+                    f"size_limit_bytes must be nonnegative; got {size_limit_bytes}"
+                )
 
-        compressed_traces_info = (pre_compressed_size, current_size)
+            if (size_limit_bytes is None or current_size < size_limit_bytes) and (
+                size_limit is None or client.compressed_traces.trace_count < size_limit
+            ):
+                return None, None
 
-        client.compressed_traces.reset()
+            # Write final boundary and close compression stream
+            client.compressed_traces.compressor_writer.write(
+                f"--{_BOUNDARY}--\r\n".encode()
+            )
+            client.compressed_traces.compressor_writer.close()
 
-    filled_buffer.seek(0)
-    return (filled_buffer, compressed_traces_info)
+            filled_buffer = client.compressed_traces.buffer
+            filled_buffer.context = client.compressed_traces._context
+
+            compressed_traces_info = (pre_compressed_size, current_size)
+
+            client.compressed_traces.reset()
+
+        filled_buffer.seek(0)
+        return (filled_buffer, compressed_traces_info)
+    except Exception:
+        logger.error("Error in tracing queue", exc_info=True)
+        # exceptions are logged elsewhere, but we need to make sure the
+        # background thread continues to run
+        pass
+    return None, None
 
 
 def _tracing_thread_handle_batch(

--- a/python/langsmith/_internal/_background_thread.py
+++ b/python/langsmith/_internal/_background_thread.py
@@ -269,10 +269,11 @@ def tracing_control_thread_func(client_ref: weakref.ref[Client]) -> None:
             client._futures = set()
             client.compressed_traces = CompressedTraces()
             client._data_available_event = threading.Event()
-            threading.Thread(
+            client._compress_control_thread = threading.Thread(
                 target=tracing_control_thread_func_compress_parallel,
                 args=(weakref.ref(client),),
-            ).start()
+            )
+            client._compress_control_thread.start()
 
             num_known_refs += 1
 

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -1426,7 +1426,6 @@ class Client:
                 self._ensure_thread_running(
                     "_compress_control_thread",
                     _tracing_control_thread_func_compress_parallel,
-                    weakref.ref(self),
                 )
                 with self.compressed_traces.lock:
                     compress_multipart_parts_and_context(
@@ -1442,7 +1441,6 @@ class Client:
                 self._ensure_thread_running(
                     "_tracing_control_thread",
                     _tracing_control_thread_func,
-                    weakref.ref(self),
                 )
                 serialized_op = serialize_run_dict("post", run_create)
                 logger.log(
@@ -2177,7 +2175,6 @@ class Client:
                 self._ensure_thread_running(
                     "_compress_control_thread",
                     _tracing_control_thread_func_compress_parallel,
-                    weakref.ref(self),
                 )
                 multipart_form, opened_files = (
                     serialized_run_operation_to_multipart_parts_and_context(
@@ -2212,7 +2209,6 @@ class Client:
                 self._ensure_thread_running(
                     "_tracing_control_thread",
                     _tracing_control_thread_func,
-                    weakref.ref(self),
                 )
                 self.tracing_queue.put(
                     TracingQueueItem(data["dotted_order"], serialized_op)
@@ -5742,7 +5738,6 @@ class Client:
                     self._ensure_thread_running(
                         "_compress_control_thread",
                         _tracing_control_thread_func_compress_parallel,
-                        weakref.ref(self),
                     )
                     multipart_form = (
                         serialized_feedback_operation_to_multipart_parts_and_context(
@@ -5762,7 +5757,6 @@ class Client:
                     self._ensure_thread_running(
                         "_tracing_control_thread",
                         _tracing_control_thread_func,
-                        weakref.ref(self),
                     )
                     self.tracing_queue.put(
                         TracingQueueItem(str(feedback.id), serialized_op)

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "langsmith"
-version = "0.3.27"
+version = "0.3.28rc1"
 description = "Client library to connect to the LangSmith LLM Tracing and Evaluation Platform."
 authors = ["LangChain <support@langchain.dev>"]
 license = "MIT"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "langsmith"
-version = "0.3.28rc1"
+version = "0.3.28rc2"
 description = "Client library to connect to the LangSmith LLM Tracing and Evaluation Platform."
 authors = ["LangChain <support@langchain.dev>"]
 license = "MIT"


### PR DESCRIPTION
If our background threads get terminated during execution, we should ensure the threads are running then when more runs are added to the queue.

Issue reported in https://github.com/langchain-ai/langsmith-sdk/issues/1630