### PR TITLE
feat(sdk): use GET /datasets/:dataset/examples endpoint in list examp…

### DIFF
--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -71,7 +71,10 @@ import { EvaluationResult, EvaluationResults } from "./evaluation/evaluator.js";
 import { __version__ } from "./index.js";
 import { assertUuid } from "./utils/_uuid.js";
 import { warnOnce } from "./utils/warn.js";
-import { parsePromptIdentifier } from "./utils/prompts.js";
+import {
+  parsePromptIdentifier,
+  isVersionGreaterOrEqual,
+} from "./utils/prompts.js";
 import { raiseForStatus, isLangSmithNotFoundError } from "./utils/error.js";
 import {
   PromptCache,
@@ -605,6 +608,8 @@ export const DEFAULT_UNCOMPRESSED_BATCH_SIZE_LIMIT_BYTES = 24 * 1024 * 1024;
 export const DEFAULT_MAX_SIZE_BYTES = 1024 * 1024 * 1024; // 1GB
 
 const SERVER_INFO_REQUEST_TIMEOUT_MS = 10000;
+
+const MIN_VERSION_DATASET_EXAMPLES_ENDPOINT = "0.13.18";
 
 /** Maximum number of operations to batch in a single request. */
 const DEFAULT_BATCH_SIZE_LIMIT = 100;
@@ -4120,7 +4125,17 @@ export class Client implements LangSmithTracingClientInterface {
     } else {
       throw new Error("Must provide a datasetName or datasetId");
     }
+    const serverInfo = await this._ensureServerInfo();
+    const useNewEndpoint =
+      serverInfo.version &&
+      isVersionGreaterOrEqual(
+        serverInfo.version,
+        MIN_VERSION_DATASET_EXAMPLES_ENDPOINT
+      );
     const params = new URLSearchParams();
+    if (!useNewEndpoint) {
+      params.append("dataset", datasetId_);
+    }
     const dataset_version = asOf
       ? typeof asOf === "string"
         ? asOf
@@ -4160,8 +4175,11 @@ export class Client implements LangSmithTracingClientInterface {
       );
     }
     let i = 0;
+    const path = useNewEndpoint
+      ? `/v1/platform/datasets/${datasetId_}/examples`
+      : "/examples";
     for await (const rawExamples of this._getPaginated<RawExample>(
-      `/v1/platform/datasets/${datasetId_}/examples`,
+      path,
       params
     )) {
       for (const rawExample of rawExamples) {

--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -4120,7 +4120,7 @@ export class Client implements LangSmithTracingClientInterface {
     } else {
       throw new Error("Must provide a datasetName or datasetId");
     }
-    const params = new URLSearchParams({ dataset: datasetId_ });
+    const params = new URLSearchParams();
     const dataset_version = asOf
       ? typeof asOf === "string"
         ? asOf
@@ -4161,7 +4161,7 @@ export class Client implements LangSmithTracingClientInterface {
     }
     let i = 0;
     for await (const rawExamples of this._getPaginated<RawExample>(
-      "/examples",
+      `/datasets/${datasetId_}/examples`,
       params
     )) {
       for (const rawExample of rawExamples) {

--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -4161,7 +4161,7 @@ export class Client implements LangSmithTracingClientInterface {
     }
     let i = 0;
     for await (const rawExamples of this._getPaginated<RawExample>(
-      `/datasets/${datasetId_}/examples`,
+      `/v1/platform/datasets/${datasetId_}/examples`,
       params
     )) {
       for (const rawExample of rawExamples) {

--- a/python/langsmith/async_client.py
+++ b/python/langsmith/async_client.py
@@ -31,7 +31,7 @@ ID_TYPE = Union[uuid.UUID, str]
 class AsyncClient:
     """Async Client for interacting with the LangSmith API."""
 
-    __slots__ = ("_retry_config", "_client", "_web_url", "_settings", "_cache")
+    __slots__ = ("_retry_config", "_client", "_web_url", "_settings", "_cache", "_info")
 
     def __init__(
         self,
@@ -86,6 +86,7 @@ class AsyncClient:
         )
         self._web_url = web_url
         self._settings: Optional[ls_schemas.LangSmithSettings] = None
+        self._info: Optional[ls_schemas.LangSmithInfo] = None
 
         # Initialize prompt cache
         # Handle backwards compatibility for deprecated `cache` parameter
@@ -689,11 +690,17 @@ class AsyncClient:
             dataset = await self.read_dataset(dataset_name=dataset_name)
             resolved_dataset_id = dataset.id
 
-        path = (
-            f"/v1/platform/datasets/{resolved_dataset_id}/examples"
-            if resolved_dataset_id is not None
-            else "/examples"
+        info = await self._aget_info()
+        use_new_endpoint = resolved_dataset_id is not None and (
+            info.version
+            and ls_utils.is_version_greater_or_equal(info.version, "0.13.18")
         )
+        if use_new_endpoint:
+            path = f"/v1/platform/datasets/{resolved_dataset_id}/examples"
+        else:
+            path = "/examples"
+            if resolved_dataset_id is not None:
+                params["dataset"] = resolved_dataset_id
         async for example in self._aget_paginated_list(path, params=params):
             yield ls_schemas.Example(**example)
 
@@ -1398,6 +1405,15 @@ class AsyncClient:
             self._settings = ls_schemas.LangSmithSettings(**response.json())
 
         return self._settings
+
+    async def _aget_info(self) -> ls_schemas.LangSmithInfo:
+        if self._info is None:
+            try:
+                response = await self._arequest_with_retries("GET", "/info")
+                self._info = ls_schemas.LangSmithInfo(**response.json())
+            except Exception:
+                self._info = ls_schemas.LangSmithInfo()
+        return self._info
 
     async def _current_tenant_is_owner(self, owner: str) -> bool:
         """Check if the current workspace has the same handle as owner.

--- a/python/langsmith/async_client.py
+++ b/python/langsmith/async_client.py
@@ -690,7 +690,7 @@ class AsyncClient:
             resolved_dataset_id = dataset.id
 
         path = (
-            f"/datasets/{resolved_dataset_id}/examples"
+            f"/v1/platform/datasets/{resolved_dataset_id}/examples"
             if resolved_dataset_id is not None
             else "/examples"
         )

--- a/python/langsmith/async_client.py
+++ b/python/langsmith/async_client.py
@@ -693,7 +693,9 @@ class AsyncClient:
         info = await self._aget_info()
         use_new_endpoint = resolved_dataset_id is not None and (
             info.version
-            and ls_utils.is_version_greater_or_equal(info.version, "0.13.18")
+            and ls_utils.is_version_greater_or_equal(
+                info.version, ls_client._MIN_VERSION_DATASET_EXAMPLES_ENDPOINT
+            )
         )
         if use_new_endpoint:
             path = f"/v1/platform/datasets/{resolved_dataset_id}/examples"

--- a/python/langsmith/async_client.py
+++ b/python/langsmith/async_client.py
@@ -682,13 +682,19 @@ class AsyncClient:
     ) -> AsyncIterator[ls_schemas.Example]:
         """List examples."""
         params = kwargs.copy()
+        resolved_dataset_id = None
         if dataset_id:
-            params["dataset"] = ls_client._as_uuid(dataset_id)
+            resolved_dataset_id = ls_client._as_uuid(dataset_id)
         elif dataset_name:
             dataset = await self.read_dataset(dataset_name=dataset_name)
-            params["dataset"] = dataset.id
+            resolved_dataset_id = dataset.id
 
-        async for example in self._aget_paginated_list("/examples", params=params):
+        path = (
+            f"/datasets/{resolved_dataset_id}/examples"
+            if resolved_dataset_id is not None
+            else "/examples"
+        )
+        async for example in self._aget_paginated_list(path, params=params):
             yield ls_schemas.Example(**example)
 
     async def create_feedback(

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -6473,9 +6473,7 @@ class Client:
             if dataset_id is not None
             else "/examples"
         )
-        for i, example in enumerate(
-            self._get_paginated_list(path, params=params)
-        ):
+        for i, example in enumerate(self._get_paginated_list(path, params=params)):
             attachments = _convert_stored_attachments_to_attachments_dict(
                 example, attachments_key="attachment_urls", api_url=self.api_url
             )

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -6464,17 +6464,17 @@ class Client:
         }
         if metadata is not None:
             params["metadata"] = _dumps_json(metadata)
-        if dataset_id is not None:
-            params["dataset"] = dataset_id
-        elif dataset_name is not None:
+        if dataset_id is None and dataset_name is not None:
             dataset_id = self.read_dataset(dataset_name=dataset_name).id
-            params["dataset"] = dataset_id
-        else:
-            pass
         if include_attachments:
             params["select"] = ["attachment_urls", "outputs", "metadata"]
+        path = (
+            f"/datasets/{dataset_id}/examples"
+            if dataset_id is not None
+            else "/examples"
+        )
         for i, example in enumerate(
-            self._get_paginated_list("/examples", params=params)
+            self._get_paginated_list(path, params=params)
         ):
             attachments = _convert_stored_attachments_to_attachments_dict(
                 example, attachments_key="attachment_urls", api_url=self.api_url

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -218,6 +218,7 @@ logger = logging.getLogger(__name__)
 _urllib3_logger = logging.getLogger("urllib3.connectionpool")
 
 X_API_KEY = "x-api-key"
+_MIN_VERSION_DATASET_EXAMPLES_ENDPOINT = "0.13.18"
 EMPTY_SEQ: tuple[dict, ...] = ()
 URLLIB3_SUPPORTS_BLOCKSIZE = "key_blocksize" in signature(PoolKey).parameters
 DEFAULT_INSTRUCTIONS = "How are people using my agent? What are they asking about?"
@@ -6470,7 +6471,9 @@ class Client:
             params["select"] = ["attachment_urls", "outputs", "metadata"]
         use_new_endpoint = dataset_id is not None and (
             self.info.version
-            and ls_utils.is_version_greater_or_equal(self.info.version, "0.13.18")
+            and ls_utils.is_version_greater_or_equal(
+                self.info.version, _MIN_VERSION_DATASET_EXAMPLES_ENDPOINT
+            )
         )
         if use_new_endpoint:
             path = f"/v1/platform/datasets/{dataset_id}/examples"

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -6468,11 +6468,16 @@ class Client:
             dataset_id = self.read_dataset(dataset_name=dataset_name).id
         if include_attachments:
             params["select"] = ["attachment_urls", "outputs", "metadata"]
-        path = (
-            f"/v1/platform/datasets/{dataset_id}/examples"
-            if dataset_id is not None
-            else "/examples"
+        use_new_endpoint = dataset_id is not None and (
+            self.info.version
+            and ls_utils.is_version_greater_or_equal(self.info.version, "0.13.18")
         )
+        if use_new_endpoint:
+            path = f"/v1/platform/datasets/{dataset_id}/examples"
+        else:
+            path = "/examples"
+            if dataset_id is not None:
+                params["dataset"] = dataset_id
         for i, example in enumerate(self._get_paginated_list(path, params=params)):
             attachments = _convert_stored_attachments_to_attachments_dict(
                 example, attachments_key="attachment_urls", api_url=self.api_url

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -6469,7 +6469,7 @@ class Client:
         if include_attachments:
             params["select"] = ["attachment_urls", "outputs", "metadata"]
         path = (
-            f"/datasets/{dataset_id}/examples"
+            f"/v1/platform/datasets/{dataset_id}/examples"
             if dataset_id is not None
             else "/examples"
         )

--- a/python/tests/unit_tests/evaluation/test_runner.py
+++ b/python/tests/unit_tests/evaluation/test_runner.py
@@ -49,7 +49,10 @@ class FakeRequest:
                     "name": self.ds_name,
                 }
                 return res
-            elif endpoint == "http://localhost:1984/examples":
+            elif endpoint == "http://localhost:1984/examples" or re.match(
+                r"http://localhost:1984/v1/platform/datasets/[^/]+/examples",
+                endpoint,
+            ):
                 res = MagicMock()
                 res.json.return_value = [
                     e.dict() if not isinstance(e, dict) else e for e in self.ds_examples


### PR DESCRIPTION
…les methods

Update Python (sync + async) and JS clients to call the new `/datasets/{dataset_id}/examples` path instead of `/examples?dataset=...`.