### PR TITLE
Handle missing attachment files gracefully

### DIFF
--- a/python/langsmith/_internal/_operations.py
+++ b/python/langsmith/_internal/_operations.py
@@ -273,8 +273,14 @@ def serialized_run_operation_to_multipart_parts_and_context(
                     )
                 )
             else:
-                file_size = os.path.getsize(data_or_path)
-                file = open(data_or_path, "rb")
+                try:
+                    file_size = os.path.getsize(data_or_path)
+                    file = open(data_or_path, "rb")
+                except FileNotFoundError:
+                    logger.warning(
+                        "Attachment file not found for run %s: %s", op.id, data_or_path
+                    )
+                    continue
                 opened_files_dict[str(data_or_path) + str(uuid.uuid4())] = file
                 acc_parts.append(
                     (

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -4206,8 +4206,16 @@ class Client:
                         mime_type, attachment_data = attachment
                     if isinstance(attachment_data, Path):
                         if dangerously_allow_filesystem:
-                            file_size = os.path.getsize(attachment_data)
-                            file = open(attachment_data, "rb")
+                            try:
+                                file_size = os.path.getsize(attachment_data)
+                                file = open(attachment_data, "rb")
+                            except FileNotFoundError:
+                                logger.warning(
+                                    "Attachment file not found for example %s: %s",
+                                    example_id,
+                                    attachment_data,
+                                )
+                                continue
                             opened_files_dict[
                                 str(attachment_data) + str(uuid.uuid4())
                             ] = file


### PR DESCRIPTION
## Summary
- catch missing attachment files when converting multipart operations
- skip attachments that were not found and log a warning

## Testing
- `make format`
- `make lint`
- `make tests` *(fails: Connection error caused failure to GET /info)*

------
https://chatgpt.com/codex/tasks/task_e_68489e320834832d8bc98183bb613757