### PR TITLE
Allow trace.end(outputs=str)

### DIFF
--- a/python/langsmith/run_trees.py
+++ b/python/langsmith/run_trees.py
@@ -440,7 +440,7 @@ class RunTree(ls_schemas.RunBase):
     def end(
         self,
         *,
-        outputs: Optional[dict] = None,
+        outputs: Optional[Union[dict, str]] = None,
         error: Optional[str] = None,
         end_time: Optional[datetime] = None,
         events: Optional[Sequence[ls_schemas.RunEvent]] = None,
@@ -452,6 +452,8 @@ class RunTree(ls_schemas.RunBase):
         # the ones that are automatically included
         if not self.extra.get(OVERRIDE_OUTPUTS):
             if outputs is not None:
+                if isinstance(outputs, str):
+                    outputs = {"output": outputs}
                 if not self.outputs:
                     self.outputs = outputs
                 else:


### PR DESCRIPTION
Just a bit of sugar that lets you pass a string to tr.end(). I suspect a string is the most common thing to pass here:
```py
    with ls.trace("Template", "prompt", inputs=input) as trace:
        prompt = template.render(**input)
        trace.end(outputs=prompt)
```
Same for llm calls that don't use a schema.

A related request - add a button to render text blocks in the output as markdown in the web ui.