### PR TITLE
fix(ci): Allow 429s for markdown link checks in CI

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -23,3 +23,4 @@ jobs:
           # Do not check the `vendor/` directory.
           folder-path: .github,js,openapi,python,rust
           file-path: ./README.md
+          config-file: .mlc_config.json

--- a/.mlc_config.json
+++ b/.mlc_config.json
@@ -1,0 +1,3 @@
+{
+  "aliveStatusCodes": [429, 200]
+}


### PR DESCRIPTION
This link was frequently 429'ing: https://github.com/langchain-ai/helm/blob/main/charts/langsmith/docker-compose/docker-compose.yaml

See: https://github.com/gaurav-nelson/github-action-markdown-link-check?tab=readme-ov-file#too-many-requests