### PR TITLE
Store only the first new_token event

### DIFF
--- a/python/langsmith/run_helpers.py
+++ b/python/langsmith/run_helpers.py
@@ -1239,6 +1239,7 @@ class _TraceableContainer(TypedDict, total=False):
     outer_tags: Optional[list[str]]
     on_end: Optional[Callable[[run_trees.RunTree], Any]]
     context: contextvars.Context
+    _token_event_logged: Optional[bool]
 
 
 class _ContainerInput(TypedDict, total=False):
@@ -1411,6 +1412,7 @@ def _setup_run(
             outer_tags=None,
             on_end=langsmith_extra.get("on_end"),
             context=copy_context(),
+            _token_event_logged=False,
         )
     id_ = id_ or str(uuid.uuid4())
     signature = inspect.signature(func)
@@ -1487,6 +1489,7 @@ def _setup_run(
         outer_tags=outer_tags,
         on_end=langsmith_extra.get("on_end"),
         context=context,
+        _token_event_logged=False,
     )
     context.run(_PROJECT_NAME.set, response_container["project_name"])
     context.run(_PARENT_RUN_TREE.set, response_container["new_run"])

--- a/python/langsmith/run_helpers.py
+++ b/python/langsmith/run_helpers.py
@@ -1614,7 +1614,11 @@ def _process_iterator(
                 traced_item = process_chunk(item)
             else:
                 traced_item = item
-            if is_llm_run and run_container["new_run"]:
+            if (
+                is_llm_run
+                and run_container["new_run"]
+                and not run_container.get("_token_event_logged")
+            ):
                 run_container["new_run"].add_event(
                     {
                         "name": "new_token",
@@ -1624,6 +1628,7 @@ def _process_iterator(
                         "kwargs": {"token": traced_item},
                     }
                 )
+                run_container["_token_event_logged"] = True
             results.append(traced_item)
             yield item
     except StopIteration as e:
@@ -1654,7 +1659,11 @@ async def _process_async_iterator(
                 traced_item = process_chunk(item)
             else:
                 traced_item = item
-            if is_llm_run and run_container["new_run"]:
+            if (
+                is_llm_run
+                and run_container["new_run"]
+                and not run_container.get("_token_event_logged")
+            ):
                 run_container["new_run"].add_event(
                     {
                         "name": "new_token",
@@ -1664,6 +1673,7 @@ async def _process_async_iterator(
                         "kwargs": {"token": traced_item},
                     }
                 )
+                run_container["_token_event_logged"] = True
             results.append(traced_item)
             yield item
     except StopAsyncIteration:

--- a/python/tests/unit_tests/test_run_helpers.py
+++ b/python/tests/unit_tests/test_run_helpers.py
@@ -1874,7 +1874,7 @@ def test_first_token_event_only(mock_client: Client) -> None:
 
     with tracing_context(enabled=True):
 
-        @traceable(client=mock_client)
+        @traceable(client=mock_client, run_type="llm")
         def token_stream() -> Generator[str, None, None]:
             for t in ["a", "b", "c"]:
                 yield t

--- a/python/tests/unit_tests/test_run_helpers.py
+++ b/python/tests/unit_tests/test_run_helpers.py
@@ -1865,6 +1865,27 @@ def test_traceable_iterator_process_chunk(mock_client: Client) -> None:
     assert body["post"][0]["outputs"]["output"] == list(range(6))
 
 
+def test_first_token_event_only(mock_client: Client) -> None:
+    collected_run: Optional[RunTree] = None
+
+    def on_end(run: RunTree) -> None:
+        nonlocal collected_run
+        collected_run = run
+
+    with tracing_context(enabled=True):
+
+        @traceable(client=mock_client)
+        def token_stream() -> Generator[str, None, None]:
+            for t in ["a", "b", "c"]:
+                yield t
+
+        list(token_stream(langsmith_extra={"on_end": on_end}))
+
+    assert collected_run is not None
+    events = [ev for ev in collected_run.events if ev.get("name") == "new_token"]
+    assert len(events) == 1
+
+
 async def test_traceable_async_iterator_process_chunk(mock_client: Client) -> None:
     with tracing_context(enabled=True):
 


### PR DESCRIPTION
## Summary
- only record the first `new_token` event during streaming
- test that only one token event is stored

## Testing
- `make format`
- `make lint` *(fails: cannot find modules)*
- `make test` *(fails: no rule to make target `test`)*
- `make tests` *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_e_68489534b878832da57d99ff50545d7c