### PR TITLE
If stream fails, fallback to buffered body request

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langsmith",
-  "version": "0.3.42",
+  "version": "0.3.43",
   "description": "Client library to connect to the LangSmith LLM Tracing and Evaluation Platform.",
   "packageManager": "yarn@1.22.19",
   "files": [

--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -1617,7 +1617,7 @@ export class Client implements LangSmithTracingClientInterface {
       if (options?.apiKey !== undefined) {
         headers["x-api-key"] = options.apiKey;
       }
-      return await this.batchIngestCaller.call(
+      return this.batchIngestCaller.call(
         _getFetchImplementation(this.debug),
         `${options?.apiUrl ?? this.apiUrl}/runs/multipart`,
         {

--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -634,6 +634,8 @@ export class Client implements LangSmithTracingClientInterface {
 
   private langSmithToOTELTranslator?: LangSmithToOTELTranslator;
 
+  private streamingEnabled = true;
+
   debug = getEnvironmentVariable("LANGSMITH_DEBUG") === "true";
 
   constructor(config: ClientConfig = {}) {
@@ -1626,8 +1628,8 @@ export class Client implements LangSmithTracingClientInterface {
       let streamedAttempt = false;
       let res: Response;
 
-      // attempt stream
-      if (!isNodeFetch) {
+      // attempt stream only if not disabled and not using node-fetch
+      if (!isNodeFetch && this.streamingEnabled) {
         streamedAttempt = true;
         res = await send(await buildStream());
       } else {
@@ -1639,6 +1641,8 @@ export class Client implements LangSmithTracingClientInterface {
         console.warn(
           `Streaming multipart request failed with EOF error, falling back to buffered mode. Context: ${context}`
         );
+        // Disable streaming for future requests
+        this.streamingEnabled = false;
         // retry with fully-buffered body
         res = await send(await buildBuffered());
       }

--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -1110,8 +1110,8 @@ export class Client implements LangSmithTracingClientInterface {
     if (this.debug) {
       console.log(
         "\n=== LangSmith Server Configuration ===\n" +
-        JSON.stringify(json, null, 2) +
-        "\n"
+          JSON.stringify(json, null, 2) +
+          "\n"
       );
     }
     return json;
@@ -1489,7 +1489,7 @@ export class Client implements LangSmithTracingClientInterface {
               if (name.includes(".")) {
                 console.warn(
                   `Skipping attachment '${name}' for run ${payload.id}: Invalid attachment name. ` +
-                  `Attachment names must not contain periods ('.'). Please rename the attachment and try again.`
+                    `Attachment names must not contain periods ('.'). Please rename the attachment and try again.`
                 );
                 continue;
               }
@@ -1635,12 +1635,10 @@ export class Client implements LangSmithTracingClientInterface {
       }
 
       // if stream fails, fallback to buffered body
-      if (
-        streamedAttempt &&
-        res.status >= 400 &&
-        res.status < 500
-      ) {
-        console.warn(`Streaming multipart request failed with EOF error, falling back to buffered mode. Context: ${context}`);
+      if (streamedAttempt && res.status >= 400 && res.status < 500) {
+        console.warn(
+          `Streaming multipart request failed with EOF error, falling back to buffered mode. Context: ${context}`
+        );
         // retry with fully-buffered body
         res = await send(await buildBuffered());
       }
@@ -1766,8 +1764,9 @@ export class Client implements LangSmithTracingClientInterface {
         sessionId = project.id;
       }
       const tenantId = await this._getTenantId();
-      return `${this.getHostUrl()}/o/${tenantId}/projects/p/${sessionId}/r/${run.id
-        }?poll=true`;
+      return `${this.getHostUrl()}/o/${tenantId}/projects/p/${sessionId}/r/${
+        run.id
+      }?poll=true`;
     } else if (runId !== undefined) {
       const run_ = await this.readRun(runId);
       if (!run_.app_path) {
@@ -2280,8 +2279,9 @@ export class Client implements LangSmithTracingClientInterface {
       }
     );
     const shareSchema = await response.json();
-    shareSchema.url = `${this.getHostUrl()}/public/${shareSchema.share_token
-      }/d`;
+    shareSchema.url = `${this.getHostUrl()}/public/${
+      shareSchema.share_token
+    }/d`;
     return shareSchema as DatasetShareSchema;
   }
 
@@ -2312,8 +2312,9 @@ export class Client implements LangSmithTracingClientInterface {
       }
     );
     const shareSchema = await response.json();
-    shareSchema.url = `${this.getHostUrl()}/public/${shareSchema.share_token
-      }/d`;
+    shareSchema.url = `${this.getHostUrl()}/public/${
+      shareSchema.share_token
+    }/d`;
     return shareSchema as DatasetShareSchema;
   }
 
@@ -2388,10 +2389,12 @@ export class Client implements LangSmithTracingClientInterface {
     if (!response.ok) {
       if ("detail" in result) {
         throw new Error(
-          `Failed to list shared examples.\nStatus: ${response.status
-          }\nMessage: ${Array.isArray(result.detail)
-            ? result.detail.join("\n")
-            : "Unspecified error"
+          `Failed to list shared examples.\nStatus: ${
+            response.status
+          }\nMessage: ${
+            Array.isArray(result.detail)
+              ? result.detail.join("\n")
+              : "Unspecified error"
           }`
         );
       }
@@ -3261,18 +3264,18 @@ export class Client implements LangSmithTracingClientInterface {
     propsOrUploads:
       | ExampleCreate[]
       | {
-        inputs?: Array<KVMap>;
-        outputs?: Array<KVMap>;
-        metadata?: Array<KVMap>;
-        splits?: Array<string | Array<string>>;
-        sourceRunIds?: Array<string>;
-        useSourceRunIOs?: Array<boolean>;
-        useSourceRunAttachments?: Array<string[]>;
-        attachments?: Array<Attachments>;
-        exampleIds?: Array<string>;
-        datasetId?: string;
-        datasetName?: string;
-      }
+          inputs?: Array<KVMap>;
+          outputs?: Array<KVMap>;
+          metadata?: Array<KVMap>;
+          splits?: Array<string | Array<string>>;
+          sourceRunIds?: Array<string>;
+          useSourceRunIOs?: Array<boolean>;
+          useSourceRunAttachments?: Array<string[]>;
+          attachments?: Array<Attachments>;
+          exampleIds?: Array<string>;
+          datasetId?: string;
+          datasetName?: string;
+        }
   ): Promise<Example[]> {
     if (Array.isArray(propsOrUploads)) {
       if (propsOrUploads.length === 0) {
@@ -3631,7 +3634,8 @@ export class Client implements LangSmithTracingClientInterface {
 
     const response = await this.caller.call(
       _getFetchImplementation(this.debug),
-      `${this.apiUrl
+      `${
+        this.apiUrl
       }/datasets/${resolvedDatasetId}/version?${params.toString()}`,
       {
         method: "GET",
@@ -4522,8 +4526,9 @@ export class Client implements LangSmithTracingClientInterface {
           8
         )}?organizationId=${settings.id}`;
       } else {
-        return `${this.getHostUrl()}/prompts/${promptName}?organizationId=${settings.id
-          }`;
+        return `${this.getHostUrl()}/prompts/${promptName}?organizationId=${
+          settings.id
+        }`;
       }
     }
   }
@@ -4702,7 +4707,8 @@ export class Client implements LangSmithTracingClientInterface {
 
     const result = await response.json();
     return this._getPromptUrl(
-      `${owner}/${promptName}${result.commit_hash ? `:${result.commit_hash}` : ""
+      `${owner}/${promptName}${
+        result.commit_hash ? `:${result.commit_hash}` : ""
       }`
     );
   }
@@ -5026,7 +5032,8 @@ export class Client implements LangSmithTracingClientInterface {
       parsePromptIdentifier(promptIdentifier);
     const response = await this.caller.call(
       _getFetchImplementation(this.debug),
-      `${this.apiUrl}/commits/${owner}/${promptName}/${commitHash}${options?.includeModel ? "?include_model=true" : ""
+      `${this.apiUrl}/commits/${owner}/${promptName}/${commitHash}${
+        options?.includeModel ? "?include_model=true" : ""
       }`,
       {
         method: "GET",
@@ -5171,7 +5178,7 @@ export class Client implements LangSmithTracingClientInterface {
     } catch (e) {
       console.error(
         `An error occurred while creating dataset ${finalDatasetName}. ` +
-        "You should delete it manually."
+          "You should delete it manually."
       );
       throw e;
     }

--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -1630,19 +1630,17 @@ export class Client implements LangSmithTracingClientInterface {
     };
 
     try {
-      let streamedAttempt = false;
       let res: Response;
 
       // attempt stream only if not disabled and not using node-fetch
       if (!isNodeFetch && this.streamingEnabled) {
-        streamedAttempt = true;
         res = await send(await buildStream());
       } else {
         res = await send(await buildBuffered());
       }
 
       // if stream fails, fallback to buffered body
-      if (streamedAttempt && res.status >= 400 && res.status < 500) {
+      if (this.streamingEnabled && res.status >= 400 && res.status < 500) {
         console.warn(
           `Streaming multipart request failed with EOF error, falling back to buffered mode. Context: ${context}`
         );

--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -1112,8 +1112,8 @@ export class Client implements LangSmithTracingClientInterface {
     if (this.debug) {
       console.log(
         "\n=== LangSmith Server Configuration ===\n" +
-        JSON.stringify(json, null, 2) +
-        "\n"
+          JSON.stringify(json, null, 2) +
+          "\n"
       );
     }
     return json;
@@ -1491,7 +1491,7 @@ export class Client implements LangSmithTracingClientInterface {
               if (name.includes(".")) {
                 console.warn(
                   `Skipping attachment '${name}' for run ${payload.id}: Invalid attachment name. ` +
-                  `Attachment names must not contain periods ('.'). Please rename the attachment and try again.`
+                    `Attachment names must not contain periods ('.'). Please rename the attachment and try again.`
                 );
                 continue;
               }
@@ -1775,8 +1775,9 @@ export class Client implements LangSmithTracingClientInterface {
         sessionId = project.id;
       }
       const tenantId = await this._getTenantId();
-      return `${this.getHostUrl()}/o/${tenantId}/projects/p/${sessionId}/r/${run.id
-        }?poll=true`;
+      return `${this.getHostUrl()}/o/${tenantId}/projects/p/${sessionId}/r/${
+        run.id
+      }?poll=true`;
     } else if (runId !== undefined) {
       const run_ = await this.readRun(runId);
       if (!run_.app_path) {
@@ -2289,8 +2290,9 @@ export class Client implements LangSmithTracingClientInterface {
       }
     );
     const shareSchema = await response.json();
-    shareSchema.url = `${this.getHostUrl()}/public/${shareSchema.share_token
-      }/d`;
+    shareSchema.url = `${this.getHostUrl()}/public/${
+      shareSchema.share_token
+    }/d`;
     return shareSchema as DatasetShareSchema;
   }
 
@@ -2321,8 +2323,9 @@ export class Client implements LangSmithTracingClientInterface {
       }
     );
     const shareSchema = await response.json();
-    shareSchema.url = `${this.getHostUrl()}/public/${shareSchema.share_token
-      }/d`;
+    shareSchema.url = `${this.getHostUrl()}/public/${
+      shareSchema.share_token
+    }/d`;
     return shareSchema as DatasetShareSchema;
   }
 
@@ -2397,10 +2400,12 @@ export class Client implements LangSmithTracingClientInterface {
     if (!response.ok) {
       if ("detail" in result) {
         throw new Error(
-          `Failed to list shared examples.\nStatus: ${response.status
-          }\nMessage: ${Array.isArray(result.detail)
-            ? result.detail.join("\n")
-            : "Unspecified error"
+          `Failed to list shared examples.\nStatus: ${
+            response.status
+          }\nMessage: ${
+            Array.isArray(result.detail)
+              ? result.detail.join("\n")
+              : "Unspecified error"
           }`
         );
       }
@@ -3270,18 +3275,18 @@ export class Client implements LangSmithTracingClientInterface {
     propsOrUploads:
       | ExampleCreate[]
       | {
-        inputs?: Array<KVMap>;
-        outputs?: Array<KVMap>;
-        metadata?: Array<KVMap>;
-        splits?: Array<string | Array<string>>;
-        sourceRunIds?: Array<string>;
-        useSourceRunIOs?: Array<boolean>;
-        useSourceRunAttachments?: Array<string[]>;
-        attachments?: Array<Attachments>;
-        exampleIds?: Array<string>;
-        datasetId?: string;
-        datasetName?: string;
-      }
+          inputs?: Array<KVMap>;
+          outputs?: Array<KVMap>;
+          metadata?: Array<KVMap>;
+          splits?: Array<string | Array<string>>;
+          sourceRunIds?: Array<string>;
+          useSourceRunIOs?: Array<boolean>;
+          useSourceRunAttachments?: Array<string[]>;
+          attachments?: Array<Attachments>;
+          exampleIds?: Array<string>;
+          datasetId?: string;
+          datasetName?: string;
+        }
   ): Promise<Example[]> {
     if (Array.isArray(propsOrUploads)) {
       if (propsOrUploads.length === 0) {
@@ -3640,7 +3645,8 @@ export class Client implements LangSmithTracingClientInterface {
 
     const response = await this.caller.call(
       _getFetchImplementation(this.debug),
-      `${this.apiUrl
+      `${
+        this.apiUrl
       }/datasets/${resolvedDatasetId}/version?${params.toString()}`,
       {
         method: "GET",
@@ -4531,8 +4537,9 @@ export class Client implements LangSmithTracingClientInterface {
           8
         )}?organizationId=${settings.id}`;
       } else {
-        return `${this.getHostUrl()}/prompts/${promptName}?organizationId=${settings.id
-          }`;
+        return `${this.getHostUrl()}/prompts/${promptName}?organizationId=${
+          settings.id
+        }`;
       }
     }
   }
@@ -4711,7 +4718,8 @@ export class Client implements LangSmithTracingClientInterface {
 
     const result = await response.json();
     return this._getPromptUrl(
-      `${owner}/${promptName}${result.commit_hash ? `:${result.commit_hash}` : ""
+      `${owner}/${promptName}${
+        result.commit_hash ? `:${result.commit_hash}` : ""
       }`
     );
   }
@@ -5035,7 +5043,8 @@ export class Client implements LangSmithTracingClientInterface {
       parsePromptIdentifier(promptIdentifier);
     const response = await this.caller.call(
       _getFetchImplementation(this.debug),
-      `${this.apiUrl}/commits/${owner}/${promptName}/${commitHash}${options?.includeModel ? "?include_model=true" : ""
+      `${this.apiUrl}/commits/${owner}/${promptName}/${commitHash}${
+        options?.includeModel ? "?include_model=true" : ""
       }`,
       {
         method: "GET",
@@ -5180,7 +5189,7 @@ export class Client implements LangSmithTracingClientInterface {
     } catch (e) {
       console.error(
         `An error occurred while creating dataset ${finalDatasetName}. ` +
-        "You should delete it manually."
+          "You should delete it manually."
       );
       throw e;
     }

--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -634,7 +634,7 @@ export class Client implements LangSmithTracingClientInterface {
 
   private langSmithToOTELTranslator?: LangSmithToOTELTranslator;
 
-  private multipartStreamingDisabled = true;
+  private multipartStreamingDisabled = false;
 
   debug = getEnvironmentVariable("LANGSMITH_DEBUG") === "true";
 
@@ -1112,8 +1112,8 @@ export class Client implements LangSmithTracingClientInterface {
     if (this.debug) {
       console.log(
         "\n=== LangSmith Server Configuration ===\n" +
-          JSON.stringify(json, null, 2) +
-          "\n"
+        JSON.stringify(json, null, 2) +
+        "\n"
       );
     }
     return json;
@@ -1491,7 +1491,7 @@ export class Client implements LangSmithTracingClientInterface {
               if (name.includes(".")) {
                 console.warn(
                   `Skipping attachment '${name}' for run ${payload.id}: Invalid attachment name. ` +
-                    `Attachment names must not contain periods ('.'). Please rename the attachment and try again.`
+                  `Attachment names must not contain periods ('.'). Please rename the attachment and try again.`
                 );
                 continue;
               }
@@ -1775,9 +1775,8 @@ export class Client implements LangSmithTracingClientInterface {
         sessionId = project.id;
       }
       const tenantId = await this._getTenantId();
-      return `${this.getHostUrl()}/o/${tenantId}/projects/p/${sessionId}/r/${
-        run.id
-      }?poll=true`;
+      return `${this.getHostUrl()}/o/${tenantId}/projects/p/${sessionId}/r/${run.id
+        }?poll=true`;
     } else if (runId !== undefined) {
       const run_ = await this.readRun(runId);
       if (!run_.app_path) {
@@ -2290,9 +2289,8 @@ export class Client implements LangSmithTracingClientInterface {
       }
     );
     const shareSchema = await response.json();
-    shareSchema.url = `${this.getHostUrl()}/public/${
-      shareSchema.share_token
-    }/d`;
+    shareSchema.url = `${this.getHostUrl()}/public/${shareSchema.share_token
+      }/d`;
     return shareSchema as DatasetShareSchema;
   }
 
@@ -2323,9 +2321,8 @@ export class Client implements LangSmithTracingClientInterface {
       }
     );
     const shareSchema = await response.json();
-    shareSchema.url = `${this.getHostUrl()}/public/${
-      shareSchema.share_token
-    }/d`;
+    shareSchema.url = `${this.getHostUrl()}/public/${shareSchema.share_token
+      }/d`;
     return shareSchema as DatasetShareSchema;
   }
 
@@ -2400,12 +2397,10 @@ export class Client implements LangSmithTracingClientInterface {
     if (!response.ok) {
       if ("detail" in result) {
         throw new Error(
-          `Failed to list shared examples.\nStatus: ${
-            response.status
-          }\nMessage: ${
-            Array.isArray(result.detail)
-              ? result.detail.join("\n")
-              : "Unspecified error"
+          `Failed to list shared examples.\nStatus: ${response.status
+          }\nMessage: ${Array.isArray(result.detail)
+            ? result.detail.join("\n")
+            : "Unspecified error"
           }`
         );
       }
@@ -3275,18 +3270,18 @@ export class Client implements LangSmithTracingClientInterface {
     propsOrUploads:
       | ExampleCreate[]
       | {
-          inputs?: Array<KVMap>;
-          outputs?: Array<KVMap>;
-          metadata?: Array<KVMap>;
-          splits?: Array<string | Array<string>>;
-          sourceRunIds?: Array<string>;
-          useSourceRunIOs?: Array<boolean>;
-          useSourceRunAttachments?: Array<string[]>;
-          attachments?: Array<Attachments>;
-          exampleIds?: Array<string>;
-          datasetId?: string;
-          datasetName?: string;
-        }
+        inputs?: Array<KVMap>;
+        outputs?: Array<KVMap>;
+        metadata?: Array<KVMap>;
+        splits?: Array<string | Array<string>>;
+        sourceRunIds?: Array<string>;
+        useSourceRunIOs?: Array<boolean>;
+        useSourceRunAttachments?: Array<string[]>;
+        attachments?: Array<Attachments>;
+        exampleIds?: Array<string>;
+        datasetId?: string;
+        datasetName?: string;
+      }
   ): Promise<Example[]> {
     if (Array.isArray(propsOrUploads)) {
       if (propsOrUploads.length === 0) {
@@ -3645,8 +3640,7 @@ export class Client implements LangSmithTracingClientInterface {
 
     const response = await this.caller.call(
       _getFetchImplementation(this.debug),
-      `${
-        this.apiUrl
+      `${this.apiUrl
       }/datasets/${resolvedDatasetId}/version?${params.toString()}`,
       {
         method: "GET",
@@ -4537,9 +4531,8 @@ export class Client implements LangSmithTracingClientInterface {
           8
         )}?organizationId=${settings.id}`;
       } else {
-        return `${this.getHostUrl()}/prompts/${promptName}?organizationId=${
-          settings.id
-        }`;
+        return `${this.getHostUrl()}/prompts/${promptName}?organizationId=${settings.id
+          }`;
       }
     }
   }
@@ -4718,8 +4711,7 @@ export class Client implements LangSmithTracingClientInterface {
 
     const result = await response.json();
     return this._getPromptUrl(
-      `${owner}/${promptName}${
-        result.commit_hash ? `:${result.commit_hash}` : ""
+      `${owner}/${promptName}${result.commit_hash ? `:${result.commit_hash}` : ""
       }`
     );
   }
@@ -5043,8 +5035,7 @@ export class Client implements LangSmithTracingClientInterface {
       parsePromptIdentifier(promptIdentifier);
     const response = await this.caller.call(
       _getFetchImplementation(this.debug),
-      `${this.apiUrl}/commits/${owner}/${promptName}/${commitHash}${
-        options?.includeModel ? "?include_model=true" : ""
+      `${this.apiUrl}/commits/${owner}/${promptName}/${commitHash}${options?.includeModel ? "?include_model=true" : ""
       }`,
       {
         method: "GET",
@@ -5189,7 +5180,7 @@ export class Client implements LangSmithTracingClientInterface {
     } catch (e) {
       console.error(
         `An error occurred while creating dataset ${finalDatasetName}. ` +
-          "You should delete it manually."
+        "You should delete it manually."
       );
       throw e;
     }

--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -1112,8 +1112,8 @@ export class Client implements LangSmithTracingClientInterface {
     if (this.debug) {
       console.log(
         "\n=== LangSmith Server Configuration ===\n" +
-          JSON.stringify(json, null, 2) +
-          "\n"
+        JSON.stringify(json, null, 2) +
+        "\n"
       );
     }
     return json;
@@ -1491,7 +1491,7 @@ export class Client implements LangSmithTracingClientInterface {
               if (name.includes(".")) {
                 console.warn(
                   `Skipping attachment '${name}' for run ${payload.id}: Invalid attachment name. ` +
-                    `Attachment names must not contain periods ('.'). Please rename the attachment and try again.`
+                  `Attachment names must not contain periods ('.'). Please rename the attachment and try again.`
                 );
                 continue;
               }
@@ -1642,8 +1642,7 @@ export class Client implements LangSmithTracingClientInterface {
       // if stream fails, fallback to buffered body
       if (
         !this.multipartStreamingDisabled &&
-        res.status >= 400 &&
-        res.status < 500
+        res.status === 422
       ) {
         console.warn(
           `Streaming multipart request failed with EOF error, falling back to buffered mode. Context: ${context}`
@@ -1775,9 +1774,8 @@ export class Client implements LangSmithTracingClientInterface {
         sessionId = project.id;
       }
       const tenantId = await this._getTenantId();
-      return `${this.getHostUrl()}/o/${tenantId}/projects/p/${sessionId}/r/${
-        run.id
-      }?poll=true`;
+      return `${this.getHostUrl()}/o/${tenantId}/projects/p/${sessionId}/r/${run.id
+        }?poll=true`;
     } else if (runId !== undefined) {
       const run_ = await this.readRun(runId);
       if (!run_.app_path) {
@@ -2290,9 +2288,8 @@ export class Client implements LangSmithTracingClientInterface {
       }
     );
     const shareSchema = await response.json();
-    shareSchema.url = `${this.getHostUrl()}/public/${
-      shareSchema.share_token
-    }/d`;
+    shareSchema.url = `${this.getHostUrl()}/public/${shareSchema.share_token
+      }/d`;
     return shareSchema as DatasetShareSchema;
   }
 
@@ -2323,9 +2320,8 @@ export class Client implements LangSmithTracingClientInterface {
       }
     );
     const shareSchema = await response.json();
-    shareSchema.url = `${this.getHostUrl()}/public/${
-      shareSchema.share_token
-    }/d`;
+    shareSchema.url = `${this.getHostUrl()}/public/${shareSchema.share_token
+      }/d`;
     return shareSchema as DatasetShareSchema;
   }
 
@@ -2400,12 +2396,10 @@ export class Client implements LangSmithTracingClientInterface {
     if (!response.ok) {
       if ("detail" in result) {
         throw new Error(
-          `Failed to list shared examples.\nStatus: ${
-            response.status
-          }\nMessage: ${
-            Array.isArray(result.detail)
-              ? result.detail.join("\n")
-              : "Unspecified error"
+          `Failed to list shared examples.\nStatus: ${response.status
+          }\nMessage: ${Array.isArray(result.detail)
+            ? result.detail.join("\n")
+            : "Unspecified error"
           }`
         );
       }
@@ -3275,18 +3269,18 @@ export class Client implements LangSmithTracingClientInterface {
     propsOrUploads:
       | ExampleCreate[]
       | {
-          inputs?: Array<KVMap>;
-          outputs?: Array<KVMap>;
-          metadata?: Array<KVMap>;
-          splits?: Array<string | Array<string>>;
-          sourceRunIds?: Array<string>;
-          useSourceRunIOs?: Array<boolean>;
-          useSourceRunAttachments?: Array<string[]>;
-          attachments?: Array<Attachments>;
-          exampleIds?: Array<string>;
-          datasetId?: string;
-          datasetName?: string;
-        }
+        inputs?: Array<KVMap>;
+        outputs?: Array<KVMap>;
+        metadata?: Array<KVMap>;
+        splits?: Array<string | Array<string>>;
+        sourceRunIds?: Array<string>;
+        useSourceRunIOs?: Array<boolean>;
+        useSourceRunAttachments?: Array<string[]>;
+        attachments?: Array<Attachments>;
+        exampleIds?: Array<string>;
+        datasetId?: string;
+        datasetName?: string;
+      }
   ): Promise<Example[]> {
     if (Array.isArray(propsOrUploads)) {
       if (propsOrUploads.length === 0) {
@@ -3645,8 +3639,7 @@ export class Client implements LangSmithTracingClientInterface {
 
     const response = await this.caller.call(
       _getFetchImplementation(this.debug),
-      `${
-        this.apiUrl
+      `${this.apiUrl
       }/datasets/${resolvedDatasetId}/version?${params.toString()}`,
       {
         method: "GET",
@@ -4537,9 +4530,8 @@ export class Client implements LangSmithTracingClientInterface {
           8
         )}?organizationId=${settings.id}`;
       } else {
-        return `${this.getHostUrl()}/prompts/${promptName}?organizationId=${
-          settings.id
-        }`;
+        return `${this.getHostUrl()}/prompts/${promptName}?organizationId=${settings.id
+          }`;
       }
     }
   }
@@ -4718,8 +4710,7 @@ export class Client implements LangSmithTracingClientInterface {
 
     const result = await response.json();
     return this._getPromptUrl(
-      `${owner}/${promptName}${
-        result.commit_hash ? `:${result.commit_hash}` : ""
+      `${owner}/${promptName}${result.commit_hash ? `:${result.commit_hash}` : ""
       }`
     );
   }
@@ -5043,8 +5034,7 @@ export class Client implements LangSmithTracingClientInterface {
       parsePromptIdentifier(promptIdentifier);
     const response = await this.caller.call(
       _getFetchImplementation(this.debug),
-      `${this.apiUrl}/commits/${owner}/${promptName}/${commitHash}${
-        options?.includeModel ? "?include_model=true" : ""
+      `${this.apiUrl}/commits/${owner}/${promptName}/${commitHash}${options?.includeModel ? "?include_model=true" : ""
       }`,
       {
         method: "GET",
@@ -5189,7 +5179,7 @@ export class Client implements LangSmithTracingClientInterface {
     } catch (e) {
       console.error(
         `An error occurred while creating dataset ${finalDatasetName}. ` +
-          "You should delete it manually."
+        "You should delete it manually."
       );
       throw e;
     }

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -20,4 +20,4 @@ export { overrideFetchImplementation } from "./singletons/fetch.js";
 export { getDefaultProjectName } from "./utils/project.js";
 
 // Update using yarn bump-version
-export const __version__ = "0.3.42";
+export const __version__ = "0.3.43";


### PR DESCRIPTION
### Description

In the case that a stream request cannot successfully be sent to LangSmith multipart tracing, fallback to tracing via buffered body.  This is a less performant method of tracing, but adding a fallback makes requests more resilient.