### PR TITLE
feat: retry GET /info with auth on 401/403

### DIFF
--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -1392,14 +1392,24 @@ class Client:
             self._info = ls_schemas.LangSmithInfo()
             return self._info
 
-        # Fetch info from API
+        # Fetch info from API.
+        # First try unauthenticated so deployments that don't require auth on
+        # /info still work without sending credentials unnecessarily. If the
+        # server returns 401 or 403, retry with the configured auth headers
+        # (supports FF_INFO_ENDPOINT_AUTH_REQUIRED on self-hosted deployments).
         try:
-            response = self.request_with_retries(
-                "GET",
-                "/info",
+            response = self.session.get(
+                _construct_url(self.api_url, "/info"),
                 headers={"Accept": "application/json"},
                 timeout=self._timeout,
             )
+            if response.status_code in (401, 403):
+                response = self.request_with_retries(
+                    "GET",
+                    "/info",
+                    headers={"Accept": "application/json"},
+                    timeout=self._timeout,
+                )
             ls_utils.raise_for_status_with_text(response)
             self._info = ls_schemas.LangSmithInfo(**response.json())
         except BaseException as e:

--- a/python/tests/unit_tests/test_client.py
+++ b/python/tests/unit_tests/test_client.py
@@ -5446,3 +5446,100 @@ class TestWriteTraceToFallbackDir:
         )
         assert client._failed_traces_dir is None
         _clear_env_cache()
+
+
+@mock.patch("langsmith.client.requests.Session")
+def test_info_unauthenticated_success(mock_session_cls: mock.Mock) -> None:
+    """GET /info succeeds without auth — no authenticated retry is made."""
+    _clear_env_cache()
+    mock_session = mock.Mock()
+    mock_session_cls.return_value = mock_session
+
+    ok_response = mock.Mock()
+    ok_response.status_code = 200
+    ok_response.json.return_value = {"version": "0.1.0"}
+    mock_session.get.return_value = ok_response
+
+    client = Client(
+        api_url="http://localhost:1984",
+        api_key="test-key",
+        auto_batch_tracing=False,
+    )
+    info = client.info
+
+    assert info.version == "0.1.0"
+    # Unauthenticated GET was made
+    mock_session.get.assert_called_once()
+    url_called = mock_session.get.call_args[0][0]
+    assert url_called.endswith("/info")
+    # Auth headers should NOT be in the unauthenticated request
+    headers_sent = mock_session.get.call_args[1].get("headers", {})
+    assert "x-api-key" not in headers_sent
+    # No authenticated retry needed
+    mock_session.request.assert_not_called()
+    _clear_env_cache()
+
+
+@mock.patch("langsmith.client.requests.Session")
+def test_info_retries_with_auth_on_401(mock_session_cls: mock.Mock) -> None:
+    """GET /info returns 401 without auth, then succeeds with auth."""
+    _clear_env_cache()
+    mock_session = mock.Mock()
+    mock_session_cls.return_value = mock_session
+
+    unauth_response = mock.Mock()
+    unauth_response.status_code = 401
+
+    auth_response = mock.Mock()
+    auth_response.status_code = 200
+    auth_response.json.return_value = {"version": "0.2.0"}
+    mock_session.get.return_value = unauth_response
+    # request_with_retries goes through session.request
+    mock_session.request.return_value = auth_response
+
+    client = Client(
+        api_url="http://localhost:1984",
+        api_key="test-key",
+        auto_batch_tracing=False,
+    )
+    with mock.patch("langsmith.client.ls_utils.raise_for_status_with_text"):
+        info = client.info
+
+    assert info.version == "0.2.0"
+    # First unauthenticated attempt
+    mock_session.get.assert_called_once()
+    # Authenticated retry via request_with_retries
+    mock_session.request.assert_called_once()
+    auth_headers = mock_session.request.call_args[1].get("headers", {})
+    assert auth_headers.get("x-api-key") == "test-key"
+    _clear_env_cache()
+
+
+@mock.patch("langsmith.client.requests.Session")
+def test_info_retries_with_auth_on_403(mock_session_cls: mock.Mock) -> None:
+    """GET /info returns 403 without auth, then succeeds with auth."""
+    _clear_env_cache()
+    mock_session = mock.Mock()
+    mock_session_cls.return_value = mock_session
+
+    unauth_response = mock.Mock()
+    unauth_response.status_code = 403
+
+    auth_response = mock.Mock()
+    auth_response.status_code = 200
+    auth_response.json.return_value = {"version": "0.3.0"}
+    mock_session.get.return_value = unauth_response
+    mock_session.request.return_value = auth_response
+
+    client = Client(
+        api_url="http://localhost:1984",
+        api_key="test-key",
+        auto_batch_tracing=False,
+    )
+    with mock.patch("langsmith.client.ls_utils.raise_for_status_with_text"):
+        info = client.info
+
+    assert info.version == "0.3.0"
+    mock_session.get.assert_called_once()
+    mock_session.request.assert_called_once()
+    _clear_env_cache()


### PR DESCRIPTION
## Summary

- `GET /info` is now tried **without auth headers first**, preserving existing behavior for all current deployments
- If the server responds with `401` or `403`, the SDK retries the request with the configured API key
- This transparently supports self-hosted deployments that enable `FF_INFO_ENDPOINT_AUTH_REQUIRED` (see companion PR langchain-ai/langchainplus#19412) without requiring any configuration change in the SDK

## Test Plan

- [x] `test_info_unauthenticated_success` — 200 on first try, no authenticated retry made, no auth headers sent on the unauthenticated request
- [x] `test_info_retries_with_auth_on_401` — 401 triggers retry with API key in headers
- [x] `test_info_retries_with_auth_on_403` — 403 triggers retry with API key in headers

## Release Note

The SDK now transparently handles `GET /info` endpoints that require authentication, retrying with credentials if the server returns 401 or 403.