### PR TITLE
fix(google-adk): add wrapt dependency

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -57,6 +57,9 @@ openai-agents = ["openai-agents>=0.0.3"]
 # Enabled via `pip install langsmith[claude-agent-sdk]`
 claude-agent-sdk = ["claude-agent-sdk>=0.1.0; python_version>='3.10'"]
 
+# Enabled via `pip install langsmith[google-adk]`
+google-adk = ["google-adk>=1.0.0", "wrapt>=1.16.0"]
+
 # Enabled via `pip install langsmith[pytest]`
 pytest = ["pytest>=7.0.0", "rich>=13.9.4", "vcrpy>=7.0.0"]
 
@@ -108,6 +111,7 @@ dev = [
     "pillow>=12.0.0",
     "ty==0.0.16",
     "pytest-httpx>=0.30.0",
+    "wrapt>=1.16.0",
 ]
 
 # Linting dependencies

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -925,6 +925,9 @@ dependencies = [
 claude-agent-sdk = [
     { name = "claude-agent-sdk" },
 ]
+google-adk = [
+    { name = "wrapt" },
+]
 langsmith-pyo3 = [
     { name = "langsmith-pyo3" },
 ]
@@ -989,6 +992,7 @@ dev = [
     { name = "types-tqdm" },
     { name = "uvicorn" },
     { name = "vcrpy" },
+    { name = "wrapt" },
 ]
 lint = [
     { name = "openai" },
@@ -1017,10 +1021,11 @@ requires-dist = [
     { name = "uuid-utils", specifier = ">=0.12.0,<1.0" },
     { name = "vcrpy", marker = "extra == 'pytest'", specifier = ">=7.0.0" },
     { name = "vcrpy", marker = "extra == 'vcr'", specifier = ">=7.0.0" },
+    { name = "wrapt", marker = "extra == 'google-adk'", specifier = ">=1.16.0" },
     { name = "xxhash", specifier = ">=3.0.0" },
     { name = "zstandard", specifier = ">=0.23.0" },
 ]
-provides-extras = ["claude-agent-sdk", "langsmith-pyo3", "openai-agents", "otel", "pytest", "vcr"]
+provides-extras = ["claude-agent-sdk", "google-adk", "langsmith-pyo3", "openai-agents", "otel", "pytest", "vcr"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1066,6 +1071,7 @@ dev = [
     { name = "types-tqdm", specifier = ">=4.66.0.20240106" },
     { name = "uvicorn", specifier = ">=0.29.0" },
     { name = "vcrpy", specifier = ">=7.0.0" },
+    { name = "wrapt", specifier = ">=1.16.0" },
 ]
 lint = [{ name = "openai", specifier = ">=2.6.0" }]
 test = [


### PR DESCRIPTION
Add `google-adk` optional dependency to install:
- `wrapt`: will fix the `Missing dependency: No module named 'wrapt'` warning when following [our official ADK tracing guide](https://docs.langchain.com/langsmith/trace-with-google-adk). Tracing isn't working without it.
- `google-adk>=1.0.0`: to follow the same pattern as `openai-agents` and `claude-agent-sdk`.

I will fix the doc to replace:
```diff
- uv add langsmith google-adk
+ uv add langsmith[google-adk]
```

## MRE
```console
❯ uv run main.py
Missing dependency: No module named 'wrapt'
Warning: there are non-text parts in the response: ['function_call'], returning concatenated text result from text parts. Check the full candidates.content.parts accessor to get the full model response.
Text: The weather in San Francisco is Sunny with a temperature of 72°F.

# Fixing pyproject.toml to use my local branch:
# [tool.uv.sources]
# langsmith = { path = "../../../../github.com/langchain/langsmith-sdk/python", editable = true }

❯ uv sync
Resolved 121 packages in 75ms
Uninstalled 1 package in 19ms
Installed 2 packages in 3ms
 - langsmith==0.7.3
 + langsmith==0.7.3 (from file:///XXX/github.com/langchain/langsmith-sdk/python)
 + wrapt==2.1.1
 
❯ uv run main.py
Text: The weather in San Francisco is Sunny with a temperature of 72°F.
```
