### PR TITLE
Remove default for fetching child_run_ids from the SDK

### DIFF
--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -1751,7 +1751,6 @@ export class Client implements LangSmithTracingClientInterface {
     }
     const default_select = [
       "app_path",
-      "child_run_ids",
       "completion_cost",
       "completion_tokens",
       "dotted_order",
@@ -4924,8 +4923,8 @@ export class Client implements LangSmithTracingClientInterface {
   }
 
   /**
-   * Clone a public dataset to your own langsmith tenant. 
-   * This operation is idempotent. If you already have a dataset with the given name, 
+   * Clone a public dataset to your own langsmith tenant.
+   * This operation is idempotent. If you already have a dataset with the given name,
    * this function will do nothing.
 
    * @param {string} tokenOrUrl The token of the public dataset to clone.

--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -1554,7 +1554,7 @@ export class Client implements LangSmithTracingClientInterface {
   ): Promise<Run> {
     assertUuid(runId);
     let run = await this._get<Run>(`/runs/${runId}`);
-    if (loadChildRuns && run.child_run_ids) {
+    if (loadChildRuns) {
       run = await this._loadChildRuns(run);
     }
     return run;

--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -1602,11 +1602,13 @@ export class Client implements LangSmithTracingClientInterface {
   }
 
   private async _loadChildRuns(run: Run): Promise<Run> {
-    const childRuns = await toArray(this.listRuns({
-      isRoot: false,
-      projectId: run.session_id,
-      traceId: run.trace_id
-    }));
+    const childRuns = await toArray(
+      this.listRuns({
+        isRoot: false,
+        projectId: run.session_id,
+        traceId: run.trace_id,
+      })
+    );
     const treemap: { [key: string]: Run[] } = {};
     const runs: { [key: string]: Run } = {};
     // TODO: make dotted order required when the migration finishes
@@ -1620,7 +1622,10 @@ export class Client implements LangSmithTracingClientInterface {
       ) {
         throw new Error(`Child run ${childRun.id} has no parent`);
       }
-      if (childRun.dotted_order?.startsWith(run.dotted_order ?? "") && childRun.id !== run.id) {
+      if (
+        childRun.dotted_order?.startsWith(run.dotted_order ?? "") &&
+        childRun.id !== run.id
+      ) {
         if (!(childRun.parent_run_id in treemap)) {
           treemap[childRun.parent_run_id] = [];
         }

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -2481,7 +2481,6 @@ class Client:
             )
         default_select = [
             "app_path",
-            "child_run_ids",
             "completion_cost",
             "completion_tokens",
             "dotted_order",

--- a/python/langsmith/run_helpers.py
+++ b/python/langsmith/run_helpers.py
@@ -236,7 +236,7 @@ P = ParamSpec("P")
 
 @runtime_checkable
 class SupportsLangsmithExtra(Protocol, Generic[P, R]):
-    """Implementations of this Protoc accept an optional langsmith_extra parameter.
+    """Implementations of this Protocol accept an optional langsmith_extra parameter.
 
     Args:
         *args: Variable length arguments.


### PR DESCRIPTION
* Make `child_run_ids` not a default field in select.
* Also fix the `load_child_runs` path to use query by trace. 