### PR TITLE
feat(sandbox): add yamux multiplexing protocol

### DIFF
--- a/python/langsmith/sandbox/_yamux.py
+++ b/python/langsmith/sandbox/_yamux.py
@@ -1,0 +1,354 @@
+"""Minimal yamux (Yet Another Multiplexer) client for TCP tunneling.
+
+Implements the client side of the yamux protocol as specified at
+https://github.com/hashicorp/yamux/blob/master/spec.md
+
+Only the subset needed for tunnel client operation is implemented:
+opening streams, sending/receiving data, flow control, and keepalive.
+"""
+
+from __future__ import annotations
+
+import struct
+import threading
+from typing import Protocol
+
+# ---------------------------------------------------------------------------
+# Protocol constants
+# ---------------------------------------------------------------------------
+
+_VERSION = 0
+
+_TYPE_DATA = 0
+_TYPE_WINDOW_UPDATE = 1
+_TYPE_PING = 2
+_TYPE_GO_AWAY = 3
+
+_FLAG_SYN = 0x0001
+_FLAG_ACK = 0x0002
+_FLAG_FIN = 0x0004
+_FLAG_RST = 0x0008
+
+_HEADER_SIZE = 12
+_HEADER_FMT = ">BBHII"  # version(1), type(1), flags(2), streamID(4), length(4)
+
+_INITIAL_WINDOW_SIZE = 256 * 1024  # 256 KB
+
+
+# ---------------------------------------------------------------------------
+# Byte-stream interface required by the session
+# ---------------------------------------------------------------------------
+
+
+class _ReadWriteCloser(Protocol):
+    def read(self, n: int) -> bytes: ...
+
+    def write(self, data: bytes) -> int: ...
+
+    def close(self) -> None: ...
+
+
+# ---------------------------------------------------------------------------
+# YamuxStream
+# ---------------------------------------------------------------------------
+
+
+class YamuxStream:
+    """A single multiplexed stream within a yamux session.
+
+    Streams are created via :meth:`YamuxSession.open_stream` and provide
+    blocking read/write/close with per-stream flow control.
+    """
+
+    def __init__(self, stream_id: int, session: YamuxSession) -> None:
+        self._id = stream_id
+        self._session = session
+
+        self._recv_buf = bytearray()
+        self._recv_cond = threading.Condition()
+        self._recv_closed = False
+        self._recv_error = False
+        self._recv_window = _INITIAL_WINDOW_SIZE
+
+        self._send_window = _INITIAL_WINDOW_SIZE
+        self._send_cond = threading.Condition()
+        self._send_closed = False
+
+    @property
+    def stream_id(self) -> int:
+        return self._id
+
+    def read(self, n: int) -> bytes:
+        """Read up to *n* bytes, blocking until data is available.
+
+        Returns ``b""`` on EOF (FIN received).
+        Raises :class:`ConnectionResetError` on RST.
+        """
+        delta_to_send = 0
+
+        with self._recv_cond:
+            while not self._recv_buf and not self._recv_closed and not self._recv_error:
+                self._recv_cond.wait()
+
+            if self._recv_error and not self._recv_buf:
+                raise ConnectionResetError("yamux stream reset by peer")
+
+            if not self._recv_buf:
+                return b""
+
+            size = min(n, len(self._recv_buf))
+            data = bytes(self._recv_buf[:size])
+            del self._recv_buf[:size]
+
+            consumed = _INITIAL_WINDOW_SIZE - self._recv_window
+            if consumed >= _INITIAL_WINDOW_SIZE // 2:
+                delta_to_send = consumed
+                self._recv_window += consumed
+
+        if delta_to_send > 0:
+            try:
+                self._session._send_window_update(self._id, delta_to_send)
+            except Exception:
+                pass
+
+        return data
+
+    def write(self, data: bytes) -> int:
+        """Write *data*, blocking if the send window is exhausted."""
+        if self._send_closed:
+            raise BrokenPipeError("yamux stream closed for writing")
+
+        offset = 0
+        mv = memoryview(data)
+
+        while offset < len(data):
+            with self._send_cond:
+                while self._send_window == 0 and not self._send_closed:
+                    self._send_cond.wait()
+                if self._send_closed:
+                    raise BrokenPipeError("yamux stream closed for writing")
+                chunk = min(len(data) - offset, self._send_window)
+                self._send_window -= chunk
+
+            self._session._send_data(self._id, bytes(mv[offset : offset + chunk]))
+            offset += chunk
+
+        return len(data)
+
+    def close(self) -> None:
+        """Close the stream (sends FIN to the remote end)."""
+        if not self._send_closed:
+            self._send_closed = True
+            try:
+                self._session._send_frame(_TYPE_DATA, _FLAG_FIN, self._id, 0)
+            except Exception:
+                pass
+
+        with self._recv_cond:
+            self._recv_closed = True
+            self._recv_cond.notify_all()
+        with self._send_cond:
+            self._send_cond.notify_all()
+
+    # -- Internal: called by YamuxSession._read_loop ------------------------
+
+    def _receive_data(self, data: bytes) -> None:
+        with self._recv_cond:
+            self._recv_buf.extend(data)
+            self._recv_window -= len(data)
+            self._recv_cond.notify_all()
+
+    def _receive_fin(self) -> None:
+        with self._recv_cond:
+            self._recv_closed = True
+            self._recv_cond.notify_all()
+
+    def _receive_rst(self) -> None:
+        with self._recv_cond:
+            self._recv_error = True
+            self._recv_cond.notify_all()
+        with self._send_cond:
+            self._send_closed = True
+            self._send_cond.notify_all()
+
+    def _update_send_window(self, delta: int) -> None:
+        with self._send_cond:
+            self._send_window += delta
+            self._send_cond.notify_all()
+
+
+# ---------------------------------------------------------------------------
+# YamuxSession
+# ---------------------------------------------------------------------------
+
+
+class YamuxSession:
+    """Client-side yamux session over a byte-stream connection.
+
+    The connection must implement ``read(n) -> bytes``, ``write(data) -> int``,
+    and ``close() -> None``.  Typically this is a :class:`_WSAdapter` wrapping
+    a WebSocket.
+
+    Usage::
+
+        session = YamuxSession(conn)
+        stream = session.open_stream()
+        stream.write(b"hello")
+        data = stream.read(1024)
+        stream.close()
+        session.close()
+    """
+
+    def __init__(self, conn: _ReadWriteCloser) -> None:
+        self._conn = conn
+        self._streams: dict[int, YamuxStream] = {}
+        self._next_stream_id = 1  # client uses odd IDs
+        self._lock = threading.Lock()
+        self._write_lock = threading.Lock()
+        self._closed = False
+        self._shutdown_event = threading.Event()
+
+        self._reader_thread = threading.Thread(
+            target=self._read_loop, daemon=True, name="yamux-reader"
+        )
+        self._reader_thread.start()
+
+        self._keepalive_thread = threading.Thread(
+            target=self._keepalive_loop, daemon=True, name="yamux-keepalive"
+        )
+        self._keepalive_thread.start()
+
+    @property
+    def is_closed(self) -> bool:
+        return self._closed
+
+    def open_stream(self) -> YamuxStream:
+        """Open a new multiplexed stream.
+
+        Raises :class:`RuntimeError` if the session is closed.
+        """
+        with self._lock:
+            if self._closed:
+                raise RuntimeError("yamux session is closed")
+            stream_id = self._next_stream_id
+            self._next_stream_id += 2
+            stream = YamuxStream(stream_id, self)
+            self._streams[stream_id] = stream
+
+        self._send_frame(_TYPE_WINDOW_UPDATE, _FLAG_SYN, stream_id, 0)
+        return stream
+
+    def close(self) -> None:
+        """Close the session and all streams."""
+        if self._closed:
+            return
+        self._closed = True
+        self._shutdown_event.set()
+
+        try:
+            self._send_frame(_TYPE_GO_AWAY, 0, 0, 0)
+        except Exception:
+            pass
+
+        with self._lock:
+            for stream in self._streams.values():
+                stream._receive_rst()
+
+        try:
+            self._conn.close()
+        except Exception:
+            pass
+
+    # -- Frame I/O ----------------------------------------------------------
+
+    def _send_frame(
+        self, msg_type: int, flags: int, stream_id: int, length: int
+    ) -> None:
+        hdr = struct.pack(_HEADER_FMT, _VERSION, msg_type, flags, stream_id, length)
+        with self._write_lock:
+            self._conn.write(hdr)
+
+    def _send_data(self, stream_id: int, data: bytes) -> None:
+        hdr = struct.pack(_HEADER_FMT, _VERSION, _TYPE_DATA, 0, stream_id, len(data))
+        with self._write_lock:
+            self._conn.write(hdr + data)
+
+    def _send_window_update(self, stream_id: int, delta: int) -> None:
+        self._send_frame(_TYPE_WINDOW_UPDATE, 0, stream_id, delta)
+
+    # -- Read loop ----------------------------------------------------------
+
+    def _read_loop(self) -> None:
+        try:
+            while not self._closed:
+                hdr_bytes = self._conn.read(_HEADER_SIZE)
+                if len(hdr_bytes) < _HEADER_SIZE:
+                    break
+
+                _ver, msg_type, flags, stream_id, length = struct.unpack(
+                    _HEADER_FMT, hdr_bytes
+                )
+
+                if msg_type == _TYPE_DATA:
+                    self._handle_data(flags, stream_id, length)
+                elif msg_type == _TYPE_WINDOW_UPDATE:
+                    self._handle_window_update(flags, stream_id, length)
+                elif msg_type == _TYPE_PING:
+                    self._handle_ping(flags, length)
+                elif msg_type == _TYPE_GO_AWAY:
+                    break
+        except Exception:
+            pass
+        finally:
+            if not self._closed:
+                self._closed = True
+                self._shutdown_event.set()
+                with self._lock:
+                    for stream in self._streams.values():
+                        stream._receive_rst()
+
+    def _handle_data(self, flags: int, stream_id: int, length: int) -> None:
+        payload = self._conn.read(length) if length > 0 else b""
+
+        with self._lock:
+            stream = self._streams.get(stream_id)
+        if stream is None:
+            return
+
+        if payload:
+            stream._receive_data(payload)
+        if flags & _FLAG_FIN:
+            stream._receive_fin()
+        if flags & _FLAG_RST:
+            stream._receive_rst()
+
+    def _handle_window_update(self, flags: int, stream_id: int, length: int) -> None:
+        with self._lock:
+            stream = self._streams.get(stream_id)
+        if stream is None:
+            return
+
+        if length > 0:
+            stream._update_send_window(length)
+        if flags & _FLAG_FIN:
+            stream._receive_fin()
+        if flags & _FLAG_RST:
+            stream._receive_rst()
+
+    def _handle_ping(self, flags: int, opaque: int) -> None:
+        if flags & _FLAG_SYN:
+            try:
+                self._send_frame(_TYPE_PING, _FLAG_ACK, 0, opaque)
+            except Exception:
+                pass
+
+    # -- Keepalive ----------------------------------------------------------
+
+    def _keepalive_loop(self) -> None:
+        ping_id = 0
+        while not self._shutdown_event.wait(30):
+            ping_id += 1
+            try:
+                self._send_frame(_TYPE_PING, _FLAG_SYN, 0, ping_id)
+            except Exception:
+                break

--- a/python/tests/unit_tests/sandbox/test_yamux.py
+++ b/python/tests/unit_tests/sandbox/test_yamux.py
@@ -1,0 +1,531 @@
+"""Unit tests for the yamux multiplexing implementation."""
+
+from __future__ import annotations
+
+import struct
+import threading
+import time
+
+import pytest
+
+from langsmith.sandbox._yamux import (
+    _FLAG_ACK,
+    _FLAG_FIN,
+    _FLAG_RST,
+    _FLAG_SYN,
+    _HEADER_FMT,
+    _HEADER_SIZE,
+    _INITIAL_WINDOW_SIZE,
+    _TYPE_DATA,
+    _TYPE_GO_AWAY,
+    _TYPE_PING,
+    _TYPE_WINDOW_UPDATE,
+    _VERSION,
+    YamuxSession,
+)
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+
+class MockConn:
+    """In-memory byte-stream for testing yamux without real I/O.
+
+    Writes are buffered and can be inspected.  Data to be read by the
+    session can be injected via :meth:`feed`.
+    """
+
+    def __init__(self) -> None:
+        self._read_buf = bytearray()
+        self._write_buf = bytearray()
+        self._cond = threading.Condition()
+        self._closed = False
+
+    def feed(self, data: bytes) -> None:
+        """Inject bytes that ``read()`` will return."""
+        with self._cond:
+            self._read_buf.extend(data)
+            self._cond.notify_all()
+
+    def read(self, n: int) -> bytes:
+        with self._cond:
+            while len(self._read_buf) < n and not self._closed:
+                if not self._cond.wait(timeout=5):
+                    raise TimeoutError("MockConn.read timed out")
+            if len(self._read_buf) < n:
+                raise ConnectionError("MockConn closed")
+            data = bytes(self._read_buf[:n])
+            del self._read_buf[:n]
+            return data
+
+    def write(self, data: bytes) -> int:
+        with self._cond:
+            if self._closed:
+                raise ConnectionError("MockConn closed")
+            self._write_buf.extend(data)
+        return len(data)
+
+    def close(self) -> None:
+        with self._cond:
+            self._closed = True
+            self._cond.notify_all()
+
+    # -- Inspection helpers --------------------------------------------------
+
+    def drain_written(self) -> bytes:
+        """Return and clear everything written so far."""
+        with self._cond:
+            data = bytes(self._write_buf)
+            self._write_buf.clear()
+            return data
+
+    def read_frame(self) -> tuple[int, int, int, int, int, bytes]:
+        """Parse one yamux frame from the write buffer.
+
+        Returns (version, msg_type, flags, stream_id, length, payload).
+        Payload is only present for DATA frames.
+        """
+        with self._cond:
+            while len(self._write_buf) < _HEADER_SIZE:
+                if not self._cond.wait(timeout=2):
+                    raise TimeoutError("read_frame: no frame available")
+
+            hdr_bytes = bytes(self._write_buf[:_HEADER_SIZE])
+            del self._write_buf[:_HEADER_SIZE]
+
+        ver, mtype, flags, sid, length = struct.unpack(_HEADER_FMT, hdr_bytes)
+
+        payload = b""
+        if mtype == _TYPE_DATA and length > 0:
+            with self._cond:
+                while len(self._write_buf) < length:
+                    if not self._cond.wait(timeout=2):
+                        raise TimeoutError("read_frame: incomplete payload")
+                payload = bytes(self._write_buf[:length])
+                del self._write_buf[:length]
+
+        return ver, mtype, flags, sid, length, payload
+
+
+def _make_frame(
+    msg_type: int,
+    flags: int,
+    stream_id: int,
+    length: int,
+    payload: bytes = b"",
+) -> bytes:
+    """Build a raw yamux frame."""
+    hdr = struct.pack(_HEADER_FMT, _VERSION, msg_type, flags, stream_id, length)
+    return hdr + payload
+
+
+# ---------------------------------------------------------------------------
+# YamuxSession.open_stream
+# ---------------------------------------------------------------------------
+
+
+class TestOpenStream:
+    def test_sends_syn(self) -> None:
+        conn = MockConn()
+        session = YamuxSession(conn)
+        try:
+            stream = session.open_stream()
+            assert stream.stream_id == 1
+
+            ver, mtype, flags, sid, length, _ = conn.read_frame()
+            assert mtype == _TYPE_WINDOW_UPDATE
+            assert flags == _FLAG_SYN
+            assert sid == 1
+            assert length == 0
+        finally:
+            session.close()
+
+    def test_stream_ids_are_odd_and_increasing(self) -> None:
+        conn = MockConn()
+        session = YamuxSession(conn)
+        try:
+            s1 = session.open_stream()
+            s2 = session.open_stream()
+            s3 = session.open_stream()
+            assert s1.stream_id == 1
+            assert s2.stream_id == 3
+            assert s3.stream_id == 5
+        finally:
+            session.close()
+
+    def test_open_after_close_raises(self) -> None:
+        conn = MockConn()
+        session = YamuxSession(conn)
+        session.close()
+        with pytest.raises(RuntimeError, match="closed"):
+            session.open_stream()
+
+
+# ---------------------------------------------------------------------------
+# Stream write
+# ---------------------------------------------------------------------------
+
+
+class TestStreamWrite:
+    def test_write_sends_data_frame(self) -> None:
+        conn = MockConn()
+        session = YamuxSession(conn)
+        try:
+            stream = session.open_stream()
+            conn.drain_written()  # clear SYN
+
+            stream.write(b"hello")
+
+            ver, mtype, flags, sid, length, payload = conn.read_frame()
+            assert mtype == _TYPE_DATA
+            assert flags == 0
+            assert sid == stream.stream_id
+            assert length == 5
+            assert payload == b"hello"
+        finally:
+            session.close()
+
+    def test_write_respects_send_window(self) -> None:
+        """Write blocks when the send window is exhausted."""
+        conn = MockConn()
+        session = YamuxSession(conn)
+        try:
+            stream = session.open_stream()
+            conn.drain_written()
+
+            stream._send_window = 3
+
+            result = stream.write(b"abc")
+            assert result == 3
+
+            _, _, _, _, length, payload = conn.read_frame()
+            assert length == 3
+            assert payload == b"abc"
+        finally:
+            session.close()
+
+
+# ---------------------------------------------------------------------------
+# Stream read (data dispatched by read loop)
+# ---------------------------------------------------------------------------
+
+
+class TestStreamRead:
+    def test_read_receives_data(self) -> None:
+        conn = MockConn()
+        session = YamuxSession(conn)
+        try:
+            stream = session.open_stream()
+            conn.drain_written()
+
+            frame = _make_frame(_TYPE_DATA, 0, stream.stream_id, 5, b"hello")
+            conn.feed(frame)
+
+            data = stream.read(5)
+            assert data == b"hello"
+        finally:
+            session.close()
+
+    def test_read_partial(self) -> None:
+        """read(n) returns up to n bytes even if more are buffered."""
+        conn = MockConn()
+        session = YamuxSession(conn)
+        try:
+            stream = session.open_stream()
+
+            conn.feed(_make_frame(_TYPE_DATA, 0, stream.stream_id, 10, b"helloworld"))
+            time.sleep(0.05)
+
+            chunk1 = stream.read(5)
+            assert chunk1 == b"hello"
+            chunk2 = stream.read(5)
+            assert chunk2 == b"world"
+        finally:
+            session.close()
+
+    def test_read_blocks_until_data(self) -> None:
+        conn = MockConn()
+        session = YamuxSession(conn)
+        try:
+            stream = session.open_stream()
+            received: list[bytes] = []
+
+            def reader() -> None:
+                received.append(stream.read(3))
+
+            t = threading.Thread(target=reader)
+            t.start()
+
+            time.sleep(0.05)
+            assert not received
+
+            conn.feed(_make_frame(_TYPE_DATA, 0, stream.stream_id, 3, b"abc"))
+            t.join(timeout=2)
+
+            assert received == [b"abc"]
+        finally:
+            session.close()
+
+
+# ---------------------------------------------------------------------------
+# FIN / RST handling
+# ---------------------------------------------------------------------------
+
+
+class TestFinRst:
+    def test_fin_causes_eof(self) -> None:
+        conn = MockConn()
+        session = YamuxSession(conn)
+        try:
+            stream = session.open_stream()
+            conn.feed(_make_frame(_TYPE_DATA, _FLAG_FIN, stream.stream_id, 0))
+            time.sleep(0.05)
+
+            data = stream.read(1024)
+            assert data == b""
+        finally:
+            session.close()
+
+    def test_fin_after_data_drains_buffer_first(self) -> None:
+        conn = MockConn()
+        session = YamuxSession(conn)
+        try:
+            stream = session.open_stream()
+
+            conn.feed(_make_frame(_TYPE_DATA, _FLAG_FIN, stream.stream_id, 3, b"end"))
+            time.sleep(0.05)
+
+            assert stream.read(3) == b"end"
+            assert stream.read(1) == b""
+        finally:
+            session.close()
+
+    def test_rst_raises_on_read(self) -> None:
+        conn = MockConn()
+        session = YamuxSession(conn)
+        try:
+            stream = session.open_stream()
+            conn.feed(_make_frame(_TYPE_DATA, _FLAG_RST, stream.stream_id, 0))
+            time.sleep(0.05)
+
+            with pytest.raises(ConnectionResetError):
+                stream.read(1)
+        finally:
+            session.close()
+
+    def test_rst_drains_buffer_before_error(self) -> None:
+        conn = MockConn()
+        session = YamuxSession(conn)
+        try:
+            stream = session.open_stream()
+            conn.feed(_make_frame(_TYPE_DATA, 0, stream.stream_id, 2, b"ok"))
+            time.sleep(0.05)
+            conn.feed(_make_frame(_TYPE_DATA, _FLAG_RST, stream.stream_id, 0))
+            time.sleep(0.05)
+
+            assert stream.read(2) == b"ok"
+            with pytest.raises(ConnectionResetError):
+                stream.read(1)
+        finally:
+            session.close()
+
+
+# ---------------------------------------------------------------------------
+# Ping / pong
+# ---------------------------------------------------------------------------
+
+
+class TestPing:
+    def test_responds_to_ping_with_ack(self) -> None:
+        conn = MockConn()
+        session = YamuxSession(conn)
+        try:
+            conn.drain_written()
+
+            conn.feed(_make_frame(_TYPE_PING, _FLAG_SYN, 0, 42))
+            time.sleep(0.1)
+
+            ver, mtype, flags, sid, opaque, _ = conn.read_frame()
+            assert mtype == _TYPE_PING
+            assert flags == _FLAG_ACK
+            assert opaque == 42
+        finally:
+            session.close()
+
+
+# ---------------------------------------------------------------------------
+# Window updates
+# ---------------------------------------------------------------------------
+
+
+class TestWindowUpdate:
+    def test_window_update_increases_send_window(self) -> None:
+        conn = MockConn()
+        session = YamuxSession(conn)
+        try:
+            stream = session.open_stream()
+            initial = stream._send_window
+
+            conn.feed(_make_frame(_TYPE_WINDOW_UPDATE, 0, stream.stream_id, 1024))
+            time.sleep(0.05)
+
+            assert stream._send_window == initial + 1024
+        finally:
+            session.close()
+
+    def test_batched_window_update_on_read(self) -> None:
+        """A window update is sent after consuming >= half the window."""
+        conn = MockConn()
+        session = YamuxSession(conn)
+        try:
+            stream = session.open_stream()
+            conn.drain_written()
+
+            half = _INITIAL_WINDOW_SIZE // 2
+            payload = b"\x00" * half
+            conn.feed(_make_frame(_TYPE_DATA, 0, stream.stream_id, half, payload))
+            time.sleep(0.05)
+
+            stream.read(half)
+            time.sleep(0.05)
+
+            ver, mtype, flags, sid, delta, _ = conn.read_frame()
+            assert mtype == _TYPE_WINDOW_UPDATE
+            assert sid == stream.stream_id
+            assert delta == half
+        finally:
+            session.close()
+
+    def test_no_update_for_small_reads(self) -> None:
+        """Small reads don't trigger window updates."""
+        conn = MockConn()
+        session = YamuxSession(conn)
+        try:
+            stream = session.open_stream()
+            conn.drain_written()
+
+            conn.feed(_make_frame(_TYPE_DATA, 0, stream.stream_id, 10, b"0123456789"))
+            time.sleep(0.05)
+
+            stream.read(10)
+            time.sleep(0.05)
+
+            remaining = conn.drain_written()
+            assert len(remaining) == 0
+        finally:
+            session.close()
+
+
+# ---------------------------------------------------------------------------
+# GoAway
+# ---------------------------------------------------------------------------
+
+
+class TestGoAway:
+    def test_go_away_closes_session(self) -> None:
+        conn = MockConn()
+        session = YamuxSession(conn)
+        try:
+            conn.feed(_make_frame(_TYPE_GO_AWAY, 0, 0, 0))
+            time.sleep(0.1)
+            assert session.is_closed
+        finally:
+            session.close()
+
+    def test_go_away_resets_open_streams(self) -> None:
+        conn = MockConn()
+        session = YamuxSession(conn)
+        try:
+            stream = session.open_stream()
+            conn.feed(_make_frame(_TYPE_GO_AWAY, 0, 0, 0))
+            time.sleep(0.1)
+
+            with pytest.raises(ConnectionResetError):
+                stream.read(1)
+        finally:
+            session.close()
+
+
+# ---------------------------------------------------------------------------
+# Session close
+# ---------------------------------------------------------------------------
+
+
+class TestSessionClose:
+    def test_close_sends_go_away(self) -> None:
+        conn = MockConn()
+        session = YamuxSession(conn)
+        conn.drain_written()
+
+        session.close()
+
+        ver, mtype, flags, sid, length, _ = conn.read_frame()
+        assert mtype == _TYPE_GO_AWAY
+
+    def test_close_is_idempotent(self) -> None:
+        conn = MockConn()
+        session = YamuxSession(conn)
+        session.close()
+        session.close()  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# Multiple concurrent streams
+# ---------------------------------------------------------------------------
+
+
+class TestConcurrentStreams:
+    def test_interleaved_data(self) -> None:
+        """Data for different streams is dispatched correctly."""
+        conn = MockConn()
+        session = YamuxSession(conn)
+        try:
+            s1 = session.open_stream()
+            s2 = session.open_stream()
+
+            conn.feed(_make_frame(_TYPE_DATA, 0, s1.stream_id, 1, b"A"))
+            conn.feed(_make_frame(_TYPE_DATA, 0, s2.stream_id, 1, b"B"))
+            conn.feed(_make_frame(_TYPE_DATA, 0, s1.stream_id, 1, b"C"))
+            time.sleep(0.1)
+
+            assert s1.read(1) == b"A"
+            assert s2.read(1) == b"B"
+            assert s1.read(1) == b"C"
+        finally:
+            session.close()
+
+
+# ---------------------------------------------------------------------------
+# Stream close
+# ---------------------------------------------------------------------------
+
+
+class TestStreamClose:
+    def test_close_sends_fin(self) -> None:
+        conn = MockConn()
+        session = YamuxSession(conn)
+        try:
+            stream = session.open_stream()
+            conn.drain_written()
+
+            stream.close()
+
+            ver, mtype, flags, sid, length, _ = conn.read_frame()
+            assert mtype == _TYPE_DATA
+            assert flags == _FLAG_FIN
+            assert sid == stream.stream_id
+        finally:
+            session.close()
+
+    def test_write_after_close_raises(self) -> None:
+        conn = MockConn()
+        session = YamuxSession(conn)
+        try:
+            stream = session.open_stream()
+            stream.close()
+
+            with pytest.raises(BrokenPipeError):
+                stream.write(b"x")
+        finally:
+            session.close()


### PR DESCRIPTION
## Add yamux multiplexing protocol

Client-side implementation of the [yamux](https://github.com/hashicorp/yamux/blob/master/spec.md) multiplexing protocol in pure Python, used as the transport layer for TCP tunnels.

- `YamuxSession` manages the WebSocket connection, background read loop, and keepalive pings.
- `YamuxStream` provides individual multiplexed streams with flow control and buffering.
- Works over any transport implementing a simple `read`/`write`/`close` interface.

Split from #2556.

### Test plan

- 23 unit tests covering stream open/read/write, FIN/RST handling, ping/pong, window updates, GoAway, session close, concurrent streams, and stream close.

Made with [Cursor](https://cursor.com)