### PR TITLE
fix(python): add _on_ending to OtelSpanProcessor for opentelemetry-sdk 1.40.0

### DIFF
--- a/python/langsmith/integrations/otel/processor.py
+++ b/python/langsmith/integrations/otel/processor.py
@@ -203,6 +203,11 @@ class OtelSpanProcessor:
         """Forward span end events to the inner processor."""
         self._processor.on_end(span)
 
+    def _on_ending(self, span):
+        """Forward span ending events to the inner processor."""
+        if hasattr(self._processor, "_on_ending"):
+            self._processor._on_ending(span)
+
     def shutdown(self):
         """Shutdown processor."""
         self._processor.shutdown()


### PR DESCRIPTION
## Summary
- `opentelemetry-sdk` 1.40.0 added `_on_ending()` to the `SpanProcessor` interface
- `OtelSpanProcessor` wraps a `BatchSpanProcessor` but only forwarded `on_start`, `on_end`, `shutdown`, and `force_flush` — missing the new `_on_ending` method
- This breaks all OTel-based tracing (CrewAI, AutoGen, Semantic Kernel, etc.) with: `AttributeError: 'OtelSpanProcessor' object has no attribute '_on_ending'`
- The fix forwards the call to the inner processor with a `hasattr` guard for backward compatibility

Fixes #2585

## Test plan
- [x] Unit tested: method exists, forwards correctly, safe when inner processor lacks it
- [x] End-to-end tested with CrewAI + `opentelemetry-sdk` 1.40.0 — traces sent to LangSmith successfully
- [x] Backward compatible: tested with `opentelemetry-sdk` 1.39.1 — `hasattr` guard makes it a no-op