### PR TITLE
fix(js): Propagate microseconds added in dotted order conversion to run tree start time

### DIFF
--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -317,8 +317,8 @@ interface CreateRunParams {
   inputs: KVMap;
   run_type: string;
   id?: string;
-  start_time?: number;
-  end_time?: number;
+  start_time?: number | string;
+  end_time?: number | string;
   extra?: KVMap;
   error?: string;
   serialized?: object;

--- a/js/src/schemas.ts
+++ b/js/src/schemas.ts
@@ -91,13 +91,13 @@ export interface BaseRun {
   name: string;
 
   /** The epoch time at which the run started, if available. */
-  start_time?: number;
+  start_time?: number | string;
 
   /** Specifies the type of run (tool, chain, llm, etc.). */
   run_type: string;
 
   /** The epoch time at which the run ended, if applicable. */
-  end_time?: number;
+  end_time?: number | string;
 
   /** Any additional metadata or settings for the run. */
   extra?: KVMap;
@@ -221,7 +221,7 @@ export interface RunCreate extends BaseRun {
 
 export interface RunUpdate {
   id?: string;
-  end_time?: number;
+  end_time?: number | string;
   extra?: KVMap;
   tags?: string[];
   error?: string;

--- a/js/src/tests/batch_client.int.test.ts
+++ b/js/src/tests/batch_client.int.test.ts
@@ -28,8 +28,8 @@ test("Test persist update run", async () => {
   await deleteProject(langchainClient, projectName);
 
   const runId = uuidv4();
-  const dottedOrder = convertToDottedOrderFormat(
-    new Date().getTime() / 1000,
+  const { dottedOrder } = convertToDottedOrderFormat(
+    new Date().getTime(),
     runId
   );
   await langchainClient.createRun({
@@ -71,8 +71,8 @@ test("Test persist update runs above the batch size limit", async () => {
 
   const createRun = async () => {
     const runId = uuidv4();
-    const dottedOrder = convertToDottedOrderFormat(
-      new Date().getTime() / 1000,
+    const { dottedOrder } = convertToDottedOrderFormat(
+      new Date().getTime(),
       runId
     );
     await langchainClient.createRun({
@@ -116,7 +116,7 @@ test("Test persist update run with delay", async () => {
   await deleteProject(langchainClient, projectName);
 
   const runId = uuidv4();
-  const dottedOrder = convertToDottedOrderFormat(
+  const { dottedOrder } = convertToDottedOrderFormat(
     new Date().getTime() / 1000,
     runId
   );
@@ -189,7 +189,7 @@ test("Test persist run with attachment", async () => {
   await deleteProject(langchainClient, projectName);
 
   const runId = uuidv4();
-  const dottedOrder = convertToDottedOrderFormat(
+  const { dottedOrder } = convertToDottedOrderFormat(
     new Date().getTime() / 1000,
     runId
   );

--- a/js/src/tests/batch_client.test.ts
+++ b/js/src/tests/batch_client.test.ts
@@ -119,7 +119,7 @@ describe.each(ENDPOINT_TYPES)(
       const projectName = "__test_batch";
 
       const runId = uuidv4();
-      const dottedOrder = convertToDottedOrderFormat(
+      const { dottedOrder } = convertToDottedOrderFormat(
         new Date().getTime() / 1000,
         runId
       );
@@ -184,7 +184,7 @@ describe.each(ENDPOINT_TYPES)(
       const projectName = "__test_batch";
 
       const runId = uuidv4();
-      const dottedOrder = convertToDottedOrderFormat(
+      const { dottedOrder } = convertToDottedOrderFormat(
         new Date().getTime() / 1000,
         runId
       );
@@ -253,7 +253,7 @@ describe.each(ENDPOINT_TYPES)(
       const projectName = "__test_batch";
 
       const runId = uuidv4();
-      const dottedOrder = convertToDottedOrderFormat(
+      const { dottedOrder } = convertToDottedOrderFormat(
         new Date().getTime() / 1000,
         runId
       );
@@ -322,7 +322,7 @@ describe.each(ENDPOINT_TYPES)(
       const projectName = "__test_batch";
 
       const runId = uuidv4();
-      const dottedOrder = convertToDottedOrderFormat(
+      const { dottedOrder } = convertToDottedOrderFormat(
         new Date().getTime() / 1000,
         runId
       );
@@ -360,7 +360,7 @@ describe.each(ENDPOINT_TYPES)(
       const projectName = "__test_batch";
 
       const runId = uuidv4();
-      const dottedOrder = convertToDottedOrderFormat(
+      const { dottedOrder } = convertToDottedOrderFormat(
         new Date().getTime() / 1000,
         runId
       );
@@ -441,7 +441,7 @@ describe.each(ENDPOINT_TYPES)(
       const projectName = "__test_batch";
 
       const runId = uuidv4();
-      const dottedOrder = convertToDottedOrderFormat(
+      const { dottedOrder } = convertToDottedOrderFormat(
         new Date().getTime() / 1000,
         runId
       );
@@ -520,7 +520,7 @@ describe.each(ENDPOINT_TYPES)(
       const projectName = "__test_batch";
 
       const runId = uuidv4();
-      const dottedOrder = convertToDottedOrderFormat(
+      const { dottedOrder } = convertToDottedOrderFormat(
         new Date().getTime() / 1000,
         runId
       );
@@ -548,7 +548,7 @@ describe.each(ENDPOINT_TYPES)(
       });
 
       const runId2 = uuidv4();
-      const dottedOrder2 = convertToDottedOrderFormat(
+      const { dottedOrder: dottedOrder2 } = convertToDottedOrderFormat(
         new Date().getTime() / 1000,
         runId2
       );
@@ -635,7 +635,7 @@ describe.each(ENDPOINT_TYPES)(
       const projectName = "__test_batch";
 
       const runId = uuidv4();
-      const dottedOrder = convertToDottedOrderFormat(
+      const { dottedOrder } = convertToDottedOrderFormat(
         new Date().getTime() / 1000,
         runId
       );
@@ -665,7 +665,7 @@ describe.each(ENDPOINT_TYPES)(
       });
 
       const runId2 = uuidv4();
-      const dottedOrder2 = convertToDottedOrderFormat(
+      const { dottedOrder: dottedOrder2 } = convertToDottedOrderFormat(
         new Date().getTime() / 1000,
         runId2
       );
@@ -753,7 +753,7 @@ describe.each(ENDPOINT_TYPES)(
       const runIds = await Promise.all(
         [...Array(15)].map(async (_, i) => {
           const runId = uuidv4();
-          const dottedOrder = convertToDottedOrderFormat(
+          const { dottedOrder } = convertToDottedOrderFormat(
             new Date().getTime() / 1000,
             runId
           );
@@ -851,7 +851,7 @@ describe.each(ENDPOINT_TYPES)(
       const runParams = await Promise.all(
         [...Array(4)].map(async (_, i) => {
           const runId = uuidv4();
-          const dottedOrder = convertToDottedOrderFormat(
+          const { dottedOrder } = convertToDottedOrderFormat(
             new Date().getTime() / 1000,
             runId
           );
@@ -877,7 +877,7 @@ describe.each(ENDPOINT_TYPES)(
       const childRunParams = await Promise.all(
         runParams.map(async (runParam, i) => {
           const runId = uuidv4();
-          const dottedOrder = convertToDottedOrderFormat(
+          const { dottedOrder } = convertToDottedOrderFormat(
             new Date().getTime() / 1000,
             runId
           );
@@ -983,7 +983,7 @@ describe.each(ENDPOINT_TYPES)(
       const runIds = await Promise.all(
         [...Array(15)].map(async (_, i) => {
           const runId = uuidv4();
-          const dottedOrder = convertToDottedOrderFormat(
+          const { dottedOrder } = convertToDottedOrderFormat(
             new Date().getTime() / 1000,
             runId
           );
@@ -1084,7 +1084,7 @@ describe.each(ENDPOINT_TYPES)(
       const runIds = await Promise.all(
         [...Array(4)].map(async (_, i) => {
           const runId = uuidv4();
-          const dottedOrder = convertToDottedOrderFormat(
+          const { dottedOrder } = convertToDottedOrderFormat(
             new Date().getTime() / 1000,
             runId
           );
@@ -1186,7 +1186,7 @@ describe.each(ENDPOINT_TYPES)(
       const projectName = "__test_batch";
 
       const runId = uuidv4();
-      const dottedOrder = convertToDottedOrderFormat(
+      const { dottedOrder } = convertToDottedOrderFormat(
         new Date().getTime() / 1000,
         runId
       );
@@ -1256,7 +1256,7 @@ describe.each(ENDPOINT_TYPES)(
       b.a = a;
 
       const runId = uuidv4();
-      const dottedOrder = convertToDottedOrderFormat(
+      const { dottedOrder } = convertToDottedOrderFormat(
         new Date().getTime() / 1000,
         runId
       );


### PR DESCRIPTION
CC @agola11 @dqbd 