### PR TITLE
Revert "docs[fix]: `-e` install `langsmith` so api refs are available (no longer using rtd)

### DIFF
--- a/python/docs/requirements.txt
+++ b/python/docs/requirements.txt
@@ -10,4 +10,3 @@ sphinx-design
 sphinx-copybutton
 beautifulsoup4
 openai
--e python


### PR DESCRIPTION
… (#1663)"

This reverts commit d45c267306443344e8659569618f1630a7e025e7.