### PR TITLE
feat(sandbox): add tunnel feature on python sdk

### DIFF
--- a/python/langsmith/sandbox/README.md
+++ b/python/langsmith/sandbox/README.md
@@ -243,6 +243,121 @@ with client.sandbox(template_name="my-python") as sb:
     sb.write("/app/data.bin", b"\x00\x01\x02\x03")
 ```
 
+## TCP Tunnel
+
+Access any TCP service running inside a sandbox (databases, Redis, HTTP servers,
+etc.) as if it were running on your local machine. The tunnel opens a local TCP
+port and forwards connections through a multiplexed WebSocket to the target port
+inside the sandbox.
+
+Requires the `websockets` package (`pip install 'langsmith[sandbox]'`).
+
+### Basic Usage — PostgreSQL
+
+Use a template with the `postgres:16` image. The entrypoint initializes and
+starts Postgres automatically:
+
+```python
+import psycopg2
+
+# Template uses the official postgres:16 image
+sb = client.create_sandbox(template_name="my-postgres")
+pg_handle = sb.run(
+    "POSTGRES_HOST_AUTH_METHOD=trust docker-entrypoint.sh postgres",
+    timeout=0,
+    wait=False,
+)
+import time; time.sleep(6)  # wait for Postgres to initialize and start
+
+try:
+    with sb.tunnel(remote_port=5432, local_port=25432) as t:
+        conn = psycopg2.connect(
+            host="127.0.0.1",
+            port=t.local_port,
+            user="postgres",
+        )
+        cursor = conn.cursor()
+        cursor.execute("SELECT version()")
+        print(cursor.fetchone())
+        conn.close()
+finally:
+    pg_handle.kill()
+    client.delete_sandbox(sb.name)
+```
+
+### Basic Usage — Redis
+
+Use a template with the `redis:7` image. Redis self-daemonizes:
+
+```python
+import redis
+
+with client.sandbox(template_name="my-redis") as sb:
+    sb.run("redis-server --daemonize yes", timeout=10)
+
+    with sb.tunnel(remote_port=6379, local_port=26379) as t:
+        r = redis.Redis(host="127.0.0.1", port=t.local_port)
+        r.set("key", "value")
+        print(r.get("key"))  # b"value"
+```
+
+### HTTP Services
+
+Works with any TCP service. Start long-running services with `wait=False` and
+`timeout=0` so they stay alive across commands:
+
+```python
+sb = client.create_sandbox(template_name="my-sandbox")
+http_handle = sb.run("python3 -m http.server 3000", timeout=0, wait=False)
+import time; time.sleep(2)
+
+try:
+    with sb.tunnel(remote_port=3000, local_port=13000) as t:
+        import urllib.request
+        resp = urllib.request.urlopen(f"http://127.0.0.1:{t.local_port}/")
+        print(resp.status)  # 200
+finally:
+    http_handle.kill()
+    client.delete_sandbox(sb.name)
+```
+
+### Multiple Tunnels
+
+Open several tunnels simultaneously to different services:
+
+```python
+http_handle2 = sb.run("python3 -m http.server 3001", timeout=0, wait=False)
+import time; time.sleep(1)
+
+with sb.tunnel(remote_port=3000, local_port=23000) as t1, \
+     sb.tunnel(remote_port=3001, local_port=23001) as t2:
+    resp1 = urllib.request.urlopen(f"http://127.0.0.1:{t1.local_port}/")
+    resp2 = urllib.request.urlopen(f"http://127.0.0.1:{t2.local_port}/")
+
+http_handle2.kill()
+```
+
+### Explicit Lifecycle
+
+For notebooks or long-lived sessions where a context manager isn't convenient:
+
+```python
+t = sb.tunnel(remote_port=3000, local_port=23002)
+
+print(t.local_port)
+# ... use the tunnel as long as needed ...
+
+t.close()
+```
+
+### Async Usage
+
+```python
+async with await client.sandbox(template_name="my-sandbox") as sb:
+    async with await sb.tunnel(remote_port=5432) as t:
+        conn = await asyncpg.connect(host="127.0.0.1", port=t.local_port)
+```
+
 ## Templates
 
 Templates define the container image and resources for sandboxes. **You must create a template before you can create sandboxes.**
@@ -445,6 +560,10 @@ from langsmith.sandbox import (
     SandboxConnectionError,   # Network/WebSocket error
     CommandTimeoutError,      # Command exceeded its timeout (extends SandboxOperationError)
     QuotaExceededError,       # Quota limit reached
+    TunnelError,              # Base for tunnel errors
+    TunnelPortNotAllowedError,       # Port blocked by daemon allowlist
+    TunnelConnectionRefusedError,    # Nothing listening on remote port
+    TunnelUnsupportedVersionError,   # Client/daemon protocol mismatch
 )
 
 try:
@@ -509,6 +628,7 @@ except SandboxClientError as e:
 | `reconnect(command_id, *, stdout_offset=0, stderr_offset=0)` | Reconnect to a running command. Returns `CommandHandle`. |
 | `write(path, content)` | Write file (str or bytes) |
 | `read(path)` | Read file (returns bytes) |
+| `tunnel(remote_port, *, local_port=0)` | Open a TCP tunnel. Returns `Tunnel` (context manager). |
 
 ### ExecutionResult
 
@@ -548,3 +668,14 @@ Returned by `sb.run(wait=False)`. Iterable, yielding `OutputChunk` objects.
 | `stream` | `"stdout"` or `"stderr"` |
 | `data` | Text content of this chunk (str) |
 | `offset` | Byte offset within the stream (int) |
+
+### Tunnel
+
+Returned by `sb.tunnel(remote_port)`. Context manager that opens a local TCP
+listener forwarding to a port inside the sandbox.
+
+| Property / Method | Description |
+|-------------------|-------------|
+| `local_port` | Local port the tunnel is listening on (int) |
+| `remote_port` | Target port inside the sandbox (int) |
+| `close()` | Shut down the tunnel and all connections |

--- a/python/langsmith/sandbox/__init__.py
+++ b/python/langsmith/sandbox/__init__.py
@@ -42,6 +42,10 @@ from langsmith.sandbox._exceptions import (
     SandboxNotReadyError,
     SandboxOperationError,
     SandboxServerReloadError,
+    TunnelConnectionRefusedError,
+    TunnelError,
+    TunnelPortNotAllowedError,
+    TunnelUnsupportedVersionError,
     ValidationError,
 )
 from langsmith.sandbox._models import (
@@ -57,6 +61,7 @@ from langsmith.sandbox._models import (
     VolumeMountSpec,
 )
 from langsmith.sandbox._sandbox import Sandbox
+from langsmith.sandbox._tunnel import AsyncTunnel, Tunnel
 
 __all__ = [
     # Main classes
@@ -97,6 +102,13 @@ __all__ = [
     "SandboxOperationError",
     "CommandTimeoutError",
     "DataplaneNotConfiguredError",
+    # Tunnel
+    "Tunnel",
+    "AsyncTunnel",
+    "TunnelError",
+    "TunnelPortNotAllowedError",
+    "TunnelConnectionRefusedError",
+    "TunnelUnsupportedVersionError",
 ]
 
 # Emit warning on import

--- a/python/langsmith/sandbox/_async_sandbox.py
+++ b/python/langsmith/sandbox/_async_sandbox.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Callable, Literal, Optional, Union, overload
 
@@ -18,6 +19,7 @@ from langsmith.sandbox._models import (
     AsyncCommandHandle,
     ExecutionResult,
 )
+from langsmith.sandbox._tunnel import AsyncTunnel
 
 if TYPE_CHECKING:
     from langsmith.sandbox._async_client import AsyncSandboxClient
@@ -444,3 +446,43 @@ class AsyncSandbox:
             handle_sandbox_http_error(e)
             # This line should never be reached but satisfies type checker
             raise  # pragma: no cover
+
+    async def tunnel(self, remote_port: int, *, local_port: int = 0) -> AsyncTunnel:
+        """Open a TCP tunnel to a port inside the sandbox.
+
+        Creates a local TCP listener that forwards connections through a
+        yamux-multiplexed WebSocket to the specified port inside the sandbox.
+        Works with any TCP protocol (databases, Redis, HTTP, etc.).
+
+        Usage::
+
+            async with await sandbox.tunnel(remote_port=5432) as t:
+                conn = await asyncpg.connect(host="127.0.0.1", port=t.local_port)
+
+        Args:
+            remote_port: TCP port inside the sandbox to tunnel to (1-65535).
+            local_port: Local port to listen on. Defaults to mirroring
+                remote_port. Use 0 to let the OS pick an available port.
+
+        Returns:
+            An AsyncTunnel instance (async context manager).
+
+        Raises:
+            ValueError: If port values are out of range.
+            DataplaneNotConfiguredError: If dataplane_url is not configured.
+            SandboxNotReadyError: If sandbox is not ready.
+        """
+        if not 1 <= remote_port <= 65535:
+            raise ValueError(
+                f"remote_port must be between 1 and 65535 (got {remote_port})"
+            )
+        if local_port and not 1 <= local_port <= 65535:
+            raise ValueError(
+                f"local_port must be between 1 and 65535 (got {local_port})"
+            )
+        dataplane_url = self._require_dataplane_url()
+        api_key = self._client._api_key
+        t = AsyncTunnel(dataplane_url, api_key, remote_port, local_port=local_port)
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(None, t._tunnel._start)
+        return t

--- a/python/langsmith/sandbox/_exceptions.py
+++ b/python/langsmith/sandbox/_exceptions.py
@@ -284,3 +284,46 @@ class CommandTimeoutError(SandboxOperationError):
         """Initialize the error."""
         super().__init__(message, operation="command", error_type="CommandTimeout")
         self.timeout = timeout
+
+
+# ========================================================================
+# Tunnel Errors
+# ========================================================================
+
+
+class TunnelError(SandboxClientError):
+    """Base exception for TCP tunnel errors."""
+
+    pass
+
+
+class TunnelPortNotAllowedError(TunnelError):
+    """The daemon rejected the port as not allowed.
+
+    Attributes:
+        port: The port that was rejected.
+    """
+
+    def __init__(self, message: str, *, port: int):
+        """Initialize the error."""
+        super().__init__(message)
+        self.port = port
+
+
+class TunnelConnectionRefusedError(TunnelError):
+    """Nothing is listening on the target port inside the sandbox.
+
+    Attributes:
+        port: The port that could not be reached.
+    """
+
+    def __init__(self, message: str, *, port: int):
+        """Initialize the error."""
+        super().__init__(message)
+        self.port = port
+
+
+class TunnelUnsupportedVersionError(TunnelError):
+    """Protocol version mismatch between the tunnel client and the daemon."""
+
+    pass

--- a/python/langsmith/sandbox/_sandbox.py
+++ b/python/langsmith/sandbox/_sandbox.py
@@ -18,6 +18,7 @@ from langsmith.sandbox._models import (
     CommandHandle,
     ExecutionResult,
 )
+from langsmith.sandbox._tunnel import Tunnel
 
 if TYPE_CHECKING:
     from langsmith.sandbox._client import SandboxClient
@@ -443,3 +444,48 @@ class Sandbox:
             handle_sandbox_http_error(e)
             # This line should never be reached but satisfies type checker
             raise  # pragma: no cover
+
+    def tunnel(self, remote_port: int, *, local_port: int = 0) -> Tunnel:
+        """Open a TCP tunnel to a port inside the sandbox.
+
+        Creates a local TCP listener that forwards connections through a
+        yamux-multiplexed WebSocket to the specified port inside the sandbox.
+        Works with any TCP protocol (databases, Redis, HTTP, etc.).
+
+        Use as a context manager for automatic cleanup::
+
+            with sandbox.tunnel(remote_port=5432) as t:
+                conn = psycopg2.connect(host="127.0.0.1", port=t.local_port)
+
+        Or manage the lifecycle explicitly::
+
+            t = sandbox.tunnel(remote_port=5432)
+            # ... use tunnel ...
+            t.close()
+
+        Args:
+            remote_port: TCP port inside the sandbox to tunnel to (1-65535).
+            local_port: Local port to listen on. Defaults to mirroring
+                remote_port. Use 0 to let the OS pick an available port.
+
+        Returns:
+            A Tunnel instance (context manager).
+
+        Raises:
+            ValueError: If port values are out of range.
+            DataplaneNotConfiguredError: If dataplane_url is not configured.
+            SandboxNotReadyError: If sandbox is not ready.
+        """
+        if not 1 <= remote_port <= 65535:
+            raise ValueError(
+                f"remote_port must be between 1 and 65535 (got {remote_port})"
+            )
+        if local_port and not 1 <= local_port <= 65535:
+            raise ValueError(
+                f"local_port must be between 1 and 65535 (got {local_port})"
+            )
+        dataplane_url = self._require_dataplane_url()
+        api_key = self._client._api_key
+        t = Tunnel(dataplane_url, api_key, remote_port, local_port=local_port)
+        t._start()
+        return t

--- a/python/langsmith/sandbox/_tunnel.py
+++ b/python/langsmith/sandbox/_tunnel.py
@@ -1,0 +1,422 @@
+"""TCP tunnel for accessing services running inside sandboxes.
+
+Establishes a WebSocket connection to the daemon's ``/tunnel`` endpoint,
+runs a yamux multiplexing session on top, and forwards local TCP connections
+through yamux streams to the target port inside the sandbox.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import socket
+import struct
+import threading
+from typing import TYPE_CHECKING, Any, Optional
+
+if TYPE_CHECKING:
+    from langsmith.sandbox._yamux import YamuxSession, YamuxStream
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Tunnel connect-header protocol (layered on top of yamux streams)
+# ---------------------------------------------------------------------------
+
+PROTOCOL_VERSION = 0x01
+
+STATUS_OK = 0x00
+STATUS_PORT_NOT_ALLOWED = 0x01
+STATUS_DIAL_FAILED = 0x02
+STATUS_UNSUPPORTED_VERSION = 0x03
+
+_CONNECT_HEADER_FMT = ">BH"  # version(1) + port(2, big-endian)
+
+
+def _write_connect_header(stream: YamuxStream, port: int) -> None:
+    """Write the 3-byte connect header on a freshly opened yamux stream."""
+    stream.write(struct.pack(_CONNECT_HEADER_FMT, PROTOCOL_VERSION, port))
+
+
+def _read_status(stream: YamuxStream) -> int:
+    """Read the 1-byte status response from the daemon."""
+    data = stream.read(1)
+    if not data:
+        raise ConnectionError("tunnel: connection closed before status")
+    return data[0]
+
+
+# ---------------------------------------------------------------------------
+# WebSocket adapter
+# ---------------------------------------------------------------------------
+
+
+class _WSAdapter:
+    """Adapts the ``websockets`` message API to a byte-stream interface.
+
+    yamux requires a plain read/write/close byte stream.  WebSocket is
+    message-based, so this adapter buffers partially consumed messages on
+    reads and sends one binary message per write.
+    """
+
+    def __init__(self, ws: Any) -> None:
+        self._ws = ws
+        self._buf = bytearray()
+        self._write_lock = threading.Lock()
+
+    def read(self, n: int) -> bytes:
+        while len(self._buf) < n:
+            msg = self._ws.recv()
+            if isinstance(msg, str):
+                msg = msg.encode()
+            self._buf.extend(msg)
+
+        result = bytes(self._buf[:n])
+        del self._buf[:n]
+        return result
+
+    def write(self, data: bytes) -> int:
+        with self._write_lock:
+            self._ws.send(data)
+        return len(data)
+
+    def close(self) -> None:
+        try:
+            self._ws.close()
+        except Exception:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Bridge: bidirectional copy between yamux stream and TCP socket
+# ---------------------------------------------------------------------------
+
+_BRIDGE_BUF_SIZE = 16384
+
+
+def _bridge(stream: YamuxStream, tcp_conn: socket.socket) -> None:
+    """Copy data bidirectionally until one side closes or errors."""
+    done = threading.Event()
+
+    def _stream_to_tcp() -> None:
+        try:
+            while True:
+                data = stream.read(_BRIDGE_BUF_SIZE)
+                if not data:
+                    break
+                tcp_conn.sendall(data)
+        except Exception:
+            pass
+        finally:
+            done.set()
+
+    def _tcp_to_stream() -> None:
+        try:
+            while True:
+                data = tcp_conn.recv(_BRIDGE_BUF_SIZE)
+                if not data:
+                    break
+                stream.write(data)
+        except Exception:
+            pass
+        finally:
+            done.set()
+
+    t1 = threading.Thread(target=_stream_to_tcp, daemon=True)
+    t2 = threading.Thread(target=_tcp_to_stream, daemon=True)
+    t1.start()
+    t2.start()
+
+    done.wait()
+
+    try:
+        stream.close()
+    except Exception:
+        pass
+    try:
+        tcp_conn.shutdown(socket.SHUT_RDWR)
+    except OSError:
+        pass
+    try:
+        tcp_conn.close()
+    except OSError:
+        pass
+
+    t1.join(timeout=5)
+    t2.join(timeout=5)
+
+
+# ---------------------------------------------------------------------------
+# Tunnel
+# ---------------------------------------------------------------------------
+
+
+def _ensure_websockets():
+    """Import websockets sync client or raise a clear error."""
+    try:
+        from websockets.sync.client import connect as ws_connect
+
+        return ws_connect
+    except ImportError:
+        raise ImportError(
+            "TCP tunnel requires the 'websockets' package. "
+            "Install it with: pip install 'langsmith[sandbox]'"
+        ) from None
+
+
+class Tunnel:
+    """TCP tunnel to a port inside a sandbox.
+
+    Opens a local TCP listener and forwards each accepted connection through
+    a yamux-multiplexed WebSocket to the daemon, which dials the target port
+    inside the sandbox.
+
+    Typically used as a context manager::
+
+        with sandbox.tunnel(remote_port=5432) as t:
+            conn = psycopg2.connect(host="127.0.0.1", port=t.local_port)
+
+    Or with explicit lifecycle::
+
+        t = sandbox.tunnel(remote_port=5432)
+        # ... use tunnel ...
+        t.close()
+    """
+
+    def __init__(
+        self,
+        dataplane_url: str,
+        api_key: Optional[str],
+        remote_port: int,
+        *,
+        local_port: int = 0,
+    ) -> None:
+        self._dataplane_url = dataplane_url
+        self._api_key = api_key
+        self._remote_port = remote_port
+        self._requested_local_port = local_port or remote_port
+        self._local_port = self._requested_local_port
+
+        self._ws: object = None
+        self._yamux: Optional[YamuxSession] = None
+        self._server_socket: Optional[socket.socket] = None
+        self._accept_thread: Optional[threading.Thread] = None
+        self._closed = False
+        self._started = False
+
+    @property
+    def local_port(self) -> int:
+        """Local port the tunnel is listening on."""
+        return self._local_port
+
+    @property
+    def remote_port(self) -> int:
+        """Port inside the sandbox that the tunnel connects to."""
+        return self._remote_port
+
+    # -- Context manager ----------------------------------------------------
+
+    def __enter__(self) -> Tunnel:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        self.close()
+
+    # -- Lifecycle ----------------------------------------------------------
+
+    def _start(self) -> None:
+        if self._started:
+            return
+        self._started = True
+
+        try:
+            self._do_start()
+        except Exception:
+            self.close()
+            raise
+
+    def _do_start(self) -> None:
+        from langsmith.sandbox._yamux import YamuxSession
+
+        ws_connect = _ensure_websockets()
+        ws_url = self._build_ws_url()
+        headers: dict[str, str] = {}
+        if self._api_key:
+            headers["X-Api-Key"] = self._api_key
+
+        self._ws = ws_connect(
+            ws_url,
+            additional_headers=headers,
+            open_timeout=15,
+            close_timeout=5,
+            ping_interval=None,  # yamux handles keepalive
+        )
+
+        adapter = _WSAdapter(self._ws)
+        self._yamux = YamuxSession(adapter)
+
+        self._server_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self._server_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+
+        # Check if another process is actively listening on this port.
+        # SO_REUSEADDR lets us rebind over TIME_WAIT, but we don't want to
+        # silently steal a port from a running service.
+        port = self._requested_local_port
+        if port != 0:
+            probe = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            try:
+                probe.settimeout(0.5)
+                probe.connect(("127.0.0.1", port))
+                probe.close()
+                raise OSError(
+                    f"Port {port} is already in use by another service. "
+                    f"Choose a different local_port."
+                )
+            except ConnectionRefusedError:
+                pass  # nothing listening — safe to bind
+            except OSError as e:
+                if "Connection refused" in str(e):
+                    pass  # same as above, different OS error message
+                elif "already in use" in str(e).lower():
+                    raise
+                else:
+                    pass  # TIME_WAIT or other transient state — safe to bind
+            finally:
+                try:
+                    probe.close()
+                except OSError:
+                    pass
+
+        self._server_socket.bind(("127.0.0.1", self._requested_local_port))
+        self._server_socket.listen(128)
+        self._local_port = self._server_socket.getsockname()[1]
+
+        self._accept_thread = threading.Thread(
+            target=self._accept_loop, daemon=True, name="tunnel-accept"
+        )
+        self._accept_thread.start()
+
+    def close(self) -> None:
+        """Shut down the tunnel, closing all connections."""
+        if self._closed:
+            return
+        self._closed = True
+
+        if self._server_socket:
+            try:
+                self._server_socket.close()
+            except OSError:
+                pass
+
+        if self._yamux:
+            self._yamux.close()
+
+    # -- Internal -----------------------------------------------------------
+
+    def _accept_loop(self) -> None:
+        while not self._closed:
+            try:
+                conn, _ = self._server_socket.accept()  # type: ignore[union-attr]
+            except OSError:
+                break
+            threading.Thread(
+                target=self._handle_conn,
+                args=(conn,),
+                daemon=True,
+                name="tunnel-bridge",
+            ).start()
+
+    def _handle_conn(self, tcp_conn: socket.socket) -> None:
+        try:
+            stream = self._yamux.open_stream()  # type: ignore[union-attr]
+            _write_connect_header(stream, self._remote_port)
+            status = _read_status(stream)
+
+            if status == STATUS_OK:
+                _bridge(stream, tcp_conn)
+                return
+
+            stream.close()
+            tcp_conn.close()
+
+            if status == STATUS_PORT_NOT_ALLOWED:
+                logger.warning(
+                    "tunnel: port %d not allowed by daemon",
+                    self._remote_port,
+                )
+            elif status == STATUS_DIAL_FAILED:
+                logger.warning(
+                    "tunnel: nothing listening on port %d inside sandbox",
+                    self._remote_port,
+                )
+            elif status == STATUS_UNSUPPORTED_VERSION:
+                logger.warning(
+                    "tunnel: protocol version mismatch (client v%d)",
+                    PROTOCOL_VERSION,
+                )
+            else:
+                logger.warning("tunnel: unknown status %d", status)
+
+        except Exception as exc:
+            logger.debug("tunnel: connection handler error: %s", exc)
+            try:
+                tcp_conn.close()
+            except OSError:
+                pass
+
+    def _build_ws_url(self) -> str:
+        url = self._dataplane_url.rstrip("/")
+        url = url.replace("https://", "wss://").replace("http://", "ws://")
+        return f"{url}/tunnel"
+
+
+# ---------------------------------------------------------------------------
+# AsyncTunnel
+# ---------------------------------------------------------------------------
+
+
+class AsyncTunnel:
+    """Async wrapper around :class:`Tunnel`.
+
+    The underlying tunnel runs in background threads (TCP listener + bridges);
+    async context-manager methods delegate to the sync tunnel via the event
+    loop's executor.
+
+    Usage::
+
+        async with await sandbox.tunnel(remote_port=5432) as t:
+            conn = await asyncpg.connect(host="127.0.0.1", port=t.local_port)
+    """
+
+    def __init__(
+        self,
+        dataplane_url: str,
+        api_key: Optional[str],
+        remote_port: int,
+        *,
+        local_port: int = 0,
+    ) -> None:
+        self._tunnel = Tunnel(
+            dataplane_url, api_key, remote_port, local_port=local_port
+        )
+
+    @property
+    def local_port(self) -> int:
+        return self._tunnel.local_port
+
+    @property
+    def remote_port(self) -> int:
+        return self._tunnel.remote_port
+
+    async def __aenter__(self) -> AsyncTunnel:
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(None, self._tunnel._start)
+        return self
+
+    async def __aexit__(self, *args: object) -> None:
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(None, self._tunnel.close)
+
+    def close(self) -> None:
+        """Shut down the tunnel (sync, safe to call from any context)."""
+        self._tunnel.close()

--- a/python/langsmith/sandbox/_ws_execute.py
+++ b/python/langsmith/sandbox/_ws_execute.py
@@ -92,10 +92,18 @@ class _WSStreamControl:
         return self._killed
 
     def send_kill(self) -> None:
-        """Send a kill message to abort the running command."""
+        """Send a kill message and immediately close the WebSocket."""
         self._killed = True
         if self._ws and not self._closed:
-            self._ws.send(json.dumps({"type": "kill"}))
+            try:
+                self._ws.send(json.dumps({"type": "kill"}))
+            except Exception:
+                pass
+            try:
+                self._ws.close_timeout = 0
+                self._ws.close()
+            except Exception:
+                pass
 
     def send_input(self, data: str) -> None:
         """Send stdin data to the running command."""
@@ -125,7 +133,15 @@ class _AsyncWSStreamControl:
     async def send_kill(self) -> None:
         self._killed = True
         if self._ws and not self._closed:
-            await self._ws.send(json.dumps({"type": "kill"}))
+            try:
+                await self._ws.send(json.dumps({"type": "kill"}))
+            except Exception:
+                pass
+            try:
+                self._ws.close_timeout = 0
+                await self._ws.close()
+            except Exception:
+                pass
 
     async def send_input(self, data: str) -> None:
         if self._ws and not self._closed:

--- a/python/langsmith/sandbox/_yamux.py
+++ b/python/langsmith/sandbox/_yamux.py
@@ -1,0 +1,354 @@
+"""Minimal yamux (Yet Another Multiplexer) client for TCP tunneling.
+
+Implements the client side of the yamux protocol as specified at
+https://github.com/hashicorp/yamux/blob/master/spec.md
+
+Only the subset needed for tunnel client operation is implemented:
+opening streams, sending/receiving data, flow control, and keepalive.
+"""
+
+from __future__ import annotations
+
+import struct
+import threading
+from typing import Protocol
+
+# ---------------------------------------------------------------------------
+# Protocol constants
+# ---------------------------------------------------------------------------
+
+_VERSION = 0
+
+_TYPE_DATA = 0
+_TYPE_WINDOW_UPDATE = 1
+_TYPE_PING = 2
+_TYPE_GO_AWAY = 3
+
+_FLAG_SYN = 0x0001
+_FLAG_ACK = 0x0002
+_FLAG_FIN = 0x0004
+_FLAG_RST = 0x0008
+
+_HEADER_SIZE = 12
+_HEADER_FMT = ">BBHII"  # version(1), type(1), flags(2), streamID(4), length(4)
+
+_INITIAL_WINDOW_SIZE = 256 * 1024  # 256 KB
+
+
+# ---------------------------------------------------------------------------
+# Byte-stream interface required by the session
+# ---------------------------------------------------------------------------
+
+
+class _ReadWriteCloser(Protocol):
+    def read(self, n: int) -> bytes: ...
+
+    def write(self, data: bytes) -> int: ...
+
+    def close(self) -> None: ...
+
+
+# ---------------------------------------------------------------------------
+# YamuxStream
+# ---------------------------------------------------------------------------
+
+
+class YamuxStream:
+    """A single multiplexed stream within a yamux session.
+
+    Streams are created via :meth:`YamuxSession.open_stream` and provide
+    blocking read/write/close with per-stream flow control.
+    """
+
+    def __init__(self, stream_id: int, session: YamuxSession) -> None:
+        self._id = stream_id
+        self._session = session
+
+        self._recv_buf = bytearray()
+        self._recv_cond = threading.Condition()
+        self._recv_closed = False
+        self._recv_error = False
+        self._recv_window = _INITIAL_WINDOW_SIZE
+
+        self._send_window = _INITIAL_WINDOW_SIZE
+        self._send_cond = threading.Condition()
+        self._send_closed = False
+
+    @property
+    def stream_id(self) -> int:
+        return self._id
+
+    def read(self, n: int) -> bytes:
+        """Read up to *n* bytes, blocking until data is available.
+
+        Returns ``b""`` on EOF (FIN received).
+        Raises :class:`ConnectionResetError` on RST.
+        """
+        delta_to_send = 0
+
+        with self._recv_cond:
+            while not self._recv_buf and not self._recv_closed and not self._recv_error:
+                self._recv_cond.wait()
+
+            if self._recv_error and not self._recv_buf:
+                raise ConnectionResetError("yamux stream reset by peer")
+
+            if not self._recv_buf:
+                return b""
+
+            size = min(n, len(self._recv_buf))
+            data = bytes(self._recv_buf[:size])
+            del self._recv_buf[:size]
+
+            consumed = _INITIAL_WINDOW_SIZE - self._recv_window
+            if consumed >= _INITIAL_WINDOW_SIZE // 2:
+                delta_to_send = consumed
+                self._recv_window += consumed
+
+        if delta_to_send > 0:
+            try:
+                self._session._send_window_update(self._id, delta_to_send)
+            except Exception:
+                pass
+
+        return data
+
+    def write(self, data: bytes) -> int:
+        """Write *data*, blocking if the send window is exhausted."""
+        if self._send_closed:
+            raise BrokenPipeError("yamux stream closed for writing")
+
+        offset = 0
+        mv = memoryview(data)
+
+        while offset < len(data):
+            with self._send_cond:
+                while self._send_window == 0 and not self._send_closed:
+                    self._send_cond.wait()
+                if self._send_closed:
+                    raise BrokenPipeError("yamux stream closed for writing")
+                chunk = min(len(data) - offset, self._send_window)
+                self._send_window -= chunk
+
+            self._session._send_data(self._id, bytes(mv[offset : offset + chunk]))
+            offset += chunk
+
+        return len(data)
+
+    def close(self) -> None:
+        """Close the stream (sends FIN to the remote end)."""
+        if not self._send_closed:
+            self._send_closed = True
+            try:
+                self._session._send_frame(_TYPE_DATA, _FLAG_FIN, self._id, 0)
+            except Exception:
+                pass
+
+        with self._recv_cond:
+            self._recv_closed = True
+            self._recv_cond.notify_all()
+        with self._send_cond:
+            self._send_cond.notify_all()
+
+    # -- Internal: called by YamuxSession._read_loop ------------------------
+
+    def _receive_data(self, data: bytes) -> None:
+        with self._recv_cond:
+            self._recv_buf.extend(data)
+            self._recv_window -= len(data)
+            self._recv_cond.notify_all()
+
+    def _receive_fin(self) -> None:
+        with self._recv_cond:
+            self._recv_closed = True
+            self._recv_cond.notify_all()
+
+    def _receive_rst(self) -> None:
+        with self._recv_cond:
+            self._recv_error = True
+            self._recv_cond.notify_all()
+        with self._send_cond:
+            self._send_closed = True
+            self._send_cond.notify_all()
+
+    def _update_send_window(self, delta: int) -> None:
+        with self._send_cond:
+            self._send_window += delta
+            self._send_cond.notify_all()
+
+
+# ---------------------------------------------------------------------------
+# YamuxSession
+# ---------------------------------------------------------------------------
+
+
+class YamuxSession:
+    """Client-side yamux session over a byte-stream connection.
+
+    The connection must implement ``read(n) -> bytes``, ``write(data) -> int``,
+    and ``close() -> None``.  Typically this is a :class:`_WSAdapter` wrapping
+    a WebSocket.
+
+    Usage::
+
+        session = YamuxSession(conn)
+        stream = session.open_stream()
+        stream.write(b"hello")
+        data = stream.read(1024)
+        stream.close()
+        session.close()
+    """
+
+    def __init__(self, conn: _ReadWriteCloser) -> None:
+        self._conn = conn
+        self._streams: dict[int, YamuxStream] = {}
+        self._next_stream_id = 1  # client uses odd IDs
+        self._lock = threading.Lock()
+        self._write_lock = threading.Lock()
+        self._closed = False
+        self._shutdown_event = threading.Event()
+
+        self._reader_thread = threading.Thread(
+            target=self._read_loop, daemon=True, name="yamux-reader"
+        )
+        self._reader_thread.start()
+
+        self._keepalive_thread = threading.Thread(
+            target=self._keepalive_loop, daemon=True, name="yamux-keepalive"
+        )
+        self._keepalive_thread.start()
+
+    @property
+    def is_closed(self) -> bool:
+        return self._closed
+
+    def open_stream(self) -> YamuxStream:
+        """Open a new multiplexed stream.
+
+        Raises :class:`RuntimeError` if the session is closed.
+        """
+        with self._lock:
+            if self._closed:
+                raise RuntimeError("yamux session is closed")
+            stream_id = self._next_stream_id
+            self._next_stream_id += 2
+            stream = YamuxStream(stream_id, self)
+            self._streams[stream_id] = stream
+
+        self._send_frame(_TYPE_WINDOW_UPDATE, _FLAG_SYN, stream_id, 0)
+        return stream
+
+    def close(self) -> None:
+        """Close the session and all streams."""
+        if self._closed:
+            return
+        self._closed = True
+        self._shutdown_event.set()
+
+        try:
+            self._send_frame(_TYPE_GO_AWAY, 0, 0, 0)
+        except Exception:
+            pass
+
+        with self._lock:
+            for stream in self._streams.values():
+                stream._receive_rst()
+
+        try:
+            self._conn.close()
+        except Exception:
+            pass
+
+    # -- Frame I/O ----------------------------------------------------------
+
+    def _send_frame(
+        self, msg_type: int, flags: int, stream_id: int, length: int
+    ) -> None:
+        hdr = struct.pack(_HEADER_FMT, _VERSION, msg_type, flags, stream_id, length)
+        with self._write_lock:
+            self._conn.write(hdr)
+
+    def _send_data(self, stream_id: int, data: bytes) -> None:
+        hdr = struct.pack(_HEADER_FMT, _VERSION, _TYPE_DATA, 0, stream_id, len(data))
+        with self._write_lock:
+            self._conn.write(hdr + data)
+
+    def _send_window_update(self, stream_id: int, delta: int) -> None:
+        self._send_frame(_TYPE_WINDOW_UPDATE, 0, stream_id, delta)
+
+    # -- Read loop ----------------------------------------------------------
+
+    def _read_loop(self) -> None:
+        try:
+            while not self._closed:
+                hdr_bytes = self._conn.read(_HEADER_SIZE)
+                if len(hdr_bytes) < _HEADER_SIZE:
+                    break
+
+                _ver, msg_type, flags, stream_id, length = struct.unpack(
+                    _HEADER_FMT, hdr_bytes
+                )
+
+                if msg_type == _TYPE_DATA:
+                    self._handle_data(flags, stream_id, length)
+                elif msg_type == _TYPE_WINDOW_UPDATE:
+                    self._handle_window_update(flags, stream_id, length)
+                elif msg_type == _TYPE_PING:
+                    self._handle_ping(flags, length)
+                elif msg_type == _TYPE_GO_AWAY:
+                    break
+        except Exception:
+            pass
+        finally:
+            if not self._closed:
+                self._closed = True
+                self._shutdown_event.set()
+                with self._lock:
+                    for stream in self._streams.values():
+                        stream._receive_rst()
+
+    def _handle_data(self, flags: int, stream_id: int, length: int) -> None:
+        payload = self._conn.read(length) if length > 0 else b""
+
+        with self._lock:
+            stream = self._streams.get(stream_id)
+        if stream is None:
+            return
+
+        if payload:
+            stream._receive_data(payload)
+        if flags & _FLAG_FIN:
+            stream._receive_fin()
+        if flags & _FLAG_RST:
+            stream._receive_rst()
+
+    def _handle_window_update(self, flags: int, stream_id: int, length: int) -> None:
+        with self._lock:
+            stream = self._streams.get(stream_id)
+        if stream is None:
+            return
+
+        if length > 0:
+            stream._update_send_window(length)
+        if flags & _FLAG_FIN:
+            stream._receive_fin()
+        if flags & _FLAG_RST:
+            stream._receive_rst()
+
+    def _handle_ping(self, flags: int, opaque: int) -> None:
+        if flags & _FLAG_SYN:
+            try:
+                self._send_frame(_TYPE_PING, _FLAG_ACK, 0, opaque)
+            except Exception:
+                pass
+
+    # -- Keepalive ----------------------------------------------------------
+
+    def _keepalive_loop(self) -> None:
+        ping_id = 0
+        while not self._shutdown_event.wait(30):
+            ping_id += 1
+            try:
+                self._send_frame(_TYPE_PING, _FLAG_SYN, 0, ping_id)
+            except Exception:
+                break

--- a/python/tests/unit_tests/sandbox/test_tunnel.py
+++ b/python/tests/unit_tests/sandbox/test_tunnel.py
@@ -1,0 +1,285 @@
+"""Unit tests for the TCP tunnel module."""
+
+from __future__ import annotations
+
+import struct
+import threading
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from langsmith.sandbox._exceptions import (
+    TunnelConnectionRefusedError,
+    TunnelError,
+    TunnelPortNotAllowedError,
+    TunnelUnsupportedVersionError,
+)
+from langsmith.sandbox._tunnel import (
+    PROTOCOL_VERSION,
+    STATUS_DIAL_FAILED,
+    STATUS_OK,
+    STATUS_PORT_NOT_ALLOWED,
+    STATUS_UNSUPPORTED_VERSION,
+    AsyncTunnel,
+    Tunnel,
+    _read_status,
+    _write_connect_header,
+    _WSAdapter,
+)
+
+# ---------------------------------------------------------------------------
+# _WSAdapter
+# ---------------------------------------------------------------------------
+
+
+class MockWS:
+    """Minimal mock matching the websockets sync client interface."""
+
+    def __init__(self, messages: list[bytes] | None = None) -> None:
+        self._messages = list(messages or [])
+        self._sent: list[bytes] = []
+        self._closed = False
+
+    def recv(self) -> bytes:
+        if not self._messages:
+            raise ConnectionError("no more messages")
+        return self._messages.pop(0)
+
+    def send(self, data: bytes) -> None:
+        self._sent.append(data)
+
+    def close(self) -> None:
+        self._closed = True
+
+
+class TestWSAdapter:
+    def test_read_buffers_and_returns_exact(self) -> None:
+        ws = MockWS([b"helloworld"])
+        adapter = _WSAdapter(ws)
+        assert adapter.read(5) == b"hello"
+        assert adapter.read(5) == b"world"
+
+    def test_read_spans_messages(self) -> None:
+        ws = MockWS([b"he", b"ll", b"o"])
+        adapter = _WSAdapter(ws)
+        assert adapter.read(5) == b"hello"
+
+    def test_write_sends_binary(self) -> None:
+        ws = MockWS()
+        adapter = _WSAdapter(ws)
+        n = adapter.write(b"test")
+        assert n == 4
+        assert ws._sent == [b"test"]
+
+    def test_write_thread_safe(self) -> None:
+        ws = MockWS()
+        adapter = _WSAdapter(ws)
+        errors: list[Exception] = []
+
+        def writer(val: bytes) -> None:
+            try:
+                for _ in range(50):
+                    adapter.write(val)
+            except Exception as e:
+                errors.append(e)
+
+        threads = [
+            threading.Thread(target=writer, args=(b"a",)),
+            threading.Thread(target=writer, args=(b"b",)),
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors
+        assert len(ws._sent) == 100
+
+    def test_close(self) -> None:
+        ws = MockWS()
+        adapter = _WSAdapter(ws)
+        adapter.close()
+        assert ws._closed
+
+    def test_read_str_converted_to_bytes(self) -> None:
+        """String messages are encoded to bytes."""
+        ws = MockWS()
+        ws._messages = ["hello"]  # type: ignore[list-item]
+        adapter = _WSAdapter(ws)
+        assert adapter.read(5) == b"hello"
+
+
+# ---------------------------------------------------------------------------
+# Protocol helpers
+# ---------------------------------------------------------------------------
+
+
+class MockStream:
+    """Minimal stream mock for protocol helper tests."""
+
+    def __init__(self) -> None:
+        self._buf = bytearray()
+
+    def write(self, data: bytes) -> int:
+        self._buf.extend(data)
+        return len(data)
+
+    def read(self, n: int) -> bytes:
+        data = bytes(self._buf[:n])
+        del self._buf[:n]
+        return data
+
+
+class TestProtocolHelpers:
+    @pytest.mark.parametrize("port", [5432, 65535])
+    def test_connect_header_encoding(self, port: int) -> None:
+        stream = MockStream()
+        _write_connect_header(stream, port)
+
+        raw = bytes(stream._buf)
+        assert len(raw) == 3
+        version, decoded_port = struct.unpack(">BH", raw)
+        assert version == PROTOCOL_VERSION
+        assert decoded_port == port
+
+    @pytest.mark.parametrize(
+        "status",
+        [
+            STATUS_OK,
+            STATUS_PORT_NOT_ALLOWED,
+            STATUS_DIAL_FAILED,
+            STATUS_UNSUPPORTED_VERSION,
+        ],
+    )
+    def test_read_status(self, status: int) -> None:
+        stream = MockStream()
+        stream._buf = bytearray([status])
+        assert _read_status(stream) == status
+
+    def test_read_status_eof_raises(self) -> None:
+        stream = MockStream()
+        with pytest.raises(ConnectionError):
+            _read_status(stream)
+
+
+# ---------------------------------------------------------------------------
+# Tunnel
+# ---------------------------------------------------------------------------
+
+
+class TestTunnelInit:
+    def test_default_local_port_mirrors_remote(self) -> None:
+        t = Tunnel("http://example.com", "key", 5432)
+        assert t.remote_port == 5432
+        assert t.local_port == 5432
+
+    def test_explicit_local_port(self) -> None:
+        t = Tunnel("http://example.com", "key", 5432, local_port=15432)
+        assert t.local_port == 15432
+
+    def test_build_ws_url_http(self) -> None:
+        t = Tunnel("http://example.com/sandbox", "key", 5432)
+        assert t._build_ws_url() == "ws://example.com/sandbox/tunnel"
+
+    def test_build_ws_url_https(self) -> None:
+        t = Tunnel("https://example.com/sandbox", "key", 5432)
+        assert t._build_ws_url() == "wss://example.com/sandbox/tunnel"
+
+    def test_build_ws_url_strips_trailing_slash(self) -> None:
+        t = Tunnel("https://example.com/sandbox/", "key", 5432)
+        assert t._build_ws_url() == "wss://example.com/sandbox/tunnel"
+
+
+class TestTunnelContextManager:
+    @patch("langsmith.sandbox._tunnel._ensure_websockets")
+    def test_close_is_idempotent(self, mock_ensure: MagicMock) -> None:
+        t = Tunnel("http://localhost", "key", 5432)
+        t._closed = True
+        t.close()  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# AsyncTunnel
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncTunnel:
+    def test_properties_delegate(self) -> None:
+        at = AsyncTunnel("http://example.com", "key", 5432, local_port=15432)
+        assert at.remote_port == 5432
+        assert at.local_port == 15432
+
+    def test_close_delegates(self) -> None:
+        at = AsyncTunnel("http://example.com", "key", 5432)
+        at._tunnel._closed = True
+        at.close()  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# Exception hierarchy
+# ---------------------------------------------------------------------------
+
+
+class TestTunnelExceptions:
+    def test_tunnel_error_is_base(self) -> None:
+        assert issubclass(TunnelPortNotAllowedError, TunnelError)
+        assert issubclass(TunnelConnectionRefusedError, TunnelError)
+        assert issubclass(TunnelUnsupportedVersionError, TunnelError)
+
+    @pytest.mark.parametrize(
+        "exc_cls,msg,port",
+        [
+            (TunnelPortNotAllowedError, "blocked", 5432),
+            (TunnelConnectionRefusedError, "nothing listening", 6379),
+        ],
+    )
+    def test_exception_has_port(self, exc_cls: type, msg: str, port: int) -> None:
+        exc = exc_cls(msg, port=port)
+        assert exc.port == port
+        assert msg in str(exc)
+
+
+# ---------------------------------------------------------------------------
+# Port validation (tested via Sandbox.tunnel / AsyncSandbox.tunnel)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def mock_sandbox():
+    from langsmith.sandbox._sandbox import Sandbox
+
+    sb = Sandbox(
+        name="test",
+        template_name="t",
+        dataplane_url="http://x",
+        status="ready",
+    )
+    sb._client = MagicMock()
+    sb._client._api_key = "key"
+    return sb
+
+
+class TestPortValidation:
+    @pytest.mark.parametrize(
+        "remote,local,match",
+        [
+            (0, 0, "remote_port"),
+            (70000, 0, "remote_port"),
+            (5432, 70000, "local_port"),
+        ],
+    )
+    def test_invalid_ports_raise(
+        self, mock_sandbox: object, remote: int, local: int, match: str
+    ) -> None:
+        with pytest.raises(ValueError, match=match):
+            mock_sandbox.tunnel(remote, local_port=local)  # type: ignore[union-attr]
+
+    @patch("langsmith.sandbox._tunnel.Tunnel._start")
+    def test_valid_ports_pass_validation(
+        self, mock_start: MagicMock, mock_sandbox: object
+    ) -> None:
+        t = mock_sandbox.tunnel(5432, local_port=15432)  # type: ignore[union-attr]
+        assert isinstance(t, Tunnel)
+        assert t.remote_port == 5432
+        assert t.local_port == 15432
+        mock_start.assert_called_once()

--- a/python/tests/unit_tests/sandbox/test_yamux.py
+++ b/python/tests/unit_tests/sandbox/test_yamux.py
@@ -1,0 +1,531 @@
+"""Unit tests for the yamux multiplexing implementation."""
+
+from __future__ import annotations
+
+import struct
+import threading
+import time
+
+import pytest
+
+from langsmith.sandbox._yamux import (
+    _FLAG_ACK,
+    _FLAG_FIN,
+    _FLAG_RST,
+    _FLAG_SYN,
+    _HEADER_FMT,
+    _HEADER_SIZE,
+    _INITIAL_WINDOW_SIZE,
+    _TYPE_DATA,
+    _TYPE_GO_AWAY,
+    _TYPE_PING,
+    _TYPE_WINDOW_UPDATE,
+    _VERSION,
+    YamuxSession,
+)
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+
+class MockConn:
+    """In-memory byte-stream for testing yamux without real I/O.
+
+    Writes are buffered and can be inspected.  Data to be read by the
+    session can be injected via :meth:`feed`.
+    """
+
+    def __init__(self) -> None:
+        self._read_buf = bytearray()
+        self._write_buf = bytearray()
+        self._cond = threading.Condition()
+        self._closed = False
+
+    def feed(self, data: bytes) -> None:
+        """Inject bytes that ``read()`` will return."""
+        with self._cond:
+            self._read_buf.extend(data)
+            self._cond.notify_all()
+
+    def read(self, n: int) -> bytes:
+        with self._cond:
+            while len(self._read_buf) < n and not self._closed:
+                if not self._cond.wait(timeout=5):
+                    raise TimeoutError("MockConn.read timed out")
+            if len(self._read_buf) < n:
+                raise ConnectionError("MockConn closed")
+            data = bytes(self._read_buf[:n])
+            del self._read_buf[:n]
+            return data
+
+    def write(self, data: bytes) -> int:
+        with self._cond:
+            if self._closed:
+                raise ConnectionError("MockConn closed")
+            self._write_buf.extend(data)
+        return len(data)
+
+    def close(self) -> None:
+        with self._cond:
+            self._closed = True
+            self._cond.notify_all()
+
+    # -- Inspection helpers --------------------------------------------------
+
+    def drain_written(self) -> bytes:
+        """Return and clear everything written so far."""
+        with self._cond:
+            data = bytes(self._write_buf)
+            self._write_buf.clear()
+            return data
+
+    def read_frame(self) -> tuple[int, int, int, int, int, bytes]:
+        """Parse one yamux frame from the write buffer.
+
+        Returns (version, msg_type, flags, stream_id, length, payload).
+        Payload is only present for DATA frames.
+        """
+        with self._cond:
+            while len(self._write_buf) < _HEADER_SIZE:
+                if not self._cond.wait(timeout=2):
+                    raise TimeoutError("read_frame: no frame available")
+
+            hdr_bytes = bytes(self._write_buf[:_HEADER_SIZE])
+            del self._write_buf[:_HEADER_SIZE]
+
+        ver, mtype, flags, sid, length = struct.unpack(_HEADER_FMT, hdr_bytes)
+
+        payload = b""
+        if mtype == _TYPE_DATA and length > 0:
+            with self._cond:
+                while len(self._write_buf) < length:
+                    if not self._cond.wait(timeout=2):
+                        raise TimeoutError("read_frame: incomplete payload")
+                payload = bytes(self._write_buf[:length])
+                del self._write_buf[:length]
+
+        return ver, mtype, flags, sid, length, payload
+
+
+def _make_frame(
+    msg_type: int,
+    flags: int,
+    stream_id: int,
+    length: int,
+    payload: bytes = b"",
+) -> bytes:
+    """Build a raw yamux frame."""
+    hdr = struct.pack(_HEADER_FMT, _VERSION, msg_type, flags, stream_id, length)
+    return hdr + payload
+
+
+# ---------------------------------------------------------------------------
+# YamuxSession.open_stream
+# ---------------------------------------------------------------------------
+
+
+class TestOpenStream:
+    def test_sends_syn(self) -> None:
+        conn = MockConn()
+        session = YamuxSession(conn)
+        try:
+            stream = session.open_stream()
+            assert stream.stream_id == 1
+
+            ver, mtype, flags, sid, length, _ = conn.read_frame()
+            assert mtype == _TYPE_WINDOW_UPDATE
+            assert flags == _FLAG_SYN
+            assert sid == 1
+            assert length == 0
+        finally:
+            session.close()
+
+    def test_stream_ids_are_odd_and_increasing(self) -> None:
+        conn = MockConn()
+        session = YamuxSession(conn)
+        try:
+            s1 = session.open_stream()
+            s2 = session.open_stream()
+            s3 = session.open_stream()
+            assert s1.stream_id == 1
+            assert s2.stream_id == 3
+            assert s3.stream_id == 5
+        finally:
+            session.close()
+
+    def test_open_after_close_raises(self) -> None:
+        conn = MockConn()
+        session = YamuxSession(conn)
+        session.close()
+        with pytest.raises(RuntimeError, match="closed"):
+            session.open_stream()
+
+
+# ---------------------------------------------------------------------------
+# Stream write
+# ---------------------------------------------------------------------------
+
+
+class TestStreamWrite:
+    def test_write_sends_data_frame(self) -> None:
+        conn = MockConn()
+        session = YamuxSession(conn)
+        try:
+            stream = session.open_stream()
+            conn.drain_written()  # clear SYN
+
+            stream.write(b"hello")
+
+            ver, mtype, flags, sid, length, payload = conn.read_frame()
+            assert mtype == _TYPE_DATA
+            assert flags == 0
+            assert sid == stream.stream_id
+            assert length == 5
+            assert payload == b"hello"
+        finally:
+            session.close()
+
+    def test_write_respects_send_window(self) -> None:
+        """Write blocks when the send window is exhausted."""
+        conn = MockConn()
+        session = YamuxSession(conn)
+        try:
+            stream = session.open_stream()
+            conn.drain_written()
+
+            stream._send_window = 3
+
+            result = stream.write(b"abc")
+            assert result == 3
+
+            _, _, _, _, length, payload = conn.read_frame()
+            assert length == 3
+            assert payload == b"abc"
+        finally:
+            session.close()
+
+
+# ---------------------------------------------------------------------------
+# Stream read (data dispatched by read loop)
+# ---------------------------------------------------------------------------
+
+
+class TestStreamRead:
+    def test_read_receives_data(self) -> None:
+        conn = MockConn()
+        session = YamuxSession(conn)
+        try:
+            stream = session.open_stream()
+            conn.drain_written()
+
+            frame = _make_frame(_TYPE_DATA, 0, stream.stream_id, 5, b"hello")
+            conn.feed(frame)
+
+            data = stream.read(5)
+            assert data == b"hello"
+        finally:
+            session.close()
+
+    def test_read_partial(self) -> None:
+        """read(n) returns up to n bytes even if more are buffered."""
+        conn = MockConn()
+        session = YamuxSession(conn)
+        try:
+            stream = session.open_stream()
+
+            conn.feed(_make_frame(_TYPE_DATA, 0, stream.stream_id, 10, b"helloworld"))
+            time.sleep(0.05)
+
+            chunk1 = stream.read(5)
+            assert chunk1 == b"hello"
+            chunk2 = stream.read(5)
+            assert chunk2 == b"world"
+        finally:
+            session.close()
+
+    def test_read_blocks_until_data(self) -> None:
+        conn = MockConn()
+        session = YamuxSession(conn)
+        try:
+            stream = session.open_stream()
+            received: list[bytes] = []
+
+            def reader() -> None:
+                received.append(stream.read(3))
+
+            t = threading.Thread(target=reader)
+            t.start()
+
+            time.sleep(0.05)
+            assert not received
+
+            conn.feed(_make_frame(_TYPE_DATA, 0, stream.stream_id, 3, b"abc"))
+            t.join(timeout=2)
+
+            assert received == [b"abc"]
+        finally:
+            session.close()
+
+
+# ---------------------------------------------------------------------------
+# FIN / RST handling
+# ---------------------------------------------------------------------------
+
+
+class TestFinRst:
+    def test_fin_causes_eof(self) -> None:
+        conn = MockConn()
+        session = YamuxSession(conn)
+        try:
+            stream = session.open_stream()
+            conn.feed(_make_frame(_TYPE_DATA, _FLAG_FIN, stream.stream_id, 0))
+            time.sleep(0.05)
+
+            data = stream.read(1024)
+            assert data == b""
+        finally:
+            session.close()
+
+    def test_fin_after_data_drains_buffer_first(self) -> None:
+        conn = MockConn()
+        session = YamuxSession(conn)
+        try:
+            stream = session.open_stream()
+
+            conn.feed(_make_frame(_TYPE_DATA, _FLAG_FIN, stream.stream_id, 3, b"end"))
+            time.sleep(0.05)
+
+            assert stream.read(3) == b"end"
+            assert stream.read(1) == b""
+        finally:
+            session.close()
+
+    def test_rst_raises_on_read(self) -> None:
+        conn = MockConn()
+        session = YamuxSession(conn)
+        try:
+            stream = session.open_stream()
+            conn.feed(_make_frame(_TYPE_DATA, _FLAG_RST, stream.stream_id, 0))
+            time.sleep(0.05)
+
+            with pytest.raises(ConnectionResetError):
+                stream.read(1)
+        finally:
+            session.close()
+
+    def test_rst_drains_buffer_before_error(self) -> None:
+        conn = MockConn()
+        session = YamuxSession(conn)
+        try:
+            stream = session.open_stream()
+            conn.feed(_make_frame(_TYPE_DATA, 0, stream.stream_id, 2, b"ok"))
+            time.sleep(0.05)
+            conn.feed(_make_frame(_TYPE_DATA, _FLAG_RST, stream.stream_id, 0))
+            time.sleep(0.05)
+
+            assert stream.read(2) == b"ok"
+            with pytest.raises(ConnectionResetError):
+                stream.read(1)
+        finally:
+            session.close()
+
+
+# ---------------------------------------------------------------------------
+# Ping / pong
+# ---------------------------------------------------------------------------
+
+
+class TestPing:
+    def test_responds_to_ping_with_ack(self) -> None:
+        conn = MockConn()
+        session = YamuxSession(conn)
+        try:
+            conn.drain_written()
+
+            conn.feed(_make_frame(_TYPE_PING, _FLAG_SYN, 0, 42))
+            time.sleep(0.1)
+
+            ver, mtype, flags, sid, opaque, _ = conn.read_frame()
+            assert mtype == _TYPE_PING
+            assert flags == _FLAG_ACK
+            assert opaque == 42
+        finally:
+            session.close()
+
+
+# ---------------------------------------------------------------------------
+# Window updates
+# ---------------------------------------------------------------------------
+
+
+class TestWindowUpdate:
+    def test_window_update_increases_send_window(self) -> None:
+        conn = MockConn()
+        session = YamuxSession(conn)
+        try:
+            stream = session.open_stream()
+            initial = stream._send_window
+
+            conn.feed(_make_frame(_TYPE_WINDOW_UPDATE, 0, stream.stream_id, 1024))
+            time.sleep(0.05)
+
+            assert stream._send_window == initial + 1024
+        finally:
+            session.close()
+
+    def test_batched_window_update_on_read(self) -> None:
+        """A window update is sent after consuming >= half the window."""
+        conn = MockConn()
+        session = YamuxSession(conn)
+        try:
+            stream = session.open_stream()
+            conn.drain_written()
+
+            half = _INITIAL_WINDOW_SIZE // 2
+            payload = b"\x00" * half
+            conn.feed(_make_frame(_TYPE_DATA, 0, stream.stream_id, half, payload))
+            time.sleep(0.05)
+
+            stream.read(half)
+            time.sleep(0.05)
+
+            ver, mtype, flags, sid, delta, _ = conn.read_frame()
+            assert mtype == _TYPE_WINDOW_UPDATE
+            assert sid == stream.stream_id
+            assert delta == half
+        finally:
+            session.close()
+
+    def test_no_update_for_small_reads(self) -> None:
+        """Small reads don't trigger window updates."""
+        conn = MockConn()
+        session = YamuxSession(conn)
+        try:
+            stream = session.open_stream()
+            conn.drain_written()
+
+            conn.feed(_make_frame(_TYPE_DATA, 0, stream.stream_id, 10, b"0123456789"))
+            time.sleep(0.05)
+
+            stream.read(10)
+            time.sleep(0.05)
+
+            remaining = conn.drain_written()
+            assert len(remaining) == 0
+        finally:
+            session.close()
+
+
+# ---------------------------------------------------------------------------
+# GoAway
+# ---------------------------------------------------------------------------
+
+
+class TestGoAway:
+    def test_go_away_closes_session(self) -> None:
+        conn = MockConn()
+        session = YamuxSession(conn)
+        try:
+            conn.feed(_make_frame(_TYPE_GO_AWAY, 0, 0, 0))
+            time.sleep(0.1)
+            assert session.is_closed
+        finally:
+            session.close()
+
+    def test_go_away_resets_open_streams(self) -> None:
+        conn = MockConn()
+        session = YamuxSession(conn)
+        try:
+            stream = session.open_stream()
+            conn.feed(_make_frame(_TYPE_GO_AWAY, 0, 0, 0))
+            time.sleep(0.1)
+
+            with pytest.raises(ConnectionResetError):
+                stream.read(1)
+        finally:
+            session.close()
+
+
+# ---------------------------------------------------------------------------
+# Session close
+# ---------------------------------------------------------------------------
+
+
+class TestSessionClose:
+    def test_close_sends_go_away(self) -> None:
+        conn = MockConn()
+        session = YamuxSession(conn)
+        conn.drain_written()
+
+        session.close()
+
+        ver, mtype, flags, sid, length, _ = conn.read_frame()
+        assert mtype == _TYPE_GO_AWAY
+
+    def test_close_is_idempotent(self) -> None:
+        conn = MockConn()
+        session = YamuxSession(conn)
+        session.close()
+        session.close()  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# Multiple concurrent streams
+# ---------------------------------------------------------------------------
+
+
+class TestConcurrentStreams:
+    def test_interleaved_data(self) -> None:
+        """Data for different streams is dispatched correctly."""
+        conn = MockConn()
+        session = YamuxSession(conn)
+        try:
+            s1 = session.open_stream()
+            s2 = session.open_stream()
+
+            conn.feed(_make_frame(_TYPE_DATA, 0, s1.stream_id, 1, b"A"))
+            conn.feed(_make_frame(_TYPE_DATA, 0, s2.stream_id, 1, b"B"))
+            conn.feed(_make_frame(_TYPE_DATA, 0, s1.stream_id, 1, b"C"))
+            time.sleep(0.1)
+
+            assert s1.read(1) == b"A"
+            assert s2.read(1) == b"B"
+            assert s1.read(1) == b"C"
+        finally:
+            session.close()
+
+
+# ---------------------------------------------------------------------------
+# Stream close
+# ---------------------------------------------------------------------------
+
+
+class TestStreamClose:
+    def test_close_sends_fin(self) -> None:
+        conn = MockConn()
+        session = YamuxSession(conn)
+        try:
+            stream = session.open_stream()
+            conn.drain_written()
+
+            stream.close()
+
+            ver, mtype, flags, sid, length, _ = conn.read_frame()
+            assert mtype == _TYPE_DATA
+            assert flags == _FLAG_FIN
+            assert sid == stream.stream_id
+        finally:
+            session.close()
+
+    def test_write_after_close_raises(self) -> None:
+        conn = MockConn()
+        session = YamuxSession(conn)
+        try:
+            stream = session.open_stream()
+            stream.close()
+
+            with pytest.raises(BrokenPipeError):
+                stream.write(b"x")
+        finally:
+            session.close()


### PR DESCRIPTION
## Add TCP tunnel support for sandboxes

You can now access services running inside a sandbox (databases, caches, HTTP servers, etc.) directly from your local machine using `sb.tunnel()`.

```python
with client.sandbox(template_name="postgres") as sb:
    sb.run("pg_ctl start", timeout=10)

    with sb.tunnel(remote_port=5432) as t:
        conn = psycopg2.connect(host="127.0.0.1", port=t.local_port, user="postgres")
        # use conn normally...
```

### What's supported

- **Any TCP protocol** -- Postgres, Redis, HTTP, or any service that speaks TCP.
- **Multiple simultaneous tunnels** to different ports on the same sandbox.
- **Custom local ports** via `local_port=` parameter, or let the OS pick one automatically with `local_port=0`.
- **Context manager and explicit lifecycle** -- use `with sb.tunnel(...)` for automatic cleanup or call `.close()` manually.
- **Sync and async** -- works with both `Sandbox` and `AsyncSandbox`.

### Changes

- New `_yamux.py` module implementing the client-side yamux multiplexing protocol.
- New `_tunnel.py` module with `Tunnel` and `AsyncTunnel` classes.
- `tunnel()` method added to `Sandbox` and `AsyncSandbox`.
- New tunnel-specific exceptions: `TunnelError`, `TunnelPortNotAllowedError`, `TunnelConnectionRefusedError`, `TunnelUnsupportedVersionError`.
- Fixed `CommandHandle.kill()` hanging when the sandbox was already gone by forcing WebSocket close.

### Test plan

- Unit tests for yamux frame handling, stream read/write, flow control, ping/pong, GoAway, and session lifecycle.
- Unit tests for tunnel protocol encoding, WebSocket adapter, port validation, and exception hierarchy.
- Integration test scripts covering Postgres, Redis, HTTP, multiple tunnels, and explicit lifecycle (sync + async).

