### PR TITLE
fix(python): fix flaky test_workspace_error_recovery_flow

### DIFF
--- a/python/tests/unit_tests/test_client.py
+++ b/python/tests/unit_tests/test_client.py
@@ -4324,11 +4324,12 @@ class TestEndToEndWorkspaceFlow:
     ) -> None:
         """Test recovery from org-scoped key error by providing workspace."""
         _clear_env_cache()
+        monkeypatch.delenv("LANGSMITH_TRACING_SAMPLING_RATE", raising=False)
+        monkeypatch.delenv("LANGCHAIN_TRACING_SAMPLING_RATE", raising=False)
 
         client = Client(api_key="org-scoped-key", auto_batch_tracing=False)
 
-        # mock requests.Session
-        with mock.patch("requests.Session.request") as mock_request:
+        with mock.patch.object(client.session, "request") as mock_request:
             # org-scoped error
             mock_response_error = mock.MagicMock()
             mock_response_error.status_code = 403


### PR DESCRIPTION
## Summary
- Patches `client.session.request` (instance) instead of `requests.Session.request` (class) to avoid interference from other Session instances — matches the pattern used by non-flaky tests in the same class
- Clears `LANGSMITH_TRACING_SAMPLING_RATE` env vars via monkeypatch to prevent environment pollution from causing the run to be silently filtered before the HTTP call is made

## Release Note
none

## Test Plan
- [x] `TestEndToEndWorkspaceFlow` test class passes locally
- [x] Verified the fix prevents silent early return when sampling rate env var is set

🤖 Generated with [Claude Code](https://claude.com/claude-code)