### PR TITLE
feat(py): add evaluate(..., error_handling="ignore")

### DIFF
--- a/python/langsmith/run_helpers.py
+++ b/python/langsmith/run_helpers.py
@@ -229,8 +229,10 @@ class LangSmithExtra(TypedDict, total=False):
     """Optional ID for the run."""
     client: Optional[ls_client.Client]
     """Optional LangSmith client."""
+    # Optional callback function to be called if the run succeeds and before it is sent.
+    _on_success: Optional[Callable[[run_trees.RunTree], None]]
     on_end: Optional[Callable[[run_trees.RunTree], Any]]
-    """Optional callback function to be called when the run ends."""
+    """Optional callback function to be called after the run ends and is sent."""
 
 
 R = TypeVar("R", covariant=True)
@@ -1237,6 +1239,7 @@ class _TraceableContainer(TypedDict, total=False):
     outer_project: Optional[str]
     outer_metadata: Optional[dict[str, Any]]
     outer_tags: Optional[list[str]]
+    _on_success: Optional[Callable[[run_trees.RunTree], Any]]
     on_end: Optional[Callable[[run_trees.RunTree], Any]]
     context: contextvars.Context
 
@@ -1285,21 +1288,27 @@ def _container_end(
             dict_outputs = {"output": outputs}
     else:
         dict_outputs = {"output": outputs}
-    error_ = None
-    if error:
-        stacktrace = utils._format_exc()
-        error_ = f"{repr(error)}\n\n{stacktrace}"
     if (usage := _extract_usage(run_tree=run_tree, outputs=dict_outputs)) is not None:
         run_tree.metadata["usage_metadata"] = usage
-    run_tree.end(outputs=dict_outputs, error=error_)
+    if error:
+        stacktrace = utils._format_exc()
+        error_repr = f"{repr(error)}\n\n{stacktrace}"
+    else:
+        error_repr = None
+        if (_on_success := container.get("_on_success")) and callable(_on_success):
+            try:
+                _on_success(run_tree)
+            except BaseException as e:
+                warnings.warn(f"Failed to run _on_success function: {e}")
+
+    run_tree.end(outputs=dict_outputs, error=error_repr)
     if utils.tracing_is_enabled() is True:
         run_tree.patch()
-    on_end = container.get("on_end")
-    if on_end is not None and callable(on_end):
+    if (on_end := container.get("on_end")) and callable(on_end):
         try:
             on_end(run_tree)
         except BaseException as e:
-            LOGGER.warning(f"Failed to run on_end function: {e}")
+            warnings.warn(f"Failed to run on_end function: {e}")
 
 
 def _collect_extra(extra_outer: dict, langsmith_extra: LangSmithExtra) -> dict:
@@ -1486,6 +1495,7 @@ def _setup_run(
         outer_metadata=outer_metadata,
         outer_tags=outer_tags,
         on_end=langsmith_extra.get("on_end"),
+        _on_success=langsmith_extra.get("_on_success"),
         context=context,
     )
     context.run(_PROJECT_NAME.set, response_container["project_name"])


### PR DESCRIPTION
in this snippet, only the run for the second example would succeed -> end up having a reference_example_id -> show up in the experiment table:

```python
from langsmith import Client

client = Client()

def foo(inputs: dict) -> dict:
    if inputs.get("a"):
        raise ValueError("gah")
    return inputs

if not client.has_dataset(dataset_name="test-ignore-error"):
    client.create_dataset(dataset_name="test-ignore-error")
    client.create_examples(dataset_name="test-ignore-error", examples=[
        {"inputs": {"a": 1}},
        {"inputs": {"b": 2}},
    ])

def metric(inputs):
    return 0
    
client.evaluate(foo, data="test-ignore-error", evaluators=[], error_handling="ignore")
```

