### PR TITLE
 feat[python]: Enable OpenTelemetry trace context propagation

### DIFF
--- a/python/langsmith/_internal/_otel_utils.py
+++ b/python/langsmith/_internal/_otel_utils.py
@@ -1,5 +1,3 @@
-"""Utilities for OpenTelemetry integration with LangSmith."""
-
 from __future__ import annotations
 
 from typing import Optional
@@ -15,16 +13,11 @@ def uuid_to_otel_trace_id(uuid_val: UUID) -> str:
     Returns:
         A 32-character lowercase hex string representing the trace ID.
     """
-    # UUIDs are already 128 bits, which is what OTel trace IDs need
-    # Convert to 32-character lowercase hex string
     return uuid_val.hex
 
 
 def uuid_to_otel_span_id(uuid_val: UUID) -> str:
     """Convert a UUID to an OpenTelemetry span ID.
-
-    Since span IDs are 64 bits (8 bytes) and UUIDs are 128 bits (16 bytes),
-    we need to derive a 64-bit value deterministically from the UUID.
 
     Args:
         uuid_val: The UUID to convert.
@@ -32,10 +25,8 @@ def uuid_to_otel_span_id(uuid_val: UUID) -> str:
     Returns:
         A 16-character lowercase hex string representing the span ID.
     """
-    # Use the first 8 bytes of the UUID for deterministic span ID
     uuid_bytes = uuid_val.bytes
     span_id_bytes = uuid_bytes[:8]
-    # Convert to 16-character lowercase hex string
     return span_id_bytes.hex()
 
 
@@ -87,48 +78,3 @@ def get_otel_span_id_from_uuid(uuid_val: UUID) -> int:
     """
     span_id_hex = uuid_to_otel_span_id(uuid_val)
     return otel_span_id_to_int(span_id_hex)
-
-
-def get_otel_trace_id_from_run_tree() -> Optional[int]:
-    """Get OpenTelemetry trace ID from current LangSmith run tree.
-
-    Returns:
-        Integer representation of the trace ID, or None if no current run tree.
-    """
-    from langsmith.run_helpers import get_current_run_tree
-
-    current_run = get_current_run_tree()
-    if current_run is None:
-        return None
-
-    return get_otel_trace_id_from_uuid(current_run.trace_id)
-
-
-def get_otel_span_id_from_run_tree() -> Optional[int]:
-    """Get OpenTelemetry span ID from current LangSmith run tree.
-
-    Returns:
-        Integer representation of the span ID, or None if no current run tree.
-    """
-    from langsmith.run_helpers import get_current_run_tree
-
-    current_run = get_current_run_tree()
-    if current_run is None:
-        return None
-
-    return get_otel_span_id_from_uuid(current_run.id)
-
-
-def get_otel_parent_span_id_from_run_tree() -> Optional[int]:
-    """Get OpenTelemetry parent span ID from current LangSmith run tree.
-
-    Returns:
-        Integer representation of the parent span ID, or None if no parent.
-    """
-    from langsmith.run_helpers import get_current_run_tree
-
-    current_run = get_current_run_tree()
-    if current_run is None or current_run.parent_run_id is None:
-        return None
-
-    return get_otel_span_id_from_uuid(current_run.parent_run_id)

--- a/python/langsmith/_internal/_otel_utils.py
+++ b/python/langsmith/_internal/_otel_utils.py
@@ -1,0 +1,134 @@
+"""Utilities for OpenTelemetry integration with LangSmith."""
+
+from __future__ import annotations
+
+from typing import Optional
+from uuid import UUID
+
+
+def uuid_to_otel_trace_id(uuid_val: UUID) -> str:
+    """Convert a UUID to an OpenTelemetry trace ID.
+
+    Args:
+        uuid_val: The UUID to convert.
+
+    Returns:
+        A 32-character lowercase hex string representing the trace ID.
+    """
+    # UUIDs are already 128 bits, which is what OTel trace IDs need
+    # Convert to 32-character lowercase hex string
+    return uuid_val.hex
+
+
+def uuid_to_otel_span_id(uuid_val: UUID) -> str:
+    """Convert a UUID to an OpenTelemetry span ID.
+
+    Since span IDs are 64 bits (8 bytes) and UUIDs are 128 bits (16 bytes),
+    we need to derive a 64-bit value deterministically from the UUID.
+
+    Args:
+        uuid_val: The UUID to convert.
+
+    Returns:
+        A 16-character lowercase hex string representing the span ID.
+    """
+    # Use the first 8 bytes of the UUID for deterministic span ID
+    uuid_bytes = uuid_val.bytes
+    span_id_bytes = uuid_bytes[:8]
+    # Convert to 16-character lowercase hex string
+    return span_id_bytes.hex()
+
+
+def otel_trace_id_to_int(trace_id: str) -> int:
+    """Convert an OpenTelemetry trace ID string to an integer.
+
+    Args:
+        trace_id: 32-character hex string representing the trace ID.
+
+    Returns:
+        Integer representation of the trace ID.
+    """
+    return int(trace_id, 16)
+
+
+def otel_span_id_to_int(span_id: str) -> int:
+    """Convert an OpenTelemetry span ID string to an integer.
+
+    Args:
+        span_id: 16-character hex string representing the span ID.
+
+    Returns:
+        Integer representation of the span ID.
+    """
+    return int(span_id, 16)
+
+
+def get_otel_trace_id_from_uuid(uuid_val: UUID) -> int:
+    """Get OpenTelemetry trace ID as integer from UUID.
+
+    Args:
+        uuid_val: The UUID to convert.
+
+    Returns:
+        Integer representation of the trace ID.
+    """
+    trace_id_hex = uuid_to_otel_trace_id(uuid_val)
+    return otel_trace_id_to_int(trace_id_hex)
+
+
+def get_otel_span_id_from_uuid(uuid_val: UUID) -> int:
+    """Get OpenTelemetry span ID as integer from UUID.
+
+    Args:
+        uuid_val: The UUID to convert.
+
+    Returns:
+        Integer representation of the span ID.
+    """
+    span_id_hex = uuid_to_otel_span_id(uuid_val)
+    return otel_span_id_to_int(span_id_hex)
+
+
+def get_otel_trace_id_from_run_tree() -> Optional[int]:
+    """Get OpenTelemetry trace ID from current LangSmith run tree.
+
+    Returns:
+        Integer representation of the trace ID, or None if no current run tree.
+    """
+    from langsmith.run_helpers import get_current_run_tree
+
+    current_run = get_current_run_tree()
+    if current_run is None:
+        return None
+
+    return get_otel_trace_id_from_uuid(current_run.trace_id)
+
+
+def get_otel_span_id_from_run_tree() -> Optional[int]:
+    """Get OpenTelemetry span ID from current LangSmith run tree.
+
+    Returns:
+        Integer representation of the span ID, or None if no current run tree.
+    """
+    from langsmith.run_helpers import get_current_run_tree
+
+    current_run = get_current_run_tree()
+    if current_run is None:
+        return None
+
+    return get_otel_span_id_from_uuid(current_run.id)
+
+
+def get_otel_parent_span_id_from_run_tree() -> Optional[int]:
+    """Get OpenTelemetry parent span ID from current LangSmith run tree.
+
+    Returns:
+        Integer representation of the parent span ID, or None if no parent.
+    """
+    from langsmith.run_helpers import get_current_run_tree
+
+    current_run = get_current_run_tree()
+    if current_run is None or current_run.parent_run_id is None:
+        return None
+
+    return get_otel_span_id_from_uuid(current_run.parent_run_id)

--- a/python/langsmith/run_helpers.py
+++ b/python/langsmith/run_helpers.py
@@ -534,12 +534,11 @@ def traceable(
                 if func_accepts_parent_run:
                     kwargs["run_tree"] = run_container["new_run"]
 
-                # Set OpenTelemetry context if available and enabled
                 otel_context_manager = _maybe_create_otel_context(
                     run_container["new_run"]
                 )
                 if otel_context_manager:
-                    # Need to apply OTEL context to the async execution as well
+
                     async def run_with_otel_context():
                         with otel_context_manager:
                             return await func(*args, **kwargs)
@@ -667,12 +666,11 @@ def traceable(
                 if func_accepts_parent_run:
                     kwargs["run_tree"] = run_container["new_run"]
 
-                # Set OpenTelemetry context if available and enabled
                 otel_context_manager = _maybe_create_otel_context(
                     run_container["new_run"]
                 )
                 if otel_context_manager:
-                    # Need to apply OTEL context to the copied context as well
+
                     def run_with_otel_context():
                         with otel_context_manager:
                             return func(*args, **kwargs)
@@ -714,12 +712,11 @@ def traceable(
                 if func_accepts_parent_run:
                     kwargs["run_tree"] = run_container["new_run"]
 
-                # Set OpenTelemetry context if available and enabled
                 otel_context_manager = _maybe_create_otel_context(
                     run_container["new_run"]
                 )
                 if otel_context_manager:
-                    # Need to apply OTEL context to the copied context as well
+
                     def run_with_otel_context():
                         with otel_context_manager:
                             return func(*args, **kwargs)
@@ -1949,11 +1946,9 @@ def _maybe_create_otel_context(run_tree: Optional[run_trees.RunTree]):
     except ImportError:
         return None
 
-    # Create deterministic OpenTelemetry trace and span IDs from LangSmith UUIDs
     trace_id = get_otel_trace_id_from_uuid(run_tree.trace_id)
     span_id = get_otel_span_id_from_uuid(run_tree.id)
 
-    # Create SpanContext with deterministic IDs
     span_context = SpanContext(
         trace_id=trace_id,
         span_id=span_id,
@@ -1962,6 +1957,5 @@ def _maybe_create_otel_context(run_tree: Optional[run_trees.RunTree]):
         trace_state=TraceState(),
     )
 
-    # Create NonRecordingSpan and return use_span context manager
     non_recording_span = NonRecordingSpan(span_context)
     return use_span(non_recording_span)


### PR DESCRIPTION
### Purpose
trace context propagation problem. Previously, when using LangSMith in otel mode. OpenTelemetry spans within LangSmith-traced functions would create disconnected traces, making it difficult to understand the complete trace.
Now:
User OpenTelemetry spans now inherit LangSmith trace context
LangSmith spans nest within existing OpenTelemetry traces
 
 Fixes #1725

  ### Changes
  - Added deterministic UUID to OpenTelemetry ID conversion
  - Added trace context propagation for both langsmith and otel spans

  Basic Usage
```
  @traceable
  def process_data(data: str) -> str:
      # This OpenTelemetry span will inherit LangSmith trace context
      with tracer.start_as_current_span("otel_processing") as span:
          span.set_attribute("data.input", data)
          result = f"Processed: {data}"
          span.set_attribute("data.output", result)
          return result
```

### Tests
Added unit tests and tested locally with langchain, traceable, and otel spans