### PR TITLE
Reduce zstd compression level to 1

### DIFF
--- a/python/langsmith/_internal/_compressed_traces.py
+++ b/python/langsmith/_internal/_compressed_traces.py
@@ -5,7 +5,7 @@ from zstandard import ZstdCompressor  # type: ignore[import]
 
 from langsmith import utils as ls_utils
 
-compression_level = ls_utils.get_env_var("RUN_COMPRESSION_LEVEL", 3)
+compression_level = ls_utils.get_env_var("RUN_COMPRESSION_LEVEL", 1)
 
 
 class CompressedTraces:


### PR DESCRIPTION
Seeing near identical compression ratio for level 1 vs 3. This will also reduce cpu usage from the SDK