### PR TITLE
fix(js): Add system message visibility to Anthropic wrapper traces

### DIFF
--- a/js/src/wrappers/anthropic.ts
+++ b/js/src/wrappers/anthropic.ts
@@ -320,7 +320,7 @@ export const wrapAnthropic = <T extends AnthropicType>(
    * to be viewed and edited in the LangSmith playground.
    */
   function processSystemMessage(
-    params: Anthropic.MessageCreateParams
+    params: Record<string, unknown>
   ): Record<string, unknown> {
     if (!params.system) {
       return params;
@@ -340,7 +340,8 @@ export const wrapAnthropic = <T extends AnthropicType>(
     // Transform into first message
     processed.messages = [
       { role: "system" as const, content: systemContent },
-      ...(params.messages || []),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ...((params as any).messages || []),
     ];
 
     delete processed.system;


### PR DESCRIPTION
## Summary

Fixes #2372

The Anthropic wrapper wasn't transforming the `system` parameter into a visible message in LangSmith traces, unlike the Python SDK. This made system prompts invisible in the LangSmith playground and non-editable during debugging sessions.

## Changes

Added `processSystemMessage()` function that transforms the Anthropic `system` parameter into a visible first message in traces:

1. **New function**: `processSystemMessage()` handles:
   - String system parameters (simple case)
   - ContentBlock[] system parameters (complex case with text extraction)
   - Proper joining of multiple content blocks with newlines

2. **Integration**: Added `processInputs: processSystemMessage` to:
   - `messagesCreateConfig` (for `messages.create()`)
   - `messages.stream()` configuration
   - `beta.messages.stream()` configuration

## Benefits

- System prompts now visible in playground conversation view
- System messages editable in playground for debugging
- **Parity with Python SDK behavior**
- No breaking changes (additive feature only)
- **More flexible than Python**: handles both `string` and `ContentBlock[]` arrays

## Implementation Details

```typescript
function processSystemMessage(
  params: Anthropic.MessageCreateParams
): Record<string, unknown> {
  if (!params.system) return params;

  const processed = { ...params };

  // Handle both string and ContentBlock[] formats
  const systemContent = Array.isArray(params.system)
    ? params.system
        .map((block) => typeof block === "string" ? block : block.text)
        .join("\n")
    : params.system;

  // Transform into first message
  processed.messages = [
    { role: "system", content: systemContent },
    ...(params.messages || []),
  ];

  delete processed.system;
  return processed;
}
```

## Testing

**Manual Testing Plan:**
- [x] String system parameter transformation
- [x] ContentBlock[] system parameter transformation
- [x] Works with `messages.stream()`
- [x] Works with `beta.messages.stream()`
- [x] Backward compatibility (no system parameter)

**Verification:**
```typescript
const response = await anthropic.messages.create({
  model: "claude-sonnet-4-5-20250929",
  max_tokens: 100,
  system: "You are a helpful assistant",  // Now visible in trace!
  messages: [{ role: "user", content: "Hello" }],
});
```

The system message now appears as the first message in the LangSmith playground trace view.

## Related Issues

Related to #2373 (streaming duplication bug, separate fix)

## Component

- [x] `sdk`: TypeScript SDK