### PR TITLE
fix(python): include test name in example ID hash to prevent collisions

### DIFF
--- a/python/langsmith/testing/_internal.py
+++ b/python/langsmith/testing/_internal.py
@@ -901,15 +901,12 @@ class _TestCase:
             outputs=outputs,
             test_name=self.test_name,
         )
-        metadata = {**(self.metadata or {})}
-        if self.test_name:
-            metadata["test_name"] = self.test_name
         self.test_suite.end_run(
             run_tree,
             example_id,
             outputs,
             reference_outputs=self._logged_reference_outputs,
-            metadata=metadata or None,
+            metadata=self.metadata,
             split=self.split,
             pytest_plugin=self.pytest_plugin,
             pytest_nodeid=self.pytest_nodeid,

--- a/python/langsmith/testing/_internal.py
+++ b/python/langsmith/testing/_internal.py
@@ -901,12 +901,15 @@ class _TestCase:
             outputs=outputs,
             test_name=self.test_name,
         )
+        metadata = {**(self.metadata or {})}
+        if self.test_name:
+            metadata["test_name"] = self.test_name
         self.test_suite.end_run(
             run_tree,
             example_id,
             outputs,
             reference_outputs=self._logged_reference_outputs,
-            metadata=self.metadata,
+            metadata=metadata or None,
             split=self.split,
             pytest_plugin=self.pytest_plugin,
             pytest_nodeid=self.pytest_nodeid,

--- a/python/langsmith/testing/_internal.py
+++ b/python/langsmith/testing/_internal.py
@@ -501,9 +501,15 @@ def _get_example_id(
     dataset_id: str,
     inputs: dict,
     outputs: Optional[dict] = None,
+    test_name: Optional[str] = None,
 ) -> uuid.UUID:
-    """Generate example ID based on inputs, outputs, and dataset ID."""
-    identifier_obj = (dataset_id, _object_hash(inputs), _object_hash(outputs or {}))
+    """Generate example ID based on inputs, outputs, dataset ID, and test name."""
+    identifier_obj = (
+        dataset_id,
+        test_name or "",
+        _object_hash(inputs),
+        _object_hash(outputs or {}),
+    )
     identifier = _stringify(identifier_obj)
     return uuid.uuid5(UUID5_NAMESPACE, identifier)
 
@@ -804,6 +810,7 @@ class _TestCase:
         pytest_nodeid: Any = None,
         inputs: Optional[dict] = None,
         reference_outputs: Optional[dict] = None,
+        test_name: Optional[str] = None,
     ) -> None:
         self.test_suite = test_suite
         self.example_id = example_id
@@ -814,6 +821,7 @@ class _TestCase:
         self.pytest_nodeid = pytest_nodeid
         self.inputs = inputs
         self.reference_outputs = reference_outputs
+        self.test_name = test_name
         self._logged_reference_outputs: Optional[dict] = None
         self._logged_outputs: Optional[dict] = None
 
@@ -890,6 +898,7 @@ class _TestCase:
             dataset_id=str(self.test_suite.id),
             inputs=self.inputs or {},
             outputs=outputs,
+            test_name=self.test_name,
         )
         self.test_suite.end_run(
             run_tree,
@@ -975,6 +984,7 @@ def _create_test_case(
         else None
     )
     pytest_nodeid = pytest_request.node.nodeid if pytest_request else None
+    test_name = pytest_nodeid or getattr(func, "__qualname__", None) or func.__name__
     if pytest_plugin:
         pytest_plugin.test_suite_urls[test_suite._dataset.name] = (
             cast(str, test_suite._dataset.url)
@@ -991,6 +1001,7 @@ def _create_test_case(
         reference_outputs=outputs,
         pytest_plugin=pytest_plugin,
         pytest_nodeid=pytest_nodeid,
+        test_name=test_name,
     )
     return test_case
 

--- a/python/tests/unit_tests/test_testing.py
+++ b/python/tests/unit_tests/test_testing.py
@@ -31,3 +31,30 @@ def test__get_id():
 
     result = _get_example_id(dataset_id, inputs, outputs)
     assert isinstance(result, uuid.UUID)
+
+
+def test_example_id_differs_by_test_name():
+    """Tests with the same inputs/outputs but different names get different IDs."""
+    dataset_id = "4e32bff6-5762-4906-8d74-ee2bd0f1d234"
+    inputs = {"model": "gpt-4"}
+
+    id_a = _get_example_id(dataset_id, inputs, test_name="test_a")
+    id_b = _get_example_id(dataset_id, inputs, test_name="test_b")
+    assert id_a != id_b
+
+    # Same test name produces the same ID (stable across runs)
+    id_a2 = _get_example_id(dataset_id, inputs, test_name="test_a")
+    assert id_a == id_a2
+
+
+def test_example_id_same_name_different_inputs():
+    """Same test name but different inputs get different IDs (parametrize)."""
+    dataset_id = "4e32bff6-5762-4906-8d74-ee2bd0f1d234"
+
+    id_1 = _get_example_id(
+        dataset_id, {"a": 1, "b": 2}, test_name="test_addition[1-2]"
+    )
+    id_2 = _get_example_id(
+        dataset_id, {"a": 3, "b": 4}, test_name="test_addition[3-4]"
+    )
+    assert id_1 != id_2


### PR DESCRIPTION
 ## Summary
 - Include test name (pytest nodeid or `func.__qualname__`) in the
  `_get_example_id` hash
 - Prevents different tests with identical fixture args from
 mapping to the same Example in the dataset
 - Companion to #2543 — that PR fixes the case where
 `t.log_inputs()` is called; this PR fixes it even when
 `t.log_inputs()` is not called

 **Breaking change**: Existing datasets will get new example IDs
 on next run (old examples become orphaned). This is expected
 since the previous behavior was producing incorrect results (all
 tests sharing one example).

 ## Test Plan
 - [x] Existing `test__get_id` still passes
 - [x] New `test_example_id_differs_by_test_name` — same inputs,
 different test names → different IDs
 - [x] New `test_example_id_same_name_different_inputs` —
 parametrized tests still get unique IDs