### PR TITLE
Clear children after runtree posts

### DIFF
--- a/python/langsmith/__init__.py
+++ b/python/langsmith/__init__.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 
 # Avoid calling into importlib on every call to __version__
 
-__version__ = "0.4.29"
+__version__ = "0.4.30"
 version = __version__  # for backwards compatibility
 
 

--- a/python/langsmith/_internal/_background_thread.py
+++ b/python/langsmith/_internal/_background_thread.py
@@ -484,7 +484,7 @@ def _is_using_internal_otlp_provider(client: Client) -> bool:
     try:
         # Use OpenTelemetry's standard API to get the global TracerProvider
         # Check if OTEL is available
-        if not ls_utils.is_truish(ls_utils.get_env_var("OTEL_ENABLED")):
+        if not ls_utils.is_env_var_truish("OTEL_ENABLED"):
             return False
 
         # Get the global TracerProvider and check its resource attributes
@@ -560,8 +560,8 @@ def get_tracing_mode() -> tuple[bool, bool]:
               true and OTEL_ONLY is not set to true
             - is_otel_only: True if only OTEL tracing is enabled
     """
-    otel_enabled = ls_utils.is_truish(ls_utils.get_env_var("OTEL_ENABLED"))
-    otel_only = ls_utils.is_truish(ls_utils.get_env_var("OTEL_ONLY"))
+    otel_enabled = ls_utils.is_env_var_truish("OTEL_ENABLED")
+    otel_only = ls_utils.is_env_var_truish("OTEL_ONLY")
 
     # If OTEL is not enabled, neither mode should be active
     if not otel_enabled:
@@ -591,7 +591,7 @@ def tracing_control_thread_func(client_ref: weakref.ref[Client]) -> None:
 
     # Disable compression if explicitly set or if using OpenTelemetry
     disable_compression = (
-        ls_utils.is_truish(ls_utils.get_env_var("DISABLE_RUN_COMPRESSION"))
+        ls_utils.is_env_var_truish("DISABLE_RUN_COMPRESSION")
         or client.otel_exporter is not None
     )
     if not disable_compression and use_multipart:

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -97,7 +97,7 @@ from langsmith.schemas import AttachmentInfo, ExampleWithRuns
 
 def _check_otel_enabled() -> bool:
     """Check if OTEL is enabled and imports are available."""
-    return ls_utils.is_truish(ls_utils.get_env_var("OTEL_ENABLED"))
+    return ls_utils.is_env_var_truish("OTEL_ENABLED")
 
 
 def _import_otel():
@@ -284,7 +284,7 @@ def _validate_api_key_if_hosted(api_url: str, api_key: Optional[str]) -> None:
     if not api_key:
         if (
             _is_langchain_hosted(api_url)
-            and not ls_utils.is_truish(ls_utils.get_env_var("OTEL_ENABLED"))
+            and not ls_utils.is_env_var_truish("OTEL_ENABLED")
             and ls_utils.tracing_is_enabled()
         ):
             warnings.warn(

--- a/python/langsmith/run_helpers.py
+++ b/python/langsmith/run_helpers.py
@@ -2042,7 +2042,7 @@ def _maybe_create_otel_context(run_tree: Optional[run_trees.RunTree]):
     Returns:
         Context manager for use_span or None if not available.
     """
-    if not run_tree or not utils.is_truish(utils.get_env_var("OTEL_ENABLED")):
+    if not run_tree or not utils.is_env_var_truish("OTEL_ENABLED"):
         return None
     if not _is_otel_available():
         return None

--- a/python/langsmith/run_trees.py
+++ b/python/langsmith/run_trees.py
@@ -502,7 +502,6 @@ class RunTree(ls_schemas.RunBase):
             attachments=attachments or {},  # type: ignore
             dangerously_allow_filesystem=self.dangerously_allow_filesystem,
         )
-        self.child_runs.append(run)
         return run
 
     def _get_dicts_safe(self):

--- a/python/langsmith/run_trees.py
+++ b/python/langsmith/run_trees.py
@@ -630,6 +630,9 @@ class RunTree(ls_schemas.RunBase):
         if not exclude_child_runs:
             for child_run in self.child_runs:
                 child_run.post(exclude_child_runs=False)
+        else:
+            # Clear child_runs
+            self.child_runs.clear()
 
     def patch(self, *, exclude_inputs: bool = False) -> None:
         """Patch the run tree to the API in a background thread.

--- a/python/langsmith/run_trees.py
+++ b/python/langsmith/run_trees.py
@@ -502,7 +502,7 @@ class RunTree(ls_schemas.RunBase):
             attachments=attachments or {},  # type: ignore
             dangerously_allow_filesystem=self.dangerously_allow_filesystem,
         )
-        if not utils.is_truish(utils.get_env_var("EXCLUDE_CHILD_RUNS")):
+        if not utils.is_env_var_truish("EXCLUDE_CHILD_RUNS"):
             self.child_runs.append(run)
         return run
 
@@ -631,7 +631,7 @@ class RunTree(ls_schemas.RunBase):
         if not exclude_child_runs:
             for child_run in self.child_runs:
                 child_run.post(exclude_child_runs=False)
-        elif utils.is_truish(utils.get_env_var("EXCLUDE_CHILD_RUNS")):
+        elif utils.is_env_var_truish("EXCLUDE_CHILD_RUNS"):
             # Clear child_runs
             self.child_runs.clear()
 

--- a/python/langsmith/run_trees.py
+++ b/python/langsmith/run_trees.py
@@ -502,6 +502,8 @@ class RunTree(ls_schemas.RunBase):
             attachments=attachments or {},  # type: ignore
             dangerously_allow_filesystem=self.dangerously_allow_filesystem,
         )
+        if not utils.is_truish(utils.get_env_var("EXCLUDE_CHILD_RUNS")):
+            self.child_runs.append(run)
         return run
 
     def _get_dicts_safe(self):
@@ -629,7 +631,7 @@ class RunTree(ls_schemas.RunBase):
         if not exclude_child_runs:
             for child_run in self.child_runs:
                 child_run.post(exclude_child_runs=False)
-        else:
+        elif utils.is_truish(utils.get_env_var("EXCLUDE_CHILD_RUNS")):
             # Clear child_runs
             self.child_runs.clear()
 

--- a/python/langsmith/utils.py
+++ b/python/langsmith/utils.py
@@ -368,6 +368,9 @@ def is_base_message_like(obj: object) -> bool:
         ]
     )
 
+def is_env_var_truish(value: Optional[str]) -> bool:
+    """Check if the given environment variable is truish."""
+    return is_truish(get_env_var(value))
 
 @functools.lru_cache(maxsize=100)
 def get_env_var(

--- a/python/langsmith/utils.py
+++ b/python/langsmith/utils.py
@@ -368,9 +368,11 @@ def is_base_message_like(obj: object) -> bool:
         ]
     )
 
+
 def is_env_var_truish(value: Optional[str]) -> bool:
     """Check if the given environment variable is truish."""
     return is_truish(get_env_var(value))
+
 
 @functools.lru_cache(maxsize=100)
 def get_env_var(

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "langsmith"
-version = "0.4.29"
+version = "0.4.30"
 description = "Client library to connect to the LangSmith LLM Tracing and Evaluation Platform."
 authors = [
     {name = "LangChain", email = "support@langchain.dev"},

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -724,7 +724,7 @@ wheels = [
 
 [[package]]
 name = "langsmith"
-version = "0.4.29"
+version = "0.4.30"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Once RunTree is posted, we don't need to keep the `child_runs` around anymore

Resolves https://github.com/langchain-ai/langsmith-sdk/issues/2009

