### PR TITLE
fix(deps): resolve glob CLI command injection (CVE-2025-64756)

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -444,6 +444,9 @@
     },
     "./package.json": "./package.json"
   },
+  "resolutions": {
+    "rimraf/**/glob": "10.5.0"
+  },
   "browser": {
     "./dist/utils/prompts_cache_fs.js": "./dist/utils/prompts_cache_fs.browser.js"
   }

--- a/js/yarn.lock
+++ b/js/yarn.lock
@@ -4785,10 +4785,10 @@ glob-parent@^6.0.2:
   dependencies:
     is-glob "^4.0.3"
 
-glob@^10.3.7:
-  version "10.4.5"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-10.4.5.tgz#f4d9f0b90ffdbab09c9d77f5f29b4262517b0956"
-  integrity sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==
+glob@10.5.0, glob@^10.3.7:
+  version "10.5.0"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-10.5.0.tgz#8ec0355919cd3338c28428a23d4f24ecc5fe738c"
+  integrity sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==
   dependencies:
     foreground-child "^3.1.0"
     jackspeak "^3.1.2"


### PR DESCRIPTION
## Summary
- high severity command injection in `glob` CLI's `-c/--cmd` option 
- Pins `glob` to `10.5.0` via yarn resolutions scoped to `rimraf/**/glob`, leaving `glob@^7.x` unaffected
- Dependency chain: `gaxios@^7.0.0` → `rimraf@^5.0.1` → `glob@^10.3.7` → `glob@10.4.5` (vulnerable)


🤖 Generated with [Claude Code](https://claude.com/claude-code)