### PR TITLE
fix(js): Respect project names set at runtime for OTEL exported traces

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langsmith",
-  "version": "0.3.44",
+  "version": "0.3.45",
   "description": "Client library to connect to the LangSmith LLM Tracing and Evaluation Platform.",
   "packageManager": "yarn@1.22.19",
   "files": [

--- a/js/src/experimental/otel/exporter.ts
+++ b/js/src/experimental/otel/exporter.ts
@@ -63,6 +63,11 @@ export type LangSmithOTLPTraceExporterConfig = ConstructorParameters<
    * The name of the project to export traces to.
    */
   projectName?: string;
+
+  /**
+   * Default headers to add to exporter requests.
+   */
+  headers?: Record<string, string>;
 };
 
 /**
@@ -85,6 +90,8 @@ export class LangSmithOTLPTraceExporter extends OTLPTraceExporter {
     span: ReadableSpan
   ) => ReadableSpan | Promise<ReadableSpan>;
 
+  private projectName?: string;
+
   constructor(config?: LangSmithOTLPTraceExporterConfig) {
     const defaultLsEndpoint =
       getEnvironmentVariable("OTEL_EXPORTER_OTLP_ENDPOINT") ||
@@ -93,29 +100,29 @@ export class LangSmithOTLPTraceExporter extends OTLPTraceExporter {
     const defaultBaseUrl = defaultLsEndpoint.replace(/\/$/, "");
     const defaultUrl = `${defaultBaseUrl}/otel/v1/traces`;
     // Configure headers with API key and project if available
-    let defaultHeaderString =
-      getEnvironmentVariable("OTEL_EXPORTER_OTLP_HEADERS") ?? "";
-    if (!defaultHeaderString) {
-      const apiKey =
-        config?.apiKey ?? getLangSmithEnvironmentVariable("API_KEY");
-      if (apiKey) {
-        defaultHeaderString = `x-api-key=${apiKey}`;
+    let headers = config?.headers;
+    if (headers === undefined) {
+      let defaultHeaderString =
+        getEnvironmentVariable("OTEL_EXPORTER_OTLP_HEADERS") ?? "";
+      if (!defaultHeaderString) {
+        const apiKey =
+          config?.apiKey ?? getLangSmithEnvironmentVariable("API_KEY");
+        if (apiKey) {
+          defaultHeaderString = `x-api-key=${apiKey}`;
+        }
       }
-
-      const project =
-        config?.projectName ?? getLangSmithEnvironmentVariable("PROJECT");
-      if (project) {
-        defaultHeaderString += `,Langsmith-Project=${project}`;
-      }
+      headers = parseHeadersString(defaultHeaderString);
     }
 
     super({
       url: defaultUrl,
-      headers: parseHeadersString(defaultHeaderString),
+      headers,
       ...config,
     });
 
     this.transformExportedSpan = config?.transformExportedSpan;
+    this.projectName =
+      config?.projectName ?? getLangSmithEnvironmentVariable("PROJECT");
   }
 
   export(
@@ -220,6 +227,12 @@ export class LangSmithOTLPTraceExporter extends OTLPTraceExporter {
           span.attributes[constants.LANGSMITH_NAME] =
             span.attributes[`${constants.LANGSMITH_METADATA}.ls_run_name`];
           delete span.attributes[`${constants.LANGSMITH_METADATA}.ls_run_name`];
+        }
+        if (
+          span.attributes[constants.LANGSMITH_SESSION_NAME] === undefined &&
+          this.projectName !== undefined
+        ) {
+          span.attributes[constants.LANGSMITH_SESSION_NAME] = this.projectName;
         }
       }
       super.export(spans, resultCallback);

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -20,4 +20,4 @@ export { overrideFetchImplementation } from "./singletons/fetch.js";
 export { getDefaultProjectName } from "./utils/project.js";
 
 // Update using yarn bump-version
-export const __version__ = "0.3.44";
+export const __version__ = "0.3.45";


### PR DESCRIPTION
Rely on span attribute rather than sending it in the header

Very frustrating that headers are not configurable at runtime in the exporter superclass :(