### PR TITLE
version bump after new method 0.4.29

### DIFF
--- a/python/langsmith/__init__.py
+++ b/python/langsmith/__init__.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 
 # Avoid calling into importlib on every call to __version__
 
-__version__ = "0.4.28"
+__version__ = "0.4.29"
 version = __version__  # for backwards compatibility
 
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "langsmith"
-version = "0.4.28"
+version = "0.4.29"
 description = "Client library to connect to the LangSmith LLM Tracing and Evaluation Platform."
 authors = [
     {name = "LangChain", email = "support@langchain.dev"},

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -724,7 +724,7 @@ wheels = [
 
 [[package]]
 name = "langsmith"
-version = "0.4.27"
+version = "0.4.29"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
since https://github.com/langchain-ai/langsmith-sdk/pull/2021 is out 