### PR TITLE
fix(js): use module-level cache for remapped UUIDs in _remapForProject

### DIFF
--- a/js/src/run_trees.ts
+++ b/js/src/run_trees.ts
@@ -168,6 +168,22 @@ type WriteReplica = {
 };
 type Replica = ProjectReplica | WriteReplica;
 
+// Module-level cache of remapped UUIDs, keyed by "<sourceRunId>:<projectName>".
+// Shared across RunTree instances so that postRun and patchRun (which may be
+// called on different RunTree objects for the same logical run) produce
+// consistent remapped IDs for non-v7 UUID inputs.
+const _remapCache = new Map<string, string>();
+
+function _cachedRemap(sourceId: string, projectName: string): string {
+  const key = `${sourceId}:${projectName}`;
+  let result = _remapCache.get(key);
+  if (result === undefined) {
+    result = nonCryptographicUuid7Deterministic(sourceId, projectName);
+    _remapCache.set(key, result);
+  }
+  return result;
+}
+
 const HEADER_SAFE_REPLICA_FIELDS = new Set([
   "projectName",
   "updates",
@@ -714,24 +730,10 @@ export class RunTree implements BaseRun {
       }
     }
 
-    // Remap IDs for the replica using nonCryptographicUuid7Deterministic
-    // This ensures consistency across runs in the same replica while
-    // preserving UUID7 properties (time-ordering, monotonicity)
-    //
-    // Cache remapped UUIDs so the same source UUID always maps to the same
-    // output within a single _remapForProject call. Without this, non-v7
-    // UUIDs (which fall back to Date.now() for the timestamp) can produce
-    // different outputs if a millisecond elapses between calls, causing
-    // trace_id / dotted_order mismatches rejected by the server.
-    const remapCache = new Map<string, string>();
-    const cachedRemap = (id: string): string => {
-      let result = remapCache.get(id);
-      if (result === undefined) {
-        result = nonCryptographicUuid7Deterministic(id, projectName);
-        remapCache.set(id, result);
-      }
-      return result;
-    };
+    // Remap IDs for the replica using the module-level _cachedRemap,
+    // which ensures consistent outputs even for non-v7 UUID inputs
+    // across separate RunTree instances (see comment above _cachedRemap).
+    const cachedRemap = (id: string) => _cachedRemap(id, projectName);
 
     const oldId = baseRun.id;
     const newId = cachedRemap(oldId);

--- a/js/src/tests/run_trees.test.ts
+++ b/js/src/tests/run_trees.test.ts
@@ -637,6 +637,62 @@ test("_remapForProject cache ensures same input UUID maps to same output", () =>
   }
 });
 
+test("_remapForProject cache works across separate RunTree instances (simulates LangChainTracer)", () => {
+  // LangChainTracer.getRunTreeWithTracingConfig creates a new RunTree instance
+  // for each onRunCreate (postRun) and onRunUpdate (patchRun) call.
+  // The module-level cache must ensure both instances remap the same source UUID
+  // to the same output, even when Date.now() advances between calls.
+
+  let tick = 1700000000000;
+  (Date.now as jest.Mock).mockImplementation(() => tick++);
+
+  try {
+    const rootId = "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d";
+    const projectName = "cross-instance-test";
+
+    // Simulate what LangChainTracer does: create two separate RunTree instances
+    // from the same logical run data (as getRunTreeWithTracingConfig does)
+    const runData = {
+      name: "root",
+      id: rootId,
+      project_name: "original-project",
+    };
+
+    const instance1 = new RunTree(runData);
+    // Advance time significantly to trigger different Date.now() values
+    tick += 5000;
+    const instance2 = new RunTree(runData);
+
+    const remapped1 = (instance1 as any)._remapForProject({
+      projectName,
+      runtimeEnv: undefined,
+      excludeChildRuns: true,
+      reroot: false,
+    });
+
+    // Advance time again before the second remap
+    tick += 5000;
+
+    const remapped2 = (instance2 as any)._remapForProject({
+      projectName,
+      runtimeEnv: undefined,
+      excludeChildRuns: true,
+      reroot: false,
+    });
+
+    // Both instances must produce identical remapped IDs
+    expect(remapped1.id).toBe(remapped2.id);
+    expect(remapped1.trace_id).toBe(remapped2.trace_id);
+    // dotted_order embeds the run's start_time prefix (from RunTree construction)
+    // which differs between instances. The UUID suffix must match.
+    const uuid1 = remapped1.dotted_order.slice(-36);
+    const uuid2 = remapped2.dotted_order.slice(-36);
+    expect(uuid1).toBe(uuid2);
+  } finally {
+    (Date.now as jest.Mock).mockImplementation(() => _DATE);
+  }
+});
+
 test("fromHeaders filters replica credentials", () => {
   const replicas = [
     {


### PR DESCRIPTION
## Summary

Fixes a bug where replicated runs (e.g., experiments triggered from the LangSmith UI
against a LangGraph JS server) appear empty — no output, no child runs, evaluators
don't fire.

## Impact

Affects anyone using `streamEvents` + replicas with any langsmith JS version before
this fix. This is because `@langchain/core`'s `_streamEventsV2()` generates the root
run ID using `v4()` (not `v7()`), hitting a non-deterministic code path in
`nonCryptographicUuid7Deterministic`.

## Root Cause

Two issues compound:

1. **Non-deterministic remapping for non-v7 UUIDs:**
   `nonCryptographicUuid7Deterministic()` falls back to `Date.now()` for the timestamp
   when the input UUID is not v7. The same source UUID remapped twice with even a
   millisecond between calls produces different outputs.

2. **`LangChainTracer` creates new `RunTree` instances per callback:**
   `LangChainTracer.getRunTreeWithTracingConfig()` (in `@langchain/core`) creates a
   fresh `RunTree` via `new RunTree({...runTree, ...})` for every `onRunCreate`
   (`postRun`) and `onRunUpdate` (`patchRun`) call. This means `postRun` and `patchRun`
   operate on different `RunTree` objects for the same logical run.

   With a per-instance or per-call cache, `postRun` remaps UUID "abc" → "xyz1", then
   `patchRun` (on a new instance) remaps "abc" → "xyz2". The patch targets a different
   run ID than was posted, so the original run never receives its end_time, outputs, or
   child runs.

## Fix

Move the remap cache from a local variable inside `_remapForProject` to a **module-level
`Map`** keyed by `"<sourceUUID>:<projectName>"`. This ensures all `RunTree` instances in
the same process share consistent UUID mappings.

Note: the module-level cache grows unboundedly over the process lifetime. For typical
experiment workloads this is negligible (a few hundred entries). For long-running servers
a bounded cache could be added in a follow-up if needed.

## Test Plan

- Added regression test that creates two separate `RunTree` instances from the same
  run data (simulating `LangChainTracer` behavior), with `Date.now` mocked to advance
  between calls — verifies both produce identical remapped IDs
- Verified the new test **fails** against the old per-call cache implementation
- All existing tests continue to pass (341 unit + 57 vitest)
- E2E: 60 concurrent `streamEvents` + replicas calls against a real LangSmith instance
  — 100% 2xx, zero errors, runs show complete traces with output and child nodes