### PR TITLE
feat(py): create_feedback with trace_id only

### DIFF
--- a/python/langsmith/__init__.py
+++ b/python/langsmith/__init__.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
     from langsmith.utils import ContextThreadPoolExecutor
 
 # Avoid calling into importlib on every call to __version__
-__version__ = "0.3.42"
+__version__ = "0.3.43"
 version = __version__  # for backwards compatibility
 
 

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -5832,7 +5832,7 @@ class Client:
                     key="correctness",
                     score=0,
                     run_id=foo_run_id,
-                    # trace_id= is optional but recommended to enable batched and backgrounded 
+                    # trace_id= is optional but recommended to enable batched and backgrounded
                     # feedback ingestion.
                     trace_id=trace_id,
                 )

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -5832,7 +5832,9 @@ class Client:
                     key="correctness",
                     score=0,
                     run_id=foo_run_id,
-                    trace_id=trace_id,  # trace_id is optional but recommended so feedback ingestion is batched and backgrounded
+                    # trace_id= is optional but recommended to enable batched and backgrounded 
+                    # feedback ingestion.
+                    trace_id=trace_id,
                 )
 
         """

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -5734,7 +5734,7 @@ class Client:
         error: Optional[bool] = None,
         **kwargs: Any,
     ) -> ls_schemas.Feedback:
-        """Create a feedback in the LangSmith API.
+        """Create feedback for a run.
 
         **NOTE**: To enable feedback to be batch uploaded in the background you must
         specify trace_id. *We highly encourage this for latency-sensitive environments.*

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -5710,11 +5710,13 @@ class Client:
 
     def create_feedback(
         self,
-        run_id: Optional[ID_TYPE],
-        key: str,
+        # TODO: make run_id a kwarg and drop default value for 'key' in breaking release.
+        run_id: Optional[ID_TYPE] = None,
+        key: str = "unnamed",
         *,
         score: Union[float, int, bool, None] = None,
         value: Union[str, dict, None] = None,
+        trace_id: Optional[ID_TYPE] = None,
         correction: Union[dict, None] = None,
         comment: Union[str, None] = None,
         source_info: Optional[dict[str, Any]] = None,
@@ -5729,22 +5731,29 @@ class Client:
         comparative_experiment_id: Optional[ID_TYPE] = None,
         feedback_group_id: Optional[ID_TYPE] = None,
         extra: Optional[dict] = None,
-        trace_id: Optional[ID_TYPE] = None,
         error: Optional[bool] = None,
         **kwargs: Any,
     ) -> ls_schemas.Feedback:
         """Create a feedback in the LangSmith API.
 
+        **NOTE**: To enable feedback to be batch uploaded in the background you must
+        specify trace_id. *We highly encourage this for latency-sensitive environments.*
+
         Args:
-            run_id (Optional[Union[UUID, str]]):
-                The ID of the run to provide feedback for. Either the run_id OR
-                the project_id must be provided.
             key (str):
-                The name of the metric or 'aspect' this feedback is about.
+                The name of the feedback metric.
             score (Optional[Union[float, int, bool]]):
                 The score to rate this run on the metric or aspect.
             value (Optional[Union[float, int, bool, str, dict]]):
                 The display value or non-numeric value for this feedback.
+            run_id (Optional[Union[UUID, str]]):
+                The ID of the run to provide feedback for. At least one of run_id,
+                trace_id, or project_id must be specified.
+            trace_id (Optional[Union[UUID, str]]):
+                The ID of the trace (i.e. root parent run) of the run to provide
+                feedback for (specified by run_id). If run_id and trace_id are the
+                same, only trace_id needs to be specified. **NOTE**: trace_id is
+                required feedback ingestion to be batched and backgrounded.
             correction (Optional[dict]):
                 The proper ground truth for this run.
             comment (Optional[str]):
@@ -5754,7 +5763,7 @@ class Client:
                 Information about the source of this feedback.
             feedback_source_type (Union[FeedbackSourceType, str]):
                 The type of feedback source, such as model (for model-generated feedback)
-                    or API.
+                or API.
             source_run_id (Optional[Union[UUID, str]]):
                 The ID of the run that generated this feedback, if a "model" type.
             feedback_id (Optional[Union[UUID, str]]):
@@ -5767,8 +5776,9 @@ class Client:
             stop_after_attempt (int, default=10):
                 The number of times to retry the request before giving up.
             project_id (Optional[Union[UUID, str]]):
-                The ID of the project_id to provide feedback on. One - and only one - of
-                this and run_id must be provided.
+                The ID of the project (or experiment) to provide feedback on. This is
+                used for creating summary metrics for experiments. Cannot specify
+                run_id or trace_id if project_id is specified, and vice versa.
             comparative_experiment_id (Optional[Union[UUID, str]]):
                 If this feedback was logged as a part of a comparative experiment, this
                 associates the feedback with that experiment.
@@ -5777,18 +5787,62 @@ class Client:
                 this is used to group feedback together.
             extra (Optional[Dict]):
                 Metadata for the feedback.
-            trace_id (Optional[Union[UUID, str]]):
-                The trace ID of the run to provide feedback for. Enables batch ingestion.
             **kwargs (Any):
                 Additional keyword arguments.
 
         Returns:
             Feedback: The created feedback object.
+
+        Example:
+            .. code-block:: python
+
+                from langsmith import trace, traceable, Client
+
+
+                @traceable
+                def foo(x):
+                    return {"y": x * 2}
+
+
+                @traceable
+                def bar(y):
+                    return {"z": y - 1}
+
+
+                client = Client()
+
+                inputs = {"x": 1}
+                with trace(name="foobar", inputs=inputs) as root_run:
+                    result = foo(**inputs)
+                    result = bar(**result)
+                    root_run.outputs = result
+                    trace_id = root_run.id
+                    child_runs = root_run.child_runs
+
+                # Provide feedback for a trace (a.k.a. a root run)
+                client.create_feedback(
+                    key="user_feedback",
+                    score=1,
+                    trace_id=trace_id,
+                )
+
+                # Provide feedback for a child run
+                foo_run_id = [run for run in child_runs if run.name == "foo"][0].id
+                client.create_feedback(
+                    key="correctness",
+                    score=0,
+                    run_id=foo_run_id,
+                    trace_id=trace_id,  # trace_id is optional but recommended so feedback ingestion is batched and backgrounded
+                )
+
         """
+        run_id = run_id or trace_id
         if run_id is None and project_id is None:
-            raise ValueError("One of run_id and project_id must be provided")
+            raise ValueError("One of run_id, trace_id, or project_id  must be provided")
         if run_id is not None and project_id is not None:
-            raise ValueError("Only one of run_id and project_id must be provided")
+            raise ValueError(
+                "project_id cannot be provided if run_id or trace_id is provided"
+            )
         if kwargs:
             warnings.warn(
                 "The following arguments are no longer used in the create_feedback"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "langsmith"
-version = "0.3.42"
+version = "0.3.43"
 description = "Client library to connect to the LangSmith LLM Tracing and Evaluation Platform."
 authors = ["LangChain <support@langchain.dev>"]
 license = "MIT"


### PR DESCRIPTION
Specifying run_id and trace_id is confusing and often redundant, given feedback is usually provided for root runs