### PR TITLE
fix(py): add missing imports during TYPE_CHECKING

### DIFF
--- a/python/langsmith/__init__.py
+++ b/python/langsmith/__init__.py
@@ -6,7 +6,12 @@ if TYPE_CHECKING:
     from langsmith._expect import expect
     from langsmith.async_client import AsyncClient
     from langsmith.client import Client
-    from langsmith.evaluation import aevaluate, evaluate
+    from langsmith.evaluation import (
+        aevaluate,
+        aevaluate_existing,
+        evaluate,
+        evaluate_existing,
+    )
     from langsmith.evaluation.evaluator import EvaluationResult, RunEvaluator
     from langsmith.run_helpers import (
         get_current_run_tree,
@@ -16,7 +21,7 @@ if TYPE_CHECKING:
         traceable,
         tracing_context,
     )
-    from langsmith.run_trees import RunTree
+    from langsmith.run_trees import RunTree, configure
     from langsmith.testing._internal import test, unit
     from langsmith.utils import ContextThreadPoolExecutor
     from langsmith.uuid import uuid7, uuid7_from_datetime
@@ -130,6 +135,7 @@ def __getattr__(name: str) -> Any:
 __all__ = [
     "Client",
     "RunTree",
+    "configure",
     "__version__",
     "EvaluationResult",
     "RunEvaluator",
@@ -140,6 +146,8 @@ __all__ = [
     "test",
     "expect",
     "evaluate",
+    "evaluate_existing",
+    "aevaluate_existing",
     "aevaluate",
     "tracing_context",
     "get_tracing_context",


### PR DESCRIPTION
Hi! 

I was doing some work that happened to use the `configure()` function and noticed that my LSP wasn't following the `from langsmith import configure` import, despite it seemingly working fine. A little closer examination showed it was just *only* present at runtime, which you can see here in the `__getattr__()` definition. 

This is just a small change that includes `configure` in the `TYPE_CHECKING` block, along with a couple of others I noticed were missing. I was trying to think of reasons why this might have been the case, and the only one I could come up with was LSP performance - anecdotally, I didn't experience any impact there.