### PR TITLE
fix[python]: Correct client reference counting in compression thread 

### DIFF
--- a/python/langsmith/__init__.py
+++ b/python/langsmith/__init__.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
     from langsmith.utils import ContextThreadPoolExecutor
 
 # Avoid calling into importlib on every call to __version__
-__version__ = "0.3.37"
+__version__ = "0.3.38"
 version = __version__  # for backwards compatibility
 
 

--- a/python/langsmith/_internal/_background_thread.py
+++ b/python/langsmith/_internal/_background_thread.py
@@ -394,6 +394,8 @@ def tracing_control_thread_func_compress_parallel(
     batch_ingest_config = _ensure_ingest_config(client.info)
     size_limit: int = batch_ingest_config["size_limit"]
     size_limit_bytes = batch_ingest_config.get("size_limit_bytes", 20_971_520)
+    # One for this func, one for the parent thread, one for getrefcount,
+    # one for _get_data_type_cached
     num_known_refs = 4
 
     def keep_thread_active() -> bool:

--- a/python/langsmith/_internal/_background_thread.py
+++ b/python/langsmith/_internal/_background_thread.py
@@ -322,7 +322,9 @@ def tracing_control_thread_func(client_ref: weakref.ref[Client]) -> None:
         if hasattr(sys, "getrefcount"):
             # check if client refs count indicates we're the only remaining
             # reference to the client
-            should_keep_thread = sys.getrefcount(client) > num_known_refs
+            should_keep_thread = sys.getrefcount(client) > num_known_refs + len(
+                sub_threads
+            )
             if not should_keep_thread:
                 logger.debug(
                     "Client refs count indicates we're the only remaining reference "

--- a/python/langsmith/_internal/_background_thread.py
+++ b/python/langsmith/_internal/_background_thread.py
@@ -322,9 +322,7 @@ def tracing_control_thread_func(client_ref: weakref.ref[Client]) -> None:
         if hasattr(sys, "getrefcount"):
             # check if client refs count indicates we're the only remaining
             # reference to the client
-            should_keep_thread = sys.getrefcount(client) > num_known_refs + len(
-                sub_threads
-            )
+            should_keep_thread = sys.getrefcount(client) > num_known_refs
             if not should_keep_thread:
                 logger.debug(
                     "Client refs count indicates we're the only remaining reference "
@@ -394,7 +392,7 @@ def tracing_control_thread_func_compress_parallel(
     batch_ingest_config = _ensure_ingest_config(client.info)
     size_limit: int = batch_ingest_config["size_limit"]
     size_limit_bytes = batch_ingest_config.get("size_limit_bytes", 20_971_520)
-    num_known_refs = 3
+    num_known_refs = 4
 
     def keep_thread_active() -> bool:
         # if `client.cleanup()` was called, stop thread
@@ -410,13 +408,7 @@ def tracing_control_thread_func_compress_parallel(
         if hasattr(sys, "getrefcount"):
             # check if client refs count indicates we're the only remaining
             # reference to the client
-
-            # Count active threads
-            thread_pool = HTTP_REQUEST_THREAD_POOL._threads
-            active_count = sum(
-                1 for thread in thread_pool if thread is not None and thread.is_alive()
-            )
-            should_keep_thread = sys.getrefcount(client) > num_known_refs + active_count
+            should_keep_thread = sys.getrefcount(client) > num_known_refs
             if not should_keep_thread:
                 logger.debug(
                     "Client refs count indicates we're the only remaining reference "

--- a/python/langsmith/_internal/_background_thread.py
+++ b/python/langsmith/_internal/_background_thread.py
@@ -297,7 +297,7 @@ def tracing_control_thread_func(client_ref: weakref.ref[Client]) -> None:
                 "version of LangSmith. Falling back to regular multipart ingestion."
             )
         else:
-            client._futures = set()
+            client._futures = weakref.WeakSet()
             client.compressed_traces = CompressedTraces()
             client._data_available_event = threading.Event()
             threading.Thread(

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -530,7 +530,7 @@ class Client:
         atexit.register(close_session, session_)
         self.compressed_traces: Optional[CompressedTraces] = None
         self._data_available_event: Optional[threading.Event] = None
-        self._futures: Optional[set[cf.Future]] = None
+        self._futures: Optional[weakref.WeakSet[cf.Future]] = None
         self.otel_exporter: Optional[OTELExporter] = None
 
         # Initialize auto batching
@@ -2250,7 +2250,8 @@ class Client:
 
         # If we got a future, wait for it to complete
         if self._futures:
-            done, _ = cf.wait(self._futures)
+            futures = list(self._futures)
+            done, _ = cf.wait(futures)
             # Remove completed futures
             self._futures.difference_update(done)
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "langsmith"
-version = "0.3.37"
+version = "0.3.38"
 description = "Client library to connect to the LangSmith LLM Tracing and Evaluation Platform."
 authors = ["LangChain <support@langchain.dev>"]
 license = "MIT"


### PR DESCRIPTION
### Purpose
The batch compression tracing thread was occasionally shutting itself down mid-session, which then also shut down the main tracing queue.

The control thread decided a Client was “orphaned” by comparing sys.getrefcount() against active_count of the ThreadPoolExecutor. The compression loop would exit early, leaving traces unsent.

### Changes
Don't include ThreadPoolExecutor threads in the refcount calculation, since they won't block process shutdown are the executor is defined globally, so won't be affected by creating multiple clients

Additionally sets futures to be a WeakSet, so that completed futures that are GC'd automatically get discarded from the set, preventing memory leaks

Resolves: https://github.com/langchain-ai/langsmith-sdk/issues/1630