### PR TITLE
fix(py): try/except writing to multiple endpoints

### DIFF
--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -1950,7 +1950,7 @@ class Client:
                     except Exception:
                         logger.warning(f"Failed to multipart ingest runs: {repr(e)}")
                     # do not retry by default
-                    return
+                    break
 
     def _send_compressed_multipart_req(
         self,
@@ -2022,7 +2022,7 @@ class Client:
                             f"Failed to send compressed multipart ingest: {repr(e)}"
                         )
                     # Do not retry by default after unknown exceptions
-                    return
+                    break
 
     def update_run(
         self,

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -1422,17 +1422,26 @@ class Client:
             self._create_run(run_create)
 
     def _create_run(self, run_create: dict):
+        errors = []
         for api_url, api_key in self._write_api_urls.items():
             headers = {**self._headers, X_API_KEY: api_key}
-            self.request_with_retries(
-                "POST",
-                f"{api_url}/runs",
-                request_kwargs={
-                    "data": _dumps_json(run_create),
-                    "headers": headers,
-                },
-                to_ignore=(ls_utils.LangSmithConflictError,),
-            )
+            try:
+                self.request_with_retries(
+                    "POST",
+                    f"{api_url}/runs",
+                    request_kwargs={
+                        "data": _dumps_json(run_create),
+                        "headers": headers,
+                    },
+                    to_ignore=(ls_utils.LangSmithConflictError,),
+                )
+            except Exception as e:
+                errors.append(e)
+        if errors:
+            if len(errors) > 1:
+                raise ls_utils.LangSmithExceptionGroup(exceptions=errors)
+            else:
+                raise errors[0]
 
     def _hide_run_inputs(self, inputs: dict):
         if self._hide_inputs is True:

--- a/python/langsmith/utils.py
+++ b/python/langsmith/utils.py
@@ -81,6 +81,17 @@ class LangSmithConnectionError(LangSmithError):
     """Couldn't connect to the LangSmith API."""
 
 
+class LangSmithExceptionGroup(LangSmithError):
+    """Port of ExceptionGroup for Py < 3.11."""
+
+    def __init__(
+        self, *args: Any, exceptions: Sequence[Exception], **kwargs: Any
+    ) -> None:
+        """Initialize."""
+        super().__init__(*args, **kwargs)
+        self.exceptions = exceptions
+
+
 ## Warning classes
 
 

--- a/python/tests/integration_tests/test_async_client.py
+++ b/python/tests/integration_tests/test_async_client.py
@@ -16,6 +16,7 @@ async def test_indexed_datasets():
         name: str  # type: ignore[annotation-unchecked]
         age: int  # type: ignore[annotation-unchecked]
 
+    dataset = None
     async with AsyncClient() as client:
         # Create a new dataset
         try:
@@ -44,7 +45,8 @@ async def test_indexed_datasets():
             )
             assert examples[0].id == example.id
         finally:
-            await client.delete_dataset(dataset_id=dataset.id)
+            if dataset:
+                await client.delete_dataset(dataset_id=dataset.id)
 
 
 # Helper function to wait for a condition


### PR DESCRIPTION
prevent one run creation failure from block all run creations, in case of multiple write endpoints