### PR TITLE
fix(js): Remove validation of usage metadata params

### DIFF
--- a/js/src/tests/utils/tree.ts
+++ b/js/src/tests/utils/tree.ts
@@ -40,7 +40,7 @@ export function getAssumedTreeFromCalls(calls: unknown[][]) {
       }
     }
 
-    if (req === "POST /runs") {
+    if (req === "POST /runs" || req === "POST /api/v1/runs") {
       const id = body!.id;
       upsertId(id);
       nodeMap[id] = { ...nodeMap[id], ...body! };
@@ -48,8 +48,15 @@ export function getAssumedTreeFromCalls(calls: unknown[][]) {
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         edges.push([nodeMap[id].parent_run_id!, nodeMap[id].id]);
       }
-    } else if (req.startsWith("PATCH /runs/")) {
-      const id = req.substring("PATCH /runs/".length);
+    } else if (
+      req.startsWith("PATCH /runs/") ||
+      req.startsWith("PATCH /api/v1/runs/")
+    ) {
+      const id = req.substring(
+        req.startsWith("PATCH /api/v1/runs/")
+          ? "PATCH /api/v1/runs/".length
+          : "PATCH /runs/".length
+      );
       upsertId(id);
       nodeMap[id] = { ...nodeMap[id], ...body! };
     }

--- a/js/src/traceable.ts
+++ b/js/src/traceable.ts
@@ -157,32 +157,6 @@ const _extractUsage = (runData: {
   return runData.outputs?.usage_metadata ?? usageMetadataFromMetadata;
 };
 
-function validateExtractedUsageMetadata(
-  data: Record<string, any>
-): ExtractedUsageMetadata {
-  const allowedKeys = new Set([
-    "input_tokens",
-    "output_tokens",
-    "total_tokens",
-    "input_token_details",
-    "output_token_details",
-    "input_cost",
-    "output_cost",
-    "total_cost",
-    "input_cost_details",
-    "output_cost_details",
-  ]);
-
-  const extraKeys = Object.keys(data).filter((key) => !allowedKeys.has(key));
-  if (extraKeys.length > 0) {
-    throw new Error(
-      `Unexpected keys in usage metadata: ${extraKeys.join(", ")}`
-    );
-  }
-
-  return data as ExtractedUsageMetadata;
-}
-
 async function handleEnd(params: {
   runTree?: RunTree;
   on_end?: (runTree: RunTree) => void;
@@ -215,7 +189,7 @@ const _populateUsageMetadata = (processedOutputs: KVMap, runTree?: RunTree) => {
     if (usageMetadata !== undefined) {
       runTree.extra.metadata = {
         ...runTree.extra.metadata,
-        usage_metadata: validateExtractedUsageMetadata(usageMetadata),
+        usage_metadata: usageMetadata,
       };
       processedOutputs.usage_metadata = usageMetadata;
     }


### PR DESCRIPTION
We no longer reject runs with invalid usage metadata fields on the backend, shouldn't do this on the client either.