### PR TITLE
feat: [ts] LANGSMITH_RUNS_ENDPOINTS

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langsmith",
-  "version": "0.3.40",
+  "version": "0.3.41",
   "description": "Client library to connect to the LangSmith LLM Tracing and Evaluation Platform.",
   "packageManager": "yarn@1.22.19",
   "files": [

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -20,4 +20,4 @@ export { overrideFetchImplementation } from "./singletons/fetch.js";
 export { getDefaultProjectName } from "./utils/project.js";
 
 // Update using yarn bump-version
-export const __version__ = "0.3.40";
+export const __version__ = "0.3.41";

--- a/js/src/tests/client.test.ts
+++ b/js/src/tests/client.test.ts
@@ -251,11 +251,11 @@ describe("Client", () => {
     });
 
     it("should parse LANGSMITH_RUNS_ENDPOINTS JSON mapping and set defaults correctly", () => {
-      const data = {
-        "https://api.smith.langsmith-endpoint_1.com": "123",
-        "https://api.smith.langsmith-endpoint_2.com": "456",
-        "https://api.smith.langsmith-endpoint_3.com": "789",
-      } as Record<string, string>;
+      const data = [
+        { url: "https://api.smith.langsmith-endpoint_1.com", apiKey: "123" },
+        { url: "https://api.smith.langsmith-endpoint_2.com", apiKey: "456" },
+        { url: "https://api.smith.langsmith-endpoint_3.com", apiKey: "789" },
+      ] as { url: string; apiKey?: string }[];
       // Ensure conflicting env vars are removed
       // eslint-disable-next-line no-process-env
       delete process.env.LANGCHAIN_ENDPOINT;
@@ -266,15 +266,14 @@ describe("Client", () => {
 
       const client = new Client({ autoBatchTracing: false });
       const internal = client as unknown as {
-        _writeApiUrls: Record<string, string>;
+        _destinations: { url: string; apiKey?: string }[];
         apiUrl: string;
         apiKey?: string;
       };
 
-      expect(internal._writeApiUrls).toEqual(data);
-      const firstUrl = Object.keys(data)[0];
-      expect(internal.apiUrl).toBe(firstUrl);
-      expect(internal.apiKey).toBe(data[firstUrl]);
+      expect(internal._destinations).toEqual(data);
+      expect(internal.apiUrl).toBe(data[0].url);
+      expect(internal.apiKey).toBe(data[0].apiKey);
     });
   });
 

--- a/js/src/utils/error.ts
+++ b/js/src/utils/error.ts
@@ -63,6 +63,27 @@ export class LangSmithConflictError extends Error {
   }
 }
 
+const ERR_CONFLICTING_ENDPOINTS = "ERR_CONFLICTING_ENDPOINTS";
+export class ConflictingEndpointsError extends Error {
+  readonly code = ERR_CONFLICTING_ENDPOINTS;
+  constructor() {
+    super(
+      "You cannot provide both LANGSMITH_ENDPOINT / LANGCHAIN_ENDPOINT " +
+        "and LANGSMITH_RUNS_ENDPOINTS."
+    );
+    this.name = "ConflictingEndpointsError"; // helpful in logs
+  }
+}
+export function isConflictingEndpointsError(
+  err: unknown
+): err is ConflictingEndpointsError {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    (err as Record<string, unknown>).code === ERR_CONFLICTING_ENDPOINTS
+  );
+}
+
 /**
  * Throws an appropriate error based on the response status and body.
  *

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -314,9 +314,11 @@ def _get_tracing_sampling_rate(
 
 
 def _get_write_api_urls(_write_api_urls: Optional[dict[str, str]]) -> dict[str, str]:
-    _write_api_urls = _write_api_urls or json.loads(
-        os.getenv("LANGSMITH_RUNS_ENDPOINTS", "{}")
-    )
+    if not _write_api_urls:
+        _runs_endpoints = os.getenv("LANGSMITH_RUNS_ENDPOINTS")
+        if not _runs_endpoints:
+            return {}
+        _write_api_urls = _orjson.loads(_runs_endpoints)
     processed_write_api_urls = {}
     for url, api_key in _write_api_urls.items():
         processed_url = url.strip()
@@ -3617,7 +3619,7 @@ class Client:
             "GET",
             f"{path}/{_as_uuid(dataset_id, 'dataset_id')}/openai_ft",
         )
-        dataset = [json.loads(line) for line in response.text.strip().split("\n")]
+        dataset = [_orjson.loads(line) for line in response.text.strip().split("\n")]
         return dataset
 
     def list_datasets(
@@ -6999,7 +7001,7 @@ class Client:
             )
 
         json_object = dumps(object)
-        manifest_dict = json.loads(json_object)
+        manifest_dict = _orjson.loads(json_object)
 
         owner, prompt_name, _ = ls_utils.parse_prompt_identifier(prompt_identifier)
         prompt_owner_and_name = f"{owner}/{prompt_name}"


### PR DESCRIPTION
Supports writing runs to mulitiple endpoints.
Takes precedence over langsmith/langchain endpoint.
Raise error if langsmith/langchain_endpoint is also provided.
used in LGP self-hosted under certain scenarios


This has been a feat in python for a while
