### PR TITLE
patch(python, js): Fix sampling logic for patch runs

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langsmith",
-  "version": "0.3.49",
+  "version": "0.3.50",
   "description": "Client library to connect to the LangSmith LLM Tracing and Evaluation Platform.",
   "packageManager": "yarn@1.22.19",
   "files": [

--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -937,10 +937,8 @@ export class Client implements LangSmithTracingClientInterface {
       for (const run of runs) {
         if (!this.filteredPostUuids.has(run.trace_id)) {
           sampled.push(run);
-        } else {
-          if (run.id === run.trace_id) {
-            this.filteredPostUuids.delete(run.trace_id);
-          }
+        } else if (run.id === run.trace_id) {
+          this.filteredPostUuids.delete(run.trace_id);
         }
       }
       return sampled;

--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -935,10 +935,12 @@ export class Client implements LangSmithTracingClientInterface {
     if (patch) {
       const sampled = [];
       for (const run of runs) {
-        if (!this.filteredPostUuids.has(run.id)) {
+        if (!this.filteredPostUuids.has(run.trace_id)) {
           sampled.push(run);
         } else {
-          this.filteredPostUuids.delete(run.id);
+          if (run.id === run.trace_id) {
+            this.filteredPostUuids.delete(run.trace_id);
+          }
         }
       }
       return sampled;

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -20,4 +20,4 @@ export { overrideFetchImplementation } from "./singletons/fetch.js";
 export { getDefaultProjectName } from "./utils/project.js";
 
 // Update using yarn bump-version
-export const __version__ = "0.3.49";
+export const __version__ = "0.3.50";

--- a/js/src/tests/client.test.ts
+++ b/js/src/tests/client.test.ts
@@ -271,7 +271,7 @@ describe("Client", () => {
     it("should filter patch runs based on trace_id instead of run.id", () => {
       const client = new Client({
         apiKey: "test-api-key",
-        tracingSamplingRate: 0.5
+        tracingSamplingRate: 0.5,
       });
 
       // Mock the _shouldSample method to control sampling decisions
@@ -349,7 +349,7 @@ describe("Client", () => {
     it("should remove trace_id from filtered set when processing root run patches", () => {
       const client = new Client({
         apiKey: "test-api-key",
-        tracingSamplingRate: 0.5
+        tracingSamplingRate: 0.5,
       });
 
       // Mock the _shouldSample method to reject first trace, accept second
@@ -406,7 +406,10 @@ describe("Client", () => {
         },
       ];
 
-      const rootPatchFiltered = (client as any)._filterForSampling(rootPatchRuns, true);
+      const rootPatchFiltered = (client as any)._filterForSampling(
+        rootPatchRuns,
+        true
+      );
 
       // Only root_run_2 should be included, and traceId1 should be removed from filtered set
       // since we're updating the root run that was originally filtered
@@ -421,7 +424,7 @@ describe("Client", () => {
     it("should handle mixed traces with patch sampling", () => {
       const client = new Client({
         apiKey: "test-api-key",
-        tracingSamplingRate: 0.5
+        tracingSamplingRate: 0.5,
       });
 
       // Mock sampling to accept every other trace
@@ -468,7 +471,9 @@ describe("Client", () => {
 
       // Only children of sampled traces should be included
       expect(patchFiltered).toHaveLength(2);
-      const patchTraceIds = new Set(patchFiltered.map((run: any) => run.trace_id));
+      const patchTraceIds = new Set(
+        patchFiltered.map((run: any) => run.trace_id)
+      );
       expect(patchTraceIds.has(traceIds[0])).toBe(true);
       expect(patchTraceIds.has(traceIds[2])).toBe(true);
       expect(patchTraceIds.has(traceIds[1])).toBe(false);

--- a/js/src/tests/client.test.ts
+++ b/js/src/tests/client.test.ts
@@ -266,4 +266,213 @@ describe("Client", () => {
       });
     });
   });
+
+  describe("_filterForSampling patch logic", () => {
+    it("should filter patch runs based on trace_id instead of run.id", () => {
+      const client = new Client({
+        apiKey: "test-api-key",
+        tracingSamplingRate: 0.5
+      });
+
+      // Mock the _shouldSample method to control sampling decisions
+      let counter = 0;
+      jest.spyOn(client as any, "_shouldSample").mockImplementation(() => {
+        counter += 1;
+        return counter % 2 === 0; // Accept even-numbered calls (2nd, 4th, etc.)
+      });
+
+      // Create two traces
+      const traceId1 = "trace-1";
+      const traceId2 = "trace-2";
+      const childRunId1 = "child-1";
+      const childRunId2 = "child-2";
+
+      // Create root runs (these will be sampled)
+      const rootRuns = [
+        {
+          id: traceId1,
+          trace_id: traceId1,
+          name: "root_run_1",
+          run_type: "llm" as const,
+          inputs: { text: "hello" },
+        },
+        {
+          id: traceId2,
+          trace_id: traceId2,
+          name: "root_run_2",
+          run_type: "llm" as const,
+          inputs: { text: "world" },
+        },
+      ];
+
+      // Test POST filtering (initial sampling)
+      const postFiltered = (client as any)._filterForSampling(rootRuns, false);
+
+      // Based on our mock, first call returns false, second returns true
+      // So only root_run_2 should be sampled
+      expect(postFiltered).toHaveLength(1);
+      expect(postFiltered[0].id).toBe(traceId2);
+
+      // Verify that traceId1 is in filtered set, traceId2 is not
+      expect((client as any).filteredPostUuids.has(traceId1)).toBe(true);
+      expect((client as any).filteredPostUuids.has(traceId2)).toBe(false);
+
+      // Test PATCH filtering - child runs should follow their trace's sampling decision
+      const patchRuns = [
+        {
+          id: childRunId1,
+          trace_id: traceId1,
+          name: "child_run_1",
+          run_type: "tool" as const,
+          inputs: { text: "child hello" },
+          outputs: { result: "child result 1" },
+        },
+        {
+          id: childRunId2,
+          trace_id: traceId2,
+          name: "child_run_2",
+          run_type: "tool" as const,
+          inputs: { text: "child world" },
+          outputs: { result: "child result 2" },
+        },
+      ];
+
+      const patchFiltered = (client as any)._filterForSampling(patchRuns, true);
+
+      // Only child_run_2 should be included (its trace was sampled)
+      // child_run_1 should be filtered out (its trace was not sampled)
+      expect(patchFiltered).toHaveLength(1);
+      expect(patchFiltered[0].id).toBe(childRunId2);
+      expect(patchFiltered[0].trace_id).toBe(traceId2);
+    });
+
+    it("should remove trace_id from filtered set when processing root run patches", () => {
+      const client = new Client({
+        apiKey: "test-api-key",
+        tracingSamplingRate: 0.5
+      });
+
+      // Mock the _shouldSample method to reject first trace, accept second
+      let counter = 0;
+      jest.spyOn(client as any, "_shouldSample").mockImplementation(() => {
+        counter += 1;
+        return counter % 2 === 0;
+      });
+
+      const traceId1 = "trace-1";
+      const traceId2 = "trace-2";
+
+      // Create root runs and sample them
+      const rootRuns = [
+        {
+          id: traceId1,
+          trace_id: traceId1,
+          name: "root_run_1",
+          run_type: "llm" as const,
+          inputs: { text: "hello" },
+        },
+        {
+          id: traceId2,
+          trace_id: traceId2,
+          name: "root_run_2",
+          run_type: "llm" as const,
+          inputs: { text: "world" },
+        },
+      ];
+
+      (client as any)._filterForSampling(rootRuns, false);
+
+      // Verify initial state
+      expect((client as any).filteredPostUuids.has(traceId1)).toBe(true);
+      expect((client as any).filteredPostUuids.has(traceId2)).toBe(false);
+
+      // Test PATCH filtering for root runs (updates to the root runs themselves)
+      const rootPatchRuns = [
+        {
+          id: traceId1,
+          trace_id: traceId1,
+          name: "root_run_1",
+          run_type: "llm" as const,
+          inputs: { text: "hello" },
+          outputs: { result: "root result 1" },
+        },
+        {
+          id: traceId2,
+          trace_id: traceId2,
+          name: "root_run_2",
+          run_type: "llm" as const,
+          inputs: { text: "world" },
+          outputs: { result: "root result 2" },
+        },
+      ];
+
+      const rootPatchFiltered = (client as any)._filterForSampling(rootPatchRuns, true);
+
+      // Only root_run_2 should be included, and traceId1 should be removed from filtered set
+      // since we're updating the root run that was originally filtered
+      expect(rootPatchFiltered).toHaveLength(1);
+      expect(rootPatchFiltered[0].id).toBe(traceId2);
+
+      // traceId1 should be removed from filtered set since we processed its root run
+      expect((client as any).filteredPostUuids.has(traceId1)).toBe(false);
+      expect((client as any).filteredPostUuids.has(traceId2)).toBe(false);
+    });
+
+    it("should handle mixed traces with patch sampling", () => {
+      const client = new Client({
+        apiKey: "test-api-key",
+        tracingSamplingRate: 0.5
+      });
+
+      // Mock sampling to accept every other trace
+      let counter = 0;
+      jest.spyOn(client as any, "_shouldSample").mockImplementation(() => {
+        counter += 1;
+        return counter % 2 === 1; // Accept odd-numbered calls (1st, 3rd, etc.)
+      });
+
+      // Create multiple traces
+      const traceIds = ["trace-0", "trace-1", "trace-2", "trace-3"];
+      const childRunIds = ["child-0", "child-1", "child-2", "child-3"];
+
+      // Create root runs
+      const rootRuns = traceIds.map((traceId, i) => ({
+        id: traceId,
+        trace_id: traceId,
+        name: `root_run_${i}`,
+        run_type: "llm" as const,
+        inputs: { text: `hello ${i}` },
+      }));
+
+      // Sample the root runs
+      const postFiltered = (client as any)._filterForSampling(rootRuns, false);
+
+      // Based on our mock: 1st and 3rd calls return true (indices 0, 2)
+      expect(postFiltered).toHaveLength(2);
+      const sampledTraceIds = new Set(postFiltered.map((run: any) => run.id));
+      expect(sampledTraceIds.has(traceIds[0])).toBe(true);
+      expect(sampledTraceIds.has(traceIds[2])).toBe(true);
+
+      // Create child runs for all traces
+      const childRuns = traceIds.map((traceId, i) => ({
+        id: childRunIds[i],
+        trace_id: traceId,
+        name: `child_run_${i}`,
+        run_type: "tool" as const,
+        inputs: { text: `child ${i}` },
+        outputs: { result: `child result ${i}` },
+      }));
+
+      // Test patch filtering for child runs
+      const patchFiltered = (client as any)._filterForSampling(childRuns, true);
+
+      // Only children of sampled traces should be included
+      expect(patchFiltered).toHaveLength(2);
+      const patchTraceIds = new Set(patchFiltered.map((run: any) => run.trace_id));
+      expect(patchTraceIds.has(traceIds[0])).toBe(true);
+      expect(patchTraceIds.has(traceIds[2])).toBe(true);
+      expect(patchTraceIds.has(traceIds[1])).toBe(false);
+      expect(patchTraceIds.has(traceIds[3])).toBe(false);
+    });
+  });
 });

--- a/python/langsmith/__init__.py
+++ b/python/langsmith/__init__.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 
 # Avoid calling into importlib on every call to __version__
 
-__version__ = "0.4.8"
+__version__ = "0.4.9"
 version = __version__  # for backwards compatibility
 
 

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -1284,11 +1284,12 @@ class Client:
         if patch:
             sampled = []
             for run in runs:
-                run_id = _as_uuid(run["id"])
-                if run_id not in self._filtered_post_uuids:
+                trace_id = _as_uuid(run["trace_id"])
+                if trace_id not in self._filtered_post_uuids:
                     sampled.append(run)
                 else:
-                    self._filtered_post_uuids.remove(run_id)
+                    if run["id"] == trace_id:
+                        self._filtered_post_uuids.remove(trace_id)
             return sampled
         else:
             sampled = []

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -1287,9 +1287,8 @@ class Client:
                 trace_id = _as_uuid(run["trace_id"])
                 if trace_id not in self._filtered_post_uuids:
                     sampled.append(run)
-                else:
-                    if run["id"] == trace_id:
-                        self._filtered_post_uuids.remove(trace_id)
+                elif run["id"] == trace_id:
+                    self._filtered_post_uuids.remove(trace_id)
             return sampled
         else:
             sampled = []

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "langsmith"
-version = "0.4.8"
+version = "0.4.9"
 description = "Client library to connect to the LangSmith LLM Tracing and Evaluation Platform."
 authors = ["LangChain <support@langchain.dev>"]
 license = "MIT"

--- a/python/tests/unit_tests/test_client.py
+++ b/python/tests/unit_tests/test_client.py
@@ -1590,7 +1590,9 @@ def test_patch_sampling_follows_trace_logic():
         }
 
         # Test POST filtering (initial sampling)
-        post_filtered = client._filter_for_sampling([root_run_1, root_run_2], patch=False)
+        post_filtered = client._filter_for_sampling(
+            [root_run_1, root_run_2], patch=False
+        )
 
         # Based on our mock, first call returns False, second returns True
         # So only root_run_2 should be sampled
@@ -1630,7 +1632,9 @@ def test_patch_sampling_follows_trace_logic():
 
         # trace_id_1 should be removed from filtered set since we processed its root run
         assert trace_id_1 not in client._filtered_post_uuids
-        assert trace_id_2 not in client._filtered_post_uuids  # Still not in filtered set
+        assert (
+            trace_id_2 not in client._filtered_post_uuids
+        )  # Still not in filtered set
 
 
 def test_patch_sampling_mixed_traces():
@@ -1664,13 +1668,15 @@ def test_patch_sampling_mixed_traces():
         # Create root runs
         root_runs = []
         for i, trace_id in enumerate(trace_ids):
-            root_runs.append({
-                "id": trace_id,
-                "trace_id": trace_id,
-                "name": f"root_run_{i}",
-                "run_type": "llm",
-                "inputs": {"text": f"hello {i}"},
-            })
+            root_runs.append(
+                {
+                    "id": trace_id,
+                    "trace_id": trace_id,
+                    "name": f"root_run_{i}",
+                    "run_type": "llm",
+                    "inputs": {"text": f"hello {i}"},
+                }
+            )
 
         # Sample the root runs
         post_filtered = client._filter_for_sampling(root_runs, patch=False)
@@ -1684,14 +1690,16 @@ def test_patch_sampling_mixed_traces():
         # Create child runs for all traces
         child_runs = []
         for i, (trace_id, child_id) in enumerate(zip(trace_ids, child_run_ids)):
-            child_runs.append({
-                "id": child_id,
-                "trace_id": trace_id,
-                "name": f"child_run_{i}",
-                "run_type": "tool",
-                "inputs": {"text": f"child {i}"},
-                "outputs": {"result": f"child result {i}"},
-            })
+            child_runs.append(
+                {
+                    "id": child_id,
+                    "trace_id": trace_id,
+                    "name": f"child_run_{i}",
+                    "run_type": "tool",
+                    "inputs": {"text": f"child {i}"},
+                    "outputs": {"result": f"child result {i}"},
+                }
+            )
 
         # Test patch filtering for child runs
         patch_filtered = client._filter_for_sampling(child_runs, patch=True)


### PR DESCRIPTION
### Description
We were not correctly filtering patch runs when the post would get filtered, meaning large amounts of patch requests were being sent to ingest API and counting toward usage limits, but not actually getting ingested.

### Changes
Check patch trace id against trace id list, only remove trace ids from list for root runs.

### Alternative Solutions
Use consistent hashing based on run_id to sample both post and patch run ids equally, prevents storage of uuids (minimal memory overhead)

## Tests
Added unit tests confirming filtering logic correctly applies to both post and patch