### PR TITLE
fix(js): Fix JSDom check for Node 22

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langsmith",
-  "version": "0.3.30",
+  "version": "0.3.31",
   "description": "Client library to connect to the LangSmith LLM Tracing and Evaluation Platform.",
   "packageManager": "yarn@1.22.19",
   "files": [

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -18,4 +18,4 @@ export { RunTree, type RunTreeConfig } from "./run_trees.js";
 export { overrideFetchImplementation } from "./singletons/fetch.js";
 
 // Update using yarn bump-version
-export const __version__ = "0.3.30";
+export const __version__ = "0.3.31";

--- a/js/src/utils/env.ts
+++ b/js/src/utils/env.ts
@@ -22,9 +22,7 @@ export const isWebWorker = () =>
 
 export const isJsDom = () =>
   (typeof window !== "undefined" && window.name === "nodejs") ||
-  (typeof navigator !== "undefined" &&
-    (navigator.userAgent.includes("Node.js") ||
-      navigator.userAgent.includes("jsdom")));
+  (typeof navigator !== "undefined" && navigator.userAgent.includes("jsdom"));
 
 // Supabase Edge Function provides a `Deno` global object
 // without `version` property


### PR DESCRIPTION
Node 21 added the navigator interface, so the JSDom check in `env.ts` will always return true for recent Node versions:

https://developer.mozilla.org/en-US/docs/Web/API/Navigator#browser_compatibility

JSDom's default user agent contains the string "jsdom" so it still should be fine:

https://github.com/jsdom/jsdom?tab=readme-ov-file#advanced-configuration