### PR TITLE
feat[python]: OTel context propagation

### DIFF
--- a/python/langsmith/__init__.py
+++ b/python/langsmith/__init__.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
     from langsmith.utils import ContextThreadPoolExecutor
 
 # Avoid calling into importlib on every call to __version__
-__version__ = "0.3.34"
+__version__ = "0.3.35"
 version = __version__  # for backwards compatibility
 
 

--- a/python/langsmith/_internal/_background_thread.py
+++ b/python/langsmith/_internal/_background_thread.py
@@ -12,7 +12,6 @@ from multiprocessing import cpu_count
 from queue import Empty, Queue
 from typing import (
     TYPE_CHECKING,
-    Any,
     Optional,
     Union,
     cast,
@@ -34,6 +33,8 @@ from langsmith._internal._operations import (
 )
 
 if TYPE_CHECKING:
+    from opentelemetry.context.context import Context
+
     from langsmith.client import Client
 
 logger = logging.getLogger("langsmith.client")
@@ -53,19 +54,19 @@ class TracingQueueItem:
 
     priority: str
     item: Union[SerializedRunOperation, SerializedFeedbackOperation]
-    context: Optional[Any]
+    otel_context: Optional[Context]
 
-    __slots__ = ("priority", "item", "context")
+    __slots__ = ("priority", "item", "otel_context")
 
     def __init__(
         self,
         priority: str,
         item: Union[SerializedRunOperation, SerializedFeedbackOperation],
-        context: Optional[Any] = None,
+        otel_context: Optional[Context] = None,
     ) -> None:
         self.priority = priority
         self.item = item
-        self.context = context
+        self.otel_context = otel_context
 
     def __lt__(self, other: TracingQueueItem) -> bool:
         return (self.priority, self.item.__class__) < (
@@ -197,10 +198,14 @@ def _otel_tracing_thread_handle_batch(
         ops = combine_serialized_queue_operations([item.item for item in batch])
 
         run_ops = [op for op in ops if isinstance(op, SerializedRunOperation)]
-        context_map = {item.item.id: item.context for item in batch}
+        otel_context_map = {
+            item.item.id: item.otel_context
+            for item in batch
+            if isinstance(item.item, SerializedRunOperation)
+        }
         if run_ops:
             if client.otel_exporter is not None:
-                client.otel_exporter.export_batch(run_ops, context_map)
+                client.otel_exporter.export_batch(run_ops, otel_context_map)
             else:
                 logger.error(
                     "LangSmith tracing error: Failed to submit OTEL trace data.\n"

--- a/python/langsmith/_internal/_background_thread.py
+++ b/python/langsmith/_internal/_background_thread.py
@@ -33,7 +33,7 @@ from langsmith._internal._operations import (
 )
 
 if TYPE_CHECKING:
-    from opentelemetry.context.context import Context
+    from opentelemetry.context.context import Context  # type: ignore[import]
 
     from langsmith.client import Client
 

--- a/python/langsmith/_internal/_background_thread.py
+++ b/python/langsmith/_internal/_background_thread.py
@@ -54,7 +54,7 @@ class TracingQueueItem:
 
     priority: str
     item: Union[SerializedRunOperation, SerializedFeedbackOperation]
-    otel_context: Optional[Context]
+    otel_context: Optional["Context"]
 
     __slots__ = ("priority", "item", "otel_context")
 
@@ -62,7 +62,7 @@ class TracingQueueItem:
         self,
         priority: str,
         item: Union[SerializedRunOperation, SerializedFeedbackOperation],
-        otel_context: Optional[Context] = None,
+        otel_context: Optional["Context"] = None,
     ) -> None:
         self.priority = priority
         self.item = item

--- a/python/langsmith/_internal/_background_thread.py
+++ b/python/langsmith/_internal/_background_thread.py
@@ -54,7 +54,7 @@ class TracingQueueItem:
 
     priority: str
     item: Union[SerializedRunOperation, SerializedFeedbackOperation]
-    otel_context: Optional["Context"]
+    otel_context: Optional[Context]
 
     __slots__ = ("priority", "item", "otel_context")
 
@@ -62,7 +62,7 @@ class TracingQueueItem:
         self,
         priority: str,
         item: Union[SerializedRunOperation, SerializedFeedbackOperation],
-        otel_context: Optional["Context"] = None,
+        otel_context: Optional[Context] = None,
     ) -> None:
         self.priority = priority
         self.item = item

--- a/python/langsmith/_internal/otel/_otel_exporter.py
+++ b/python/langsmith/_internal/otel/_otel_exporter.py
@@ -1,5 +1,7 @@
 """OpenTelemetry exporter for LangSmith runs."""
 
+from __future__ import annotations
+
 import datetime
 import logging
 import uuid
@@ -114,7 +116,7 @@ class OTELExporter:
     def export_batch(
         self,
         operations: list[SerializedRunOperation],
-        otel_context_map: dict[uuid.UUID, Optional["Context"]],
+        otel_context_map: dict[uuid.UUID, Optional[Context]],
     ) -> None:
         """Export a batch of serialized run operations to OTEL.
 
@@ -162,8 +164,8 @@ class OTELExporter:
         self,
         op: SerializedRunOperation,
         run_info: dict,
-        otel_context: Optional["Context"] = None,
-    ) -> Optional["Span"]:
+        otel_context: Optional[Context] = None,
+    ) -> Optional[Span]:
         """Create an OpenTelemetry span for a run operation.
 
         Args:
@@ -287,7 +289,7 @@ class OTELExporter:
         return None
 
     def _set_span_attributes(
-        self, span: "Span", run_info: dict, op: SerializedRunOperation
+        self, span: Span, run_info: dict, op: SerializedRunOperation
     ) -> None:
         """Set attributes on the span.
 
@@ -378,7 +380,7 @@ class OTELExporter:
         # Set inputs/outputs if available
         self._set_io_attributes(span, op)
 
-    def _set_gen_ai_system(self, span: "Span", run_info: dict) -> None:
+    def _set_gen_ai_system(self, span: Span, run_info: dict) -> None:
         """Set the gen_ai.system attribute on the span based on the model provider.
 
         Args:
@@ -424,7 +426,7 @@ class OTELExporter:
         span.set_attribute(GEN_AI_SYSTEM, system)
         setattr(span, "_gen_ai_system", system)
 
-    def _set_invocation_parameters(self, span: "Span", run_info: dict) -> None:
+    def _set_invocation_parameters(self, span: Span, run_info: dict) -> None:
         """Set invocation parameters on the span.
 
         Args:
@@ -464,7 +466,7 @@ class OTELExporter:
                 GEN_AI_REQUEST_PRESENCE_PENALTY, invocation_params["presence_penalty"]
             )
 
-    def _set_io_attributes(self, span: "Span", op: SerializedRunOperation) -> None:
+    def _set_io_attributes(self, span: Span, op: SerializedRunOperation) -> None:
         """Set input/output attributes on the span.
 
         Args:

--- a/python/langsmith/_internal/otel/_otel_exporter.py
+++ b/python/langsmith/_internal/otel/_otel_exporter.py
@@ -114,7 +114,7 @@ class OTELExporter:
     def export_batch(
         self,
         operations: list[SerializedRunOperation],
-        otel_context_map: dict[uuid.UUID, Context | None],
+        otel_context_map: dict[uuid.UUID, Optional[Context]],
     ) -> None:
         """Export a batch of serialized run operations to OTEL.
 

--- a/python/langsmith/_internal/otel/_otel_exporter.py
+++ b/python/langsmith/_internal/otel/_otel_exporter.py
@@ -26,7 +26,6 @@ try:
 except ImportError:
     pass
 
-
 logger = logging.getLogger(__name__)
 
 # OpenTelemetry GenAI semconv attribute names

--- a/python/langsmith/_internal/otel/_otel_exporter.py
+++ b/python/langsmith/_internal/otel/_otel_exporter.py
@@ -110,7 +110,9 @@ class OTELExporter:
         self._tracer = trace.get_tracer("langsmith", tracer_provider=tracer_provider)
         self._spans = {}
 
-    def export_batch(self, operations: list[SerializedRunOperation]) -> None:
+    def export_batch(
+        self, operations: list[SerializedRunOperation], context_map: dict[str, Any]
+    ) -> None:
         """Export a batch of serialized run operations to OTEL.
 
         Args:
@@ -124,7 +126,9 @@ class OTELExporter:
                 if not run_info:
                     continue
                 if op.operation == "post":
-                    span = self._create_span_for_run(op, run_info)
+                    span = self._create_span_for_run(
+                        op, run_info, context_map.get(op.id)
+                    )
                     if span:
                         self._spans[op.id] = span
                 else:
@@ -155,6 +159,7 @@ class OTELExporter:
         self,
         op: SerializedRunOperation,
         run_info: dict,
+        context: Optional[Any] = None,
     ) -> Optional["Span"]:
         """Create an OpenTelemetry span for a run operation.
 
@@ -184,6 +189,7 @@ class OTELExporter:
             else:
                 span = self._tracer.start_span(
                     run_info.get("name"),
+                    context=context,
                     start_time=start_time_utc_nano,
                 )
 

--- a/python/langsmith/_internal/otel/_otel_exporter.py
+++ b/python/langsmith/_internal/otel/_otel_exporter.py
@@ -26,6 +26,7 @@ try:
 except ImportError:
     pass
 
+
 logger = logging.getLogger(__name__)
 
 # OpenTelemetry GenAI semconv attribute names
@@ -114,7 +115,7 @@ class OTELExporter:
     def export_batch(
         self,
         operations: list[SerializedRunOperation],
-        otel_context_map: dict[uuid.UUID, Optional[Context]],
+        otel_context_map: dict[uuid.UUID, Optional["Context"]],
     ) -> None:
         """Export a batch of serialized run operations to OTEL.
 
@@ -162,7 +163,7 @@ class OTELExporter:
         self,
         op: SerializedRunOperation,
         run_info: dict,
-        otel_context: Optional[Context] = None,
+        otel_context: Optional["Context"] = None,
     ) -> Optional["Span"]:
         """Create an OpenTelemetry span for a run operation.
 

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -98,7 +98,7 @@ HAS_OTEL = False
 try:
     if ls_utils.is_truish(ls_utils.get_env_var("OTEL_ENABLED")):
         from opentelemetry import trace as otel_trace  # type: ignore[import]
-        from opentelemetry.trace import set_span_in_context
+        from opentelemetry.trace import set_span_in_context  # type: ignore[import]
 
         from langsmith._internal.otel._otel_client import (
             get_otlp_tracer_provider,

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -98,12 +98,12 @@ HAS_OTEL = False
 try:
     if ls_utils.is_truish(ls_utils.get_env_var("OTEL_ENABLED")):
         from opentelemetry import trace as otel_trace  # type: ignore[import]
+        from opentelemetry.trace import set_span_in_context
 
         from langsmith._internal.otel._otel_client import (
             get_otlp_tracer_provider,
         )
         from langsmith._internal.otel._otel_exporter import OTELExporter
-        from opentelemetry.trace import set_span_in_context
 
         HAS_OTEL = True
 except ImportError:
@@ -1408,7 +1408,9 @@ class Client:
                         TracingQueueItem(
                             run_create["dotted_order"],
                             serialized_op,
-                            context=set_span_in_context(otel_trace.get_current_span()),
+                            otel_context=set_span_in_context(
+                                otel_trace.get_current_span()
+                            ),
                         )
                     )
                 else:
@@ -2179,7 +2181,9 @@ class Client:
                         TracingQueueItem(
                             data["dotted_order"],
                             serialized_op,
-                            context=set_span_in_context(otel_trace.get_current_span()),
+                            otel_context=set_span_in_context(
+                                otel_trace.get_current_span()
+                            ),
                         )
                     )
                 else:

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "langsmith"
-version = "0.3.34"
+version = "0.3.35"
 description = "Client library to connect to the LangSmith LLM Tracing and Evaluation Platform."
 authors = ["LangChain <support@langchain.dev>"]
 license = "MIT"


### PR DESCRIPTION
Adds support for context propagation. This means LangSmith spans can be nested within larger OTel traces, maintaining parent-child relationships between spans.

Can now nest LangSmith operations within an existing OTel context:
```
with tracer.start_as_current_span("langchain_invoke"):
    chain.invoke(...)
```

Resolves: https://github.com/langchain-ai/langsmith-sdk/issues/1682