### PR TITLE
[Bug Fix] input extraction of _serialize_inputs() in custom evaluators

### DIFF
--- a/python/langsmith/evaluation/evaluator.py
+++ b/python/langsmith/evaluation/evaluator.py
@@ -425,9 +425,11 @@ def _maxsize_repr(obj: Any):
 
 
 def _serialize_inputs(inputs: dict) -> dict:
-    run_truncated = _maxsize_repr(inputs.get("run"))
-    example_truncated = _maxsize_repr(inputs.get("example"))
-    return {"run": run_truncated, "example": example_truncated}
+    run = inputs.get("run")
+    example = inputs.get("example")
+    run_inputs_truncated: str = _maxsize_repr(run.inputs.get("inputs", ""))
+    example_inputs_truncated: str = _maxsize_repr(example.inputs)
+    return {"run": run_inputs_truncated, "example": example_inputs_truncated}
 
 
 class DynamicComparisonRunEvaluator:


### PR DESCRIPTION
**Bug Description**

When using evaluate() with custom evaluators, the LangSmith trace UI displays raw Run and Example objects instead of rendering their inputs and outputs as plain text:

<img width="665" alt="Trace UI showing raw objects" src="https://github.com/user-attachments/assets/760cf787-0acd-4dd6-9043-95127267808e" />

**Root Cause & Solution**

The issue originates from the _serialize_inputs() method, which is passed as the input processor to [run_helpers.ensure_traceable](https://github.com/langchain-ai/langsmith-sdk/blob/main/python/langsmith/evaluation/evaluator.py#L220) by both the [DynamicRunEvaluator](https://github.com/langchain-ai/langsmith-sdk/blob/main/python/langsmith/evaluation/evaluator.py#L181) and [DynamicComparisonRunEvaluator](https://github.com/langchain-ai/langsmith-sdk/blob/main/python/langsmith/evaluation/evaluator.py#L433). Currently, _serialize_inputs() returns entire Run and Example objects, which are not serializable in a meaningful way for the UI.

This PR updates _serialize_inputs() to properly extract and return the .inputs from both Run and Example objects, ensuring that the trace UI displays these values as expected.

**Testing**

I tested this fix by running a custom evaluator (based on [this example](https://github.com/langchain-ai/langsmith-sdk/compare/main...EugeneJinXin:langsmith-sdk:fix/url)) with the changes applied. The trace UI now correctly displays inputs as shown below:

<img width="934" alt="Fixed trace UI showing inputs" src="https://github.com/user-attachments/assets/74ecf33d-078e-4b47-81ab-f67f683b6a47" />

**Additional Considerations**

While this PR fixes input serialization, the trace currently still lacks visibility into the Example.output (i.e., reference output). A similar output_processor should ideally be introduced in a follow-up to improve trace clarity further.