### PR TITLE
Bump version: 0.7.12 → 0.7.13

### DIFF
--- a/python/.bumpversion.cfg
+++ b/python/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.7.12
+current_version = 0.7.13
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
 serialize = {major}.{minor}.{patch}
 search = {current_version}

--- a/python/langsmith/__init__.py
+++ b/python/langsmith/__init__.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
 
 # Avoid calling into importlib on every call to __version__
 
-__version__ = "0.7.12"
+__version__ = "0.7.13"
 version = __version__  # for backwards compatibility
 
 


### PR DESCRIPTION
## Summary
- Patch release 0.7.13
- Includes experiment-level metadata support for pytest integration (#2524)

## Test Plan
- [x] Version bumped in `python/.bumpversion.cfg` and `python/langsmith/__init__.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)