### PR TITLE
fix(python): Avoid resetting operation.name to "chain" during update_run

### DIFF
--- a/python/langsmith/_internal/otel/_otel_exporter.py
+++ b/python/langsmith/_internal/otel/_otel_exporter.py
@@ -341,8 +341,9 @@ class OTELExporter:
 
         # Set GenAI attributes according to OTEL semantic conventions
         # Set gen_ai.operation.name
-        operation_name = _get_operation_name(run_info.get("run_type", "chain"))
-        span.set_attribute(GEN_AI_OPERATION_NAME, operation_name)
+        if op.operation == "post":
+            operation_name = _get_operation_name(run_info.get("run_type", "chain"))
+            span.set_attribute(GEN_AI_OPERATION_NAME, operation_name)
 
         # Set gen_ai.system
         self._set_gen_ai_system(span, run_info)


### PR DESCRIPTION
Prevents gen_ai.operation.name from being unintentionally reset to "chain" during spec conversion.
The issue stems from a missing run_type in update_run.