### PR TITLE
fix(js): Remove default Jestlike timeout

### DIFF
--- a/js/src/utils/jestlike/constants.ts
+++ b/js/src/utils/jestlike/constants.ts
@@ -1,5 +1,3 @@
-export const DEFAULT_TEST_TIMEOUT = 30_000;
-
 export const UUID5_NAMESPACE = "6ba7b810-9dad-11d1-80b4-00c04fd430c8";
 
 // From https://stackoverflow.com/a/29497680

--- a/js/src/utils/jestlike/index.ts
+++ b/js/src/utils/jestlike/index.ts
@@ -40,7 +40,6 @@ import { getEnvironmentVariable, isJsDom } from "../env.js";
 import {
   STRIP_ANSI_REGEX,
   TEST_ID_DELIMITER,
-  DEFAULT_TEST_TIMEOUT,
   UUID5_NAMESPACE,
 } from "./constants.js";
 
@@ -765,7 +764,7 @@ export function generateWrapperFromJestlikeMethods(
               );
             }
           },
-          timeout ?? DEFAULT_TEST_TIMEOUT
+          timeout
         );
       }
     };


### PR DESCRIPTION
Fixes #1785

Should have done this as part of the recent minor bump but think still worth doing now since relatively few people have upgraded so far and it's still marked as beta