### PR TITLE
fix(python): Support Attachment objects in patch method

### DIFF
--- a/python/langsmith/run_trees.py
+++ b/python/langsmith/run_trees.py
@@ -644,7 +644,9 @@ class RunTree(ls_schemas.RunBase):
         if not self.end_time:
             self.end()
         attachments = {
-            a: v for a, v in self.attachments.items() if isinstance(v, tuple)
+            a: v
+            for a, v in self.attachments.items()
+            if isinstance(v, (tuple, ls_schemas.Attachment))
         }
         try:
             # Avoid loading the same attachment twice


### PR DESCRIPTION
### Purpose
RunTree.patch() only supported tuple format attachments ("mime/type", data) but not Attachment objects. I could not find a reason for this restriction since attachment is a named tuple