### PR TITLE
fix(sandbox): endpoint for python async

### DIFF
--- a/python/langsmith/sandbox/README.md
+++ b/python/langsmith/sandbox/README.md
@@ -46,7 +46,7 @@ client = SandboxClient()
 
 # Or configure explicitly
 client = SandboxClient(
-    api_endpoint="https://api.smith.langchain.com/api/v2/sandboxes",
+    api_endpoint="https://api.smith.langchain.com/v2/sandboxes",
     api_key="your-api-key",
     timeout=30.0,
 )

--- a/python/langsmith/sandbox/_async_client.py
+++ b/python/langsmith/sandbox/_async_client.py
@@ -32,7 +32,7 @@ def _get_default_api_endpoint() -> str:
     Derives the endpoint from LANGSMITH_ENDPOINT (or LANGCHAIN_ENDPOINT).
     """
     base = ls_utils.get_env_var("ENDPOINT", default="https://api.smith.langchain.com")
-    return f"{base.rstrip('/')}/api/v2/sandboxes"
+    return f"{base.rstrip('/')}/v2/sandboxes"
 
 
 def _get_default_api_key() -> Optional[str]:

--- a/python/langsmith/sandbox/_client.py
+++ b/python/langsmith/sandbox/_client.py
@@ -51,7 +51,7 @@ class SandboxClient:
 
         # Or with explicit configuration
         client = SandboxClient(
-            api_endpoint="https://api.smith.langchain.com/api/v2/sandboxes",
+            api_endpoint="https://api.smith.langchain.com/v2/sandboxes",
             api_key="your-api-key",
         )
 

--- a/python/tests/unit_tests/sandbox/test_async_client.py
+++ b/python/tests/unit_tests/sandbox/test_async_client.py
@@ -49,17 +49,17 @@ class TestAsyncSandboxClientInit:
         """Test endpoint derivation from LANGSMITH_ENDPOINT."""
         with patch(
             "langsmith.sandbox._async_client._get_default_api_endpoint",
-            return_value="https://custom.langsmith.com/api/v2/sandboxes",
+            return_value="https://custom.langsmith.com/v2/sandboxes",
         ):
             client = AsyncSandboxClient()
-            assert client._base_url == "https://custom.langsmith.com/api/v2/sandboxes"
+            assert client._base_url == "https://custom.langsmith.com/v2/sandboxes"
             await client.aclose()
 
     async def test_explicit_endpoint_overrides_env(self):
         """Test explicit endpoint overrides environment variable."""
         with patch(
             "langsmith.sandbox._async_client._get_default_api_endpoint",
-            return_value="https://env.langsmith.com/api/v2/sandboxes",
+            return_value="https://env.langsmith.com/v2/sandboxes",
         ):
             client = AsyncSandboxClient(api_endpoint="http://explicit:8080")
             assert client._base_url == "http://explicit:8080"

--- a/python/tests/unit_tests/sandbox/test_client.py
+++ b/python/tests/unit_tests/sandbox/test_client.py
@@ -48,27 +48,27 @@ class TestSandboxClientInit:
         """Test endpoint derivation from LANGSMITH_ENDPOINT."""
         with patch(
             "langsmith.sandbox._client._get_default_api_endpoint",
-            return_value="https://custom.langsmith.com/api/v2/sandboxes",
+            return_value="https://custom.langsmith.com/v2/sandboxes",
         ):
             client = SandboxClient()
-            assert client._base_url == "https://custom.langsmith.com/api/v2/sandboxes"
+            assert client._base_url == "https://custom.langsmith.com/v2/sandboxes"
             client.close()
 
     def test_derives_endpoint_from_langchain_endpoint(self):
         """Test endpoint derivation from LANGCHAIN_ENDPOINT (fallback)."""
         with patch(
             "langsmith.sandbox._client._get_default_api_endpoint",
-            return_value="https://custom.langchain.com/api/v2/sandboxes",
+            return_value="https://custom.langchain.com/v2/sandboxes",
         ):
             client = SandboxClient()
-            assert client._base_url == "https://custom.langchain.com/api/v2/sandboxes"
+            assert client._base_url == "https://custom.langchain.com/v2/sandboxes"
             client.close()
 
     def test_explicit_endpoint_overrides_env(self):
         """Test explicit endpoint overrides environment variable."""
         with patch(
             "langsmith.sandbox._client._get_default_api_endpoint",
-            return_value="https://env.langsmith.com/api/v2/sandboxes",
+            return_value="https://env.langsmith.com/v2/sandboxes",
         ):
             client = SandboxClient(api_endpoint="http://explicit:8080")
             assert client._base_url == "http://explicit:8080"


### PR DESCRIPTION
Fix the detault endpoint used by the python async lib when interacting with sandboxes
