### PR TITLE
fix(py): avoid async trace context retention

### DIFF
--- a/python/langsmith/run_helpers.py
+++ b/python/langsmith/run_helpers.py
@@ -602,7 +602,6 @@ def traceable(
             )
 
             try:
-                accepts_context = aitertools.asyncio_accepts_context()
                 if func_accepts_parent_run:
                     kwargs["run_tree"] = run_container["new_run"]
 
@@ -615,28 +614,11 @@ def traceable(
                         with otel_context_manager:
                             return await func(*args, **kwargs)
 
-                    if accepts_context:
-                        function_result = await asyncio.create_task(  # type: ignore[call-arg]
-                            run_with_otel_context(), context=run_container["context"]
-                        )
-                    else:
-                        # Python < 3.11
-                        with tracing_context(
-                            **get_tracing_context(run_container["context"])
-                        ):
-                            function_result = await run_with_otel_context()
+                    with _swap_tracing_context(run_container["context"]):
+                        function_result = await run_with_otel_context()
                 else:
-                    fr_coro = func(*args, **kwargs)
-                    if accepts_context:
-                        function_result = await asyncio.create_task(  # type: ignore[call-arg]
-                            fr_coro, context=run_container["context"]
-                        )
-                    else:
-                        # Python < 3.11
-                        with tracing_context(
-                            **get_tracing_context(run_container["context"])
-                        ):
-                            function_result = await fr_coro
+                    with _swap_tracing_context(run_container["context"]):
+                        function_result = await func(*args, **kwargs)
             except BaseException as e:
                 # shield from cancellation, given we're catching all exceptions
                 _cleanup_traceback(e)
@@ -677,18 +659,9 @@ def traceable(
 
                 async_gen_result = func(*args, **kwargs)
                 # Can't iterate through if it's a coroutine
-                accepts_context = aitertools.asyncio_accepts_context()
                 if inspect.iscoroutine(async_gen_result):
-                    if accepts_context:
-                        async_gen_result = await asyncio.create_task(
-                            async_gen_result, context=run_container["context"]
-                        )  # type: ignore
-                    else:
-                        # Python < 3.11
-                        with tracing_context(
-                            **get_tracing_context(run_container["context"])
-                        ):
-                            async_gen_result = await async_gen_result
+                    with _swap_tracing_context(run_container["context"]):
+                        async_gen_result = await async_gen_result
 
                 async for item in _process_async_iterator(
                     generator=async_gen_result,
@@ -698,7 +671,6 @@ def traceable(
                         if run_container["new_run"]
                         else False
                     ),
-                    accepts_context=accepts_context,
                     results=results,
                     process_chunk=container_input.get("process_chunk"),
                     otel_context_manager=otel_context_manager,
@@ -1854,6 +1826,24 @@ def _set_tracing_context(context: Optional[dict[str, Any]] = None):
         var.set(v)
 
 
+@contextlib.contextmanager
+def _swap_tracing_context(
+    context: contextvars.Context,
+) -> Generator[None, None, None]:
+    """Temporarily apply tracing vars from a copied context to the current task.
+
+    `_setup_run()` starts from a copy of the active task context and only mutates
+    LangSmith-specific contextvars. Reusing the current task here avoids helper
+    tasks that can retain the copied context after completion on Python 3.11+.
+    """
+    current_context = get_tracing_context()
+    _set_tracing_context(get_tracing_context(context))
+    try:
+        yield
+    finally:
+        _set_tracing_context(current_context)
+
+
 def _process_iterator(
     generator: Iterator[T],
     run_container: _TraceableContainer,
@@ -1910,7 +1900,6 @@ async def _process_async_iterator(
     run_container: _TraceableContainer,
     *,
     is_llm_run: bool,
-    accepts_context: bool,
     results: list[Any],
     process_chunk: Optional[Callable],
     otel_context_manager: Optional[Any] = None,
@@ -1929,29 +1918,11 @@ async def _process_async_iterator(
                                 return await aitertools.py_anext(generator)
                     return await aitertools.py_anext(generator)
 
-                if accepts_context:
-                    item = await asyncio.create_task(  # type: ignore[call-arg, var-annotated]
-                        anext_with_otel_context(),
-                        context=run_container["context"],
-                    )
-                else:
-                    # Python < 3.11
-                    with tracing_context(
-                        **get_tracing_context(run_container["context"])
-                    ):
-                        item = await anext_with_otel_context()
+                with _swap_tracing_context(run_container["context"]):
+                    item = await anext_with_otel_context()
             else:
-                if accepts_context:
-                    item = await asyncio.create_task(  # type: ignore[call-arg, var-annotated]
-                        aitertools.py_anext(generator),  # type: ignore[arg-type]
-                        context=run_container["context"],
-                    )
-                else:
-                    # Python < 3.11
-                    with tracing_context(
-                        **get_tracing_context(run_container["context"])
-                    ):
-                        item = await aitertools.py_anext(generator)
+                with _swap_tracing_context(run_container["context"]):
+                    item = await aitertools.py_anext(generator)
             if process_chunk:
                 traced_item = process_chunk(item)
             else:
@@ -2112,7 +2083,6 @@ class _TracedAsyncStream(_TracedStreamBase, Generic[T]):
             generator=self.__ls_stream__,
             run_container=self.__ls_trace_container__,
             is_llm_run=self.__is_llm_run__,
-            accepts_context=aitertools.asyncio_accepts_context(),
             results=self.__ls_accumulated_output__,
             process_chunk=process_chunk,
         )

--- a/python/tests/unit_tests/test_run_helpers.py
+++ b/python/tests/unit_tests/test_run_helpers.py
@@ -27,6 +27,7 @@ from requests_toolbelt import MultipartEncoder
 from typing_extensions import Annotated, Literal
 
 import langsmith
+import langsmith.run_helpers as run_helpers
 from langsmith import Client
 from langsmith import client as ls_client
 from langsmith import schemas as ls_schemas
@@ -1127,6 +1128,69 @@ async def test_traceable_async(enabled: Union[bool, Literal["local"]]):
     assert run is not None
     run = cast(RunTree, run)
     assert run.name == "expand_and_answer_questions"
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 11),
+    reason="context-aware create_task is only available on Python 3.11+",
+)
+async def test_traceable_async_does_not_create_tasks_with_context(
+    mock_client: Client,
+) -> None:
+    create_task_calls: list[dict[str, Any]] = []
+    original_create_task = asyncio.create_task
+
+    def record_create_task(coro: Any, *args: Any, **kwargs: Any) -> asyncio.Task[Any]:
+        create_task_calls.append(dict(kwargs))
+        return original_create_task(coro, *args, **kwargs)
+
+    @traceable(client=mock_client)
+    async def my_function(a: int) -> int:
+        assert get_current_run_tree() is not None
+        await asyncio.sleep(0)
+        return a + 1
+
+    with tracing_context(enabled=True):
+        with patch.object(
+            run_helpers.asyncio,
+            "create_task",
+            side_effect=record_create_task,
+        ):
+            assert await my_function(1) == 2
+
+    assert all(call.get("context") is None for call in create_task_calls)
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 11),
+    reason="context-aware create_task is only available on Python 3.11+",
+)
+async def test_traceable_async_generator_does_not_create_tasks_with_context(
+    mock_client: Client,
+) -> None:
+    create_task_calls: list[dict[str, Any]] = []
+    original_create_task = asyncio.create_task
+
+    def record_create_task(coro: Any, *args: Any, **kwargs: Any) -> asyncio.Task[Any]:
+        create_task_calls.append(dict(kwargs))
+        return original_create_task(coro, *args, **kwargs)
+
+    @traceable(client=mock_client)
+    async def my_function(a: int) -> AsyncGenerator[int, None]:
+        assert get_current_run_tree() is not None
+        for i in range(a):
+            await asyncio.sleep(0)
+            yield i
+
+    with tracing_context(enabled=True):
+        with patch.object(
+            run_helpers.asyncio,
+            "create_task",
+            side_effect=record_create_task,
+        ):
+            assert [item async for item in my_function(3)] == [0, 1, 2]
+
+    assert all(call.get("context") is None for call in create_task_calls)
 
 
 @pytest.mark.parametrize("enabled", [True, "local"])


### PR DESCRIPTION
## Summary
- Avoid retaining LangSmith trace context snapshots in completed async `@traceable` calls on Python 3.11+.

## Technical Reason
- `asyncio.create_task(..., context=copy_context())` can keep the copied context alive after task completion.
- That retained `_PARENT_RUN_TREE` and `RunTree` objects across traced async requests, causing unbounded memory growth.
- Reusing the current task for LangSmith context propagation fixes the leak without changing trace nesting semantics.

## Changes Made
- Replace helper `asyncio.create_task(..., context=...)` calls in `python/langsmith/run_helpers.py` with an in-task `_swap_tracing_context()` helper.
- Apply the same context-swapping approach to async wrappers, async generator setup, and traced async stream iteration.
- Add Python 3.11+ regression tests in `python/tests/unit_tests/test_run_helpers.py` to assert traced async paths no longer create tasks with a `context=` snapshot.
