### PR TITLE
feat(py): Allow overriding max batch size parameter on client, fix for disabled run compression

### DIFF
--- a/python/langsmith/_internal/_background_thread.py
+++ b/python/langsmith/_internal/_background_thread.py
@@ -689,7 +689,7 @@ def tracing_control_thread_func(client_ref: weakref.ref[Client]) -> None:
 
         hybrid_otel_and_langsmith, is_otel_only = get_tracing_mode()
         max_batch_size = (
-            getattr(client, "_max_batch_size_bytes", None)
+            client._max_batch_size_bytes
             or batch_ingest_config.get("size_limit_bytes")
             or 0
         )
@@ -713,9 +713,7 @@ def tracing_control_thread_func(client_ref: weakref.ref[Client]) -> None:
     # drain the queue on exit - apply same logic
     hybrid_otel_and_langsmith, is_otel_only = get_tracing_mode()
     max_batch_size = (
-        getattr(client, "_max_batch_size_bytes", None)
-        or batch_ingest_config.get("size_limit_bytes")
-        or 0
+        client._max_batch_size_bytes or batch_ingest_config.get("size_limit_bytes") or 0
     )
     while next_batch := _tracing_thread_drain_queue(
         tracing_queue, limit=size_limit, block=False, max_size_bytes=max_batch_size
@@ -912,7 +910,7 @@ def _tracing_sub_thread_func(
         <= batch_ingest_config["scale_down_nempty_trigger"]
     ):
         max_batch_size = (
-            getattr(client, "_max_batch_size_bytes", None)
+            client._max_batch_size_bytes
             or batch_ingest_config.get("size_limit_bytes")
             or 0
         )
@@ -941,9 +939,7 @@ def _tracing_sub_thread_func(
     # drain the queue on exit - apply same logic
     hybrid_otel_and_langsmith, is_otel_only = get_tracing_mode()
     max_batch_size = (
-        getattr(client, "_max_batch_size_bytes", None)
-        or batch_ingest_config.get("size_limit_bytes")
-        or 0
+        client._max_batch_size_bytes or batch_ingest_config.get("size_limit_bytes") or 0
     )
     while next_batch := _tracing_thread_drain_queue(
         tracing_queue, limit=size_limit, block=False, max_size_bytes=max_batch_size

--- a/python/langsmith/_internal/_background_thread.py
+++ b/python/langsmith/_internal/_background_thread.py
@@ -105,31 +105,6 @@ class TracingQueueItem:
         ) == (other.priority, other.item.__class__)
 
 
-def _calculate_serialized_size(
-    op: Union[SerializedRunOperation, SerializedFeedbackOperation],
-) -> int:
-    """Calculate actual serialized size of an operation."""
-    size = 0
-    if hasattr(op, "_none") and op._none:
-        size += len(op._none)
-    if hasattr(op, "inputs") and op.inputs:
-        size += len(op.inputs)
-    if hasattr(op, "outputs") and op.outputs:
-        size += len(op.outputs)
-    if hasattr(op, "events") and op.events:
-        size += len(op.events)
-    if hasattr(op, "extra") and op.extra:
-        size += len(op.extra)
-    if hasattr(op, "error") and op.error:
-        size += len(op.error)
-    if hasattr(op, "serialized") and op.serialized:
-        size += len(op.serialized)
-    if hasattr(op, "feedback") and op.feedback:
-        size += len(op.feedback)
-
-    return size
-
-
 def _tracing_thread_drain_queue(
     tracing_queue: Queue, limit: int = 100, block: bool = True, max_size_bytes: int = 0
 ) -> list[TracingQueueItem]:

--- a/python/langsmith/_internal/_background_thread.py
+++ b/python/langsmith/_internal/_background_thread.py
@@ -131,6 +131,8 @@ def _tracing_thread_drain_compressed_buffer(
         with client.compressed_traces.lock:
             pre_compressed_size = client.compressed_traces.uncompressed_size
 
+            size_limit_bytes = client._max_batch_size_bytes or size_limit_bytes
+
             if size_limit is not None and size_limit <= 0:
                 raise ValueError(f"size_limit must be positive; got {size_limit}")
             if size_limit_bytes is not None and size_limit_bytes < 0:
@@ -692,7 +694,9 @@ def tracing_control_thread_func_compress_parallel(
 
     batch_ingest_config = _ensure_ingest_config(client.info)
     size_limit: int = batch_ingest_config["size_limit"]
-    size_limit_bytes = batch_ingest_config.get("size_limit_bytes", 20_971_520)
+    size_limit_bytes = client._max_batch_size_bytes or batch_ingest_config.get(
+        "size_limit_bytes", 20_971_520
+    )
     # One for this func, one for the parent thread, one for getrefcount,
     # one for _get_data_type_cached
     num_known_refs = 4

--- a/python/langsmith/_internal/_operations.py
+++ b/python/langsmith/_internal/_operations.py
@@ -74,6 +74,29 @@ class SerializedRunOperation:
         self.serialized = serialized
         self.attachments = attachments
 
+    def calculate_serialized_size(self) -> int:
+        """Calculate actual serialized size of this operation."""
+        size = 0
+        if self._none:
+            size += len(self._none)
+        if self.inputs:
+            size += len(self.inputs)
+        if self.outputs:
+            size += len(self.outputs)
+        if self.events:
+            size += len(self.events)
+        if self.extra:
+            size += len(self.extra)
+        if self.error:
+            size += len(self.error)
+        if self.serialized:
+            size += len(self.serialized)
+        if self.attachments:
+            for content_type, data_or_path in self.attachments.values():
+                if isinstance(data_or_path, bytes):
+                    size += len(data_or_path)
+        return size
+
     def __eq__(self, other: object) -> bool:
         return isinstance(other, SerializedRunOperation) and (
             self.operation,
@@ -113,6 +136,10 @@ class SerializedFeedbackOperation:
         self.id = id
         self.trace_id = trace_id
         self.feedback = feedback
+
+    def calculate_serialized_size(self) -> int:
+        """Calculate actual serialized size of this operation."""
+        return len(self.feedback)
 
     def __eq__(self, other: object) -> bool:
         return isinstance(other, SerializedFeedbackOperation) and (

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -64,7 +64,6 @@ from langsmith import utils as ls_utils
 from langsmith._internal import _orjson
 from langsmith._internal._background_thread import (
     TracingQueueItem,
-    _calculate_serialized_size,
 )
 from langsmith._internal._background_thread import (
     tracing_control_thread_func as _tracing_control_thread_func,
@@ -1578,7 +1577,7 @@ class Client:
                         TracingQueueItem(
                             run_create["dotted_order"],
                             serialized_op,
-                            _calculate_serialized_size(serialized_op),
+                            serialized_op.calculate_serialized_size(),
                             api_key=api_key,
                             api_url=api_url,
                             otel_context=self._set_span_in_context(
@@ -1591,7 +1590,7 @@ class Client:
                         TracingQueueItem(
                             run_create["dotted_order"],
                             serialized_op,
-                            _calculate_serialized_size(serialized_op),
+                            serialized_op.calculate_serialized_size(),
                             api_key=api_key,
                             api_url=api_url,
                         )
@@ -2538,7 +2537,7 @@ class Client:
                         TracingQueueItem(
                             run_update["dotted_order"],
                             serialized_op,
-                            _calculate_serialized_size(serialized_op),
+                            serialized_op.calculate_serialized_size(),
                             api_key=api_key,
                             api_url=api_url,
                             otel_context=self._set_span_in_context(
@@ -2551,7 +2550,7 @@ class Client:
                         TracingQueueItem(
                             run_update["dotted_order"],
                             serialized_op,
-                            _calculate_serialized_size(serialized_op),
+                            serialized_op.calculate_serialized_size(),
                             api_key=api_key,
                             api_url=api_url,
                         )
@@ -6333,7 +6332,7 @@ class Client:
                         TracingQueueItem(
                             str(feedback.id),
                             serialized_op,
-                            _calculate_serialized_size(serialized_op),
+                            serialized_op.calculate_serialized_size(),
                         )
                     )
             else:

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -6325,10 +6325,7 @@ class Client:
                             self._data_available_event.set()
                 elif self.tracing_queue is not None:
                     self.tracing_queue.put(
-                        TracingQueueItem(
-                            str(feedback.id),
-                            serialized_op,
-                        )
+                        TracingQueueItem(str(feedback.id), serialized_op)
                     )
             else:
                 feedback_block = _dumps_json(feedback.dict(exclude_none=True))

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -1577,7 +1577,6 @@ class Client:
                         TracingQueueItem(
                             run_create["dotted_order"],
                             serialized_op,
-                            serialized_op.calculate_serialized_size(),
                             api_key=api_key,
                             api_url=api_url,
                             otel_context=self._set_span_in_context(
@@ -1590,7 +1589,6 @@ class Client:
                         TracingQueueItem(
                             run_create["dotted_order"],
                             serialized_op,
-                            serialized_op.calculate_serialized_size(),
                             api_key=api_key,
                             api_url=api_url,
                         )
@@ -2537,7 +2535,6 @@ class Client:
                         TracingQueueItem(
                             run_update["dotted_order"],
                             serialized_op,
-                            serialized_op.calculate_serialized_size(),
                             api_key=api_key,
                             api_url=api_url,
                             otel_context=self._set_span_in_context(
@@ -2550,7 +2547,6 @@ class Client:
                         TracingQueueItem(
                             run_update["dotted_order"],
                             serialized_op,
-                            serialized_op.calculate_serialized_size(),
                             api_key=api_key,
                             api_url=api_url,
                         )
@@ -6332,7 +6328,6 @@ class Client:
                         TracingQueueItem(
                             str(feedback.id),
                             serialized_op,
-                            serialized_op.calculate_serialized_size(),
                         )
                     )
             else:

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -64,6 +64,7 @@ from langsmith import utils as ls_utils
 from langsmith._internal import _orjson
 from langsmith._internal._background_thread import (
     TracingQueueItem,
+    _calculate_serialized_size,
 )
 from langsmith._internal._background_thread import (
     tracing_control_thread_func as _tracing_control_thread_func,
@@ -1577,6 +1578,7 @@ class Client:
                         TracingQueueItem(
                             run_create["dotted_order"],
                             serialized_op,
+                            _calculate_serialized_size(serialized_op),
                             api_key=api_key,
                             api_url=api_url,
                             otel_context=self._set_span_in_context(
@@ -1589,6 +1591,7 @@ class Client:
                         TracingQueueItem(
                             run_create["dotted_order"],
                             serialized_op,
+                            _calculate_serialized_size(serialized_op),
                             api_key=api_key,
                             api_url=api_url,
                         )
@@ -2535,6 +2538,7 @@ class Client:
                         TracingQueueItem(
                             run_update["dotted_order"],
                             serialized_op,
+                            _calculate_serialized_size(serialized_op),
                             api_key=api_key,
                             api_url=api_url,
                             otel_context=self._set_span_in_context(
@@ -2547,6 +2551,7 @@ class Client:
                         TracingQueueItem(
                             run_update["dotted_order"],
                             serialized_op,
+                            _calculate_serialized_size(serialized_op),
                             api_key=api_key,
                             api_url=api_url,
                         )
@@ -6325,7 +6330,11 @@ class Client:
                             self._data_available_event.set()
                 elif self.tracing_queue is not None:
                     self.tracing_queue.put(
-                        TracingQueueItem(str(feedback.id), serialized_op)
+                        TracingQueueItem(
+                            str(feedback.id),
+                            serialized_op,
+                            _calculate_serialized_size(serialized_op),
+                        )
                     )
             else:
                 feedback_block = _dumps_json(feedback.dict(exclude_none=True))

--- a/python/tests/unit_tests/test_client.py
+++ b/python/tests/unit_tests/test_client.py
@@ -2961,7 +2961,7 @@ def test_create_run_with_disabled_compression(mock_session_cls: mock.Mock) -> No
             batch_ingest_config=ls_schemas.BatchIngestConfig(
                 use_multipart_endpoint=True,
                 size_limit=1,
-                size_limit_bytes=128,
+                size_limit_bytes=1024 * 1024 * 20,
                 scale_up_nthreads_limit=4,
                 scale_up_qsize_trigger=3,
                 scale_down_nempty_trigger=1,

--- a/python/tests/unit_tests/test_client.py
+++ b/python/tests/unit_tests/test_client.py
@@ -2853,7 +2853,7 @@ def test_create_run_without_compression_support(mock_session_cls: mock.Mock) -> 
             batch_ingest_config=ls_schemas.BatchIngestConfig(
                 use_multipart_endpoint=True,
                 size_limit=1,
-                size_limit_bytes=128,
+                size_limit_bytes=1024 * 1024 * 20,
                 scale_up_nthreads_limit=4,
                 scale_up_qsize_trigger=3,
                 scale_down_nempty_trigger=1,

--- a/python/tests/unit_tests/test_multiple_endpoints.py
+++ b/python/tests/unit_tests/test_multiple_endpoints.py
@@ -268,7 +268,11 @@ class TestLangsmithRunsEndpoints:
                 api_url="https://api1.com",
             ),
             TracingQueueItem(
-                "priority2", serialized_op2, api_key="key2", api_url="https://api2.com"
+                "priority2",
+                serialized_op2,
+                _calculate_serialized_size(serialized_op2),
+                api_key="key2",
+                api_url="https://api2.com",
             ),
         ]
 
@@ -329,7 +333,13 @@ class TestLangsmithRunsEndpoints:
                 api_url="https://api1.com",
             ),
             # Should use default
-            TracingQueueItem("priority2", serialized_op2, api_key=None, api_url=None),
+            TracingQueueItem(
+                "priority2",
+                serialized_op2,
+                _calculate_serialized_size(serialized_op2),
+                api_key=None,
+                api_url=None,
+            ),
             TracingQueueItem(
                 "priority3",
                 serialized_op3,

--- a/python/tests/unit_tests/test_multiple_endpoints.py
+++ b/python/tests/unit_tests/test_multiple_endpoints.py
@@ -18,7 +18,6 @@ import pytest
 from langsmith import Client
 from langsmith._internal._background_thread import (
     TracingQueueItem,
-    _calculate_serialized_size,
     _tracing_thread_handle_batch,
 )
 from langsmith._internal._operations import serialize_run_dict
@@ -198,7 +197,7 @@ class TestLangsmithRunsEndpoints:
             TracingQueueItem(
                 "priority1",
                 serialized_op1,
-                _calculate_serialized_size(serialized_op1),
+                serialized_op1.calculate_serialized_size(),
                 api_key="key1",
                 api_url="https://api1.com",
             ),
@@ -206,7 +205,7 @@ class TestLangsmithRunsEndpoints:
             TracingQueueItem(
                 "priority2",
                 serialized_op2,
-                _calculate_serialized_size(serialized_op2),
+                serialized_op2.calculate_serialized_size(),
                 api_key="key1",
                 api_url="https://api1.com",
             ),
@@ -214,7 +213,7 @@ class TestLangsmithRunsEndpoints:
             TracingQueueItem(
                 "priority3",
                 serialized_op3,
-                _calculate_serialized_size(serialized_op3),
+                serialized_op3.calculate_serialized_size(),
                 api_key="key2",
                 api_url="https://api2.com",
             ),
@@ -263,14 +262,14 @@ class TestLangsmithRunsEndpoints:
             TracingQueueItem(
                 "priority1",
                 serialized_op1,
-                _calculate_serialized_size(serialized_op1),
+                serialized_op1.calculate_serialized_size(),
                 api_key="key1",
                 api_url="https://api1.com",
             ),
             TracingQueueItem(
                 "priority2",
                 serialized_op2,
-                _calculate_serialized_size(serialized_op2),
+                serialized_op2.calculate_serialized_size(),
                 api_key="key2",
                 api_url="https://api2.com",
             ),
@@ -328,7 +327,7 @@ class TestLangsmithRunsEndpoints:
             TracingQueueItem(
                 "priority1",
                 serialized_op1,
-                _calculate_serialized_size(serialized_op1),
+                serialized_op1.calculate_serialized_size(),
                 api_key="key1",
                 api_url="https://api1.com",
             ),
@@ -336,14 +335,14 @@ class TestLangsmithRunsEndpoints:
             TracingQueueItem(
                 "priority2",
                 serialized_op2,
-                _calculate_serialized_size(serialized_op2),
+                serialized_op2.calculate_serialized_size(),
                 api_key=None,
                 api_url=None,
             ),
             TracingQueueItem(
                 "priority3",
                 serialized_op3,
-                _calculate_serialized_size(serialized_op3),
+                serialized_op3.calculate_serialized_size(),
                 api_key="key2",
                 api_url="https://api2.com",
             ),

--- a/python/tests/unit_tests/test_multiple_endpoints.py
+++ b/python/tests/unit_tests/test_multiple_endpoints.py
@@ -197,7 +197,6 @@ class TestLangsmithRunsEndpoints:
             TracingQueueItem(
                 "priority1",
                 serialized_op1,
-                serialized_op1.calculate_serialized_size(),
                 api_key="key1",
                 api_url="https://api1.com",
             ),
@@ -205,7 +204,6 @@ class TestLangsmithRunsEndpoints:
             TracingQueueItem(
                 "priority2",
                 serialized_op2,
-                serialized_op2.calculate_serialized_size(),
                 api_key="key1",
                 api_url="https://api1.com",
             ),
@@ -213,7 +211,6 @@ class TestLangsmithRunsEndpoints:
             TracingQueueItem(
                 "priority3",
                 serialized_op3,
-                serialized_op3.calculate_serialized_size(),
                 api_key="key2",
                 api_url="https://api2.com",
             ),
@@ -262,14 +259,12 @@ class TestLangsmithRunsEndpoints:
             TracingQueueItem(
                 "priority1",
                 serialized_op1,
-                serialized_op1.calculate_serialized_size(),
                 api_key="key1",
                 api_url="https://api1.com",
             ),
             TracingQueueItem(
                 "priority2",
                 serialized_op2,
-                serialized_op2.calculate_serialized_size(),
                 api_key="key2",
                 api_url="https://api2.com",
             ),
@@ -327,7 +322,6 @@ class TestLangsmithRunsEndpoints:
             TracingQueueItem(
                 "priority1",
                 serialized_op1,
-                serialized_op1.calculate_serialized_size(),
                 api_key="key1",
                 api_url="https://api1.com",
             ),
@@ -335,14 +329,12 @@ class TestLangsmithRunsEndpoints:
             TracingQueueItem(
                 "priority2",
                 serialized_op2,
-                serialized_op2.calculate_serialized_size(),
                 api_key=None,
                 api_url=None,
             ),
             TracingQueueItem(
                 "priority3",
                 serialized_op3,
-                serialized_op3.calculate_serialized_size(),
                 api_key="key2",
                 api_url="https://api2.com",
             ),

--- a/python/tests/unit_tests/test_multiple_endpoints.py
+++ b/python/tests/unit_tests/test_multiple_endpoints.py
@@ -18,6 +18,7 @@ import pytest
 from langsmith import Client
 from langsmith._internal._background_thread import (
     TracingQueueItem,
+    _calculate_serialized_size,
     _tracing_thread_handle_batch,
 )
 from langsmith._internal._operations import serialize_run_dict
@@ -195,15 +196,27 @@ class TestLangsmithRunsEndpoints:
 
         batch = [
             TracingQueueItem(
-                "priority1", serialized_op1, api_key="key1", api_url="https://api1.com"
+                "priority1",
+                serialized_op1,
+                _calculate_serialized_size(serialized_op1),
+                api_key="key1",
+                api_url="https://api1.com",
             ),
             # Same endpoint
             TracingQueueItem(
-                "priority2", serialized_op2, api_key="key1", api_url="https://api1.com"
+                "priority2",
+                serialized_op2,
+                _calculate_serialized_size(serialized_op2),
+                api_key="key1",
+                api_url="https://api1.com",
             ),
             # Different endpoint
             TracingQueueItem(
-                "priority3", serialized_op3, api_key="key2", api_url="https://api2.com"
+                "priority3",
+                serialized_op3,
+                _calculate_serialized_size(serialized_op3),
+                api_key="key2",
+                api_url="https://api2.com",
             ),
         ]
 
@@ -248,7 +261,11 @@ class TestLangsmithRunsEndpoints:
 
         batch = [
             TracingQueueItem(
-                "priority1", serialized_op1, api_key="key1", api_url="https://api1.com"
+                "priority1",
+                serialized_op1,
+                _calculate_serialized_size(serialized_op1),
+                api_key="key1",
+                api_url="https://api1.com",
             ),
             TracingQueueItem(
                 "priority2", serialized_op2, api_key="key2", api_url="https://api2.com"
@@ -305,12 +322,20 @@ class TestLangsmithRunsEndpoints:
 
         batch = [
             TracingQueueItem(
-                "priority1", serialized_op1, api_key="key1", api_url="https://api1.com"
+                "priority1",
+                serialized_op1,
+                _calculate_serialized_size(serialized_op1),
+                api_key="key1",
+                api_url="https://api1.com",
             ),
             # Should use default
             TracingQueueItem("priority2", serialized_op2, api_key=None, api_url=None),
             TracingQueueItem(
-                "priority3", serialized_op3, api_key="key2", api_url="https://api2.com"
+                "priority3",
+                serialized_op3,
+                _calculate_serialized_size(serialized_op3),
+                api_key="key2",
+                api_url="https://api2.com",
             ),
         ]
 


### PR DESCRIPTION
If you are tracing many runs on multiple threads, due to threading batches can exceed stated size limits

This is more complex to fix when run compression is enabled due to incremental compression, but this PR allows for restricting this when run compression is disabled
