### PR TITLE
fix(py): Fix URL construction in attachment downloading

### DIFF
--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -4757,7 +4757,7 @@ class Client:
 
         example = response.json()
         attachments = _convert_stored_attachments_to_attachments_dict(
-            example, attachments_key="attachment_urls"
+            example, attachments_key="attachment_urls", api_url=self._api_url
         )
 
         return ls_schemas.Example(
@@ -4884,7 +4884,7 @@ class Client:
             self._get_paginated_list("/examples", params=params)
         ):
             attachments = _convert_stored_attachments_to_attachments_dict(
-                example, attachments_key="attachment_urls"
+                example, attachments_key="attachment_urls", api_url=self._api_url
             )
 
             yield ls_schemas.Example(
@@ -7944,7 +7944,7 @@ def convert_prompt_to_anthropic_format(
 
 
 def _convert_stored_attachments_to_attachments_dict(
-    data: dict, *, attachments_key: str
+    data: dict, *, attachments_key: str, api_url: Optional[str] = None
 ) -> dict[str, AttachmentInfo]:
     """Convert attachments from the backend database format to the user facing format."""
     attachments_dict = {}
@@ -7952,7 +7952,11 @@ def _convert_stored_attachments_to_attachments_dict(
         for key, value in data[attachments_key].items():
             if not key.startswith("attachment."):
                 continue
-            response = requests.get(value["presigned_url"], stream=True)
+            if api_url is not None:
+                full_url = _construct_url(api_url, value["presigned_url"])
+            else:
+                full_url = value["presigned_url"]
+            response = requests.get(full_url, stream=True)
             response.raise_for_status()
             reader = io.BytesIO(response.content)
             attachments_dict[key.removeprefix("attachment.")] = AttachmentInfo(

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -4757,7 +4757,7 @@ class Client:
 
         example = response.json()
         attachments = _convert_stored_attachments_to_attachments_dict(
-            example, attachments_key="attachment_urls", api_url=self._api_url
+            example, attachments_key="attachment_urls", api_url=self.api_url
         )
 
         return ls_schemas.Example(
@@ -4884,7 +4884,7 @@ class Client:
             self._get_paginated_list("/examples", params=params)
         ):
             attachments = _convert_stored_attachments_to_attachments_dict(
-                example, attachments_key="attachment_urls", api_url=self._api_url
+                example, attachments_key="attachment_urls", api_url=self.api_url
             )
 
             yield ls_schemas.Example(

--- a/python/tests/unit_tests/test_client.py
+++ b/python/tests/unit_tests/test_client.py
@@ -38,6 +38,7 @@ from langsmith._internal._serde import _serialize_json
 from langsmith.client import (
     Client,
     _construct_url,
+    _convert_stored_attachments_to_attachments_dict,
     _dataset_examples_path,
     _dumps_json,
     _is_langchain_hosted,
@@ -2627,3 +2628,132 @@ def test__construct_url():
         for prefix in ("", "/", "https://foobar.com/api/"):
             actual = _construct_url(api_url + suffix, prefix + pathname)
             assert actual == expected
+
+
+@mock.patch("langsmith.client.requests.get")
+def test__convert_stored_attachments_to_attachments_dict(mock_get: mock.Mock):
+    """Test URL construction in attachment downloading."""
+    # Mock the requests.get response
+    mock_response = mock.Mock()
+    mock_response.content = b"test attachment data"
+    mock_response.raise_for_status.return_value = None
+    mock_get.return_value = mock_response
+
+    # Test case 1: api_url=None (existing behavior - presigned_url is already complete URL)
+    data_with_complete_url = {
+        "attachment_urls": {
+            "attachment.test_file": {
+                "presigned_url": "https://foobar.com/bucket/file.txt?signature=xyz",
+                "mime_type": "text/plain"
+            }
+        }
+    }
+    
+    result = _convert_stored_attachments_to_attachments_dict(
+        data_with_complete_url, 
+        attachments_key="attachment_urls",
+        api_url=None
+    )
+    
+    assert "test_file" in result
+    assert result["test_file"]["presigned_url"] == "https://foobar.com/bucket/file.txt?signature=xyz"
+    assert result["test_file"]["mime_type"] == "text/plain"
+    assert result["test_file"]["reader"].read() == b"test attachment data"
+    
+    # Verify requests.get was called with the complete URL as-is
+    mock_get.assert_called_with("https://foobar.com/bucket/file.txt?signature=xyz", stream=True)
+    
+    # Reset mock for next test case
+    mock_get.reset_mock()
+    mock_response.content = b"test attachment data 2"
+
+    # Test case 2: api_url provided (new behavior - constructs full URL from API base + path)
+    data_with_relative_url = {
+        "attachment_urls": {
+            "attachment.test_file2": {
+                "presigned_url": "/api/public/download?jwt=abc123",
+                "mime_type": "image/png"
+            }
+        }
+    }
+    
+    result = _convert_stored_attachments_to_attachments_dict(
+        data_with_relative_url,
+        attachments_key="attachment_urls", 
+        api_url="https://api.langsmith.com"
+    )
+    
+    assert "test_file2" in result
+    assert result["test_file2"]["presigned_url"] == "/api/public/download?jwt=abc123"  # Original preserved
+    assert result["test_file2"]["mime_type"] == "image/png"
+    assert result["test_file2"]["reader"].read() == b"test attachment data 2"
+    
+    # Verify requests.get was called with the constructed full URL
+    mock_get.assert_called_with("https://api.langsmith.com/api/public/download?jwt=abc123", stream=True)
+    
+    # Reset mock for edge case test
+    mock_get.reset_mock()
+
+    # Test case 3: Edge case - api_url provided but presigned_url is already complete URL
+    data_with_complete_url_edge_case = {
+        "attachment_urls": {
+            "attachment.test_file3": {
+                "presigned_url": "https://example.foobar.com/file.jpg?token=456",
+                "mime_type": "image/jpeg"
+            }
+        }
+    }
+    
+    result = _convert_stored_attachments_to_attachments_dict(
+        data_with_complete_url_edge_case,
+        attachments_key="attachment_urls",
+        api_url="https://api.langsmith.com"
+    )
+    
+    assert "test_file3" in result
+    # Verify requests.get was called with the complete URL unchanged
+    mock_get.assert_called_with("https://example.foobar.com/file.jpg?token=456", stream=True)
+
+    # Test case 4: No attachments key present
+    data_no_attachments = {}
+    result = _convert_stored_attachments_to_attachments_dict(
+        data_no_attachments,
+        attachments_key="attachment_urls",
+        api_url="https://api.langsmith.com"
+    )
+    assert result == {}
+
+    # Test case 5: Empty attachments
+    data_empty_attachments = {"attachment_urls": {}}
+    result = _convert_stored_attachments_to_attachments_dict(
+        data_empty_attachments,
+        attachments_key="attachment_urls",
+        api_url="https://api.langsmith.com"
+    )
+    assert result == {}
+
+    # Test case 6: Attachments without "attachment." prefix are ignored
+    data_mixed_keys = {
+        "attachment_urls": {
+            "attachment.valid_file": {
+                "presigned_url": "/download/valid",
+                "mime_type": "text/plain"
+            },
+            "invalid_file": {
+                "presigned_url": "/download/invalid", 
+                "mime_type": "text/plain"
+            }
+        }
+    }
+    
+    mock_get.reset_mock()
+    result = _convert_stored_attachments_to_attachments_dict(
+        data_mixed_keys,
+        attachments_key="attachment_urls",
+        api_url="https://api.langsmith.com"
+    )
+    
+    assert "valid_file" in result
+    assert "invalid_file" not in result
+    # Only valid attachment should trigger a request
+    mock_get.assert_called_once_with("https://api.langsmith.com/download/valid", stream=True)

--- a/python/tests/unit_tests/test_client.py
+++ b/python/tests/unit_tests/test_client.py
@@ -2644,25 +2644,28 @@ def test__convert_stored_attachments_to_attachments_dict(mock_get: mock.Mock):
         "attachment_urls": {
             "attachment.test_file": {
                 "presigned_url": "https://foobar.com/bucket/file.txt?signature=xyz",
-                "mime_type": "text/plain"
+                "mime_type": "text/plain",
             }
         }
     }
-    
+
     result = _convert_stored_attachments_to_attachments_dict(
-        data_with_complete_url, 
-        attachments_key="attachment_urls",
-        api_url=None
+        data_with_complete_url, attachments_key="attachment_urls", api_url=None
     )
-    
+
     assert "test_file" in result
-    assert result["test_file"]["presigned_url"] == "https://foobar.com/bucket/file.txt?signature=xyz"
+    assert (
+        result["test_file"]["presigned_url"]
+        == "https://foobar.com/bucket/file.txt?signature=xyz"
+    )
     assert result["test_file"]["mime_type"] == "text/plain"
     assert result["test_file"]["reader"].read() == b"test attachment data"
-    
+
     # Verify requests.get was called with the complete URL as-is
-    mock_get.assert_called_with("https://foobar.com/bucket/file.txt?signature=xyz", stream=True)
-    
+    mock_get.assert_called_with(
+        "https://foobar.com/bucket/file.txt?signature=xyz", stream=True
+    )
+
     # Reset mock for next test case
     mock_get.reset_mock()
     mock_response.content = b"test attachment data 2"
@@ -2672,25 +2675,29 @@ def test__convert_stored_attachments_to_attachments_dict(mock_get: mock.Mock):
         "attachment_urls": {
             "attachment.test_file2": {
                 "presigned_url": "/api/public/download?jwt=abc123",
-                "mime_type": "image/png"
+                "mime_type": "image/png",
             }
         }
     }
-    
+
     result = _convert_stored_attachments_to_attachments_dict(
         data_with_relative_url,
-        attachments_key="attachment_urls", 
-        api_url="https://api.langsmith.com"
+        attachments_key="attachment_urls",
+        api_url="https://api.langsmith.com",
     )
-    
+
     assert "test_file2" in result
-    assert result["test_file2"]["presigned_url"] == "/api/public/download?jwt=abc123"  # Original preserved
+    assert (
+        result["test_file2"]["presigned_url"] == "/api/public/download?jwt=abc123"
+    )  # Original preserved
     assert result["test_file2"]["mime_type"] == "image/png"
     assert result["test_file2"]["reader"].read() == b"test attachment data 2"
-    
+
     # Verify requests.get was called with the constructed full URL
-    mock_get.assert_called_with("https://api.langsmith.com/api/public/download?jwt=abc123", stream=True)
-    
+    mock_get.assert_called_with(
+        "https://api.langsmith.com/api/public/download?jwt=abc123", stream=True
+    )
+
     # Reset mock for edge case test
     mock_get.reset_mock()
 
@@ -2699,27 +2706,29 @@ def test__convert_stored_attachments_to_attachments_dict(mock_get: mock.Mock):
         "attachment_urls": {
             "attachment.test_file3": {
                 "presigned_url": "https://example.foobar.com/file.jpg?token=456",
-                "mime_type": "image/jpeg"
+                "mime_type": "image/jpeg",
             }
         }
     }
-    
+
     result = _convert_stored_attachments_to_attachments_dict(
         data_with_complete_url_edge_case,
         attachments_key="attachment_urls",
-        api_url="https://api.langsmith.com"
+        api_url="https://api.langsmith.com",
     )
-    
+
     assert "test_file3" in result
     # Verify requests.get was called with the complete URL unchanged
-    mock_get.assert_called_with("https://example.foobar.com/file.jpg?token=456", stream=True)
+    mock_get.assert_called_with(
+        "https://example.foobar.com/file.jpg?token=456", stream=True
+    )
 
     # Test case 4: No attachments key present
     data_no_attachments = {}
     result = _convert_stored_attachments_to_attachments_dict(
         data_no_attachments,
         attachments_key="attachment_urls",
-        api_url="https://api.langsmith.com"
+        api_url="https://api.langsmith.com",
     )
     assert result == {}
 
@@ -2728,7 +2737,7 @@ def test__convert_stored_attachments_to_attachments_dict(mock_get: mock.Mock):
     result = _convert_stored_attachments_to_attachments_dict(
         data_empty_attachments,
         attachments_key="attachment_urls",
-        api_url="https://api.langsmith.com"
+        api_url="https://api.langsmith.com",
     )
     assert result == {}
 
@@ -2737,23 +2746,25 @@ def test__convert_stored_attachments_to_attachments_dict(mock_get: mock.Mock):
         "attachment_urls": {
             "attachment.valid_file": {
                 "presigned_url": "/download/valid",
-                "mime_type": "text/plain"
+                "mime_type": "text/plain",
             },
             "invalid_file": {
-                "presigned_url": "/download/invalid", 
-                "mime_type": "text/plain"
-            }
+                "presigned_url": "/download/invalid",
+                "mime_type": "text/plain",
+            },
         }
     }
-    
+
     mock_get.reset_mock()
     result = _convert_stored_attachments_to_attachments_dict(
         data_mixed_keys,
         attachments_key="attachment_urls",
-        api_url="https://api.langsmith.com"
+        api_url="https://api.langsmith.com",
     )
-    
+
     assert "valid_file" in result
     assert "invalid_file" not in result
     # Only valid attachment should trigger a request
-    mock_get.assert_called_once_with("https://api.langsmith.com/download/valid", stream=True)
+    mock_get.assert_called_once_with(
+        "https://api.langsmith.com/download/valid", stream=True
+    )


### PR DESCRIPTION
## Fix URL construction bug in attachment downloading

### Problem
The `_convert_stored_attachments_to_attachments_dict` function was attempting to download attachments using `requests.get(value["presigned_url"])`, but `value["presigned_url"]` often contains only an API path (e.g., `/api/public/download?jwt=...`) rather than a complete URL. This caused `requests.get()` to fail with connection errors when trying to download attachment data.

### Solution
- **Modified function signature**: Updated `_convert_stored_attachments_to_attachments_dict` to accept an optional `api_url` parameter
- **Added URL construction logic**: When `api_url` is provided, the function now uses the existing `_construct_url` helper to properly construct the complete URL by combining the API base URL with the attachment path
- **Backward compatibility**: Made `api_url` optional (defaults to `None`) so the function can handle cases where `presigned_url` is already a complete URL
- **Updated call sites**: Modified `list_examples()` and `read_example()` call sites within the `Client` class to pass `self.api_url` as the `api_url` parameter
