### PR TITLE
feat(js) Add function to get Group Runs

### DIFF
--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -205,7 +205,12 @@ interface GroupRunsParams {
   /**
    * The ID or IDs of the project(s) to filter by.
    */
-  projectId: string;
+  projectId?: string;
+
+  /**
+   * The ID or IDs of the project(s) to filter by.
+   */
+  projectName?: string;
 
   /**
    * @example "conversation"
@@ -1690,10 +1695,21 @@ export class Client implements LangSmithTracingClientInterface {
   }
 
   public async *groupRuns(props: GroupRunsParams): AsyncIterable<Thread> {
-    const { projectId, groupBy, filter, startTime, endTime, limit, offset } =
-      props;
+    const {
+      projectId,
+      projectName,
+      groupBy,
+      filter,
+      startTime,
+      endTime,
+      limit,
+      offset,
+    } = props;
+
+    const sessionId = projectId || (await this.readProject({ projectName })).id;
+
     const baseBody = {
-      session_id: projectId,
+      session_id: sessionId,
       group_by: groupBy,
       filter,
       start_time: startTime ? startTime.toISOString() : null,

--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -123,6 +123,11 @@ interface ListRunsParams {
   parentRunId?: string;
 
   /**
+   * The order by run start date
+   */
+  order?: "asc" | "desc";
+
+  /**
    * The ID of the reference example to filter by.
    */
   referenceExampleId?: string;
@@ -1595,6 +1600,7 @@ export class Client implements LangSmithTracingClientInterface {
       treeFilter,
       limit,
       select,
+      order,
     } = props;
     let projectIds: string[] = [];
     if (projectId) {
@@ -1658,6 +1664,7 @@ export class Client implements LangSmithTracingClientInterface {
       trace: traceId,
       select: select ? select : default_select,
       is_root: isRoot,
+      order,
     };
 
     let runsYielded = 0;

--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -1694,7 +1694,7 @@ export class Client implements LangSmithTracingClientInterface {
     }
   }
 
-  public async *groupRuns(props: GroupRunsParams): AsyncIterable<Thread> {
+  public async *listGroupRuns(props: GroupRunsParams): AsyncIterable<Thread> {
     const {
       projectId,
       projectName,


### PR DESCRIPTION
Add GroupRunsParams interface and implement groupRuns method for run grouping

Function implemented for [Group Runs](https://api.smith.langchain.com/redoc#tag/run/operation/group_runs_api_v1_runs_group_post)