### PR TITLE
fix(python): handle concurrent example creation in pytest-xdist

### DIFF
--- a/python/langsmith/testing/_internal.py
+++ b/python/langsmith/testing/_internal.py
@@ -673,15 +673,20 @@ class _LangSmithTestSuite:
         try:
             example = self.client.read_example(example_id=example_id)
         except ls_utils.LangSmithNotFoundError:
-            example = self.client.create_example(
-                example_id=example_id,
-                inputs=inputs,
-                outputs=outputs,
-                dataset_id=self.id,
-                metadata=metadata,
-                split=split,
-                created_at=self._experiment.start_time,
-            )
+            try:
+                example = self.client.create_example(
+                    example_id=example_id,
+                    inputs=inputs,
+                    outputs=outputs,
+                    dataset_id=self.id,
+                    metadata=metadata,
+                    split=split,
+                    created_at=self._experiment.start_time,
+                )
+            except ls_utils.LangSmithConflictError:
+                # Another worker (e.g. pytest-xdist) created this example
+                # concurrently between our read and create. Read the existing one.
+                example = self.client.read_example(example_id=example_id)
         else:
             normalized_split = split
             if isinstance(normalized_split, str):


### PR DESCRIPTION
## Summary

- When multiple `pytest-xdist` workers run the same test class simultaneously, both can call `sync_example()` for the same `example_id` at nearly the same time
- Both workers pass the `read_example` → `LangSmithNotFoundError` check, then race to `create_example`
- The second worker's `create_example` returns a 409 conflict, which was unhandled and surfaced as a confusing `LangSmithConflictError` rather than a test failure in the actual test
- Fix: wrap `create_example` in a `try/except LangSmithConflictError` and fall back to reading the now-existing example — the same pattern used at lines 472 and 496 of the same file

## Test Plan

- [x] Existing unit tests pass (`tests/unit_tests/evaluation/test_runner.py`, `tests/unit_tests/test_testing.py`)
- [x] Manual: run a test suite with `pytest-xdist` (`-n auto`) where multiple workers share the same test class to confirm no spurious `LangSmithConflictError`