### PR TITLE
fix: add debug logging to background thread shutdown and final flush

### DIFF
--- a/python/langsmith/_internal/_background_thread.py
+++ b/python/langsmith/_internal/_background_thread.py
@@ -658,13 +658,16 @@ def tracing_control_thread_func(client_ref: weakref.ref[Client]) -> None:
         if hasattr(sys, "getrefcount"):
             # check if client refs count indicates we're the only remaining
             # reference to the client
-            should_keep_thread = sys.getrefcount(client) > num_known_refs + len(
-                sub_threads
-            )
+            refcount = sys.getrefcount(client)
+            threshold = num_known_refs + len(sub_threads)
+            should_keep_thread = refcount > threshold
             if not should_keep_thread:
                 logger.debug(
                     "Client refs count indicates we're the only remaining reference "
-                    "to the client, stopping tracing thread",
+                    "to the client, stopping tracing thread "
+                    "(refcount=%d, threshold=%d)",
+                    refcount,
+                    threshold,
                 )
             return should_keep_thread
         else:
@@ -713,6 +716,10 @@ def tracing_control_thread_func(client_ref: weakref.ref[Client]) -> None:
                 )
 
     # drain the queue on exit - apply same logic
+    logger.debug(
+        "Tracing thread draining queue on exit: qsize=%d",
+        tracing_queue.qsize(),
+    )
     hybrid_otel_and_langsmith, is_otel_only = get_tracing_mode()
     max_batch_size = (
         client._max_batch_size_bytes or batch_ingest_config.get("size_limit_bytes") or 0
@@ -781,11 +788,15 @@ def tracing_control_thread_func_compress_parallel(
         if hasattr(sys, "getrefcount"):
             # check if client refs count indicates we're the only remaining
             # reference to the client
-            should_keep_thread = sys.getrefcount(client) > num_known_refs
+            refcount = sys.getrefcount(client)
+            should_keep_thread = refcount > num_known_refs
             if not should_keep_thread:
                 logger.debug(
                     "Client refs count indicates we're the only remaining reference "
-                    "to the client, stopping compression thread",
+                    "to the client, stopping compression thread "
+                    "(refcount=%d, threshold=%d)",
+                    refcount,
+                    num_known_refs,
                 )
             return should_keep_thread
         else:
@@ -851,6 +862,15 @@ def tracing_control_thread_func_compress_parallel(
 
     # Drain the buffer on exit (final flush)
     try:
+        trace_count = (
+            client.compressed_traces.trace_count
+            if client.compressed_traces is not None
+            else 0
+        )
+        logger.debug(
+            "Compression thread final flush: trace_count=%d",
+            trace_count,
+        )
         (
             final_data_stream,
             compressed_traces_info,
@@ -858,6 +878,10 @@ def tracing_control_thread_func_compress_parallel(
             client, size_limit=1, size_limit_bytes=1
         )
         if final_data_stream is not None:
+            logger.debug(
+                "Compression thread final flush: sending %d bytes",
+                final_data_stream.getbuffer().nbytes,
+            )
             try:
                 cf.wait(
                     [
@@ -868,11 +892,19 @@ def tracing_control_thread_func_compress_parallel(
                         )
                     ]
                 )
+                logger.debug("Compression thread final flush: send completed")
             except RuntimeError:
+                logger.debug(
+                    "Compression thread final flush: thread pool shutdown, "
+                    "sending synchronously"
+                )
                 client._send_compressed_multipart_req(
                     final_data_stream,
                     compressed_traces_info,
                 )
+                logger.debug("Compression thread final flush: sync send completed")
+        else:
+            logger.debug("Compression thread final flush: no data to send")
 
     except Exception:
         logger.error(


### PR DESCRIPTION
Adds instrumentation to diagnose issues where the background tracing threads shut down prematurely and fail to send trace data. 

Changes:
- Log actual refcount and threshold values when threads decide to exit
- Log tracing queue size when main thread begins exit drain
- Log trace_count, byte size, and send status during compression thread final flush