### PR TITLE
fix(js): Fallback to parent run id if parent run is not present in run trees loaded from LangChain

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langsmith",
-  "version": "0.3.45",
+  "version": "0.3.46",
   "description": "Client library to connect to the LangSmith LLM Tracing and Evaluation Platform.",
   "packageManager": "yarn@1.22.19",
   "files": [

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -20,4 +20,4 @@ export { overrideFetchImplementation } from "./singletons/fetch.js";
 export { getDefaultProjectName } from "./utils/project.js";
 
 // Update using yarn bump-version
-export const __version__ = "0.3.45";
+export const __version__ = "0.3.46";

--- a/js/src/run_trees.ts
+++ b/js/src/run_trees.ts
@@ -45,8 +45,8 @@ export interface RunTreeConfig {
   parent_run?: RunTree;
   parent_run_id?: string;
   child_runs?: RunTree[];
-  start_time?: number;
-  end_time?: number;
+  start_time?: number | string;
+  end_time?: number | string;
   extra?: KVMap;
   metadata?: KVMap;
   tags?: string[];
@@ -192,6 +192,7 @@ export class RunTree implements BaseRun {
   run_type: string;
   project_name: string;
   parent_run?: RunTree;
+  parent_run_id?: string;
   child_runs: RunTree[];
   start_time: number;
   end_time?: number;
@@ -415,7 +416,7 @@ export class RunTree implements BaseRun {
       );
       parent_run_id = undefined;
     } else {
-      parent_run_id = run.parent_run?.id;
+      parent_run_id = run.parent_run?.id ?? run.parent_run_id;
       child_runs = [];
     }
     return {
@@ -578,7 +579,7 @@ export class RunTree implements BaseRun {
           error: this.error,
           inputs: this.inputs,
           outputs: this.outputs,
-          parent_run_id: this.parent_run?.id,
+          parent_run_id: this.parent_run?.id ?? this.parent_run_id,
           reference_example_id: this.reference_example_id,
           extra: this.extra,
           events: this.events,


### PR DESCRIPTION
This is difficult to test in langsmith due to circular deps but verified independently and will add a test to LangChain.