### PR TITLE
feat: set source: "sdk" on SDK-created datasets  

### DIFF
--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -3473,7 +3473,7 @@ export class Client implements LangSmithTracingClientInterface {
     const body: KVMap = {
       name,
       description,
-      extra: metadata ? { metadata } : undefined,
+      extra: { source: "sdk", ...(metadata ? { metadata } : {}) },
     };
     if (dataType) {
       body.data_type = dataType;

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -4866,7 +4866,8 @@ class Client:
                 "metadata": {
                     "runtime": ls_env.get_runtime_environment(),
                     **(metadata or {}),
-                }
+                },
+                "source": "sdk",
             },
         }
         if description is not None:


### PR DESCRIPTION
When a dataset is created via the Python or JS SDK, extra.source is now explicitly set to "sdk". This allows the backend and analytics dashboards to distinguish SDK-created datasets from UI-created ones ("upload", "playground", "manual"), which previously had no way to tell them apart since SDK calls left extra.source null.   