### PR TITLE
fix: attach UTC timezone to naive datetimes in RunBase to prevent 422 on multipart upload

### DIFF
--- a/python/langsmith/schemas.py
+++ b/python/langsmith/schemas.py
@@ -26,6 +26,7 @@ from pydantic import (
     StrictBool,
     StrictFloat,
     StrictInt,
+    field_validator,
 )
 from typing_extensions import Literal, NotRequired, TypedDict
 
@@ -369,6 +370,22 @@ class RunBase(BaseModel):
     
     Each entry is a tuple of `(mime_type, bytes)`.
     """
+
+    @field_validator("start_time", "end_time", mode="before")
+    @classmethod
+    def _ensure_tz_aware(cls, v: Any) -> Any:
+        """Attach UTC timezone to naive datetimes deserialized from the API.
+
+        The LangSmith API returns ISO-8601 timestamps without a timezone suffix
+        in some code paths (e.g. list_runs used by aevaluate_existing). When these
+        naive datetimes are later serialized via .isoformat() for multipart upload,
+        the Go-based API parser rejects them with a 422 because it requires the
+        RFC3339 suffix (Z or +00:00). Attaching UTC here fixes the serialization
+        at the source without requiring callers to guard every usage site.
+        """
+        if isinstance(v, datetime) and v.tzinfo is None:
+            return v.replace(tzinfo=timezone.utc)
+        return v
 
     @property
     def metadata(self) -> dict[str, Any]:


### PR DESCRIPTION
## Problem

When `aevaluate` (or `evaluate`) is called against an existing experiment name, the SDK loads runs via `client.list_runs()`, which deserializes `Run.start_time` as a **naive datetime** (no `tzinfo`). This datetime is later serialized via `.isoformat()` when building the feedback multipart payload:

```
2026-03-03T20:15:03.650083        ← no timezone suffix ❌
```

The LangSmith API Go backend rejects the request with a **silent 422** error:
```
parsing time "2026-03-03T20:15:03.650083" as "2006-01-02T15:04:05Z07:00":
cannot parse "" as "Z07:00"
```

Evaluators appear to succeed locally (they execute in-process), but **no feedback is ever uploaded to LangSmith**. The failure appears only in background logs after the `evaluate` call returns.

## Fix

Add a `@field_validator` on `RunBase.start_time` / `end_time` that attaches UTC timezone to any naive datetime at deserialization time:

```python
@field_validator("start_time", "end_time", mode="before")
@classmethod
def _ensure_tz_aware(cls, v):
    if isinstance(v, datetime) and v.tzinfo is None:
        return v.replace(tzinfo=timezone.utc)
    return v
```

The LangSmith API only ever returns UTC timestamps, so attaching UTC to naive datetimes is always the correct interpretation. The pattern is already used elsewhere in the SDK (e.g. `client.py` line 3907).

After the fix, `.isoformat()` produces RFC3339-valid output accepted by the Go backend:
```
2026-03-03T20:15:03.650083+00:00  ← with UTC suffix ✅
```

Closes #2533