### PR TITLE
Fix race for cached client initialization

### DIFF
--- a/python/langsmith/run_trees.py
+++ b/python/langsmith/run_trees.py
@@ -37,7 +37,7 @@ LANGSMITH_PROJECT = sys.intern(f"{LANGSMITH_PREFIX}project")
 OVERRIDE_OUTPUTS = sys.intern("__omit_auto_outputs")
 NOT_PROVIDED = cast(None, object())
 _CLIENT: Optional[Client] = None
-_LOCK = threading.Lock()  # Keeping around for a while for backwards compat
+_LOCK = threading.Lock()
 
 # Context variables
 _REPLICAS = contextvars.ContextVar[Optional[Sequence[tuple[str, Optional[dict]]]]](
@@ -51,8 +51,9 @@ _REPLICAS = contextvars.ContextVar[Optional[Sequence[tuple[str, Optional[dict]]]
 def get_cached_client(**init_kwargs: Any) -> Client:
     global _CLIENT
     if _CLIENT is None:
-        if _CLIENT is None:
-            _CLIENT = Client(**init_kwargs)
+        with _LOCK:
+            if _CLIENT is None:
+                _CLIENT = Client(**init_kwargs)
     return _CLIENT
 
 


### PR DESCRIPTION
## Summary
- guard creation of the cached client with `_LOCK`
- remove outdated comment on `_LOCK`

## Testing
- `make format`
- `make lint`
- `make test` *(fails: No rule to make target 'test')*
- `make tests` *(fails: FAILED tests/unit_tests/test_env.py::test_git_info - assert None is not None)*

------
https://chatgpt.com/codex/tasks/task_e_68489e090940832da486811fecd1e446