### PR TITLE
fix(python): Fix pytest behavior with fixtures

### DIFF
--- a/python/langsmith/testing/_internal.py
+++ b/python/langsmith/testing/_internal.py
@@ -839,6 +839,7 @@ class _TestCase:
         )
 
     def log_inputs(self, inputs: dict) -> None:
+        self.inputs = inputs
         if self.pytest_plugin and self.pytest_nodeid:
             self.pytest_plugin.update_process_status(
                 self.pytest_nodeid, {"inputs": inputs}
@@ -1194,7 +1195,7 @@ def log_inputs(inputs: dict, /) -> None:
         )
         raise ValueError(msg)
     run_tree.add_inputs(inputs)
-    test_case.log_inputs(inputs)
+    test_case.log_inputs(run_tree.inputs)
 
 
 def log_outputs(outputs: dict, /) -> None:

--- a/python/tests/unit_tests/test_testing.py
+++ b/python/tests/unit_tests/test_testing.py
@@ -1,6 +1,11 @@
 import uuid
+from unittest.mock import MagicMock
 
-from langsmith.testing._internal import _get_example_id, _serde_example_values
+from langsmith.testing._internal import (
+    _get_example_id,
+    _serde_example_values,
+    _TestCase,
+)
 
 
 def test__serde_example_values():
@@ -31,3 +36,43 @@ def test__get_id():
 
     result = _get_example_id(dataset_id, inputs, outputs)
     assert isinstance(result, uuid.UUID)
+
+
+def test_log_inputs_updates_test_case_inputs():
+    """Test that calling log_inputs updates _TestCase.inputs.
+
+    When a test has fixture params (e.g. model: BaseChatModel), the initial
+    inputs captured from the function signature include the fixture values.
+    Calling log_inputs should update self.inputs so that example ID generation
+    in end_run uses the correct inputs.
+    """
+    mock_test_suite = MagicMock()
+    mock_test_suite.id = uuid.uuid4()
+
+    test_case = _TestCase(
+        test_suite=mock_test_suite,
+        run_id=uuid.uuid4(),
+        inputs={"model": "<fixture object>", "db": "<db fixture>"},
+    )
+
+    # Before log_inputs, inputs reflect fixtures
+    assert test_case.inputs == {"model": "<fixture object>", "db": "<db fixture>"}
+
+    # User calls t.log_inputs({"question": "fix typo"}) inside their test.
+    # The global log_inputs merges into run_tree then passes run_tree.inputs
+    # to test_case.log_inputs. Simulate that merged result:
+    test_case.log_inputs({"question": "fix typo"})
+
+    assert test_case.inputs == {"question": "fix typo"}
+
+    # Verify the example ID is now derived from the logged inputs,
+    # not the original fixture-based inputs
+    dataset_id = str(mock_test_suite.id)
+    expected_id = _get_example_id(dataset_id, {"question": "fix typo"})
+    fixture_id = _get_example_id(
+        dataset_id, {"model": "<fixture object>", "db": "<db fixture>"}
+    )
+    # end_run falls back to _get_example_id when no explicit id is set
+    actual_id = _get_example_id(dataset_id, test_case.inputs or {})
+    assert actual_id == expected_id
+    assert actual_id != fixture_id


### PR DESCRIPTION
`log_inputs` wasn't updating `TestCase.inputs`

This was then passed into `get_example_id` which it seems would then resolve to whatever was initially passed in as an id