### PR TITLE
feat: add raw response parsing for responses api to openai wrapper

### DIFF
--- a/python/langsmith/wrappers/_openai.py
+++ b/python/langsmith/wrappers/_openai.py
@@ -630,6 +630,13 @@ def wrap_openai(
 def _process_responses_api_output(response: Any) -> dict:
     if response:
         try:
+            # Unwrap APIResponse from with_raw_response for tracing
+            if hasattr(response, "parse") and callable(response.parse):
+                try:
+                    response = response.parse()
+                except Exception:
+                    pass
+
             output = response.model_dump(exclude_none=True, mode="json")
             if usage := output.pop("usage", None):
                 output["usage_metadata"] = _create_usage_metadata(

--- a/python/tests/integration_tests/cassettes/test_with_raw_response_test_responses_with_raw_response_async.yaml
+++ b/python/tests/integration_tests/cassettes/test_with_raw_response_test_responses_with_raw_response_async.yaml
@@ -1,0 +1,115 @@
+interactions:
+- request:
+    body: '{"input": "Say ''foo''", "model": "gpt-4o"}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate, zstd
+      connection:
+      - keep-alive
+      content-length:
+      - '41'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 2.6.0
+      x-stainless-raw-response:
+      - 'true'
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.11.12
+    method: POST
+    uri: https://api.openai.com/v1/responses
+  response:
+    body:
+      string: "{\n  \"id\": \"resp_03a1e9d8fb65473200699e1f762ce48198b19c5f342e4fc358\",\n
+        \ \"object\": \"response\",\n  \"created_at\": 1771970422,\n  \"status\":
+        \"completed\",\n  \"background\": false,\n  \"billing\": {\n    \"payer\":
+        \"developer\"\n  },\n  \"completed_at\": 1771970422,\n  \"error\": null,\n
+        \ \"frequency_penalty\": 0.0,\n  \"incomplete_details\": null,\n  \"instructions\":
+        null,\n  \"max_output_tokens\": null,\n  \"max_tool_calls\": null,\n  \"model\":
+        \"gpt-4o-2024-08-06\",\n  \"output\": [\n    {\n      \"id\": \"msg_03a1e9d8fb65473200699e1f76bdf0819894390ee0e10c50d7\",\n
+        \     \"type\": \"message\",\n      \"status\": \"completed\",\n      \"content\":
+        [\n        {\n          \"type\": \"output_text\",\n          \"annotations\":
+        [],\n          \"logprobs\": [],\n          \"text\": \"foo\"\n        }\n
+        \     ],\n      \"role\": \"assistant\"\n    }\n  ],\n  \"parallel_tool_calls\":
+        true,\n  \"presence_penalty\": 0.0,\n  \"previous_response_id\": null,\n  \"prompt_cache_key\":
+        null,\n  \"prompt_cache_retention\": null,\n  \"reasoning\": {\n    \"effort\":
+        null,\n    \"summary\": null\n  },\n  \"safety_identifier\": null,\n  \"service_tier\":
+        \"default\",\n  \"store\": true,\n  \"temperature\": 1.0,\n  \"text\": {\n
+        \   \"format\": {\n      \"type\": \"text\"\n    },\n    \"verbosity\": \"medium\"\n
+        \ },\n  \"tool_choice\": \"auto\",\n  \"tools\": [],\n  \"top_logprobs\":
+        0,\n  \"top_p\": 1.0,\n  \"truncation\": \"disabled\",\n  \"usage\": {\n    \"input_tokens\":
+        11,\n    \"input_tokens_details\": {\n      \"cached_tokens\": 0\n    },\n
+        \   \"output_tokens\": 2,\n    \"output_tokens_details\": {\n      \"reasoning_tokens\":
+        0\n    },\n    \"total_tokens\": 13\n  },\n  \"user\": null,\n  \"metadata\":
+        {}\n}"
+    headers:
+      CF-RAY:
+      - 9d323c409ef87adc-SJC
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 24 Feb 2026 22:00:22 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '1525'
+      openai-organization:
+      - langchain
+      openai-processing-ms:
+      - '689'
+      openai-project:
+      - proj_IfpviNC2vx5jMiYFE4hbElsy
+      openai-version:
+      - '2020-10-01'
+      set-cookie:
+      - __cf_bm=JFuk2_I1W1nnMXX10eHBq5Gi6OHxfixu2A29ZfiIvs0-1771970421.853175-1.0.1.1-y2gS12wwXdnUMyjBJUjUK.i9_hYrXwOi51YDLMeUJ0PxV09L0TgBNtFXm6vq98G1KIcoxabFxKYPK6h8o3puW8ed6aFazRCpOyIFQa6Z0pxCGoCCTwUdFFzvX_6ZGzuM;
+        HttpOnly; Secure; Path=/; Domain=api.openai.com; Expires=Tue, 24 Feb 2026
+        22:30:22 GMT
+      x-ratelimit-limit-requests:
+      - '10000'
+      x-ratelimit-limit-tokens:
+      - '30000000'
+      x-ratelimit-remaining-requests:
+      - '9999'
+      x-ratelimit-remaining-tokens:
+      - '29999970'
+      x-ratelimit-reset-requests:
+      - 6ms
+      x-ratelimit-reset-tokens:
+      - 0s
+      x-request-id:
+      - req_3149696b57a84675aa158d0609aae73f
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/integration_tests/cassettes/test_with_raw_response_test_responses_with_raw_response_sync.yaml
+++ b/python/tests/integration_tests/cassettes/test_with_raw_response_test_responses_with_raw_response_sync.yaml
@@ -1,0 +1,115 @@
+interactions:
+- request:
+    body: '{"input": "Say ''foo''", "model": "gpt-4o"}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate, zstd
+      connection:
+      - keep-alive
+      content-length:
+      - '41'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 2.6.0
+      x-stainless-raw-response:
+      - 'true'
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.11.12
+    method: POST
+    uri: https://api.openai.com/v1/responses
+  response:
+    body:
+      string: "{\n  \"id\": \"resp_02bffa675f5fa12b00699e1f74ced4819497d7192d579ec233\",\n
+        \ \"object\": \"response\",\n  \"created_at\": 1771970420,\n  \"status\":
+        \"completed\",\n  \"background\": false,\n  \"billing\": {\n    \"payer\":
+        \"developer\"\n  },\n  \"completed_at\": 1771970421,\n  \"error\": null,\n
+        \ \"frequency_penalty\": 0.0,\n  \"incomplete_details\": null,\n  \"instructions\":
+        null,\n  \"max_output_tokens\": null,\n  \"max_tool_calls\": null,\n  \"model\":
+        \"gpt-4o-2024-08-06\",\n  \"output\": [\n    {\n      \"id\": \"msg_02bffa675f5fa12b00699e1f75517c8194b9d3f42b68c4d71b\",\n
+        \     \"type\": \"message\",\n      \"status\": \"completed\",\n      \"content\":
+        [\n        {\n          \"type\": \"output_text\",\n          \"annotations\":
+        [],\n          \"logprobs\": [],\n          \"text\": \"foo\"\n        }\n
+        \     ],\n      \"role\": \"assistant\"\n    }\n  ],\n  \"parallel_tool_calls\":
+        true,\n  \"presence_penalty\": 0.0,\n  \"previous_response_id\": null,\n  \"prompt_cache_key\":
+        null,\n  \"prompt_cache_retention\": null,\n  \"reasoning\": {\n    \"effort\":
+        null,\n    \"summary\": null\n  },\n  \"safety_identifier\": null,\n  \"service_tier\":
+        \"default\",\n  \"store\": true,\n  \"temperature\": 1.0,\n  \"text\": {\n
+        \   \"format\": {\n      \"type\": \"text\"\n    },\n    \"verbosity\": \"medium\"\n
+        \ },\n  \"tool_choice\": \"auto\",\n  \"tools\": [],\n  \"top_logprobs\":
+        0,\n  \"top_p\": 1.0,\n  \"truncation\": \"disabled\",\n  \"usage\": {\n    \"input_tokens\":
+        11,\n    \"input_tokens_details\": {\n      \"cached_tokens\": 0\n    },\n
+        \   \"output_tokens\": 2,\n    \"output_tokens_details\": {\n      \"reasoning_tokens\":
+        0\n    },\n    \"total_tokens\": 13\n  },\n  \"user\": null,\n  \"metadata\":
+        {}\n}"
+    headers:
+      CF-RAY:
+      - 9d323c387875f31f-SJC
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 24 Feb 2026 22:00:21 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '1525'
+      openai-organization:
+      - langchain
+      openai-processing-ms:
+      - '796'
+      openai-project:
+      - proj_IfpviNC2vx5jMiYFE4hbElsy
+      openai-version:
+      - '2020-10-01'
+      set-cookie:
+      - __cf_bm=64iGpk8GQoOVpemlgo9uhEB1qk3qU13WsKHZ2kIbuHo-1771970420.5520854-1.0.1.1-s489Flcz6LWxT1bYCo7UjB7ZVeRtxBW66EMsIojDZ11GdKOh_4xf5w89_y4sppSJ7QwcVZo1oII1YgE8bQGOIIhzucqX8_PTGb2dhog7w22DYCdtDU5boKjgwV4Q9Gmf;
+        HttpOnly; Secure; Path=/; Domain=api.openai.com; Expires=Tue, 24 Feb 2026
+        22:30:21 GMT
+      x-ratelimit-limit-requests:
+      - '10000'
+      x-ratelimit-limit-tokens:
+      - '30000000'
+      x-ratelimit-remaining-requests:
+      - '9999'
+      x-ratelimit-remaining-tokens:
+      - '29999970'
+      x-ratelimit-reset-requests:
+      - 6ms
+      x-ratelimit-reset-tokens:
+      - 0s
+      x-request-id:
+      - req_d09ed670c03540c0ae8ff1079d229f7f
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/integration_tests/wrappers/test_with_raw_response.py
+++ b/python/tests/integration_tests/wrappers/test_with_raw_response.py
@@ -119,3 +119,108 @@ async def test_chat_with_raw_response_async():
     assert "choices" in outputs
     assert isinstance(outputs["choices"], list)
     assert len(outputs["choices"]) > 0
+
+
+def test_responses_with_raw_response_sync():
+    """Test that with_raw_response returns proper parsed data in traces
+    for the Responses API."""
+    import openai
+
+    mock_session = mock.MagicMock()
+    ls_client = langsmith.Client(session=mock_session)
+    patched_client = wrap_openai(openai.Client(), tracing_extra={"client": ls_client})
+
+    class Collector:
+        def __init__(self):
+            self.run = None
+
+        def __call__(self, run):
+            self.run = run
+
+    collect = Collector()
+
+    with langsmith.tracing_context(enabled=True):
+        # Test with_raw_response on Responses API
+        raw_response = patched_client.responses.with_raw_response.create(
+            input="Say 'foo'",
+            model="gpt-4o",
+            langsmith_extra={"on_end": collect},
+        )
+
+        # Verify we can access headers
+        assert raw_response.headers is not None
+        assert (
+            "content-type" in raw_response.headers
+            or "Content-Type" in raw_response.headers
+        )
+
+        # Verify we can parse the response
+        parsed = raw_response.parse()
+        assert parsed.output
+
+    # Give background thread a chance
+    time.sleep(0.1)
+
+    # Verify the trace has proper parsed output, not stringified APIResponse
+    assert collect.run is not None
+    outputs = collect.run.outputs
+    assert "output" not in outputs or not str(outputs.get("output", "")).startswith(
+        "<APIResponse"
+    )
+    # Should have proper Responses API structure
+    assert "model" in outputs
+    assert "output" in outputs
+
+
+@pytest.mark.asyncio
+async def test_responses_with_raw_response_async():
+    """Test that with_raw_response returns proper parsed data in traces
+    for the Responses API (async)."""
+    import openai
+
+    mock_session = mock.MagicMock()
+    ls_client = langsmith.Client(session=mock_session)
+    patched_client = wrap_openai(
+        openai.AsyncClient(), tracing_extra={"client": ls_client}
+    )
+
+    class Collector:
+        def __init__(self):
+            self.run = None
+
+        def __call__(self, run):
+            self.run = run
+
+    collect = Collector()
+
+    with langsmith.tracing_context(enabled=True):
+        # Test with_raw_response on Responses API
+        raw_response = await patched_client.responses.with_raw_response.create(
+            input="Say 'foo'",
+            model="gpt-4o",
+            langsmith_extra={"on_end": collect},
+        )
+
+        # Verify we can access headers
+        assert raw_response.headers is not None
+        assert (
+            "content-type" in raw_response.headers
+            or "Content-Type" in raw_response.headers
+        )
+
+        # Verify we can parse the response
+        parsed = raw_response.parse()
+        assert parsed.output
+
+    # Give background thread a chance
+    time.sleep(0.1)
+
+    # Verify the trace has proper parsed output, not stringified APIResponse
+    assert collect.run is not None
+    outputs = collect.run.outputs
+    assert "output" not in outputs or not str(outputs.get("output", "")).startswith(
+        "<APIResponse"
+    )
+    # Should have proper Responses API structure
+    assert "model" in outputs
+    assert "output" in outputs


### PR DESCRIPTION
Extend raw response support to the Responses API, matching the implementation from PR [#2134](https://github.com/langchain-ai/langsmith-sdk/pull/2134) for chat completions.

When using `client.responses.with_raw_response.create()`, traces now properly unwrap and display the response data instead of the stringified APIResponse object.

  Changes:
  - Add .parse() unwrapping to _process_responses_api_output()
  - Add integration tests for sync and async Responses API with raw responses
  - Simplify comment style to match repo conventions

  Tested and verified working in LangSmith project traces.