### PR TITLE
patch[python, js]: Update runs with project name

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langsmith",
-  "version": "0.3.15",
+  "version": "0.3.16",
   "description": "Client library to connect to the LangSmith LLM Tracing and Evaluation Platform.",
   "packageManager": "yarn@1.22.19",
   "files": [

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -18,4 +18,4 @@ export { RunTree, type RunTreeConfig } from "./run_trees.js";
 export { overrideFetchImplementation } from "./singletons/fetch.js";
 
 // Update using yarn bump-version
-export const __version__ = "0.3.15";
+export const __version__ = "0.3.16";

--- a/js/src/run_trees.ts
+++ b/js/src/run_trees.ts
@@ -422,6 +422,7 @@ export class RunTree implements BaseRun {
         trace_id: this.trace_id,
         tags: this.tags,
         attachments: this.attachments,
+        session_name: this.project_name,
       };
 
       await this.client.updateRun(this.id, runUpdate);
@@ -525,9 +526,9 @@ export class RunTree implements BaseRun {
     const rawHeaders: Record<string, string | string[] | null> =
       "get" in headers && typeof headers.get === "function"
         ? {
-            "langsmith-trace": headers.get("langsmith-trace"),
-            baggage: headers.get("baggage"),
-          }
+          "langsmith-trace": headers.get("langsmith-trace"),
+          baggage: headers.get("baggage"),
+        }
         : (headers as Record<string, string | string[]>);
 
     const headerTrace = rawHeaders["langsmith-trace"];

--- a/js/src/run_trees.ts
+++ b/js/src/run_trees.ts
@@ -526,9 +526,9 @@ export class RunTree implements BaseRun {
     const rawHeaders: Record<string, string | string[] | null> =
       "get" in headers && typeof headers.get === "function"
         ? {
-          "langsmith-trace": headers.get("langsmith-trace"),
-          baggage: headers.get("baggage"),
-        }
+            "langsmith-trace": headers.get("langsmith-trace"),
+            baggage: headers.get("baggage"),
+          }
         : (headers as Record<string, string | string[]>);
 
     const headerTrace = rawHeaders["langsmith-trace"];

--- a/js/src/schemas.ts
+++ b/js/src/schemas.ts
@@ -231,6 +231,7 @@ export interface RunUpdate {
   reference_example_id?: string;
   events?: KVMap[];
   session_id?: string;
+  session_name?: string;
   /** Unique ID assigned to every run within this nested trace. **/
   trace_id?: string;
 
@@ -270,7 +271,7 @@ export interface ExampleCreate {
   use_source_run_attachments?: string[];
 }
 
-export interface ExampleUploadWithAttachments extends ExampleCreate {}
+export interface ExampleUploadWithAttachments extends ExampleCreate { }
 export interface ExampleUpdate {
   id: string;
   inputs?: KVMap;
@@ -282,16 +283,16 @@ export interface ExampleUpdate {
   dataset_id?: string;
 }
 
-export interface ExampleUpdateWithoutId extends Omit<ExampleUpdate, "id"> {}
+export interface ExampleUpdateWithoutId extends Omit<ExampleUpdate, "id"> { }
 
-export interface ExampleUpdateWithAttachments extends ExampleUpdate {}
+export interface ExampleUpdateWithAttachments extends ExampleUpdate { }
 
 export interface UploadExamplesResponse {
   count: number;
   example_ids: string[];
 }
 
-export interface UpdateExamplesResponse extends UploadExamplesResponse {}
+export interface UpdateExamplesResponse extends UploadExamplesResponse { }
 
 export interface Example extends BaseExample {
   id: string;
@@ -317,7 +318,7 @@ export interface RawExample extends BaseExample {
   attachment_urls?: Record<string, RawAttachmentInfo>;
 }
 
-export interface ExampleUpdateWithId extends ExampleUpdate {}
+export interface ExampleUpdateWithId extends ExampleUpdate { }
 
 export interface ExampleSearch extends BaseExample {
   id: string;

--- a/js/src/schemas.ts
+++ b/js/src/schemas.ts
@@ -271,7 +271,7 @@ export interface ExampleCreate {
   use_source_run_attachments?: string[];
 }
 
-export interface ExampleUploadWithAttachments extends ExampleCreate { }
+export interface ExampleUploadWithAttachments extends ExampleCreate {}
 export interface ExampleUpdate {
   id: string;
   inputs?: KVMap;
@@ -283,16 +283,16 @@ export interface ExampleUpdate {
   dataset_id?: string;
 }
 
-export interface ExampleUpdateWithoutId extends Omit<ExampleUpdate, "id"> { }
+export interface ExampleUpdateWithoutId extends Omit<ExampleUpdate, "id"> {}
 
-export interface ExampleUpdateWithAttachments extends ExampleUpdate { }
+export interface ExampleUpdateWithAttachments extends ExampleUpdate {}
 
 export interface UploadExamplesResponse {
   count: number;
   example_ids: string[];
 }
 
-export interface UpdateExamplesResponse extends UploadExamplesResponse { }
+export interface UpdateExamplesResponse extends UploadExamplesResponse {}
 
 export interface Example extends BaseExample {
   id: string;
@@ -318,7 +318,7 @@ export interface RawExample extends BaseExample {
   attachment_urls?: Record<string, RawAttachmentInfo>;
 }
 
-export interface ExampleUpdateWithId extends ExampleUpdate { }
+export interface ExampleUpdateWithId extends ExampleUpdate {}
 
 export interface ExampleSearch extends BaseExample {
   id: string;

--- a/python/langsmith/run_trees.py
+++ b/python/langsmith/run_trees.py
@@ -367,6 +367,7 @@ class RunTree(ls_schemas.RunBase):
             outputs=self.outputs.copy() if self.outputs else None,
             error=self.error,
             parent_run_id=self.parent_run_id,
+            session_name=self.session_name,
             reference_example_id=self.reference_example_id,
             end_time=self.end_time,
             dotted_order=self.dotted_order,

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "langsmith"
-version = "0.3.29"
+version = "0.3.31"
 description = "Client library to connect to the LangSmith LLM Tracing and Evaluation Platform."
 authors = ["LangChain <support@langchain.dev>"]
 license = "MIT"


### PR DESCRIPTION
Currently, patch requests don't carry information about the project they are associated with. This causes upstream issues on ingestion when the patch is sent separately and we don't know the trace tier of the project, and thus, assign it the default tracing project tier. The result of this is that we upgrade the s3 urls post ingestion API: resulting in higher storage costs and an increase in class A operations.