### PR TITLE
feat(python): Add distributed tracing with sliced traces for child projects

### DIFF
--- a/python/langsmith/run_helpers.py
+++ b/python/langsmith/run_helpers.py
@@ -97,6 +97,8 @@ def get_tracing_context(
             "metadata": _METADATA.get(),
             "enabled": _TRACING_ENABLED.get(),
             "client": _CLIENT.get(),
+            "replicas": run_trees._REPLICAS.get(),
+            "distributed_parent_id": run_trees._DISTRIBUTED_PARENT_ID.get(),
         }
     return {k: context.get(v) for k, v in _CONTEXT_KEYS.items()}
 

--- a/python/langsmith/run_helpers.py
+++ b/python/langsmith/run_helpers.py
@@ -72,6 +72,7 @@ _CONTEXT_KEYS: dict[str, contextvars.ContextVar] = {
     "enabled": _TRACING_ENABLED,
     "client": _CLIENT,
     "replicas": run_trees._REPLICAS,
+    "distributed_parent_id": run_trees._DISTRIBUTED_PARENT_ID,
 }
 
 _EXCLUDED_FRAME_FNAME = "langsmith/run_helpers.py"
@@ -140,9 +141,12 @@ def tracing_context(
         if parent is not False
         else None
     )
+    distributed_parent_id = None
     if parent_run is not None:
+        # TODO(angus): decide if we want to merge tags and metadata
         tags = sorted(set(tags or []) | set(parent_run.tags or []))
         metadata = {**parent_run.metadata, **(metadata or {})}
+        distributed_parent_id = parent_run.id
     enabled = enabled if enabled is not None else current_context.get("enabled")
     _set_tracing_context(
         {
@@ -153,6 +157,7 @@ def tracing_context(
             "enabled": enabled,
             "client": client,
             "replicas": replicas,
+            "distributed_parent_id": distributed_parent_id,
         }
     )
     try:

--- a/python/langsmith/run_trees.py
+++ b/python/langsmith/run_trees.py
@@ -1012,9 +1012,8 @@ def _parse_write_replicas_from_env_var(env_var: Optional[str]) -> list[WriteRepl
 
 def _get_write_replicas_from_env() -> list[WriteReplica]:
     """Get write replicas from LANGSMITH_RUNS_ENDPOINTS environment variable."""
-    import os
-
-    env_var = os.getenv("LANGSMITH_RUNS_ENDPOINTS")
+    env_var = utils.get_env_var("RUNS_ENDPOINTS")
+    
     return _parse_write_replicas_from_env_var(env_var)
 
 

--- a/python/langsmith/run_trees.py
+++ b/python/langsmith/run_trees.py
@@ -543,7 +543,7 @@ class RunTree(ls_schemas.RunBase):
                 # Rebuild dotted_order
                 run_dict["dotted_order"] = ".".join(trimmed_segs)
                 if trimmed_segs:
-                    run_dict["trace_id"] = trimmed_segs[0][-36:]
+                    run_dict["trace_id"] = UUID(trimmed_segs[0][-36:])
                 else:
                     run_dict["trace_id"] = run_dict["id"]
         if str(run_dict.get("parent_run_id")) == parent_id:
@@ -857,7 +857,12 @@ class RunTree(ls_schemas.RunBase):
         if baggage.replicas:
             init_args["replicas"] = baggage.replicas
 
-        return RunTree(**init_args)
+        run_tree = RunTree(**init_args)
+
+        # Set the distributed parent ID to this run's ID for rerooting
+        _DISTRIBUTED_PARENT_ID.set(str(run_tree.id))
+
+        return run_tree
 
     def to_headers(self) -> dict[str, str]:
         """Return the RunTree as a dictionary of headers."""

--- a/python/langsmith/run_trees.py
+++ b/python/langsmith/run_trees.py
@@ -527,12 +527,13 @@ class RunTree(ls_schemas.RunBase):
         the parent_run_id to None, and set the trace id to the new root id after
         parent_id.
         """
-        if run_dict.get("dotted_order"):
-            segs = _parse_dotted_order(run_dict["dotted_order"])
-            # Find the index where seg_id == parent_id
+        if dotted_order := run_dict.get("dotted_order"):
+            segs = _parse_dotted_order(dotted_order)
             start_idx = None
+            parent_id = str(parent_id)
+            # TODO(angus): potentially use binary search to find the index
             for idx, (_, seg_id) in enumerate(segs):
-                if str(seg_id) == str(parent_id):
+                if str(seg_id) == parent_id:
                     start_idx = idx
                     break
             if start_idx is not None:
@@ -548,7 +549,7 @@ class RunTree(ls_schemas.RunBase):
                 else:
                     run_dict["trace_id"] = run_dict["id"]
         # Remove parent_run_id if it matches parent_id
-        if str(run_dict.get("parent_run_id")) == str(parent_id):
+        if str(run_dict.get("parent_run_id")) == parent_id:
             run_dict.pop("parent_run_id", None)
 
     def _remap_for_project(

--- a/python/langsmith/run_trees.py
+++ b/python/langsmith/run_trees.py
@@ -560,7 +560,7 @@ class RunTree(ls_schemas.RunBase):
         if project_name == self.session_name:
             return run_dict
 
-        if updates and updates.get("distributed", False):
+        if updates and updates.get("reroot", False):
             distributed_parent_id = _DISTRIBUTED_PARENT_ID.get()
 
             if distributed_parent_id:
@@ -1013,7 +1013,7 @@ def _parse_write_replicas_from_env_var(env_var: Optional[str]) -> list[WriteRepl
 def _get_write_replicas_from_env() -> list[WriteReplica]:
     """Get write replicas from LANGSMITH_RUNS_ENDPOINTS environment variable."""
     env_var = utils.get_env_var("RUNS_ENDPOINTS")
-    
+
     return _parse_write_replicas_from_env_var(env_var)
 
 

--- a/python/langsmith/run_trees.py
+++ b/python/langsmith/run_trees.py
@@ -56,6 +56,10 @@ _REPLICAS = contextvars.ContextVar[Optional[Sequence[WriteReplica]]](
     "_REPLICAS", default=None
 )
 
+_DISTRIBUTED_PARENT_ID = contextvars.ContextVar[Optional[str]](
+    "_DISTRIBUTED_PARENT_ID", default=None
+)
+
 _SENTINEL = cast(None, object())
 
 # Note, this is called directly by langchain. Do not remove.
@@ -516,6 +520,37 @@ class RunTree(ls_schemas.RunBase):
             self_dict["outputs"] = self.outputs.copy()
         return self_dict
 
+    def _slice_parent_id(self, parent_id: str, run_dict: dict) -> None:
+        """Slice the parent id from dotted order.
+
+        Additionally check if the current run is a child of the parent. If so, update
+        the parent_run_id to None, and set the trace id to the new root id after
+        parent_id.
+        """
+        if run_dict.get("dotted_order"):
+            segs = _parse_dotted_order(run_dict["dotted_order"])
+            # Find the index where seg_id == parent_id
+            start_idx = None
+            for idx, (_, seg_id) in enumerate(segs):
+                if str(seg_id) == str(parent_id):
+                    start_idx = idx
+                    break
+            if start_idx is not None:
+                # Trim segments to start after parent_id (exclusive)
+                trimmed_segs = segs[start_idx + 1 :]
+                # Rebuild dotted_order
+                run_dict["dotted_order"] = ".".join(
+                    ts.strftime("%Y%m%dT%H%M%S%fZ") + str(seg_id)
+                    for ts, seg_id in trimmed_segs
+                )
+                if trimmed_segs:
+                    run_dict["trace_id"] = trimmed_segs[0][1]
+                else:
+                    run_dict["trace_id"] = run_dict["id"]
+        # Remove parent_run_id if it matches parent_id
+        if str(run_dict.get("parent_run_id")) == str(parent_id):
+            run_dict.pop("parent_run_id", None)
+
     def _remap_for_project(
         self, project_name: str, updates: Optional[dict] = None
     ) -> dict:
@@ -523,6 +558,12 @@ class RunTree(ls_schemas.RunBase):
         run_dict = self._get_dicts_safe()
         if project_name == self.session_name:
             return run_dict
+
+        if updates and updates.get("distributed", False):
+            distributed_parent_id = _DISTRIBUTED_PARENT_ID.get()
+
+            if distributed_parent_id:
+                self._slice_parent_id(distributed_parent_id, run_dict)
 
         old_id = run_dict["id"]
         new_id = uuid5(NAMESPACE_DNS, f"{old_id}:{project_name}")
@@ -570,7 +611,8 @@ class RunTree(ls_schemas.RunBase):
         if write_replicas:
             for replica in write_replicas:
                 project_name = replica.get("project_name") or self.session_name
-                run_dict = self._remap_for_project(project_name)
+                updates = replica.get("updates")
+                run_dict = self._remap_for_project(project_name, updates)
                 self.client.create_run(
                     **run_dict,
                     api_key=replica.get("api_key"),

--- a/python/tests/unit_tests/test_replica_endpoints.py
+++ b/python/tests/unit_tests/test_replica_endpoints.py
@@ -76,12 +76,14 @@ class TestEnvironmentVariableParsing:
 
     def test_get_write_replicas_from_env_empty(self):
         """Test _get_write_replicas_from_env with no environment variable."""
+        ls_utils.get_env_var.cache_clear()
         with patch.dict(os.environ, {}, clear=True):
             result = _get_write_replicas_from_env()
             assert result == []
 
     def test_get_write_replicas_from_env_valid_json(self):
         """Test _get_write_replicas_from_env with valid JSON."""
+        ls_utils.get_env_var.cache_clear()
         endpoints_config = {
             "https://api.smith.langchain.com": "primary-key-123",
             "https://replica1.example.com": "replica1-key-456",
@@ -113,12 +115,14 @@ class TestEnvironmentVariableParsing:
 
     def test_get_write_replicas_from_env_invalid_json(self):
         """Test _get_write_replicas_from_env with invalid JSON."""
+        ls_utils.get_env_var.cache_clear()
         with patch.dict(os.environ, {"LANGSMITH_RUNS_ENDPOINTS": "invalid-json"}):
             result = _get_write_replicas_from_env()
             assert result == []
 
     def test_get_write_replicas_from_env_conflicting_endpoints(self):
         """Test _get_write_replicas_from_env with conflicting env vars."""
+        ls_utils.get_env_var.cache_clear()
         with patch.dict(
             os.environ,
             {
@@ -131,6 +135,7 @@ class TestEnvironmentVariableParsing:
 
     def test_langsmith_runs_endpoints_not_in_write_api_urls(self):
         """Test that LANGSMITH_RUNS_ENDPOINTS is not parsed into _write_api_urls."""
+        ls_utils.get_env_var.cache_clear()
         endpoints_config = {
             "https://replica1.example.com": "replica1-key",
             "https://replica2.example.com": "replica2-key",

--- a/python/tests/unit_tests/test_run_helpers.py
+++ b/python/tests/unit_tests/test_run_helpers.py
@@ -1494,6 +1494,7 @@ async def test_traceable_async_exception(auto_batch_tracing: bool):
 
 @pytest.mark.parametrize("auto_batch_tracing", [True, False])
 async def test_traceable_async_gen_exception(auto_batch_tracing: bool):
+    ls_utils.get_env_var.cache_clear()
     mock_client = _get_mock_client(
         auto_batch_tracing=auto_batch_tracing,
         info=ls_schemas.LangSmithInfo(
@@ -1534,6 +1535,7 @@ async def test_traceable_async_gen_exception(auto_batch_tracing: bool):
 
 @pytest.mark.parametrize("auto_batch_tracing", [True, False])
 async def test_traceable_gen_exception(auto_batch_tracing: bool):
+    ls_utils.get_env_var.cache_clear()
     mock_client = _get_mock_client(
         auto_batch_tracing=auto_batch_tracing,
         info=ls_schemas.LangSmithInfo(

--- a/python/tests/unit_tests/test_run_trees.py
+++ b/python/tests/unit_tests/test_run_trees.py
@@ -235,8 +235,6 @@ def test_distributed_parent_id_from_headers():
     parent = grandparent.create_child(name="Parent")
     child = parent.create_child(name="Child")
 
-    headers = child.to_headers()
-
     current_distributed_parent_id = run_trees._DISTRIBUTED_PARENT_ID.get()
 
     new_run = RunTree(

--- a/python/tests/unit_tests/test_run_trees.py
+++ b/python/tests/unit_tests/test_run_trees.py
@@ -235,6 +235,10 @@ def test_distributed_parent_id_from_headers():
     parent = grandparent.create_child(name="Parent")
     child = parent.create_child(name="Child")
 
+    headers = child.to_headers()
+
+    RunTree.from_headers(headers)
+
     current_distributed_parent_id = run_trees._DISTRIBUTED_PARENT_ID.get()
 
     new_run = RunTree(

--- a/python/tests/unit_tests/test_run_trees.py
+++ b/python/tests/unit_tests/test_run_trees.py
@@ -2,7 +2,7 @@ import json
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
 from unittest.mock import MagicMock
-from uuid import UUID, uuid4
+from uuid import UUID
 
 import pytest
 
@@ -190,7 +190,7 @@ def test_distributed_tracing_remap_for_project():
         name="Grandparent",
         inputs={"text": "root"},
         client=mock_client,
-        session_name="original_project"
+        session_name="original_project",
     )
     parent = grandparent.create_child(name="Parent")
     child = parent.create_child(name="Child")
@@ -199,7 +199,7 @@ def test_distributed_tracing_remap_for_project():
     run_trees._DISTRIBUTED_PARENT_ID.set(parent_id)
 
     try:
-        updates = {"distributed": True}
+        updates = {"reroot": True}
         remapped_dict = child._remap_for_project("child_project", updates)
 
         assert remapped_dict.get("parent_run_id") is None
@@ -208,9 +208,10 @@ def test_distributed_tracing_remap_for_project():
         parsed_order = run_trees._parse_dotted_order(remapped_dict["dotted_order"])
         assert len(parsed_order) == 1
 
-        updates_no_dist = {"distributed": False}
-        remapped_dict_no_dist = child._remap_for_project("child_project_2", updates_no_dist)
-
+        updates_no_dist = {"reroot": False}
+        remapped_dict_no_dist = child._remap_for_project(
+            "child_project_2", updates_no_dist
+        )
         assert remapped_dict_no_dist.get("parent_run_id") is not None
         remapped_dict_no_updates = child._remap_for_project("child_project_3", None)
 


### PR DESCRIPTION
### Description
Adds support for distributed tracing where parent projects receive the full trace while child projects receive a sliced trace starting from the distributed parent ID.
<img width="1299" height="685" alt="Screenshot 2025-07-10 at 9 34 36 AM" src="https://github.com/user-attachments/assets/a1eedfc4-9c7a-4fc1-ad02-9d1a10fcd31a" />

## Usage
Requires manual configuration: The `reroot: True` flag must be explicitly set in replica configuration for each child project that should receive sliced traces.

## Features
1. Cross workspace support

## Limitations
2. Tracing will only work for a parent-child relationship. It will not work for chains of 3 or more distributed graphs (e.g., A→B→C). Only the immediate parent-child pair will have proper trace slicing.