### PR TITLE
fix(python): legacy replicas conversion

### DIFF
--- a/python/langsmith/__init__.py
+++ b/python/langsmith/__init__.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 
 # Avoid calling into importlib on every call to __version__
 
-__version__ = "0.4.12"
+__version__ = "0.4.13"
 version = __version__  # for backwards compatibility
 
 

--- a/python/langsmith/run_trees.py
+++ b/python/langsmith/run_trees.py
@@ -927,7 +927,10 @@ class _Baggage:
                     replicas_data = json.loads(urllib.parse.unquote(value))
                     parsed_replicas: list[WriteReplica] = []
                     for replica_item in replicas_data:
-                        if isinstance(replica_item, tuple) and len(replica_item) == 2:
+                        if (
+                            isinstance(replica_item, (tuple, list))
+                            and len(replica_item) == 2
+                        ):
                             # Convert legacy format to WriteReplica
                             parsed_replicas.append(
                                 WriteReplica(

--- a/python/langsmith/run_trees.py
+++ b/python/langsmith/run_trees.py
@@ -927,7 +927,7 @@ class _Baggage:
                     replicas_data = json.loads(urllib.parse.unquote(value))
                     parsed_replicas: list[WriteReplica] = []
                     for replica_item in replicas_data:
-                        if isinstance(replica_item, list) and len(replica_item) == 2:
+                        if isinstance(replica_item, tuple) and len(replica_item) == 2:
                             # Convert legacy format to WriteReplica
                             parsed_replicas.append(
                                 WriteReplica(
@@ -991,7 +991,7 @@ class _Baggage:
 def _parse_write_replicas_from_env_var(env_var: Optional[str]) -> list[WriteReplica]:
     """Parse write replicas from LANGSMITH_RUNS_ENDPOINTS environment variable value.
 
-    Supports array format [{"api_url": "x", "api_key": "y"}] and object format 
+    Supports array format [{"api_url": "x", "api_key": "y"}] and object format
     {"url": "key"}.
     """
     if not env_var:

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "langsmith"
-version = "0.4.12"
+version = "0.4.13"
 description = "Client library to connect to the LangSmith LLM Tracing and Evaluation Platform."
 authors = [
     {name = "LangChain", email = "support@langchain.dev"},

--- a/python/tests/unit_tests/test_replica_endpoints.py
+++ b/python/tests/unit_tests/test_replica_endpoints.py
@@ -345,11 +345,13 @@ class TestParseWriteReplicasFromEnvVar:
 
     def test_parse_new_array_format(self):
         """Test parsing new array format."""
-        env_var = json.dumps([
-            {"api_url": "https://api.example.com", "api_key": "key1"},
-            {"api_url": "https://api.example.com", "api_key": "key2"},
-            {"api_url": "https://api.example.com", "api_key": "key3"},
-        ])
+        env_var = json.dumps(
+            [
+                {"api_url": "https://api.example.com", "api_key": "key1"},
+                {"api_url": "https://api.example.com", "api_key": "key2"},
+                {"api_url": "https://api.example.com", "api_key": "key3"},
+            ]
+        )
 
         with patch.dict(
             os.environ, {"LANGSMITH_ENDPOINT": "", "LANGCHAIN_ENDPOINT": ""}, clear=True
@@ -396,10 +398,12 @@ class TestParseWriteReplicasFromEnvVar:
     def test_parse_url_trailing_slash_removal(self):
         """Test that trailing slashes are removed from URLs."""
         # Test with new array format
-        env_var = json.dumps([
-            {"api_url": "https://api.example.com/", "api_key": "key1"},
-            {"api_url": "https://other.example.com/path/", "api_key": "key2"},
-        ])
+        env_var = json.dumps(
+            [
+                {"api_url": "https://api.example.com/", "api_key": "key1"},
+                {"api_url": "https://other.example.com/path/", "api_key": "key2"},
+            ]
+        )
 
         with patch.dict(
             os.environ, {"LANGSMITH_ENDPOINT": "", "LANGCHAIN_ENDPOINT": ""}, clear=True
@@ -416,9 +420,11 @@ class TestParseWriteReplicasFromEnvVar:
         assert "https://other.example.com/path/" not in urls
 
         # Test with object format
-        env_var2 = json.dumps({
-            "https://object.example.com/": "object-key",
-        })
+        env_var2 = json.dumps(
+            {
+                "https://object.example.com/": "object-key",
+            }
+        )
 
         with patch.dict(
             os.environ, {"LANGSMITH_ENDPOINT": "", "LANGCHAIN_ENDPOINT": ""}, clear=True
@@ -505,14 +511,16 @@ class TestParseWriteReplicasFromEnvVar:
 
     def test_parse_new_array_format_invalid_items(self):
         """Test parsing new array format with invalid items."""
-        env_var = json.dumps([
-            {"api_url": "https://valid.example.com", "api_key": "valid-key"},
-            "invalid-string-item",
-            {"api_url": "https://missing-key.example.com"},  # missing api_key
-            {"api_key": "missing-url-key"},  # missing api_url
-            {"api_url": 123, "api_key": "invalid-url-type"},  # invalid api_url type
-            {"api_url": "https://invalid-key-type.example.com", "api_key": 456},
-        ])
+        env_var = json.dumps(
+            [
+                {"api_url": "https://valid.example.com", "api_key": "valid-key"},
+                "invalid-string-item",
+                {"api_url": "https://missing-key.example.com"},  # missing api_key
+                {"api_key": "missing-url-key"},  # missing api_url
+                {"api_url": 123, "api_key": "invalid-url-type"},  # invalid api_url type
+                {"api_url": "https://invalid-key-type.example.com", "api_key": 456},
+            ]
+        )
 
         with patch.dict(
             os.environ, {"LANGSMITH_ENDPOINT": "", "LANGCHAIN_ENDPOINT": ""}, clear=True
@@ -677,10 +685,10 @@ class TestBaggageReplicaParsing:
 
         from langsmith.run_trees import _Baggage
 
-        # tuple format: [project_name, updates]
+        # tuple format: (project_name, updates)
         tuple_replicas = [
-            ["replica-project-1", {"environment": "staging"}],
-            ["replica-project-2", None],
+            ("replica-project-1", {"environment": "staging"}),
+            ("replica-project-2", None),
         ]
 
         baggage_value = (
@@ -745,7 +753,7 @@ class TestBaggageReplicaParsing:
 
         # Mixed format: both tuple and new
         mixed_replicas = [
-            ["tuple-project", {"tuple": "true"}],  # tuple format
+            ("tuple-project", {"tuple": "true"}),  # tuple format
             {
                 "api_url": "https://new.example.com",
                 "api_key": "new-key",


### PR DESCRIPTION
This PR fixes the logic for converting legacy replicas in `run_trees`. We were incorrectly expecting lists when legacy replica items were actually tuples