### PR TITLE
fiz(python): Alleviate memory allocations from zstd flush

### DIFF
--- a/python/langsmith/_internal/_background_thread.py
+++ b/python/langsmith/_internal/_background_thread.py
@@ -129,9 +129,6 @@ def _tracing_thread_drain_compressed_buffer(
         if client.compressed_traces is None:
             return None, None
         with client.compressed_traces.lock:
-            client.compressed_traces.compressor_writer.flush()
-            current_size = client.compressed_traces.buffer.tell()
-
             pre_compressed_size = client.compressed_traces.uncompressed_size
 
             if size_limit is not None and size_limit <= 0:
@@ -141,7 +138,7 @@ def _tracing_thread_drain_compressed_buffer(
                     f"size_limit_bytes must be nonnegative; got {size_limit_bytes}"
                 )
 
-            if (size_limit_bytes is None or current_size < size_limit_bytes) and (
+            if (size_limit_bytes is None or pre_compressed_size < size_limit_bytes) and (
                 size_limit is None or client.compressed_traces.trace_count < size_limit
             ):
                 return None, None
@@ -151,6 +148,7 @@ def _tracing_thread_drain_compressed_buffer(
                 f"--{_BOUNDARY}--\r\n".encode()
             )
             client.compressed_traces.compressor_writer.close()
+            current_size = client.compressed_traces.buffer.tell()
 
             filled_buffer = client.compressed_traces.buffer
             filled_buffer.context = client.compressed_traces._context

--- a/python/langsmith/_internal/_compressed_traces.py
+++ b/python/langsmith/_internal/_compressed_traces.py
@@ -6,7 +6,6 @@ from zstandard import ZstdCompressor  # type: ignore[import]
 from langsmith import utils as ls_utils
 
 compression_level = int(ls_utils.get_env_var("RUN_COMPRESSION_LEVEL", 1))
-compression_threads = int(ls_utils.get_env_var("RUN_COMPRESSION_THREADS", 2))
 
 
 class CompressedTraces:
@@ -18,7 +17,7 @@ class CompressedTraces:
         self._context = []
 
         self.compressor_writer = ZstdCompressor(
-            level=compression_level, threads=compression_threads
+            level=compression_level, threads=-1
         ).stream_writer(self.buffer, closefd=False)
 
     def reset(self):

--- a/python/langsmith/_internal/_compressed_traces.py
+++ b/python/langsmith/_internal/_compressed_traces.py
@@ -5,7 +5,8 @@ from zstandard import ZstdCompressor  # type: ignore[import]
 
 from langsmith import utils as ls_utils
 
-compression_level = ls_utils.get_env_var("RUN_COMPRESSION_LEVEL", 1)
+compression_level = int(ls_utils.get_env_var("RUN_COMPRESSION_LEVEL", 1))
+compression_threads = int(ls_utils.get_env_var("RUN_COMPRESSION_THREADS", 2))
 
 
 class CompressedTraces:
@@ -17,7 +18,7 @@ class CompressedTraces:
         self._context = []
 
         self.compressor_writer = ZstdCompressor(
-            level=compression_level, threads=-1
+            level=compression_level, threads=compression_threads
         ).stream_writer(self.buffer, closefd=False)
 
     def reset(self):


### PR DESCRIPTION
### Description
Reduce calls to flush zstd buffer

### Changes
- Use uncompressed size to determine if we should flush or not.

### Results
15% decrease in peak memory usage
