### PR TITLE
fix(py): attachments url construction

### DIFF
--- a/python/langsmith/__init__.py
+++ b/python/langsmith/__init__.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 
 # Avoid calling into importlib on every call to __version__
 
-__version__ = "0.4.13"
+__version__ = "0.4.14"
 version = __version__  # for backwards compatibility
 
 

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -3001,8 +3001,11 @@ class Client:
         )
 
     def list_shared_examples(
-        self, share_token: str, *, example_ids: Optional[list[ID_TYPE]] = None,
-        limit: Optional[int] = None
+        self,
+        share_token: str,
+        *,
+        example_ids: Optional[list[ID_TYPE]] = None,
+        limit: Optional[int] = None,
     ) -> Iterator[ls_schemas.Example]:
         """Get shared examples.
 
@@ -8096,10 +8099,35 @@ def _dataset_examples_path(api_url: str, dataset_id: ID_TYPE) -> str:
 def _construct_url(api_url: str, pathname: str) -> str:
     if pathname.startswith("http"):
         return pathname
-    elif pathname.startswith("/"):
-        return api_url.rstrip("/") + pathname
+    if api_url.startswith("https://"):
+        http = "https://"
+        api_url = api_url[len("https://") :]
+    elif api_url.startswith("http://"):
+        http = "http://"
+        api_url = api_url[len("http://") :]
     else:
-        return api_url.rstrip("/") + "/" + pathname
+        raise ValueError(
+            f"api_url must start with 'http://' or 'https://'. Received {api_url=}"
+        )
+
+    api_parts = api_url.rstrip("/").split("/")
+    path_parts = pathname.lstrip("/").split("/")
+
+    if not api_parts:
+        raise ValueError(
+            "Must specify non-empty api_url or pathname must be a full url. "
+            f"Received {api_url=}, {pathname=}"
+        )
+    if not path_parts:
+        return api_url
+
+    if path_parts[0] == "api":
+        if api_parts[-1] == "api":
+            api_parts = api_parts[:-1]
+        elif api_parts[-2:] == ["api", "v1"]:
+            api_parts = api_parts[:-2]
+    parts = api_parts + path_parts
+    return http + "/".join(p for p in parts if p)
 
 
 def dump_model(model) -> dict[str, Any]:

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "langsmith"
-version = "0.4.13"
+version = "0.4.14"
 description = "Client library to connect to the LangSmith LLM Tracing and Evaluation Platform."
 authors = [
     {name = "LangChain", email = "support@langchain.dev"},

--- a/python/tests/integration_tests/test_async_client.py
+++ b/python/tests/integration_tests/test_async_client.py
@@ -205,6 +205,7 @@ async def test_list_examples(async_client: AsyncClient):
 
     await async_client.delete_dataset(dataset_id=dataset.id)
 
+
 @pytest.mark.asyncio
 async def test_create_feedback(async_client: AsyncClient):
     project_name = "__test_create_feedback" + uuid.uuid4().hex[:8]

--- a/python/tests/integration_tests/test_client.py
+++ b/python/tests/integration_tests/test_client.py
@@ -3298,6 +3298,7 @@ def test_annotation_queue_with_rubric_instructions_2(langchain_client: Client):
         if langchain_client.has_project(project_name=project_name):
             langchain_client.delete_project(project_name=project_name)
 
+
 @pytest.mark.skip(reason="flaky")
 def test_list_runs_with_child_runs(langchain_client: Client):
     """Test listing runs with child runs."""

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -657,7 +657,7 @@ wheels = [
 
 [[package]]
 name = "langsmith"
-version = "0.4.13"
+version = "0.4.14"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.9"
 resolution-markers = [
     "python_full_version >= '3.11' and platform_python_implementation == 'PyPy'",
@@ -657,7 +657,7 @@ wheels = [
 
 [[package]]
 name = "langsmith"
-version = "0.4.9"
+version = "0.4.13"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Fix attachments url construction in case that api_url ends in /api or /api/v1 and attachments url starts with /api