### PR TITLE
feat(python): add CommandHandle for streaming, kill, stdin, and reconnect

### DIFF
--- a/python/langsmith/sandbox/__init__.py
+++ b/python/langsmith/sandbox/__init__.py
@@ -45,7 +45,10 @@ from langsmith.sandbox._exceptions import (
     ValidationError,
 )
 from langsmith.sandbox._models import (
+    AsyncCommandHandle,
+    CommandHandle,
     ExecutionResult,
+    OutputChunk,
     Pool,
     ResourceSpec,
     SandboxTemplate,
@@ -67,6 +70,10 @@ __all__ = [
     "Volume",
     "VolumeMountSpec",
     "Pool",
+    # WebSocket streaming models
+    "CommandHandle",
+    "AsyncCommandHandle",
+    "OutputChunk",
     # Base and connection errors
     "SandboxClientError",
     "SandboxAPIError",

--- a/python/langsmith/sandbox/_models.py
+++ b/python/langsmith/sandbox/_models.py
@@ -2,8 +2,23 @@
 
 from __future__ import annotations
 
+from collections.abc import AsyncIterator, Iterator
 from dataclasses import dataclass, field
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any, Optional
+
+from langsmith.sandbox._exceptions import (
+    SandboxConnectionError,
+    SandboxOperationError,
+    SandboxServerReloadError,
+)
+
+if TYPE_CHECKING:
+    from langsmith.sandbox._async_sandbox import AsyncSandbox
+    from langsmith.sandbox._sandbox import Sandbox
+    from langsmith.sandbox._ws_execute import (
+        _AsyncWSStreamControl,
+        _WSStreamControl,
+    )
 
 
 @dataclass
@@ -149,4 +164,496 @@ class Pool:
             id=data.get("id"),
             created_at=data.get("created_at"),
             updated_at=data.get("updated_at"),
+        )
+
+
+# =============================================================================
+# WebSocket Command Execution Models
+# =============================================================================
+
+
+@dataclass
+class OutputChunk:
+    """A single chunk of streaming output from command execution.
+
+    Attributes:
+        stream: Either "stdout" or "stderr".
+        data: The text content of this chunk (valid UTF-8, server handles
+            boundary splitting).
+        offset: Byte offset within the stream. Used internally for
+            reconnection; users typically don't need this.
+    """
+
+    stream: str
+    data: str
+    offset: int
+
+
+class CommandHandle:
+    """Handle to a running command with streaming output and auto-reconnect.
+
+    Iterable, yielding OutputChunk objects (stdout and stderr interleaved
+    in arrival order). Access .result after iteration to get the full
+    ExecutionResult.
+
+    Auto-reconnect behavior:
+    - Server hot-reload (1001 Going Away): reconnect immediately
+    - Network error / unexpected close:    reconnect with exponential backoff
+    - User called kill():                  do NOT reconnect (propagate error)
+
+    The auto-reconnect is transparent -- the iterator reconnects and
+    continues yielding chunks without any user intervention. If all
+    reconnect attempts are exhausted, SandboxConnectionError is raised.
+
+    Construction modes (controlled by ``command_id``):
+    - **New execution** (``command_id=""``, the default): the constructor
+      eagerly reads the server's ``"started"`` message to populate
+      ``command_id`` and ``pid`` before returning.
+    - **Reconnection** (``command_id`` set): skips the started-message
+      read, since reconnect streams don't emit one.
+
+    Example:
+        handle = sandbox.run("make build", timeout=600, wait=False)
+
+        for chunk in handle:          # auto-reconnects on transient errors
+            print(chunk.data, end="")
+
+        result = handle.result
+        print(f"Exit code: {result.exit_code}")
+    """
+
+    MAX_AUTO_RECONNECTS = 5
+    _BACKOFF_BASE = 0.5  # seconds
+    _BACKOFF_MAX = 8.0  # seconds
+
+    def __init__(
+        self,
+        message_stream: Iterator[dict],
+        control: Optional[_WSStreamControl],
+        sandbox: Sandbox,
+        *,
+        command_id: str = "",
+        stdout_offset: int = 0,
+        stderr_offset: int = 0,
+    ) -> None:
+        self._stream = message_stream
+        self._control = control
+        self._sandbox = sandbox
+        self._command_id: Optional[str] = None
+        self._pid: Optional[int] = None
+        self._result: Optional[ExecutionResult] = None
+        self._stdout_parts: list[str] = []
+        self._stderr_parts: list[str] = []
+        self._exhausted = False
+        self._last_stdout_offset = stdout_offset
+        self._last_stderr_offset = stderr_offset
+
+        # New executions (command_id=""): eager_start reads "started" message.
+        # Reconnections (command_id set): skip eager_start since reconnect
+        # streams don't send a "started" message.
+        if command_id:
+            self._command_id = command_id
+        else:
+            self._consume_started()
+
+    def _consume_started(self) -> None:
+        """Eagerly read the 'started' message to populate command_id and pid.
+
+        Blocks briefly until the server sends the started message (arrives
+        near-instantly after connection). After this call, command_id and
+        pid are available, and the WebSocket is bound to the control object
+        (so kill() works).
+        """
+        try:
+            first_msg = next(self._stream)
+        except StopIteration:
+            raise SandboxOperationError(
+                "Command stream ended before 'started' message",
+                operation="command",
+            )
+        if first_msg.get("type") != "started":
+            raise SandboxOperationError(
+                f"Expected 'started' message, got '{first_msg.get('type')}'",
+                operation="command",
+            )
+        self._command_id = first_msg.get("command_id")
+        self._pid = first_msg.get("pid")
+
+    @property
+    def command_id(self) -> Optional[str]:
+        """The server-assigned command ID. Available after construction."""
+        return self._command_id
+
+    @property
+    def pid(self) -> Optional[int]:
+        """The process ID on the sandbox. Available after construction."""
+        return self._pid
+
+    @property
+    def result(self) -> ExecutionResult:
+        """The final execution result. Blocks until the command completes.
+
+        Drains the remaining stream if not already exhausted, then returns
+        the ExecutionResult with aggregated stdout, stderr, and exit_code.
+        """
+        if self._result is None:
+            for _ in self:
+                pass
+        if self._result is None:
+            raise SandboxOperationError(
+                "Command stream ended without exit message",
+                operation="command",
+            )
+        return self._result
+
+    def _iter_stream(self) -> Iterator[OutputChunk]:
+        """Iterate over output chunks from the current stream (no reconnect)."""
+        if self._exhausted:
+            return
+        for msg in self._stream:
+            msg_type = msg.get("type")
+            if msg_type in ("stdout", "stderr"):
+                chunk = OutputChunk(
+                    stream=msg_type,
+                    data=msg["data"],
+                    offset=msg.get("offset", 0),
+                )
+                if msg_type == "stdout":
+                    self._stdout_parts.append(msg["data"])
+                else:
+                    self._stderr_parts.append(msg["data"])
+                yield chunk
+            elif msg_type == "exit":
+                self._result = ExecutionResult(
+                    stdout="".join(self._stdout_parts),
+                    stderr="".join(self._stderr_parts),
+                    exit_code=msg["exit_code"],
+                )
+                self._exhausted = True
+                return
+        self._exhausted = True
+
+    def __iter__(self) -> Iterator[OutputChunk]:
+        """Iterate over output chunks, auto-reconnecting on transient errors.
+
+        Reconnect strategy:
+        - 1001 Going Away (hot-reload): immediate reconnect, no delay
+        - Other SandboxConnectionError:  exponential backoff (0.5s, 1s, 2s...)
+        - After kill():                  no reconnect, error propagates
+        """
+        import time
+
+        reconnect_attempts = 0
+        while True:
+            try:
+                for chunk in self._iter_stream():
+                    reconnect_attempts = 0  # Reset on successful data
+                    if chunk.stream == "stdout":
+                        self._last_stdout_offset = chunk.offset + len(
+                            chunk.data.encode("utf-8")
+                        )
+                    else:
+                        self._last_stderr_offset = chunk.offset + len(
+                            chunk.data.encode("utf-8")
+                        )
+                    yield chunk
+                return  # Stream ended normally (exit message received)
+
+            except SandboxConnectionError as e:
+                if self._control and self._control.killed:
+                    raise
+
+                reconnect_attempts += 1
+                if reconnect_attempts > self.MAX_AUTO_RECONNECTS:
+                    raise SandboxConnectionError(
+                        f"Lost connection {reconnect_attempts} times in "
+                        f"succession, giving up"
+                    ) from e
+
+                is_hot_reload = isinstance(e, SandboxServerReloadError)
+                if not is_hot_reload:
+                    delay = min(
+                        self._BACKOFF_BASE * (2 ** (reconnect_attempts - 1)),
+                        self._BACKOFF_MAX,
+                    )
+                    time.sleep(delay)
+
+                assert self._command_id is not None
+                new_handle = self._sandbox.reconnect(
+                    self._command_id,
+                    stdout_offset=self._last_stdout_offset,
+                    stderr_offset=self._last_stderr_offset,
+                )
+                self._stream = new_handle._stream
+                self._control = new_handle._control
+                self._exhausted = False
+
+    def kill(self) -> None:
+        """Send a kill signal to the running command (SIGKILL).
+
+        The server kills the entire process group. The stream will
+        subsequently yield an exit message with a non-zero exit code.
+
+        Has no effect if the command has already exited or the
+        WebSocket connection is closed.
+        """
+        if self._control:
+            self._control.send_kill()
+
+    def send_input(self, data: str) -> None:
+        """Write data to the command's stdin.
+
+        Args:
+            data: String data to write to stdin.
+
+        Has no effect if the command has already exited or the
+        WebSocket connection is closed.
+        """
+        if self._control:
+            self._control.send_input(data)
+
+    @property
+    def last_stdout_offset(self) -> int:
+        """Last known stdout byte offset (for manual reconnection)."""
+        return self._last_stdout_offset
+
+    @property
+    def last_stderr_offset(self) -> int:
+        """Last known stderr byte offset (for manual reconnection)."""
+        return self._last_stderr_offset
+
+    def reconnect(self) -> CommandHandle:
+        """Reconnect to this command from the last known offsets.
+
+        Returns a new handle that resumes output from where this one
+        left off. Any output produced while disconnected is replayed
+        from the server's ring buffer.
+
+        Returns:
+            A new CommandHandle.
+
+        Raises:
+            SandboxOperationError: If command_id is not found or
+                session expired.
+            SandboxConnectionError: If connection to sandbox fails.
+        """
+        assert self._command_id is not None
+        return self._sandbox.reconnect(
+            self._command_id,
+            stdout_offset=self._last_stdout_offset,
+            stderr_offset=self._last_stderr_offset,
+        )
+
+
+class AsyncCommandHandle:
+    """Async handle to a running command with streaming output and auto-reconnect.
+
+    Async iterable, yielding OutputChunk objects (stdout and stderr interleaved
+    in arrival order). Access .result after iteration to get the full
+    ExecutionResult.
+
+    Auto-reconnect behavior:
+    - Server hot-reload (1001 Going Away): reconnect immediately
+    - Network error / unexpected close:    reconnect with exponential backoff
+    - User called kill():                  do NOT reconnect (propagate error)
+
+    Construction modes (controlled by ``command_id``):
+    - **New execution** (``command_id=""``, the default): call
+      ``await handle._ensure_started()`` after construction to read the
+      server's ``"started"`` message and populate ``command_id`` / ``pid``.
+    - **Reconnection** (``command_id`` set): skips the started-message
+      read, since reconnect streams don't emit one.
+
+    Example:
+        handle = await sandbox.run("make build", timeout=600, wait=False)
+
+        async for chunk in handle:    # auto-reconnects on transient errors
+            print(chunk.data, end="")
+
+        result = await handle.result
+        print(f"Exit code: {result.exit_code}")
+    """
+
+    MAX_AUTO_RECONNECTS = 5
+    _BACKOFF_BASE = 0.5  # seconds
+    _BACKOFF_MAX = 8.0  # seconds
+
+    def __init__(
+        self,
+        message_stream: AsyncIterator[dict],
+        control: Optional[_AsyncWSStreamControl],
+        sandbox: AsyncSandbox,
+        *,
+        command_id: str = "",
+        stdout_offset: int = 0,
+        stderr_offset: int = 0,
+    ) -> None:
+        self._stream = message_stream
+        self._control = control
+        self._sandbox = sandbox
+        self._command_id: Optional[str] = None
+        self._pid: Optional[int] = None
+        self._result: Optional[ExecutionResult] = None
+        self._stdout_parts: list[str] = []
+        self._stderr_parts: list[str] = []
+        self._exhausted = False
+        self._last_stdout_offset = stdout_offset
+        self._last_stderr_offset = stderr_offset
+
+        # New executions (command_id=""): _ensure_started reads "started".
+        # Reconnections (command_id set): skip since reconnect streams
+        # don't send a "started" message.
+        if command_id:
+            self._command_id = command_id
+            self._started = True
+        else:
+            self._started = False
+
+    async def _ensure_started(self) -> None:
+        """Read the 'started' message to populate command_id and pid."""
+        if self._started:
+            return
+        try:
+            first_msg = await self._stream.__anext__()
+        except StopAsyncIteration:
+            raise SandboxOperationError(
+                "Command stream ended before 'started' message",
+                operation="command",
+            )
+        if first_msg.get("type") != "started":
+            raise SandboxOperationError(
+                f"Expected 'started' message, got '{first_msg.get('type')}'",
+                operation="command",
+            )
+        self._command_id = first_msg.get("command_id")
+        self._pid = first_msg.get("pid")
+        self._started = True
+
+    @property
+    def command_id(self) -> Optional[str]:
+        """The server-assigned command ID. Available after _ensure_started."""
+        return self._command_id
+
+    @property
+    def pid(self) -> Optional[int]:
+        """The process ID on the sandbox. Available after _ensure_started."""
+        return self._pid
+
+    @property
+    async def result(self) -> ExecutionResult:
+        """The final execution result. Awaitable."""
+        if self._result is None:
+            async for _ in self:
+                pass
+        if self._result is None:
+            raise SandboxOperationError(
+                "Command stream ended without exit message",
+                operation="command",
+            )
+        return self._result
+
+    async def _aiter_stream(self) -> AsyncIterator[OutputChunk]:
+        """Iterate over output chunks from the current stream (no reconnect)."""
+        await self._ensure_started()
+        if self._exhausted:
+            return
+        async for msg in self._stream:
+            msg_type = msg.get("type")
+            if msg_type in ("stdout", "stderr"):
+                chunk = OutputChunk(
+                    stream=msg_type,
+                    data=msg["data"],
+                    offset=msg.get("offset", 0),
+                )
+                if msg_type == "stdout":
+                    self._stdout_parts.append(msg["data"])
+                else:
+                    self._stderr_parts.append(msg["data"])
+                yield chunk
+            elif msg_type == "exit":
+                self._result = ExecutionResult(
+                    stdout="".join(self._stdout_parts),
+                    stderr="".join(self._stderr_parts),
+                    exit_code=msg["exit_code"],
+                )
+                self._exhausted = True
+                return
+        self._exhausted = True
+
+    async def __aiter__(self) -> AsyncIterator[OutputChunk]:
+        """Async iterate with auto-reconnect on transient errors."""
+        import asyncio
+
+        reconnect_attempts = 0
+        while True:
+            try:
+                async for chunk in self._aiter_stream():
+                    reconnect_attempts = 0
+                    if chunk.stream == "stdout":
+                        self._last_stdout_offset = chunk.offset + len(
+                            chunk.data.encode("utf-8")
+                        )
+                    else:
+                        self._last_stderr_offset = chunk.offset + len(
+                            chunk.data.encode("utf-8")
+                        )
+                    yield chunk
+                return  # Stream ended normally
+
+            except SandboxConnectionError as e:
+                if self._control and self._control.killed:
+                    raise
+
+                reconnect_attempts += 1
+                if reconnect_attempts > self.MAX_AUTO_RECONNECTS:
+                    raise SandboxConnectionError(
+                        f"Lost connection {reconnect_attempts} times "
+                        f"in succession, giving up"
+                    ) from e
+
+                is_hot_reload = isinstance(e, SandboxServerReloadError)
+                if not is_hot_reload:
+                    delay = min(
+                        self._BACKOFF_BASE * (2 ** (reconnect_attempts - 1)),
+                        self._BACKOFF_MAX,
+                    )
+                    await asyncio.sleep(delay)
+
+                assert self._command_id is not None
+                new_handle = await self._sandbox.reconnect(
+                    self._command_id,
+                    stdout_offset=self._last_stdout_offset,
+                    stderr_offset=self._last_stderr_offset,
+                )
+                self._stream = new_handle._stream
+                self._control = new_handle._control
+                self._exhausted = False
+
+    async def kill(self) -> None:
+        """Send a kill signal to the running command."""
+        if self._control:
+            await self._control.send_kill()
+
+    async def send_input(self, data: str) -> None:
+        """Write data to the command's stdin."""
+        if self._control:
+            await self._control.send_input(data)
+
+    @property
+    def last_stdout_offset(self) -> int:
+        """Last known stdout byte offset (for manual reconnection)."""
+        return self._last_stdout_offset
+
+    @property
+    def last_stderr_offset(self) -> int:
+        """Last known stderr byte offset (for manual reconnection)."""
+        return self._last_stderr_offset
+
+    async def reconnect(self) -> AsyncCommandHandle:
+        """Reconnect to this command from the last known offsets."""
+        assert self._command_id is not None
+        return await self._sandbox.reconnect(
+            self._command_id,
+            stdout_offset=self._last_stdout_offset,
+            stderr_offset=self._last_stderr_offset,
         )

--- a/python/langsmith/sandbox/_sandbox.py
+++ b/python/langsmith/sandbox/_sandbox.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Callable, Literal, Optional, Union, overload
 
 import httpx
 
@@ -13,7 +13,10 @@ from langsmith.sandbox._exceptions import (
     SandboxConnectionError,
 )
 from langsmith.sandbox._helpers import handle_sandbox_http_error
-from langsmith.sandbox._models import ExecutionResult
+from langsmith.sandbox._models import (
+    CommandHandle,
+    ExecutionResult,
+)
 
 if TYPE_CHECKING:
     from langsmith.sandbox._client import SandboxClient
@@ -115,6 +118,34 @@ class Sandbox:
             )
         return self.dataplane_url
 
+    @overload
+    def run(
+        self,
+        command: str,
+        *,
+        timeout: int = ...,
+        env: Optional[dict[str, str]] = ...,
+        cwd: Optional[str] = ...,
+        shell: str = ...,
+        on_stdout: Optional[Callable[[str], Any]] = ...,
+        on_stderr: Optional[Callable[[str], Any]] = ...,
+        wait: Literal[True] = ...,
+    ) -> ExecutionResult: ...
+
+    @overload
+    def run(
+        self,
+        command: str,
+        *,
+        timeout: int = ...,
+        env: Optional[dict[str, str]] = ...,
+        cwd: Optional[str] = ...,
+        shell: str = ...,
+        on_stdout: Optional[Callable[[str], Any]] = ...,
+        on_stderr: Optional[Callable[[str], Any]] = ...,
+        wait: Literal[False],
+    ) -> CommandHandle: ...
+
     def run(
         self,
         command: str,
@@ -123,7 +154,10 @@ class Sandbox:
         env: Optional[dict[str, str]] = None,
         cwd: Optional[str] = None,
         shell: str = "/bin/bash",
-    ) -> ExecutionResult:
+        on_stdout: Optional[Callable[[str], Any]] = None,
+        on_stderr: Optional[Callable[[str], Any]] = None,
+        wait: bool = True,
+    ) -> Union[ExecutionResult, CommandHandle]:
         """Execute a command in the sandbox.
 
         Args:
@@ -132,19 +166,56 @@ class Sandbox:
             env: Environment variables to set for the command.
             cwd: Working directory for command execution. If None, uses sandbox default.
             shell: Shell to use for command execution. Defaults to "/bin/bash".
+            on_stdout: Callback invoked with each stdout chunk as it arrives.
+                Blocks until the command completes and returns ExecutionResult.
+                Cannot be combined with wait=False.
+            on_stderr: Callback invoked with each stderr chunk as it arrives.
+                Blocks until the command completes and returns ExecutionResult.
+                Cannot be combined with wait=False.
+            wait: If True (default), block until the command completes and
+                return ExecutionResult. If False, return a
+                CommandHandle immediately for streaming output,
+                kill, stdin input, and reconnection. Cannot be combined with
+                on_stdout/on_stderr callbacks.
 
         Returns:
-            ExecutionResult with stdout, stderr, and exit_code.
+            ExecutionResult when wait=True (default).
+            CommandHandle when wait=False.
 
         Raises:
+            ValueError: If wait=False is combined with callbacks.
             DataplaneNotConfiguredError: If dataplane_url is not configured.
             SandboxOperationError: If command execution fails.
+            CommandTimeoutError: If command exceeds its timeout.
             SandboxConnectionError: If connection to sandbox fails.
             SandboxNotReadyError: If sandbox is not ready.
             SandboxClientError: For other errors.
         """
+        if not wait and (on_stdout or on_stderr):
+            raise ValueError(
+                "Cannot combine wait=False with on_stdout/on_stderr callbacks. "
+                "Use wait=False and iterate the CommandHandle, or use callbacks."
+            )
+
         self._require_dataplane_url()
 
+        # When not waiting or callbacks are requested, WS is required
+        use_ws = not wait or on_stdout or on_stderr
+        if use_ws:
+            return self._run_ws(
+                command,
+                timeout=timeout,
+                env=env,
+                cwd=cwd,
+                shell=shell,
+                wait=wait,
+                on_stdout=on_stdout,
+                on_stderr=on_stderr,
+            )
+
+        # Default (wait=True, no callbacks): try WS, fall back to HTTP.
+        # Catch broad exceptions so that unexpected WS failures (e.g. version
+        # incompatibilities) don't break users who don't need WS features.
         try:
             return self._run_ws(
                 command,
@@ -152,6 +223,9 @@ class Sandbox:
                 env=env,
                 cwd=cwd,
                 shell=shell,
+                wait=True,
+                on_stdout=None,
+                on_stderr=None,
             )
         except (SandboxConnectionError, ImportError, OSError, TypeError):
             return self._run_http(
@@ -170,14 +244,17 @@ class Sandbox:
         env: Optional[dict[str, str]],
         cwd: Optional[str],
         shell: str,
-    ) -> ExecutionResult:
+        wait: bool,
+        on_stdout: Optional[Callable[[str], Any]],
+        on_stderr: Optional[Callable[[str], Any]],
+    ) -> Union[ExecutionResult, CommandHandle]:
         """Execute via WebSocket /execute/ws."""
         from langsmith.sandbox._ws_execute import run_ws_stream
 
         dataplane_url = self._require_dataplane_url()
         api_key = self._client._api_key
 
-        msg_stream, _control = run_ws_stream(
+        msg_stream, control = run_ws_stream(
             dataplane_url,
             api_key,
             command,
@@ -185,26 +262,16 @@ class Sandbox:
             env=env,
             cwd=cwd,
             shell=shell,
+            on_stdout=on_stdout,
+            on_stderr=on_stderr,
         )
 
-        stdout_parts: list[str] = []
-        stderr_parts: list[str] = []
-        exit_code = -1
+        handle = CommandHandle(msg_stream, control, self)
 
-        for msg in msg_stream:
-            msg_type = msg.get("type")
-            if msg_type == "stdout":
-                stdout_parts.append(msg["data"])
-            elif msg_type == "stderr":
-                stderr_parts.append(msg["data"])
-            elif msg_type == "exit":
-                exit_code = msg["exit_code"]
+        if not wait:
+            return handle
 
-        return ExecutionResult(
-            stdout="".join(stdout_parts),
-            stderr="".join(stderr_parts),
-            exit_code=exit_code,
-        )
+        return handle.result  # blocks until command completes
 
     def _run_http(
         self,
@@ -215,7 +282,7 @@ class Sandbox:
         cwd: Optional[str],
         shell: str,
     ) -> ExecutionResult:
-        """Execute via HTTP POST /execute."""
+        """Execute via HTTP POST /execute (existing implementation)."""
         dataplane_url = self._require_dataplane_url()
         url = f"{dataplane_url}/execute"
         payload: dict[str, Any] = {
@@ -245,6 +312,52 @@ class Sandbox:
             handle_sandbox_http_error(e)
             # This line should never be reached but satisfies type checker
             raise  # pragma: no cover
+
+    def reconnect(
+        self,
+        command_id: str,
+        *,
+        stdout_offset: int = 0,
+        stderr_offset: int = 0,
+    ) -> CommandHandle:
+        """Reconnect to a running or recently-finished command.
+
+        Resumes output from the given byte offsets. Any output produced while
+        the client was disconnected is replayed from the server's ring buffer.
+
+        Args:
+            command_id: The command ID from handle.command_id.
+            stdout_offset: Byte offset to resume stdout from (default: 0).
+            stderr_offset: Byte offset to resume stderr from (default: 0).
+
+        Returns:
+            A CommandHandle for the command.
+
+        Raises:
+            SandboxOperationError: If command_id is not found or session expired.
+            SandboxConnectionError: If connection to sandbox fails.
+        """
+        from langsmith.sandbox._ws_execute import reconnect_ws_stream
+
+        dataplane_url = self._require_dataplane_url()
+        api_key = self._client._api_key
+
+        msg_stream, control = reconnect_ws_stream(
+            dataplane_url,
+            api_key,
+            command_id,
+            stdout_offset=stdout_offset,
+            stderr_offset=stderr_offset,
+        )
+
+        return CommandHandle(
+            msg_stream,
+            control,
+            self,
+            command_id=command_id,
+            stdout_offset=stdout_offset,
+            stderr_offset=stderr_offset,
+        )
 
     def write(
         self,

--- a/python/tests/unit_tests/sandbox/test_models.py
+++ b/python/tests/unit_tests/sandbox/test_models.py
@@ -2,12 +2,24 @@
 
 from langsmith.sandbox import (
     ExecutionResult,
+    OutputChunk,
     Pool,
     ResourceSpec,
     SandboxTemplate,
     Volume,
     VolumeMountSpec,
 )
+
+
+class TestOutputChunk:
+    """Tests for OutputChunk."""
+
+    def test_dataclass(self):
+        """Test OutputChunk fields."""
+        chunk = OutputChunk(stream="stdout", data="hello", offset=0)
+        assert chunk.stream == "stdout"
+        assert chunk.data == "hello"
+        assert chunk.offset == 0
 
 
 class TestExecutionResult:


### PR DESCRIPTION
## Summary

- Adds `CommandHandle` / `AsyncCommandHandle` for streaming command output in real time via `wait=False` mode.
- Adds `on_stdout` / `on_stderr` callbacks for real-time output while still returning `ExecutionResult`.
- Supports `kill()`, `send_input()`, and automatic reconnection on transient failures.
- Adds `reconnect()` method to `Sandbox` / `AsyncSandbox` for resuming output from a previous handle.

Part 5 of sandbox WebSocket execution support (split from #2437). Stacked on #2446.

Made with [Cursor](https://cursor.com)