### PR TITLE
feat(sandbox): add TCP tunnel support

### DIFF
--- a/python/langsmith/sandbox/__init__.py
+++ b/python/langsmith/sandbox/__init__.py
@@ -42,6 +42,10 @@ from langsmith.sandbox._exceptions import (
     SandboxNotReadyError,
     SandboxOperationError,
     SandboxServerReloadError,
+    TunnelConnectionRefusedError,
+    TunnelError,
+    TunnelPortNotAllowedError,
+    TunnelUnsupportedVersionError,
     ValidationError,
 )
 from langsmith.sandbox._models import (
@@ -57,6 +61,7 @@ from langsmith.sandbox._models import (
     VolumeMountSpec,
 )
 from langsmith.sandbox._sandbox import Sandbox
+from langsmith.sandbox._tunnel import AsyncTunnel, Tunnel
 
 __all__ = [
     # Main classes
@@ -97,6 +102,13 @@ __all__ = [
     "SandboxOperationError",
     "CommandTimeoutError",
     "DataplaneNotConfiguredError",
+    # Tunnel
+    "Tunnel",
+    "AsyncTunnel",
+    "TunnelError",
+    "TunnelPortNotAllowedError",
+    "TunnelConnectionRefusedError",
+    "TunnelUnsupportedVersionError",
 ]
 
 # Emit warning on import

--- a/python/langsmith/sandbox/_async_sandbox.py
+++ b/python/langsmith/sandbox/_async_sandbox.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Callable, Literal, Optional, Union, overload
 
@@ -18,6 +19,7 @@ from langsmith.sandbox._models import (
     AsyncCommandHandle,
     ExecutionResult,
 )
+from langsmith.sandbox._tunnel import AsyncTunnel
 
 if TYPE_CHECKING:
     from langsmith.sandbox._async_client import AsyncSandboxClient
@@ -444,3 +446,43 @@ class AsyncSandbox:
             handle_sandbox_http_error(e)
             # This line should never be reached but satisfies type checker
             raise  # pragma: no cover
+
+    async def tunnel(self, remote_port: int, *, local_port: int = 0) -> AsyncTunnel:
+        """Open a TCP tunnel to a port inside the sandbox.
+
+        Creates a local TCP listener that forwards connections through a
+        yamux-multiplexed WebSocket to the specified port inside the sandbox.
+        Works with any TCP protocol (databases, Redis, HTTP, etc.).
+
+        Usage::
+
+            async with await sandbox.tunnel(remote_port=5432) as t:
+                conn = await asyncpg.connect(host="127.0.0.1", port=t.local_port)
+
+        Args:
+            remote_port: TCP port inside the sandbox to tunnel to (1-65535).
+            local_port: Local port to listen on. Defaults to mirroring
+                remote_port. Use 0 to let the OS pick an available port.
+
+        Returns:
+            An AsyncTunnel instance (async context manager).
+
+        Raises:
+            ValueError: If port values are out of range.
+            DataplaneNotConfiguredError: If dataplane_url is not configured.
+            SandboxNotReadyError: If sandbox is not ready.
+        """
+        if not 1 <= remote_port <= 65535:
+            raise ValueError(
+                f"remote_port must be between 1 and 65535 (got {remote_port})"
+            )
+        if local_port and not 1 <= local_port <= 65535:
+            raise ValueError(
+                f"local_port must be between 1 and 65535 (got {local_port})"
+            )
+        dataplane_url = self._require_dataplane_url()
+        api_key = self._client._api_key
+        t = AsyncTunnel(dataplane_url, api_key, remote_port, local_port=local_port)
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(None, t._tunnel._start)
+        return t

--- a/python/langsmith/sandbox/_exceptions.py
+++ b/python/langsmith/sandbox/_exceptions.py
@@ -284,3 +284,46 @@ class CommandTimeoutError(SandboxOperationError):
         """Initialize the error."""
         super().__init__(message, operation="command", error_type="CommandTimeout")
         self.timeout = timeout
+
+
+# ========================================================================
+# Tunnel Errors
+# ========================================================================
+
+
+class TunnelError(SandboxClientError):
+    """Base exception for TCP tunnel errors."""
+
+    pass
+
+
+class TunnelPortNotAllowedError(TunnelError):
+    """The daemon rejected the port as not allowed.
+
+    Attributes:
+        port: The port that was rejected.
+    """
+
+    def __init__(self, message: str, *, port: int):
+        """Initialize the error."""
+        super().__init__(message)
+        self.port = port
+
+
+class TunnelConnectionRefusedError(TunnelError):
+    """Nothing is listening on the target port inside the sandbox.
+
+    Attributes:
+        port: The port that could not be reached.
+    """
+
+    def __init__(self, message: str, *, port: int):
+        """Initialize the error."""
+        super().__init__(message)
+        self.port = port
+
+
+class TunnelUnsupportedVersionError(TunnelError):
+    """Protocol version mismatch between the tunnel client and the daemon."""
+
+    pass

--- a/python/langsmith/sandbox/_sandbox.py
+++ b/python/langsmith/sandbox/_sandbox.py
@@ -18,6 +18,7 @@ from langsmith.sandbox._models import (
     CommandHandle,
     ExecutionResult,
 )
+from langsmith.sandbox._tunnel import Tunnel
 
 if TYPE_CHECKING:
     from langsmith.sandbox._client import SandboxClient
@@ -443,3 +444,48 @@ class Sandbox:
             handle_sandbox_http_error(e)
             # This line should never be reached but satisfies type checker
             raise  # pragma: no cover
+
+    def tunnel(self, remote_port: int, *, local_port: int = 0) -> Tunnel:
+        """Open a TCP tunnel to a port inside the sandbox.
+
+        Creates a local TCP listener that forwards connections through a
+        yamux-multiplexed WebSocket to the specified port inside the sandbox.
+        Works with any TCP protocol (databases, Redis, HTTP, etc.).
+
+        Use as a context manager for automatic cleanup::
+
+            with sandbox.tunnel(remote_port=5432) as t:
+                conn = psycopg2.connect(host="127.0.0.1", port=t.local_port)
+
+        Or manage the lifecycle explicitly::
+
+            t = sandbox.tunnel(remote_port=5432)
+            # ... use tunnel ...
+            t.close()
+
+        Args:
+            remote_port: TCP port inside the sandbox to tunnel to (1-65535).
+            local_port: Local port to listen on. Defaults to mirroring
+                remote_port. Use 0 to let the OS pick an available port.
+
+        Returns:
+            A Tunnel instance (context manager).
+
+        Raises:
+            ValueError: If port values are out of range.
+            DataplaneNotConfiguredError: If dataplane_url is not configured.
+            SandboxNotReadyError: If sandbox is not ready.
+        """
+        if not 1 <= remote_port <= 65535:
+            raise ValueError(
+                f"remote_port must be between 1 and 65535 (got {remote_port})"
+            )
+        if local_port and not 1 <= local_port <= 65535:
+            raise ValueError(
+                f"local_port must be between 1 and 65535 (got {local_port})"
+            )
+        dataplane_url = self._require_dataplane_url()
+        api_key = self._client._api_key
+        t = Tunnel(dataplane_url, api_key, remote_port, local_port=local_port)
+        t._start()
+        return t

--- a/python/langsmith/sandbox/_tunnel.py
+++ b/python/langsmith/sandbox/_tunnel.py
@@ -1,0 +1,422 @@
+"""TCP tunnel for accessing services running inside sandboxes.
+
+Establishes a WebSocket connection to the daemon's ``/tunnel`` endpoint,
+runs a yamux multiplexing session on top, and forwards local TCP connections
+through yamux streams to the target port inside the sandbox.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import socket
+import struct
+import threading
+from typing import TYPE_CHECKING, Any, Optional
+
+if TYPE_CHECKING:
+    from langsmith.sandbox._yamux import YamuxSession, YamuxStream
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Tunnel connect-header protocol (layered on top of yamux streams)
+# ---------------------------------------------------------------------------
+
+PROTOCOL_VERSION = 0x01
+
+STATUS_OK = 0x00
+STATUS_PORT_NOT_ALLOWED = 0x01
+STATUS_DIAL_FAILED = 0x02
+STATUS_UNSUPPORTED_VERSION = 0x03
+
+_CONNECT_HEADER_FMT = ">BH"  # version(1) + port(2, big-endian)
+
+
+def _write_connect_header(stream: YamuxStream, port: int) -> None:
+    """Write the 3-byte connect header on a freshly opened yamux stream."""
+    stream.write(struct.pack(_CONNECT_HEADER_FMT, PROTOCOL_VERSION, port))
+
+
+def _read_status(stream: YamuxStream) -> int:
+    """Read the 1-byte status response from the daemon."""
+    data = stream.read(1)
+    if not data:
+        raise ConnectionError("tunnel: connection closed before status")
+    return data[0]
+
+
+# ---------------------------------------------------------------------------
+# WebSocket adapter
+# ---------------------------------------------------------------------------
+
+
+class _WSAdapter:
+    """Adapts the ``websockets`` message API to a byte-stream interface.
+
+    yamux requires a plain read/write/close byte stream.  WebSocket is
+    message-based, so this adapter buffers partially consumed messages on
+    reads and sends one binary message per write.
+    """
+
+    def __init__(self, ws: Any) -> None:
+        self._ws = ws
+        self._buf = bytearray()
+        self._write_lock = threading.Lock()
+
+    def read(self, n: int) -> bytes:
+        while len(self._buf) < n:
+            msg = self._ws.recv()
+            if isinstance(msg, str):
+                msg = msg.encode()
+            self._buf.extend(msg)
+
+        result = bytes(self._buf[:n])
+        del self._buf[:n]
+        return result
+
+    def write(self, data: bytes) -> int:
+        with self._write_lock:
+            self._ws.send(data)
+        return len(data)
+
+    def close(self) -> None:
+        try:
+            self._ws.close()
+        except Exception:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Bridge: bidirectional copy between yamux stream and TCP socket
+# ---------------------------------------------------------------------------
+
+_BRIDGE_BUF_SIZE = 16384
+
+
+def _bridge(stream: YamuxStream, tcp_conn: socket.socket) -> None:
+    """Copy data bidirectionally until one side closes or errors."""
+    done = threading.Event()
+
+    def _stream_to_tcp() -> None:
+        try:
+            while True:
+                data = stream.read(_BRIDGE_BUF_SIZE)
+                if not data:
+                    break
+                tcp_conn.sendall(data)
+        except Exception:
+            pass
+        finally:
+            done.set()
+
+    def _tcp_to_stream() -> None:
+        try:
+            while True:
+                data = tcp_conn.recv(_BRIDGE_BUF_SIZE)
+                if not data:
+                    break
+                stream.write(data)
+        except Exception:
+            pass
+        finally:
+            done.set()
+
+    t1 = threading.Thread(target=_stream_to_tcp, daemon=True)
+    t2 = threading.Thread(target=_tcp_to_stream, daemon=True)
+    t1.start()
+    t2.start()
+
+    done.wait()
+
+    try:
+        stream.close()
+    except Exception:
+        pass
+    try:
+        tcp_conn.shutdown(socket.SHUT_RDWR)
+    except OSError:
+        pass
+    try:
+        tcp_conn.close()
+    except OSError:
+        pass
+
+    t1.join(timeout=5)
+    t2.join(timeout=5)
+
+
+# ---------------------------------------------------------------------------
+# Tunnel
+# ---------------------------------------------------------------------------
+
+
+def _ensure_websockets():
+    """Import websockets sync client or raise a clear error."""
+    try:
+        from websockets.sync.client import connect as ws_connect
+
+        return ws_connect
+    except ImportError:
+        raise ImportError(
+            "TCP tunnel requires the 'websockets' package. "
+            "Install it with: pip install 'langsmith[sandbox]'"
+        ) from None
+
+
+class Tunnel:
+    """TCP tunnel to a port inside a sandbox.
+
+    Opens a local TCP listener and forwards each accepted connection through
+    a yamux-multiplexed WebSocket to the daemon, which dials the target port
+    inside the sandbox.
+
+    Typically used as a context manager::
+
+        with sandbox.tunnel(remote_port=5432) as t:
+            conn = psycopg2.connect(host="127.0.0.1", port=t.local_port)
+
+    Or with explicit lifecycle::
+
+        t = sandbox.tunnel(remote_port=5432)
+        # ... use tunnel ...
+        t.close()
+    """
+
+    def __init__(
+        self,
+        dataplane_url: str,
+        api_key: Optional[str],
+        remote_port: int,
+        *,
+        local_port: int = 0,
+    ) -> None:
+        self._dataplane_url = dataplane_url
+        self._api_key = api_key
+        self._remote_port = remote_port
+        self._requested_local_port = local_port or remote_port
+        self._local_port = self._requested_local_port
+
+        self._ws: object = None
+        self._yamux: Optional[YamuxSession] = None
+        self._server_socket: Optional[socket.socket] = None
+        self._accept_thread: Optional[threading.Thread] = None
+        self._closed = False
+        self._started = False
+
+    @property
+    def local_port(self) -> int:
+        """Local port the tunnel is listening on."""
+        return self._local_port
+
+    @property
+    def remote_port(self) -> int:
+        """Port inside the sandbox that the tunnel connects to."""
+        return self._remote_port
+
+    # -- Context manager ----------------------------------------------------
+
+    def __enter__(self) -> Tunnel:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        self.close()
+
+    # -- Lifecycle ----------------------------------------------------------
+
+    def _start(self) -> None:
+        if self._started:
+            return
+        self._started = True
+
+        try:
+            self._do_start()
+        except Exception:
+            self.close()
+            raise
+
+    def _do_start(self) -> None:
+        from langsmith.sandbox._yamux import YamuxSession
+
+        ws_connect = _ensure_websockets()
+        ws_url = self._build_ws_url()
+        headers: dict[str, str] = {}
+        if self._api_key:
+            headers["X-Api-Key"] = self._api_key
+
+        self._ws = ws_connect(
+            ws_url,
+            additional_headers=headers,
+            open_timeout=15,
+            close_timeout=5,
+            ping_interval=None,  # yamux handles keepalive
+        )
+
+        adapter = _WSAdapter(self._ws)
+        self._yamux = YamuxSession(adapter)
+
+        self._server_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self._server_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+
+        # Check if another process is actively listening on this port.
+        # SO_REUSEADDR lets us rebind over TIME_WAIT, but we don't want to
+        # silently steal a port from a running service.
+        port = self._requested_local_port
+        if port != 0:
+            probe = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            try:
+                probe.settimeout(0.5)
+                probe.connect(("127.0.0.1", port))
+                probe.close()
+                raise OSError(
+                    f"Port {port} is already in use by another service. "
+                    f"Choose a different local_port."
+                )
+            except ConnectionRefusedError:
+                pass  # nothing listening — safe to bind
+            except OSError as e:
+                if "Connection refused" in str(e):
+                    pass  # same as above, different OS error message
+                elif "already in use" in str(e).lower():
+                    raise
+                else:
+                    pass  # TIME_WAIT or other transient state — safe to bind
+            finally:
+                try:
+                    probe.close()
+                except OSError:
+                    pass
+
+        self._server_socket.bind(("127.0.0.1", self._requested_local_port))
+        self._server_socket.listen(128)
+        self._local_port = self._server_socket.getsockname()[1]
+
+        self._accept_thread = threading.Thread(
+            target=self._accept_loop, daemon=True, name="tunnel-accept"
+        )
+        self._accept_thread.start()
+
+    def close(self) -> None:
+        """Shut down the tunnel, closing all connections."""
+        if self._closed:
+            return
+        self._closed = True
+
+        if self._server_socket:
+            try:
+                self._server_socket.close()
+            except OSError:
+                pass
+
+        if self._yamux:
+            self._yamux.close()
+
+    # -- Internal -----------------------------------------------------------
+
+    def _accept_loop(self) -> None:
+        while not self._closed:
+            try:
+                conn, _ = self._server_socket.accept()  # type: ignore[union-attr]
+            except OSError:
+                break
+            threading.Thread(
+                target=self._handle_conn,
+                args=(conn,),
+                daemon=True,
+                name="tunnel-bridge",
+            ).start()
+
+    def _handle_conn(self, tcp_conn: socket.socket) -> None:
+        try:
+            stream = self._yamux.open_stream()  # type: ignore[union-attr]
+            _write_connect_header(stream, self._remote_port)
+            status = _read_status(stream)
+
+            if status == STATUS_OK:
+                _bridge(stream, tcp_conn)
+                return
+
+            stream.close()
+            tcp_conn.close()
+
+            if status == STATUS_PORT_NOT_ALLOWED:
+                logger.warning(
+                    "tunnel: port %d not allowed by daemon",
+                    self._remote_port,
+                )
+            elif status == STATUS_DIAL_FAILED:
+                logger.warning(
+                    "tunnel: nothing listening on port %d inside sandbox",
+                    self._remote_port,
+                )
+            elif status == STATUS_UNSUPPORTED_VERSION:
+                logger.warning(
+                    "tunnel: protocol version mismatch (client v%d)",
+                    PROTOCOL_VERSION,
+                )
+            else:
+                logger.warning("tunnel: unknown status %d", status)
+
+        except Exception as exc:
+            logger.debug("tunnel: connection handler error: %s", exc)
+            try:
+                tcp_conn.close()
+            except OSError:
+                pass
+
+    def _build_ws_url(self) -> str:
+        url = self._dataplane_url.rstrip("/")
+        url = url.replace("https://", "wss://").replace("http://", "ws://")
+        return f"{url}/tunnel"
+
+
+# ---------------------------------------------------------------------------
+# AsyncTunnel
+# ---------------------------------------------------------------------------
+
+
+class AsyncTunnel:
+    """Async wrapper around :class:`Tunnel`.
+
+    The underlying tunnel runs in background threads (TCP listener + bridges);
+    async context-manager methods delegate to the sync tunnel via the event
+    loop's executor.
+
+    Usage::
+
+        async with await sandbox.tunnel(remote_port=5432) as t:
+            conn = await asyncpg.connect(host="127.0.0.1", port=t.local_port)
+    """
+
+    def __init__(
+        self,
+        dataplane_url: str,
+        api_key: Optional[str],
+        remote_port: int,
+        *,
+        local_port: int = 0,
+    ) -> None:
+        self._tunnel = Tunnel(
+            dataplane_url, api_key, remote_port, local_port=local_port
+        )
+
+    @property
+    def local_port(self) -> int:
+        return self._tunnel.local_port
+
+    @property
+    def remote_port(self) -> int:
+        return self._tunnel.remote_port
+
+    async def __aenter__(self) -> AsyncTunnel:
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(None, self._tunnel._start)
+        return self
+
+    async def __aexit__(self, *args: object) -> None:
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(None, self._tunnel.close)
+
+    def close(self) -> None:
+        """Shut down the tunnel (sync, safe to call from any context)."""
+        self._tunnel.close()

--- a/python/tests/unit_tests/sandbox/test_tunnel.py
+++ b/python/tests/unit_tests/sandbox/test_tunnel.py
@@ -1,0 +1,285 @@
+"""Unit tests for the TCP tunnel module."""
+
+from __future__ import annotations
+
+import struct
+import threading
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from langsmith.sandbox._exceptions import (
+    TunnelConnectionRefusedError,
+    TunnelError,
+    TunnelPortNotAllowedError,
+    TunnelUnsupportedVersionError,
+)
+from langsmith.sandbox._tunnel import (
+    PROTOCOL_VERSION,
+    STATUS_DIAL_FAILED,
+    STATUS_OK,
+    STATUS_PORT_NOT_ALLOWED,
+    STATUS_UNSUPPORTED_VERSION,
+    AsyncTunnel,
+    Tunnel,
+    _read_status,
+    _write_connect_header,
+    _WSAdapter,
+)
+
+# ---------------------------------------------------------------------------
+# _WSAdapter
+# ---------------------------------------------------------------------------
+
+
+class MockWS:
+    """Minimal mock matching the websockets sync client interface."""
+
+    def __init__(self, messages: list[bytes] | None = None) -> None:
+        self._messages = list(messages or [])
+        self._sent: list[bytes] = []
+        self._closed = False
+
+    def recv(self) -> bytes:
+        if not self._messages:
+            raise ConnectionError("no more messages")
+        return self._messages.pop(0)
+
+    def send(self, data: bytes) -> None:
+        self._sent.append(data)
+
+    def close(self) -> None:
+        self._closed = True
+
+
+class TestWSAdapter:
+    def test_read_buffers_and_returns_exact(self) -> None:
+        ws = MockWS([b"helloworld"])
+        adapter = _WSAdapter(ws)
+        assert adapter.read(5) == b"hello"
+        assert adapter.read(5) == b"world"
+
+    def test_read_spans_messages(self) -> None:
+        ws = MockWS([b"he", b"ll", b"o"])
+        adapter = _WSAdapter(ws)
+        assert adapter.read(5) == b"hello"
+
+    def test_write_sends_binary(self) -> None:
+        ws = MockWS()
+        adapter = _WSAdapter(ws)
+        n = adapter.write(b"test")
+        assert n == 4
+        assert ws._sent == [b"test"]
+
+    def test_write_thread_safe(self) -> None:
+        ws = MockWS()
+        adapter = _WSAdapter(ws)
+        errors: list[Exception] = []
+
+        def writer(val: bytes) -> None:
+            try:
+                for _ in range(50):
+                    adapter.write(val)
+            except Exception as e:
+                errors.append(e)
+
+        threads = [
+            threading.Thread(target=writer, args=(b"a",)),
+            threading.Thread(target=writer, args=(b"b",)),
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors
+        assert len(ws._sent) == 100
+
+    def test_close(self) -> None:
+        ws = MockWS()
+        adapter = _WSAdapter(ws)
+        adapter.close()
+        assert ws._closed
+
+    def test_read_str_converted_to_bytes(self) -> None:
+        """String messages are encoded to bytes."""
+        ws = MockWS()
+        ws._messages = ["hello"]  # type: ignore[list-item]
+        adapter = _WSAdapter(ws)
+        assert adapter.read(5) == b"hello"
+
+
+# ---------------------------------------------------------------------------
+# Protocol helpers
+# ---------------------------------------------------------------------------
+
+
+class MockStream:
+    """Minimal stream mock for protocol helper tests."""
+
+    def __init__(self) -> None:
+        self._buf = bytearray()
+
+    def write(self, data: bytes) -> int:
+        self._buf.extend(data)
+        return len(data)
+
+    def read(self, n: int) -> bytes:
+        data = bytes(self._buf[:n])
+        del self._buf[:n]
+        return data
+
+
+class TestProtocolHelpers:
+    @pytest.mark.parametrize("port", [5432, 65535])
+    def test_connect_header_encoding(self, port: int) -> None:
+        stream = MockStream()
+        _write_connect_header(stream, port)
+
+        raw = bytes(stream._buf)
+        assert len(raw) == 3
+        version, decoded_port = struct.unpack(">BH", raw)
+        assert version == PROTOCOL_VERSION
+        assert decoded_port == port
+
+    @pytest.mark.parametrize(
+        "status",
+        [
+            STATUS_OK,
+            STATUS_PORT_NOT_ALLOWED,
+            STATUS_DIAL_FAILED,
+            STATUS_UNSUPPORTED_VERSION,
+        ],
+    )
+    def test_read_status(self, status: int) -> None:
+        stream = MockStream()
+        stream._buf = bytearray([status])
+        assert _read_status(stream) == status
+
+    def test_read_status_eof_raises(self) -> None:
+        stream = MockStream()
+        with pytest.raises(ConnectionError):
+            _read_status(stream)
+
+
+# ---------------------------------------------------------------------------
+# Tunnel
+# ---------------------------------------------------------------------------
+
+
+class TestTunnelInit:
+    def test_default_local_port_mirrors_remote(self) -> None:
+        t = Tunnel("http://example.com", "key", 5432)
+        assert t.remote_port == 5432
+        assert t.local_port == 5432
+
+    def test_explicit_local_port(self) -> None:
+        t = Tunnel("http://example.com", "key", 5432, local_port=15432)
+        assert t.local_port == 15432
+
+    def test_build_ws_url_http(self) -> None:
+        t = Tunnel("http://example.com/sandbox", "key", 5432)
+        assert t._build_ws_url() == "ws://example.com/sandbox/tunnel"
+
+    def test_build_ws_url_https(self) -> None:
+        t = Tunnel("https://example.com/sandbox", "key", 5432)
+        assert t._build_ws_url() == "wss://example.com/sandbox/tunnel"
+
+    def test_build_ws_url_strips_trailing_slash(self) -> None:
+        t = Tunnel("https://example.com/sandbox/", "key", 5432)
+        assert t._build_ws_url() == "wss://example.com/sandbox/tunnel"
+
+
+class TestTunnelContextManager:
+    @patch("langsmith.sandbox._tunnel._ensure_websockets")
+    def test_close_is_idempotent(self, mock_ensure: MagicMock) -> None:
+        t = Tunnel("http://localhost", "key", 5432)
+        t._closed = True
+        t.close()  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# AsyncTunnel
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncTunnel:
+    def test_properties_delegate(self) -> None:
+        at = AsyncTunnel("http://example.com", "key", 5432, local_port=15432)
+        assert at.remote_port == 5432
+        assert at.local_port == 15432
+
+    def test_close_delegates(self) -> None:
+        at = AsyncTunnel("http://example.com", "key", 5432)
+        at._tunnel._closed = True
+        at.close()  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# Exception hierarchy
+# ---------------------------------------------------------------------------
+
+
+class TestTunnelExceptions:
+    def test_tunnel_error_is_base(self) -> None:
+        assert issubclass(TunnelPortNotAllowedError, TunnelError)
+        assert issubclass(TunnelConnectionRefusedError, TunnelError)
+        assert issubclass(TunnelUnsupportedVersionError, TunnelError)
+
+    @pytest.mark.parametrize(
+        "exc_cls,msg,port",
+        [
+            (TunnelPortNotAllowedError, "blocked", 5432),
+            (TunnelConnectionRefusedError, "nothing listening", 6379),
+        ],
+    )
+    def test_exception_has_port(self, exc_cls: type, msg: str, port: int) -> None:
+        exc = exc_cls(msg, port=port)
+        assert exc.port == port
+        assert msg in str(exc)
+
+
+# ---------------------------------------------------------------------------
+# Port validation (tested via Sandbox.tunnel / AsyncSandbox.tunnel)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def mock_sandbox():
+    from langsmith.sandbox._sandbox import Sandbox
+
+    sb = Sandbox(
+        name="test",
+        template_name="t",
+        dataplane_url="http://x",
+        status="ready",
+    )
+    sb._client = MagicMock()
+    sb._client._api_key = "key"
+    return sb
+
+
+class TestPortValidation:
+    @pytest.mark.parametrize(
+        "remote,local,match",
+        [
+            (0, 0, "remote_port"),
+            (70000, 0, "remote_port"),
+            (5432, 70000, "local_port"),
+        ],
+    )
+    def test_invalid_ports_raise(
+        self, mock_sandbox: object, remote: int, local: int, match: str
+    ) -> None:
+        with pytest.raises(ValueError, match=match):
+            mock_sandbox.tunnel(remote, local_port=local)  # type: ignore[union-attr]
+
+    @patch("langsmith.sandbox._tunnel.Tunnel._start")
+    def test_valid_ports_pass_validation(
+        self, mock_start: MagicMock, mock_sandbox: object
+    ) -> None:
+        t = mock_sandbox.tunnel(5432, local_port=15432)  # type: ignore[union-attr]
+        assert isinstance(t, Tunnel)
+        assert t.remote_port == 5432
+        assert t.local_port == 15432
+        mock_start.assert_called_once()


### PR DESCRIPTION
## Add TCP tunnel support

`Tunnel` and `AsyncTunnel` classes that open a local TCP listener forwarding connections through a yamux-multiplexed WebSocket to a port inside the sandbox.

```python
with sb.tunnel(remote_port=5432) as t:
    conn = psycopg2.connect(host="127.0.0.1", port=t.local_port, user="postgres")
```

- `tunnel()` method on both `Sandbox` and `AsyncSandbox`.
- Custom local ports via `local_port=`, or `local_port=0` for OS-assigned.
- Context manager and explicit `.close()` lifecycle.
- Tunnel-specific exceptions: `TunnelError`, `TunnelPortNotAllowedError`, `TunnelConnectionRefusedError`, `TunnelUnsupportedVersionError`.

Split from #2556. Stacked on #2558.

### Test plan

- 28 unit tests covering WebSocket adapter, protocol encoding, port validation, tunnel init/URL building, exception hierarchy, and Sandbox integration.

Made with [Cursor](https://cursor.com)