### PR TITLE
Bump version: 0.7.18 → 0.7.19

### DIFF
--- a/python/.bumpversion.cfg
+++ b/python/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.7.18
+current_version = 0.7.19
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
 serialize = {major}.{minor}.{patch}
 search = {current_version}

--- a/python/langsmith/__init__.py
+++ b/python/langsmith/__init__.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
 
 # Avoid calling into importlib on every call to __version__
 
-__version__ = "0.7.18"
+__version__ = "0.7.19"
 version = __version__  # for backwards compatibility
 
 


### PR DESCRIPTION
Bump version: 0.7.18 → 0.7.19

Includes fix from #2586: add `_on_ending` to `OtelSpanProcessor` for compatibility with `opentelemetry-sdk` 1.40.0.

## Test Results

Built `langsmith-0.7.19` wheel from source and tested against both SDK versions:

```
============================================
TEST 1: langsmith 0.7.19 + otel 1.39.1
============================================
=== langsmith-0.7.19_otel-sdk-1.39.1_fix-yes ===
  OtelSpanProcessor has _on_ending: True
  RESULT: PASS

============================================
TEST 2: langsmith 0.7.19 + otel 1.40.0
============================================
=== langsmith-0.7.19_otel-sdk-1.40.0_fix-yes ===
  OtelSpanProcessor has _on_ending: True
  RESULT: PASS
```

Also confirmed the bug on `0.7.18 (PyPI) + otel 1.40.0`:

```
=== langsmith-0.7.18_otel-sdk-1.40.0_fix-no ===
  OtelSpanProcessor has _on_ending: False
  RESULT: FAIL — 'OtelSpanProcessor' object has no attribute '_on_ending'
```

Full end-to-end CrewAI execution (2 agents, 3 tools) sending traces to LangSmith — confirmed working on both `1.39.1` and `1.40.0`.