### PR TITLE
chore: bump python SDK version to 0.7.21

### DIFF
--- a/python/.bumpversion.cfg
+++ b/python/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.7.19
+current_version = 0.7.21
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
 serialize = {major}.{minor}.{patch}
 search = {current_version}

--- a/python/langsmith/__init__.py
+++ b/python/langsmith/__init__.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
 
 # Avoid calling into importlib on every call to __version__
 
-__version__ = "0.7.20"
+__version__ = "0.7.21"
 version = __version__  # for backwards compatibility
 
 


### PR DESCRIPTION
## Summary
- Bumps Python SDK version to 0.7.21
- Includes debug logging improvements from #2597 for diagnosing background thread shutdown issues

## Release Note
none

## Test Plan
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)