### PR TITLE
Fix(python): Return wrapper for stream enter

### DIFF
--- a/python/langsmith/run_helpers.py
+++ b/python/langsmith/run_helpers.py
@@ -1944,7 +1944,8 @@ class _TracedStream(_TracedStreamBase, Generic[T]):
             self._end_trace()
 
     def __enter__(self):
-        return self.__ls_stream__.__enter__()
+        self.__ls_stream__.__enter__()
+        return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         try:
@@ -2003,7 +2004,8 @@ class _TracedAsyncStream(_TracedStreamBase, Generic[T]):
             await self._aend_trace()
 
     async def __aenter__(self):
-        return await self.__ls_stream__.__aenter__()
+        await self.__ls_stream__.__aenter__()
+        return self
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         try:

--- a/python/tests/unit_tests/test_run_helpers.py
+++ b/python/tests/unit_tests/test_run_helpers.py
@@ -442,6 +442,39 @@ def test_traceable_iterator_noargs(_: MagicMock) -> None:
     assert list(my_iterator_fn(1, 2, 3)) == [0, 1, 2, 3, 4, 5]
 
 
+def test_traceable_stream_context_manager_returns_wrapper(
+    mock_client: Client,
+) -> None:
+    with tracing_context(enabled=True):
+
+        @traceable(client=mock_client, reduce_fn=lambda chunks: chunks)
+        def my_stream_fn():
+            class SyncCtxStream:
+                def __init__(self) -> None:
+                    self.entered = False
+                    self.exited = False
+
+                def __enter__(self):
+                    self.entered = True
+                    return self
+
+                def __exit__(self, exc_type, exc_val, exc_tb):
+                    self.exited = True
+
+                def __iter__(self):
+                    return iter([])
+
+            stream = SyncCtxStream()
+            return stream
+
+        stream = my_stream_fn()
+        with stream as s:
+            assert s is stream
+        # Ensure the underlying stream context manager was used
+        assert stream.__ls_stream__.entered
+        assert stream.__ls_stream__.exited
+
+
 @patch("langsmith.run_trees.Client", autospec=True)
 async def test_traceable_async_iterator_noargs(_: MagicMock) -> None:
     # Check that it's callable without the parens
@@ -451,6 +484,49 @@ async def test_traceable_async_iterator_noargs(_: MagicMock) -> None:
             yield i
 
     assert [i async for i in my_iterator_fn(1, 2, 3)] == [0, 1, 2, 3, 4, 5]
+
+
+@pytest.mark.asyncio
+async def test_traceable_async_stream_context_manager_returns_wrapper(
+    mock_client: Client,
+) -> None:
+    with tracing_context(enabled=True):
+
+        @traceable(client=mock_client, reduce_fn=lambda chunks: chunks)
+        async def my_stream_fn():
+            class AsyncCtxStream:
+                def __init__(self) -> None:
+                    self.entered = False
+                    self.exited = False
+                    self._done = False
+
+                async def __aenter__(self):
+                    self.entered = True
+                    return self
+
+                async def __aexit__(self, exc_type, exc_val, exc_tb):
+                    self.exited = True
+
+                def __aiter__(self):
+                    return self
+
+                async def __anext__(self):
+                    if self._done:
+                        raise StopAsyncIteration
+                    self._done = True
+                    return "chunk"
+
+            stream = AsyncCtxStream()
+            return stream
+
+        stream = await my_stream_fn()
+        async with stream as s:
+            assert s is stream
+            collected = [item async for item in s]
+            assert collected == ["chunk"]
+        # Ensure the underlying stream context manager was used
+        assert stream.__ls_stream__.entered
+        assert stream.__ls_stream__.exited
 
 
 @patch("langsmith.client.requests.Session", autospec=True)


### PR DESCRIPTION
### Description
Update `_TracedStream.__enter__` and `_TracedAsyncStream.__aenter__` to return the wrapper instead of the underlying stream object, while still delegating enter/exit to the wrapped stream.

This means using  `async with stream as s:` or `AsyncExitStack.enter_async_context` use the traced wrapper, so streamed tokens are traced.

Resolves #2140

### Tests
Add unit tests for both sync and async traced streams.