### PR TITLE
fix(python): replace busy-wait in AsyncExperimentResults.__anext__

### DIFF
--- a/python/langsmith/evaluation/_arunner.py
+++ b/python/langsmith/evaluation/_arunner.py
@@ -1174,7 +1174,7 @@ class AsyncExperimentResults:
     ):
         self._manager = experiment_manager
         self._results: list[ExperimentResultRow] = []
-        self._lock = asyncio.Lock()
+        self._condition = asyncio.Condition()
         self._task = asyncio.create_task(self._process_data(self._manager))
         self._processed_count = 0
 
@@ -1186,31 +1186,26 @@ class AsyncExperimentResults:
         return self
 
     async def __anext__(self) -> ExperimentResultRow:
-        async def _wait_until_index(index: int) -> None:
-            while self._processed_count < index:
-                await asyncio.sleep(0.05)
-
-        while True:
-            async with self._lock:
+        async with self._condition:
+            while True:
                 if self._processed_count < len(self._results):
                     result = self._results[self._processed_count]
                     self._processed_count += 1
                     return result
                 elif self._task.done():
                     raise StopAsyncIteration
-
-            await asyncio.shield(
-                asyncio.wait_for(_wait_until_index(len(self._results)), timeout=None)
-            )
+                await self._condition.wait()
 
     async def _process_data(self, manager: _AsyncExperimentManager) -> None:
         tqdm = _load_tqdm()
         async for item in tqdm(manager.aget_results()):
-            async with self._lock:
+            async with self._condition:
                 self._results.append(item)
+                self._condition.notify()
         summary_scores = await manager.aget_summary_scores()
-        async with self._lock:
+        async with self._condition:
             self._summary_results = summary_scores
+            self._condition.notify_all()
 
     def to_pandas(
         self, start: Optional[int] = 0, end: Optional[int] = None


### PR DESCRIPTION
## Summary

- `AsyncExperimentResults.__anext__` had a polling loop (`await asyncio.sleep(0.05)`) to wait for new results from the background `_process_data` task
- When the consumer was already caught up (`_processed_count == len(_results)`) but the task was still running, `_wait_until_index` returned immediately, causing the outer `while True` to spin at full CPU speed until the next result arrived
- Additionally, even when new results were available the consumer could wait up to 50ms before waking
- Fix: replace `asyncio.Lock` + polling with `asyncio.Condition`; `_process_data` calls `condition.notify()` each time a result is appended and `condition.notify_all()` on completion; `__anext__` blocks on `condition.wait()` instead of spinning

## Test Plan

- [x] Existing unit tests pass (`tests/unit_tests/evaluation/test_runner.py`)
- [ ] Manual: run `aevaluate()` on a dataset and confirm results stream back with no noticeable delay and reduced CPU usage while waiting