### PR TITLE
patch[python]: Use multipart EP for feedback creation

### DIFF
--- a/python/langsmith/testing/_internal.py
+++ b/python/langsmith/testing/_internal.py
@@ -464,13 +464,13 @@ def _end_tests(test_suite: _LangSmithTestSuite):
         test_suite.client.update_dataset_tag(
             dataset_id=dataset_id,
             as_of=dataset_version,
-            tag=f'git:commit:{git_info["commit"]}',
+            tag=f"git:commit:{git_info['commit']}",
         )
     if dataset_version and git_info["branch"] is not None:
         test_suite.client.update_dataset_tag(
             dataset_id=dataset_id,
             as_of=dataset_version,
-            tag=f'git:branch:{git_info["branch"]}',
+            tag=f"git:branch:{git_info['branch']}",
         )
 
 
@@ -560,7 +560,7 @@ class _LangSmithTestSuite:
         self._executor.submit(self._submit_result, run_id, score)
 
     def _submit_result(self, run_id: uuid.UUID, score: Optional[int]) -> None:
-        self.client.create_feedback(run_id, key="pass", score=score)
+        self.client.create_feedback(run_id, key="pass", score=score, trace_id=run_id)
 
     def sync_example(
         self,
@@ -914,10 +914,11 @@ def _run_test(
             "reference_example_id": str(test_case.example_id),
         },
     }
-    with rh.tracing_context(
-        **{**current_context, "metadata": metadata}
-    ), ls_utils.with_optional_cache(
-        cache_path, ignore_hosts=[test_case.test_suite.client.api_url]
+    with (
+        rh.tracing_context(**{**current_context, "metadata": metadata}),
+        ls_utils.with_optional_cache(
+            cache_path, ignore_hosts=[test_case.test_suite.client.api_url]
+        ),
     ):
         _test()
 
@@ -982,10 +983,11 @@ async def _arun_test(
             "reference_example_id": str(test_case.example_id),
         },
     }
-    with rh.tracing_context(
-        **{**current_context, "metadata": metadata}
-    ), ls_utils.with_optional_cache(
-        cache_path, ignore_hosts=[test_case.test_suite.client.api_url]
+    with (
+        rh.tracing_context(**{**current_context, "metadata": metadata}),
+        ls_utils.with_optional_cache(
+            cache_path, ignore_hosts=[test_case.test_suite.client.api_url]
+        ),
     ):
         await _test()
 
@@ -1020,9 +1022,7 @@ def log_inputs(inputs: dict, /) -> None:
                 assert foo(x, y) == 2
     """
     if ls_utils.test_tracking_is_disabled():
-        logger.info(
-            "LANGSMITH_TEST_TRACKING is set to 'false'." " Skipping log_inputs."
-        )
+        logger.info("LANGSMITH_TEST_TRACKING is set to 'false'. Skipping log_inputs.")
         return
     run_tree = rh.get_current_run_tree()
     test_case = _TEST_CASE.get()
@@ -1064,9 +1064,7 @@ def log_outputs(outputs: dict, /) -> None:
                 assert result == 2
     """
     if ls_utils.test_tracking_is_disabled():
-        logger.info(
-            "LANGSMITH_TEST_TRACKING is set to 'false'." " Skipping log_outputs."
-        )
+        logger.info("LANGSMITH_TEST_TRACKING is set to 'false'. Skipping log_outputs.")
         return
     run_tree = rh.get_current_run_tree()
     test_case = _TEST_CASE.get()
@@ -1110,8 +1108,7 @@ def log_reference_outputs(reference_outputs: dict, /) -> None:
     """
     if ls_utils.test_tracking_is_disabled():
         logger.info(
-            "LANGSMITH_TEST_TRACKING is set to 'false'."
-            " Skipping log_reference_outputs."
+            "LANGSMITH_TEST_TRACKING is set to 'false'. Skipping log_reference_outputs."
         )
         return
     test_case = _TEST_CASE.get()
@@ -1164,9 +1161,7 @@ def log_feedback(
                 assert result == expected
     """
     if ls_utils.test_tracking_is_disabled():
-        logger.info(
-            "LANGSMITH_TEST_TRACKING is set to 'false'." " Skipping log_feedback."
-        )
+        logger.info("LANGSMITH_TEST_TRACKING is set to 'false'. Skipping log_feedback.")
         return
     if feedback and any((key, score, value)):
         msg = "Must specify one of 'feedback' and ('key', 'score', 'value'), not both."
@@ -1270,9 +1265,7 @@ def trace_feedback(
                 assert "hello" in response.choices[0].message.content.lower()
     """  # noqa: E501
     if ls_utils.test_tracking_is_disabled():
-        logger.info(
-            "LANGSMITH_TEST_TRACKING is set to 'false'." " Skipping log_feedback."
-        )
+        logger.info("LANGSMITH_TEST_TRACKING is set to 'false'. Skipping log_feedback.")
         yield None
         return
     parent_run = rh.get_current_run_tree()

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "langsmith"
-version = "0.3.29"
+version = "0.3.30"
 description = "Client library to connect to the LangSmith LLM Tracing and Evaluation Platform."
 authors = ["LangChain <support@langchain.dev>"]
 license = "MIT"


### PR DESCRIPTION
### Purpose
All feedback ingest should go through multipart, in order to do this, we need to set the`trace_id`.