### PR TITLE
docs: fix some docstrings

### DIFF
--- a/python/langsmith/async_client.py
+++ b/python/langsmith/async_client.py
@@ -53,10 +53,13 @@ class AsyncClient:
             timeout_ms: Timeout for requests in milliseconds.
             retry_config: Retry configuration.
             web_url: URL for the LangSmith web app.
-            cache: Configuration for caching. Can be:
-                - True: Enable caching with default settings
-                - AsyncCache instance: Use custom cache configuration
-                - False: Disable caching (default)
+            cache: Configuration for caching.
+
+                Can be:
+
+                - `True`: Enable caching with default settings
+                - `AsyncCache` instance: Use custom cache configuration
+                - `False`: Disable caching (default)
         """
         self._retry_config = retry_config or {"max_retries": 3}
         _headers = {
@@ -294,137 +297,94 @@ class AsyncClient:
     ) -> AsyncIterator[ls_schemas.Run]:
         """List runs from the LangSmith API.
 
-        Parameters
-        ----------
-        project_id : UUID or None, default=None
-            The ID(s) of the project to filter by.
-        project_name : str or None, default=None
-            The name(s) of the project to filter by.
-        run_type : str or None, default=None
-            The type of the runs to filter by.
-        trace_id : UUID or None, default=None
-            The ID of the trace to filter by.
-        reference_example_id : UUID or None, default=None
-            The ID of the reference example to filter by.
-        query : str or None, default=None
-            The query string to filter by.
-        filter : str or None, default=None
-            The filter string to filter by.
-        trace_filter : str or None, default=None
-            Filter to apply to the ROOT run in the trace tree. This is meant to
-            be used in conjunction with the regular `filter` parameter to let you
-            filter runs by attributes of the root run within a trace.
-        tree_filter : str or None, default=None
-            Filter to apply to OTHER runs in the trace tree, including
-            sibling and child runs. This is meant to be used in conjunction with
-            the regular `filter` parameter to let you filter runs by attributes
-            of any run within a trace.
-        is_root : bool or None, default=None
-            Whether to filter by root runs.
-        parent_run_id : UUID or None, default=None
-            The ID of the parent run to filter by.
-        start_time : datetime or None, default=None
-            The start time to filter by.
-        error : bool or None, default=None
-            Whether to filter by error status.
-        run_ids : List[str or UUID] or None, default=None
-            The IDs of the runs to filter by.
-        limit : int or None, default=None
-            The maximum number of runs to return.
-        **kwargs : Any
-            Additional keyword arguments.
+        Args:
+            project_id: The ID(s) of the project to filter by.
+            project_name: The name(s) of the project to filter by.
+            run_type: The type of the runs to filter by.
+            trace_id: The ID of the trace to filter by.
+            reference_example_id: The ID of the reference example to filter by.
+            query: The query string to filter by.
+            filter: The filter string to filter by.
+            trace_filter: Filter to apply to the ROOT run in the trace tree.
+
+                This is meant to be used in conjunction with the regular `filter`
+                parameter to let you filter runs by attributes of the root run within a
+                trace.
+            tree_filter: Filter to apply to OTHER runs in the trace tree, including
+                sibling and child runs.
+
+                This is meant to be used in conjunction with the regular `filter`
+                parameter to let you filter runs by attributes of any run within a
+                trace.
+            is_root: Whether to filter by root runs.
+            parent_run_id: The ID of the parent run to filter by.
+            start_time: The start time to filter by.
+            error: Whether to filter by error status.
+            run_ids: The IDs of the runs to filter by.
+            select: The fields to select.
+            limit: The maximum number of runs to return.
+            **kwargs: Additional keyword arguments.
 
         Yields:
-        ------
-        Run
             The runs.
 
         Examples:
-        --------
-        List all runs in a project:
+            ```python
+            # List all runs in a project
+            project_runs = client.list_runs(project_name="<your_project>")
 
-        ```python
-        project_runs = client.list_runs(project_name="<your_project>")
-        ```
+            # List LLM and Chat runs in the last 24 hours
+            todays_llm_runs = client.list_runs(
+                project_name="<your_project>",
+                start_time=datetime.now() - timedelta(days=1),
+                run_type="llm",
+            )
 
-        List LLM and Chat runs in the last 24 hours:
+            # List root traces in a project
+            root_runs = client.list_runs(project_name="<your_project>", is_root=1)
 
-        ```python
-        todays_llm_runs = client.list_runs(
-            project_name="<your_project>",
-            start_time=datetime.now() - timedelta(days=1),
-            run_type="llm",
-        )
-        ```
+            # List runs without errors
+            correct_runs = client.list_runs(project_name="<your_project>", error=False)
 
-        List root traces in a project:
+            # List runs and only return their inputs/outputs (to speed up the query)
+            input_output_runs = client.list_runs(
+                project_name="<your_project>", select=["inputs", "outputs"]
+            )
 
-        ```python
-        root_runs = client.list_runs(project_name="<your_project>", is_root=1)
-        ```
+            # List runs by run ID
+            run_ids = [
+                "a36092d2-4ad5-4fb4-9c0d-0dba9a2ed836",
+                "9398e6be-964f-4aa4-8ae9-ad78cd4b7074",
+            ]
+            selected_runs = client.list_runs(id=run_ids)
 
-        List runs without errors:
+            # List all "chain" type runs that took more than 10 seconds and had
+            # `total_tokens` greater than 5000
+            chain_runs = client.list_runs(
+                project_name="<your_project>",
+                filter='and(eq(run_type, "chain"), gt(latency, 10), gt(total_tokens, 5000))',
+            )
 
-        ```python
-        correct_runs = client.list_runs(project_name="<your_project>", error=False)
-        ```
+            # List all runs called "extractor" whose root of the trace was assigned feedback "user_score" score of 1
+            good_extractor_runs = client.list_runs(
+                project_name="<your_project>",
+                filter='eq(name, "extractor")',
+                trace_filter='and(eq(feedback_key, "user_score"), eq(feedback_score, 1))',
+            )
 
-        List runs and only return their inputs/outputs (to speed up the query):
+            # List all runs that started after a specific timestamp and either have "error" not equal to null or a "Correctness" feedback score equal to 0
+            complex_runs = client.list_runs(
+                project_name="<your_project>",
+                filter='and(gt(start_time, "2023-07-15T12:34:56Z"), or(neq(error, null), and(eq(feedback_key, "Correctness"), eq(feedback_score, 0.0))))',
+            )
 
-        ```python
-        input_output_runs = client.list_runs(
-            project_name="<your_project>", select=["inputs", "outputs"]
-        )
-        ```
-
-        List runs by run ID:
-
-        ```python
-        run_ids = [
-            "a36092d2-4ad5-4fb4-9c0d-0dba9a2ed836",
-            "9398e6be-964f-4aa4-8ae9-ad78cd4b7074",
-        ]
-        selected_runs = client.list_runs(id=run_ids)
-        ```
-
-        List all "chain" type runs that took more than 10 seconds and had
-        `total_tokens` greater than 5000:
-
-        ```python
-        chain_runs = client.list_runs(
-            project_name="<your_project>",
-            filter='and(eq(run_type, "chain"), gt(latency, 10), gt(total_tokens, 5000))',
-        )
-        ```
-
-        List all runs called "extractor" whose root of the trace was assigned feedback "user_score" score of 1:
-
-        ```python
-        good_extractor_runs = client.list_runs(
-            project_name="<your_project>",
-            filter='eq(name, "extractor")',
-            trace_filter='and(eq(feedback_key, "user_score"), eq(feedback_score, 1))',
-        )
-        ```
-
-        List all runs that started after a specific timestamp and either have "error" not equal to null or a "Correctness" feedback score equal to 0:
-
-        ```python
-        complex_runs = client.list_runs(
-            project_name="<your_project>",
-            filter='and(gt(start_time, "2023-07-15T12:34:56Z"), or(neq(error, null), and(eq(feedback_key, "Correctness"), eq(feedback_score, 0.0))))',
-        )
-        ```
-
-        List all runs where `tags` include "experimental" or "beta" and `latency` is greater than 2 seconds:
-
-        ```python
-        tagged_runs = client.list_runs(
-            project_name="<your_project>",
-            filter='and(or(has(tags, "experimental"), has(tags, "beta")), gt(latency, 2))',
-        )
-        ```
-        """
+            # List all runs where `tags` include "experimental" or "beta" and `latency` is greater than 2 seconds
+            tagged_runs = client.list_runs(
+                project_name="<your_project>",
+                filter='and(or(has(tags, "experimental"), has(tags, "beta")), gt(latency, 2))',
+            )
+            ```
+        """  # noqa: E501
         project_ids = []
         if isinstance(project_id, (uuid.UUID, str)):
             project_ids.append(project_id)
@@ -483,11 +443,12 @@ class AsyncClient:
 
         Args:
             run_id (ID_TYPE): The ID of the run to share.
-            share_id (Optional[ID_TYPE], optional): Custom share ID.
+            share_id: Custom share ID.
+
                 If not provided, a random UUID will be generated.
 
         Returns:
-            str: The URL of the shared run.
+            The URL of the shared run.
 
         Raises:
             httpx.HTTPStatusError: If the API request fails.
@@ -577,12 +538,9 @@ class AsyncClient:
     ) -> None:
         """Delete a project from LangSmith.
 
-        Parameters
-        ----------
-        project_name : str or None, default=None
-            The name of the project to delete.
-        project_id : str or None, default=None
-            The ID of the project to delete.
+        Args:
+            project_name: The name of the project to delete.
+            project_id: The ID of the project to delete.
         """
         if project_id is None and project_name is None:
             raise ValueError("Either project_name or project_id must be provided")
@@ -712,16 +670,17 @@ class AsyncClient:
         """Create feedback for a run.
 
         Args:
-            run_id (Optional[ls_client.ID_TYPE]): The ID of the run to provide feedback for.
-                Can be None for project-level feedback.
-            key (str): The name of the metric or aspect this feedback is about.
-            score (Optional[float]): The score to rate this run on the metric or aspect.
-            value (Union[float, int, bool, str, dict, None]): The display value or non-numeric value for this feedback.
-            comment (Optional[str]): A comment about this feedback.
+            run_id: The ID of the run to provide feedback for.
+
+                Can be `None` for project-level feedback.
+            key: The name of the metric or aspect this feedback is about.
+            score: The score to rate this run on the metric or aspect.
+            value: The display value or non-numeric value for this feedback.
+            comment: A comment about this feedback.
             **kwargs: Additional keyword arguments to include in the feedback data.
 
         Returns:
-            ls_schemas.Feedback: The created feedback object.
+            The created feedback object.
 
         Raises:
             httpx.HTTPStatusError: If the API request fails.
@@ -752,24 +711,18 @@ class AsyncClient:
         """Create feedback from a presigned token or URL.
 
         Args:
-            token_or_url (Union[str, uuid.UUID]): The token or URL from which to create
-                 feedback.
-            score (Union[float, int, bool, None], optional): The score of the feedback.
-                Defaults to None.
-            value (Union[float, int, bool, str, dict, None], optional): The value of the
-                feedback. Defaults to None.
-            correction (Union[dict, None], optional): The correction of the feedback.
-                Defaults to None.
-            comment (Union[str, None], optional): The comment of the feedback. Defaults
-                to None.
-            metadata (Optional[dict], optional): Additional metadata for the feedback.
-                Defaults to None.
+            token_or_url: The token or URL from which to create feedback.
+            score: The score of the feedback.
+            value: The value of the feedback.
+            correction: The correction of the feedback.
+            comment: The comment of the feedback.
+            metadata: Additional metadata for the feedback.
 
         Raises:
             ValueError: If the source API URL is invalid.
 
         Returns:
-            None: This method does not return anything.
+            This method does not return anything.
         """
         source_api_url, token_uuid = ls_client._parse_token_or_url(
             token_or_url, self._api_url, num_parts=1
@@ -808,18 +761,21 @@ class AsyncClient:
         API key.
 
         Args:
-            run_id:
-            feedback_key:
+            run_id (Union[UUID, str]): The ID of the run to provide feedback for.
+            feedback_key: The name of the metric or aspect this feedback is about.
             expiration: The expiration time of the pre-signed URL.
+
                 Either a datetime or a timedelta offset from now.
+
                 Default to 3 hours.
-            feedback_config: FeedbackConfig or None.
-                If creating a feedback_key for the first time,
-                this defines how the metric should be interpreted,
-                such as a continuous score (w/ optional bounds),
-                or distribution over categorical values.
-            feedback_id: The ID of the feedback to create. If not provided, a new
-                feedback will be created.
+            feedback_config: `FeedbackConfig` or `None`.
+
+                If creating a feedback_key for the first time, this defines how the
+                metric should be interpreted, such as a continuous score (w/ optional
+                bounds), or distribution over categorical values.
+            feedback_id: The ID of the feedback to create.
+
+                If not provided, a new feedback will be created.
 
         Returns:
             The pre-signed URL for uploading feedback data.
@@ -898,11 +854,7 @@ class AsyncClient:
         """Delete a feedback by ID.
 
         Args:
-            feedback_id (Union[UUID, str]):
-                The ID of the feedback to delete.
-
-        Returns:
-            None
+            feedback_id (Union[UUID, str]): The ID of the feedback to delete.
         """
         response = await self._arequest_with_retries(
             "DELETE", f"/feedback/{ls_client._as_uuid(feedback_id, 'feedback_id')}"
@@ -922,14 +874,11 @@ class AsyncClient:
         """List the annotation queues on the LangSmith API.
 
         Args:
-            queue_ids (Optional[List[Union[UUID, str]]]):
-                The IDs of the queues to filter by.
-            name (Optional[str]):
-                The name of the queue to filter by.
-            name_contains (Optional[str]):
-                The substring that the queue name should contain.
-            limit (Optional[int]):
-                The maximum number of queues to return.
+            queue_ids (Optional[List[Union[UUID, str]]]): The IDs of the queues to
+                filter by.
+            name: The name of the queue to filter by.
+            name_contains: The substring that the queue name should contain.
+            limit: The maximum number of queues to return.
 
         Yields:
             The annotation queues.
@@ -966,15 +915,12 @@ class AsyncClient:
         """Create an annotation queue on the LangSmith API.
 
         Args:
-            name (str):
-                The name of the annotation queue.
-            description (Optional[str]):
-                The description of the annotation queue.
-            queue_id (Optional[Union[UUID, str]]):
-                The ID of the annotation queue.
+            name: The name of the annotation queue.
+            description: The description of the annotation queue.
+            queue_id (Optional[Union[UUID, str]]): The ID of the annotation queue.
 
         Returns:
-            AnnotationQueue: The created annotation queue object.
+            The created annotation queue object.
         """
         body = {
             "name": name,
@@ -1000,7 +946,7 @@ class AsyncClient:
             queue_id (Union[UUID, str]): The ID of the annotation queue to read.
 
         Returns:
-            AnnotationQueue: The annotation queue object.
+            The annotation queue object.
         """
         # TODO: Replace when actual endpoint is added
         return await self.list_annotation_queues(queue_ids=[queue_id]).__anext__()
@@ -1012,12 +958,8 @@ class AsyncClient:
 
         Args:
             queue_id (Union[UUID, str]): The ID of the annotation queue to update.
-            name (str): The new name for the annotation queue.
-            description (Optional[str]): The new description for the
-                annotation queue. Defaults to None.
-
-        Returns:
-            None
+            name: The new name for the annotation queue.
+            description: The new description for the annotation queue.
         """
         response = await self._arequest_with_retries(
             "PATCH",
@@ -1034,9 +976,6 @@ class AsyncClient:
 
         Args:
             queue_id (Union[UUID, str]): The ID of the annotation queue to delete.
-
-        Returns:
-            None
         """
         response = await self._arequest_with_retries(
             "DELETE",
@@ -1052,11 +991,8 @@ class AsyncClient:
 
         Args:
             queue_id (Union[UUID, str]): The ID of the annotation queue.
-            run_ids (List[Union[UUID, str]]): The IDs of the runs to be added to the annotation
-                queue.
-
-        Returns:
-            None
+            run_ids (list[Union[UUID, str]]): The IDs of the runs to be added to the
+                annotation queue.
         """
         response = await self._arequest_with_retries(
             "POST",
@@ -1077,9 +1013,6 @@ class AsyncClient:
             queue_id (Union[UUID, str]): The ID of the annotation queue.
             run_id (Union[UUID, str]): The ID of the run to be added to the annotation
                 queue.
-
-        Returns:
-            None
         """
         response = await self._arequest_with_retries(
             "DELETE",
@@ -1094,10 +1027,10 @@ class AsyncClient:
 
         Args:
             queue_id (Union[UUID, str]): The ID of the annotation queue.
-            index (int): The index of the run to retrieve.
+            index: The index of the run to retrieve.
 
         Returns:
-            RunWithAnnotationQueueInfo: The run at the specified index.
+            The run at the specified index.
 
         Raises:
             LangSmithNotFoundError: If the run is not found at the given index.
@@ -1119,16 +1052,14 @@ class AsyncClient:
         """Enable dataset indexing. Examples are indexed by their inputs.
 
         This enables searching for similar examples by inputs with
-        ``client.similar_examples()``.
+        `client.similar_examples()`.
 
         Args:
-            dataset_id (UUID): The ID of the dataset to index.
-            tag (str, optional): The version of the dataset to index. If 'latest'
-                then any updates to the dataset (additions, updates, deletions of
-                examples) will be reflected in the index.
+            dataset_id (Union[UUID, str]): The ID of the dataset to index.
+            tag: The version of the dataset to index.
 
-        Returns:
-            None
+                If `'latest'` then any updates to the dataset (additions, updates,
+                deletions of examples) will be reflected in the index.
 
         Raises:
             requests.HTTPError: If the request fails.
@@ -1154,10 +1085,7 @@ class AsyncClient:
         force a sync.
 
         Args:
-            dataset_id (UUID): The ID of the dataset to sync.
-
-        Returns:
-            None
+            dataset_id (Union[UUID, str]): The ID of the dataset to sync.
 
         Raises:
             requests.HTTPError: If the request fails.
@@ -1188,17 +1116,22 @@ class AsyncClient:
             Must have few-shot indexing enabled for the dataset. See `client.index_dataset()`.
 
         Args:
-            inputs (dict): The inputs to use as a search query. Must match the dataset
-                input schema. Must be JSON serializable.
-            limit (int): The maximum number of examples to return.
-            dataset_id (str or UUID): The ID of the dataset to search over.
-            filter (str, optional): A filter string to apply to the search results. Uses
-                the same syntax as the `filter` parameter in `list_runs()`. Only a subset
-                of operations are supported. Defaults to None.
-            kwargs (Any): Additional keyword args to pass as part of request body.
+            inputs: The inputs to use as a search query.
+
+                Must match the dataset input schema.
+
+                Must be JSON serializable.
+            limit: The maximum number of examples to return.
+            dataset_id (Union[UUID, str]): The ID of the dataset to search over.
+            filter: A filter string to apply to the search results.
+
+                Uses the same syntax as the `filter` parameter in `list_runs()`.
+
+                Only a subset of operations are supported.
+            kwargs: Additional keyword args to pass as part of request body.
 
         Returns:
-            List of ExampleSearch objects.
+            List of `ExampleSearch` objects.
 
         Examples:
             ```python
@@ -1284,10 +1217,10 @@ class AsyncClient:
         """Check if the current workspace has the same handle as owner.
 
         Args:
-            owner (str): The owner to check against.
+            owner: The owner to check against.
 
         Returns:
-            bool: True if the current tenant is the owner, False otherwise.
+            bool: `True` if the current tenant is the owner, `False` otherwise.
         """
         settings = await self._get_settings()
         return owner == "-" or settings.tenant_handle == owner
@@ -1308,12 +1241,12 @@ class AsyncClient:
         """Get the latest commit hash for a prompt.
 
         Args:
-            prompt_owner_and_name (str): The owner and name of the prompt.
-            limit (int, default=1): The maximum number of commits to fetch. Defaults to 1.
-            offset (int, default=0): The number of commits to skip. Defaults to 0.
+            prompt_owner_and_name: The owner and name of the prompt.
+            limit: The maximum number of commits to fetch.
+            offset: The number of commits to skip.
 
         Returns:
-            Optional[str]: The latest commit hash, or None if no commits are found.
+            The latest commit hash, or `None` if no commits are found.
         """
         response = await self._arequest_with_retries(
             "GET",
@@ -1329,9 +1262,9 @@ class AsyncClient:
         """Update tags for a prompt commit.
 
         Args:
-            prompt_owner_and_name (str): The owner and name of the prompt in the format 'owner/repo'.
-            commit_id (str): The commit ID to tag.
-            tags (Union[str, list[str]]): A single tag or list of tags to apply to the commit.
+            prompt_owner_and_name: The owner and name of the prompt in the format 'owner/repo'.
+            commit_id: The commit ID to tag.
+            tags: A single tag or list of tags to apply to the commit.
 
         Raises:
             requests.exceptions.HTTPError: If the request fails.
@@ -1358,15 +1291,15 @@ class AsyncClient:
         """Like or unlike a prompt.
 
         Args:
-            prompt_identifier (str): The identifier of the prompt.
-            like (bool): True to like the prompt, False to unlike it.
+            prompt_identifier: The identifier of the prompt.
+            like: True to like the prompt, False to unlike it.
 
         Returns:
-            A dictionary with the key 'likes' and the count of likes as the value.
+            A dictionary with the key `'likes'` and the count of likes as the value.
 
         Raises:
-            requests.exceptions.HTTPError: If the prompt is not found or
-            another error occurs.
+            requests.exceptions.HTTPError: If the prompt is not found or another error
+                occurs.
         """
         owner, prompt_name, _ = ls_utils.parse_prompt_identifier(prompt_identifier)
         response = await self._arequest_with_retries(
@@ -1379,10 +1312,10 @@ class AsyncClient:
         """Get a URL for a prompt.
 
         Args:
-            prompt_identifier (str): The identifier of the prompt.
+            prompt_identifier: The identifier of the prompt.
 
         Returns:
-            str: The URL for the prompt.
+            The URL for the prompt.
 
         """
         owner, prompt_name, commit_hash = ls_utils.parse_prompt_identifier(
@@ -1402,10 +1335,10 @@ class AsyncClient:
         """Check if a prompt exists.
 
         Args:
-            prompt_identifier (str): The identifier of the prompt.
+            prompt_identifier: The identifier of the prompt.
 
         Returns:
-            bool: True if the prompt exists, False otherwise.
+            `True` if the prompt exists, `False` otherwise.
         """
         prompt = await self.get_prompt(prompt_identifier)
         return True if prompt else False
@@ -1414,11 +1347,10 @@ class AsyncClient:
         """Like a prompt.
 
         Args:
-            prompt_identifier (str): The identifier of the prompt.
+            prompt_identifier: The identifier of the prompt.
 
         Returns:
-            Dict[str, int]: A dictionary with the key 'likes' and the count of likes as the value.
-
+            A dictionary with the key `'likes'` and the count of likes as the value.
         """
         return await self._like_or_unlike_prompt(prompt_identifier, like=True)
 
@@ -1426,11 +1358,10 @@ class AsyncClient:
         """Unlike a prompt.
 
         Args:
-            prompt_identifier (str): The identifier of the prompt.
+            prompt_identifier: The identifier of the prompt.
 
         Returns:
-            Dict[str, int]: A dictionary with the key 'likes' and the count of likes as the value.
-
+            A dictionary with the key `'likes'` and the count of likes as the value.
         """
         return await self._like_or_unlike_prompt(prompt_identifier, like=False)
 
@@ -1448,19 +1379,18 @@ class AsyncClient:
         """List prompts with pagination.
 
         Args:
-            limit (int, default=100): The maximum number of prompts to return. Defaults to 100.
-            offset (int, default=0): The number of prompts to skip. Defaults to 0.
-            is_public (Optional[bool]): Filter prompts by if they are public.
-            is_archived (Optional[bool]): Filter prompts by if they are archived.
+            limit: The maximum number of prompts to return.
+            offset: The number of prompts to skip.
+            is_public: Filter prompts by if they are public.
+            is_archived: Filter prompts by if they are archived.
             sort_field (PromptSortField): The field to sort by.
-                Defaults to "updated_at".
-            sort_direction (Literal["desc", "asc"], default="desc"): The order to sort by.
-                Defaults to "desc".
-            query (Optional[str]): Filter prompts by a search query.
+
+                Defaults to `'updated_at'`.
+            sort_direction: The order to sort by.
+            query: Filter prompts by a search query.
 
         Returns:
-            ListPromptsResponse: A response object containing
-            the list of prompts.
+            A response object containing the list of prompts.
         """
         params = {
             "limit": limit,
@@ -1488,11 +1418,13 @@ class AsyncClient:
         """Get a specific prompt by its identifier.
 
         Args:
-            prompt_identifier (str): The identifier of the prompt.
-                The identifier should be in the format "prompt_name" or "owner/prompt_name".
+            prompt_identifier: The identifier of the prompt.
+
+                The identifier should be in the format `'prompt_name'` or
+                `'owner/prompt_name'`.
 
         Returns:
-            Optional[Prompt]: The prompt object.
+            The prompt object.
 
         Raises:
             requests.exceptions.HTTPError: If the prompt is not found or
@@ -1521,15 +1453,17 @@ class AsyncClient:
         Does not attach prompt object, just creates an empty prompt.
 
         Args:
-            prompt_identifier (str): The identifier of the prompt.
-                The identifier should be in the formatof owner/name:hash, name:hash, owner/name, or name
-            description (Optional[str]): A description of the prompt.
-            readme (Optional[str]): A readme for the prompt.
-            tags (Optional[Sequence[str]]): A list of tags for the prompt.
-            is_public (bool): Whether the prompt should be public. Defaults to False.
+            prompt_identifier: The identifier of the prompt.
+
+                The identifier should be in the format of `owner/name:hash`,
+                `name:hash`, `owner/name`, or `name`
+            description: A description of the prompt.
+            readme: A readme for the prompt.
+            tags: A list of tags for the prompt.
+            is_public: Whether the prompt should be public.
 
         Returns:
-            Prompt: The created prompt object.
+            The created `Prompt` object.
 
         Raises:
             ValueError: If the current tenant is not the owner.
@@ -1571,15 +1505,17 @@ class AsyncClient:
         """Create a commit for an existing prompt.
 
         Args:
-            prompt_identifier (str): The identifier of the prompt.
-            object (Any): The LangChain object to commit.
-            parent_commit_hash (Optional[str]): The hash of the parent commit.
+            prompt_identifier: The identifier of the prompt.
+            object: The LangChain object to commit.
+            parent_commit_hash: The hash of the parent commit.
+
                 Defaults to latest commit.
-            tags (Optional[str | list[str]]): A single tag or list of tags to apply to the commit.
-                Defaults to None.
+            tags: A single tag or list of tags to apply to the commit.
+
+                Defaults to `None`.
 
         Returns:
-            str: The url of the prompt commit.
+            The url of the prompt commit.
 
         Raises:
             HTTPError: If the server request fails.
@@ -1638,18 +1574,18 @@ class AsyncClient:
         To update the content of a prompt, use push_prompt or create_commit instead.
 
         Args:
-            prompt_identifier (str): The identifier of the prompt to update.
-            description (Optional[str]): New description for the prompt.
-            readme (Optional[str]): New readme for the prompt.
-            tags (Optional[Sequence[str]]): New list of tags for the prompt.
-            is_public (Optional[bool]): New public status for the prompt.
-            is_archived (Optional[bool]): New archived status for the prompt.
+            prompt_identifier: The identifier of the prompt to update.
+            description: New description for the prompt.
+            readme: New readme for the prompt.
+            tags: New list of tags for the prompt.
+            is_public: New public status for the prompt.
+            is_archived: New archived status for the prompt.
 
         Returns:
-            Dict[str, Any]: The updated prompt data as returned by the server.
+            The updated prompt data as returned by the server.
 
         Raises:
-            ValueError: If the prompt_identifier is empty.
+            ValueError: If the `prompt_identifier` is empty.
             HTTPError: If the server request fails.
         """
         settings = await self._get_settings()
@@ -1685,10 +1621,10 @@ class AsyncClient:
         """Delete a prompt.
 
         Args:
-            prompt_identifier (str): The identifier of the prompt to delete.
+            prompt_identifier: The identifier of the prompt to delete.
 
         Returns:
-            bool: True if the prompt was successfully deleted, False otherwise.
+            `True` if the prompt was successfully deleted, `False` otherwise.
 
         Raises:
             ValueError: If the current tenant is not the owner of the prompt.
@@ -1729,7 +1665,7 @@ class AsyncClient:
             include_model: Whether to include model information.
 
         Returns:
-            The PromptCommit object.
+            The `PromptCommit` object.
         """
         owner, prompt_name, commit_hash = ls_utils.parse_prompt_identifier(
             prompt_identifier
@@ -1755,14 +1691,14 @@ class AsyncClient:
         """Pull a prompt object from the LangSmith API.
 
         Args:
-            prompt_identifier (str): The identifier of the prompt.
-            include_model (Optional[bool]): Whether to include model information.
-            skip_cache (bool): Whether to skip the prompt cache.
+            prompt_identifier: The identifier of the prompt.
+            include_model: Whether to include model information.
+            skip_cache: Whether to skip the prompt cache.
 
                 Defaults to `False`.
 
         Returns:
-            PromptCommit: The prompt object.
+            The prompt object.
 
         Raises:
             ValueError: If no commits are found for the prompt.
@@ -1795,13 +1731,15 @@ class AsyncClient:
         """List commits for a given prompt.
 
         Args:
-            prompt_identifier (str): The identifier of the prompt in the format 'owner/repo_name'.
-            limit (Optional[int]): The maximum number of commits to return. If None, returns all commits. Defaults to None.
-            offset (int, default=0): The number of commits to skip before starting to return results. Defaults to 0.
-            include_model (bool, default=False): Whether to include the model information in the commit data. Defaults to False.
+            prompt_identifier: The identifier of the prompt in the format `owner/repo_name`.
+            limit: The maximum number of commits to return.
+
+                If `None`, returns all commits.
+            offset: The number of commits to skip before starting to return results.
+            include_model: Whether to include the model information in the commit data.
 
         Yields:
-            A ListedPromptCommit object for each commit.
+            A `ListedPromptCommit` object for each commit.
 
         !!! note
 
@@ -1870,7 +1808,7 @@ class AsyncClient:
             skip_cache: Whether to skip the prompt cache. Defaults to `False`.
 
         Returns:
-            Any: The prompt object in the specified format.
+            The prompt object in the specified format.
 
         !!! warning "Behavior changed in `langsmith` 0.5.1"
 
@@ -1917,28 +1855,36 @@ class AsyncClient:
         Can be used to update prompt metadata or prompt content.
 
         If the prompt does not exist, it will be created.
+
         If the prompt exists, it will be updated.
 
         Args:
-            prompt_identifier (str): The identifier of the prompt.
-            object (Optional[Any]): The LangChain object to push.
-            parent_commit_hash (str): The parent commit hash.
-                Defaults to "latest".
-            is_public (Optional[bool]): Whether the prompt should be public.
-                If None (default), the current visibility status is maintained for existing prompts.
-                For new prompts, None defaults to private.
-                Set to True to make public, or False to make private.
-            description (Optional[str]): A description of the prompt.
+            prompt_identifier: The identifier of the prompt.
+            object: The LangChain object to push.
+            parent_commit_hash: The parent commit hash.
+            is_public: Whether the prompt should be public.
+
+                If `None` (default), the current visibility status is maintained for
+                existing prompts.
+
+                For new prompts, `None` defaults to private.
+
+                Set to `True` to make public, or `False` to make private.
+            description: A description of the prompt.
+
                 Defaults to an empty string.
-            readme (Optional[str]): A readme for the prompt.
+            readme: A readme for the prompt.
+
                 Defaults to an empty string.
-            tags (Optional[Sequence[str]]): A list of tags for the prompt.
+            tags: A list of tags for the prompt.
+
                 Defaults to an empty list.
-            commit_tags (Optional[str | list[str]]): A single tag or list of tags for the prompt commit.
+            commit_tags: A single tag or list of tags for the prompt commit.
+
                 Defaults to an empty list.
 
         Returns:
-            str: The URL of the prompt.
+            The URL of the prompt.
         """
         # Create or update prompt metadata
         if await self._prompt_exists(prompt_identifier):
@@ -1975,5 +1921,5 @@ class AsyncClient:
 
 
 def _exclude_none(d: dict) -> dict:
-    """Exclude None values from a dictionary."""
+    """Exclude `None` values from a dictionary."""
     return {k: v for k, v in d.items() if v is not None}

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -188,9 +188,9 @@ DEFAULT_INSTRUCTIONS = "How are people using my agent? What are they asking abou
 
 @lru_cache(maxsize=1)
 def _lc_load_allowed_objects_arg_supported() -> bool:
-    """Check if the installed langchain_core.load.load supports the 'allowed_objects' parameter.
+    """Check if the installed `langchain_core.load.load` supports the `allowed_objects` parameter.
 
-    Returns True if langchain-core >= 0.3.81 and < 1.0, or >= 1.2.5.
+    Returns `True` if `langchain-core >= 0.3.81` and `< 1.0`, or `>= 1.2.5`.
     """
     allowed_objects_supported = False
     try:
@@ -257,8 +257,8 @@ def _process_prompt_manifest(
 ) -> Any:
     """Process a prompt manifest into a LangChain prompt object.
 
-    This is the common logic shared between Client.pull_prompt() and
-    AsyncClient.pull_prompt().
+    This is the common logic shared between `Client.pull_prompt()` and
+    `AsyncClient.pull_prompt()`.
 
     Args:
         prompt_object: The prompt commit object containing the manifest.
@@ -270,7 +270,7 @@ def _process_prompt_manifest(
         The processed prompt object.
 
     Raises:
-        ImportError: If langchain-core is not installed.
+        ImportError: If `langchain-core` is not installed.
         ValueError: If secrets are required but not provided.
     """
     try:
@@ -418,10 +418,10 @@ def _is_langchain_hosted(url: str) -> bool:
     """Check if the URL is langchain hosted.
 
     Args:
-        url (str): The URL to check.
+        url: The URL to check.
 
     Returns:
-        bool: True if the URL is langchain hosted, False otherwise.
+        `True` if the URL is langchain hosted, `False` otherwise.
     """
     try:
         netloc = urllib_parse.urlsplit(url).netloc.split(":")[0]
@@ -440,10 +440,10 @@ RUN_TYPE_T = Literal[
 def _default_retry_config() -> Retry:
     """Get the default retry configuration.
 
-    If urllib3 version is 1.26 or greater, retry on all methods.
+    If `urllib3` version is `1.26` or greater, retry on all methods.
 
     Returns:
-        Retry: The default retry configuration.
+        The default retry configuration.
     """
     retry_params = dict(
         total=3,
@@ -472,7 +472,7 @@ def close_session(session: requests.Session) -> None:
     """Close the session.
 
     Args:
-        session (requests.Session): The session to close.
+        session: The session to close.
     """
     logger.debug("Closing Client.session")
     session.close()
@@ -482,11 +482,8 @@ def _validate_api_key_if_hosted(api_url: str, api_key: Optional[str]) -> None:
     """Verify API key is provided if url not localhost.
 
     Args:
-        api_url (str): The API URL.
-        api_key (Optional[str]): The API key.
-
-    Returns:
-        None
+        api_url: The API URL.
+        api_key: The API key.
 
     Raises:
         LangSmithUserError: If the API key is not provided when using the hosted service.
@@ -525,7 +522,7 @@ def _get_tracing_sampling_rate(
     """Get the tracing sampling rate.
 
     Returns:
-        Optional[float]: The tracing sampling rate.
+        The tracing sampling rate.
     """
     if tracing_sampling_rate is None:
         sampling_rate_str = ls_utils.get_env_var("TRACING_SAMPLING_RATE")
@@ -709,58 +706,69 @@ class Client:
         """Initialize a `Client` instance.
 
         Args:
-            api_url (Optional[str]): URL for the LangSmith API. Defaults to the `LANGCHAIN_ENDPOINT`
-                environment variable or `https://api.smith.langchain.com` if not set.
-            api_key (Optional[str]): API key for the LangSmith API. Defaults to the `LANGCHAIN_API_KEY`
-                environment variable.
-            retry_config (Optional[Retry]): Retry configuration for the `HTTPAdapter`.
-            timeout_ms (Optional[Union[int, Tuple[int, int]]]): Timeout for the `HTTPAdapter`.
+            api_url: URL for the LangSmith API.
 
-                Can also be a 2-tuple of `(connect timeout, read timeout)` to set them separately.
-            web_url (Optional[str]): URL for the LangSmith web app. Default is auto-inferred from
-                the `ENDPOINT`.
-            session (Optional[requests.Session]): The session to use for requests.
+                Defaults to the `LANGCHAIN_ENDPOINT` environment variable or
+                `https://api.smith.langchain.com` if not set.
+            api_key: API key for the LangSmith API.
+
+                Defaults to the `LANGCHAIN_API_KEY` environment variable.
+            retry_config: Retry configuration for the `HTTPAdapter`.
+            timeout_ms: Timeout for the `HTTPAdapter`.
+
+                Can also be a 2-tuple of `(connect timeout, read timeout)` to set them
+                separately.
+            web_url: URL for the LangSmith web app.
+
+                Default is auto-inferred from the `ENDPOINT`.
+            session: The session to use for requests.
 
                 If `None`, a new session will be created.
-            auto_batch_tracing (bool, default=True): Whether to automatically batch tracing.
-            anonymizer (Optional[Callable[[dict], dict]]): A function applied for masking serialized run inputs and outputs,
-                before sending to the API.
-            hide_inputs (Optional[Union[Callable[[dict], dict], bool]]): Whether to hide run inputs when tracing with this client.
+            auto_batch_tracing: Whether to automatically batch tracing.
+            anonymizer: A function applied for masking serialized run inputs and
+                outputs, before sending to the API.
+            hide_inputs: Whether to hide run inputs when tracing with this client.
 
                 If `True`, hides the entire inputs.
 
                 If a function, applied to all run inputs when creating runs.
-            hide_outputs (Optional[Union[Callable[[dict], dict], bool]]): Whether to hide run outputs when tracing with this client.
+            hide_outputs: Whether to hide run outputs when tracing with this client.
 
                 If `True`, hides the entire outputs.
 
                 If a function, applied to all run outputs when creating runs.
-            hide_metadata (Optional[Union[Callable[[dict], dict], bool]]): Whether to hide run metadata when tracing with this client.
+            hide_metadata: Whether to hide run metadata when tracing with this client.
 
                 If `True`, hides the entire metadata.
 
                 If a function, applied to all run metadata when creating runs.
-            omit_traced_runtime_info (bool): Whether to omit runtime information from traced runs.
+            omit_traced_runtime_info: Whether to omit runtime information from traced
+                runs.
 
-                If `True`, runtime information (SDK version, platform, Python version, etc.)
-                will not be stored in the `extra.runtime` field of runs.
+                If `True`, runtime information (SDK version, platform, Python version,
+                etc.) will not be stored in the `extra.runtime` field of runs.
 
                 Defaults to `False`.
-            process_buffered_run_ops (Optional[Callable[[Sequence[dict]], Sequence[dict]]]): A function applied to buffered run operations
-                that allows for modification of the raw run dicts before they are converted to multipart and compressed.
+            process_buffered_run_ops: A function applied to buffered run operations that
+                allows for modification of the raw run dicts before they are converted
+                to multipart and compressed.
 
-                Useful specifically for high throughput tracing where you need to apply a rate-limited API or other
-                costly process to the runs before they are sent to the API.
+                Useful specifically for high throughput tracing where you need to apply
+                a rate-limited API or other costly process to the runs before they are
+                sent to the API.
 
-                Note that the buffer will only flush automatically when `run_ops_buffer_size` is reached or a new run is added to the
-                buffer after `run_ops_buffer_timeout_ms` has elapsed - it will not flush outside of these conditions unless you manually
-                call `client.flush()`, so be sure to do this before your code exits.
-            run_ops_buffer_size (Optional[int]): Maximum number of run operations to collect in the buffer before applying
-                `process_buffered_run_ops` and sending to the API.
+                Note that the buffer will only flush automatically when
+                `run_ops_buffer_size` is reached or a new run is added to the buffer
+                after `run_ops_buffer_timeout_ms` has elapsed - it will not flush
+                outside of these conditions unless you manually call `client.flush()`,
+                so be sure to do this before your code exits.
+            run_ops_buffer_size: Maximum number of run operations to collect in the
+                buffer before applying `process_buffered_run_ops` and sending to the
+                API.
 
                 Required when `process_buffered_run_ops` is provided.
-            run_ops_buffer_timeout_ms (Optional[int]): Maximum time in milliseconds to wait before flushing the run ops buffer
-                when new runs are added.
+            run_ops_buffer_timeout_ms: Maximum time in milliseconds to wait before
+                flushing the run ops buffer when new runs are added.
 
                 Defaults to `5000`.
 
@@ -768,41 +776,50 @@ class Client:
             info: The information about the LangSmith API.
 
                 If not provided, it will be fetched from the API.
-            api_urls (Optional[Dict[str, str]]): A dictionary of write API URLs and their corresponding API keys.
+            api_urls: A dictionary of write API URLs and their corresponding API keys.
 
-                Useful for multi-tenant setups. Data is only read from the first
-                URL in the dictionary. However, ONLY Runs are written (`POST` and `PATCH`)
-                to all URLs in the dictionary. Feedback, sessions, datasets, examples,
-                annotation queues and evaluation results are only written to the first.
-            otel_tracer_provider (Optional[TracerProvider]): Optional tracer provider for OpenTelemetry integration.
+                Useful for multi-tenant setups.
+
+                Data is only read from the first URL in the dictionary. However, ONLY
+                Runs are written (`POST` and `PATCH`) to all URLs in the dictionary.
+                Feedback, sessions, datasets, examples, annotation queues and evaluation
+                results are only written to the first.
+            otel_tracer_provider: Optional tracer provider for OpenTelemetry
+                integration.
 
                 If not provided, a LangSmith-specific tracer provider will be used.
-            tracing_sampling_rate (Optional[float]): The sampling rate for tracing.
+            tracing_sampling_rate: The sampling rate for tracing.
 
-                If provided, overrides the `LANGCHAIN_TRACING_SAMPLING_RATE` environment variable.
+                If provided, overrides the `LANGCHAIN_TRACING_SAMPLING_RATE` environment
+                variable.
 
                 Should be a float between `0` and `1`, where `1` means trace everything
                 and `0` means trace nothing.
-            workspace_id (Optional[str]): The workspace ID.
+            workspace_id: The workspace ID.
 
                 Required for org-scoped API keys.
-            max_batch_size_bytes (Optional[int]): The maximum size of a batch of runs in bytes.
+            max_batch_size_bytes: The maximum size of a batch of runs in bytes.
 
                 If not provided, the default is set by the server.
-            headers (Optional[Dict[str, str]]): Additional HTTP headers to include in all requests.
-                These headers will be merged with the default headers (User-Agent, Accept, x-api-key, etc.).
-                Custom headers will not override the default required headers.
-            tracing_error_callback (Optional[Callable[[Exception], None]]): Optional callback function to handle errors.
+            headers: Additional HTTP headers to include in all requests.
+
+                These headers will be merged with the default headers (User-Agent,
+                Accept, x-api-key, etc.). Custom headers will not override the default
+                required headers.
+            tracing_error_callback: Optional callback function to handle errors.
 
                 Called when exceptions occur during tracing operations.
-            cache (Union[Cache, bool]): Configuration for caching. Can be:
+            cache: Configuration for caching.
 
-                - ``True``: Enable caching with default settings
-                - ``Cache`` instance: Use custom cache configuration
-                - ``False``: Disable caching (default)
+                Can be:
 
-                Example::
+                - `True`: Enable caching with default settings
+                - `Cache` instance: Use custom cache configuration
+                - `False`: Disable caching (default)
 
+                !!! example
+
+                    ```python
                     from langsmith import Client, Cache
 
                     # Enable with defaults
@@ -814,6 +831,7 @@ class Client:
                         ttl_seconds=3600,  # 1 hour, or None for infinite TTL
                     )
                     client = Client(cache=my_cache)
+                    ```
 
         Raises:
             LangSmithUserError: If the API key is not provided when using the hosted service.
@@ -1034,7 +1052,7 @@ class Client:
         """Return an HTML representation of the instance with a link to the URL.
 
         Returns:
-            str: The HTML representation of the instance.
+            The HTML representation of the instance.
         """
         link = self._host_url
         return f'<a href="{link}", target="_blank" rel="noopener">LangSmith Client</a>'
@@ -1058,7 +1076,7 @@ class Client:
         """Return a string representation of the instance with a link to the URL.
 
         Returns:
-            str: The string representation of the instance.
+            The string representation of the instance.
         """
         return f"Client (API URL: {self.api_url})"
 
@@ -1149,7 +1167,7 @@ class Client:
         """Get the settings for the current tenant.
 
         Returns:
-            dict: The settings for the current tenant.
+            The settings for the current tenant.
         """
         if self._settings is None:
             response = self.request_with_retries("GET", "/settings")
@@ -1192,17 +1210,18 @@ class Client:
         """Send a request with retries.
 
         Args:
-            method (str): The HTTP request method.
-            pathname (str): The pathname of the request URL. Will be appended to the API URL.
-            request_kwargs (Mapping): Additional request parameters.
-            stop_after_attempt (int, default=1): The number of attempts to make.
-            retry_on (Optional[Sequence[Type[BaseException]]]): The exceptions to retry on.
+            method: The HTTP request method.
+            pathname: The pathname of the request URL. Will be appended to the API URL.
+            request_kwargs: Additional request parameters.
+            stop_after_attempt: The number of attempts to make.
+            retry_on: The exceptions to retry on.
 
                 In addition to: `[LangSmithConnectionError, LangSmithAPIError]`.
-            to_ignore (Optional[Sequence[Type[BaseException]]]): The exceptions to ignore / pass on.
-            handle_response (Optional[Callable[[requests.Response, int], Any]]): A function to handle the response and return whether to continue retrying.
-            _context (str, default=""): The context of the request.
-            **kwargs (Any): Additional keyword arguments to pass to the request.
+            to_ignore: The exceptions to ignore / pass on.
+            handle_response: A function to handle the response and return whether to
+                continue retrying.
+            _context: The context of the request.
+            **kwargs: Additional keyword arguments to pass to the request.
 
         Returns:
             The response object.
@@ -1416,8 +1435,8 @@ class Client:
         """Get a paginated list of items.
 
         Args:
-            path (str): The path of the request URL.
-            params (Optional[dict]): The query parameters.
+            path: The path of the request URL.
+            params: The query parameters.
 
         Yields:
             The items in the paginated list.
@@ -1453,10 +1472,10 @@ class Client:
         """Get a cursor paginated list of items.
 
         Args:
-            path (str): The path of the request URL.
-            body (Optional[dict]): The query body.
-            request_method (Literal["GET", "POST"], default="POST"): The HTTP request method.
-            data_key (str, default="runs"): The key in the response body that contains the items.
+            path: The path of the request URL.
+            body: The query body.
+            request_method: The HTTP request method.
+            data_key: The key in the response body that contains the items.
 
         Yields:
             The items in the paginated list.
@@ -1496,15 +1515,15 @@ class Client:
         """Upload a dataframe as individual examples to the LangSmith API.
 
         Args:
-            df (pd.DataFrame): The dataframe to upload.
-            name (str): The name of the dataset.
-            input_keys (Sequence[str]): The input keys.
-            output_keys (Sequence[str]): The output keys.
-            description (Optional[str]): The description of the dataset.
-            data_type (Optional[DataType]): The data type of the dataset.
+            df: The dataframe to upload.
+            name: The name of the dataset.
+            input_keys: The input keys.
+            output_keys: The output keys.
+            description: The description of the dataset.
+            data_type: The data type of the dataset.
 
         Returns:
-            Dataset: The uploaded dataset.
+            The uploaded dataset.
 
         Raises:
             ValueError: If the `csv_file` is not a `str` or `tuple`.
@@ -1556,20 +1575,20 @@ class Client:
         """Upload a CSV file to the LangSmith API.
 
         Args:
-            csv_file (Union[str, Tuple[str, io.BytesIO]]): The CSV file to upload.
+            csv_file: The CSV file to upload.
 
                 If a string, it should be the path.
 
-                If a tuple, it should be a tuple containing the filename
-                and a `BytesIO` object.
-            input_keys (Sequence[str]): The input keys.
-            output_keys (Sequence[str]): The output keys.
-            name (Optional[str]): The name of the dataset.
-            description (Optional[str]): The description of the dataset.
-            data_type (Optional[ls_schemas.DataType]): The data type of the dataset.
+                If a tuple, it should be a tuple containing the filename and a `BytesIO`
+                object.
+            input_keys: The input keys.
+            output_keys: The output keys.
+            name: The name of the dataset.
+            description: The description of the dataset.
+            data_type: The data type of the dataset.
 
         Returns:
-            Dataset: The uploaded dataset.
+            The uploaded dataset.
 
         Raises:
             ValueError: If the `csv_file` is not a string or tuple.
@@ -1646,12 +1665,12 @@ class Client:
         """Transform the given run object into a dictionary representation.
 
         Args:
-            run (Union[ls_schemas.Run, dict]): The run object to transform.
-            update (Optional[bool]): Whether the payload is for an "update" event.
-            copy (Optional[bool]): Whether to deepcopy run inputs/outputs.
+            run: The run object to transform.
+            update: Whether the payload is for an "update" event.
+            copy: Whether to deepcopy run inputs/outputs.
 
         Returns:
-            dict: The transformed run object as a dictionary.
+            The transformed run object as a dictionary.
         """
         if hasattr(run, "model_dump") and callable(getattr(run, "model_dump")):
             run_create: dict = run.model_dump()  # type: ignore
@@ -3105,32 +3124,32 @@ class Client:
         """List runs from the LangSmith API.
 
         Args:
-            project_id (Optional[Union[UUID, str], Sequence[Union[UUID, str]]]):
-                The ID(s) of the project to filter by.
-            project_name (Optional[Union[str, Sequence[str]]]): The name(s) of the project to filter by.
-            run_type (Optional[str]): The type of the runs to filter by.
-            trace_id (Optional[Union[UUID, str]]): The ID of the trace to filter by.
-            reference_example_id (Optional[Union[UUID, str]]): The ID of the reference example to filter by.
-            query (Optional[str]): The query string to filter by.
-            filter (Optional[str]): The filter string to filter by.
-            trace_filter (Optional[str]): Filter to apply to the ROOT run in the trace tree. This is meant to
-                be used in conjunction with the regular `filter` parameter to let you
-                filter runs by attributes of the root run within a trace.
-            tree_filter (Optional[str]): Filter to apply to OTHER runs in the trace tree, including
-                sibling and child runs. This is meant to be used in conjunction with
-                the regular `filter` parameter to let you filter runs by attributes
-                of any run within a trace.
-            is_root (Optional[bool]): Whether to filter by root runs.
-            parent_run_id (Optional[Union[UUID, str]]):
-                The ID of the parent run to filter by.
-            start_time (Optional[datetime.datetime]):
-                The start time to filter by.
-            error (Optional[bool]): Whether to filter by error status.
-            run_ids (Optional[Sequence[Union[UUID, str]]]):
-                The IDs of the runs to filter by.
-            select (Optional[Sequence[str]]): The fields to select.
-            limit (Optional[int]): The maximum number of runs to return.
-            **kwargs (Any): Additional keyword arguments.
+            project_id: The ID(s) of the project to filter by.
+            project_name: The name(s) of the project to filter by.
+            run_type: The type of the runs to filter by.
+            trace_id: The ID of the trace to filter by.
+            reference_example_id: The ID of the reference example to filter by.
+            query: The query string to filter by.
+            filter: The filter string to filter by.
+            trace_filter: Filter to apply to the ROOT run in the trace tree.
+
+                This is meant to be used in conjunction with the regular `filter`
+                parameter to let you filter runs by attributes of the root run within a
+                trace.
+            tree_filter: Filter to apply to OTHER runs in the trace tree, including
+                sibling and child runs.
+
+                This is meant to be used in conjunction with the regular `filter`
+                parameter to let you filter runs by attributes of any run within a
+                trace.
+            is_root: Whether to filter by root runs.
+            parent_run_id: The ID of the parent run to filter by.
+            start_time: The start time to filter by.
+            error: Whether to filter by error status.
+            run_ids: The IDs of the runs to filter by.
+            select: The fields to select.
+            limit: The maximum number of runs to return.
+            **kwargs: Additional keyword arguments.
 
         Yields:
             The runs.
@@ -9271,7 +9290,7 @@ def convert_prompt_to_openai_format(
             `stop` and any other required arguments.
 
     Returns:
-        dict: The prompt in OpenAI format.
+        The prompt in OpenAI format.
 
     Raises:
         ImportError: If the `langchain_openai` package is not installed.
@@ -9310,7 +9329,7 @@ def convert_prompt_to_anthropic_format(
             Model configuration arguments including `model_name` and `stop`.
 
     Returns:
-        dict: The prompt in Anthropic format.
+        The prompt in Anthropic format.
     """
     try:
         from langchain_anthropic import ChatAnthropic  # type: ignore


### PR DESCRIPTION
some general cleanup work to fix the API reference docs (notably, numpy style docstrings are not parsed correctly)

also removal of types/defaults in param descriptions where they can be inferred from signatures

<img width="990" height="651" alt="Screenshot" src="https://github.com/user-attachments/assets/2efd027b-9f9d-4fba-a808-6bc245ad3f9e" />