### PR TITLE
Add RunTree.set() support

### DIFF
--- a/python/langsmith/__init__.py
+++ b/python/langsmith/__init__.py
@@ -14,7 +14,6 @@ if TYPE_CHECKING:
         trace,
         traceable,
         tracing_context,
-        update_current_run,
     )
     from langsmith.run_trees import RunTree
     from langsmith.testing._internal import test, unit
@@ -92,10 +91,6 @@ def __getattr__(name: str) -> Any:
         from langsmith.run_helpers import get_tracing_context
 
         return get_tracing_context
-    elif name == "update_current_run":
-        from langsmith.run_helpers import update_current_run
-
-        return update_current_run
     elif name == "get_current_run_tree":
         from langsmith.run_helpers import get_current_run_tree
 
@@ -130,7 +125,6 @@ __all__ = [
     "tracing_context",
     "get_tracing_context",
     "get_current_run_tree",
-    "update_current_run",
     "ContextThreadPoolExecutor",
     "AsyncClient",
 ]

--- a/python/langsmith/__init__.py
+++ b/python/langsmith/__init__.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
     from langsmith.utils import ContextThreadPoolExecutor
 
 # Avoid calling into importlib on every call to __version__
-__version__ = "0.3.39"
+__version__ = "0.3.40"
 version = __version__  # for backwards compatibility
 
 

--- a/python/langsmith/__init__.py
+++ b/python/langsmith/__init__.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
         trace,
         traceable,
         tracing_context,
+        update_current_run,
     )
     from langsmith.run_trees import RunTree
     from langsmith.testing._internal import test, unit
@@ -91,7 +92,10 @@ def __getattr__(name: str) -> Any:
         from langsmith.run_helpers import get_tracing_context
 
         return get_tracing_context
+    elif name == "update_current_run":
+        from langsmith.run_helpers import update_current_run
 
+        return update_current_run
     elif name == "get_current_run_tree":
         from langsmith.run_helpers import get_current_run_tree
 
@@ -126,6 +130,7 @@ __all__ = [
     "tracing_context",
     "get_tracing_context",
     "get_current_run_tree",
+    "update_current_run",
     "ContextThreadPoolExecutor",
     "AsyncClient",
 ]

--- a/python/langsmith/run_helpers.py
+++ b/python/langsmith/run_helpers.py
@@ -81,60 +81,6 @@ def get_current_run_tree() -> Optional[run_trees.RunTree]:
     return _PARENT_RUN_TREE.get()
 
 
-def update_current_run(
-    *,
-    inputs: Optional[dict[str, Any]] = NOT_PROVIDED,
-    outputs: Optional[dict[str, Any]] = NOT_PROVIDED,
-    metadata: Optional[dict[str, Any]] = NOT_PROVIDED,
-    tags: Optional[list[str]] = NOT_PROVIDED,
-    # Default is to override rather than upsert
-    omit_auto_outputs: Optional[bool] = NOT_PROVIDED,
-    omit_auto_inputs: Optional[bool] = NOT_PROVIDED,
-) -> None:
-    """Update the current run."""
-    run_tree = _PARENT_RUN_TREE.get()
-    if run_tree is None:
-        LOGGER.debug("update_current_run: no run tree found to update.")
-        return
-    if inputs is not NOT_PROVIDED:
-        if omit_auto_inputs in (True, NOT_PROVIDED):
-            if inputs is None:
-                run_tree.inputs = {}
-            else:
-                run_tree.inputs = inputs
-        else:
-            run_tree.add_inputs(inputs)
-        # This is used by LangChain core to determine whether to
-        # re-upload the inputs upon run completion
-        run_tree.extra["inputs_is_truthy"] = False
-    elif omit_auto_inputs is True:
-        run_tree.extra["inputs_is_truthy"] = False
-        run_tree.inputs = {}
-    if outputs is not NOT_PROVIDED:
-        if omit_auto_outputs is NOT_PROVIDED:
-            # Default to True if user is setting
-            omit_auto_outputs = True
-        if omit_auto_outputs in (True, NOT_PROVIDED):
-            if outputs is None:
-                run_tree.outputs = {}
-            else:
-                run_tree.outputs = outputs
-        else:
-            run_tree.add_outputs(outputs)
-    if omit_auto_outputs is not NOT_PROVIDED:
-        run_tree.extra["omit_auto_outputs"] = omit_auto_outputs
-    if metadata is not NOT_PROVIDED:
-        if metadata is None:
-            run_tree.metadata = {}
-        else:
-            run_tree.add_metadata(metadata)
-    if tags is not NOT_PROVIDED:
-        if tags is None:
-            run_tree.tags = []
-        else:
-            run_tree.add_tags(tags)
-
-
 def get_tracing_context(
     context: Optional[contextvars.Context] = None,
 ) -> dict[str, Any]:

--- a/python/langsmith/run_helpers.py
+++ b/python/langsmith/run_helpers.py
@@ -50,7 +50,6 @@ if TYPE_CHECKING:
 
     from langchain_core.runnables import Runnable
 
-NOT_PROVIDED = cast(None, object())
 LOGGER = logging.getLogger(__name__)
 _PARENT_RUN_TREE = contextvars.ContextVar[Optional[run_trees.RunTree]](
     "_PARENT_RUN_TREE", default=None

--- a/python/langsmith/run_trees.py
+++ b/python/langsmith/run_trees.py
@@ -33,6 +33,9 @@ LANGSMITH_DOTTED_ORDER_BYTES = LANGSMITH_DOTTED_ORDER.encode("utf-8")
 LANGSMITH_METADATA = sys.intern(f"{LANGSMITH_PREFIX}metadata")
 LANGSMITH_TAGS = sys.intern(f"{LANGSMITH_PREFIX}tags")
 LANGSMITH_PROJECT = sys.intern(f"{LANGSMITH_PREFIX}project")
+OVERRIDE_INPUTS = sys.intern("__omit_auto_inputs")
+OVERRIDE_OUTPUTS = sys.intern("__omit_auto_outputs")
+NOT_PROVIDED = cast(None, object())
 _CLIENT: Optional[Client] = None
 _LOCK = threading.Lock()  # Keeping around for a while for backwards compat
 
@@ -191,6 +194,7 @@ class RunTree(ls_schemas.RunBase):
         if self.outputs is None:
             self.outputs = {}
         self.outputs.update(outputs)
+        self.extra[OVERRIDE_OUTPUTS] = True
 
     def add_inputs(self, inputs: dict[str, Any]) -> None:
         """Upsert the given outputs into the run.

--- a/python/langsmith/run_trees.py
+++ b/python/langsmith/run_trees.py
@@ -33,7 +33,6 @@ LANGSMITH_DOTTED_ORDER_BYTES = LANGSMITH_DOTTED_ORDER.encode("utf-8")
 LANGSMITH_METADATA = sys.intern(f"{LANGSMITH_PREFIX}metadata")
 LANGSMITH_TAGS = sys.intern(f"{LANGSMITH_PREFIX}tags")
 LANGSMITH_PROJECT = sys.intern(f"{LANGSMITH_PREFIX}project")
-OVERRIDE_INPUTS = sys.intern("__omit_auto_inputs")
 OVERRIDE_OUTPUTS = sys.intern("__omit_auto_outputs")
 NOT_PROVIDED = cast(None, object())
 _CLIENT: Optional[Client] = None
@@ -167,6 +166,51 @@ class RunTree(ls_schemas.RunBase):
         else:
             return super().__setattr__(name, value)
 
+    def set(
+        self,
+        *,
+        inputs: Optional[Mapping[str, Any]] = NOT_PROVIDED,
+        outputs: Optional[Mapping[str, Any]] = NOT_PROVIDED,
+        tags: Optional[Sequence[str]] = NOT_PROVIDED,
+        metadata: Optional[Mapping[str, Any]] = NOT_PROVIDED,
+    ) -> None:
+        """Set the inputs, outputs, tags, and metadata of the run.
+
+        If performed, this will override the default behavior of the
+        end() method to ignore new outputs (that would otherwise be added)
+        by the @traceable decorator.
+
+        If your LangChain or LangGraph versions are sufficiently up-to-date,
+        this will also override the default behavior LangChainTracer.
+
+        Args:
+            inputs: The inputs to set.
+            outputs: The outputs to set.
+            tags: The tags to set.
+            metadata: The metadata to set.
+
+        Returns:
+            None
+        """
+        if tags is not NOT_PROVIDED:
+            self.tags = list(tags)
+        if metadata is not NOT_PROVIDED:
+            self.extra.setdefault("metadata", {}).update(metadata or {})
+        if inputs is not NOT_PROVIDED:
+            # Used by LangChain core to determine whether to
+            # re-upload the inputs upon run completion
+            self.extra["inputs_is_truthy"] = False
+            if inputs is None:
+                self.inputs = {}
+            else:
+                self.inputs = dict(inputs)
+        if outputs is not NOT_PROVIDED:
+            self.extra[OVERRIDE_OUTPUTS] = True
+            if outputs is None:
+                self.outputs = {}
+            else:
+                self.outputs = dict(outputs)
+
     def add_tags(self, tags: Union[Sequence[str], str]) -> None:
         """Add tags to the run."""
         if isinstance(tags, str):
@@ -194,7 +238,6 @@ class RunTree(ls_schemas.RunBase):
         if self.outputs is None:
             self.outputs = {}
         self.outputs.update(outputs)
-        self.extra[OVERRIDE_OUTPUTS] = True
 
     def add_inputs(self, inputs: dict[str, Any]) -> None:
         """Upsert the given outputs into the run.
@@ -208,6 +251,9 @@ class RunTree(ls_schemas.RunBase):
         if self.inputs is None:
             self.inputs = {}
         self.inputs.update(inputs)
+        # Set to False so LangChain things it needs to
+        # re-upload inputs
+        self.extra["inputs_is_truthy"] = False
 
     def add_event(
         self,
@@ -256,11 +302,14 @@ class RunTree(ls_schemas.RunBase):
     ) -> None:
         """Set the end time of the run and all child runs."""
         self.end_time = end_time or datetime.now(timezone.utc)
-        if outputs is not None:
-            if not self.outputs:
-                self.outputs = outputs
-            else:
-                self.outputs.update(outputs)
+        # We've already 'set' the outputs, so ignore
+        # the ones that are automatically included
+        if not self.extra.get(OVERRIDE_OUTPUTS):
+            if outputs is not None:
+                if not self.outputs:
+                    self.outputs = outputs
+                else:
+                    self.outputs.update(outputs)
         if error is not None:
             self.error = error
         if events is not None:

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "langsmith"
-version = "0.3.39"
+version = "0.3.40"
 description = "Client library to connect to the LangSmith LLM Tracing and Evaluation Platform."
 authors = ["LangChain <support@langchain.dev>"]
 license = "MIT"


### PR DESCRIPTION
Useful in conjunction with https://github.com/langchain-ai/langchain/pull/31090.

Then from within a langchain runnable, you can do.

```
def my_node(state):
    if rt := ls.get_current_run_tree():
        rt.set(inputs={"foo": state.foo}, outputs={"bar": "my_bar"})
```

And have it override the defaults. Useful for filtering PII or large values etc.