### PR TITLE
fix: memory leak risk from otel exporter persistance

### DIFF
--- a/python/langsmith/_internal/otel/_otel_exporter.py
+++ b/python/langsmith/_internal/otel/_otel_exporter.py
@@ -130,14 +130,14 @@ class OTELExporter:
     ]
     """OpenTelemetry exporter for LangSmith runs."""
 
-    def __init__(self, tracer_provider=None, max_spans=100000, span_ttl_seconds=3600):
+    def __init__(self, tracer_provider=None, max_spans=100000, span_ttl_seconds=5400):
         """Initialize the OTEL exporter.
 
         Args:
             tracer_provider: Optional tracer provider to use. If not provided,
                 the global tracer provider will be used.
             max_spans: Maximum number of spans to keep in memory (default: 100000)
-            span_ttl_seconds:TTL for incomplete traces in seconds (default: 7200s)
+            span_ttl_seconds:TTL for incomplete traces in seconds (default: 5400s)
         """
         otel_imports = _import_otel_exporter()
         if otel_imports is None:

--- a/python/langsmith/_internal/otel/_otel_exporter.py
+++ b/python/langsmith/_internal/otel/_otel_exporter.py
@@ -130,14 +130,14 @@ class OTELExporter:
     ]
     """OpenTelemetry exporter for LangSmith runs."""
 
-    def __init__(self, tracer_provider=None, max_spans=100000, span_ttl_seconds=5400):
+    def __init__(self, tracer_provider=None, max_spans=100000, span_ttl_seconds=3600):
         """Initialize the OTEL exporter.
 
         Args:
             tracer_provider: Optional tracer provider to use. If not provided,
                 the global tracer provider will be used.
             max_spans: Maximum number of spans to keep in memory (default: 100000)
-            span_ttl_seconds:TTL for incomplete traces in seconds (default: 5400s)
+            span_ttl_seconds:TTL for incomplete traces in seconds (default: 3600s)
         """
         otel_imports = _import_otel_exporter()
         if otel_imports is None:

--- a/python/langsmith/_internal/otel/_otel_exporter.py
+++ b/python/langsmith/_internal/otel/_otel_exporter.py
@@ -387,6 +387,9 @@ class OTELExporter:
             if info["created_at"] < cutoff_time
         ]
 
+        if stale_span_ids:
+            logger.debug(f"Cleaning up {len(stale_span_ids)} stale spans")
+
         for span_id in stale_span_ids:
             self._remove_span(span_id)
 

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -559,7 +559,7 @@ class Client:
         )
         # Initialize workspace attribute first
         self._workspace_id = ls_utils.get_workspace_id(workspace_id)
-        
+
         if self._write_api_urls:
             self.api_url = next(iter(self._write_api_urls))
             self.api_key = self._write_api_urls[self.api_url]
@@ -977,7 +977,7 @@ class Client:
                             raise ls_utils.LangSmithConflictError(
                                 f"Conflict for {pathname}. {repr(e)}{_context}"
                             )
-                        elif (response.status_code == 403):
+                        elif response.status_code == 403:
                             try:
                                 error_data = response.json()
                                 error_code = error_data.get("error", "")

--- a/python/tests/integration_tests/test_client.py
+++ b/python/tests/integration_tests/test_client.py
@@ -3476,9 +3476,12 @@ def test_otel_trace_attributes(monkeypatch: pytest.MonkeyPatch):
                             op, run_info, otel_context_map.get(op.id)
                         )
                         if span:
-                            self.original_otel_exporter._spans[op.id] = span
+                            self.original_otel_exporter._span_info[op.id] = {
+                                "span": span,
+                                "created_at": time.time(),
+                            }
                     else:
-                        future.put(self.original_otel_exporter._spans[op.id])
+                        future.put(self.original_otel_exporter._span_info[op.id]["span"])
                         self.original_otel_exporter._update_span_for_run(op, run_info)
                 except Exception as e:
                     logger.exception(f"Error processing operation {op.id}: {e}")

--- a/python/tests/integration_tests/test_client.py
+++ b/python/tests/integration_tests/test_client.py
@@ -3481,7 +3481,9 @@ def test_otel_trace_attributes(monkeypatch: pytest.MonkeyPatch):
                                 "created_at": time.time(),
                             }
                     else:
-                        future.put(self.original_otel_exporter._span_info[op.id]["span"])
+                        future.put(
+                            self.original_otel_exporter._span_info[op.id]["span"]
+                        )
                         self.original_otel_exporter._update_span_for_run(op, run_info)
                 except Exception as e:
                     logger.exception(f"Error processing operation {op.id}: {e}")

--- a/python/tests/unit_tests/test_otel_exporter.py
+++ b/python/tests/unit_tests/test_otel_exporter.py
@@ -1,0 +1,77 @@
+"""Unit tests for OTELExporter cleanup functionality."""
+
+import time
+import uuid
+from unittest.mock import MagicMock, patch
+
+from langsmith._internal.otel._otel_exporter import OTELExporter
+
+
+def test_cleanup_stale_spans():
+    """Test cleanup of stale spans based on TTL."""
+    with patch(
+        "langsmith._internal.otel._otel_exporter._import_otel_exporter"
+    ) as mock_import:
+        mock_import.return_value = (MagicMock(),) * 8
+
+        exporter = OTELExporter(span_ttl_seconds=1)
+
+        # Add stale and fresh spans
+        stale_span = MagicMock()
+        fresh_span = MagicMock()
+        stale_id = uuid.uuid4()
+        fresh_id = uuid.uuid4()
+
+        exporter._span_info[stale_id] = {
+            "span": stale_span,
+            "created_at": time.time() - 2,
+        }
+        exporter._span_info[fresh_id] = {"span": fresh_span, "created_at": time.time()}
+        exporter._last_cleanup = 0.0  # Force cleanup
+
+        exporter._cleanup_stale_spans()
+
+        # Verify cleanup
+        assert stale_id not in exporter._span_info
+        assert fresh_id in exporter._span_info
+        stale_span.end.assert_called_once()
+        fresh_span.end.assert_not_called()
+
+
+def test_cleanup_periodic_behavior():
+    """Test cleanup only runs periodically."""
+    with patch(
+        "langsmith._internal.otel._otel_exporter._import_otel_exporter"
+    ) as mock_import:
+        mock_import.return_value = (MagicMock(),) * 8
+
+        exporter = OTELExporter(span_ttl_seconds=1)
+        stale_span = MagicMock()
+        stale_id = uuid.uuid4()
+
+        exporter._span_info[stale_id] = {
+            "span": stale_span,
+            "created_at": time.time() - 2,
+        }
+        exporter._last_cleanup = time.time() - 5  # Recent cleanup
+
+        exporter._cleanup_stale_spans()
+
+        # Should not clean up due to periodic check
+        assert stale_id in exporter._span_info
+        stale_span.end.assert_not_called()
+
+
+@patch("langsmith.utils.get_env_var")
+def test_env_var_ttl(mock_get_env_var):
+    """Test TTL loading from environment variable with correct default."""
+    with patch(
+        "langsmith._internal.otel._otel_exporter._import_otel_exporter"
+    ) as mock_import:
+        mock_import.return_value = (MagicMock(),) * 8
+        mock_get_env_var.return_value = "1800"
+
+        exporter = OTELExporter()
+
+        assert exporter._span_ttl_seconds == 1800
+        mock_get_env_var.assert_called_with("OTEL_SPAN_TTL_SECONDS", default="3600")


### PR DESCRIPTION
Problem: 
Memory leak when otel exporter process traces that never ended. Specifically,  the OTEL exporter stores spans for correlation between post (create) and patch (update) operations, but spans are only cleaned up when patch operations contain end_time. Those span that doesn't have end_time stays there forever now  

Solution:
Adds a proactive span cleanup:
- TTL-based cleanup: Remove spans older than 2 hours
- Count-based limits: Cap maximum spans at 100,000 
- Proactive processing: Clean up before each batch to prevent accumulation

Want to see if this remediates problem for customer OOM, if it works we can follow up on further fine tune the clean up logic such as make max_count and ttl configurable  


Test: 
- test hybrid and otel-only mode still sends trace to right party(s) 
- asked claude to help stress testing to confirm this seems to bound the memory usage with 10k incomplete spans 


  1,000 Incomplete Spans:

  | Metric         | Before Fix | After Fix     | Improvement          |
  |----------------|------------|---------------|----------------------|
  | Hybrid Mode    | 21.5 MB    | 26.5 MB       | Bounded (no runaway) |
  | OTEL-ONLY Mode | 4.5 MB     | 5.7 MB        | Bounded (no runaway) |
  | Active Spans   | Unlimited  | Exactly 1,000 | ✅ Controlled         |

  10,000 Incomplete Spans (Stress Test):

  | Metric         | Before Fix (Projected) | After Fix      | Improvement  |
  |----------------|------------------------|----------------|--------------|
  | Hybrid Mode    | ~215 MB → ∞            | 136.8 MB       | ✅ Bounded    |
  | OTEL-ONLY Mode | ~45 MB → ∞             | 23.4 MB        | ✅ Bounded    |
  | Active Spans   | Unlimited growth       | Exactly 10,000 | ✅ Controlled |


 