### PR TITLE
fix(js): Fix AI SDK token counting issues for legacy exporter

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langsmith",
-  "version": "0.3.38",
+  "version": "0.3.39",
   "description": "Client library to connect to the LangSmith LLM Tracing and Evaluation Platform.",
   "packageManager": "yarn@1.22.19",
   "files": [

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -20,4 +20,4 @@ export { overrideFetchImplementation } from "./singletons/fetch.js";
 export { getDefaultProjectName } from "./utils/project.js";
 
 // Update using yarn bump-version
-export const __version__ = "0.3.38";
+export const __version__ = "0.3.39";

--- a/js/src/tests/vercel/vercel_rate_limit.int.test.ts
+++ b/js/src/tests/vercel/vercel_rate_limit.int.test.ts
@@ -1,0 +1,155 @@
+import { NodeSDK } from "@opentelemetry/sdk-node";
+import { getNodeAutoInstrumentations } from "@opentelemetry/auto-instrumentations-node";
+import { v4 as uuid } from "uuid";
+import { generateText } from "ai";
+import { MockLanguageModelV1 } from "ai/test";
+
+import { AISDKExporter } from "../../vercel.js";
+import { waitUntilRunFound } from "../utils.js";
+import { Client } from "../../index.js";
+import { traceable } from "../../traceable.js";
+
+const client = new Client();
+
+test("rate limit errors with token tracking", async () => {
+  const sdk = new NodeSDK({
+    traceExporter: new AISDKExporter(),
+    instrumentations: [getNodeAutoInstrumentations()],
+  });
+
+  sdk.start();
+
+  const runId = uuid();
+  const aiSDKResponses: any[] = [];
+  const errors: any[] = [];
+
+  // Create mock models for different scenarios
+  const successfulModel1 = new MockLanguageModelV1({
+    provider: "openai",
+    modelId: "gpt-4.1-nano",
+    doGenerate: async () => ({
+      rawCall: { rawPrompt: null, rawSettings: {} },
+      finishReason: "stop",
+      usage: { promptTokens: 5, completionTokens: 5 },
+      text: "Hello world response",
+    }),
+  });
+
+  const successfulModel2 = new MockLanguageModelV1({
+    provider: "openai",
+    modelId: "gpt-4.1-nano",
+    doGenerate: async () => ({
+      rawCall: { rawPrompt: null, rawSettings: {} },
+      finishReason: "stop",
+      usage: { promptTokens: 8, completionTokens: 7 },
+      text: "Another successful response",
+    }),
+  });
+
+  const rateLimitModel = new MockLanguageModelV1({
+    provider: "openai",
+    modelId: "gpt-4.1-nano",
+    doGenerate: async () => {
+      const error = new Error("Rate limit exceeded");
+      error.name = "RateLimitError";
+      throw error;
+    },
+  });
+
+  const wrapper = traceable(
+    async () => {
+      // First successful call
+      try {
+        const res1 = await generateText({
+          model: successfulModel1,
+          experimental_telemetry: AISDKExporter.getSettings({
+            runName: "Successful call 1",
+          }),
+          messages: [
+            {
+              role: "user",
+              content: "Hello world",
+            },
+          ],
+        });
+        aiSDKResponses.push(res1);
+      } catch (error) {
+        errors.push(error);
+      }
+
+      // Second successful call
+      try {
+        const res2 = await generateText({
+          model: successfulModel2,
+          experimental_telemetry: AISDKExporter.getSettings({
+            runName: "Successful call 2",
+          }),
+          messages: [
+            {
+              role: "user",
+              content: "Another message",
+            },
+          ],
+        });
+        aiSDKResponses.push(res2);
+      } catch (error) {
+        errors.push(error);
+      }
+
+      // Rate limited calls
+      for (let i = 0; i < 3; i++) {
+        try {
+          const res = await generateText({
+            model: rateLimitModel,
+            experimental_telemetry: AISDKExporter.getSettings({
+              runName: `Rate limited call ${i + 1}`,
+            }),
+            messages: [
+              {
+                role: "user",
+                content: `Rate limit test ${i + 1}`,
+              },
+            ],
+          });
+          aiSDKResponses.push(res);
+        } catch (error) {
+          errors.push(error);
+        }
+      }
+
+      return "completed";
+    },
+    { name: "Rate Limit Test Wrapper", id: runId, project_name: "lsjs-test" }
+  );
+
+  await wrapper();
+  await sdk.shutdown();
+  await waitUntilRunFound(client, runId, true);
+
+  const storedRun = await client.readRun(runId, { loadChildRuns: true });
+  expect(storedRun.id).toEqual(runId);
+
+  // Sum token counts from successful AI SDK responses only
+  const totalSuccessfulTokens = aiSDKResponses.reduce((sum, response) => {
+    return sum + (response.usage?.totalTokens || 0);
+  }, 0);
+
+  // Verify that only successful calls contribute to token count
+  expect(storedRun.total_tokens).toEqual(totalSuccessfulTokens);
+
+  // Verify we have exactly 2 successful calls and 3 errors
+  expect(aiSDKResponses.length).toBe(2);
+  expect(errors.length).toBe(3);
+
+  // Verify token counts are correct (5+5 + 8+7 = 25)
+  expect(totalSuccessfulTokens).toBe(25);
+
+  // Verify that error runs still exist in the trace but don't contribute tokens
+  const childRuns = storedRun.child_runs || [];
+  expect(childRuns.length).toBeGreaterThan(0);
+
+  // Verify all errors are rate limit errors
+  errors.forEach((error) => {
+    expect(error.name).toBe("RateLimitError");
+  });
+});

--- a/js/src/vercel.ts
+++ b/js/src/vercel.ts
@@ -717,10 +717,13 @@ export class AISDKExporter {
             ? "chain"
             : "llm";
 
+        const error = span.status?.code === 2 ? span.status.message : undefined;
+
         // TODO: add first_token_time
         return asRunCreate({
           run_type: runType,
           name: span.attributes["ai.model.provider"],
+          error,
           inputs,
           outputs,
           events,
@@ -728,6 +731,15 @@ export class AISDKExporter {
             invocation_params: invocationParams,
             batch_size: 1,
             metadata: {
+              ...(error
+                ? {
+                    usage_metadata: {
+                      input_tokens: 0,
+                      output_tokens: 0,
+                      total_tokens: 0,
+                    },
+                  }
+                : undefined),
               ls_provider: span.attributes["ai.model.provider"]
                 .split(".")
                 .at(0),
@@ -755,9 +767,23 @@ export class AISDKExporter {
           outputs = output;
         }
 
+        const error = span.status?.code === 2 ? span.status.message : undefined;
+
         return asRunCreate({
           run_type: "tool",
           name: span.attributes["ai.toolCall.name"],
+          error,
+          extra: error
+            ? {
+                metadata: {
+                  usage_metadata: {
+                    input_tokens: 0,
+                    output_tokens: 0,
+                    total_tokens: 0,
+                  },
+                },
+              }
+            : undefined,
           inputs,
           outputs,
         });
@@ -827,15 +853,26 @@ export class AISDKExporter {
             ? "chain"
             : "llm";
 
+        const error = span.status?.code === 2 ? span.status.message : undefined;
         return asRunCreate({
           run_type: runType,
           name: span.attributes["ai.model.provider"],
+          error,
           inputs,
           outputs,
           events,
           extra: {
             batch_size: 1,
             metadata: {
+              ...(error
+                ? {
+                    usage_metadata: {
+                      input_tokens: 0,
+                      output_tokens: 0,
+                      total_tokens: 0,
+                    },
+                  }
+                : undefined),
               ls_provider: span.attributes["ai.model.provider"]
                 .split(".")
                 .at(0),

--- a/js/src/vercel.ts
+++ b/js/src/vercel.ts
@@ -712,9 +712,14 @@ export class AISDKExporter {
           });
         }
 
+        const runType =
+          span.name === "ai.generateText" || span.name === "ai.streamText"
+            ? "chain"
+            : "llm";
+
         // TODO: add first_token_time
         return asRunCreate({
-          run_type: "llm",
+          run_type: runType,
           name: span.attributes["ai.model.provider"],
           inputs,
           outputs,
@@ -817,8 +822,13 @@ export class AISDKExporter {
           });
         }
 
+        const runType =
+          span.name === "ai.generateObject" || span.name === "ai.streamObject"
+            ? "chain"
+            : "llm";
+
         return asRunCreate({
-          run_type: "llm",
+          run_type: runType,
           name: span.attributes["ai.model.provider"],
           inputs,
           outputs,


### PR DESCRIPTION
- Mark top level AI SDK runs as chain runs instead of LLM to avoid double token counting issues (already in new method)
- Properly pass through model call errors and treat usage as 0