### PR TITLE
fix(evaluation): add 1ms epsilon to example_version to fix stale snapshot after update_example()

### DIFF
--- a/python/langsmith/evaluation/_arunner.py
+++ b/python/langsmith/evaluation/_arunner.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import asyncio
-import datetime
 import concurrent.futures as cf
+import datetime
 import io
 import logging
 import pathlib

--- a/python/langsmith/evaluation/_arunner.py
+++ b/python/langsmith/evaluation/_arunner.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import datetime
 import concurrent.futures as cf
 import io
 import logging
@@ -1285,7 +1286,12 @@ async def _aforward(
         project_name=experiment_name,
         metadata={
             **metadata,
-            "example_version": (example.modified_at or example.created_at).isoformat(),
+            # Add 1ms so the server's exclusive upper-bound version resolution
+            # returns the state AT modified_at rather than the state before it.
+            "example_version": (
+                (example.modified_at or example.created_at)
+                + datetime.timedelta(milliseconds=1)
+            ).isoformat(),
         },
         client=client,
     )

--- a/python/langsmith/evaluation/_runner.py
+++ b/python/langsmith/evaluation/_runner.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import ast
+import datetime
 import collections
 import concurrent.futures as cf
 import functools
@@ -1917,7 +1918,10 @@ def _forward(
     def _set_reference_example_id(r: rt.RunTree) -> None:
         r.reference_example_id = example.id
 
-    example_version = (example.modified_at or example.created_at).isoformat()
+    # Add 1ms so the server's exclusive upper-bound version resolution returns
+    # the state AT modified_at rather than the state before it.
+    _example_ts = example.modified_at or example.created_at
+    example_version = (_example_ts + datetime.timedelta(milliseconds=1)).isoformat()
     langsmith_extra = rh.LangSmithExtra(
         on_end=_get_run,
         project_name=experiment_name,

--- a/python/langsmith/evaluation/_runner.py
+++ b/python/langsmith/evaluation/_runner.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 import ast
-import datetime
 import collections
 import concurrent.futures as cf
+import datetime
 import functools
 import inspect
 import io


### PR DESCRIPTION
## Summary

Fixes #2430

- `evaluate()` and `aevaluate()` now capture `example_version` as `modified_at + 1ms` instead of `modified_at` exactly
- The LangSmith server resolves example versions using an exclusive upper-bound (`< T`), so using `modified_at = T` returns the state *before* T — the pre-update snapshot
- Adding 1ms ensures the resolved snapshot is the state *at* T — the correct post-update outputs

## Root cause

In `_runner.py` and `_arunner.py`:

```python
# Before (always returns pre-update state)
example_version = (example.modified_at or example.created_at).isoformat()
```

The server uses `modified_at < T` for version resolution. When `update_example()` sets `modified_at = T` and the SDK reads `example_version = T`, the server looks up the state before T — which is the stale pre-update value.

## Fix

```python
# After (returns post-update state)
_example_ts = example.modified_at or example.created_at
example_version = (_example_ts + datetime.timedelta(milliseconds=1)).isoformat()
```

The 1ms shift makes the exclusive bound `< T+1ms` include T, resolving to the state at T.

## Test plan

- [x] The fix is deterministic — no race condition, no flakiness
- [x] Applied in both sync (`_runner.py`) and async (`_arunner.py`) runners
- [ ] Reproduce using the steps in #2430, verify `expected_output` shows updated value after `update_example()`