### PR TITLE
chore[python]: Set dotted order for openai agents sdk integration

### DIFF
--- a/python/langsmith/__init__.py
+++ b/python/langsmith/__init__.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
     from langsmith.utils import ContextThreadPoolExecutor
 
 # Avoid calling into importlib on every call to __version__
-__version__ = "0.3.31"
+__version__ = "0.3.33"
 version = __version__  # for backwards compatibility
 
 

--- a/python/langsmith/wrappers/_agent_utils.py
+++ b/python/langsmith/wrappers/_agent_utils.py
@@ -223,18 +223,15 @@ if HAVE_AGENTS:
 
         return data
 
-    def _create_current_dotted_order(
-        start_time: Optional[datetime], run_id: Optional[str]
+    def ensure_dotted_order(
+        start_time: Optional[datetime],
+        run_id: Optional[str],
+        parent_dotted_order: Optional[str] = None,
     ) -> str:
-        """Create the current dotted order."""
+        """Create a dotted order from a start time and run id."""
         st = start_time or datetime.now(timezone.utc)
         id_ = run_id or str(uuid4())
-        return st.strftime("%Y%m%dT%H%M%S%fZ") + id_
-
-    def ensure_dotted_order(
-        start_time: datetime, run_id: str, parent_dotted_order: Optional[str] = None
-    ) -> str:
-        current_dotted_order = _create_current_dotted_order(start_time, run_id)
+        current_dotted_order = st.strftime("%Y%m%dT%H%M%S%fZ") + id_
         if parent_dotted_order is not None:
             return parent_dotted_order + "." + current_dotted_order
         return current_dotted_order

--- a/python/langsmith/wrappers/_agent_utils.py
+++ b/python/langsmith/wrappers/_agent_utils.py
@@ -1,6 +1,8 @@
 import json
 import logging
-from typing import Any, Dict, Literal
+from datetime import datetime, timezone
+from typing import Any, Dict, Literal, Optional
+from uuid import uuid4
 
 try:
     from agents import tracing  # type: ignore[import]
@@ -220,3 +222,19 @@ if HAVE_AGENTS:
             return {}
 
         return data
+
+    def _create_current_dotted_order(
+        start_time: Optional[datetime], run_id: Optional[str]
+    ) -> str:
+        """Create the current dotted order."""
+        st = start_time or datetime.now(timezone.utc)
+        id_ = run_id or str(uuid4())
+        return st.strftime("%Y%m%dT%H%M%S%fZ") + id_
+
+    def ensure_dotted_order(
+        start_time: datetime, run_id: str, parent_dotted_order: Optional[str] = None
+    ) -> str:
+        current_dotted_order = _create_current_dotted_order(start_time, run_id)
+        if parent_dotted_order is not None:
+            return parent_dotted_order + "." + current_dotted_order
+        return current_dotted_order

--- a/python/langsmith/wrappers/_openai_agents.py
+++ b/python/langsmith/wrappers/_openai_agents.py
@@ -1,7 +1,7 @@
-import datetime
 import logging
-import uuid
-from typing import Dict, Optional
+from datetime import datetime, timezone
+from typing import Dict, Optional, TypedDict
+from uuid import uuid4
 
 from langsmith import run_trees as rt
 
@@ -80,6 +80,13 @@ logger = logging.getLogger(__name__)
 
 if HAVE_AGENTS:
 
+    class RunData(TypedDict):
+        id: str
+        trace_id: str
+        start_time: datetime
+        dotted_order: str
+        parent_run_id: Optional[str]
+
     class OpenAIAgentsTracingProcessor(tracing.TracingProcessor):  # type: ignore[no-redef]
         """Tracing processor for the `OpenAI Agents SDK <https://openai.github.io/openai-agents-python/>`_.
 
@@ -154,7 +161,7 @@ if HAVE_AGENTS:
             self._first_response_inputs: dict = {}
             self._last_response_outputs: dict = {}
 
-            self._runs: Dict[str, str] = {}
+            self._runs: Dict[str, RunData] = {}
 
         def on_trace_start(self, trace: tracing.Trace) -> None:
             if self._name:
@@ -163,8 +170,22 @@ if HAVE_AGENTS:
                 run_name = trace.name
             else:
                 run_name = "Agent workflow"
-            trace_run_id = str(uuid.uuid4())
-            self._runs[trace.trace_id] = trace_run_id
+            trace_run_id = str(uuid4())
+
+            start_time = datetime.now(timezone.utc)
+
+            dotted_order = agent_utils.ensure_dotted_order(
+                start_time=start_time,
+                run_id=trace_run_id,
+            )
+            self._runs[trace.trace_id] = RunData(
+                id=trace_run_id,
+                trace_id=trace_run_id,
+                start_time=start_time,
+                dotted_order=dotted_order,
+                parent_run_id=None,
+            )
+
             run_extra = {"metadata": self._metadata or {}}
 
             trace_dict = trace.export() or {}
@@ -177,23 +198,30 @@ if HAVE_AGENTS:
                     inputs={},
                     run_type="chain",
                     id=trace_run_id,
+                    trace_id=trace_run_id,
+                    dotted_order=dotted_order,
+                    start_time=start_time,
                     revision_id=None,
                     extra=run_extra,
                     tags=self._tags,
                     project_name=self._project_name,
                 )
+
                 self.client.create_run(**run_data)
             except Exception as e:
                 logger.exception(f"Error creating trace run: {e}")
 
         def on_trace_end(self, trace: tracing.Trace) -> None:
-            run_id = self._runs.pop(trace.trace_id, None)
+            run = self._runs.pop(trace.trace_id, None)
             trace_dict = trace.export() or {}
             metadata = {**(trace_dict.get("metadata") or {}), **(self._metadata or {})}
-            if run_id:
+
+            if run:
                 try:
                     self.client.update_run(
-                        run_id=run_id,
+                        run_id=run["id"],
+                        trace_id=run["trace_id"],
+                        dotted_order=run["dotted_order"],
                         inputs=self._first_response_inputs.pop(trace.trace_id, {}),
                         outputs=self._last_response_outputs.pop(trace.trace_id, {}),
                         extra={"metadata": metadata},
@@ -202,9 +230,38 @@ if HAVE_AGENTS:
                     logger.exception(f"Error updating trace run: {e}")
 
         def on_span_start(self, span: tracing.Span) -> None:
-            parent_run_id = self._runs.get(span.parent_id or span.trace_id)
-            span_run_id = str(uuid.uuid4())
-            self._runs[span.span_id] = span_run_id
+            parent_run = (
+                self._runs.get(span.parent_id)
+                if span.parent_id
+                else self._runs.get(span.trace_id)
+            )
+
+            if parent_run is None:
+                logger.warning(
+                    f"No trace info found for span, skipping: {span.span_id}"
+                )
+                return
+
+            trace_id = parent_run["trace_id"]
+
+            span_run_id = str(uuid4())
+            span_start_time = (
+                datetime.fromisoformat(span.started_at)
+                if span.started_at
+                else datetime.now(timezone.utc)
+            )
+            dotted_order = agent_utils.ensure_dotted_order(
+                start_time=span_start_time,
+                run_id=span_run_id,
+                parent_dotted_order=parent_run["dotted_order"] if parent_run else None,
+            )
+            self._runs[span.span_id] = RunData(
+                id=span_run_id,
+                trace_id=trace_id,
+                start_time=span_start_time,
+                dotted_order=dotted_order,
+                parent_run_id=parent_run["id"],
+            )
 
             run_name = agent_utils.get_run_name(span)
             run_type = agent_utils.get_run_type(span)
@@ -215,20 +272,20 @@ if HAVE_AGENTS:
                     name=run_name,
                     run_type=run_type,
                     id=span_run_id,
-                    parent_run_id=parent_run_id,
+                    trace_id=trace_id,
+                    parent_run_id=parent_run["id"],
+                    dotted_order=dotted_order,
                     inputs=extracted.get("inputs", {}),
                 )
                 if span.started_at:
-                    run_data["start_time"] = datetime.datetime.fromisoformat(
-                        span.started_at
-                    )
+                    run_data["start_time"] = datetime.fromisoformat(span.started_at)
                 self.client.create_run(**run_data)
             except Exception as e:
                 logger.exception(f"Error creating span run: {e}")
 
         def on_span_end(self, span: tracing.Span) -> None:
-            run_id = self._runs.pop(span.span_id, None)
-            if run_id:
+            run = self._runs.pop(span.span_id, None)
+            if run:
                 extracted = agent_utils.extract_span_data(span)
                 metadata = extracted.get("metadata", {})
                 metadata["openai_parent_id"] = span.parent_id
@@ -238,16 +295,17 @@ if HAVE_AGENTS:
                 outputs = extracted.pop("outputs", {})
                 inputs = extracted.pop("inputs", {})
                 run_data: dict = dict(
-                    run_id=run_id,
+                    run_id=run["id"],
+                    trace_id=run["trace_id"],
+                    dotted_order=run["dotted_order"],
+                    parent_run_id=run["parent_run_id"],
                     error=str(span.error) if span.error else None,
                     outputs=outputs,
                     inputs=inputs,
                     extra=extracted,
                 )
                 if span.ended_at:
-                    run_data["end_time"] = datetime.datetime.fromisoformat(
-                        span.ended_at
-                    )
+                    run_data["end_time"] = datetime.fromisoformat(span.ended_at)
 
                 if isinstance(span.span_data, tracing.ResponseSpanData):
                     self._first_response_inputs[span.trace_id] = (

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "langsmith"
-version = "0.3.32"
+version = "0.3.33"
 description = "Client library to connect to the LangSmith LLM Tracing and Evaluation Platform."
 authors = ["LangChain <support@langchain.dev>"]
 license = "MIT"


### PR DESCRIPTION
Currently our openai agents sdk calls create/update run methods without `trace_id` and `dotted_order`, which means tracing will happen in the main thread.

This fix sets those variables in the agents integration

Issue discovered in: https://github.com/openai/openai-agents-python/issues/529