### PR TITLE
fix(js): Use context placeholder to preserve LangChain context variables even if tracing is disabled

### DIFF
--- a/js/src/singletons/traceable.ts
+++ b/js/src/singletons/traceable.ts
@@ -1,10 +1,10 @@
 import { isRunTree, RunTree } from "../run_trees.js";
-import { TraceableFunction } from "./types.js";
+import type { ContextPlaceholder, TraceableFunction } from "./types.js";
 
 interface AsyncLocalStorageInterface {
-  getStore: () => RunTree | undefined;
+  getStore: () => RunTree | ContextPlaceholder | undefined;
 
-  run: (context: RunTree | undefined, fn: () => void) => void;
+  run: (context: RunTree | ContextPlaceholder | undefined, fn: () => void) => void;
 }
 
 class MockAsyncLocalStorage implements AsyncLocalStorageInterface {
@@ -12,7 +12,7 @@ class MockAsyncLocalStorage implements AsyncLocalStorageInterface {
     return undefined;
   }
 
-  run(_: RunTree | undefined, callback: () => void): void {
+  run(_: RunTree | ContextPlaceholder | undefined, callback: () => void): void {
     return callback();
   }
 }
@@ -55,7 +55,7 @@ export function getCurrentRunTree(
 
 export function getCurrentRunTree(permitAbsentRunTree = false) {
   const runTree = AsyncLocalStorageProviderSingleton.getInstance().getStore();
-  if (!permitAbsentRunTree && !isRunTree(runTree)) {
+  if (!permitAbsentRunTree && runTree === undefined) {
     throw new Error(
       "Could not get the current run tree.\n\nPlease make sure you are calling this method within a traceable function and that tracing is enabled."
     );

--- a/js/src/singletons/traceable.ts
+++ b/js/src/singletons/traceable.ts
@@ -1,4 +1,4 @@
-import { isRunTree, RunTree } from "../run_trees.js";
+import type { RunTree } from "../run_trees.js";
 import type { ContextPlaceholder, TraceableFunction } from "./types.js";
 
 interface AsyncLocalStorageInterface {

--- a/js/src/singletons/traceable.ts
+++ b/js/src/singletons/traceable.ts
@@ -4,7 +4,10 @@ import type { ContextPlaceholder, TraceableFunction } from "./types.js";
 interface AsyncLocalStorageInterface {
   getStore: () => RunTree | ContextPlaceholder | undefined;
 
-  run: (context: RunTree | ContextPlaceholder | undefined, fn: () => void) => void;
+  run: (
+    context: RunTree | ContextPlaceholder | undefined,
+    fn: () => void
+  ) => void;
 }
 
 class MockAsyncLocalStorage implements AsyncLocalStorageInterface {

--- a/js/src/singletons/types.ts
+++ b/js/src/singletons/types.ts
@@ -1,5 +1,6 @@
 import { RunTree, RunnableConfigLike } from "../run_trees.js";
 import { ROOT } from "./traceable.js";
+import { _LC_CONTEXT_VARIABLES_KEY } from "./constants.js";
 
 type SmartPromise<T> = T extends AsyncGenerator
   ? T
@@ -75,3 +76,7 @@ export type TraceableFunction<Func extends (...args: any[]) => any> =
   };
 
 export type RunTreeLike = RunTree;
+
+export type ContextPlaceholder = {
+  [_LC_CONTEXT_VARIABLES_KEY]?: Record<string, unknown>;
+};

--- a/js/src/tests/traceable_langchain.test.ts
+++ b/js/src/tests/traceable_langchain.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-process-env */
 import { traceable } from "../traceable.js";
 import { getAssumedTreeFromCalls } from "./utils/tree.js";
 import { mockClient } from "./utils/mock_client.js";

--- a/js/src/tests/traceable_langchain.test.ts
+++ b/js/src/tests/traceable_langchain.test.ts
@@ -406,6 +406,7 @@ describe("LangChain context variables", () => {
   test.each(["true", "false"])(
     "set and get context variables at top level with tracingEnabled=%s",
     async (tracingEnabled) => {
+      process.env.LANGSMITH_TRACING = tracingEnabled;
       const { client } = mockClient();
       setContextVariable("foo", "bar");
       expect(getContextVariable("foo")).toEqual("bar");
@@ -417,7 +418,6 @@ describe("LangChain context variables", () => {
         },
         {
           client,
-          tracingEnabled: tracingEnabled === "true",
         }
       );
       await main();
@@ -428,6 +428,7 @@ describe("LangChain context variables", () => {
   test.each(["true", "false"])(
     "set and get context variables from runnable nested in traceable with tracingEnabled=%s",
     async (tracingEnabled) => {
+      process.env.LANGSMITH_TRACING = tracingEnabled;
       const { client } = mockClient();
 
       const nested = RunnableLambda.from(async () => {
@@ -444,7 +445,6 @@ describe("LangChain context variables", () => {
         },
         {
           client,
-          tracingEnabled: tracingEnabled === "true",
         }
       );
       await main();
@@ -455,6 +455,7 @@ describe("LangChain context variables", () => {
   test.each(["true", "false"])(
     "set and get context variables from traceable nested in runnable with tracingEnabled=%s",
     async (tracingEnabled) => {
+      process.env.LANGSMITH_TRACING = tracingEnabled;
       const { client } = mockClient();
 
       const nested = traceable(
@@ -464,7 +465,6 @@ describe("LangChain context variables", () => {
         },
         {
           client,
-          tracingEnabled: tracingEnabled === "true",
         }
       );
 

--- a/js/src/tests/traceable_langchain.test.ts
+++ b/js/src/tests/traceable_langchain.test.ts
@@ -9,7 +9,10 @@ import { BaseMessage, HumanMessage } from "@langchain/core/messages";
 import { awaitAllCallbacks } from "@langchain/core/callbacks/promises";
 import { RunnableTraceable, getLangchainCallbacks } from "../langchain.js";
 import { RunnableLambda } from "@langchain/core/runnables";
-import { setContextVariable, getContextVariable } from "@langchain/core/context";
+import {
+  setContextVariable,
+  getContextVariable,
+} from "@langchain/core/context";
 
 describe("to langchain", () => {
   const llm = new FakeChatModel({});
@@ -400,71 +403,80 @@ test("explicit nested", async () => {
 });
 
 describe("LangChain context variables", () => {
-  test.each([
-    "true",
-    "false"
-  ])("set and get context variables at top level with tracingEnabled=%s", async (tracingEnabled) => {
-    const { client } = mockClient();
-    setContextVariable("foo", "bar");
-    expect(getContextVariable("foo")).toEqual("bar");
-
-    const main = traceable(async () => {
+  test.each(["true", "false"])(
+    "set and get context variables at top level with tracingEnabled=%s",
+    async (tracingEnabled) => {
+      const { client } = mockClient();
+      setContextVariable("foo", "bar");
       expect(getContextVariable("foo")).toEqual("bar");
-      return "Something";
-    }, {
-      client,
-      tracingEnabled: tracingEnabled === "true",
-    });
-    await main();
-    await awaitAllCallbacks();
-  });
-  
-  test.each([
-    "true",
-    "false"
-  ])("set and get context variables from runnable nested in traceable with tracingEnabled=%s", async (tracingEnabled) => {
-    const { client } = mockClient();
-    
-    const nested = RunnableLambda.from(async () => {
-      expect(getContextVariable("foo")).toEqual("baz");
-      
-      return "Something";
-    });
 
-    const main = traceable(async () => {
-      setContextVariable("foo", "baz");
-      expect(getContextVariable("foo")).toEqual("baz");
-      return nested.invoke({});
-    }, {
-      client,
-      tracingEnabled: tracingEnabled === "true",
-    });
-    await main();
-    await awaitAllCallbacks();
-  });
-  
-  test.each([
-    "true",
-    "false"
-  ])("set and get context variables from traceable nested in runnable with tracingEnabled=%s", async (tracingEnabled) => {
-    const { client } = mockClient();
-    
-    const nested = traceable(async () => {
-      expect(getContextVariable("foo")).toEqual("qux");
-      return "Something";
-    }, {
-      client,
-      tracingEnabled: tracingEnabled === "true",
-    });
+      const main = traceable(
+        async () => {
+          expect(getContextVariable("foo")).toEqual("bar");
+          return "Something";
+        },
+        {
+          client,
+          tracingEnabled: tracingEnabled === "true",
+        }
+      );
+      await main();
+      await awaitAllCallbacks();
+    }
+  );
 
-    const main = RunnableLambda.from(async () => {
-      setContextVariable("foo", "qux");
-      expect(getContextVariable("foo")).toEqual("qux");
-      return nested();
-    });
-    await main.invoke({});
-    await awaitAllCallbacks();
-  });
+  test.each(["true", "false"])(
+    "set and get context variables from runnable nested in traceable with tracingEnabled=%s",
+    async (tracingEnabled) => {
+      const { client } = mockClient();
+
+      const nested = RunnableLambda.from(async () => {
+        expect(getContextVariable("foo")).toEqual("baz");
+
+        return "Something";
+      });
+
+      const main = traceable(
+        async () => {
+          setContextVariable("foo", "baz");
+          expect(getContextVariable("foo")).toEqual("baz");
+          return nested.invoke({});
+        },
+        {
+          client,
+          tracingEnabled: tracingEnabled === "true",
+        }
+      );
+      await main();
+      await awaitAllCallbacks();
+    }
+  );
+
+  test.each(["true", "false"])(
+    "set and get context variables from traceable nested in runnable with tracingEnabled=%s",
+    async (tracingEnabled) => {
+      const { client } = mockClient();
+
+      const nested = traceable(
+        async () => {
+          expect(getContextVariable("foo")).toEqual("qux");
+          return "Something";
+        },
+        {
+          client,
+          tracingEnabled: tracingEnabled === "true",
+        }
+      );
+
+      const main = RunnableLambda.from(async () => {
+        setContextVariable("foo", "qux");
+        expect(getContextVariable("foo")).toEqual("qux");
+        return nested();
+      });
+      await main.invoke({});
+      await awaitAllCallbacks();
+    }
+  );
 });
 
 // skip until the @langchain/core 0.2.17 is out

--- a/js/src/traceable.ts
+++ b/js/src/traceable.ts
@@ -19,7 +19,10 @@ import {
   AsyncLocalStorageProviderSingleton,
 } from "./singletons/traceable.js";
 import { _LC_CONTEXT_VARIABLES_KEY } from "./singletons/constants.js";
-import type { TraceableFunction, ContextPlaceholder } from "./singletons/types.js";
+import type {
+  TraceableFunction,
+  ContextPlaceholder,
+} from "./singletons/types.js";
 import {
   isKVMap,
   isReadableStream,
@@ -564,7 +567,10 @@ export function traceable<Func extends (...args: any[]) => any>(
       processedArgs[i] = convertSerializableArg(processedArgs[i]);
     }
 
-    const [currentContext, rawInputs] = ((): [RunTree | ContextPlaceholder, Inputs] => {
+    const [currentContext, rawInputs] = ((): [
+      RunTree | ContextPlaceholder,
+      Inputs
+    ] => {
       const [firstArg, ...restArgs] = processedArgs;
 
       // used for handoff between LangChain.JS and traceable functions
@@ -644,7 +650,9 @@ export function traceable<Func extends (...args: any[]) => any>(
       return [currentRunTree, processedArgs as Inputs];
     })();
 
-    const currentRunTree = isRunTree(currentContext) ? currentContext : undefined;
+    const currentRunTree = isRunTree(currentContext)
+      ? currentContext
+      : undefined;
 
     const otelContextManager = maybeCreateOtelContext(
       currentRunTree,


### PR DESCRIPTION
Fixes #1818

FYI @hntrl