### PR TITLE
fix[python]: Correct reference count in compression thread

### DIFF
--- a/python/langsmith/__init__.py
+++ b/python/langsmith/__init__.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
     from langsmith.utils import ContextThreadPoolExecutor
 
 # Avoid calling into importlib on every call to __version__
-__version__ = "0.3.35"
+__version__ = "0.3.36rc0"
 version = __version__  # for backwards compatibility
 
 

--- a/python/langsmith/_internal/_background_thread.py
+++ b/python/langsmith/_internal/_background_thread.py
@@ -306,8 +306,9 @@ def tracing_control_thread_func(
             client._bg_threads.append(compress_thread)
             compress_thread.start()
 
-    def keep_thread_active(client: Optional[Client] = client) -> bool:
+    def keep_thread_active() -> bool:
         # if `client.cleanup()` was called, stop thread
+        client = client_ref()
         if not client or (
             hasattr(client, "_manual_cleanup") and client._manual_cleanup
         ):
@@ -382,8 +383,9 @@ def tracing_control_thread_func_compress_parallel(
     size_limit: int = batch_ingest_config["size_limit"]
     size_limit_bytes = batch_ingest_config.get("size_limit_bytes", 20_971_520)
 
-    def keep_thread_active(client: Optional[Client] = client) -> bool:
+    def keep_thread_active() -> bool:
         # if `client.cleanup()` was called, stop thread
+        client = client_ref()
         if not client or (
             hasattr(client, "_manual_cleanup") and client._manual_cleanup
         ):

--- a/python/langsmith/_internal/_background_thread.py
+++ b/python/langsmith/_internal/_background_thread.py
@@ -306,7 +306,7 @@ def tracing_control_thread_func(
             client._bg_threads.append(compress_thread)
             compress_thread.start()
 
-    def keep_thread_active() -> bool:
+    def keep_thread_active(client: Optional[Client] = client) -> bool:
         # if `client.cleanup()` was called, stop thread
         if not client or (
             hasattr(client, "_manual_cleanup") and client._manual_cleanup
@@ -382,7 +382,7 @@ def tracing_control_thread_func_compress_parallel(
     size_limit: int = batch_ingest_config["size_limit"]
     size_limit_bytes = batch_ingest_config.get("size_limit_bytes", 20_971_520)
 
-    def keep_thread_active() -> bool:
+    def keep_thread_active(client: Optional[Client] = client) -> bool:
         # if `client.cleanup()` was called, stop thread
         if not client or (
             hasattr(client, "_manual_cleanup") and client._manual_cleanup

--- a/python/langsmith/_internal/_background_thread.py
+++ b/python/langsmith/_internal/_background_thread.py
@@ -344,6 +344,7 @@ def tracing_control_thread_func(
                 client, tracing_queue, next_batch, use_multipart
             )
     logger.debug("Tracing control thread is shutting down")
+    del client
 
 
 def tracing_control_thread_func_compress_parallel(
@@ -471,6 +472,7 @@ def tracing_control_thread_func_compress_parallel(
             exc_info=True,
         )
     logger.debug("Compressed traces control thread is shutting down")
+    del client
 
 
 def _tracing_sub_thread_func(
@@ -524,3 +526,4 @@ def _tracing_sub_thread_func(
                 client, tracing_queue, next_batch, use_multipart
             )
     logger.debug("Tracing control sub-thread is shutting down")
+    del client

--- a/python/langsmith/_internal/_background_thread.py
+++ b/python/langsmith/_internal/_background_thread.py
@@ -384,7 +384,8 @@ def tracing_control_thread_func_compress_parallel(
     batch_ingest_config = _ensure_ingest_config(client.info)
     size_limit: int = batch_ingest_config["size_limit"]
     size_limit_bytes = batch_ingest_config.get("size_limit_bytes", 20_971_520)
-    num_known_refs = 3
+    # one for this func, one for the parent tracing thread, one for getrefcount, one for _get_data_type_cached
+    num_known_refs = 4
 
     def keep_thread_active() -> bool:
         # if `client.cleanup()` was called, stop thread

--- a/python/langsmith/_internal/_background_thread.py
+++ b/python/langsmith/_internal/_background_thread.py
@@ -269,12 +269,11 @@ def _ensure_ingest_config(
 def tracing_control_thread_func(
     client_ref: weakref.ref[Client], shutdown_event: threading.Event
 ) -> None:
-    client = client_ref()
-    if client is None:
+    if client_ref() is None:
         return
-    tracing_queue = client.tracing_queue
+    tracing_queue = client_ref().tracing_queue
     assert tracing_queue is not None
-    batch_ingest_config = _ensure_ingest_config(client.info)
+    batch_ingest_config = _ensure_ingest_config(client_ref().info)
     size_limit: int = batch_ingest_config["size_limit"]
     scale_up_nthreads_limit: int = batch_ingest_config["scale_up_nthreads_limit"]
     scale_up_qsize_trigger: int = batch_ingest_config["scale_up_qsize_trigger"]
@@ -285,10 +284,10 @@ def tracing_control_thread_func(
     # Disable compression if explicitly set or if using OpenTelemetry
     disable_compression = (
         ls_utils.is_truish(ls_utils.get_env_var("DISABLE_RUN_COMPRESSION"))
-        or client.otel_exporter is not None
+        or client_ref().otel_exporter is not None
     )
     if not disable_compression and use_multipart:
-        if not (client.info.instance_flags or {}).get(
+        if not (client_ref().info.instance_flags or {}).get(
             "zstd_compression_enabled", False
         ):
             logger.warning(
@@ -296,21 +295,20 @@ def tracing_control_thread_func(
                 "version of LangSmith. Falling back to regular multipart ingestion."
             )
         else:
-            client._futures = set()
-            client.compressed_traces = CompressedTraces()
-            client._data_available_event = threading.Event()
+            client_ref()._futures = set()
+            client_ref().compressed_traces = CompressedTraces()
+            client_ref()._data_available_event = threading.Event()
             compress_thread = threading.Thread(
                 target=tracing_control_thread_func_compress_parallel,
-                args=(weakref.ref(client), shutdown_event),
+                args=(weakref.ref(client_ref()), shutdown_event),
             )
-            client._bg_threads.append(compress_thread)
+            client_ref()._bg_threads.append(compress_thread)
             compress_thread.start()
 
     def keep_thread_active() -> bool:
         # if `client.cleanup()` was called, stop thread
-        client = client_ref()
-        if not client or (
-            hasattr(client, "_manual_cleanup") and client._manual_cleanup
+        if not client_ref() or (
+            hasattr(client_ref(), "_manual_cleanup") and client_ref()._manual_cleanup
         ):
             logger.debug("Client is being cleaned up, stopping tracing thread")
             return False
@@ -332,30 +330,31 @@ def tracing_control_thread_func(
         ):
             new_thread = threading.Thread(
                 target=_tracing_sub_thread_func,
-                args=(weakref.ref(client), use_multipart, shutdown_event),
+                args=(weakref.ref(client_ref()), use_multipart, shutdown_event),
             )
             sub_threads.append(new_thread)
             new_thread.start()
         if next_batch := _tracing_thread_drain_queue(tracing_queue, limit=size_limit):
-            if client.otel_exporter is not None:
-                _otel_tracing_thread_handle_batch(client, tracing_queue, next_batch)
+            if client_ref().otel_exporter is not None:
+                _otel_tracing_thread_handle_batch(
+                    client_ref(), tracing_queue, next_batch
+                )
             else:
                 _tracing_thread_handle_batch(
-                    client, tracing_queue, next_batch, use_multipart
+                    client_ref(), tracing_queue, next_batch, use_multipart
                 )
 
     # drain the queue on exit
     while next_batch := _tracing_thread_drain_queue(
         tracing_queue, limit=size_limit, block=False
     ):
-        if client.otel_exporter is not None:
-            _otel_tracing_thread_handle_batch(client, tracing_queue, next_batch)
+        if client_ref().otel_exporter is not None:
+            _otel_tracing_thread_handle_batch(client_ref(), tracing_queue, next_batch)
         else:
             _tracing_thread_handle_batch(
-                client, tracing_queue, next_batch, use_multipart
+                client_ref(), tracing_queue, next_batch, use_multipart
             )
     logger.debug("Tracing control thread is shutting down")
-    del client
 
 
 def tracing_control_thread_func_compress_parallel(
@@ -363,14 +362,13 @@ def tracing_control_thread_func_compress_parallel(
     shutdown_event: threading.Event,
     flush_interval: float = 0.5,
 ) -> None:
-    client = client_ref()
-    if client is None:
+    if client_ref() is None:
         return
 
     if (
-        client.compressed_traces is None
-        or client._data_available_event is None
-        or client._futures is None
+        client_ref().compressed_traces is None
+        or client_ref()._data_available_event is None
+        or client_ref()._futures is None
     ):
         logger.error(
             "LangSmith tracing error: Required compression attributes not "
@@ -379,15 +377,14 @@ def tracing_control_thread_func_compress_parallel(
         )
         return
 
-    batch_ingest_config = _ensure_ingest_config(client.info)
+    batch_ingest_config = _ensure_ingest_config(client_ref().info)
     size_limit: int = batch_ingest_config["size_limit"]
     size_limit_bytes = batch_ingest_config.get("size_limit_bytes", 20_971_520)
 
     def keep_thread_active() -> bool:
         # if `client.cleanup()` was called, stop thread
-        client = client_ref()
-        if not client or (
-            hasattr(client, "_manual_cleanup") and client._manual_cleanup
+        if not client_ref() or (
+            hasattr(client_ref(), "_manual_cleanup") and client_ref()._manual_cleanup
         ):
             logger.debug("Client is being cleaned up, stopping compression thread")
             return False
@@ -400,28 +397,28 @@ def tracing_control_thread_func_compress_parallel(
     last_flush_time = time.monotonic()
 
     while True:
-        triggered = client._data_available_event.wait(timeout=0.05)
+        triggered = client_ref()._data_available_event.wait(timeout=0.05)
         if not keep_thread_active():
             break
 
         # If data arrived, clear the event and attempt a drain
         if triggered:
-            client._data_available_event.clear()
+            client_ref()._data_available_event.clear()
 
             data_stream, compressed_traces_info = (
                 _tracing_thread_drain_compressed_buffer
-            )(client, size_limit, size_limit_bytes)
+            )(client_ref(), size_limit, size_limit_bytes)
             # If we have data, submit the send request
             if data_stream is not None:
                 try:
                     future = HTTP_REQUEST_THREAD_POOL.submit(
-                        client._send_compressed_multipart_req,
+                        client_ref()._send_compressed_multipart_req,
                         data_stream,
                         compressed_traces_info,
                     )
-                    client._futures.add(future)
+                    client_ref()._futures.add(future)
                 except RuntimeError:
-                    client._send_compressed_multipart_req(
+                    client_ref()._send_compressed_multipart_req(
                         data_stream,
                         compressed_traces_info,
                     )
@@ -431,7 +428,7 @@ def tracing_control_thread_func_compress_parallel(
             if (time.monotonic() - last_flush_time) >= flush_interval:
                 data_stream, compressed_traces_info = (
                     _tracing_thread_drain_compressed_buffer(
-                        client, size_limit=1, size_limit_bytes=1
+                        client_ref(), size_limit=1, size_limit_bytes=1
                     )
                 )
                 if data_stream is not None:
@@ -439,14 +436,14 @@ def tracing_control_thread_func_compress_parallel(
                         cf.wait(
                             [
                                 HTTP_REQUEST_THREAD_POOL.submit(
-                                    client._send_compressed_multipart_req,
+                                    client_ref()._send_compressed_multipart_req,
                                     data_stream,
                                     compressed_traces_info,
                                 )
                             ]
                         )
                     except RuntimeError:
-                        client._send_compressed_multipart_req(
+                        client_ref()._send_compressed_multipart_req(
                             data_stream,
                             compressed_traces_info,
                         )
@@ -456,7 +453,7 @@ def tracing_control_thread_func_compress_parallel(
     try:
         final_data_stream, compressed_traces_info = (
             _tracing_thread_drain_compressed_buffer(
-                client, size_limit=1, size_limit_bytes=1
+                client_ref(), size_limit=1, size_limit_bytes=1
             )
         )
         if final_data_stream is not None:
@@ -464,14 +461,14 @@ def tracing_control_thread_func_compress_parallel(
                 cf.wait(
                     [
                         HTTP_REQUEST_THREAD_POOL.submit(
-                            client._send_compressed_multipart_req,
+                            client_ref()._send_compressed_multipart_req,
                             final_data_stream,
                             compressed_traces_info,
                         )
                     ]
                 )
             except RuntimeError:
-                client._send_compressed_multipart_req(
+                client_ref()._send_compressed_multipart_req(
                     final_data_stream,
                     compressed_traces_info,
                 )
@@ -484,7 +481,6 @@ def tracing_control_thread_func_compress_parallel(
             exc_info=True,
         )
     logger.debug("Compressed traces control thread is shutting down")
-    del client
 
 
 def _tracing_sub_thread_func(
@@ -492,18 +488,17 @@ def _tracing_sub_thread_func(
     use_multipart: bool,
     shutdown_event: threading.Event,
 ) -> None:
-    client = client_ref()
-    if client is None:
+    if client_ref() is None:
         return
     try:
-        if not client.info:
+        if not client_ref().info:
             return
     except BaseException as e:
         logger.debug("Error in tracing control thread: %s", e)
         return
-    tracing_queue = client.tracing_queue
+    tracing_queue = client_ref().tracing_queue
     assert tracing_queue is not None
-    batch_ingest_config = _ensure_ingest_config(client.info)
+    batch_ingest_config = _ensure_ingest_config(client_ref().info)
     size_limit = batch_ingest_config.get("size_limit", 100)
     seen_successive_empty_queues = 0
 
@@ -518,11 +513,13 @@ def _tracing_sub_thread_func(
     ):
         if next_batch := _tracing_thread_drain_queue(tracing_queue, limit=size_limit):
             seen_successive_empty_queues = 0
-            if client.otel_exporter is not None:
-                _otel_tracing_thread_handle_batch(client, tracing_queue, next_batch)
+            if client_ref().otel_exporter is not None:
+                _otel_tracing_thread_handle_batch(
+                    client_ref(), tracing_queue, next_batch
+                )
             else:
                 _tracing_thread_handle_batch(
-                    client, tracing_queue, next_batch, use_multipart
+                    client_ref(), tracing_queue, next_batch, use_multipart
                 )
         else:
             seen_successive_empty_queues += 1
@@ -531,11 +528,10 @@ def _tracing_sub_thread_func(
     while next_batch := _tracing_thread_drain_queue(
         tracing_queue, limit=size_limit, block=False
     ):
-        if client.otel_exporter is not None:
-            _otel_tracing_thread_handle_batch(client, tracing_queue, next_batch)
+        if client_ref().otel_exporter is not None:
+            _otel_tracing_thread_handle_batch(client_ref(), tracing_queue, next_batch)
         else:
             _tracing_thread_handle_batch(
-                client, tracing_queue, next_batch, use_multipart
+                client_ref(), tracing_queue, next_batch, use_multipart
             )
     logger.debug("Tracing control sub-thread is shutting down")
-    del client

--- a/python/langsmith/_internal/_background_thread.py
+++ b/python/langsmith/_internal/_background_thread.py
@@ -11,6 +11,7 @@ from multiprocessing import cpu_count
 from queue import Empty, Queue
 from typing import (
     TYPE_CHECKING,
+    Callable,
     Optional,
     Union,
     cast,
@@ -267,14 +268,13 @@ def _ensure_ingest_config(
 
 
 def tracing_control_thread_func(
-    client_ref: weakref.ref[Client], shutdown_event: threading.Event
+    client_ref: Callable[[], Client], shutdown_event: threading.Event
 ) -> None:
     if client_ref() is None:
         return
-    client = cast(Client, client_ref())
-    tracing_queue = client.tracing_queue
+    tracing_queue = client_ref().tracing_queue
     assert tracing_queue is not None
-    batch_ingest_config = _ensure_ingest_config(client.info)
+    batch_ingest_config = _ensure_ingest_config(client_ref().info)
     size_limit: int = batch_ingest_config["size_limit"]
     scale_up_nthreads_limit: int = batch_ingest_config["scale_up_nthreads_limit"]
     scale_up_qsize_trigger: int = batch_ingest_config["scale_up_qsize_trigger"]
@@ -285,10 +285,10 @@ def tracing_control_thread_func(
     # Disable compression if explicitly set or if using OpenTelemetry
     disable_compression = (
         ls_utils.is_truish(ls_utils.get_env_var("DISABLE_RUN_COMPRESSION"))
-        or client.otel_exporter is not None
+        or client_ref().otel_exporter is not None
     )
     if not disable_compression and use_multipart:
-        if not (client.info.instance_flags or {}).get(
+        if not (client_ref().info.instance_flags or {}).get(
             "zstd_compression_enabled", False
         ):
             logger.warning(
@@ -296,20 +296,20 @@ def tracing_control_thread_func(
                 "version of LangSmith. Falling back to regular multipart ingestion."
             )
         else:
-            client._futures = set()
-            client.compressed_traces = CompressedTraces()
-            client._data_available_event = threading.Event()
+            client_ref()._futures = set()
+            client_ref().compressed_traces = CompressedTraces()
+            client_ref()._data_available_event = threading.Event()
             compress_thread = threading.Thread(
                 target=tracing_control_thread_func_compress_parallel,
                 args=(weakref.ref(client_ref()), shutdown_event),
             )
-            client._bg_threads.append(compress_thread)
+            client_ref()._bg_threads.append(compress_thread)
             compress_thread.start()
 
     def keep_thread_active() -> bool:
         # if `client.cleanup()` was called, stop thread
-        if not client or (
-            hasattr(client, "_manual_cleanup") and client._manual_cleanup
+        if not client_ref() or (
+            hasattr(client_ref(), "_manual_cleanup") and client_ref()._manual_cleanup
         ):
             logger.debug("Client is being cleaned up, stopping tracing thread")
             return False
@@ -336,38 +336,39 @@ def tracing_control_thread_func(
             sub_threads.append(new_thread)
             new_thread.start()
         if next_batch := _tracing_thread_drain_queue(tracing_queue, limit=size_limit):
-            if client.otel_exporter is not None:
-                _otel_tracing_thread_handle_batch(client, tracing_queue, next_batch)
+            if client_ref().otel_exporter is not None:
+                _otel_tracing_thread_handle_batch(
+                    client_ref(), tracing_queue, next_batch
+                )
             else:
                 _tracing_thread_handle_batch(
-                    client, tracing_queue, next_batch, use_multipart
+                    client_ref(), tracing_queue, next_batch, use_multipart
                 )
 
     # drain the queue on exit
     while next_batch := _tracing_thread_drain_queue(
         tracing_queue, limit=size_limit, block=False
     ):
-        if client.otel_exporter is not None:
-            _otel_tracing_thread_handle_batch(client, tracing_queue, next_batch)
+        if client_ref().otel_exporter is not None:
+            _otel_tracing_thread_handle_batch(client_ref(), tracing_queue, next_batch)
         else:
             _tracing_thread_handle_batch(
-                client, tracing_queue, next_batch, use_multipart
+                client_ref(), tracing_queue, next_batch, use_multipart
             )
     logger.debug("Tracing control thread is shutting down")
 
 
 def tracing_control_thread_func_compress_parallel(
-    client_ref: weakref.ref[Client],
+    client_ref: Callable[[], Client],
     shutdown_event: threading.Event,
     flush_interval: float = 0.5,
 ) -> None:
     if client_ref() is None:
         return
-    client = cast(Client, client_ref())
     if (
-        client.compressed_traces is None
-        or client._data_available_event is None
-        or client._futures is None
+        client_ref().compressed_traces is None
+        or client_ref()._data_available_event is None
+        or client_ref()._futures is None
     ):
         logger.error(
             "LangSmith tracing error: Required compression attributes not "
@@ -376,14 +377,14 @@ def tracing_control_thread_func_compress_parallel(
         )
         return
 
-    batch_ingest_config = _ensure_ingest_config(client.info)
+    batch_ingest_config = _ensure_ingest_config(client_ref().info)
     size_limit: int = batch_ingest_config["size_limit"]
     size_limit_bytes = batch_ingest_config.get("size_limit_bytes", 20_971_520)
 
     def keep_thread_active() -> bool:
         # if `client.cleanup()` was called, stop thread
-        if not client or (
-            hasattr(client, "_manual_cleanup") and client._manual_cleanup
+        if not client_ref() or (
+            hasattr(client_ref(), "_manual_cleanup") and client_ref()._manual_cleanup
         ):
             logger.debug("Client is being cleaned up, stopping compression thread")
             return False
@@ -396,28 +397,28 @@ def tracing_control_thread_func_compress_parallel(
     last_flush_time = time.monotonic()
 
     while True:
-        triggered = client._data_available_event.wait(timeout=0.05)
+        triggered = client_ref()._data_available_event.wait(timeout=0.05)  # type: ignore
         if not keep_thread_active():
             break
 
         # If data arrived, clear the event and attempt a drain
         if triggered:
-            client._data_available_event.clear()
+            client_ref()._data_available_event.clear()  # type: ignore
 
             data_stream, compressed_traces_info = (
                 _tracing_thread_drain_compressed_buffer
-            )(client, size_limit, size_limit_bytes)
+            )(client_ref(), size_limit, size_limit_bytes)
             # If we have data, submit the send request
             if data_stream is not None:
                 try:
                     future = HTTP_REQUEST_THREAD_POOL.submit(
-                        client._send_compressed_multipart_req,
+                        client_ref()._send_compressed_multipart_req,
                         data_stream,
                         compressed_traces_info,
                     )
-                    client._futures.add(future)
+                    client_ref()._futures.add(future)  # type: ignore
                 except RuntimeError:
-                    client._send_compressed_multipart_req(
+                    client_ref()._send_compressed_multipart_req(
                         data_stream,
                         compressed_traces_info,
                     )
@@ -427,7 +428,7 @@ def tracing_control_thread_func_compress_parallel(
             if (time.monotonic() - last_flush_time) >= flush_interval:
                 data_stream, compressed_traces_info = (
                     _tracing_thread_drain_compressed_buffer(
-                        client, size_limit=1, size_limit_bytes=1
+                        client_ref(), size_limit=1, size_limit_bytes=1
                     )
                 )
                 if data_stream is not None:
@@ -435,14 +436,14 @@ def tracing_control_thread_func_compress_parallel(
                         cf.wait(
                             [
                                 HTTP_REQUEST_THREAD_POOL.submit(
-                                    client._send_compressed_multipart_req,
+                                    client_ref()._send_compressed_multipart_req,
                                     data_stream,
                                     compressed_traces_info,
                                 )
                             ]
                         )
                     except RuntimeError:
-                        client._send_compressed_multipart_req(
+                        client_ref()._send_compressed_multipart_req(
                             data_stream,
                             compressed_traces_info,
                         )
@@ -452,7 +453,7 @@ def tracing_control_thread_func_compress_parallel(
     try:
         final_data_stream, compressed_traces_info = (
             _tracing_thread_drain_compressed_buffer(
-                client, size_limit=1, size_limit_bytes=1
+                client_ref(), size_limit=1, size_limit_bytes=1
             )
         )
         if final_data_stream is not None:
@@ -460,14 +461,14 @@ def tracing_control_thread_func_compress_parallel(
                 cf.wait(
                     [
                         HTTP_REQUEST_THREAD_POOL.submit(
-                            client._send_compressed_multipart_req,
+                            client_ref()._send_compressed_multipart_req,
                             final_data_stream,
                             compressed_traces_info,
                         )
                     ]
                 )
             except RuntimeError:
-                client._send_compressed_multipart_req(
+                client_ref()._send_compressed_multipart_req(
                     final_data_stream,
                     compressed_traces_info,
                 )
@@ -483,22 +484,21 @@ def tracing_control_thread_func_compress_parallel(
 
 
 def _tracing_sub_thread_func(
-    client_ref: weakref.ref[Client],
+    client_ref: Callable[[], Client],
     use_multipart: bool,
     shutdown_event: threading.Event,
 ) -> None:
     if client_ref() is None:
         return
-    client = cast(Client, client_ref())
     try:
-        if not client.info:
+        if not client_ref().info:
             return
     except BaseException as e:
         logger.debug("Error in tracing control thread: %s", e)
         return
-    tracing_queue = client.tracing_queue
+    tracing_queue = client_ref().tracing_queue
     assert tracing_queue is not None
-    batch_ingest_config = _ensure_ingest_config(client.info)
+    batch_ingest_config = _ensure_ingest_config(client_ref().info)
     size_limit = batch_ingest_config.get("size_limit", 100)
     seen_successive_empty_queues = 0
 
@@ -513,11 +513,13 @@ def _tracing_sub_thread_func(
     ):
         if next_batch := _tracing_thread_drain_queue(tracing_queue, limit=size_limit):
             seen_successive_empty_queues = 0
-            if client.otel_exporter is not None:
-                _otel_tracing_thread_handle_batch(client, tracing_queue, next_batch)
+            if client_ref().otel_exporter is not None:
+                _otel_tracing_thread_handle_batch(
+                    client_ref(), tracing_queue, next_batch
+                )
             else:
                 _tracing_thread_handle_batch(
-                    client, tracing_queue, next_batch, use_multipart
+                    client_ref(), tracing_queue, next_batch, use_multipart
                 )
         else:
             seen_successive_empty_queues += 1
@@ -526,10 +528,10 @@ def _tracing_sub_thread_func(
     while next_batch := _tracing_thread_drain_queue(
         tracing_queue, limit=size_limit, block=False
     ):
-        if client.otel_exporter is not None:
-            _otel_tracing_thread_handle_batch(client, tracing_queue, next_batch)
+        if client_ref().otel_exporter is not None:
+            _otel_tracing_thread_handle_batch(client_ref(), tracing_queue, next_batch)
         else:
             _tracing_thread_handle_batch(
-                client, tracing_queue, next_batch, use_multipart
+                client_ref(), tracing_queue, next_batch, use_multipart
             )
     logger.debug("Tracing control sub-thread is shutting down")

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "langsmith"
-version = "0.3.38
+version = "0.3.38"
 description = "Client library to connect to the LangSmith LLM Tracing and Evaluation Platform."
 authors = ["LangChain <support@langchain.dev>"]
 license = "MIT"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "langsmith"
-version = "0.3.35"
+version = "0.3.36rc0"
 description = "Client library to connect to the LangSmith LLM Tracing and Evaluation Platform."
 authors = ["LangChain <support@langchain.dev>"]
 license = "MIT"


### PR DESCRIPTION
### Purpose
Batch-compression was occasionally shutting itself down mid-session, which then also shut down the main tracing queue.
The control thread decided a Client was “orphaned” by comparing sys.getrefcount() against active_count of the ThreadPoolExecutor. The compression loop would exit early, leaving traces unsent.

### Changes
**Deterministic lifetime control**

1. Introduced a single _shutdown_event per Client.

2. All background threads (control + compression) run until that event is set; no more ref-count math.

3. Weak-ref finalizer owns the shutdown

**Code cleanup**

1. Removed all `getrefcount` / `active_count` heuristics and the `num_known_refs` bookkeeping.

Resolves: https://github.com/langchain-ai/langsmith-sdk/issues/1630