### PR TITLE
feat(python): Add replica endpoints support to Python SDK

### DIFF
--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -314,16 +314,13 @@ def _get_tracing_sampling_rate(
 
 
 def _get_write_api_urls(_write_api_urls: Optional[dict[str, str]]) -> dict[str, str]:
-    _write_api_urls = _write_api_urls or json.loads(
-        os.getenv("LANGSMITH_RUNS_ENDPOINTS", "{}")
-    )
+    # Note: LANGSMITH_RUNS_ENDPOINTS is now handled via replicas, not _write_api_urls
+    _write_api_urls = _write_api_urls or {}
     processed_write_api_urls = {}
     for url, api_key in _write_api_urls.items():
         processed_url = url.strip()
         if not processed_url:
-            raise ls_utils.LangSmithUserError(
-                "LangSmith runs API URL within LANGSMITH_RUNS_ENDPOINTS cannot be empty"
-            )
+            raise ls_utils.LangSmithUserError("LangSmith runs API URL cannot be empty")
         processed_url = processed_url.strip().strip('"').strip("'").rstrip("/")
         processed_api_key = api_key.strip().strip('"').strip("'")
         _validate_api_key_if_hosted(processed_url, processed_api_key)
@@ -504,10 +501,7 @@ class Client:
         if (
             os.getenv("LANGSMITH_ENDPOINT") or os.getenv("LANGCHAIN_ENDPOINT")
         ) and os.getenv("LANGSMITH_RUNS_ENDPOINTS"):
-            raise ls_utils.LangSmithUserError(
-                "You cannot provide both LANGSMITH_ENDPOINT / LANGCHAIN_ENDPOINT "
-                "and LANGSMITH_RUNS_ENDPOINTS."
-            )
+            raise ls_utils.LangSmithConflictingEndpointsError()
 
         self.tracing_sample_rate = _get_tracing_sampling_rate(tracing_sampling_rate)
         self._filtered_post_uuids: set[uuid.UUID] = set()
@@ -1319,6 +1313,8 @@ class Client:
         project_name: Optional[str] = None,
         revision_id: Optional[str] = None,
         dangerously_allow_filesystem: bool = False,
+        api_key: Optional[str] = None,
+        api_url: Optional[str] = None,
         **kwargs: Any,
     ) -> None:
         """Persist a run to the LangSmith API.
@@ -1330,6 +1326,8 @@ class Client:
                 embedding, prompt, or parser.
             project_name (Optional[str]): The project name of the run.
             revision_id (Optional[Union[UUID, str]]): The revision ID of the run.
+            api_key (Optional[str]): The API key to use for this specific run.
+            api_url (Optional[str]): The API URL to use for this specific run.
             **kwargs (Any): Additional keyword arguments.
 
         Returns:
@@ -1450,18 +1448,27 @@ class Client:
             else:
                 # Neither Rust nor Python batch ingestion is configured,
                 # fall back to the non-batch approach.
-                self._create_run(run_create)
+                self._create_run(run_create, api_key=api_key, api_url=api_url)
         else:
-            self._create_run(run_create)
+            self._create_run(run_create, api_key=api_key, api_url=api_url)
 
-    def _create_run(self, run_create: dict):
+    def _create_run(
+        self,
+        run_create: dict,
+        *,
+        api_key: Optional[str] = None,
+        api_url: Optional[str] = None,
+    ):
         errors = []
-        for api_url, api_key in self._write_api_urls.items():
-            headers = {**self._headers, X_API_KEY: api_key}
+        # If specific api_key/api_url provided, use those; otherwise use all configured endpoints
+        if api_key is not None or api_url is not None:
+            target_api_url = api_url or self.api_url
+            target_api_key = api_key or self.api_key
+            headers = {**self._headers, X_API_KEY: target_api_key}
             try:
                 self.request_with_retries(
                     "POST",
-                    f"{api_url}/runs",
+                    f"{target_api_url}/runs",
                     request_kwargs={
                         "data": _dumps_json(run_create),
                         "headers": headers,
@@ -1470,6 +1477,22 @@ class Client:
                 )
             except Exception as e:
                 errors.append(e)
+        else:
+            # Use all configured write API URLs
+            for write_api_url, write_api_key in self._write_api_urls.items():
+                headers = {**self._headers, X_API_KEY: write_api_key}
+                try:
+                    self.request_with_retries(
+                        "POST",
+                        f"{write_api_url}/runs",
+                        request_kwargs={
+                            "data": _dumps_json(run_create),
+                            "headers": headers,
+                        },
+                        to_ignore=(ls_utils.LangSmithConflictError,),
+                    )
+                except Exception as e:
+                    errors.append(e)
         if errors:
             if len(errors) > 1:
                 raise ls_utils.LangSmithExceptionGroup(exceptions=errors)
@@ -2080,6 +2103,8 @@ class Client:
         attachments: Optional[ls_schemas.Attachments] = None,
         dangerously_allow_filesystem: bool = False,
         reference_example_id: str | uuid.UUID | None = None,
+        api_key: Optional[str] = None,
+        api_url: Optional[str] = None,
         **kwargs: Any,
     ) -> None:
         """Update a run in the LangSmith API.
@@ -2099,6 +2124,8 @@ class Client:
             reference_example_id (Optional[Union[str, uuid.UUID]]): ID of the example
                 that was the source of the run inputs. Used for runs that were part of
                 an experiment.
+            api_key (Optional[str]): The API key to use for this specific run.
+            api_url (Optional[str]): The API URL to use for this specific run.
             **kwargs (Any): Kwargs are ignored.
 
         Returns:
@@ -2238,23 +2265,48 @@ class Client:
                         TracingQueueItem(data["dotted_order"], serialized_op)
                     )
         else:
-            self._update_run(data)
+            self._update_run(data, api_key=api_key, api_url=api_url)
 
-    def _update_run(self, run_update: dict) -> None:
-        for api_url, api_key in self._write_api_urls.items():
+    def _update_run(
+        self,
+        run_update: dict,
+        *,
+        api_key: Optional[str] = None,
+        api_url: Optional[str] = None,
+    ) -> None:
+        # If specific api_key/api_url provided, use those; otherwise use all configured endpoints
+        if api_key is not None or api_url is not None:
+            target_api_url = api_url or self.api_url
+            target_api_key = api_key or self.api_key
             headers = {
                 **self._headers,
-                X_API_KEY: api_key,
+                X_API_KEY: target_api_key,
             }
 
             self.request_with_retries(
                 "PATCH",
-                f"{api_url}/runs/{run_update['id']}",
+                f"{target_api_url}/runs/{run_update['id']}",
                 request_kwargs={
                     "data": _dumps_json(run_update),
                     "headers": headers,
                 },
             )
+        else:
+            # Use all configured write API URLs
+            for write_api_url, write_api_key in self._write_api_urls.items():
+                headers = {
+                    **self._headers,
+                    X_API_KEY: write_api_key,
+                }
+
+                self.request_with_retries(
+                    "PATCH",
+                    f"{write_api_url}/runs/{run_update['id']}",
+                    request_kwargs={
+                        "data": _dumps_json(run_update),
+                        "headers": headers,
+                    },
+                )
 
     def flush_compressed_traces(self, attempts: int = 3) -> None:
         """Force flush the currently buffered compressed runs."""

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -501,7 +501,10 @@ class Client:
         if (
             os.getenv("LANGSMITH_ENDPOINT") or os.getenv("LANGCHAIN_ENDPOINT")
         ) and os.getenv("LANGSMITH_RUNS_ENDPOINTS"):
-            raise ls_utils.LangSmithConflictingEndpointsError()
+            raise ls_utils.LangSmithUserError(
+                "You cannot provide both LANGSMITH_ENDPOINT / LANGCHAIN_ENDPOINT "
+                "and LANGSMITH_RUNS_ENDPOINTS."
+            )
 
         self.tracing_sample_rate = _get_tracing_sampling_rate(tracing_sampling_rate)
         self._filtered_post_uuids: set[uuid.UUID] = set()

--- a/python/langsmith/run_helpers.py
+++ b/python/langsmith/run_helpers.py
@@ -44,6 +44,7 @@ from langsmith import client as ls_client
 from langsmith import run_trees, schemas, utils
 from langsmith._internal import _aiter as aitertools
 from langsmith.env import _runtime_env
+from langsmith.run_trees import Replica
 
 if TYPE_CHECKING:
     from types import TracebackType
@@ -108,7 +109,7 @@ def tracing_context(
     parent: Optional[Union[run_trees.RunTree, Mapping, str, Literal[False]]] = None,
     enabled: Optional[Union[bool, Literal["local"]]] = None,
     client: Optional[ls_client.Client] = None,
-    replicas: Optional[Sequence[tuple[str, Optional[dict]]]] = None,
+    replicas: Optional[Sequence[Replica]] = None,
     **kwargs: Any,
 ) -> Generator[None, None, None]:
     """Set the tracing context for a block of code.
@@ -123,8 +124,11 @@ def tracing_context(
         client: The client to use for logging the run to LangSmith. Defaults to None,
         enabled: Whether tracing is enabled. Defaults to None, meaning it will use the
             current context value or environment variables.
-        replicas: A sequence of tuples containing project names and optional updates for each replica.
-            Example: [("my_experiment", {"reference_example_id": None}), ("my_project", None)]
+        replicas: A sequence of replicas to send runs to. Can be either:
+            - Legacy format: tuples of (project_name, updates)
+              Example: [("my_experiment", {"reference_example_id": None}), ("my_project", None)]
+            - New format: WriteReplica dictionaries with api_url, api_key, project_name, updates
+              Example: [{"api_url": "https://api.example.com", "api_key": "key", "project_name": "proj"}]
     """
     if kwargs:
         # warn

--- a/python/langsmith/run_helpers.py
+++ b/python/langsmith/run_helpers.py
@@ -44,7 +44,7 @@ from langsmith import client as ls_client
 from langsmith import run_trees, schemas, utils
 from langsmith._internal import _aiter as aitertools
 from langsmith.env import _runtime_env
-from langsmith.run_trees import Replica
+from langsmith.run_trees import WriteReplica
 
 if TYPE_CHECKING:
     from types import TracebackType
@@ -109,7 +109,7 @@ def tracing_context(
     parent: Optional[Union[run_trees.RunTree, Mapping, str, Literal[False]]] = None,
     enabled: Optional[Union[bool, Literal["local"]]] = None,
     client: Optional[ls_client.Client] = None,
-    replicas: Optional[Sequence[Replica]] = None,
+    replicas: Optional[Sequence[WriteReplica]] = None,
     **kwargs: Any,
 ) -> Generator[None, None, None]:
     """Set the tracing context for a block of code.
@@ -124,11 +124,9 @@ def tracing_context(
         client: The client to use for logging the run to LangSmith. Defaults to None,
         enabled: Whether tracing is enabled. Defaults to None, meaning it will use the
             current context value or environment variables.
-        replicas: A sequence of replicas to send runs to. Can be either:
-            - Legacy format: tuples of (project_name, updates)
-              Example: [("my_experiment", {"reference_example_id": None}), ("my_project", None)]
-            - New format: WriteReplica dictionaries with api_url, api_key, project_name, updates
+        replicas: A sequence of WriteReplica dictionaries to send runs to.
               Example: [{"api_url": "https://api.example.com", "api_key": "key", "project_name": "proj"}]
+              or [{"project_name": "my_experiment", "updates": {"reference_example_id": None}}]
     """
     if kwargs:
         # warn

--- a/python/langsmith/run_trees.py
+++ b/python/langsmith/run_trees.py
@@ -10,6 +10,8 @@ from datetime import datetime, timezone
 from typing import Any, Optional, Union, cast
 from uuid import NAMESPACE_DNS, UUID, uuid4, uuid5
 
+from typing_extensions import TypedDict
+
 try:
     from pydantic.v1 import Field, root_validator  # type: ignore[import]
 except ImportError:
@@ -28,6 +30,18 @@ from langsmith.client import ID_TYPE, RUN_TYPE_T, Client, _dumps_json, _ensure_u
 
 logger = logging.getLogger(__name__)
 
+
+class WriteReplica(TypedDict, total=False):
+    api_url: Optional[str]
+    api_key: Optional[str]
+    project_name: Optional[str]
+    updates: Optional[dict]
+
+
+ProjectReplica = tuple[str, Optional[dict]]
+
+Replica = Union[WriteReplica, ProjectReplica]
+
 LANGSMITH_PREFIX = "langsmith-"
 LANGSMITH_DOTTED_ORDER = sys.intern(f"{LANGSMITH_PREFIX}trace")
 LANGSMITH_DOTTED_ORDER_BYTES = LANGSMITH_DOTTED_ORDER.encode("utf-8")
@@ -41,7 +55,7 @@ _CLIENT: Optional[Client] = None
 _LOCK = threading.Lock()
 
 # Context variables
-_REPLICAS = contextvars.ContextVar[Optional[Sequence[tuple[str, Optional[dict]]]]](
+_REPLICAS = contextvars.ContextVar[Optional[Sequence[Replica]]](
     "_REPLICAS", default=None
 )
 
@@ -203,7 +217,7 @@ class RunTree(ls_schemas.RunBase):
     dangerously_allow_filesystem: Optional[bool] = Field(
         default=False, description="Whether to allow filesystem access for attachments."
     )
-    replicas: Optional[Sequence[tuple[str, Optional[dict]]]] = Field(
+    replicas: Optional[Sequence[Replica]] = Field(
         default=None,
         description="Projects to replicate this run to with optional updates.",
     )
@@ -555,10 +569,16 @@ class RunTree(ls_schemas.RunBase):
 
     def post(self, exclude_child_runs: bool = True) -> None:
         """Post the run tree to the API asynchronously."""
-        if self.replicas:
-            for project_name, updates in self.replicas:
+        write_replicas = _ensure_write_replicas(self.replicas)
+        if write_replicas:
+            for replica in write_replicas:
+                project_name = replica.get("project_name") or self.session_name
                 run_dict = self._remap_for_project(project_name)
-                self.client.create_run(**run_dict)
+                self.client.create_run(
+                    **run_dict,
+                    api_key=replica.get("api_key"),
+                    api_url=replica.get("api_url"),
+                )
         else:
             kwargs = self._get_dicts_safe()
             self.client.create_run(**kwargs)
@@ -606,8 +626,11 @@ class RunTree(ls_schemas.RunBase):
         except Exception as e:
             logger.warning(f"Error filtering attachments to upload: {e}")
         # Fanout logic for patch
-        if self.replicas:
-            for project_name, updates in self.replicas:
+        write_replicas = _ensure_write_replicas(self.replicas)
+        if write_replicas:
+            for replica in write_replicas:
+                project_name = replica.get("project_name") or self.session_name
+                updates = replica.get("updates")
                 run_dict = self._remap_for_project(project_name, updates)
                 self.client.update_run(
                     name=run_dict["name"],
@@ -625,6 +648,8 @@ class RunTree(ls_schemas.RunBase):
                     tags=run_dict.get("tags"),
                     extra=run_dict.get("extra"),
                     attachments=attachments,
+                    api_key=replica.get("api_key"),
+                    api_url=replica.get("api_url"),
                 )
         else:
             self.client.update_run(
@@ -827,7 +852,7 @@ class _Baggage:
         metadata: Optional[dict[str, str]] = None,
         tags: Optional[list[str]] = None,
         project_name: Optional[str] = None,
-        replicas: Optional[Sequence[tuple[str, Optional[dict]]]] = None,
+        replicas: Optional[Sequence[Replica]] = None,
     ):
         """Initialize the Baggage object."""
         self.metadata = metadata or {}
@@ -843,7 +868,7 @@ class _Baggage:
         metadata = {}
         tags = []
         project_name = None
-        replicas = None
+        replicas: Optional[list[Replica]] = None
         try:
             for item in header_value.split(","):
                 key, value = item.split("=", 1)
@@ -855,7 +880,22 @@ class _Baggage:
                     project_name = urllib.parse.unquote(value)
                 elif key == LANGSMITH_REPLICAS:
                     replicas_data = json.loads(urllib.parse.unquote(value))
-                    replicas = [(str(proj), updates) for proj, updates in replicas_data]
+                    parsed_replicas: list[Replica] = []
+                    for replica_item in replicas_data:
+                        if isinstance(replica_item, list) and len(replica_item) == 2:
+                            # Legacy format: [project_name, updates]
+                            parsed_replicas.append(
+                                (str(replica_item[0]), replica_item[1])
+                            )
+                        elif isinstance(replica_item, dict):
+                            # New WriteReplica format: preserve as dict
+                            parsed_replicas.append(cast(WriteReplica, replica_item))
+                        else:
+                            logger.warning(
+                                f"Unknown replica format in baggage: {replica_item}"
+                            )
+                            continue
+                    replicas = parsed_replicas
         except Exception as e:
             logger.warning(f"Error parsing baggage header: {e}")
 
@@ -895,6 +935,67 @@ class _Baggage:
                 f"{LANGSMITH_PREFIX}replicas={urllib.parse.quote(serialized_replicas)}"
             )
         return ",".join(items)
+
+
+def _get_write_replicas_from_env() -> list[WriteReplica]:
+    """Get write replicas from LANGSMITH_RUNS_ENDPOINTS environment variable."""
+    import os
+
+    env_var = os.getenv("LANGSMITH_RUNS_ENDPOINTS")
+    if not env_var:
+        return []
+
+    try:
+        parsed = json.loads(env_var)
+        _check_endpoint_env_unset(parsed)
+        return [
+            WriteReplica(
+                api_url=url.rstrip("/"),
+                api_key=key,
+                project_name=None,
+                updates=None,
+            )
+            for url, key in parsed.items()
+        ]
+    except utils.LangSmithConflictingEndpointsError:
+        raise
+    except Exception as e:
+        logger.warning(
+            "Invalid LANGSMITH_RUNS_ENDPOINTS – must be valid JSON mapping of "
+            f"url->apiKey: {e}"
+        )
+        return []
+
+
+def _check_endpoint_env_unset(parsed: dict[str, str]) -> None:
+    """Check if endpoint environment variables conflict with runs endpoints."""
+    import os
+
+    if parsed and (os.getenv("LANGSMITH_ENDPOINT") or os.getenv("LANGCHAIN_ENDPOINT")):
+        raise utils.LangSmithConflictingEndpointsError()
+
+
+def _ensure_write_replicas(replicas: Optional[Sequence[Replica]]) -> list[WriteReplica]:
+    """Convert replicas to WriteReplica format."""
+    if replicas is None:
+        return _get_write_replicas_from_env()
+
+    write_replicas = []
+    for replica in replicas:
+        if isinstance(replica, tuple):
+            project_name, updates = replica
+            write_replicas.append(
+                WriteReplica(
+                    api_url=None,
+                    api_key=None,
+                    project_name=project_name,
+                    updates=updates,
+                )
+            )
+        else:
+            write_replicas.append(replica)
+
+    return write_replicas
 
 
 def _parse_dotted_order(dotted_order: str) -> list[tuple[datetime, UUID]]:

--- a/python/langsmith/run_trees.py
+++ b/python/langsmith/run_trees.py
@@ -957,7 +957,7 @@ def _get_write_replicas_from_env() -> list[WriteReplica]:
             )
             for url, key in parsed.items()
         ]
-    except utils.LangSmithConflictingEndpointsError:
+    except utils.LangSmithUserError:
         raise
     except Exception as e:
         logger.warning(
@@ -972,7 +972,10 @@ def _check_endpoint_env_unset(parsed: dict[str, str]) -> None:
     import os
 
     if parsed and (os.getenv("LANGSMITH_ENDPOINT") or os.getenv("LANGCHAIN_ENDPOINT")):
-        raise utils.LangSmithConflictingEndpointsError()
+        raise utils.LangSmithUserError(
+            "You cannot provide both LANGSMITH_ENDPOINT / LANGCHAIN_ENDPOINT "
+            "and LANGSMITH_RUNS_ENDPOINTS."
+        )
 
 
 def _ensure_write_replicas(replicas: Optional[Sequence[Replica]]) -> list[WriteReplica]:

--- a/python/langsmith/utils.py
+++ b/python/langsmith/utils.py
@@ -85,6 +85,30 @@ class LangSmithExceptionGroup(LangSmithError):
         self.exceptions = exceptions
 
 
+ERR_CONFLICTING_ENDPOINTS = "ERR_CONFLICTING_ENDPOINTS"
+
+
+class LangSmithConflictingEndpointsError(LangSmithError):
+    """Error raised when both LANGSMITH_ENDPOINT and LANGSMITH_RUNS_ENDPOINTS are set."""  # noqa: E501
+
+    def __init__(self) -> None:
+        """Initialize the error."""
+        super().__init__(
+            "You cannot provide both LANGSMITH_ENDPOINT / LANGCHAIN_ENDPOINT "
+            "and LANGSMITH_RUNS_ENDPOINTS."
+        )
+        self.code = ERR_CONFLICTING_ENDPOINTS
+
+
+def is_conflicting_endpoints_error(err: Exception) -> bool:
+    """Check if an error is a ConflictingEndpointsError."""
+    return (
+        isinstance(err, LangSmithConflictingEndpointsError)
+        and hasattr(err, "code")
+        and err.code == ERR_CONFLICTING_ENDPOINTS
+    )
+
+
 ## Warning classes
 
 

--- a/python/langsmith/utils.py
+++ b/python/langsmith/utils.py
@@ -85,30 +85,6 @@ class LangSmithExceptionGroup(LangSmithError):
         self.exceptions = exceptions
 
 
-ERR_CONFLICTING_ENDPOINTS = "ERR_CONFLICTING_ENDPOINTS"
-
-
-class LangSmithConflictingEndpointsError(LangSmithError):
-    """Error raised when both LANGSMITH_ENDPOINT and LANGSMITH_RUNS_ENDPOINTS are set."""  # noqa: E501
-
-    def __init__(self) -> None:
-        """Initialize the error."""
-        super().__init__(
-            "You cannot provide both LANGSMITH_ENDPOINT / LANGCHAIN_ENDPOINT "
-            "and LANGSMITH_RUNS_ENDPOINTS."
-        )
-        self.code = ERR_CONFLICTING_ENDPOINTS
-
-
-def is_conflicting_endpoints_error(err: Exception) -> bool:
-    """Check if an error is a ConflictingEndpointsError."""
-    return (
-        isinstance(err, LangSmithConflictingEndpointsError)
-        and hasattr(err, "code")
-        and err.code == ERR_CONFLICTING_ENDPOINTS
-    )
-
-
 ## Warning classes
 
 

--- a/python/tests/unit_tests/test_client.py
+++ b/python/tests/unit_tests/test_client.py
@@ -147,7 +147,7 @@ def test_validate_multiple_urls(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("LANGSMITH_ENDPOINT", "https://api.smith.langsmith-endpoint.com")
     monkeypatch.setenv("LANGSMITH_RUNS_ENDPOINTS", "{}")
 
-    with pytest.raises(ls_utils.LangSmithConflictingEndpointsError):
+    with pytest.raises(ls_utils.LangSmithUserError):
         Client()
 
     monkeypatch.undo()

--- a/python/tests/unit_tests/test_replica_endpoints.py
+++ b/python/tests/unit_tests/test_replica_endpoints.py
@@ -197,8 +197,8 @@ class TestClientReplicaMethods:
 class TestRunTreeReplicas:
     """Test RunTree with replica functionality."""
 
-    def test_run_tree_with_tuple_replicas(self):
-        """Test RunTree with tuple replica format."""
+    def test_run_tree_with_write_replicas(self):
+        """Test RunTree with WriteReplica format."""
         client = Mock()
 
         run_tree = RunTree(
@@ -206,7 +206,9 @@ class TestRunTreeReplicas:
             inputs={"input": "test"},
             client=client,
             project_name="test-project",
-            replicas=[("replica-project", {"key": "value"})],
+            replicas=[
+                WriteReplica(project_name="replica-project", updates={"key": "value"})
+            ],
         )
 
         run_tree.post()

--- a/python/tests/unit_tests/test_replica_endpoints.py
+++ b/python/tests/unit_tests/test_replica_endpoints.py
@@ -8,14 +8,12 @@ from unittest.mock import Mock, patch
 import pytest
 
 from langsmith import Client
+from langsmith import utils as ls_utils
 from langsmith.run_trees import (
     RunTree,
     WriteReplica,
     _ensure_write_replicas,
     _get_write_replicas_from_env,
-)
-from langsmith.utils import (
-    LangSmithConflictingEndpointsError,
 )
 
 
@@ -128,7 +126,7 @@ class TestEnvironmentVariableParsing:
                 "LANGSMITH_RUNS_ENDPOINTS": '{"https://replica.example.com": "key123"}',
             },
         ):
-            with pytest.raises(LangSmithConflictingEndpointsError):
+            with pytest.raises(ls_utils.LangSmithUserError):
                 _get_write_replicas_from_env()
 
     def test_langsmith_runs_endpoints_not_in_write_api_urls(self):

--- a/python/tests/unit_tests/test_replica_endpoints.py
+++ b/python/tests/unit_tests/test_replica_endpoints.py
@@ -1,0 +1,429 @@
+"""Tests for replica endpoints functionality."""
+
+import json
+import os
+import uuid
+from unittest.mock import Mock, patch
+
+import pytest
+
+from langsmith import Client
+from langsmith.run_trees import (
+    RunTree,
+    WriteReplica,
+    _ensure_write_replicas,
+    _get_write_replicas_from_env,
+)
+from langsmith.utils import (
+    LangSmithConflictingEndpointsError,
+)
+
+
+class TestWriteReplicaTypes:
+    """Test the WriteReplica type definitions and conversion functions."""
+
+    def test_ensure_write_replicas_with_none(self):
+        with patch.dict(os.environ, {}, clear=True):
+            result = _ensure_write_replicas(None)
+            assert result == []
+
+    def test_ensure_write_replicas_with_tuple_format(self):
+        """Test _ensure_write_replicas with tuple format."""
+        tuple_replicas = [
+            ("project1", {"key": "value"}),
+            ("project2", None),
+        ]
+
+        result = _ensure_write_replicas(tuple_replicas)
+
+        assert len(result) == 2
+        assert result[0]["project_name"] == "project1"
+        assert result[0]["updates"] == {"key": "value"}
+        assert result[0]["api_key"] is None
+        assert result[0]["api_url"] is None
+
+        assert result[1]["project_name"] == "project2"
+        assert result[1]["updates"] is None
+
+    def test_ensure_write_replicas_with_new_format(self):
+        """Test _ensure_write_replicas with WriteReplica format."""
+        new_replicas = [
+            WriteReplica(
+                api_url="https://replica1.example.com",
+                api_key="key1",
+                project_name="project1",
+                updates={"test": "value"},
+            ),
+            WriteReplica(
+                api_url="https://replica2.example.com",
+                api_key="key2",
+            ),
+        ]
+
+        result = _ensure_write_replicas(new_replicas)
+
+        assert len(result) == 2
+        assert result[0]["api_url"] == "https://replica1.example.com"
+        assert result[0]["api_key"] == "key1"
+        assert result[0]["project_name"] == "project1"
+        assert result[0]["updates"] == {"test": "value"}
+
+        assert result[1]["api_url"] == "https://replica2.example.com"
+        assert result[1]["api_key"] == "key2"
+        assert result[1].get("project_name") is None
+
+
+class TestEnvironmentVariableParsing:
+    """Test environment variable parsing for LANGSMITH_RUNS_ENDPOINTS."""
+
+    def test_get_write_replicas_from_env_empty(self):
+        """Test _get_write_replicas_from_env with no environment variable."""
+        with patch.dict(os.environ, {}, clear=True):
+            result = _get_write_replicas_from_env()
+            assert result == []
+
+    def test_get_write_replicas_from_env_valid_json(self):
+        """Test _get_write_replicas_from_env with valid JSON."""
+        endpoints_config = {
+            "https://api.smith.langchain.com": "primary-key-123",
+            "https://replica1.example.com": "replica1-key-456",
+            "https://replica2.example.com": "replica2-key-789",
+        }
+
+        # Clear conflicting environment variables
+        with patch.dict(
+            os.environ,
+            {
+                "LANGSMITH_RUNS_ENDPOINTS": json.dumps(endpoints_config),
+                "LANGSMITH_ENDPOINT": "",
+                "LANGCHAIN_ENDPOINT": "",
+            },
+            clear=False,
+        ):
+            result = _get_write_replicas_from_env()
+
+            assert len(result) == 3
+            urls = [r["api_url"] for r in result]
+            keys = [r["api_key"] for r in result]
+
+            assert "https://api.smith.langchain.com" in urls
+            assert "https://replica1.example.com" in urls
+            assert "https://replica2.example.com" in urls
+            assert "primary-key-123" in keys
+            assert "replica1-key-456" in keys
+            assert "replica2-key-789" in keys
+
+    def test_get_write_replicas_from_env_invalid_json(self):
+        """Test _get_write_replicas_from_env with invalid JSON."""
+        with patch.dict(os.environ, {"LANGSMITH_RUNS_ENDPOINTS": "invalid-json"}):
+            result = _get_write_replicas_from_env()
+            assert result == []
+
+    def test_get_write_replicas_from_env_conflicting_endpoints(self):
+        """Test _get_write_replicas_from_env with conflicting env vars."""
+        with patch.dict(
+            os.environ,
+            {
+                "LANGSMITH_ENDPOINT": "https://api.smith.langchain.com",
+                "LANGSMITH_RUNS_ENDPOINTS": '{"https://replica.example.com": "key123"}',
+            },
+        ):
+            with pytest.raises(LangSmithConflictingEndpointsError):
+                _get_write_replicas_from_env()
+
+    def test_langsmith_runs_endpoints_not_in_write_api_urls(self):
+        """Test that LANGSMITH_RUNS_ENDPOINTS is not parsed into _write_api_urls."""
+        endpoints_config = {
+            "https://replica1.example.com": "replica1-key",
+            "https://replica2.example.com": "replica2-key",
+        }
+
+        # Use a clean environment with only LANGSMITH_RUNS_ENDPOINTS set
+        clean_env = {"LANGSMITH_RUNS_ENDPOINTS": json.dumps(endpoints_config)}
+
+        with patch.dict(os.environ, clean_env, clear=True):
+            client = Client(auto_batch_tracing=False)
+
+            # _write_api_urls should only contain the default endpoint
+            assert len(client._write_api_urls) == 1
+            assert client.api_url == "https://api.smith.langchain.com"
+
+            # LANGSMITH_RUNS_ENDPOINTS should be available via replicas instead
+            replicas = _get_write_replicas_from_env()
+            assert len(replicas) == 2
+            replica_urls = [r["api_url"] for r in replicas]
+            assert "https://replica1.example.com" in replica_urls
+            assert "https://replica2.example.com" in replica_urls
+
+
+class TestClientReplicaMethods:
+    """Test Client methods with replica support."""
+
+    def test_create_run_accepts_api_key_and_url_parameters(self):
+        """Test that create_run accepts api_key and api_url parameters without error."""
+        client = Client(auto_batch_tracing=False)
+
+        # Mock the session to avoid actual HTTP requests
+        with patch.object(client.session, "request") as mock_request:
+            mock_request.return_value.status_code = 200
+            mock_request.return_value.text = ""
+
+            # This should not raise an error
+            client.create_run(
+                name="test_run",
+                inputs={"input": "test"},
+                run_type="chain",
+                api_key="custom-key",
+                api_url="https://custom.example.com",
+            )
+
+    def test_update_run_accepts_api_key_and_url_parameters(self):
+        """Test that update_run accepts api_key and api_url parameters without error."""
+        client = Client(auto_batch_tracing=False)
+        run_id = uuid.uuid4()
+
+        # Mock the session to avoid actual HTTP requests
+        with patch.object(client.session, "request") as mock_request:
+            mock_request.return_value.status_code = 200
+            mock_request.return_value.text = ""
+
+            # This should not raise an error
+            client.update_run(
+                run_id=run_id,
+                outputs={"output": "test"},
+                api_key="custom-key",
+                api_url="https://custom.example.com",
+            )
+
+
+class TestRunTreeReplicas:
+    """Test RunTree with replica functionality."""
+
+    def test_run_tree_with_tuple_replicas(self):
+        """Test RunTree with tuple replica format."""
+        client = Mock()
+
+        run_tree = RunTree(
+            name="test_run",
+            inputs={"input": "test"},
+            client=client,
+            project_name="test-project",
+            replicas=[("replica-project", {"key": "value"})],
+        )
+
+        run_tree.post()
+
+        # Verify client.create_run was called with replica parameters
+        assert client.create_run.call_count == 1
+        call_args = client.create_run.call_args
+        assert call_args[1]["api_key"] is None
+        assert call_args[1]["api_url"] is None
+
+    def test_run_tree_with_new_replicas(self):
+        """Test RunTree with WriteReplica format."""
+        client = Mock()
+
+        replicas = [
+            WriteReplica(
+                api_url="https://replica1.example.com",
+                api_key="replica1-key",
+                project_name="replica1-project",
+            ),
+            WriteReplica(
+                api_url="https://replica2.example.com",
+                api_key="replica2-key",
+                project_name="replica2-project",
+            ),
+        ]
+
+        run_tree = RunTree(
+            name="test_run",
+            inputs={"input": "test"},
+            client=client,
+            project_name="test-project",
+            replicas=replicas,
+        )
+
+        run_tree.post()
+
+        # Verify client.create_run was called twice with different replica parameters
+        assert client.create_run.call_count == 2
+
+        calls = client.create_run.call_args_list
+        assert calls[0][1]["api_key"] == "replica1-key"
+        assert calls[0][1]["api_url"] == "https://replica1.example.com"
+        assert calls[1][1]["api_key"] == "replica2-key"
+        assert calls[1][1]["api_url"] == "https://replica2.example.com"
+
+    def test_run_tree_patch_with_replicas(self):
+        """Test RunTree patch method with replicas."""
+        client = Mock()
+
+        replicas = [
+            WriteReplica(
+                api_url="https://replica.example.com",
+                api_key="replica-key",
+                project_name="replica-project",
+                updates={"extra_field": "extra_value"},
+            )
+        ]
+
+        run_tree = RunTree(
+            name="test_run",
+            inputs={"input": "test"},
+            client=client,
+            project_name="test-project",
+            replicas=replicas,
+        )
+
+        run_tree.patch()
+
+        # Verify client.update_run was called with replica parameters
+        assert client.update_run.call_count == 1
+        call_args = client.update_run.call_args
+        assert call_args[1]["api_key"] == "replica-key"
+        assert call_args[1]["api_url"] == "https://replica.example.com"
+
+
+class TestBaggageReplicaParsing:
+    """Test baggage header parsing for replicas."""
+
+    def test_baggage_parsing_tuple_format(self):
+        """Test that baggage headers with tuple replica format are parsed correctly."""
+        import json
+        import urllib.parse
+
+        from langsmith.run_trees import _Baggage
+
+        # tuple format: [project_name, updates]
+        tuple_replicas = [
+            ["replica-project-1", {"environment": "staging"}],
+            ["replica-project-2", None],
+        ]
+
+        baggage_value = (
+            f"langsmith-replicas={urllib.parse.quote(json.dumps(tuple_replicas))}"
+        )
+        baggage = _Baggage.from_header(baggage_value)
+
+        assert len(baggage.replicas) == 2
+        assert baggage.replicas[0] == ("replica-project-1", {"environment": "staging"})
+        assert baggage.replicas[1] == ("replica-project-2", None)
+
+    def test_baggage_parsing_new_format(self):
+        """Test baggage headers with WriteReplica format are parsed
+        correctly."""
+        import json
+        import urllib.parse
+
+        from langsmith.run_trees import _Baggage
+
+        #  WriteReplica format
+        new_replicas = [
+            {
+                "api_url": "https://replica1.example.com",
+                "api_key": "replica1-key",
+                "project_name": "replica1-project",
+                "updates": {"environment": "production"},
+            },
+            {
+                "api_url": "https://replica2.example.com",
+                "api_key": "replica2-key",
+                "project_name": "replica2-project",
+            },
+        ]
+
+        baggage_value = (
+            f"langsmith-replicas={urllib.parse.quote(json.dumps(new_replicas))}"
+        )
+        baggage = _Baggage.from_header(baggage_value)
+
+        assert len(baggage.replicas) == 2
+        assert baggage.replicas[0]["api_url"] == "https://replica1.example.com"
+        assert baggage.replicas[0]["api_key"] == "replica1-key"
+        assert baggage.replicas[0]["project_name"] == "replica1-project"
+        assert baggage.replicas[0]["updates"] == {"environment": "production"}
+
+        assert baggage.replicas[1]["api_url"] == "https://replica2.example.com"
+        assert baggage.replicas[1]["api_key"] == "replica2-key"
+        assert baggage.replicas[1]["project_name"] == "replica2-project"
+
+    def test_baggage_parsing_mixed_format(self):
+        """Test that baggage headers with mixed replica formats are parsed correctly."""
+        import json
+        import urllib.parse
+
+        from langsmith.run_trees import _Baggage
+
+        # Mixed format: both tuple and new
+        mixed_replicas = [
+            ["tuple-project", {"tuple": "true"}],  # tuple format
+            {
+                "api_url": "https://new.example.com",
+                "api_key": "new-key",
+                "project_name": "new-project",
+            },  # New format
+        ]
+
+        baggage_value = (
+            f"langsmith-replicas={urllib.parse.quote(json.dumps(mixed_replicas))}"
+        )
+        baggage = _Baggage.from_header(baggage_value)
+
+        assert len(baggage.replicas) == 2
+        # First should be tuple tuple format
+        assert baggage.replicas[0] == ("tuple-project", {"tuple": "true"})
+        # Second should be new dict format
+        assert baggage.replicas[1]["api_url"] == "https://new.example.com"
+        assert baggage.replicas[1]["api_key"] == "new-key"
+        assert baggage.replicas[1]["project_name"] == "new-project"
+
+
+class TestTracingContextReplicas:
+    """Test tracing_context function with replica support."""
+
+    def test_tracing_context_with_new_replica_format(self):
+        """Test that tracing_context accepts the WriteReplica format."""
+        from langsmith.run_helpers import tracing_context
+        from langsmith.run_trees import WriteReplica
+
+        replicas = [
+            WriteReplica(
+                api_url="https://replica.example.com",
+                api_key="replica-key",
+                project_name="replica-project",
+                updates={"environment": "test"},
+            )
+        ]
+
+        # This should not raise a type error
+        with tracing_context(replicas=replicas):
+            pass  # Just testing that the context manager works
+
+    def test_tracing_context_with_tuple_replica_format(self):
+        """Test that tracing_context still accepts the tuple tuple format."""
+        from langsmith.run_helpers import tracing_context
+
+        replicas = [("tuple-project", {"tuple": True}), ("another-project", None)]
+
+        # This should not raise a type error
+        with tracing_context(replicas=replicas):
+            pass  # Just testing that the context manager works
+
+    def test_tracing_context_with_mixed_replica_formats(self):
+        """Test that tracing_context accepts mixed replica formats."""
+        from langsmith.run_helpers import tracing_context
+        from langsmith.run_trees import WriteReplica
+
+        replicas = [
+            ("tuple-project", {"tuple": True}),  # tuple format
+            WriteReplica(
+                api_url="https://new.example.com",
+                api_key="new-key",
+                project_name="new-project",
+            ),
+        ]
+
+        # This should not raise a type error
+        with tracing_context(replicas=replicas):
+            pass  # Just testing that the context manager works


### PR DESCRIPTION
### Description
Backport the replica endpoints functionality from JavaScript to Python, enabling runs to be sent to multiple LangSmith instances with different API keys and URLs via replicas, instead of a separate slot.

### Changes
1. New replica format: Added WriteReplica type supporting api_url, api_key,  project_name, and updates
2. Environment variable support: LANGSMITH_RUNS_ENDPOINTS now parsed into replicas (replaces old _write_api_urls logic)
3. Tracing context: Baggage headers now support both legacy and new replica formats for distributed tracing
4. Client methods: create_run() and update_run() accept optional api_key/api_url parameters
5. Backward compatibility: Legacy tuple format (project_name, updates) still supported

### Breaking Changes
1. LANGSMITH_RUNS_ENDPOINTS no longer populates _write_api_urls (now handled via replicas)