### PR TITLE
fix(js): Pull start time from dotted order for legacy AI SDK exporter

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langsmith",
-  "version": "0.3.53",
+  "version": "0.3.54",
   "description": "Client library to connect to the LangSmith LLM Tracing and Evaluation Platform.",
   "packageManager": "yarn@1.22.19",
   "files": [

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -20,4 +20,4 @@ export { overrideFetchImplementation } from "./singletons/fetch.js";
 export { getDefaultProjectName } from "./utils/project.js";
 
 // Update using yarn bump-version
-export const __version__ = "0.3.53";
+export const __version__ = "0.3.54";


### PR DESCRIPTION
Should help normalize start times