### PR TITLE
fix(js): Allow null to be passed as a first arg to traceable

### DIFF
--- a/js/src/run_trees.ts
+++ b/js/src/run_trees.ts
@@ -766,7 +766,7 @@ export class RunTree implements BaseRun {
 
 export function isRunTree(x?: unknown): x is RunTree {
   return (
-    x !== undefined &&
+    x != null &&
     typeof (x as RunTree).createChild === "function" &&
     typeof (x as RunTree).postRun === "function"
   );
@@ -809,7 +809,7 @@ export function isRunnableConfigLike(x?: unknown): x is RunnableConfigLike {
   // or an array with a LangChainTracerLike object within it
 
   return (
-    x !== undefined &&
+    x != null &&
     typeof (x as RunnableConfigLike).callbacks === "object" &&
     // Callback manager with a langchain tracer
     (containsLangChainTracerLike(

--- a/js/src/tests/traceable.test.ts
+++ b/js/src/tests/traceable.test.ts
@@ -2212,3 +2212,22 @@ test("traceable promise for async generator break", async () => {
   expect(tree.data["i_traceable:0"].outputs).toEqual({ outputs: "0" });
   expect(tree.data["i_traceable:0"].error).toEqual("Cancelled");
 });
+
+test("passing null doesn't throw an error", async () => {
+  const { client, callSpy } = mockClient();
+  const runId = uuidv4();
+
+  const func = traceable(async (input: null) => input, {
+    name: "i_traceable",
+    project_name: "__test_traceable_wrapper_aggregator",
+    client: client,
+    id: runId,
+    tracingEnabled: true,
+  });
+
+  expect(await func(null)).toBe(null);
+  const tree = getAssumedTreeFromCalls(callSpy.mock.calls);
+  expect(tree.nodes).toEqual(["i_traceable:0"]);
+  expect(tree.data["i_traceable:0"].inputs).toEqual({ inputs: null });
+  expect(tree.data["i_traceable:0"].outputs).toEqual({ outputs: null });
+});

--- a/js/src/traceable.ts
+++ b/js/src/traceable.ts
@@ -119,7 +119,9 @@ const runInputsToMap = (rawInputs: unknown[]) => {
   const firstInput = rawInputs[0];
   let inputs: KVMap;
 
-  if (firstInput == null) {
+  if (firstInput === null) {
+    inputs = { inputs: null };
+  } else if (firstInput === undefined) {
     inputs = {};
   } else if (rawInputs.length > 1) {
     inputs = { args: rawInputs };
@@ -671,7 +673,7 @@ export function traceable<Func extends (...args: any[]) => any>(
     const asyncLocalStorage = AsyncLocalStorageProviderSingleton.getInstance();
 
     // TODO: deal with possible nested promises and async iterables
-    const processedArgs = args as unknown as Inputs;
+    const processedArgs = args as Inputs;
     let deferredInput = false;
     for (let i = 0; i < processedArgs.length; i++) {
       const { converted, deferredInput: argDefersInput } =


### PR DESCRIPTION
Fixes #1911