### PR TITLE
fix: propagate tracingEnabled to nested traceables

### DIFF
--- a/js/src/singletons/types.ts
+++ b/js/src/singletons/types.ts
@@ -82,4 +82,5 @@ export type RunTreeLike = RunTree;
 
 export type ContextPlaceholder = {
   [_LC_CONTEXT_VARIABLES_KEY]?: Record<string, unknown>;
+  tracingEnabled?: boolean;
 };


### PR DESCRIPTION
## Summary

Fixes a bug where nested `traceable` calls would still produce traces even when an ancestor `traceable` had `tracingEnabled: false`, because the `ContextPlaceholder` stored in `AsyncLocalStorage` did not carry the disabled tracing signal.

This is the langsmith-sdk side of a two-part fix: https://github.com/langchain-ai/langchainjs/pull/10044

## Changes

### `js/src/traceable.ts`

1. **`getTracingRunTree`**: When tracing is disabled, the returned `ContextPlaceholder` now carries `{ tracingEnabled: runTree.tracingEnabled }` instead of an empty `{}`. This preserves the disabled signal for downstream consumers.

2. **Child config inheritance**: When a child `traceable` runs inside a parent that stored a `ContextPlaceholder` with `tracingEnabled: false`, and the child didn't explicitly set `tracingEnabled`, the child's config now inherits `tracingEnabled: false` from the parent context.

### `js/src/singletons/types.ts`

- Added optional `tracingEnabled?: boolean` property to `ContextPlaceholder` type so it can carry the tracing signal.