### PR TITLE
Make __version__ a constant

### DIFF
--- a/.github/workflows/python_test.yml
+++ b/.github/workflows/python_test.yml
@@ -40,6 +40,8 @@ jobs:
           poetry run pip install -U langchain langchain-core langchain_anthropic langchain_openai
       - name: Build ${{ matrix.python-version }}
         run: poetry build
+      - name: Check version alignment
+        run: make check-version
       - name: Lint ${{ matrix.python-version }}
         run: make lint
       - name: Run Unit tests ${{ matrix.python-version }}

--- a/python/Makefile
+++ b/python/Makefile
@@ -77,3 +77,24 @@ api_docs_build:
 
 api_docs_clean:
 	git clean -fd ./docs/
+
+sync-version:
+	# Update version in __init__.py to match pyproject.toml
+	$(eval VERSION := $(shell grep '^version =' pyproject.toml | sed 's/version = "\(.*\)"/\1/'))
+	sed -i '' 's/__version__ = "[^"]*"/__version__ = "$(VERSION)"/' langsmith/__init__.py
+	echo "Synced version: $(VERSION)"
+
+check-version:
+	# Get version from pyproject.toml
+	$(eval VERSION := $(shell grep '^version =' pyproject.toml | sed 's/version = "\(.*\)"/\1/'))
+	# Get version from __init__.py
+	$(eval INIT_VERSION := $(shell grep '__version__ =' langsmith/__init__.py | sed 's/__version__ = "\(.*\)"/\1/'))
+	@echo "Checking version alignment..."
+	@echo "pyproject.toml version: $(VERSION)"
+	@echo "__init__.py version: $(INIT_VERSION)"
+	@if [ "$(VERSION)" = "$(INIT_VERSION)" ]; then \
+		echo "✅ Versions are aligned"; \
+	else \
+		echo "❌ Version mismatch! Please run 'make sync-version' to sync versions"; \
+		exit 1; \
+	fi

--- a/python/langsmith/__init__.py
+++ b/python/langsmith/__init__.py
@@ -1,6 +1,5 @@
 """LangSmith Client."""
 
-from importlib import metadata
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -18,16 +17,11 @@ if TYPE_CHECKING:
     )
     from langsmith.run_trees import RunTree
     from langsmith.testing._internal import test, unit
-    from langsmith.utils import (
-        ContextThreadPoolExecutor,
-    )
+    from langsmith.utils import ContextThreadPoolExecutor
 
 # Avoid calling into importlib on every call to __version__
-version = ""
-try:
-    version = metadata.version(__package__)
-except metadata.PackageNotFoundError:
-    pass
+__version__ = "0.3.31"
+version = __version__  # for backwards compatibility
 
 
 def __getattr__(name: str) -> Any:
@@ -108,9 +102,7 @@ def __getattr__(name: str) -> Any:
 
         return unit
     elif name == "ContextThreadPoolExecutor":
-        from langsmith.utils import (
-            ContextThreadPoolExecutor,
-        )
+        from langsmith.utils import ContextThreadPoolExecutor
 
         return ContextThreadPoolExecutor
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -151,3 +151,7 @@ dynamic = ["version"]
 
 [tool.poetry.plugins."pytest11"]
 langsmith_plugin = "langsmith.pytest_plugin"
+
+[tool.poetry_bumpversion.file."langsmith/__init__.py"]
+search = '__version__ = "{current_version}"'
+replace = '__version__ = "{new_version}"'


### PR DESCRIPTION
To speed up import times.

Add check in CI to avoid misalignment.

(drops raw import langsmith times from .05 to .02 for me)