### PR TITLE
fix(python): LLM runs orphaned after first yield in Claude Agent SDK

### DIFF
--- a/python/langsmith/integrations/claude_agent_sdk/_client.py
+++ b/python/langsmith/integrations/claude_agent_sdk/_client.py
@@ -14,7 +14,7 @@ from ._messages import (
     extract_usage_from_result_message,
     flatten_content_blocks,
 )
-from ._tools import clear_parent_run_tree, set_parent_run_tree
+from ._tools import clear_parent_run_tree, get_parent_run_tree, set_parent_run_tree
 
 logger = logging.getLogger(__name__)
 
@@ -85,7 +85,7 @@ def begin_llm_run_from_assistant_messages(
     last_msg = messages[-1]
     model = getattr(last_msg, "model", None)
     if parent is None:
-        parent = get_current_run_tree()
+        parent = get_parent_run_tree() or get_current_run_tree()
     if not parent:
         return None, None
 


### PR DESCRIPTION
## Summary

- Fixes `begin_llm_run_from_assistant_messages` losing its parent run after the first async yield in `receive_response()`, causing subsequent LLM turns to be orphaned or silently dropped
- Uses `get_parent_run_tree()` (thread-local) as the primary fallback before `get_current_run_tree()` (contextvar), matching the pattern already used in `pre_tool_use_hook()`

Fixes #2431

🤖 Generated with [Claude Code](https://claude.com/claude-code)