### PR TITLE
Bump version: 0.7.17 → 0.7.18

### DIFF
--- a/python/.bumpversion.cfg
+++ b/python/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.7.17
+current_version = 0.7.18
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
 serialize = {major}.{minor}.{patch}
 search = {current_version}

--- a/python/langsmith/__init__.py
+++ b/python/langsmith/__init__.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
 
 # Avoid calling into importlib on every call to __version__
 
-__version__ = "0.7.17"
+__version__ = "0.7.18"
 version = __version__  # for backwards compatibility
 
 


### PR DESCRIPTION
## Summary
- Patch bump Python SDK version from 0.7.17 to 0.7.18

## Release Note
langsmith==0.7.18

## Test Plan
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)