### PR TITLE
Add agent instructions for Python SDK

### DIFF
--- a/python/AGENTS.md
+++ b/python/AGENTS.md
@@ -1,0 +1,26 @@
+# Instructions for code modifications in the Python SDK
+
+This folder contains the Python version of the LangSmith SDK.
+
+When modifying code in this library, **always** run the following commands from this directory before submitting a pull request:
+
+```
+make format
+make lint
+make test
+```
+
+These commands format the code, run static analysis, and execute the test suite respectively.
+
+To run a particular test file or pass custom pytest arguments, set the `TEST` environment variable. For example:
+
+```bash
+TEST=tests/unit_tests/test_client.py make test
+```
+
+Any pytest options may be included inside the `TEST` variable.
+
+## Notes
+- The project uses `poetry` for dependency management and the Makefile commands will automatically run inside the `poetry` environment.
+- `make test` sets some environment variables (such as disabling network access) for reliability. If a test requires network access, adjust it accordingly.
+


### PR DESCRIPTION
## Summary
- add `AGENTS.md` to document pre-PR workflow for the Python SDK

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68488f909880832dbeb9b7ee4ea0bad3