### PR TITLE
fix: move otel check to client init time to avoid timing issue

### DIFF
--- a/python/langsmith/__init__.py
+++ b/python/langsmith/__init__.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 
 # Avoid calling into importlib on every call to __version__
 
-__version__ = "0.4.16"
+__version__ = "0.4.17"
 version = __version__  # for backwards compatibility
 
 

--- a/python/langsmith/_internal/otel/_otel_client.py
+++ b/python/langsmith/_internal/otel/_otel_client.py
@@ -3,6 +3,13 @@
 
 import os
 import warnings
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    try:
+        from opentelemetry.sdk.trace import TracerProvider  # type: ignore[import]
+    except ImportError:
+        TracerProvider = object  # type: ignore[assignment, misc]
 
 from langsmith import utils as ls_utils
 

--- a/python/langsmith/_internal/otel/_otel_client.py
+++ b/python/langsmith/_internal/otel/_otel_client.py
@@ -1,5 +1,4 @@
 """Client configuration for OpenTelemetry integration with LangSmith."""
-# ruff: noqa: F821
 
 import os
 import warnings

--- a/python/langsmith/_internal/otel/_otel_exporter.py
+++ b/python/langsmith/_internal/otel/_otel_exporter.py
@@ -1,5 +1,4 @@
 """OpenTelemetry exporter for LangSmith runs."""
-# ruff: noqa: F821
 
 from __future__ import annotations
 

--- a/python/langsmith/_internal/otel/_otel_exporter.py
+++ b/python/langsmith/_internal/otel/_otel_exporter.py
@@ -7,7 +7,15 @@ import datetime
 import logging
 import uuid
 import warnings
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any, Optional
+
+if TYPE_CHECKING:
+    try:
+        from opentelemetry.context.context import Context  # type: ignore[import]
+        from opentelemetry.trace import Span  # type: ignore[import]
+    except ImportError:
+        Context = Any  # type: ignore[assignment, misc]
+        Span = Any  # type: ignore[assignment, misc]
 
 from langsmith._internal import _orjson
 from langsmith._internal._operations import (

--- a/python/langsmith/_internal/otel/_otel_exporter.py
+++ b/python/langsmith/_internal/otel/_otel_exporter.py
@@ -163,7 +163,6 @@ class OTELExporter:
         Args:
             operations: List of serialized run operations to export.
         """
-
         # Create a dictionary mapping run IDs to their operations
 
         for op in operations:

--- a/python/langsmith/_internal/otel/_otel_exporter.py
+++ b/python/langsmith/_internal/otel/_otel_exporter.py
@@ -163,9 +163,6 @@ class OTELExporter:
         Args:
             operations: List of serialized run operations to export.
         """
-        # Return early if OTEL not available
-        if not self._otel_available:
-            return
 
         # Create a dictionary mapping run IDs to their operations
 

--- a/python/langsmith/_internal/otel/_otel_exporter.py
+++ b/python/langsmith/_internal/otel/_otel_exporter.py
@@ -237,7 +237,9 @@ class OTELExporter:
                 return None
             (
                 trace,
+                Context,
                 NonRecordingSpan,
+                Span,
                 SpanContext,
                 TraceFlags,
                 TraceState,

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -94,9 +94,14 @@ from langsmith._internal._operations import (
 from langsmith._internal._serde import dumps_json as _dumps_json
 from langsmith.schemas import AttachmentInfo
 
-HAS_OTEL = False
-try:
-    if ls_utils.is_truish(ls_utils.get_env_var("OTEL_ENABLED")):
+def _check_otel_enabled() -> bool:
+    """Check if OTEL is enabled and imports are available."""
+    return ls_utils.is_truish(ls_utils.get_env_var("OTEL_ENABLED"))
+
+
+def _import_otel():
+    """Dynamically import OTEL modules when needed."""
+    try:
         from opentelemetry import trace as otel_trace  # type: ignore[import]
         from opentelemetry.trace import set_span_in_context  # type: ignore[import]
 
@@ -105,11 +110,11 @@ try:
         )
         from langsmith._internal.otel._otel_exporter import OTELExporter
 
-        HAS_OTEL = True
-except ImportError:
-    raise ImportError(
-        "To use OTEL tracing, you must install it with `pip install langsmith[otel]`"
-    )
+        return otel_trace, set_span_in_context, get_otlp_tracer_provider, OTELExporter
+    except ImportError:
+        raise ImportError(
+            "To use OTEL tracing, you must install it with `pip install langsmith[otel]`"
+        )
 
 try:
     from zoneinfo import ZoneInfo  # type: ignore[import-not-found]
@@ -429,6 +434,8 @@ class Client:
         "_run_ops_buffer",
         "_run_ops_buffer_lock",
         "otel_exporter",
+        "_otel_trace",
+        "_set_span_in_context",
     ]
 
     _api_key: Optional[str]
@@ -458,6 +465,7 @@ class Client:
         info: Optional[Union[dict, ls_schemas.LangSmithInfo]] = None,
         api_urls: Optional[dict[str, str]] = None,
         otel_tracer_provider: Optional[TracerProvider] = None,
+        otel_enabled: Optional[bool] = None,
         tracing_sampling_rate: Optional[float] = None,
     ) -> None:
         """Initialize a Client instance.
@@ -665,33 +673,44 @@ class Client:
 
         self._manual_cleanup = False
 
-        if ls_utils.is_truish(ls_utils.get_env_var("OTEL_ENABLED")):
-            if not HAS_OTEL:
-                warnings.warn(
-                    "LANGSMITH_OTEL_ENABLED is set but OpenTelemetry packages are not installed. "
-                    "Install with `pip install langsmith[otel]`"
-                )
-            existing_provider = otel_trace.get_tracer_provider()
-            tracer = existing_provider.get_tracer(__name__)
-            if otel_tracer_provider is None:
-                # Use existing global provider if available
-                if not (
-                    isinstance(existing_provider, otel_trace.ProxyTracerProvider)
-                    and hasattr(tracer, "_tracer")
-                    and isinstance(
-                        cast(
-                            otel_trace.ProxyTracer,
-                            tracer,
-                        )._tracer,
-                        otel_trace.NoOpTracer,
-                    )
-                ):
-                    otel_tracer_provider = cast(TracerProvider, existing_provider)
-                else:
-                    otel_tracer_provider = get_otlp_tracer_provider()
-                    otel_trace.set_tracer_provider(otel_tracer_provider)
+        if _check_otel_enabled() or otel_enabled:
+            try:
+                otel_trace, set_span_in_context, get_otlp_tracer_provider, OTELExporter = _import_otel()
+                
+                existing_provider = otel_trace.get_tracer_provider()
+                tracer = existing_provider.get_tracer(__name__)
+                if otel_tracer_provider is None:
+                    # Use existing global provider if available
+                    if not (
+                        isinstance(existing_provider, otel_trace.ProxyTracerProvider)
+                        and hasattr(tracer, "_tracer")
+                        and isinstance(
+                            cast(
+                                otel_trace.ProxyTracer,
+                                tracer,
+                            )._tracer,
+                            otel_trace.NoOpTracer,
+                        )
+                    ):
+                        otel_tracer_provider = cast(TracerProvider, existing_provider)
+                    else:
+                        otel_tracer_provider = get_otlp_tracer_provider()
+                        otel_trace.set_tracer_provider(otel_tracer_provider)
 
-            self.otel_exporter = OTELExporter(tracer_provider=otel_tracer_provider)
+                self.otel_exporter = OTELExporter(tracer_provider=otel_tracer_provider)
+                
+                # Store imports for later use
+                self._otel_trace = otel_trace
+                self._set_span_in_context = set_span_in_context
+                
+            except ImportError as e:
+                warnings.warn(
+                    f"LANGSMITH_OTEL_ENABLED is set but OpenTelemetry packages are not installed: {e}"
+                )
+                self.otel_exporter = None
+        else:
+            self.otel_exporter = None
+
 
     def _repr_html_(self) -> str:
         """Return an HTML representation of the instance with a link to the URL.
@@ -1494,16 +1513,14 @@ class Client:
                     serialized_op.trace_id,
                     serialized_op.id,
                 )
-                if HAS_OTEL:
+                if self.otel_exporter is not None:
                     self.tracing_queue.put(
                         TracingQueueItem(
                             run_create["dotted_order"],
                             serialized_op,
                             api_key=api_key,
                             api_url=api_url,
-                            otel_context=set_span_in_context(
-                                otel_trace.get_current_span()
-                            ),
+                            otel_context=self._set_span_in_context(self._otel_trace.get_current_span()),
                         )
                     )
                 else:
@@ -2450,16 +2467,14 @@ class Client:
                     serialized_op.trace_id,
                     serialized_op.id,
                 )
-                if HAS_OTEL:
+                if self.otel_exporter is not None:
                     self.tracing_queue.put(
                         TracingQueueItem(
                             run_update["dotted_order"],
                             serialized_op,
                             api_key=api_key,
                             api_url=api_url,
-                            otel_context=set_span_in_context(
-                                otel_trace.get_current_span()
-                            ),
+                            otel_context=self._set_span_in_context(self._otel_trace.get_current_span()),
                         )
                     )
                 else:

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -94,6 +94,7 @@ from langsmith._internal._operations import (
 from langsmith._internal._serde import dumps_json as _dumps_json
 from langsmith.schemas import AttachmentInfo
 
+
 def _check_otel_enabled() -> bool:
     """Check if OTEL is enabled and imports are available."""
     return ls_utils.is_truish(ls_utils.get_env_var("OTEL_ENABLED"))
@@ -115,6 +116,7 @@ def _import_otel():
         raise ImportError(
             "To use OTEL tracing, you must install it with `pip install langsmith[otel]`"
         )
+
 
 try:
     from zoneinfo import ZoneInfo  # type: ignore[import-not-found]
@@ -675,8 +677,13 @@ class Client:
 
         if _check_otel_enabled() or otel_enabled:
             try:
-                otel_trace, set_span_in_context, get_otlp_tracer_provider, OTELExporter = _import_otel()
-                
+                (
+                    otel_trace,
+                    set_span_in_context,
+                    get_otlp_tracer_provider,
+                    OTELExporter,
+                ) = _import_otel()
+
                 existing_provider = otel_trace.get_tracer_provider()
                 tracer = existing_provider.get_tracer(__name__)
                 if otel_tracer_provider is None:
@@ -698,11 +705,11 @@ class Client:
                         otel_trace.set_tracer_provider(otel_tracer_provider)
 
                 self.otel_exporter = OTELExporter(tracer_provider=otel_tracer_provider)
-                
+
                 # Store imports for later use
                 self._otel_trace = otel_trace
                 self._set_span_in_context = set_span_in_context
-                
+
             except ImportError as e:
                 warnings.warn(
                     f"LANGSMITH_OTEL_ENABLED is set but OpenTelemetry packages are not installed: {e}"
@@ -710,7 +717,6 @@ class Client:
                 self.otel_exporter = None
         else:
             self.otel_exporter = None
-
 
     def _repr_html_(self) -> str:
         """Return an HTML representation of the instance with a link to the URL.
@@ -1520,7 +1526,9 @@ class Client:
                             serialized_op,
                             api_key=api_key,
                             api_url=api_url,
-                            otel_context=self._set_span_in_context(self._otel_trace.get_current_span()),
+                            otel_context=self._set_span_in_context(
+                                self._otel_trace.get_current_span()
+                            ),
                         )
                     )
                 else:
@@ -2474,7 +2482,9 @@ class Client:
                             serialized_op,
                             api_key=api_key,
                             api_url=api_url,
-                            otel_context=self._set_span_in_context(self._otel_trace.get_current_span()),
+                            otel_context=self._set_span_in_context(
+                                self._otel_trace.get_current_span()
+                            ),
                         )
                     )
                 else:

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -719,9 +719,9 @@ class Client:
                 self._otel_trace = otel_trace
                 self._set_span_in_context = set_span_in_context
 
-            except ImportError as e:
+            except ImportError:
                 warnings.warn(
-                    f"LANGSMITH_OTEL_ENABLED is set but OpenTelemetry packages are not installed: {e}"
+                    "LANGSMITH_OTEL_ENABLED is set but OpenTelemetry packages are not installed: Install with `pip install langsmith[otel]"
                 )
                 self.otel_exporter = None
         else:

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -139,6 +139,15 @@ if TYPE_CHECKING:
     from langchain_core.runnables import Runnable
 
     from langsmith import schemas
+
+    # OTEL imports for type hints
+    try:
+        from opentelemetry import trace as otel_trace  # type: ignore[import]
+
+        from langsmith._internal.otel._otel_exporter import OTELExporter
+    except ImportError:
+        otel_trace = Any  # type: ignore[assignment, misc]
+        OTELExporter = Any  # type: ignore[assignment, misc]
     from langsmith.evaluation import evaluator as ls_evaluator
     from langsmith.evaluation._arunner import (
         AEVALUATOR_T,
@@ -693,7 +702,7 @@ class Client:
                         and hasattr(tracer, "_tracer")
                         and isinstance(
                             cast(
-                                otel_trace.ProxyTracer,
+                                otel_trace.ProxyTracer,  # type: ignore[attr-defined, name-defined]
                                 tracer,
                             )._tracer,
                             otel_trace.NoOpTracer,

--- a/python/langsmith/utils.py
+++ b/python/langsmith/utils.py
@@ -364,7 +364,7 @@ def is_base_message_like(obj: object) -> bool:
     )
 
 
-@functools.lru_cache(maxsize=100)
+@functools.lru_cache(maxsize=10)
 def get_env_var(
     name: str,
     default: Optional[str] = None,

--- a/python/langsmith/utils.py
+++ b/python/langsmith/utils.py
@@ -364,7 +364,7 @@ def is_base_message_like(obj: object) -> bool:
     )
 
 
-@functools.lru_cache(maxsize=10)
+@functools.lru_cache(maxsize=100)
 def get_env_var(
     name: str,
     default: Optional[str] = None,

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "langsmith"
-version = "0.4.16"
+version = "0.4.17"
 description = "Client library to connect to the LangSmith LLM Tracing and Evaluation Platform."
 authors = [
     {name = "LangChain", email = "support@langchain.dev"},

--- a/python/tests/unit_tests/test_multiple_endpoints.py
+++ b/python/tests/unit_tests/test_multiple_endpoints.py
@@ -30,15 +30,15 @@ class TestLangsmithRunsEndpoints:
     def setup_method(self):
         """Set up test data."""
         self.run_data = {
-            'id': uuid.uuid4(),
-            'trace_id': uuid.uuid4(),
-            'dotted_order': '20231201T120000000000Z' + str(uuid.uuid4()),
-            'session_name': 'test-project',
-            'name': 'test_run',
-            'inputs': {'input': 'test'},
-            'run_type': 'llm',
+            "id": uuid.uuid4(),
+            "trace_id": uuid.uuid4(),
+            "dotted_order": "20231201T120000000000Z" + str(uuid.uuid4()),
+            "session_name": "test-project",
+            "name": "test_run",
+            "inputs": {"input": "test"},
+            "run_type": "llm",
         }
-        
+
         self.endpoints_config = [
             {"api_url": "https://api1.example.com", "api_key": "key1"},
             {"api_url": "https://api2.example.com", "api_key": "key2"},
@@ -52,21 +52,21 @@ class TestLangsmithRunsEndpoints:
         # Create client with multiple write API URLs
         api_urls = {
             "https://api1.example.com": "key1",
-            "https://api2.example.com": "key2", 
+            "https://api2.example.com": "key2",
             "https://api3.example.com": "key3",
         }
-        
+
         client = Client(api_urls=api_urls, auto_batch_tracing=False)
-        
-        with patch.object(client.session, 'request') as mock_request:
+
+        with patch.object(client.session, "request") as mock_request:
             mock_response = Mock()
             mock_response.json.return_value = {}
             mock_request.return_value = mock_response
-            
+
             # Call create_run without specific api_key/api_url
             # (should use all endpoints)
             client.create_run(**self.run_data)
-            
+
             # Verify requests were made to all 3 endpoints
             assert mock_request.call_count == 3
 
@@ -76,7 +76,7 @@ class TestLangsmithRunsEndpoints:
                 # The URL is the second positional argument:
                 # session.request(method, url, ...)
                 full_url = call_args[0][1]  # call_args[0] is args tuple, [1] is the URL
-                base_url = full_url.replace('/runs', '')
+                base_url = full_url.replace("/runs", "")
                 called_urls.append(base_url)
 
             # Verify all endpoints were called
@@ -87,8 +87,8 @@ class TestLangsmithRunsEndpoints:
             # Verify correct API keys were used
             for i, call_args in enumerate(mock_request.call_args_list):
                 # Headers are in kwargs
-                headers = call_args[1].get('headers', {})
-                api_key = headers.get('x-api-key')  # Note: lowercase header key
+                headers = call_args[1].get("headers", {})
+                api_key = headers.get("x-api-key")  # Note: lowercase header key
                 assert api_key in ["key1", "key2", "key3"]
 
     def test_client_create_run_with_specific_endpoint(self):
@@ -99,49 +99,49 @@ class TestLangsmithRunsEndpoints:
             "https://api1.example.com": "key1",
             "https://api2.example.com": "key2",
         }
-        
+
         client = Client(api_urls=api_urls, auto_batch_tracing=False)
-        
-        with patch.object(client.session, 'request') as mock_request:
+
+        with patch.object(client.session, "request") as mock_request:
             mock_response = Mock()
             mock_response.json.return_value = {}
             mock_request.return_value = mock_response
-            
+
             # Call create_run with specific endpoint
             client.create_run(
                 **self.run_data,
                 api_key="custom_key",
-                api_url="https://custom.example.com"
+                api_url="https://custom.example.com",
             )
-            
+
             # Verify only one request was made to the specific endpoint
             assert mock_request.call_count == 1
             call_args = mock_request.call_args
             full_url = call_args[0][1]  # Second positional argument is the URL
             assert full_url == "https://custom.example.com/runs"
 
-            headers = call_args[1].get('headers', {})
+            headers = call_args[1].get("headers", {})
             # Note: lowercase header key
-            assert headers.get('x-api-key') == "custom_key"
+            assert headers.get("x-api-key") == "custom_key"
 
     def test_run_tree_with_replicas(self):
         """Test RunTree.post() with replicas containing api_key/api_url."""
         client = Mock()
-        
+
         # Create RunTree with replicas that have different endpoints
         replicas = [
             WriteReplica(
                 api_url="https://replica1.example.com",
                 api_key="replica_key1",
-                project_name="project1"
+                project_name="project1",
             ),
             WriteReplica(
-                api_url="https://replica2.example.com", 
+                api_url="https://replica2.example.com",
                 api_key="replica_key2",
-                project_name="project2"
+                project_name="project2",
             ),
         ]
-        
+
         run_tree = RunTree(
             name="test_run",
             inputs={"input": "test"},
@@ -149,27 +149,27 @@ class TestLangsmithRunsEndpoints:
             project_name="main-project",
             replicas=replicas,
         )
-        
+
         # Call post()
         run_tree.post()
-        
+
         # Verify client.create_run was called once for each replica
         assert client.create_run.call_count == 2
-        
+
         # Verify the calls had correct api_key/api_url parameters
         calls = client.create_run.call_args_list
-        
+
         # First replica call
         first_call = calls[0]
-        assert first_call.kwargs['api_key'] == 'replica_key1'
-        assert first_call.kwargs['api_url'] == 'https://replica1.example.com'
-        assert first_call.kwargs['session_name'] == 'project1'
-        
-        # Second replica call  
+        assert first_call.kwargs["api_key"] == "replica_key1"
+        assert first_call.kwargs["api_url"] == "https://replica1.example.com"
+        assert first_call.kwargs["session_name"] == "project1"
+
+        # Second replica call
         second_call = calls[1]
-        assert second_call.kwargs['api_key'] == 'replica_key2'
-        assert second_call.kwargs['api_url'] == 'https://replica2.example.com'
-        assert second_call.kwargs['session_name'] == 'project2'
+        assert second_call.kwargs["api_key"] == "replica_key2"
+        assert second_call.kwargs["api_url"] == "https://replica2.example.com"
+        assert second_call.kwargs["session_name"] == "project2"
 
     def test_background_threading_with_different_endpoints(self):
         """Test background threading correctly groups and sends to different
@@ -177,55 +177,55 @@ class TestLangsmithRunsEndpoints:
         """
         client = Mock()
         tracing_queue = Mock()
-        
+
         # Mock the client methods
         client._multipart_ingest_ops = Mock()
         client._batch_ingest_run_ops = Mock()
-        
+
         # Create batch with items for different endpoints
         serialized_op1 = serialize_run_dict(
-            'post', {**self.run_data, 'id': uuid.uuid4()}
+            "post", {**self.run_data, "id": uuid.uuid4()}
         )
         serialized_op2 = serialize_run_dict(
-            'post', {**self.run_data, 'id': uuid.uuid4()}
+            "post", {**self.run_data, "id": uuid.uuid4()}
         )
         serialized_op3 = serialize_run_dict(
-            'post', {**self.run_data, 'id': uuid.uuid4()}
+            "post", {**self.run_data, "id": uuid.uuid4()}
         )
-        
+
         batch = [
             TracingQueueItem(
-                'priority1', serialized_op1, api_key='key1', api_url='https://api1.com'
+                "priority1", serialized_op1, api_key="key1", api_url="https://api1.com"
             ),
             # Same endpoint
             TracingQueueItem(
-                'priority2', serialized_op2, api_key='key1', api_url='https://api1.com'
+                "priority2", serialized_op2, api_key="key1", api_url="https://api1.com"
             ),
             # Different endpoint
             TracingQueueItem(
-                'priority3', serialized_op3, api_key='key2', api_url='https://api2.com'
+                "priority3", serialized_op3, api_key="key2", api_url="https://api2.com"
             ),
         ]
-        
+
         # Test multipart mode
         _tracing_thread_handle_batch(client, tracing_queue, batch, use_multipart=True)
-        
+
         # Verify _multipart_ingest_ops was called twice (once per unique endpoint)
         assert client._multipart_ingest_ops.call_count == 2
-        
+
         # Verify the calls had correct endpoint parameters
         calls = client._multipart_ingest_ops.call_args_list
         endpoint_calls = [
-            (call.kwargs.get('api_url'), call.kwargs.get('api_key')) for call in calls
+            (call.kwargs.get("api_url"), call.kwargs.get("api_key")) for call in calls
         ]
-        
-        assert ('https://api1.com', 'key1') in endpoint_calls
-        assert ('https://api2.com', 'key2') in endpoint_calls
-        
+
+        assert ("https://api1.com", "key1") in endpoint_calls
+        assert ("https://api2.com", "key2") in endpoint_calls
+
         # Verify the first endpoint got 2 operations, second got 1
         for call in calls:
             ops = call.args[0]  # First positional argument is the operations list
-            if call.kwargs.get('api_url') == 'https://api1.com':
+            if call.kwargs.get("api_url") == "https://api1.com":
                 assert len(ops) == 2  # Two operations for api1
             else:
                 assert len(ops) == 1  # One operation for api2
@@ -234,101 +234,99 @@ class TestLangsmithRunsEndpoints:
         """Test background threading in non-multipart mode with different endpoints."""
         client = Mock()
         tracing_queue = Mock()
-        
+
         # Mock the client methods
         client._batch_ingest_run_ops = Mock()
-        
+
         # Create batch with items for different endpoints
         serialized_op1 = serialize_run_dict(
-            'post', {**self.run_data, 'id': uuid.uuid4()}
+            "post", {**self.run_data, "id": uuid.uuid4()}
         )
         serialized_op2 = serialize_run_dict(
-            'post', {**self.run_data, 'id': uuid.uuid4()}
+            "post", {**self.run_data, "id": uuid.uuid4()}
         )
-        
+
         batch = [
             TracingQueueItem(
-                'priority1', serialized_op1, api_key='key1', api_url='https://api1.com'
+                "priority1", serialized_op1, api_key="key1", api_url="https://api1.com"
             ),
             TracingQueueItem(
-                'priority2', serialized_op2, api_key='key2', api_url='https://api2.com'
+                "priority2", serialized_op2, api_key="key2", api_url="https://api2.com"
             ),
         ]
-        
+
         # Test non-multipart mode
         _tracing_thread_handle_batch(client, tracing_queue, batch, use_multipart=False)
-        
+
         # Verify _batch_ingest_run_ops was called twice (once per endpoint)
         assert client._batch_ingest_run_ops.call_count == 2
-        
+
         # Verify the calls had correct endpoint parameters
         calls = client._batch_ingest_run_ops.call_args_list
         endpoint_calls = [
-            (call.kwargs.get('api_url'), call.kwargs.get('api_key')) for call in calls
+            (call.kwargs.get("api_url"), call.kwargs.get("api_key")) for call in calls
         ]
-        
-        assert ('https://api1.com', 'key1') in endpoint_calls
-        assert ('https://api2.com', 'key2') in endpoint_calls
+
+        assert ("https://api1.com", "key1") in endpoint_calls
+        assert ("https://api2.com", "key2") in endpoint_calls
 
     def test_langsmith_runs_endpoints_env_var_integration(self):
         """Test integration with LANGSMITH_RUNS_ENDPOINTS environment variable."""
         from langsmith.run_trees import _parse_write_replicas_from_env_var
-        
+
         # Test the parsing function directly
         env_var = json.dumps(self.endpoints_config)
         replicas = _parse_write_replicas_from_env_var(env_var)
-        
+
         assert len(replicas) == 3
-        assert replicas[0]['api_url'] == 'https://api1.example.com'
-        assert replicas[0]['api_key'] == 'key1'
-        assert replicas[1]['api_url'] == 'https://api2.example.com'
-        assert replicas[1]['api_key'] == 'key2'
-        assert replicas[2]['api_url'] == 'https://api3.example.com'
-        assert replicas[2]['api_key'] == 'key3'
+        assert replicas[0]["api_url"] == "https://api1.example.com"
+        assert replicas[0]["api_key"] == "key1"
+        assert replicas[1]["api_url"] == "https://api2.example.com"
+        assert replicas[1]["api_key"] == "key2"
+        assert replicas[2]["api_url"] == "https://api3.example.com"
+        assert replicas[2]["api_key"] == "key3"
 
     def test_mixed_endpoints_and_default_fallback(self):
         """Test batch with mixed endpoints and items that should use default."""
         client = Mock()
         tracing_queue = Mock()
         client._multipart_ingest_ops = Mock()
-        
+
         # Create batch with mixed endpoint specifications
         serialized_op1 = serialize_run_dict(
-            'post', {**self.run_data, 'id': uuid.uuid4()}
+            "post", {**self.run_data, "id": uuid.uuid4()}
         )
         serialized_op2 = serialize_run_dict(
-            'post', {**self.run_data, 'id': uuid.uuid4()}
+            "post", {**self.run_data, "id": uuid.uuid4()}
         )
         serialized_op3 = serialize_run_dict(
-            'post', {**self.run_data, 'id': uuid.uuid4()}
+            "post", {**self.run_data, "id": uuid.uuid4()}
         )
-        
+
         batch = [
             TracingQueueItem(
-                'priority1', serialized_op1, api_key='key1', api_url='https://api1.com'
+                "priority1", serialized_op1, api_key="key1", api_url="https://api1.com"
             ),
             # Should use default
+            TracingQueueItem("priority2", serialized_op2, api_key=None, api_url=None),
             TracingQueueItem(
-                'priority2', serialized_op2, api_key=None, api_url=None
-            ),
-            TracingQueueItem(
-                'priority3', serialized_op3, api_key='key2', api_url='https://api2.com'
+                "priority3", serialized_op3, api_key="key2", api_url="https://api2.com"
             ),
         ]
-        
+
         _tracing_thread_handle_batch(client, tracing_queue, batch, use_multipart=True)
-        
+
         # Should have 3 calls: one for each unique endpoint combination
         assert client._multipart_ingest_ops.call_count == 3
-        
+
         # Verify endpoint combinations
         calls = client._multipart_ingest_ops.call_args_list
         endpoint_calls = [
-            (call.kwargs.get('api_url'), call.kwargs.get('api_key')) for call in calls
+            (call.kwargs.get("api_url"), call.kwargs.get("api_key")) for call in calls
         ]
-        
-        assert ('https://api1.com', 'key1') in endpoint_calls
-        assert ('https://api2.com', 'key2') in endpoint_calls
+
+        assert ("https://api1.com", "key1") in endpoint_calls
+        assert ("https://api2.com", "key2") in endpoint_calls
         assert (None, None) in endpoint_calls  # Default endpoint
 
 

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -657,7 +657,7 @@ wheels = [
 
 [[package]]
 name = "langsmith"
-version = "0.4.16"
+version = "0.4.17"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.9"
 resolution-markers = [
     "python_full_version >= '3.11' and platform_python_implementation == 'PyPy'",
@@ -657,7 +657,7 @@ wheels = [
 
 [[package]]
 name = "langsmith"
-version = "0.4.14"
+version = "0.4.16"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
**Issue:** for dynamic values like env var, you usually want to check them inside the instance or function, not at import time. because under the hood, python Imports are cached (in sys.modules), so in the case of some customer who's using pytest with otel,  their  second import of langsmith.client (during pytest unit test run time) weren't able to override initial one (during langsmith_plugin pytest plugin import, happened at very first of pytest set up).  This is causing subtle issue like if pytest plugin run first (`has_otel=False`), then later even if env var got reset (`has_otel=True`) the python still doesn't recognize the change.

I also found that the env var cache a bit problematic in such case, but if we fix the import, that might be less concerning, so i just reduced max size a little bit to make it less likely to be an issue. 