### PR TITLE
feat(js): Allow async functions in client hideInputs and hideOutputs

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langsmith",
-  "version": "0.3.19",
+  "version": "0.3.20",
   "description": "Client library to connect to the LangSmith LLM Tracing and Evaluation Platform.",
   "packageManager": "yarn@1.22.19",
   "files": [

--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -74,8 +74,8 @@ export interface ClientConfig {
   timeout_ms?: number;
   webUrl?: string;
   anonymizer?: (values: KVMap) => KVMap;
-  hideInputs?: boolean | ((inputs: KVMap) => KVMap);
-  hideOutputs?: boolean | ((outputs: KVMap) => KVMap);
+  hideInputs?: boolean | ((inputs: KVMap) => KVMap | Promise<KVMap>);
+  hideOutputs?: boolean | ((outputs: KVMap) => KVMap | Promise<KVMap>);
   autoBatchTracing?: boolean;
   batchSizeBytesLimit?: number;
   blockOnRootRunFinalization?: boolean;
@@ -488,9 +488,9 @@ export class Client implements LangSmithTracingClientInterface {
 
   private _tenantId: string | null = null;
 
-  private hideInputs?: boolean | ((inputs: KVMap) => KVMap);
+  private hideInputs?: boolean | ((inputs: KVMap) => KVMap | Promise<KVMap>);
 
-  private hideOutputs?: boolean | ((outputs: KVMap) => KVMap);
+  private hideOutputs?: boolean | ((outputs: KVMap) => KVMap | Promise<KVMap>);
 
   private tracingSampleRate?: number;
 
@@ -633,7 +633,7 @@ export class Client implements LangSmithTracingClientInterface {
     return headers;
   }
 
-  private processInputs(inputs: KVMap): KVMap {
+  private async processInputs(inputs: KVMap): Promise<KVMap> {
     if (this.hideInputs === false) {
       return inputs;
     }
@@ -646,7 +646,7 @@ export class Client implements LangSmithTracingClientInterface {
     return inputs;
   }
 
-  private processOutputs(outputs: KVMap): KVMap {
+  private async processOutputs(outputs: KVMap): Promise<KVMap> {
     if (this.hideOutputs === false) {
       return outputs;
     }
@@ -659,17 +659,21 @@ export class Client implements LangSmithTracingClientInterface {
     return outputs;
   }
 
-  private prepareRunCreateOrUpdateInputs(run: RunUpdate): RunUpdate;
-  private prepareRunCreateOrUpdateInputs(run: RunCreate): RunCreate;
-  private prepareRunCreateOrUpdateInputs(
+  private async prepareRunCreateOrUpdateInputs(
+    run: RunUpdate
+  ): Promise<RunUpdate>;
+  private async prepareRunCreateOrUpdateInputs(
+    run: RunCreate
+  ): Promise<RunCreate>;
+  private async prepareRunCreateOrUpdateInputs(
     run: RunCreate | RunUpdate
-  ): RunCreate | RunUpdate {
+  ): Promise<RunCreate | RunUpdate> {
     const runParams = { ...run };
     if (runParams.inputs !== undefined) {
-      runParams.inputs = this.processInputs(runParams.inputs);
+      runParams.inputs = await this.processInputs(runParams.inputs);
     }
     if (runParams.outputs !== undefined) {
-      runParams.outputs = this.processOutputs(runParams.outputs);
+      runParams.outputs = await this.processOutputs(runParams.outputs);
     }
     return runParams;
   }
@@ -980,7 +984,7 @@ export class Client implements LangSmithTracingClientInterface {
     const session_name = run.project_name;
     delete run.project_name;
 
-    const runCreate: RunCreate = this.prepareRunCreateOrUpdateInputs({
+    const runCreate: RunCreate = await this.prepareRunCreateOrUpdateInputs({
       session_name,
       ...run,
       start_time: run.start_time ?? Date.now(),
@@ -1026,14 +1030,16 @@ export class Client implements LangSmithTracingClientInterface {
     if (runCreates === undefined && runUpdates === undefined) {
       return;
     }
-    let preparedCreateParams =
+    let preparedCreateParams = await Promise.all(
       runCreates?.map((create) =>
         this.prepareRunCreateOrUpdateInputs(create)
-      ) ?? [];
-    let preparedUpdateParams =
+      ) ?? []
+    );
+    let preparedUpdateParams = await Promise.all(
       runUpdates?.map((update) =>
         this.prepareRunCreateOrUpdateInputs(update)
-      ) ?? [];
+      ) ?? []
+    );
 
     if (preparedCreateParams.length > 0 && preparedUpdateParams.length > 0) {
       const createById = preparedCreateParams.reduce(
@@ -1125,7 +1131,7 @@ export class Client implements LangSmithTracingClientInterface {
     let preparedCreateParams = [];
 
     for (const create of runCreates ?? []) {
-      const preparedCreate = this.prepareRunCreateOrUpdateInputs(create);
+      const preparedCreate = await this.prepareRunCreateOrUpdateInputs(create);
       if (
         preparedCreate.id !== undefined &&
         preparedCreate.attachments !== undefined
@@ -1137,7 +1143,9 @@ export class Client implements LangSmithTracingClientInterface {
     }
     let preparedUpdateParams = [];
     for (const update of runUpdates ?? []) {
-      preparedUpdateParams.push(this.prepareRunCreateOrUpdateInputs(update));
+      preparedUpdateParams.push(
+        await this.prepareRunCreateOrUpdateInputs(update)
+      );
     }
 
     // require trace_id and dotted_order
@@ -1322,11 +1330,11 @@ export class Client implements LangSmithTracingClientInterface {
   public async updateRun(runId: string, run: RunUpdate): Promise<void> {
     assertUuid(runId);
     if (run.inputs) {
-      run.inputs = this.processInputs(run.inputs);
+      run.inputs = await this.processInputs(run.inputs);
     }
 
     if (run.outputs) {
-      run.outputs = this.processOutputs(run.outputs);
+      run.outputs = await this.processOutputs(run.outputs);
     }
     // TODO: Untangle types
     const data: UpdateRunParams = { ...run, id: runId };

--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -73,7 +73,7 @@ export interface ClientConfig {
   callerOptions?: AsyncCallerParams;
   timeout_ms?: number;
   webUrl?: string;
-  anonymizer?: (values: KVMap) => KVMap;
+  anonymizer?: (values: KVMap) => KVMap | Promise<KVMap>;
   hideInputs?: boolean | ((inputs: KVMap) => KVMap | Promise<KVMap>);
   hideOutputs?: boolean | ((outputs: KVMap) => KVMap | Promise<KVMap>);
   autoBatchTracing?: boolean;

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -18,4 +18,4 @@ export { RunTree, type RunTreeConfig } from "./run_trees.js";
 export { overrideFetchImplementation } from "./singletons/fetch.js";
 
 // Update using yarn bump-version
-export const __version__ = "0.3.19";
+export const __version__ = "0.3.20";

--- a/js/src/tests/traceable_langchain.test.ts
+++ b/js/src/tests/traceable_langchain.test.ts
@@ -39,6 +39,8 @@ describe("to langchain", () => {
     const result = await main({ text: "Hello world" });
     expect(result).toEqual("Hello world");
 
+    await awaitAllCallbacks();
+
     expect(getAssumedTreeFromCalls(callSpy.mock.calls)).toMatchObject({
       nodes: [
         "main:0",


### PR DESCRIPTION
`traceable`'s typing makes this more difficult to update `processInputs` and `processOutputs` in a similar way - would say let's just add here to unblock async PII masking use cases.