### PR TITLE
fix(py): adjust traceable reduce_fn type to allow returning str

### DIFF
--- a/python/langsmith/run_helpers.py
+++ b/python/langsmith/run_helpers.py
@@ -190,7 +190,7 @@ def ensure_traceable(
     metadata: Optional[Mapping[str, Any]] = None,
     tags: Optional[list[str]] = None,
     client: Optional[ls_client.Client] = None,
-    reduce_fn: Optional[Callable[[Sequence], dict]] = None,
+    reduce_fn: Optional[Callable[[Sequence], Union[dict, str]]] = None,
     project_name: Optional[str] = None,
     process_inputs: Optional[Callable[[dict], dict]] = None,
     process_outputs: Optional[Callable[..., dict]] = None,

--- a/python/langsmith/run_helpers.py
+++ b/python/langsmith/run_helpers.py
@@ -311,7 +311,7 @@ def traceable(
     metadata: Optional[Mapping[str, Any]] = None,
     tags: Optional[list[str]] = None,
     client: Optional[ls_client.Client] = None,
-    reduce_fn: Optional[Callable[[Sequence], dict]] = None,
+    reduce_fn: Optional[Callable[[Sequence], Union[dict, str]]] = None,
     project_name: Optional[str] = None,
     process_inputs: Optional[Callable[[dict], dict]] = None,
     process_outputs: Optional[Callable[..., dict]] = None,


### PR DESCRIPTION
This already works as expected, and returning str is suggested by https://docs.smith.langchain.com/observability/how_to_guides/trace_generator_functions

Closes #1949

Otherwise mypy complains:

```py

    @traceable("llm", reduce_fn=lambda chunks: "".join(chunks))
    def stream_llm(self, prompt: str) -> Iterator[str]:
        ...
```

```
src/prediction/llm_client.py:810: error: No overload variant of "traceable" matches argument types "str", "Callable[[Any], str]"  [call-overload]
src/prediction/llm_client.py:810: note: Possible overload variants:
src/prediction/llm_client.py:810: note:     def [P`-1, R] traceable(func: Callable[P, R]) -> SupportsLangsmithExtra[P, R]
src/prediction/llm_client.py:810: note:     def traceable(run_type: Literal['tool', 'chain', 'llm', 'retriever', 'embedding', 'prompt', 'parser'] = ..., *, name: str | None = ..., metadata: Mapping[str, Any] | None = ..., tags: list[str] | None = ..., client: Client | None = ..., reduce_fn: Callable[[Sequence[Any]], dict[Any, Any]] | None = ..., project_name: str | None = ..., process_inputs: Callable[[dict[Any, Any]], dict[Any, Any]] | None = ..., process_outputs: Callable[..., dict[Any, Any]] | None = ..., process_chunk: Callable[..., Any] | None = ..., _invocation_params_fn: Callable[[dict[Any, Any]], dict[Any, Any]] | None = ..., dangerously_allow_filesystem: bool = ...) -> Callable[[Callable[P, R]], SupportsLangsmithExtra[P, R]]
src/prediction/llm_client.py:810: error: Untyped decorator makes function "stream_llm" untyped  [misc]
```