### PR TITLE
feat(js): Allow .concurrent, throw error when nesting describe blocks in Jestlike runners

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langsmith",
-  "version": "0.3.20",
+  "version": "0.3.21",
   "description": "Client library to connect to the LangSmith LLM Tracing and Evaluation Platform.",
   "packageManager": "yarn@1.22.19",
   "files": [

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -18,4 +18,4 @@ export { RunTree, type RunTreeConfig } from "./run_trees.js";
 export { overrideFetchImplementation } from "./singletons/fetch.js";
 
 // Update using yarn bump-version
-export const __version__ = "0.3.20";
+export const __version__ = "0.3.21";

--- a/js/src/tests/jestlike/jest.test.ts
+++ b/js/src/tests/jestlike/jest.test.ts
@@ -136,7 +136,7 @@ ls.describe(
       }
     );
 
-    ls.test.each(
+    ls.test.concurrent.each(
       [
         {
           inputs: {

--- a/js/src/tests/jestlike/vitest.vitesteval.ts
+++ b/js/src/tests/jestlike/vitest.vitesteval.ts
@@ -115,7 +115,6 @@ ls.describe(
           return { bar: "bad" };
         };
         const res = myApp();
-        await new Promise((resolve) => setTimeout(resolve, 3000));
         await ls
           .expect(res)
           .evaluatedBy(myEvaluator)

--- a/js/src/tests/jestlike/vitest.vitesteval.ts
+++ b/js/src/tests/jestlike/vitest.vitesteval.ts
@@ -88,7 +88,7 @@ ls.describe(
       }
     );
 
-    ls.test.each(
+    ls.test.concurrent.each(
       [
         {
           inputs: {
@@ -115,6 +115,7 @@ ls.describe(
           return { bar: "bad" };
         };
         const res = myApp();
+        await new Promise((resolve) => setTimeout(resolve, 3000));
         await ls
           .expect(res)
           .evaluatedBy(myEvaluator)

--- a/js/src/utils/jestlike/globals.ts
+++ b/js/src/utils/jestlike/globals.ts
@@ -21,6 +21,7 @@ export type TestWrapperAsyncLocalStorageData = {
   suiteUuid: string;
   suiteName: string;
   testRootRunTree?: RunTree;
+  setupPromise?: Promise<void>;
 };
 
 export const testWrapperAsyncLocalStorageInstance =

--- a/js/src/utils/jestlike/index.ts
+++ b/js/src/utils/jestlike/index.ts
@@ -284,16 +284,16 @@ export function generateWrapperFromJestlikeMethods(
         `[LANGSMITH]: You seem to be using a jsdom environment. This is not supported and you may experience unexpected behavior. Please set the "environment" or "testEnvironment" field in your test config file to "node".`
       );
     }
-    if (typeof method !== "function") {
-      throw new Error(
-        `"${methodName}" is not supported in your test runner environment. We generally recommend using Vitest for best results.`
-      );
-    }
     return function (
       testSuiteName: string,
       fn: () => void | Promise<void>,
       experimentConfig?: LangSmithJestlikeDescribeWrapperConfig
     ) {
+      if (typeof method !== "function") {
+        throw new Error(
+          `"${methodName}" is not supported by your test runner.`
+        );
+      }
       if (testWrapperAsyncLocalStorageInstance.getStore() !== undefined) {
         throw new Error(
           [


### PR DESCRIPTION
Fixes #1563 and fixes #1643