### PR TITLE
Cache request settings for Client

### DIFF
--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -401,9 +401,11 @@ class Client:
     __slots__ = [
         "__weakref__",
         "api_url",
-        "api_key",
+        "_api_key",
+        "_headers",
         "retry_config",
         "timeout_ms",
+        "_timeout",
         "session",
         "_get_data_type_cached",
         "_web_url",
@@ -425,6 +427,11 @@ class Client:
         "_futures",
         "otel_exporter",
     ]
+
+    _api_key: Optional[str]
+    _headers: dict[str, str]
+    _timeout: tuple[float, float]
+    _manual_cleanup: bool
 
     def __init__(
         self,
@@ -509,7 +516,7 @@ class Client:
         )
         if self._write_api_urls:
             self.api_url = next(iter(self._write_api_urls))
-            self.api_key: Optional[str] = self._write_api_urls[self.api_url]
+            self.api_key = self._write_api_urls[self.api_url]
         else:
             self.api_url = ls_utils.get_api_url(api_url)
             self.api_key = ls_utils.get_api_key(api_key)
@@ -521,6 +528,7 @@ class Client:
             if isinstance(timeout_ms, int)
             else (timeout_ms or (10_000, 90_001))
         )
+        self._timeout = (self.timeout_ms[0] / 1000, self.timeout_ms[1] / 1000)
         self._web_url = web_url
         self._tenant_id: Optional[uuid.UUID] = None
         # Create a session and register a finalizer to close it
@@ -676,13 +684,7 @@ class Client:
         """The web host url."""
         return ls_utils.get_host_url(self._web_url, self.api_url)
 
-    @property
-    def _headers(self) -> dict[str, str]:
-        """Get the headers for the API request.
-
-        Returns:
-            Dict[str, str]: The headers for the API request.
-        """
+    def _compute_headers(self) -> dict[str, str]:
         headers = {
             "User-Agent": f"langsmith-py/{langsmith.__version__}",
             "Accept": "application/json",
@@ -690,6 +692,16 @@ class Client:
         if self.api_key:
             headers[X_API_KEY] = self.api_key
         return headers
+
+    @property
+    def api_key(self) -> Optional[str]:
+        """Return the API key used for authentication."""
+        return self._api_key
+
+    @api_key.setter
+    def api_key(self, value: Optional[str]) -> None:
+        object.__setattr__(self, "_api_key", value)
+        object.__setattr__(self, "_headers", self._compute_headers())
 
     @property
     def info(self) -> ls_schemas.LangSmithInfo:
@@ -705,7 +717,7 @@ class Client:
                     "GET",
                     "/info",
                     headers={"Accept": "application/json"},
-                    timeout=(self.timeout_ms[0] / 1000, self.timeout_ms[1] / 1000),
+                    timeout=self._timeout,
                 )
                 ls_utils.raise_for_status_with_text(response)
                 self._info = ls_schemas.LangSmithInfo(**response.json())
@@ -785,7 +797,7 @@ class Client:
         """
         request_kwargs = request_kwargs or {}
         request_kwargs = {
-            "timeout": (self.timeout_ms[0] / 1000, self.timeout_ms[1] / 1000),
+            "timeout": self._timeout,
             **request_kwargs,
             **kwargs,
             "headers": {


### PR DESCRIPTION
## Summary
- compute `_headers` and `_timeout` during client initialization
- update request logic to reuse cached values
- refresh `_headers` when the API key changes
- update unit tests for header caching

## Testing
- `make format`
- `make lint`
- `make tests`


------
https://chatgpt.com/codex/tasks/task_e_6848a9ac7f0c832d9f48d9faac108d32