### PR TITLE
feat(js): add feedback config CRUD and annotation queue rubric items (closes LSPE-67)

### DIFF
--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -51,6 +51,8 @@ import {
   AttachmentData,
   DatasetVersion,
   AnnotationQueueWithDetails,
+  AnnotationQueueRubricItem,
+  FeedbackConfigSchema,
 } from "./schemas.js";
 import {
   convertLangChainMessageToExample,
@@ -4573,6 +4575,146 @@ export class Client implements LangSmithTracingClientInterface {
   }
 
   /**
+   * API for managing feedback configs
+   */
+
+  /**
+   * Create a feedback configuration on the LangSmith API.
+   *
+   * This upserts: if an identical config already exists, it returns it.
+   * If a conflicting config exists for the same key, a 400 error is raised.
+   *
+   * @param options - The options for creating a feedback config
+   * @param options.feedbackKey - The unique key for this feedback config
+   * @param options.feedbackConfig - The config specifying type, bounds, and categories
+   * @param options.isLowerScoreBetter - Whether a lower score is better
+   * @returns The created FeedbackConfigSchema object
+   */
+  public async createFeedbackConfig(options: {
+    feedbackKey: string;
+    feedbackConfig: FeedbackConfig;
+    isLowerScoreBetter?: boolean;
+  }): Promise<FeedbackConfigSchema> {
+    const { feedbackKey, feedbackConfig, isLowerScoreBetter = false } = options;
+    const body = {
+      feedback_key: feedbackKey,
+      feedback_config: feedbackConfig,
+      is_lower_score_better: isLowerScoreBetter,
+    };
+
+    const response = await this.caller.call(async () => {
+      const res = await this._fetch(`${this.apiUrl}/feedback-configs`, {
+        method: "POST",
+        headers: { ...this.headers, "Content-Type": "application/json" },
+        signal: AbortSignal.timeout(this.timeout_ms),
+        ...this.fetchOptions,
+        body: JSON.stringify(body),
+      });
+      await raiseForStatus(res, "create feedback config");
+      return res;
+    });
+    return response.json();
+  }
+
+  /**
+   * List feedback configurations on the LangSmith API.
+   * @param options - The options for listing feedback configs
+   * @param options.feedbackKeys - Filter by specific feedback keys
+   * @param options.nameContains - Filter by name substring
+   * @param options.limit - The maximum number of configs to return
+   * @returns An async iterator of FeedbackConfigSchema objects
+   */
+  public async *listFeedbackConfigs(
+    options: {
+      feedbackKeys?: string[];
+      nameContains?: string;
+      limit?: number;
+    } = {}
+  ): AsyncIterableIterator<FeedbackConfigSchema> {
+    const { feedbackKeys, nameContains, limit } = options;
+    const params = new URLSearchParams();
+    if (feedbackKeys) {
+      feedbackKeys.forEach((key) => {
+        params.append("key", key);
+      });
+    }
+    if (nameContains) params.append("name_contains", nameContains);
+    params.append(
+      "limit",
+      (limit !== undefined ? Math.min(limit, 100) : 100).toString()
+    );
+
+    let count = 0;
+    for await (const configs of this._getPaginated<FeedbackConfigSchema>(
+      "/feedback-configs",
+      params
+    )) {
+      yield* configs;
+      count += configs.length;
+      if (limit !== undefined && count >= limit) break;
+    }
+  }
+
+  /**
+   * Update a feedback configuration on the LangSmith API.
+   * @param feedbackKey - The key of the feedback config to update
+   * @param options - The options for updating the feedback config
+   * @param options.feedbackConfig - The new feedback config
+   * @param options.isLowerScoreBetter - Whether a lower score is better
+   * @returns The updated FeedbackConfigSchema object
+   */
+  public async updateFeedbackConfig(
+    feedbackKey: string,
+    options: {
+      feedbackConfig?: FeedbackConfig;
+      isLowerScoreBetter?: boolean;
+    } = {}
+  ): Promise<FeedbackConfigSchema> {
+    const { feedbackConfig, isLowerScoreBetter } = options;
+    const body: Record<string, unknown> = { feedback_key: feedbackKey };
+    if (feedbackConfig !== undefined) {
+      body.feedback_config = feedbackConfig;
+    }
+    if (isLowerScoreBetter !== undefined) {
+      body.is_lower_score_better = isLowerScoreBetter;
+    }
+
+    const response = await this.caller.call(async () => {
+      const res = await this._fetch(`${this.apiUrl}/feedback-configs`, {
+        method: "PATCH",
+        headers: { ...this.headers, "Content-Type": "application/json" },
+        signal: AbortSignal.timeout(this.timeout_ms),
+        ...this.fetchOptions,
+        body: JSON.stringify(body),
+      });
+      await raiseForStatus(res, "update feedback config");
+      return res;
+    });
+    return response.json();
+  }
+
+  /**
+   * Delete a feedback configuration on the LangSmith API.
+   * @param feedbackKey - The key of the feedback config to delete
+   */
+  public async deleteFeedbackConfig(feedbackKey: string): Promise<void> {
+    const params = new URLSearchParams({ feedback_key: feedbackKey });
+    await this.caller.call(async () => {
+      const res = await this._fetch(
+        `${this.apiUrl}/feedback-configs?${params}`,
+        {
+          method: "DELETE",
+          headers: this.headers,
+          signal: AbortSignal.timeout(this.timeout_ms),
+          ...this.fetchOptions,
+        }
+      );
+      await raiseForStatus(res, "delete feedback config", true);
+      return res;
+    });
+  }
+
+  /**
    * API for managing annotation queues
    */
 
@@ -4632,13 +4774,16 @@ export class Client implements LangSmithTracingClientInterface {
     description?: string;
     queueId?: string;
     rubricInstructions?: string;
+    rubricItems?: AnnotationQueueRubricItem[];
   }): Promise<AnnotationQueueWithDetails> {
-    const { name, description, queueId, rubricInstructions } = options;
-    const body = {
+    const { name, description, queueId, rubricInstructions, rubricItems } =
+      options;
+    const body: Record<string, unknown> = {
       name,
       description,
       id: queueId || uuid.v4(),
       rubric_instructions: rubricInstructions,
+      rubric_items: rubricItems,
     };
 
     const serializedBody = JSON.stringify(
@@ -4694,17 +4839,20 @@ export class Client implements LangSmithTracingClientInterface {
   public async updateAnnotationQueue(
     queueId: string,
     options: {
-      name: string;
+      name?: string;
       description?: string;
       rubricInstructions?: string;
+      rubricItems?: AnnotationQueueRubricItem[];
     }
   ): Promise<void> {
-    const { name, description, rubricInstructions } = options;
-    const body = JSON.stringify({
-      name,
-      description,
-      rubric_instructions: rubricInstructions,
-    });
+    const { name, description, rubricInstructions, rubricItems } = options;
+    const bodyObj: Record<string, unknown> = {};
+    if (name !== undefined) bodyObj.name = name;
+    if (description !== undefined) bodyObj.description = description;
+    if (rubricInstructions !== undefined)
+      bodyObj.rubric_instructions = rubricInstructions;
+    if (rubricItems !== undefined) bodyObj.rubric_items = rubricItems;
+    const body = JSON.stringify(bodyObj);
     await this.caller.call(async () => {
       const res = await this._fetch(
         `${this.apiUrl}/annotation-queues/${assertUuid(queueId, "queueId")}`,

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -10,6 +10,7 @@ export type {
   TracerSession,
   Run,
   Feedback,
+  FeedbackConfigSchema,
   RetrieverOutput,
 } from "./schemas.js";
 

--- a/js/src/schemas.ts
+++ b/js/src/schemas.ts
@@ -573,9 +573,46 @@ export interface AnnotationQueue {
   tenant_id: string;
 }
 
+export interface AnnotationQueueRubricItem {
+  /** The feedback key this rubric item is associated with. */
+  feedback_key: string;
+
+  /** An optional description of the rubric item. */
+  description?: string | null;
+
+  /** Descriptions for categorical values. */
+  value_descriptions?: Record<string, string> | null;
+
+  /** Descriptions for continuous score values. */
+  score_descriptions?: Record<string, string> | null;
+
+  /** Whether this rubric item is required. */
+  is_required?: boolean | null;
+}
+
 export interface AnnotationQueueWithDetails extends AnnotationQueue {
   /** The rubric instructions for the annotation queue. */
   rubric_instructions?: string;
+
+  /** The rubric items for the annotation queue. */
+  rubric_items?: AnnotationQueueRubricItem[];
+}
+
+export interface FeedbackConfigSchema {
+  /** The unique key identifying this feedback configuration. */
+  feedback_key: string;
+
+  /** The configuration specifying the type, bounds, and categories. */
+  feedback_config: FeedbackConfig;
+
+  /** The ID of the tenant that owns this feedback configuration. */
+  tenant_id: string;
+
+  /** When this feedback configuration was last modified. */
+  modified_at: string;
+
+  /** Whether a lower score is considered better for this feedback key. */
+  is_lower_score_better?: boolean | null;
 }
 
 export interface RunWithAnnotationQueueInfo extends BaseRun {


### PR DESCRIPTION
## Summary
- Add `createFeedbackConfig`, `listFeedbackConfigs`, `updateFeedbackConfig`, `deleteFeedbackConfig` methods to the JS SDK `Client`
- Add `FeedbackConfigSchema` and `AnnotationQueueRubricItem` types to `schemas.ts`
- Add `rubricItems` parameter to `createAnnotationQueue` and `updateAnnotationQueue`
- Make `name` optional on `updateAnnotationQueue` (matches backend schema)
- Export `FeedbackConfigSchema` from package index

## Why this approach?
Mirrors the Python SDK implementation from PR #2419. Follows existing JS SDK patterns — async generators for list methods via `_getPaginated`, `caller.call` + `_fetch` for HTTP, camelCase public API with snake_case wire format.

## Test Plan
- [x] `yarn test:integration --testNamePattern="feedback config crud"` passes
- [x] `yarn build` succeeds
- [x] `yarn lint` passes (0 errors)