### PR TITLE
fix(js): Fix retries for empty bodies

### DIFF
--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -848,7 +848,7 @@ export class Client implements LangSmithTracingClientInterface {
         signal: AbortSignal.timeout(this.timeout_ms),
         ...this.fetchOptions,
       });
-      await raiseForStatus(res, `Failed to fetch ${path}`);
+      await raiseForStatus(res, `fetch ${path}`);
       return res;
     });
     return response;
@@ -881,7 +881,7 @@ export class Client implements LangSmithTracingClientInterface {
           signal: AbortSignal.timeout(this.timeout_ms),
           ...this.fetchOptions,
         });
-        await raiseForStatus(res, `Failed to fetch ${path}`);
+        await raiseForStatus(res, `fetch ${path}`);
         return res;
       });
       const items: T[] = transform
@@ -917,7 +917,7 @@ export class Client implements LangSmithTracingClientInterface {
           ...this.fetchOptions,
           body,
         });
-        await raiseForStatus(res, `Failed to fetch ${path}`);
+        await raiseForStatus(res, `fetch ${path}`);
         return res;
       });
       const responseBody = await response.json();

--- a/js/src/tests/client.test.ts
+++ b/js/src/tests/client.test.ts
@@ -580,7 +580,7 @@ describe("Client", () => {
             run_type: "llm",
             inputs: { text: "hello" },
           })
-        ).rejects.toThrow("403 Forbidden");
+        ).rejects.toThrow("[403]: Forbidden");
 
         expect(mockFetch).toHaveBeenCalled();
       });

--- a/js/src/utils/error.ts
+++ b/js/src/utils/error.ts
@@ -109,6 +109,7 @@ export async function raiseForStatus(
   if (errorBody === undefined) {
     try {
       errorBody = await response.text();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } catch (e: any) {
       errorBody = "Empty";
     }

--- a/js/src/utils/error.ts
+++ b/js/src/utils/error.ts
@@ -111,7 +111,7 @@ export async function raiseForStatus(
       errorBody = await response.text();
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } catch (e: any) {
-      errorBody = "Empty";
+      errorBody = "";
     }
   }
 

--- a/js/src/utils/error.ts
+++ b/js/src/utils/error.ts
@@ -114,7 +114,7 @@ export async function raiseForStatus(
     }
   }
 
-  const fullMessage = `Failed to ${context}. Received status [${response.status}]: ${response.statusText}. Server response: ${errorBody}`;
+  const fullMessage = `Failed to ${context}. Received status [${response.status}]: ${response.statusText}. Message: ${errorBody}`;
 
   if (response.status === 409) {
     throw new LangSmithConflictError(fullMessage);


### PR DESCRIPTION
`await response.text()` will throw an error if the body is empty. If this happens, it overrides the existing error and does not set a status code, causing it to be retried inappropriately.