### PR TITLE
Adopt pagination to list_shared_examples to ensure all data returned

### DIFF
--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -2851,31 +2851,30 @@ class Client:
         )
 
     def list_shared_examples(
-        self, share_token: str, *, example_ids: Optional[list[ID_TYPE]] = None
-    ) -> list[ls_schemas.Example]:
+        self, share_token: str, *, example_ids: Optional[List[ID_TYPE]] = None,
+        limit: Optional[int] = None
+    ) -> List[ls_schemas.Example]:
         """Get shared examples.
 
         Args:
             share_token (Union[UUID, str]): The share token or URL of the shared dataset.
             example_ids (Optional[List[UUID, str]], optional): The IDs of the examples to filter by. Defaults to None.
-
+            limit (Optional[int]): Maximum number of examples to return, by default None.
         Returns:
             List[ls_schemas.Example]: The list of shared examples.
         """
         params = {}
         if example_ids is not None:
             params["id"] = [str(id) for id in example_ids]
-        response = self.request_with_retries(
-            "GET",
-            f"/public/{_as_uuid(share_token, 'share_token')}/examples",
-            headers=self._headers,
-            params=params,
-        )
-        ls_utils.raise_for_status_with_text(response)
-        return [
-            ls_schemas.Example(**dataset, _host_url=self._host_url)
-            for dataset in response.json()
-        ]
+        for i, example in enumerate(
+            self._get_paginated_list(
+                f"/public/{_as_uuid(share_token, 'share_token')}/examples",
+                params=params,
+            )
+        ):
+            yield ls_schemas.Example(**example, _host_url=self._host_url)
+            if limit is not None and i + 1 >= limit:
+                break
 
     def list_shared_projects(
         self,

--- a/python/tests/unit_tests/test_client.py
+++ b/python/tests/unit_tests/test_client.py
@@ -2551,3 +2551,54 @@ def test__construct_url():
         for prefix in ("", "/", "https://foobar.com/api/"):
             actual = _construct_url(api_url + suffix, prefix + pathname)
             assert actual == expected
+
+
+@mock.patch("langsmith.client.requests.Session")
+def test_list_shared_examples_pagination(mock_session_cls: mock.Mock) -> None:
+    """Test list_shared_examples handles pagination correctly."""
+    mock_session = mock.Mock()
+
+    def mock_request(*args, **kwargs):
+        response = mock.Mock()
+        response.status_code = 200
+
+        if "/info" in args[1]:
+            response.json.return_value = {}
+            return response
+
+        # First request will return 100 examples, second request 50 examples
+        if kwargs.get('params', {}).get('offset', 0) == 0:
+            examples = [
+                {
+                    "id": str(uuid.uuid4()),
+                    "created_at": _CREATED_AT.isoformat(),
+                    "inputs": {"text": f"input_{i}"},
+                    "outputs": {"result": f"output_{i}"},
+                    "dataset_id": str(uuid.uuid4())
+                }
+                for i in range(100)
+            ]
+        else:
+            examples = [
+                {
+                    "id": str(uuid.uuid4()),
+                    "created_at": _CREATED_AT.isoformat(),
+                    "inputs": {"text": f"input_{i}"},
+                    "outputs": {"result": f"output_{i}"},
+                    "dataset_id": str(uuid.uuid4())
+                }
+                for i in range(100, 150)
+            ]
+
+        response.json.return_value = examples
+        return response
+
+    mock_session.request.side_effect = mock_request
+    mock_session_cls.return_value = mock_session
+
+    client = Client(api_url="http://localhost:1984", api_key="fake-key", session=mock_session)
+    examples = list(client.list_shared_examples(str(uuid.uuid4())))
+
+    assert len(examples) == 150  # Should get all examples
+    assert examples[0].inputs["text"] == "input_0"
+    assert examples[149].inputs["text"] == "input_149"


### PR DESCRIPTION
**Bug**
When use client.clone_public_dataset(), it's only cloning the first 100 examples instead of the full dataset. Causing data miss and user confusion. 

Reproduction steps (attach a script at the end of PR as well):

1. Find a public dataset with >100 examples
2. Run client.clone_public_dataset(...)
3. Count examples in the cloned dataset
4. Result: Only 100 examples are copied

**Solution**
Add reuse of  [_get_paginated_list](https://github.com/langchain-ai/langsmith-sdk/blame/main/python/langsmith/client.py#L2904) () in below [method](https://github.com/langchain-ai/langsmith-sdk/blame/main/python/langsmith/client.py#L2868) fixed issue and ensure all data returns in current manual test, to be confirm and release tomorrow

**Test**

With the PR's change,  I conducted data clone (from langsmith personal cloud account, to a langsmith through local docker-compose) and successfully verified clone data. See reproduce with below script. 

> eujin@eujin-mn1 langsmith-project % python3 /Users/eujin/langsmith-project/main.py -v
> Passed! All 214 rows cloned

```python
def reproduce_issue():
    """ Clone a dataset with 200+ example, verify output is exact match"

    ls_client = Client(api_url='http://localhost:1980/api/v1')
    dataset_name = "eujin_test_200_rows"

    dataset_public_url = (
        "https://smith.langchain.com/public/0dfe83c3-079e-4ee3-b6a5-01a6508066ea/d"
    )
    ls_client.clone_public_dataset(dataset_public_url)
    cloned_dataset = ls_client.read_dataset(dataset_name=dataset_name)
    
    assert cloned_dataset.example_count == 214, f"Expected 214 examples, got {cloned_dataset.example_count}"
    
    print("Passed! All 214 rows cloned")
```

In addition, added a unit test in test_client.py to make sure list_shared_examples handles pagination correctly. 

 