### PR TITLE
feat: add extra & metadata into dataset pydantic schema

### DIFF
--- a/python/langsmith/schemas.py
+++ b/python/langsmith/schemas.py
@@ -283,6 +283,7 @@ class Dataset(DatasetBase):
     inputs_schema: Optional[dict[str, Any]] = None
     outputs_schema: Optional[dict[str, Any]] = None
     transformations: Optional[list[DatasetTransformation]] = None
+    extra: Optional[dict[str, Any]] = None
     _host_url: Optional[str] = PrivateAttr(default=None)
     _tenant_id: Optional[UUID] = PrivateAttr(default=None)
     _public_path: Optional[str] = PrivateAttr(default=None)
@@ -316,6 +317,13 @@ class Dataset(DatasetBase):
                 return f"{self._host_url}/o/{str(self._tenant_id)}/datasets/{self.id}"
             return f"{self._host_url}/datasets/{self.id}"
         return None
+
+    @property
+    def metadata(self) -> dict[str, Any]:
+        """Retrieve the metadata (if any)."""
+        if self.extra is None or "metadata" not in self.extra:
+            return {}
+        return self.extra["metadata"]
 
 
 class DatasetVersion(BaseModel):

--- a/python/tests/integration_tests/test_client.py
+++ b/python/tests/integration_tests/test_client.py
@@ -711,6 +711,7 @@ def test_dataset_schema_validation(langchain_client: Client) -> None:
         data_type=DataType.kv,
         inputs_schema=InputSchema.model_json_schema(),
         outputs_schema=OutputSchema.model_json_schema(),
+        metadata={"test": "schema_validation", "version": "1.0"},
     )
 
     # confirm we store the schema from the create request
@@ -744,6 +745,12 @@ def test_dataset_schema_validation(langchain_client: Client) -> None:
     read_dataset = langchain_client.read_dataset(dataset_id=dataset.id)
     assert read_dataset.inputs_schema == InputSchema.model_json_schema()
     assert read_dataset.outputs_schema == OutputSchema.model_json_schema()
+    
+    # assert read API includes the extra field and metadata
+    assert read_dataset.extra is not None
+    assert "metadata" in read_dataset.extra
+    assert read_dataset.extra["metadata"] == {"test": "schema_validation", "version": "1.0"}
+    assert read_dataset.metadata == {"test": "schema_validation", "version": "1.0"}
 
     safe_delete_dataset(langchain_client, dataset_id=dataset.id)
 
@@ -759,6 +766,10 @@ def test_list_datasets(langchain_client: Client) -> None:
         dataset2 = langchain_client.create_dataset(ds2n, data_type=DataType.kv)
         assert dataset1.url is not None
         assert dataset2.url is not None
+        
+        # Test datasets without metadata return empty metadata
+        assert dataset2.metadata == {}  # dataset2 has no metadata
+        assert dataset2.extra is None or dataset2.extra.get("metadata", {}) == {}
         datasets = list(
             langchain_client.list_datasets(dataset_ids=[dataset1.id, dataset2.id])
         )
@@ -785,6 +796,21 @@ def test_list_datasets(langchain_client: Client) -> None:
             )
         )
         assert len(datasets) == 1
+        
+        # Test extra field and metadata property
+        dataset_with_metadata = next(d for d in datasets if d.id == dataset1.id)
+        assert dataset_with_metadata.extra is not None
+        assert "metadata" in dataset_with_metadata.extra
+        assert dataset_with_metadata.extra["metadata"] == {"foo": "barqux"}
+        assert dataset_with_metadata.metadata == {"foo": "barqux"}
+        
+        # Test read_dataset also includes extra/metadata
+        read_dataset = langchain_client.read_dataset(dataset_id=dataset1.id)
+        assert read_dataset.extra is not None
+        assert "metadata" in read_dataset.extra
+        assert read_dataset.extra["metadata"] == {"foo": "barqux"}
+        assert read_dataset.metadata == {"foo": "barqux"}
+        
     finally:
         # Delete datasets
         for name in [ds1n, ds2n]:


### PR DESCRIPTION

Issue: The create_dataset() method accepts a metadata parameter, but the created dataset doesn't expose this metadata through the Dataset schema or any retrieval methods.  [Linear tickert](https://linear.app/langchain/issue/LS-3906/issue-dataset-metadata-parameter-in-create-dataset-not-accessible-via
)

Also addressed LS backend to make sure extra is returned here https://github.com/langchain-ai/langchainplus/pull/11649/files

 