### PR TITLE
fix(py): list_examples() pagination with ID filters

### DIFF
--- a/python/langsmith/async_client.py
+++ b/python/langsmith/async_client.py
@@ -167,6 +167,10 @@ class AsyncClient:
                 yield item
             if len(items) < params["limit"]:
                 break
+            # When querying by specific IDs, all results are returned in first page
+            # Pagination doesn't apply since we're not doing a range query
+            if params.get("id") is not None or params.get("example_ids") is not None:
+                break
             offset += len(items)
 
     async def _aget_cursor_paginated_list(

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -1139,6 +1139,10 @@ class Client:
                 # offset and limit isn't respected if we're
                 # querying for specific values
                 break
+            # When querying by specific IDs, all results are returned in first page
+            # Pagination doesn't apply since we're not doing a range query
+            if params_.get("id") is not None or params_.get("example_ids") is not None:
+                break
             offset += len(items)
 
     def _get_cursor_paginated_list(

--- a/python/tests/integration_tests/test_async_client.py
+++ b/python/tests/integration_tests/test_async_client.py
@@ -208,6 +208,47 @@ async def test_list_examples(async_client: AsyncClient):
 
 
 @pytest.mark.asyncio
+async def test_list_examples_by_ids_multiple_of_100(async_client: AsyncClient):
+    """Test list_examples with exactly 100 example IDs."""
+    dataset_name = "__test_list_examples_by_ids_" + uuid.uuid4().hex[:8]
+    dataset = await async_client.create_dataset(dataset_name)
+
+    for i in range(100):
+        await async_client.create_example(
+            inputs={"text": f"input_{i}"},
+            outputs={"label": f"output_{i}"},
+            dataset_id=dataset.id,
+        )
+
+    all_examples = [
+        example async for example in async_client.list_examples(dataset_id=dataset.id)
+    ]
+    assert len(all_examples) == 100
+
+    example_ids = [ex.id for ex in all_examples]
+
+    examples_by_id = [
+        example async for example in async_client.list_examples(example_ids=example_ids)
+    ]
+    assert len(examples_by_id) == 100
+    assert {ex.id for ex in examples_by_id} == {ex.id for ex in all_examples}
+
+    examples_by_id_50 = [
+        example
+        async for example in async_client.list_examples(example_ids=example_ids[:50])
+    ]
+    assert len(examples_by_id_50) == 50
+
+    examples_by_id_99 = [
+        example
+        async for example in async_client.list_examples(example_ids=example_ids[:99])
+    ]
+    assert len(examples_by_id_99) == 99
+
+    await async_client.delete_dataset(dataset_id=dataset.id)
+
+
+@pytest.mark.asyncio
 async def test_create_feedback(async_client: AsyncClient):
     project_name = "__test_create_feedback" + uuid.uuid4().hex[:8]
     run_id = uuid.uuid4()

--- a/python/tests/unit_tests/test_async_client.py
+++ b/python/tests/unit_tests/test_async_client.py
@@ -39,3 +39,48 @@ async def test_list_runs_child_run_ids_deprecation_warning(
         warnings.simplefilter("error", DeprecationWarning)
         async for _ in client.list_runs(project_id=uuid4(), select=["id", "name"]):
             pass
+
+
+@mock.patch("langsmith.async_client.httpx.AsyncClient")
+@pytest.mark.asyncio
+async def test_list_examples_pagination_with_ids(mock_client_cls: mock.Mock) -> None:
+    """Test list_examples does not paginate when filtering by IDs."""
+    mock_httpx_client = mock.AsyncMock()
+    mock_client_cls.return_value = mock_httpx_client
+    request_offsets = []
+
+    async def mock_request(*args, **kwargs):
+        mock_response = mock.Mock()
+        mock_response.status_code = 200
+        mock_response.raise_for_status = mock.Mock()
+
+        params = kwargs.get("params", {})
+        offset = params.get("offset", 0)
+        request_offsets.append(offset)
+
+        if offset == 0:
+            examples = [
+                {
+                    "id": str(uuid4()),
+                    "inputs": {"text": f"input_{i}"},
+                    "outputs": {"result": f"output_{i}"},
+                }
+                for i in range(100)
+            ]
+            mock_response.json.return_value = examples
+        else:
+            raise Exception(f"Unexpected pagination request with offset={offset}")
+
+        return mock_response
+
+    mock_httpx_client.request.side_effect = mock_request
+
+    client = AsyncClient(api_key="test-key")
+    example_ids = [str(uuid4()) for _ in range(100)]
+
+    examples = []
+    async for example in client.list_examples(example_ids=example_ids):
+        examples.append(example)
+
+    assert len(examples) == 100
+    assert all(offset == 0 for offset in request_offsets)


### PR DESCRIPTION
## fix(py): list_examples() pagination with ID filters

  Fixes pagination bug where list_examples() would fail with 404 when
  example_ids parameter contained exactly 100, 200, or any multiple of
  100 IDs.

  The pagination logic in _get_paginated_list() and _aget_paginated_list()
  incorrectly continued paginating when len(items) == limit, even for
  ID-based queries where all results are returned in the first page.

  Added check to stop pagination when filtering by specific IDs (checks
  for both "id" and "example_ids" parameters to handle both sync and
  async client implementations).

  **Testing:**
  - Added unit tests for sync and async clients
  - Added integration tests with 50, 99, and 100 example IDs
  - All existing pagination tests still pass