### PR TITLE
fix: Store ended span to reserve parent span context

### DIFF
--- a/python/langsmith/__init__.py
+++ b/python/langsmith/__init__.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 
 # Avoid calling into importlib on every call to __version__
 
-__version__ = "0.4.27"
+__version__ = "0.4.28"
 version = __version__  # for backwards compatibility
 
 

--- a/python/langsmith/_internal/otel/_otel_exporter.py
+++ b/python/langsmith/_internal/otel/_otel_exporter.py
@@ -196,18 +196,10 @@ class OTELExporter:
                         op, run_info, otel_context_map.get(op.id)
                     )
                     if span:
-                        # Only store spans that are still active (not already ended)
-                        if hasattr(span, "is_recording") and span.is_recording():
-                            self._span_info[op.id] = {
-                                "span": span,
-                                "created_at": time.time(),
-                            }
-                            logger.debug(
-                                f"Created active span, total: {len(self._span_info)}"
-                            )
-                        else:
-                            # Span ended in _create_span_for_run (had end_time)
-                            logger.debug("completed span (not tracked - already ended)")
+                        self._span_info[op.id] = {
+                            "span": span,
+                            "created_at": time.time(),
+                        }
                 else:
                     self._update_span_for_run(op, run_info)
             except Exception as e:

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "langsmith"
-version = "0.4.27"
+version = "0.4.28"
 description = "Client library to connect to the LangSmith LLM Tracing and Evaluation Platform."
 authors = [
     {name = "LangChain", email = "support@langchain.dev"},


### PR DESCRIPTION
Fix issue https://github.com/langchain-ai/langsmith-sdk/issues/2005

Issue: We introduced the memory leak fix in previous PR to Only store spans that are still active (not already ended), but this had caused side-effect issue when child span cannot find the parent span context. 

Fix: Partially revert the previous change and keeps (a bit dangerously from memory perspective) all spans from _create_span_for_run even though span already ended.  Rely on span TTL (3600 sec by default, configurable).

Note:  This is like a bandaid unfortunatley. The fundamental fix instead should be a large re-architect of combine_serialized_queue_operations to make sure parent's don't merge _Creation+Update_ until all children has merged and merged children operation should come first to make sure. That's not straightforward and need investment.  