### PR TITLE
update SDK readme for org-scoped API keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ To get started with the Python SDK, [install the package](https://pypi.org/proje
 pip install -U langsmith
 export LANGSMITH_TRACING=true
 export LANGSMITH_API_KEY=ls_...
+export LANGSMITH_WORKSPACE_ID=<your-workspace-id> # Required for org-scoped keys
 ```
 
 Then start tracing your app:
@@ -45,6 +46,7 @@ To get started with the JavaScript / TypeScript SDK, [install the package](https
 yarn add langsmith
 export LANGSMITH_TRACING=true
 export LANGSMITH_API_KEY=ls_...
+export LANGSMITH_WORKSPACE_ID=<your-workspace-id> # Required for org-scoped keys
 ```
 
 Then start tracing your app!

--- a/js/README.md
+++ b/js/README.md
@@ -55,6 +55,7 @@ process.env.LANGSMITH_ENDPOINT = "https://api.smith.langchain.com";
 // process.env.LANGSMITH_ENDPOINT = "https://eu.api.smith.langchain.com"; // If signed up in the EU region
 process.env.LANGSMITH_API_KEY = "<YOUR-LANGSMITH-API-KEY>";
 // process.env.LANGSMITH_PROJECT = "My Project Name"; // Optional: "default" is used if not set
+// process.env.LANGSMITH_WORKSPACE_ID = "<YOUR-WORKSPACE-ID>"; // Required for org-scoped API keys
 ```
 
 > **Tip:** Projects are groups of traces. All runs are logged to a project. If not specified, the project is set to `default`.

--- a/python/README.md
+++ b/python/README.md
@@ -75,6 +75,7 @@ os.environ["LANGSMITH_ENDPOINT"] = "https://api.smith.langchain.com"
 # os.environ["LANGSMITH_ENDPOINT"] = "https://eu.api.smith.langchain.com" # If signed up in the EU region
 os.environ["LANGSMITH_API_KEY"] = "<YOUR-LANGSMITH-API-KEY>"
 # os.environ["LANGSMITH_PROJECT"] = "My Project Name" # Optional: "default" is used if not set
+# os.environ["LANGSMITH_WORKSPACE_ID"] = "<YOUR-WORKSPACE-ID>" # Required for org-scoped API keys
 ```
 
 > **Tip:** Projects are groups of traces. All runs are logged to a project. If not specified, the project is set to `default`.


### PR DESCRIPTION
Updated Python, JS, and general README files for new LANGSMITH_WORKSPACE_ID env variable.