### PR TITLE
Bump version: 0.6.3 → 0.6.4

### DIFF
--- a/python/.bumpversion.cfg
+++ b/python/.bumpversion.cfg
@@ -1,15 +1,11 @@
 [bumpversion]
-current_version = 0.6.3
+current_version = 0.6.4
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
 serialize = {major}.{minor}.{patch}
 search = {current_version}
 replace = {new_version}
 commit = True
 tag = True
-
-[bumpversion:file:pyproject.toml]
-search = version = "{current_version}"
-replace = version = "{new_version}"
 
 [bumpversion:file:langsmith/__init__.py]
 search = __version__ = "{current_version}"

--- a/python/langsmith/__init__.py
+++ b/python/langsmith/__init__.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
 
 # Avoid calling into importlib on every call to __version__
 
-__version__ = "0.6.3"
+__version__ = "0.6.4"
 version = __version__  # for backwards compatibility
 
 


### PR DESCRIPTION
Bump versions
Also removes the broken dependency in `python/.bumpversion.cfg`

```
[bumpversion:file:pyproject.toml]
search = version = "{current_version}"
replace = version = "{new_version}"
```