### PR TITLE
feat: add native thread querying support

### DIFF
--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -489,7 +489,7 @@ type Thread = {
   latency_p50: number;
   latency_p99: number;
   feedback_stats: any | null;
-  group_key: string;
+  thread_id: string;
   first_inputs: string;
   last_outputs: string;
   last_error: string | null;
@@ -2558,7 +2558,7 @@ export class Client implements LangSmithTracingClientInterface {
     }
 
     const result: ListThreadsItem[] = [];
-    for (const [groupKey, runs] of threadsMap.entries()) {
+    for (const [threadId, runs] of threadsMap.entries()) {
       runs.sort((a, b) => {
         const aRun = a as unknown as Record<string, unknown>;
         const bRun = b as unknown as Record<string, unknown>;
@@ -2580,7 +2580,7 @@ export class Client implements LangSmithTracingClientInterface {
         ? sortedTimes[sortedTimes.length - 1]
         : "";
       result.push({
-        group_key: groupKey,
+        thread_id: threadId,
         runs,
         count: runs.length,
         filter: "",

--- a/js/src/tests/client.int.test.ts
+++ b/js/src/tests/client.int.test.ts
@@ -2400,7 +2400,7 @@ test("listThreads returns threads grouped by thread_id", async () => {
     expect(Array.isArray(threads)).toBe(true);
     expect(threads.length).toBeGreaterThanOrEqual(2);
     for (const item of threads) {
-      expect(item).toHaveProperty("group_key");
+      expect(item).toHaveProperty("thread_id");
       expect(item).toHaveProperty("runs");
       expect(item).toHaveProperty("count");
       expect(item).toHaveProperty("min_start_time");
@@ -2408,11 +2408,11 @@ test("listThreads returns threads grouped by thread_id", async () => {
       expect(Array.isArray(item.runs)).toBe(true);
       expect(item.count).toEqual(item.runs.length);
     }
-    const groupKeys = new Set(threads.map((t) => t.group_key));
-    expect(groupKeys.has(threadA)).toBe(true);
-    expect(groupKeys.has(threadB)).toBe(true);
-    const threadAItem = threads.find((t) => t.group_key === threadA);
-    const threadBItem = threads.find((t) => t.group_key === threadB);
+    const threadIds = new Set(threads.map((t) => t.thread_id));
+    expect(threadIds.has(threadA)).toBe(true);
+    expect(threadIds.has(threadB)).toBe(true);
+    const threadAItem = threads.find((t) => t.thread_id === threadA);
+    const threadBItem = threads.find((t) => t.thread_id === threadB);
     expect(threadAItem).toBeDefined();
     expect(threadBItem).toBeDefined();
     expect(threadAItem!.count).toEqual(2);

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -657,7 +657,7 @@ class _LangSmithHttpAdapter(requests_adapters.HTTPAdapter):
 class ListThreadsItem(TypedDict):
     """Item returned by :meth:`Client.list_threads`."""
 
-    group_key: str
+    thread_id: str
     runs: list[ls_schemas.Run]
     count: int
     min_start_time: Optional[str]
@@ -3737,7 +3737,7 @@ class Client:
             start_time: Only include runs from this time. Default: 1 day ago.
 
         Returns:
-            List of thread items, each with "group_key", "runs", "count",
+            List of thread items, each with "thread_id", "runs", "count",
             "min_start_time", and "max_start_time".
         """
         if project_id is None and project_name is None:
@@ -3796,7 +3796,7 @@ class Client:
                 threads_map[tid].append(run_dict)
 
         result: list[ListThreadsItem] = []
-        for group_key, run_dicts in threads_map.items():
+        for thread_id, run_dicts in threads_map.items():
             run_dicts.sort(
                 key=lambda r: (
                     r.get("start_time") or "",
@@ -3822,7 +3822,7 @@ class Client:
             ]
             result.append(
                 {
-                    "group_key": group_key,
+                    "thread_id": thread_id,
                     "runs": runs,
                     "count": len(runs),
                     "min_start_time": min(start_times) if start_times else None,

--- a/python/tests/integration_tests/test_client.py
+++ b/python/tests/integration_tests/test_client.py
@@ -3630,18 +3630,18 @@ def test_list_threads(langchain_client: Client) -> None:
         assert len(threads) >= 2
         for item in threads:
             assert isinstance(item, dict)
-            assert "group_key" in item
+            assert "thread_id" in item
             assert "runs" in item
             assert "count" in item
             assert "min_start_time" in item
             assert "max_start_time" in item
             assert isinstance(item["runs"], list)
             assert item["count"] == len(item["runs"])
-        group_keys = {t["group_key"] for t in threads}
-        assert thread_a in group_keys
-        assert thread_b in group_keys
-        thread_a_item = next(t for t in threads if t["group_key"] == thread_a)
-        thread_b_item = next(t for t in threads if t["group_key"] == thread_b)
+        thread_ids = {t["thread_id"] for t in threads}
+        assert thread_a in thread_ids
+        assert thread_b in thread_ids
+        thread_a_item = next(t for t in threads if t["thread_id"] == thread_a)
+        thread_b_item = next(t for t in threads if t["thread_id"] == thread_b)
         assert thread_a_item["count"] == 2
         assert thread_b_item["count"] == 1
     finally:


### PR DESCRIPTION
Added native support for querying threads and their runs in the Python and JS SDKs, using the existing /runs/group API and thread-scoped run listing.