### PR TITLE
feat(python, js): Support tracing to multiple orgs/workspaces

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langsmith",
-  "version": "0.3.50",
+  "version": "0.3.51",
   "description": "Client library to connect to the LangSmith LLM Tracing and Evaluation Platform.",
   "packageManager": "yarn@1.22.19",
   "files": [

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -20,4 +20,4 @@ export { overrideFetchImplementation } from "./singletons/fetch.js";
 export { getDefaultProjectName } from "./utils/project.js";
 
 // Update using yarn bump-version
-export const __version__ = "0.3.50";
+export const __version__ = "0.3.51";

--- a/js/src/run_trees.ts
+++ b/js/src/run_trees.ts
@@ -930,7 +930,7 @@ function _ensureWriteReplicas(replicas?: Replica[]): WriteReplica[] {
   return _getWriteReplicasFromEnv();
 }
 
-function _checkEndpointEnvUnset(parsed: Record<string, any>) {
+function _checkEndpointEnvUnset(parsed: Record<string, unknown>) {
   if (
     Object.keys(parsed).length > 0 &&
     getLangSmithEnvironmentVariable("ENDPOINT")

--- a/js/src/tests/replica_endpoints.test.ts
+++ b/js/src/tests/replica_endpoints.test.ts
@@ -616,6 +616,11 @@ describe("LANGSMITH_RUNS_ENDPOINTS Replica Testing", () => {
 
       const client = new Client({ autoBatchTracing: false });
 
+      // Mock HTTP calls to prevent actual requests
+      jest
+        .spyOn((client as any).caller, "call")
+        .mockResolvedValue({ ok: true, text: () => "" });
+
       // Create a RunTree to trigger replica parsing
       const runTree = new RunTree({
         name: "test-run",
@@ -654,6 +659,10 @@ describe("LANGSMITH_RUNS_ENDPOINTS Replica Testing", () => {
       const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
 
       const client = new Client({ autoBatchTracing: false });
+
+      jest
+        .spyOn((client as any).caller, "call")
+        .mockResolvedValue({ ok: true, text: () => "" });
 
       // Create a RunTree to trigger replica parsing
       const runTree = new RunTree({

--- a/js/src/tests/replica_endpoints.test.ts
+++ b/js/src/tests/replica_endpoints.test.ts
@@ -141,11 +141,12 @@ describe("LANGSMITH_RUNS_ENDPOINTS Replica Testing", () => {
       });
     });
 
-    it("should parse LANGSMITH_RUNS_ENDPOINTS with array of API keys", () => {
-      const endpointsConfig = {
-        "https://api.smith.langchain.com": ["key1", "key2", "key3"],
-        "https://replica.example.com": "single-key",
-      };
+    it("should parse LANGSMITH_RUNS_ENDPOINTS with new array format", () => {
+      const endpointsConfig = [
+        { api_url: "https://api.smith.langchain.com", api_key: "key1" },
+        { api_url: "https://api.smith.langchain.com", api_key: "key2" },
+        { api_url: "https://replica.example.com", api_key: "replica-key" },
+      ];
 
       process.env.LANGSMITH_RUNS_ENDPOINTS = JSON.stringify(endpointsConfig);
 
@@ -156,16 +157,18 @@ describe("LANGSMITH_RUNS_ENDPOINTS Replica Testing", () => {
       expect(parsed).toEqual(endpointsConfig);
     });
 
-    it("should handle mixed string and array API key formats", () => {
+    it("should parse LANGSMITH_RUNS_ENDPOINTS with object format", () => {
       const endpointsConfig = {
-        "https://primary.example.com": "single-key",
-        "https://multi.example.com": ["key1", "key2"],
-        "https://another.example.com": ["key3"],
+        "https://api.smith.langchain.com": "key1",
+        "https://replica.example.com": "single-key",
+        "https://another.example.com": "key3",
       };
 
       process.env.LANGSMITH_RUNS_ENDPOINTS = JSON.stringify(endpointsConfig);
 
       const envVar = getLangSmithEnvironmentVariable("RUNS_ENDPOINTS");
+      expect(envVar).toBe(JSON.stringify(endpointsConfig));
+
       const parsed = JSON.parse(envVar!);
       expect(parsed).toEqual(endpointsConfig);
     });
@@ -292,12 +295,47 @@ describe("LANGSMITH_RUNS_ENDPOINTS Replica Testing", () => {
       expect(callSpy).toHaveBeenCalled();
     });
 
-    it("should handle multiple API keys per URL (array format)", async () => {
+    it("should handle new array format with multiple endpoints", async () => {
+      const endpointsConfig = [
+        {
+          api_url: "https://workspace1.example.com",
+          api_key: "workspace1-key",
+        },
+        {
+          api_url: "https://workspace2.example.com",
+          api_key: "workspace2-key",
+        },
+        {
+          api_url: "https://workspace1.example.com",
+          api_key: "workspace1-alt-key",
+        },
+      ];
+
+      process.env.LANGSMITH_RUNS_ENDPOINTS = JSON.stringify(endpointsConfig);
+
+      const client = new Client({ autoBatchTracing: false });
+
+      const callSpy = jest
+        .spyOn((client as any).caller, "call")
+        .mockResolvedValue({ ok: true, text: () => "" });
+
+      const runTree = new RunTree({
+        name: "test-run",
+        inputs: { input: "test" },
+        client,
+        project_name: "test-project",
+      });
+
+      await runTree.postRun();
+
+      // Should make calls for all replicas
+      expect(callSpy).toHaveBeenCalled();
+    });
+
+    it("should handle object format", async () => {
       const endpointsConfig = {
-        "https://multi-workspace.example.com": [
-          "workspace1-key",
-          "workspace2-key",
-        ],
+        "https://workspace1.example.com": "workspace1-key",
+        "https://workspace2.example.com": "workspace2-key",
         "https://single.example.com": "single-key",
       };
 
@@ -318,47 +356,8 @@ describe("LANGSMITH_RUNS_ENDPOINTS Replica Testing", () => {
 
       await runTree.postRun();
 
-      // Should make calls for all replicas (3 total: 2 for multi-workspace + 1 for single)
+      // Should make calls for all replicas (3 total)
       expect(callSpy).toHaveBeenCalled();
-    });
-
-    it("should handle invalid API key types in arrays gracefully", async () => {
-      const endpointsConfig = {
-        "https://valid.example.com": ["valid-key"],
-        "https://invalid.example.com": ["valid-key", 123, "another-valid-key"], // 123 should be skipped
-      };
-
-      process.env.LANGSMITH_RUNS_ENDPOINTS = JSON.stringify(endpointsConfig);
-
-      const client = new Client({ autoBatchTracing: false });
-
-      const callSpy = jest
-        .spyOn((client as any).caller, "call")
-        .mockResolvedValue({ ok: true, text: () => "" });
-
-      // Spy on console.warn to check warning messages
-      const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
-
-      const runTree = new RunTree({
-        name: "test-run",
-        inputs: { input: "test" },
-        client,
-        project_name: "test-project",
-      });
-
-      await runTree.postRun();
-
-      // Should warn about invalid API key type
-      expect(warnSpy).toHaveBeenCalledWith(
-        expect.stringContaining(
-          "Invalid API key type in LANGSMITH_RUNS_ENDPOINTS"
-        )
-      );
-
-      // Should still make calls for valid keys
-      expect(callSpy).toHaveBeenCalled();
-
-      warnSpy.mockRestore();
     });
   });
 
@@ -603,7 +602,6 @@ describe("LANGSMITH_RUNS_ENDPOINTS Replica Testing", () => {
     it("should handle invalid value types in LANGSMITH_RUNS_ENDPOINTS", async () => {
       const invalidEndpointsConfig = {
         "https://valid-string.example.com": "valid-key",
-        "https://valid-array.example.com": ["key1", "key2"],
         "https://invalid-number.example.com": 123,
         "https://invalid-object.example.com": { key: "value" },
         "https://invalid-null.example.com": null,
@@ -617,11 +615,6 @@ describe("LANGSMITH_RUNS_ENDPOINTS Replica Testing", () => {
       const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
 
       const client = new Client({ autoBatchTracing: false });
-
-      // Mock HTTP calls
-      const callSpy = jest
-        .spyOn((client as any).caller, "call")
-        .mockResolvedValue({ ok: true, text: () => "" });
 
       // Create a RunTree to trigger replica parsing
       const runTree = new RunTree({
@@ -637,6 +630,53 @@ describe("LANGSMITH_RUNS_ENDPOINTS Replica Testing", () => {
       expect(warnSpy).toHaveBeenCalledWith(
         expect.stringContaining(
           "Invalid value type in LANGSMITH_RUNS_ENDPOINTS"
+        )
+      );
+
+      warnSpy.mockRestore();
+    });
+
+    it("should handle invalid items in new array format", async () => {
+      const invalidEndpointsConfig = [
+        { api_url: "https://valid.example.com", api_key: "valid-key" },
+        "invalid-string-item",
+        { api_url: "https://missing-key.example.com" }, // missing api_key
+        { api_key: "missing-url-key" }, // missing api_url
+        { api_url: 123, api_key: "invalid-url-type" }, // invalid api_url type
+        { api_url: "https://invalid-key-type.example.com", api_key: 456 }, // invalid api_key type
+      ];
+
+      process.env.LANGSMITH_RUNS_ENDPOINTS = JSON.stringify(
+        invalidEndpointsConfig
+      );
+
+      // Spy on console.warn to check warning messages
+      const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+
+      const client = new Client({ autoBatchTracing: false });
+
+      // Create a RunTree to trigger replica parsing
+      const runTree = new RunTree({
+        name: "test-run",
+        inputs: { input: "test" },
+        client,
+        project_name: "test-project",
+      });
+
+      await runTree.postRun();
+
+      // Should warn about various invalid types
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Invalid item type in LANGSMITH_RUNS_ENDPOINTS")
+      );
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "Invalid api_url type in LANGSMITH_RUNS_ENDPOINTS"
+        )
+      );
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "Invalid api_key type in LANGSMITH_RUNS_ENDPOINTS"
         )
       );
 

--- a/python/langsmith/__init__.py
+++ b/python/langsmith/__init__.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 
 # Avoid calling into importlib on every call to __version__
 
-__version__ = "0.4.10"
+__version__ = "0.4.11"
 version = __version__  # for backwards compatibility
 
 

--- a/python/langsmith/run_trees.py
+++ b/python/langsmith/run_trees.py
@@ -991,28 +991,59 @@ class _Baggage:
 def _parse_write_replicas_from_env_var(env_var: Optional[str]) -> list[WriteReplica]:
     """Parse write replicas from LANGSMITH_RUNS_ENDPOINTS environment variable value.
 
-    Supports url -> apiKey and url -> [apiKeys] formats.
+    Supports array format [{"api_url": "x", "api_key": "y"}] and object format 
+    {"url": "key"}.
     """
     if not env_var:
         return []
 
     try:
         parsed = json.loads(env_var)
-        _check_endpoint_env_unset(parsed)
 
-        replicas = []
-        for url, key_or_keys in parsed.items():
-            url = url.rstrip("/")
+        if isinstance(parsed, list):
+            replicas = []
+            for item in parsed:
+                if not isinstance(item, dict):
+                    logger.warning(
+                        f"Invalid item type in LANGSMITH_RUNS_ENDPOINTS: "
+                        f"expected dict, got {type(item).__name__}"
+                    )
+                    continue
 
-            if isinstance(key_or_keys, list):
-                for key in key_or_keys:
-                    if not isinstance(key, str):
-                        logger.warning(
-                            f"Invalid API key type in LANGSMITH_RUNS_ENDPOINTS for URL "
-                            f"{url}: "
-                            f"expected string, got {type(key).__name__}"
-                        )
-                        continue
+                api_url = item.get("api_url")
+                api_key = item.get("api_key")
+
+                if not isinstance(api_url, str):
+                    logger.warning(
+                        f"Invalid api_url type in LANGSMITH_RUNS_ENDPOINTS: "
+                        f"expected string, got {type(api_url).__name__}"
+                    )
+                    continue
+
+                if not isinstance(api_key, str):
+                    logger.warning(
+                        f"Invalid api_key type in LANGSMITH_RUNS_ENDPOINTS: "
+                        f"expected string, got {type(api_key).__name__}"
+                    )
+                    continue
+
+                replicas.append(
+                    WriteReplica(
+                        api_url=api_url.rstrip("/"),
+                        api_key=api_key,
+                        project_name=None,
+                        updates=None,
+                    )
+                )
+            return replicas
+        elif isinstance(parsed, dict):
+            _check_endpoint_env_unset(parsed)
+
+            replicas = []
+            for url, key in parsed.items():
+                url = url.rstrip("/")
+
+                if isinstance(key, str):
                     replicas.append(
                         WriteReplica(
                             api_url=url,
@@ -1021,31 +1052,28 @@ def _parse_write_replicas_from_env_var(env_var: Optional[str]) -> list[WriteRepl
                             updates=None,
                         )
                     )
-            elif isinstance(key_or_keys, str):
-                replicas.append(
-                    WriteReplica(
-                        api_url=url,
-                        api_key=key_or_keys,
-                        project_name=None,
-                        updates=None,
+                else:
+                    logger.warning(
+                        f"Invalid value type in LANGSMITH_RUNS_ENDPOINTS for URL "
+                        f"{url}: "
+                        f"expected string, got {type(key).__name__}"
                     )
-                )
-            else:
-                logger.warning(
-                    f"Invalid value type in LANGSMITH_RUNS_ENDPOINTS for URL "
-                    f"{url}: "
-                    f"expected string or list of strings, got "
-                    f"{type(key_or_keys).__name__}"
-                )
-                continue
-
-        return replicas
+                    continue
+            return replicas
+        else:
+            logger.warning(
+                f"Invalid LANGSMITH_RUNS_ENDPOINTS – must be valid JSON list of "
+                "objects with api_url and api_key properties, or object mapping "
+                f"url->apiKey, got {type(parsed).__name__}"
+            )
+            return []
     except utils.LangSmithUserError:
         raise
     except Exception as e:
         logger.warning(
-            "Invalid LANGSMITH_RUNS_ENDPOINTS – must be valid JSON mapping of "
-            f"url->apiKey or url->[apiKeys]: {e}"
+            "Invalid LANGSMITH_RUNS_ENDPOINTS – must be valid JSON list of "
+            f"objects with api_url and api_key properties, or object mapping"
+            f" url->apiKey: {e}"
         )
         return []
 

--- a/python/langsmith/run_trees.py
+++ b/python/langsmith/run_trees.py
@@ -1008,7 +1008,8 @@ def _parse_write_replicas_from_env_var(env_var: Optional[str]) -> list[WriteRepl
                 for key in key_or_keys:
                     if not isinstance(key, str):
                         logger.warning(
-                            f"Invalid API key type in LANGSMITH_RUNS_ENDPOINTS for URL {url}: "
+                            f"Invalid API key type in LANGSMITH_RUNS_ENDPOINTS for URL "
+                            f"{url}: "
                             f"expected string, got {type(key).__name__}"
                         )
                         continue
@@ -1031,8 +1032,10 @@ def _parse_write_replicas_from_env_var(env_var: Optional[str]) -> list[WriteRepl
                 )
             else:
                 logger.warning(
-                    f"Invalid value type in LANGSMITH_RUNS_ENDPOINTS for URL {url}: "
-                    f"expected string or list of strings, got {type(key_or_keys).__name__}"
+                    f"Invalid value type in LANGSMITH_RUNS_ENDPOINTS for URL "
+                    f"{url}: "
+                    f"expected string or list of strings, got "
+                    f"{type(key_or_keys).__name__}"
                 )
                 continue
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "langsmith"
-version = "0.4.10"
+version = "0.4.11"
 description = "Client library to connect to the LangSmith LLM Tracing and Evaluation Platform."
 authors = [
     {name = "LangChain", email = "support@langchain.dev"},

--- a/python/tests/unit_tests/test_replica_endpoints.py
+++ b/python/tests/unit_tests/test_replica_endpoints.py
@@ -171,7 +171,8 @@ class TestEnvironmentVariableParsing:
             ls_utils.get_env_var.cache_clear()
 
     def test_get_write_replicas_from_env_array_format(self):
-        """Test _get_write_replicas_from_env with array format for multiple keys per URL."""
+        """Test _get_write_replicas_from_env with array format for multiple keys
+        per URL."""
         ls_utils.get_env_var.cache_clear()
         try:
             endpoints_config = {
@@ -193,7 +194,9 @@ class TestEnvironmentVariableParsing:
                 assert len(result) == 4  # 3 from array + 1 single
 
                 # Check that we have 3 replicas for the first URL
-                api_example_replicas = [r for r in result if r["api_url"] == "https://api.example.com"]
+                api_example_replicas = [
+                    r for r in result if r["api_url"] == "https://api.example.com"
+                ]
                 assert len(api_example_replicas) == 3
 
                 api_keys = [r["api_key"] for r in api_example_replicas]
@@ -202,7 +205,9 @@ class TestEnvironmentVariableParsing:
                 assert "key3" in api_keys
 
                 # Check single key replica
-                replica_example_replicas = [r for r in result if r["api_url"] == "https://replica.example.com"]
+                replica_example_replicas = [
+                    r for r in result if r["api_url"] == "https://replica.example.com"
+                ]
                 assert len(replica_example_replicas) == 1
                 assert replica_example_replicas[0]["api_key"] == "single-key"
 
@@ -280,7 +285,12 @@ class TestEnvironmentVariableParsing:
         ls_utils.get_env_var.cache_clear()
         try:
             endpoints_config = {
-                "https://api.example.com": ["valid-key", 123, None, "another-valid-key"],
+                "https://api.example.com": [
+                    "valid-key",
+                    123,
+                    None,
+                    "another-valid-key",
+                ],
                 "https://valid.example.com": "valid-key",
             }
 
@@ -345,7 +355,9 @@ class TestParseWriteReplicasFromEnvVar:
         """Test parsing array format with single URL."""
         env_var = '{"https://api.example.com": ["key1", "key2", "key3"]}'
 
-        with patch.dict(os.environ, {"LANGSMITH_ENDPOINT": "", "LANGCHAIN_ENDPOINT": ""}, clear=True):
+        with patch.dict(
+            os.environ, {"LANGSMITH_ENDPOINT": "", "LANGCHAIN_ENDPOINT": ""}, clear=True
+        ):
             result = _parse_write_replicas_from_env_var(env_var)
 
         assert len(result) == 3
@@ -362,23 +374,31 @@ class TestParseWriteReplicasFromEnvVar:
 
     def test_parse_mixed_format(self):
         """Test parsing mixed single and array formats."""
-        env_var = json.dumps({
-            "https://single.example.com": "single-key",
-            "https://multi.example.com": ["multi1", "multi2"],
-        })
+        env_var = json.dumps(
+            {
+                "https://single.example.com": "single-key",
+                "https://multi.example.com": ["multi1", "multi2"],
+            }
+        )
 
-        with patch.dict(os.environ, {"LANGSMITH_ENDPOINT": "", "LANGCHAIN_ENDPOINT": ""}, clear=True):
+        with patch.dict(
+            os.environ, {"LANGSMITH_ENDPOINT": "", "LANGCHAIN_ENDPOINT": ""}, clear=True
+        ):
             result = _parse_write_replicas_from_env_var(env_var)
 
         assert len(result) == 3
 
         # Check single format replica
-        single_replicas = [r for r in result if r["api_url"] == "https://single.example.com"]
+        single_replicas = [
+            r for r in result if r["api_url"] == "https://single.example.com"
+        ]
         assert len(single_replicas) == 1
         assert single_replicas[0]["api_key"] == "single-key"
 
         # Check array format replicas
-        multi_replicas = [r for r in result if r["api_url"] == "https://multi.example.com"]
+        multi_replicas = [
+            r for r in result if r["api_url"] == "https://multi.example.com"
+        ]
         assert len(multi_replicas) == 2
         multi_keys = [r["api_key"] for r in multi_replicas]
         assert "multi1" in multi_keys
@@ -386,12 +406,16 @@ class TestParseWriteReplicasFromEnvVar:
 
     def test_parse_url_trailing_slash_removal(self):
         """Test that trailing slashes are removed from URLs."""
-        env_var = json.dumps({
-            "https://api.example.com/": ["key1", "key2"],
-            "https://other.example.com/path/": "single-key",
-        })
+        env_var = json.dumps(
+            {
+                "https://api.example.com/": ["key1", "key2"],
+                "https://other.example.com/path/": "single-key",
+            }
+        )
 
-        with patch.dict(os.environ, {"LANGSMITH_ENDPOINT": "", "LANGCHAIN_ENDPOINT": ""}, clear=True):
+        with patch.dict(
+            os.environ, {"LANGSMITH_ENDPOINT": "", "LANGCHAIN_ENDPOINT": ""}, clear=True
+        ):
             result = _parse_write_replicas_from_env_var(env_var)
 
         assert len(result) == 3
@@ -405,12 +429,16 @@ class TestParseWriteReplicasFromEnvVar:
 
     def test_parse_empty_array(self):
         """Test parsing with empty array."""
-        env_var = json.dumps({
-            "https://empty.example.com": [],
-            "https://valid.example.com": "valid-key",
-        })
+        env_var = json.dumps(
+            {
+                "https://empty.example.com": [],
+                "https://valid.example.com": "valid-key",
+            }
+        )
 
-        with patch.dict(os.environ, {"LANGSMITH_ENDPOINT": "", "LANGCHAIN_ENDPOINT": ""}, clear=True):
+        with patch.dict(
+            os.environ, {"LANGSMITH_ENDPOINT": "", "LANGCHAIN_ENDPOINT": ""}, clear=True
+        ):
             result = _parse_write_replicas_from_env_var(env_var)
 
         # Should only have the valid replica
@@ -420,11 +448,21 @@ class TestParseWriteReplicasFromEnvVar:
 
     def test_parse_invalid_array_elements(self):
         """Test parsing with invalid elements in array."""
-        env_var = json.dumps({
-            "https://api.example.com": ["valid1", 123, None, "valid2", {"invalid": "dict"}],
-        })
+        env_var = json.dumps(
+            {
+                "https://api.example.com": [
+                    "valid1",
+                    123,
+                    None,
+                    "valid2",
+                    {"invalid": "dict"},
+                ],
+            }
+        )
 
-        with patch.dict(os.environ, {"LANGSMITH_ENDPOINT": "", "LANGCHAIN_ENDPOINT": ""}, clear=True):
+        with patch.dict(
+            os.environ, {"LANGSMITH_ENDPOINT": "", "LANGCHAIN_ENDPOINT": ""}, clear=True
+        ):
             result = _parse_write_replicas_from_env_var(env_var)
 
         # Should only have valid string elements
@@ -435,13 +473,17 @@ class TestParseWriteReplicasFromEnvVar:
 
     def test_parse_invalid_value_types(self):
         """Test parsing with invalid value types."""
-        env_var = json.dumps({
-            "https://dict.example.com": {"invalid": "dict"},
-            "https://number.example.com": 123,
-            "https://valid.example.com": "valid-key",
-        })
+        env_var = json.dumps(
+            {
+                "https://dict.example.com": {"invalid": "dict"},
+                "https://number.example.com": 123,
+                "https://valid.example.com": "valid-key",
+            }
+        )
 
-        with patch.dict(os.environ, {"LANGSMITH_ENDPOINT": "", "LANGCHAIN_ENDPOINT": ""}, clear=True):
+        with patch.dict(
+            os.environ, {"LANGSMITH_ENDPOINT": "", "LANGCHAIN_ENDPOINT": ""}, clear=True
+        ):
             result = _parse_write_replicas_from_env_var(env_var)
 
         # Should only have the valid replica


### PR DESCRIPTION
### Description
Support tracing to multiple orgs/workspaces via LANGSMITH_RUNS_ENDPOINTS by supporting dict format for LANGSMITH_RUNS_ENDPOINTS
```
{
  "api_url": "x",
  "api_key": "y",
}
```