### PR TITLE
feat(python/sandbox): add snapshot API and start/stop lifecycle

### DIFF
--- a/python/langsmith/sandbox/README.md
+++ b/python/langsmith/sandbox/README.md
@@ -559,8 +559,8 @@ async with await client.sandbox(template_name="my-sandbox") as sb:
 
 ## Snapshots
 
-Snapshots are rootfs images built from Docker images or captured from running
-sandboxes. Use snapshots to create sandboxes with persistent state.
+Snapshots are built from Docker images or captured from running sandboxes.
+Use snapshots to create sandboxes with persistent state.
 
 ### Build a Snapshot from a Docker Image
 
@@ -591,9 +591,9 @@ sb = client.create_sandbox(snapshot_id=base_snapshot_id, name="setup-box")
 sb.run("pip install numpy pandas scikit-learn")
 
 # Capture current state as a new snapshot
-snapshot = client.capture_snapshot("setup-box", "ml-ready")
+snapshot = sb.capture_snapshot("ml-ready")
 
-client.delete_sandbox("setup-box")
+sb.delete()
 
 # Later: spin up sandboxes from the captured snapshot
 with client.sandbox(snapshot_id=snapshot.id) as sb:
@@ -623,14 +623,14 @@ snapshot = client.create_snapshot(
 
 ## Start / Stop
 
-Snapshot-based sandboxes can be stopped and restarted. The rootfs is preserved
-across stop/start cycles.
+Snapshot-based sandboxes can be stopped and restarted. The sandbox files are
+preserved across stop/start cycles.
 
 ```python
 sb = client.create_sandbox(snapshot_id=snapshot.id, name="my-vm")
 sb.run("echo 'hello' > /tmp/state.txt")
 
-# Stop the sandbox (preserves rootfs)
+# Stop the sandbox (preserves sandbox files)
 sb.stop()
 
 # Later: restart it
@@ -947,7 +947,7 @@ except SandboxClientError as e:
 | `update_sandbox(name, *, new_name=None, ttl_seconds=None, idle_ttl_seconds=None)` | Update a sandbox's name or TTL settings |
 | `delete_sandbox(name)` | Delete a sandbox |
 | `start_sandbox(name, *, timeout=120)` | Start a stopped sandbox, poll until ready |
-| `stop_sandbox(name)` | Stop a running sandbox (preserves rootfs) |
+| `stop_sandbox(name)` | Stop a running sandbox (preserves sandbox files) |
 | `create_snapshot(name, docker_image, fs_capacity_bytes, *, timeout=60)` | Build a snapshot from a Docker image |
 | `capture_snapshot(sandbox_name, name, *, timeout=60)` | Capture a snapshot from a running sandbox |
 | `get_snapshot(snapshot_id)` | Get a snapshot by ID |
@@ -992,7 +992,9 @@ except SandboxClientError as e:
 | `tunnel(remote_port, *, local_port=0)` | Open a TCP tunnel. Returns `Tunnel` (context manager). |
 | `service(port, *, expires_in_seconds=600)` | Get a `ServiceURL` for an HTTP service. Auto-refreshes token. |
 | `start(*, timeout=120)` | Start a stopped sandbox and wait until ready. |
-| `stop()` | Stop a running sandbox (preserves rootfs for later restart). |
+| `stop()` | Stop a running sandbox (preserves sandbox files for later restart). |
+| `delete()` | Delete this sandbox. |
+| `capture_snapshot(name, *, timeout=60)` | Capture a snapshot from this sandbox. |
 
 ### ExecutionResult
 

--- a/python/langsmith/sandbox/README.md
+++ b/python/langsmith/sandbox/README.md
@@ -557,6 +557,96 @@ async with await client.sandbox(template_name="my-sandbox") as sb:
     url = await svc.get_service_url()
 ```
 
+## Snapshots
+
+Snapshots are rootfs images built from Docker images or captured from running
+sandboxes. Use snapshots to create sandboxes with persistent state.
+
+### Build a Snapshot from a Docker Image
+
+```python
+from langsmith.sandbox import SandboxClient
+
+client = SandboxClient()
+
+# Build a snapshot — blocks until ready (default timeout=60s)
+snapshot = client.create_snapshot(
+    "my-python-env",
+    docker_image="python:3.12-slim",
+    fs_capacity_bytes=4 * 1024**3,  # 4 GB
+)
+
+# Create a sandbox from the snapshot
+with client.sandbox(snapshot_id=snapshot.id) as sb:
+    result = sb.run("python --version")
+    print(result.stdout)
+```
+
+### Capture a Running Sandbox
+
+Install packages or configure state, then capture it as a reusable snapshot:
+
+```python
+sb = client.create_sandbox(snapshot_id=base_snapshot_id, name="setup-box")
+sb.run("pip install numpy pandas scikit-learn")
+
+# Capture current state as a new snapshot
+snapshot = client.capture_snapshot("setup-box", "ml-ready")
+
+client.delete_sandbox("setup-box")
+
+# Later: spin up sandboxes from the captured snapshot
+with client.sandbox(snapshot_id=snapshot.id) as sb:
+    sb.run("python -c 'import numpy; print(numpy.__version__)'")
+```
+
+### Snapshot CRUD
+
+```python
+# List all snapshots
+snapshots = client.list_snapshots()
+
+# Get a snapshot by ID
+snapshot = client.get_snapshot("550e8400-...")
+
+# Delete a snapshot
+client.delete_snapshot("550e8400-...")
+
+# Build with longer timeout for large images
+snapshot = client.create_snapshot(
+    "heavy-image",
+    docker_image="nvidia/cuda:12.0-devel-ubuntu22.04",
+    fs_capacity_bytes=16 * 1024**3,
+    timeout=600,
+)
+```
+
+## Start / Stop
+
+Snapshot-based sandboxes can be stopped and restarted. The rootfs is preserved
+across stop/start cycles.
+
+```python
+sb = client.create_sandbox(snapshot_id=snapshot.id, name="my-vm")
+sb.run("echo 'hello' > /tmp/state.txt")
+
+# Stop the sandbox (preserves rootfs)
+sb.stop()
+
+# Later: restart it
+sb.start()  # blocks until ready (default timeout=120s)
+
+result = sb.run("cat /tmp/state.txt")
+assert result.stdout.strip() == "hello"
+```
+
+You can also use the client methods directly:
+
+```python
+client.stop_sandbox("my-vm")
+sandbox = client.start_sandbox("my-vm")
+```
+
 ## Templates
 
 Templates define the container image and resources for sandboxes. **You must create a template before you can create sandboxes.**
@@ -847,8 +937,8 @@ except SandboxClientError as e:
 
 | Method | Description |
 |--------|-------------|
-| `sandbox(template_name, *, ttl_seconds=None, idle_ttl_seconds=None, ...)` | Create a sandbox (auto-deleted on context exit) |
-| `create_sandbox(template_name, *, wait_for_ready=True, ttl_seconds=None, idle_ttl_seconds=None, ...)` | Create a sandbox (requires explicit delete). Pass `wait_for_ready=False` for async creation. |
+| `sandbox(template_name=None, *, snapshot_id=None, ttl_seconds=None, idle_ttl_seconds=None, ...)` | Create a sandbox (auto-deleted on context exit). Provide `template_name` or `snapshot_id`. |
+| `create_sandbox(template_name=None, *, snapshot_id=None, wait_for_ready=True, ...)` | Create a sandbox (requires explicit delete). Provide `template_name` or `snapshot_id`. |
 | `get_sandbox(name)` | Get an existing sandbox by name |
 | `get_sandbox_status(name)` | Get lightweight provisioning status (`ResourceStatus`) |
 | `wait_for_sandbox(name, *, timeout=120, poll_interval=1.0)` | Poll until sandbox is ready or failed |
@@ -856,6 +946,14 @@ except SandboxClientError as e:
 | `list_sandboxes()` | List all sandboxes |
 | `update_sandbox(name, *, new_name=None, ttl_seconds=None, idle_ttl_seconds=None)` | Update a sandbox's name or TTL settings |
 | `delete_sandbox(name)` | Delete a sandbox |
+| `start_sandbox(name, *, timeout=120)` | Start a stopped sandbox, poll until ready |
+| `stop_sandbox(name)` | Stop a running sandbox (preserves rootfs) |
+| `create_snapshot(name, docker_image, fs_capacity_bytes, *, timeout=60)` | Build a snapshot from a Docker image |
+| `capture_snapshot(sandbox_name, name, *, timeout=60)` | Capture a snapshot from a running sandbox |
+| `get_snapshot(snapshot_id)` | Get a snapshot by ID |
+| `list_snapshots()` | List all snapshots |
+| `delete_snapshot(snapshot_id)` | Delete a snapshot |
+| `wait_for_snapshot(snapshot_id, *, timeout=300)` | Poll until snapshot is ready or failed |
 | `create_template(name, image, ...)` | Create a template |
 | `list_templates()` | List all templates |
 | `get_template(name)` | Get template by name |
@@ -876,7 +974,8 @@ except SandboxClientError as e:
 |----------|-------------|
 | `name` | Display name |
 | `template_name` | Template used to create this sandbox |
-| `status` | Lifecycle status: `"provisioning"`, `"ready"`, or `"failed"` |
+| `snapshot_id` | Snapshot ID used to create this sandbox |
+| `status` | Lifecycle status: `"provisioning"`, `"ready"`, `"failed"`, or `"stopped"` |
 | `status_message` | Human-readable details when status is `"failed"`, `None` otherwise |
 | `dataplane_url` | URL for runtime operations (only functional when status is `"ready"`) |
 | `id` | Unique identifier (UUID) |
@@ -892,6 +991,8 @@ except SandboxClientError as e:
 | `read(path)` | Read file (returns bytes) |
 | `tunnel(remote_port, *, local_port=0)` | Open a TCP tunnel. Returns `Tunnel` (context manager). |
 | `service(port, *, expires_in_seconds=600)` | Get a `ServiceURL` for an HTTP service. Auto-refreshes token. |
+| `start(*, timeout=120)` | Start a stopped sandbox and wait until ready. |
+| `stop()` | Stop a running sandbox (preserves rootfs for later restart). |
 
 ### ExecutionResult
 

--- a/python/langsmith/sandbox/__init__.py
+++ b/python/langsmith/sandbox/__init__.py
@@ -59,6 +59,7 @@ from langsmith.sandbox._models import (
     ResourceStatus,
     SandboxTemplate,
     ServiceURL,
+    Snapshot,
     Volume,
     VolumeMountSpec,
 )
@@ -79,6 +80,7 @@ __all__ = [
     "Volume",
     "VolumeMountSpec",
     "Pool",
+    "Snapshot",
     "ServiceURL",
     "AsyncServiceURL",
     # WebSocket streaming models

--- a/python/langsmith/sandbox/_async_client.py
+++ b/python/langsmith/sandbox/_async_client.py
@@ -1209,7 +1209,7 @@ class AsyncSandboxClient:
         return await self.wait_for_sandbox(name, timeout=timeout, headers=headers)
 
     async def stop_sandbox(self, name: str, *, headers: RequestHeaders = None) -> None:
-        """Stop a running sandbox (preserves rootfs for later restart).
+        """Stop a running sandbox (preserves sandbox files for later restart).
 
         Args:
             name: Sandbox name.

--- a/python/langsmith/sandbox/_async_client.py
+++ b/python/langsmith/sandbox/_async_client.py
@@ -758,8 +758,7 @@ class AsyncSandboxClient:
                 a multiple of 60. 0 or None disables this TTL.
             vcpus: Number of vCPUs.
             mem_bytes: Memory in bytes.
-            fs_capacity_bytes: Root filesystem capacity in bytes
-               .
+            fs_capacity_bytes: Root filesystem capacity in bytes.
 
         Returns:
             AsyncSandbox instance.
@@ -825,8 +824,7 @@ class AsyncSandboxClient:
                 a multiple of 60. 0 or None disables this TTL.
             vcpus: Number of vCPUs.
             mem_bytes: Memory in bytes.
-            fs_capacity_bytes: Root filesystem capacity in bytes
-               .
+            fs_capacity_bytes: Root filesystem capacity in bytes.
 
         Returns:
             Created AsyncSandbox. When wait_for_ready=False, the sandbox will have

--- a/python/langsmith/sandbox/_async_client.py
+++ b/python/langsmith/sandbox/_async_client.py
@@ -1208,9 +1208,7 @@ class AsyncSandboxClient:
 
         return await self.wait_for_sandbox(name, timeout=timeout, headers=headers)
 
-    async def stop_sandbox(
-        self, name: str, *, headers: RequestHeaders = None
-    ) -> None:
+    async def stop_sandbox(self, name: str, *, headers: RequestHeaders = None) -> None:
         """Stop a running sandbox (preserves rootfs for later restart).
 
         Args:
@@ -1374,9 +1372,7 @@ class AsyncSandboxClient:
         url = f"{self._base_url}/snapshots/{snapshot_id}"
 
         try:
-            response = await self._http.get(
-                url, headers=self._request_headers(headers)
-            )
+            response = await self._http.get(url, headers=self._request_headers(headers))
             response.raise_for_status()
             return Snapshot.from_dict(response.json())
         except httpx.HTTPStatusError as e:
@@ -1387,9 +1383,7 @@ class AsyncSandboxClient:
             handle_client_http_error(e)
             raise  # pragma: no cover
 
-    async def list_snapshots(
-        self, *, headers: RequestHeaders = None
-    ) -> list[Snapshot]:
+    async def list_snapshots(self, *, headers: RequestHeaders = None) -> list[Snapshot]:
         """List all snapshots.
 
         Returns:
@@ -1398,9 +1392,7 @@ class AsyncSandboxClient:
         url = f"{self._base_url}/snapshots"
 
         try:
-            response = await self._http.get(
-                url, headers=self._request_headers(headers)
-            )
+            response = await self._http.get(url, headers=self._request_headers(headers))
             response.raise_for_status()
             data = response.json()
             return [Snapshot.from_dict(s) for s in data.get("snapshots", [])]

--- a/python/langsmith/sandbox/_async_client.py
+++ b/python/langsmith/sandbox/_async_client.py
@@ -34,6 +34,7 @@ from langsmith.sandbox._models import (
     Pool,
     ResourceStatus,
     SandboxTemplate,
+    Snapshot,
     Volume,
     VolumeMountSpec,
 )
@@ -716,12 +717,16 @@ class AsyncSandboxClient:
 
     async def sandbox(
         self,
-        template_name: str,
+        template_name: Optional[str] = None,
         *,
+        snapshot_id: Optional[str] = None,
         name: Optional[str] = None,
         timeout: int = 30,
         ttl_seconds: Optional[int] = None,
         idle_ttl_seconds: Optional[int] = None,
+        vcpus: Optional[int] = None,
+        mem_bytes: Optional[int] = None,
+        fs_capacity_bytes: Optional[int] = None,
         headers: RequestHeaders = None,
     ) -> AsyncSandbox:
         """Create a sandbox and return an AsyncSandbox instance.
@@ -732,11 +737,17 @@ class AsyncSandboxClient:
             async with await client.sandbox(template_name="my-template") as sandbox:
                 result = await sandbox.run("echo hello")
 
+            async with await client.sandbox(snapshot_id="<uuid>") as sandbox:
+                result = await sandbox.run("echo hello")
+
         The sandbox is automatically deleted when exiting the context manager.
         For sandboxes with manual lifecycle management, use create_sandbox().
 
         Args:
             template_name: Name of the SandboxTemplate to use.
+                Mutually exclusive with snapshot_id.
+            snapshot_id: Snapshot ID to boot from.
+                Mutually exclusive with template_name.
             name: Optional sandbox name (auto-generated if not provided).
             timeout: Timeout in seconds when waiting for ready.
             ttl_seconds: Maximum lifetime in seconds from creation. The sandbox
@@ -745,6 +756,10 @@ class AsyncSandboxClient:
             idle_ttl_seconds: Idle timeout in seconds. The sandbox will be
                 automatically deleted after this duration of inactivity. Must be
                 a multiple of 60. 0 or None disables this TTL.
+            vcpus: Number of vCPUs.
+            mem_bytes: Memory in bytes.
+            fs_capacity_bytes: Root filesystem capacity in bytes
+               .
 
         Returns:
             AsyncSandbox instance.
@@ -753,14 +768,19 @@ class AsyncSandboxClient:
             ResourceTimeoutError: If timeout waiting for sandbox to be ready.
             ResourceCreationError: If sandbox creation fails.
             SandboxClientError: For other errors.
-            ValueError: If TTL values are invalid.
+            ValueError: If TTL values are invalid or neither template_name
+                nor snapshot_id is provided.
         """
         sb = await self.create_sandbox(
             template_name=template_name,
+            snapshot_id=snapshot_id,
             name=name,
             timeout=timeout,
             ttl_seconds=ttl_seconds,
             idle_ttl_seconds=idle_ttl_seconds,
+            vcpus=vcpus,
+            mem_bytes=mem_bytes,
+            fs_capacity_bytes=fs_capacity_bytes,
             headers=headers,
         )
         sb._auto_delete = True
@@ -768,13 +788,17 @@ class AsyncSandboxClient:
 
     async def create_sandbox(
         self,
-        template_name: str,
+        template_name: Optional[str] = None,
         *,
+        snapshot_id: Optional[str] = None,
         name: Optional[str] = None,
         timeout: int = 30,
         wait_for_ready: bool = True,
         ttl_seconds: Optional[int] = None,
         idle_ttl_seconds: Optional[int] = None,
+        vcpus: Optional[int] = None,
+        mem_bytes: Optional[int] = None,
+        fs_capacity_bytes: Optional[int] = None,
         headers: RequestHeaders = None,
     ) -> AsyncSandbox:
         """Create a new Sandbox.
@@ -784,6 +808,9 @@ class AsyncSandboxClient:
 
         Args:
             template_name: Name of the SandboxTemplate to use.
+                Mutually exclusive with snapshot_id.
+            snapshot_id: Snapshot ID to boot from.
+                Mutually exclusive with template_name.
             name: Optional sandbox name (auto-generated if not provided).
             timeout: Timeout in seconds when waiting for ready (only used when
                 wait_for_ready=True).
@@ -796,6 +823,10 @@ class AsyncSandboxClient:
             idle_ttl_seconds: Idle timeout in seconds. The sandbox will be
                 automatically deleted after this duration of inactivity. Must be
                 a multiple of 60. 0 or None disables this TTL.
+            vcpus: Number of vCPUs.
+            mem_bytes: Memory in bytes.
+            fs_capacity_bytes: Root filesystem capacity in bytes
+               .
 
         Returns:
             Created AsyncSandbox. When wait_for_ready=False, the sandbox will have
@@ -805,17 +836,26 @@ class AsyncSandboxClient:
             ResourceTimeoutError: If timeout waiting for sandbox to be ready.
             ResourceCreationError: If sandbox creation fails.
             SandboxClientError: For other errors.
-            ValueError: If TTL values are invalid.
+            ValueError: If TTL values are invalid or neither template_name
+                nor snapshot_id is provided.
         """
+        if not template_name and not snapshot_id:
+            raise ValueError("Either template_name or snapshot_id is required")
+        if template_name and snapshot_id:
+            raise ValueError("Cannot specify both template_name and snapshot_id")
+
         validate_ttl(ttl_seconds, "ttl_seconds")
         validate_ttl(idle_ttl_seconds, "idle_ttl_seconds")
 
         url = f"{self._base_url}/boxes"
 
         payload: dict[str, Any] = {
-            "template_name": template_name,
             "wait_for_ready": wait_for_ready,
         }
+        if template_name:
+            payload["template_name"] = template_name
+        if snapshot_id:
+            payload["snapshot_id"] = snapshot_id
         if wait_for_ready:
             payload["timeout"] = timeout
         if name:
@@ -824,6 +864,12 @@ class AsyncSandboxClient:
             payload["ttl_seconds"] = ttl_seconds
         if idle_ttl_seconds is not None:
             payload["idle_ttl_seconds"] = idle_ttl_seconds
+        if vcpus is not None:
+            payload["vcpus"] = vcpus
+        if mem_bytes is not None:
+            payload["mem_bytes"] = mem_bytes
+        if fs_capacity_bytes is not None:
+            payload["fs_capacity_bytes"] = fs_capacity_bytes
 
         http_timeout = (timeout + 30) if wait_for_ready else 30
 
@@ -1123,5 +1169,319 @@ class AsyncSandboxClient:
                     f"Sandbox '{name}' not ready after {timeout}s",
                     resource_type="sandbox",
                     last_status=status.status,
+                )
+            await asyncio.sleep(min(poll_interval, remaining))
+
+    async def start_sandbox(
+        self,
+        name: str,
+        *,
+        timeout: int = 120,
+        headers: RequestHeaders = None,
+    ) -> AsyncSandbox:
+        """Start a stopped sandbox and wait until ready.
+
+        Args:
+            name: Sandbox name.
+            timeout: Timeout in seconds when waiting for ready.
+
+        Returns:
+            AsyncSandbox in "ready" status.
+
+        Raises:
+            ResourceNotFoundError: If sandbox not found.
+            ResourceCreationError: If sandbox fails during startup.
+            ResourceTimeoutError: If sandbox doesn't become ready within timeout.
+            SandboxClientError: For other errors.
+        """
+        url = f"{self._base_url}/boxes/{name}/start"
+
+        try:
+            response = await self._http.post(
+                url, json={}, headers=self._request_headers(headers)
+            )
+            response.raise_for_status()
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 404:
+                raise ResourceNotFoundError(
+                    f"Sandbox '{name}' not found", resource_type="sandbox"
+                ) from e
+            handle_client_http_error(e)
+
+        return await self.wait_for_sandbox(name, timeout=timeout, headers=headers)
+
+    async def stop_sandbox(
+        self, name: str, *, headers: RequestHeaders = None
+    ) -> None:
+        """Stop a running sandbox (preserves rootfs for later restart).
+
+        Args:
+            name: Sandbox name.
+
+        Raises:
+            ResourceNotFoundError: If sandbox not found.
+            SandboxClientError: For other errors.
+        """
+        url = f"{self._base_url}/boxes/{name}/stop"
+
+        try:
+            response = await self._http.post(
+                url, json={}, headers=self._request_headers(headers)
+            )
+            response.raise_for_status()
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 404:
+                raise ResourceNotFoundError(
+                    f"Sandbox '{name}' not found", resource_type="sandbox"
+                ) from e
+            handle_client_http_error(e)
+
+    # ========================================================================
+    # Snapshot Operations
+    # ========================================================================
+
+    async def create_snapshot(
+        self,
+        name: str,
+        docker_image: str,
+        fs_capacity_bytes: int,
+        *,
+        registry_id: Optional[str] = None,
+        registry_url: Optional[str] = None,
+        registry_username: Optional[str] = None,
+        registry_password: Optional[str] = None,
+        timeout: int = 60,
+        headers: RequestHeaders = None,
+    ) -> Snapshot:
+        """Build a snapshot from a Docker image.
+
+        Blocks until the snapshot is ready (polls with 2s interval).
+
+        Args:
+            name: Snapshot name.
+            docker_image: Docker image to build from (e.g., "python:3.12-slim").
+            fs_capacity_bytes: Filesystem capacity in bytes.
+            registry_id: Private registry ID (alternative to URL/credentials).
+            registry_url: Registry URL for private images.
+            registry_username: Registry username.
+            registry_password: Registry password.
+            timeout: Timeout in seconds when waiting for ready.
+
+        Returns:
+            Snapshot in "ready" status.
+
+        Raises:
+            ResourceTimeoutError: If snapshot doesn't become ready within timeout.
+            ResourceCreationError: If snapshot build fails.
+            SandboxClientError: For other errors.
+        """
+        url = f"{self._base_url}/snapshots"
+
+        payload: dict[str, Any] = {
+            "name": name,
+            "docker_image": docker_image,
+            "fs_capacity_bytes": fs_capacity_bytes,
+        }
+        if registry_id is not None:
+            payload["registry_id"] = registry_id
+        if registry_url is not None:
+            payload["registry_url"] = registry_url
+        if registry_username is not None:
+            payload["registry_username"] = registry_username
+        if registry_password is not None:
+            payload["registry_password"] = registry_password
+
+        try:
+            response = await self._http.post(
+                url, json=payload, headers=self._request_headers(headers)
+            )
+            response.raise_for_status()
+            snapshot = Snapshot.from_dict(response.json())
+        except httpx.HTTPStatusError as e:
+            handle_client_http_error(e)
+            raise  # pragma: no cover
+
+        return await self.wait_for_snapshot(
+            snapshot.id, timeout=timeout, headers=headers
+        )
+
+    async def capture_snapshot(
+        self,
+        sandbox_name: str,
+        name: str,
+        *,
+        checkpoint: Optional[str] = None,
+        timeout: int = 60,
+        headers: RequestHeaders = None,
+    ) -> Snapshot:
+        """Capture a snapshot from a running sandbox.
+
+        Blocks until the snapshot is ready (polls with 2s interval).
+
+        Args:
+            sandbox_name: Name of the sandbox to capture from.
+            name: Snapshot name.
+            checkpoint: Checkpoint timestamp to use. If omitted, creates a
+                fresh checkpoint from the running VM's current state.
+            timeout: Timeout in seconds when waiting for ready.
+
+        Returns:
+            Snapshot in "ready" status.
+
+        Raises:
+            ResourceNotFoundError: If sandbox not found.
+            ResourceTimeoutError: If snapshot doesn't become ready within timeout.
+            ResourceCreationError: If snapshot capture fails.
+            SandboxClientError: For other errors.
+        """
+        url = f"{self._base_url}/boxes/{sandbox_name}/snapshot"
+
+        payload: dict[str, Any] = {"name": name}
+        if checkpoint is not None:
+            payload["checkpoint"] = checkpoint
+
+        try:
+            response = await self._http.post(
+                url, json=payload, headers=self._request_headers(headers)
+            )
+            response.raise_for_status()
+            snapshot = Snapshot.from_dict(response.json())
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 404:
+                raise ResourceNotFoundError(
+                    f"Sandbox '{sandbox_name}' not found", resource_type="sandbox"
+                ) from e
+            handle_client_http_error(e)
+            raise  # pragma: no cover
+
+        return await self.wait_for_snapshot(
+            snapshot.id, timeout=timeout, headers=headers
+        )
+
+    async def get_snapshot(
+        self, snapshot_id: str, *, headers: RequestHeaders = None
+    ) -> Snapshot:
+        """Get a snapshot by ID.
+
+        Args:
+            snapshot_id: Snapshot UUID.
+
+        Returns:
+            Snapshot.
+
+        Raises:
+            ResourceNotFoundError: If snapshot not found.
+            SandboxClientError: For other errors.
+        """
+        url = f"{self._base_url}/snapshots/{snapshot_id}"
+
+        try:
+            response = await self._http.get(
+                url, headers=self._request_headers(headers)
+            )
+            response.raise_for_status()
+            return Snapshot.from_dict(response.json())
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 404:
+                raise ResourceNotFoundError(
+                    f"Snapshot '{snapshot_id}' not found", resource_type="snapshot"
+                ) from e
+            handle_client_http_error(e)
+            raise  # pragma: no cover
+
+    async def list_snapshots(
+        self, *, headers: RequestHeaders = None
+    ) -> list[Snapshot]:
+        """List all snapshots.
+
+        Returns:
+            List of Snapshots.
+        """
+        url = f"{self._base_url}/snapshots"
+
+        try:
+            response = await self._http.get(
+                url, headers=self._request_headers(headers)
+            )
+            response.raise_for_status()
+            data = response.json()
+            return [Snapshot.from_dict(s) for s in data.get("snapshots", [])]
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 404:
+                raise SandboxAPIError(
+                    f"API endpoint not found: {url}. "
+                    f"Check that api_endpoint is correct."
+                ) from e
+            handle_client_http_error(e)
+            raise  # pragma: no cover
+
+    async def delete_snapshot(
+        self, snapshot_id: str, *, headers: RequestHeaders = None
+    ) -> None:
+        """Delete a snapshot.
+
+        Args:
+            snapshot_id: Snapshot UUID.
+
+        Raises:
+            ResourceNotFoundError: If snapshot not found.
+            SandboxClientError: For other errors.
+        """
+        url = f"{self._base_url}/snapshots/{snapshot_id}"
+
+        try:
+            response = await self._http.delete(
+                url, headers=self._request_headers(headers)
+            )
+            response.raise_for_status()
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 404:
+                raise ResourceNotFoundError(
+                    f"Snapshot '{snapshot_id}' not found", resource_type="snapshot"
+                ) from e
+            handle_client_http_error(e)
+
+    async def wait_for_snapshot(
+        self,
+        snapshot_id: str,
+        *,
+        timeout: int = 300,
+        poll_interval: float = 2.0,
+        headers: RequestHeaders = None,
+    ) -> Snapshot:
+        """Poll until a snapshot reaches "ready" or "failed" status.
+
+        Args:
+            snapshot_id: Snapshot UUID.
+            timeout: Maximum time to wait in seconds.
+            poll_interval: Time between status checks in seconds.
+
+        Returns:
+            Snapshot in "ready" status.
+
+        Raises:
+            ResourceCreationError: If snapshot status becomes "failed".
+            ResourceTimeoutError: If timeout expires.
+            ResourceNotFoundError: If snapshot not found.
+            SandboxClientError: For other errors.
+        """
+        import time
+
+        deadline = time.monotonic() + timeout
+        while True:
+            snapshot = await self.get_snapshot(snapshot_id, headers=headers)
+            if snapshot.status == "ready":
+                return snapshot
+            if snapshot.status == "failed":
+                raise ResourceCreationError(
+                    snapshot.status_message or "Snapshot build failed",
+                    resource_type="snapshot",
+                )
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise ResourceTimeoutError(
+                    f"Snapshot '{snapshot_id}' not ready after {timeout}s",
+                    resource_type="snapshot",
+                    last_status=snapshot.status,
                 )
             await asyncio.sleep(min(poll_interval, remaining))

--- a/python/langsmith/sandbox/_async_sandbox.py
+++ b/python/langsmith/sandbox/_async_sandbox.py
@@ -44,13 +44,18 @@ class AsyncSandbox:
             Only functional when status is "ready".
         id: Unique identifier (UUID). Remains constant even if name changes.
             May be None for resources created before ID support was added.
-        status: Sandbox lifecycle status. One of "provisioning", "ready", "failed".
+        status: Sandbox lifecycle status. One of "provisioning", "ready",
+            "failed", "stopped".
         status_message: Human-readable details when status is "failed", None otherwise.
         created_at: Timestamp when the sandbox was created.
         updated_at: Timestamp when the sandbox was last updated.
         ttl_seconds: Maximum lifetime TTL in seconds (0 means disabled).
         idle_ttl_seconds: Idle timeout TTL in seconds (0 means disabled).
         expires_at: Computed expiration timestamp, or None if no TTL is set.
+        snapshot_id: Snapshot ID used to create this sandbox.
+        vcpus: Number of vCPUs allocated.
+        mem_bytes: Memory allocation in bytes.
+        fs_capacity_bytes: Root filesystem capacity in bytes.
 
     Example:
         async with await client.sandbox(template_name="python-sandbox") as sandbox:
@@ -60,7 +65,7 @@ class AsyncSandbox:
 
     # Data fields (from API response)
     name: str
-    template_name: str
+    template_name: Optional[str] = None
     dataplane_url: Optional[str] = None
     id: Optional[str] = None
     status: str = "ready"
@@ -70,6 +75,10 @@ class AsyncSandbox:
     ttl_seconds: Optional[int] = None
     idle_ttl_seconds: Optional[int] = None
     expires_at: Optional[str] = None
+    snapshot_id: Optional[str] = None
+    vcpus: Optional[int] = None
+    mem_bytes: Optional[int] = None
+    fs_capacity_bytes: Optional[int] = None
 
     # Internal fields (not from API)
     _client: AsyncSandboxClient = field(repr=False, default=None)  # type: ignore
@@ -94,7 +103,7 @@ class AsyncSandbox:
         """
         return cls(
             name=data.get("name", ""),
-            template_name=data.get("template_name", ""),
+            template_name=data.get("template_name"),
             dataplane_url=data.get("dataplane_url"),
             id=data.get("id"),
             status=data.get("status", "ready"),
@@ -104,6 +113,10 @@ class AsyncSandbox:
             ttl_seconds=data.get("ttl_seconds"),
             idle_ttl_seconds=data.get("idle_ttl_seconds"),
             expires_at=data.get("expires_at"),
+            snapshot_id=data.get("snapshot_id"),
+            vcpus=data.get("vcpus"),
+            mem_bytes=data.get("mem_bytes"),
+            fs_capacity_bytes=data.get("fs_capacity_bytes"),
             _client=client,
             _auto_delete=auto_delete,
         )
@@ -624,3 +637,44 @@ class AsyncSandbox:
             expires_in_seconds=expires_in_seconds,
             headers=headers,
         )
+
+    async def start(
+        self,
+        *,
+        timeout: int = 120,
+        headers: RequestHeaders = None,
+    ) -> None:
+        """Start a stopped sandbox and wait until ready.
+
+        After starting, the sandbox's status and dataplane_url are updated
+        in place.
+
+        Args:
+            timeout: Timeout in seconds when waiting for ready.
+            headers: Optional per-request header overrides.
+
+        Raises:
+            ResourceNotFoundError: If sandbox not found.
+            ResourceCreationError: If sandbox fails during startup.
+            ResourceTimeoutError: If sandbox doesn't become ready within timeout.
+            SandboxClientError: For other errors.
+        """
+        refreshed = await self._client.start_sandbox(
+            self.name, timeout=timeout, headers=headers
+        )
+        self.status = refreshed.status
+        self.dataplane_url = refreshed.dataplane_url
+
+    async def stop(self, *, headers: RequestHeaders = None) -> None:
+        """Stop a running sandbox (preserves rootfs for later restart).
+
+        Args:
+            headers: Optional per-request header overrides.
+
+        Raises:
+            ResourceNotFoundError: If sandbox not found.
+            SandboxClientError: For other errors.
+        """
+        await self._client.stop_sandbox(self.name, headers=headers)
+        self.status = "stopped"
+        self.dataplane_url = None

--- a/python/langsmith/sandbox/_async_sandbox.py
+++ b/python/langsmith/sandbox/_async_sandbox.py
@@ -20,6 +20,7 @@ from langsmith.sandbox._models import (
     AsyncCommandHandle,
     AsyncServiceURL,
     ExecutionResult,
+    Snapshot,
 )
 from langsmith.sandbox._tunnel import AsyncTunnel
 
@@ -666,7 +667,7 @@ class AsyncSandbox:
         self.dataplane_url = refreshed.dataplane_url
 
     async def stop(self, *, headers: RequestHeaders = None) -> None:
-        """Stop a running sandbox (preserves rootfs for later restart).
+        """Stop a running sandbox (preserves sandbox files for later restart).
 
         Args:
             headers: Optional per-request header overrides.
@@ -678,3 +679,49 @@ class AsyncSandbox:
         await self._client.stop_sandbox(self.name, headers=headers)
         self.status = "stopped"
         self.dataplane_url = None
+
+    async def delete(self, *, headers: RequestHeaders = None) -> None:
+        """Delete this sandbox.
+
+        Args:
+            headers: Optional per-request header overrides.
+
+        Raises:
+            ResourceNotFoundError: If sandbox not found.
+            SandboxClientError: For other errors.
+        """
+        await self._client.delete_sandbox(self.name, headers=headers)
+
+    async def capture_snapshot(
+        self,
+        name: str,
+        *,
+        checkpoint: Optional[str] = None,
+        timeout: int = 60,
+        headers: RequestHeaders = None,
+    ) -> Snapshot:
+        """Capture a snapshot from this sandbox.
+
+        Args:
+            name: Snapshot name.
+            checkpoint: Checkpoint timestamp to use. If omitted, creates a
+                fresh checkpoint from the current state.
+            timeout: Timeout in seconds when waiting for ready.
+            headers: Optional per-request header overrides.
+
+        Returns:
+            Snapshot in "ready" status.
+
+        Raises:
+            ResourceNotFoundError: If sandbox not found.
+            ResourceTimeoutError: If snapshot doesn't become ready within timeout.
+            ResourceCreationError: If snapshot capture fails.
+            SandboxClientError: For other errors.
+        """
+        return await self._client.capture_snapshot(
+            self.name,
+            name,
+            checkpoint=checkpoint,
+            timeout=timeout,
+            headers=headers,
+        )

--- a/python/langsmith/sandbox/_client.py
+++ b/python/langsmith/sandbox/_client.py
@@ -749,8 +749,7 @@ class SandboxClient:
                 a multiple of 60. 0 or None disables this TTL.
             vcpus: Number of vCPUs.
             mem_bytes: Memory in bytes.
-            fs_capacity_bytes: Root filesystem capacity in bytes
-               .
+            fs_capacity_bytes: Root filesystem capacity in bytes.
 
         Returns:
             Sandbox instance.
@@ -816,8 +815,7 @@ class SandboxClient:
                 a multiple of 60. 0 or None disables this TTL.
             vcpus: Number of vCPUs.
             mem_bytes: Memory in bytes.
-            fs_capacity_bytes: Root filesystem capacity in bytes
-               .
+            fs_capacity_bytes: Root filesystem capacity in bytes.
 
         Returns:
             Created Sandbox. When wait_for_ready=False, the sandbox will have

--- a/python/langsmith/sandbox/_client.py
+++ b/python/langsmith/sandbox/_client.py
@@ -1184,9 +1184,7 @@ class SandboxClient:
 
         return self.wait_for_sandbox(name, timeout=timeout, headers=headers)
 
-    def stop_sandbox(
-        self, name: str, *, headers: RequestHeaders = None
-    ) -> None:
+    def stop_sandbox(self, name: str, *, headers: RequestHeaders = None) -> None:
         """Stop a running sandbox (preserves rootfs for later restart).
 
         Args:
@@ -1275,9 +1273,7 @@ class SandboxClient:
             handle_client_http_error(e)
             raise  # pragma: no cover
 
-        return self.wait_for_snapshot(
-            snapshot.id, timeout=timeout, headers=headers
-        )
+        return self.wait_for_snapshot(snapshot.id, timeout=timeout, headers=headers)
 
     def capture_snapshot(
         self,
@@ -1328,9 +1324,7 @@ class SandboxClient:
             handle_client_http_error(e)
             raise  # pragma: no cover
 
-        return self.wait_for_snapshot(
-            snapshot.id, timeout=timeout, headers=headers
-        )
+        return self.wait_for_snapshot(snapshot.id, timeout=timeout, headers=headers)
 
     def get_snapshot(
         self, snapshot_id: str, *, headers: RequestHeaders = None
@@ -1361,9 +1355,7 @@ class SandboxClient:
             handle_client_http_error(e)
             raise  # pragma: no cover
 
-    def list_snapshots(
-        self, *, headers: RequestHeaders = None
-    ) -> list[Snapshot]:
+    def list_snapshots(self, *, headers: RequestHeaders = None) -> list[Snapshot]:
         """List all snapshots.
 
         Returns:
@@ -1400,9 +1392,7 @@ class SandboxClient:
         url = f"{self._base_url}/snapshots/{snapshot_id}"
 
         try:
-            response = self._http.delete(
-                url, headers=self._request_headers(headers)
-            )
+            response = self._http.delete(url, headers=self._request_headers(headers))
             response.raise_for_status()
         except httpx.HTTPStatusError as e:
             if e.response.status_code == 404:

--- a/python/langsmith/sandbox/_client.py
+++ b/python/langsmith/sandbox/_client.py
@@ -32,6 +32,7 @@ from langsmith.sandbox._models import (
     ResourceStatus,
     SandboxTemplate,
     ServiceURL,
+    Snapshot,
     Volume,
     VolumeMountSpec,
 )
@@ -707,12 +708,16 @@ class SandboxClient:
 
     def sandbox(
         self,
-        template_name: str,
+        template_name: Optional[str] = None,
         *,
+        snapshot_id: Optional[str] = None,
         name: Optional[str] = None,
         timeout: int = 30,
         ttl_seconds: Optional[int] = None,
         idle_ttl_seconds: Optional[int] = None,
+        vcpus: Optional[int] = None,
+        mem_bytes: Optional[int] = None,
+        fs_capacity_bytes: Optional[int] = None,
         headers: RequestHeaders = None,
     ) -> Sandbox:
         """Create a sandbox and return a Sandbox instance.
@@ -723,11 +728,17 @@ class SandboxClient:
             with client.sandbox(template_name="my-template") as sandbox:
                 result = sandbox.run("echo hello")
 
+            with client.sandbox(snapshot_id="<uuid>") as sandbox:
+                result = sandbox.run("echo hello")
+
         The sandbox is automatically deleted when exiting the context manager.
         For sandboxes with manual lifecycle management, use create_sandbox().
 
         Args:
             template_name: Name of the SandboxTemplate to use.
+                Mutually exclusive with snapshot_id.
+            snapshot_id: Snapshot ID to boot from.
+                Mutually exclusive with template_name.
             name: Optional sandbox name (auto-generated if not provided).
             timeout: Timeout in seconds when waiting for ready.
             ttl_seconds: Maximum lifetime in seconds from creation. The sandbox
@@ -736,6 +747,10 @@ class SandboxClient:
             idle_ttl_seconds: Idle timeout in seconds. The sandbox will be
                 automatically deleted after this duration of inactivity. Must be
                 a multiple of 60. 0 or None disables this TTL.
+            vcpus: Number of vCPUs.
+            mem_bytes: Memory in bytes.
+            fs_capacity_bytes: Root filesystem capacity in bytes
+               .
 
         Returns:
             Sandbox instance.
@@ -744,14 +759,19 @@ class SandboxClient:
             ResourceTimeoutError: If timeout waiting for sandbox to be ready.
             ResourceCreationError: If sandbox creation fails.
             SandboxClientError: For other errors.
-            ValueError: If TTL values are invalid.
+            ValueError: If TTL values are invalid or neither template_name
+                nor snapshot_id is provided.
         """
         sb = self.create_sandbox(
             template_name=template_name,
+            snapshot_id=snapshot_id,
             name=name,
             timeout=timeout,
             ttl_seconds=ttl_seconds,
             idle_ttl_seconds=idle_ttl_seconds,
+            vcpus=vcpus,
+            mem_bytes=mem_bytes,
+            fs_capacity_bytes=fs_capacity_bytes,
             headers=headers,
         )
         sb._auto_delete = True
@@ -759,13 +779,17 @@ class SandboxClient:
 
     def create_sandbox(
         self,
-        template_name: str,
+        template_name: Optional[str] = None,
         *,
+        snapshot_id: Optional[str] = None,
         name: Optional[str] = None,
         timeout: int = 30,
         wait_for_ready: bool = True,
         ttl_seconds: Optional[int] = None,
         idle_ttl_seconds: Optional[int] = None,
+        vcpus: Optional[int] = None,
+        mem_bytes: Optional[int] = None,
+        fs_capacity_bytes: Optional[int] = None,
         headers: RequestHeaders = None,
     ) -> Sandbox:
         """Create a new Sandbox.
@@ -775,6 +799,9 @@ class SandboxClient:
 
         Args:
             template_name: Name of the SandboxTemplate to use.
+                Mutually exclusive with snapshot_id.
+            snapshot_id: Snapshot ID to boot from.
+                Mutually exclusive with template_name.
             name: Optional sandbox name (auto-generated if not provided).
             timeout: Timeout in seconds when waiting for ready (only used when
                 wait_for_ready=True).
@@ -787,6 +814,10 @@ class SandboxClient:
             idle_ttl_seconds: Idle timeout in seconds. The sandbox will be
                 automatically deleted after this duration of inactivity. Must be
                 a multiple of 60. 0 or None disables this TTL.
+            vcpus: Number of vCPUs.
+            mem_bytes: Memory in bytes.
+            fs_capacity_bytes: Root filesystem capacity in bytes
+               .
 
         Returns:
             Created Sandbox. When wait_for_ready=False, the sandbox will have
@@ -796,17 +827,26 @@ class SandboxClient:
             ResourceTimeoutError: If timeout waiting for sandbox to be ready.
             ResourceCreationError: If sandbox creation fails.
             SandboxClientError: For other errors.
-            ValueError: If TTL values are invalid.
+            ValueError: If TTL values are invalid or neither template_name
+                nor snapshot_id is provided.
         """
+        if not template_name and not snapshot_id:
+            raise ValueError("Either template_name or snapshot_id is required")
+        if template_name and snapshot_id:
+            raise ValueError("Cannot specify both template_name and snapshot_id")
+
         validate_ttl(ttl_seconds, "ttl_seconds")
         validate_ttl(idle_ttl_seconds, "idle_ttl_seconds")
 
         url = f"{self._base_url}/boxes"
 
         payload: dict[str, Any] = {
-            "template_name": template_name,
             "wait_for_ready": wait_for_ready,
         }
+        if template_name:
+            payload["template_name"] = template_name
+        if snapshot_id:
+            payload["snapshot_id"] = snapshot_id
         if wait_for_ready:
             payload["timeout"] = timeout
         if name:
@@ -815,6 +855,12 @@ class SandboxClient:
             payload["ttl_seconds"] = ttl_seconds
         if idle_ttl_seconds is not None:
             payload["idle_ttl_seconds"] = idle_ttl_seconds
+        if vcpus is not None:
+            payload["vcpus"] = vcpus
+        if mem_bytes is not None:
+            payload["mem_bytes"] = mem_bytes
+        if fs_capacity_bytes is not None:
+            payload["fs_capacity_bytes"] = fs_capacity_bytes
 
         http_timeout = (timeout + 30) if wait_for_ready else 30
 
@@ -1099,5 +1145,315 @@ class SandboxClient:
                     f"Sandbox '{name}' not ready after {timeout}s",
                     resource_type="sandbox",
                     last_status=status.status,
+                )
+            time.sleep(min(poll_interval, remaining))
+
+    def start_sandbox(
+        self,
+        name: str,
+        *,
+        timeout: int = 120,
+        headers: RequestHeaders = None,
+    ) -> Sandbox:
+        """Start a stopped sandbox and wait until ready.
+
+        Args:
+            name: Sandbox name.
+            timeout: Timeout in seconds when waiting for ready.
+
+        Returns:
+            Sandbox in "ready" status.
+
+        Raises:
+            ResourceNotFoundError: If sandbox not found.
+            ResourceCreationError: If sandbox fails during startup.
+            ResourceTimeoutError: If sandbox doesn't become ready within timeout.
+            SandboxClientError: For other errors.
+        """
+        url = f"{self._base_url}/boxes/{name}/start"
+
+        try:
+            response = self._http.post(
+                url, json={}, headers=self._request_headers(headers)
+            )
+            response.raise_for_status()
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 404:
+                raise ResourceNotFoundError(
+                    f"Sandbox '{name}' not found", resource_type="sandbox"
+                ) from e
+            handle_client_http_error(e)
+
+        return self.wait_for_sandbox(name, timeout=timeout, headers=headers)
+
+    def stop_sandbox(
+        self, name: str, *, headers: RequestHeaders = None
+    ) -> None:
+        """Stop a running sandbox (preserves rootfs for later restart).
+
+        Args:
+            name: Sandbox name.
+
+        Raises:
+            ResourceNotFoundError: If sandbox not found.
+            SandboxClientError: For other errors.
+        """
+        url = f"{self._base_url}/boxes/{name}/stop"
+
+        try:
+            response = self._http.post(
+                url, json={}, headers=self._request_headers(headers)
+            )
+            response.raise_for_status()
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 404:
+                raise ResourceNotFoundError(
+                    f"Sandbox '{name}' not found", resource_type="sandbox"
+                ) from e
+            handle_client_http_error(e)
+
+    # ========================================================================
+    # Snapshot Operations
+    # ========================================================================
+
+    def create_snapshot(
+        self,
+        name: str,
+        docker_image: str,
+        fs_capacity_bytes: int,
+        *,
+        registry_id: Optional[str] = None,
+        registry_url: Optional[str] = None,
+        registry_username: Optional[str] = None,
+        registry_password: Optional[str] = None,
+        timeout: int = 60,
+        headers: RequestHeaders = None,
+    ) -> Snapshot:
+        """Build a snapshot from a Docker image.
+
+        Blocks until the snapshot is ready (polls with 2s interval).
+
+        Args:
+            name: Snapshot name.
+            docker_image: Docker image to build from (e.g., "python:3.12-slim").
+            fs_capacity_bytes: Filesystem capacity in bytes.
+            registry_id: Private registry ID (alternative to URL/credentials).
+            registry_url: Registry URL for private images.
+            registry_username: Registry username.
+            registry_password: Registry password.
+            timeout: Timeout in seconds when waiting for ready.
+
+        Returns:
+            Snapshot in "ready" status.
+
+        Raises:
+            ResourceTimeoutError: If snapshot doesn't become ready within timeout.
+            ResourceCreationError: If snapshot build fails.
+            SandboxClientError: For other errors.
+        """
+        url = f"{self._base_url}/snapshots"
+
+        payload: dict[str, Any] = {
+            "name": name,
+            "docker_image": docker_image,
+            "fs_capacity_bytes": fs_capacity_bytes,
+        }
+        if registry_id is not None:
+            payload["registry_id"] = registry_id
+        if registry_url is not None:
+            payload["registry_url"] = registry_url
+        if registry_username is not None:
+            payload["registry_username"] = registry_username
+        if registry_password is not None:
+            payload["registry_password"] = registry_password
+
+        try:
+            response = self._http.post(
+                url, json=payload, headers=self._request_headers(headers)
+            )
+            response.raise_for_status()
+            snapshot = Snapshot.from_dict(response.json())
+        except httpx.HTTPStatusError as e:
+            handle_client_http_error(e)
+            raise  # pragma: no cover
+
+        return self.wait_for_snapshot(
+            snapshot.id, timeout=timeout, headers=headers
+        )
+
+    def capture_snapshot(
+        self,
+        sandbox_name: str,
+        name: str,
+        *,
+        checkpoint: Optional[str] = None,
+        timeout: int = 60,
+        headers: RequestHeaders = None,
+    ) -> Snapshot:
+        """Capture a snapshot from a running sandbox.
+
+        Blocks until the snapshot is ready (polls with 2s interval).
+
+        Args:
+            sandbox_name: Name of the sandbox to capture from.
+            name: Snapshot name.
+            checkpoint: Checkpoint timestamp to use. If omitted, creates a
+                fresh checkpoint from the running VM's current state.
+            timeout: Timeout in seconds when waiting for ready.
+
+        Returns:
+            Snapshot in "ready" status.
+
+        Raises:
+            ResourceNotFoundError: If sandbox not found.
+            ResourceTimeoutError: If snapshot doesn't become ready within timeout.
+            ResourceCreationError: If snapshot capture fails.
+            SandboxClientError: For other errors.
+        """
+        url = f"{self._base_url}/boxes/{sandbox_name}/snapshot"
+
+        payload: dict[str, Any] = {"name": name}
+        if checkpoint is not None:
+            payload["checkpoint"] = checkpoint
+
+        try:
+            response = self._http.post(
+                url, json=payload, headers=self._request_headers(headers)
+            )
+            response.raise_for_status()
+            snapshot = Snapshot.from_dict(response.json())
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 404:
+                raise ResourceNotFoundError(
+                    f"Sandbox '{sandbox_name}' not found", resource_type="sandbox"
+                ) from e
+            handle_client_http_error(e)
+            raise  # pragma: no cover
+
+        return self.wait_for_snapshot(
+            snapshot.id, timeout=timeout, headers=headers
+        )
+
+    def get_snapshot(
+        self, snapshot_id: str, *, headers: RequestHeaders = None
+    ) -> Snapshot:
+        """Get a snapshot by ID.
+
+        Args:
+            snapshot_id: Snapshot UUID.
+
+        Returns:
+            Snapshot.
+
+        Raises:
+            ResourceNotFoundError: If snapshot not found.
+            SandboxClientError: For other errors.
+        """
+        url = f"{self._base_url}/snapshots/{snapshot_id}"
+
+        try:
+            response = self._http.get(url, headers=self._request_headers(headers))
+            response.raise_for_status()
+            return Snapshot.from_dict(response.json())
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 404:
+                raise ResourceNotFoundError(
+                    f"Snapshot '{snapshot_id}' not found", resource_type="snapshot"
+                ) from e
+            handle_client_http_error(e)
+            raise  # pragma: no cover
+
+    def list_snapshots(
+        self, *, headers: RequestHeaders = None
+    ) -> list[Snapshot]:
+        """List all snapshots.
+
+        Returns:
+            List of Snapshots.
+        """
+        url = f"{self._base_url}/snapshots"
+
+        try:
+            response = self._http.get(url, headers=self._request_headers(headers))
+            response.raise_for_status()
+            data = response.json()
+            return [Snapshot.from_dict(s) for s in data.get("snapshots", [])]
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 404:
+                raise SandboxAPIError(
+                    f"API endpoint not found: {url}. "
+                    f"Check that api_endpoint is correct."
+                ) from e
+            handle_client_http_error(e)
+            raise  # pragma: no cover
+
+    def delete_snapshot(
+        self, snapshot_id: str, *, headers: RequestHeaders = None
+    ) -> None:
+        """Delete a snapshot.
+
+        Args:
+            snapshot_id: Snapshot UUID.
+
+        Raises:
+            ResourceNotFoundError: If snapshot not found.
+            SandboxClientError: For other errors.
+        """
+        url = f"{self._base_url}/snapshots/{snapshot_id}"
+
+        try:
+            response = self._http.delete(
+                url, headers=self._request_headers(headers)
+            )
+            response.raise_for_status()
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 404:
+                raise ResourceNotFoundError(
+                    f"Snapshot '{snapshot_id}' not found", resource_type="snapshot"
+                ) from e
+            handle_client_http_error(e)
+
+    def wait_for_snapshot(
+        self,
+        snapshot_id: str,
+        *,
+        timeout: int = 300,
+        poll_interval: float = 2.0,
+        headers: RequestHeaders = None,
+    ) -> Snapshot:
+        """Poll until a snapshot reaches "ready" or "failed" status.
+
+        Args:
+            snapshot_id: Snapshot UUID.
+            timeout: Maximum time to wait in seconds.
+            poll_interval: Time between status checks in seconds.
+
+        Returns:
+            Snapshot in "ready" status.
+
+        Raises:
+            ResourceCreationError: If snapshot status becomes "failed".
+            ResourceTimeoutError: If timeout expires.
+            ResourceNotFoundError: If snapshot not found.
+            SandboxClientError: For other errors.
+        """
+        import time
+
+        deadline = time.monotonic() + timeout
+        while True:
+            snapshot = self.get_snapshot(snapshot_id, headers=headers)
+            if snapshot.status == "ready":
+                return snapshot
+            if snapshot.status == "failed":
+                raise ResourceCreationError(
+                    snapshot.status_message or "Snapshot build failed",
+                    resource_type="snapshot",
+                )
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise ResourceTimeoutError(
+                    f"Snapshot '{snapshot_id}' not ready after {timeout}s",
+                    resource_type="snapshot",
+                    last_status=snapshot.status,
                 )
             time.sleep(min(poll_interval, remaining))

--- a/python/langsmith/sandbox/_client.py
+++ b/python/langsmith/sandbox/_client.py
@@ -1185,7 +1185,7 @@ class SandboxClient:
         return self.wait_for_sandbox(name, timeout=timeout, headers=headers)
 
     def stop_sandbox(self, name: str, *, headers: RequestHeaders = None) -> None:
-        """Stop a running sandbox (preserves rootfs for later restart).
+        """Stop a running sandbox (preserves sandbox files for later restart).
 
         Args:
             name: Sandbox name.

--- a/python/langsmith/sandbox/_models.py
+++ b/python/langsmith/sandbox/_models.py
@@ -193,7 +193,7 @@ class Pool:
 
 @dataclass
 class Snapshot:
-    """Represents a sandbox snapshot (ext4 rootfs image).
+    """Represents a sandbox snapshot.
 
     Snapshots are built from Docker images or captured from running sandboxes.
     They are used to create new sandboxes.

--- a/python/langsmith/sandbox/_models.py
+++ b/python/langsmith/sandbox/_models.py
@@ -191,6 +191,63 @@ class Pool:
         )
 
 
+@dataclass
+class Snapshot:
+    """Represents a sandbox snapshot (ext4 rootfs image).
+
+    Snapshots are built from Docker images or captured from running sandboxes.
+    They are used to create new sandboxes.
+
+    Attributes:
+        id: Unique identifier (UUID).
+        name: Display name.
+        status: Build status. One of "building", "ready", "failed".
+        fs_capacity_bytes: Filesystem capacity in bytes.
+        docker_image: Source Docker image (for build snapshots).
+        image_digest: Docker image digest after pull.
+        source_sandbox_id: Source sandbox (for capture snapshots).
+        status_message: Human-readable details when status is "failed".
+        fs_used_bytes: Actual bytes used on the filesystem.
+        created_by: User or service that created the snapshot.
+        registry_id: Private registry ID, if applicable.
+        created_at: Timestamp when the snapshot was created.
+        updated_at: Timestamp when the snapshot was last updated.
+    """
+
+    id: str
+    name: str
+    status: str
+    fs_capacity_bytes: int
+    docker_image: Optional[str] = None
+    image_digest: Optional[str] = None
+    source_sandbox_id: Optional[str] = None
+    status_message: Optional[str] = None
+    fs_used_bytes: Optional[int] = None
+    created_by: Optional[str] = None
+    registry_id: Optional[str] = None
+    created_at: Optional[str] = None
+    updated_at: Optional[str] = None
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Snapshot:
+        """Create a Snapshot from API response dict."""
+        return cls(
+            id=data.get("id", ""),
+            name=data.get("name", ""),
+            status=data.get("status", "building"),
+            fs_capacity_bytes=data.get("fs_capacity_bytes", 0),
+            docker_image=data.get("docker_image"),
+            image_digest=data.get("image_digest"),
+            source_sandbox_id=data.get("source_sandbox_id"),
+            status_message=data.get("status_message"),
+            fs_used_bytes=data.get("fs_used_bytes"),
+            created_by=data.get("created_by"),
+            registry_id=data.get("registry_id"),
+            created_at=data.get("created_at"),
+            updated_at=data.get("updated_at"),
+        )
+
+
 # =============================================================================
 # Service URL Models
 # =============================================================================

--- a/python/langsmith/sandbox/_sandbox.py
+++ b/python/langsmith/sandbox/_sandbox.py
@@ -43,13 +43,18 @@ class Sandbox:
             Only functional when status is "ready".
         id: Unique identifier (UUID). Remains constant even if name changes.
             May be None for resources created before ID support was added.
-        status: Sandbox lifecycle status. One of "provisioning", "ready", "failed".
+        status: Sandbox lifecycle status. One of "provisioning", "ready",
+            "failed", "stopped".
         status_message: Human-readable details when status is "failed", None otherwise.
         created_at: Timestamp when the sandbox was created.
         updated_at: Timestamp when the sandbox was last updated.
         ttl_seconds: Maximum lifetime TTL in seconds (0 means disabled).
         idle_ttl_seconds: Idle timeout TTL in seconds (0 means disabled).
         expires_at: Computed expiration timestamp, or None if no TTL is set.
+        snapshot_id: Snapshot ID used to create this sandbox.
+        vcpus: Number of vCPUs allocated.
+        mem_bytes: Memory allocation in bytes.
+        fs_capacity_bytes: Root filesystem capacity in bytes.
 
     Example:
         with client.sandbox(template_name="python-sandbox") as sandbox:
@@ -59,7 +64,7 @@ class Sandbox:
 
     # Data fields (from API response)
     name: str
-    template_name: str
+    template_name: Optional[str] = None
     dataplane_url: Optional[str] = None
     id: Optional[str] = None
     status: str = "ready"
@@ -69,6 +74,10 @@ class Sandbox:
     ttl_seconds: Optional[int] = None
     idle_ttl_seconds: Optional[int] = None
     expires_at: Optional[str] = None
+    snapshot_id: Optional[str] = None
+    vcpus: Optional[int] = None
+    mem_bytes: Optional[int] = None
+    fs_capacity_bytes: Optional[int] = None
 
     # Internal fields (not from API)
     _client: SandboxClient = field(repr=False, default=None)  # type: ignore
@@ -93,7 +102,7 @@ class Sandbox:
         """
         return cls(
             name=data.get("name", ""),
-            template_name=data.get("template_name", ""),
+            template_name=data.get("template_name"),
             dataplane_url=data.get("dataplane_url"),
             id=data.get("id"),
             status=data.get("status", "ready"),
@@ -103,6 +112,10 @@ class Sandbox:
             ttl_seconds=data.get("ttl_seconds"),
             idle_ttl_seconds=data.get("idle_ttl_seconds"),
             expires_at=data.get("expires_at"),
+            snapshot_id=data.get("snapshot_id"),
+            vcpus=data.get("vcpus"),
+            mem_bytes=data.get("mem_bytes"),
+            fs_capacity_bytes=data.get("fs_capacity_bytes"),
             _client=client,
             _auto_delete=auto_delete,
         )
@@ -629,3 +642,44 @@ class Sandbox:
             expires_in_seconds=expires_in_seconds,
             headers=headers,
         )
+
+    def start(
+        self,
+        *,
+        timeout: int = 120,
+        headers: RequestHeaders = None,
+    ) -> None:
+        """Start a stopped sandbox and wait until ready.
+
+        After starting, the sandbox's status and dataplane_url are updated
+        in place.
+
+        Args:
+            timeout: Timeout in seconds when waiting for ready.
+            headers: Optional per-request header overrides.
+
+        Raises:
+            ResourceNotFoundError: If sandbox not found.
+            ResourceCreationError: If sandbox fails during startup.
+            ResourceTimeoutError: If sandbox doesn't become ready within timeout.
+            SandboxClientError: For other errors.
+        """
+        refreshed = self._client.start_sandbox(
+            self.name, timeout=timeout, headers=headers
+        )
+        self.status = refreshed.status
+        self.dataplane_url = refreshed.dataplane_url
+
+    def stop(self, *, headers: RequestHeaders = None) -> None:
+        """Stop a running sandbox (preserves rootfs for later restart).
+
+        Args:
+            headers: Optional per-request header overrides.
+
+        Raises:
+            ResourceNotFoundError: If sandbox not found.
+            SandboxClientError: For other errors.
+        """
+        self._client.stop_sandbox(self.name, headers=headers)
+        self.status = "stopped"
+        self.dataplane_url = None

--- a/python/langsmith/sandbox/_sandbox.py
+++ b/python/langsmith/sandbox/_sandbox.py
@@ -19,6 +19,7 @@ from langsmith.sandbox._models import (
     CommandHandle,
     ExecutionResult,
     ServiceURL,
+    Snapshot,
 )
 from langsmith.sandbox._tunnel import Tunnel
 
@@ -671,7 +672,7 @@ class Sandbox:
         self.dataplane_url = refreshed.dataplane_url
 
     def stop(self, *, headers: RequestHeaders = None) -> None:
-        """Stop a running sandbox (preserves rootfs for later restart).
+        """Stop a running sandbox (preserves sandbox files for later restart).
 
         Args:
             headers: Optional per-request header overrides.
@@ -683,3 +684,49 @@ class Sandbox:
         self._client.stop_sandbox(self.name, headers=headers)
         self.status = "stopped"
         self.dataplane_url = None
+
+    def delete(self, *, headers: RequestHeaders = None) -> None:
+        """Delete this sandbox.
+
+        Args:
+            headers: Optional per-request header overrides.
+
+        Raises:
+            ResourceNotFoundError: If sandbox not found.
+            SandboxClientError: For other errors.
+        """
+        self._client.delete_sandbox(self.name, headers=headers)
+
+    def capture_snapshot(
+        self,
+        name: str,
+        *,
+        checkpoint: Optional[str] = None,
+        timeout: int = 60,
+        headers: RequestHeaders = None,
+    ) -> Snapshot:
+        """Capture a snapshot from this sandbox.
+
+        Args:
+            name: Snapshot name.
+            checkpoint: Checkpoint timestamp to use. If omitted, creates a
+                fresh checkpoint from the current state.
+            timeout: Timeout in seconds when waiting for ready.
+            headers: Optional per-request header overrides.
+
+        Returns:
+            Snapshot in "ready" status.
+
+        Raises:
+            ResourceNotFoundError: If sandbox not found.
+            ResourceTimeoutError: If snapshot doesn't become ready within timeout.
+            ResourceCreationError: If snapshot capture fails.
+            SandboxClientError: For other errors.
+        """
+        return self._client.capture_snapshot(
+            self.name,
+            name,
+            checkpoint=checkpoint,
+            timeout=timeout,
+            headers=headers,
+        )

--- a/python/tests/unit_tests/sandbox/test_client.py
+++ b/python/tests/unit_tests/sandbox/test_client.py
@@ -1556,3 +1556,331 @@ class TestService:
         assert svc._refresher is not None
         fresh = svc._refresher()
         assert fresh._token == "token-2"
+
+
+class TestSnapshotOperations:
+    """Tests for snapshot operations."""
+
+    def test_create_snapshot(self, client: SandboxClient, httpx_mock: HTTPXMock):
+        """Test building a snapshot from a Docker image."""
+        # First response: POST /snapshots returns building snapshot
+        httpx_mock.add_response(
+            method="POST",
+            url="http://test-server:8080/snapshots",
+            json={
+                "id": "snap-1",
+                "name": "my-env",
+                "status": "building",
+                "fs_capacity_bytes": 4294967296,
+                "docker_image": "python:3.12-slim",
+            },
+            status_code=201,
+        )
+        # Second response: GET /snapshots/snap-1 returns ready
+        httpx_mock.add_response(
+            method="GET",
+            url="http://test-server:8080/snapshots/snap-1",
+            json={
+                "id": "snap-1",
+                "name": "my-env",
+                "status": "ready",
+                "fs_capacity_bytes": 4294967296,
+                "docker_image": "python:3.12-slim",
+            },
+        )
+
+        snapshot = client.create_snapshot(
+            "my-env", "python:3.12-slim", 4294967296
+        )
+
+        assert snapshot.id == "snap-1"
+        assert snapshot.status == "ready"
+
+    def test_capture_snapshot(self, client: SandboxClient, httpx_mock: HTTPXMock):
+        """Test capturing a snapshot from a running sandbox."""
+        httpx_mock.add_response(
+            method="POST",
+            url="http://test-server:8080/boxes/my-vm/snapshot",
+            json={
+                "id": "snap-2",
+                "name": "captured",
+                "status": "building",
+                "fs_capacity_bytes": 4294967296,
+                "source_sandbox_id": "my-vm",
+            },
+            status_code=201,
+        )
+        httpx_mock.add_response(
+            method="GET",
+            url="http://test-server:8080/snapshots/snap-2",
+            json={
+                "id": "snap-2",
+                "name": "captured",
+                "status": "ready",
+                "fs_capacity_bytes": 4294967296,
+                "source_sandbox_id": "my-vm",
+            },
+        )
+
+        snapshot = client.capture_snapshot("my-vm", "captured")
+
+        assert snapshot.id == "snap-2"
+        assert snapshot.status == "ready"
+        assert snapshot.source_sandbox_id == "my-vm"
+
+    def test_capture_snapshot_not_found(
+        self, client: SandboxClient, httpx_mock: HTTPXMock
+    ):
+        """Test capturing from a non-existent sandbox."""
+        httpx_mock.add_response(
+            method="POST",
+            url="http://test-server:8080/boxes/nonexistent/snapshot",
+            json={"detail": {"error": "not_found", "message": "not found"}},
+            status_code=404,
+        )
+
+        with pytest.raises(ResourceNotFoundError):
+            client.capture_snapshot("nonexistent", "snap")
+
+    def test_get_snapshot(self, client: SandboxClient, httpx_mock: HTTPXMock):
+        """Test getting a snapshot by ID."""
+        httpx_mock.add_response(
+            method="GET",
+            url="http://test-server:8080/snapshots/snap-1",
+            json={
+                "id": "snap-1",
+                "name": "my-env",
+                "status": "ready",
+                "fs_capacity_bytes": 4294967296,
+            },
+        )
+
+        snapshot = client.get_snapshot("snap-1")
+
+        assert snapshot.id == "snap-1"
+        assert snapshot.name == "my-env"
+
+    def test_get_snapshot_not_found(
+        self, client: SandboxClient, httpx_mock: HTTPXMock
+    ):
+        """Test getting a non-existent snapshot."""
+        httpx_mock.add_response(
+            method="GET",
+            url="http://test-server:8080/snapshots/nonexistent",
+            json={"detail": {"error": "not_found", "message": "not found"}},
+            status_code=404,
+        )
+
+        with pytest.raises(ResourceNotFoundError):
+            client.get_snapshot("nonexistent")
+
+    def test_list_snapshots(self, client: SandboxClient, httpx_mock: HTTPXMock):
+        """Test listing snapshots."""
+        httpx_mock.add_response(
+            method="GET",
+            url="http://test-server:8080/snapshots",
+            json={
+                "snapshots": [
+                    {
+                        "id": "snap-1",
+                        "name": "env-1",
+                        "status": "ready",
+                        "fs_capacity_bytes": 4294967296,
+                    },
+                    {
+                        "id": "snap-2",
+                        "name": "env-2",
+                        "status": "building",
+                        "fs_capacity_bytes": 8589934592,
+                    },
+                ],
+                "offset": 0,
+            },
+        )
+
+        snapshots = client.list_snapshots()
+
+        assert len(snapshots) == 2
+        assert snapshots[0].name == "env-1"
+        assert snapshots[1].status == "building"
+
+    def test_delete_snapshot(self, client: SandboxClient, httpx_mock: HTTPXMock):
+        """Test deleting a snapshot."""
+        httpx_mock.add_response(
+            method="DELETE",
+            url="http://test-server:8080/snapshots/snap-1",
+            status_code=204,
+        )
+
+        client.delete_snapshot("snap-1")
+
+    def test_delete_snapshot_not_found(
+        self, client: SandboxClient, httpx_mock: HTTPXMock
+    ):
+        """Test deleting a non-existent snapshot."""
+        httpx_mock.add_response(
+            method="DELETE",
+            url="http://test-server:8080/snapshots/nonexistent",
+            json={"detail": {"error": "not_found", "message": "not found"}},
+            status_code=404,
+        )
+
+        with pytest.raises(ResourceNotFoundError):
+            client.delete_snapshot("nonexistent")
+
+    def test_wait_for_snapshot_immediate_ready(
+        self, client: SandboxClient, httpx_mock: HTTPXMock
+    ):
+        """Test waiting for an already-ready snapshot."""
+        httpx_mock.add_response(
+            method="GET",
+            url="http://test-server:8080/snapshots/snap-1",
+            json={
+                "id": "snap-1",
+                "name": "env",
+                "status": "ready",
+                "fs_capacity_bytes": 4294967296,
+            },
+        )
+
+        snapshot = client.wait_for_snapshot("snap-1")
+        assert snapshot.status == "ready"
+
+    def test_wait_for_snapshot_failed(
+        self, client: SandboxClient, httpx_mock: HTTPXMock
+    ):
+        """Test waiting for a snapshot that fails."""
+        httpx_mock.add_response(
+            method="GET",
+            url="http://test-server:8080/snapshots/snap-1",
+            json={
+                "id": "snap-1",
+                "name": "env",
+                "status": "failed",
+                "status_message": "Docker pull failed",
+                "fs_capacity_bytes": 4294967296,
+            },
+        )
+
+        with pytest.raises(ResourceCreationError, match="Docker pull failed"):
+            client.wait_for_snapshot("snap-1")
+
+
+class TestStartStopOperations:
+    """Tests for sandbox start/stop lifecycle."""
+
+    def test_start_sandbox(self, client: SandboxClient, httpx_mock: HTTPXMock):
+        """Test starting a stopped sandbox."""
+        httpx_mock.add_response(
+            method="POST",
+            url="http://test-server:8080/boxes/my-vm/start",
+            json={},
+            status_code=202,
+        )
+        # wait_for_sandbox polls status then gets full sandbox
+        httpx_mock.add_response(
+            method="GET",
+            url="http://test-server:8080/boxes/my-vm/status",
+            json={"status": "ready"},
+        )
+        httpx_mock.add_response(
+            method="GET",
+            url="http://test-server:8080/boxes/my-vm",
+            json={
+                "name": "my-vm",
+                "status": "ready",
+                "dataplane_url": "https://dp.example.com/my-vm",
+            },
+        )
+
+        sandbox = client.start_sandbox("my-vm")
+
+        assert sandbox.name == "my-vm"
+        assert sandbox.status == "ready"
+        assert sandbox.dataplane_url == "https://dp.example.com/my-vm"
+
+    def test_start_sandbox_not_found(
+        self, client: SandboxClient, httpx_mock: HTTPXMock
+    ):
+        """Test starting a non-existent sandbox."""
+        httpx_mock.add_response(
+            method="POST",
+            url="http://test-server:8080/boxes/nonexistent/start",
+            json={"detail": {"error": "not_found", "message": "not found"}},
+            status_code=404,
+        )
+
+        with pytest.raises(ResourceNotFoundError):
+            client.start_sandbox("nonexistent")
+
+    def test_stop_sandbox(self, client: SandboxClient, httpx_mock: HTTPXMock):
+        """Test stopping a sandbox."""
+        httpx_mock.add_response(
+            method="POST",
+            url="http://test-server:8080/boxes/my-vm/stop",
+            status_code=204,
+        )
+
+        client.stop_sandbox("my-vm")
+
+    def test_stop_sandbox_not_found(
+        self, client: SandboxClient, httpx_mock: HTTPXMock
+    ):
+        """Test stopping a non-existent sandbox."""
+        httpx_mock.add_response(
+            method="POST",
+            url="http://test-server:8080/boxes/nonexistent/stop",
+            json={"detail": {"error": "not_found", "message": "not found"}},
+            status_code=404,
+        )
+
+        with pytest.raises(ResourceNotFoundError):
+            client.stop_sandbox("nonexistent")
+
+    def test_create_sandbox_with_snapshot_id(
+        self, client: SandboxClient, httpx_mock: HTTPXMock
+    ):
+        """Test creating a sandbox from a snapshot."""
+        httpx_mock.add_response(
+            method="POST",
+            url="http://test-server:8080/boxes",
+            json={
+                "name": "my-vm",
+                "snapshot_id": "snap-1",
+                "status": "ready",
+                "dataplane_url": "https://dp.example.com/my-vm",
+                "vcpus": 4,
+                "mem_bytes": 1073741824,
+            },
+            status_code=201,
+        )
+
+        sandbox = client.create_sandbox(snapshot_id="snap-1", name="my-vm")
+
+        assert sandbox.name == "my-vm"
+        assert sandbox.snapshot_id == "snap-1"
+        assert sandbox.vcpus == 4
+        assert sandbox.mem_bytes == 1073741824
+
+        import json
+
+        request = httpx_mock.get_request()
+        body = json.loads(request.content)
+        assert body["snapshot_id"] == "snap-1"
+        assert "template_name" not in body
+
+    def test_create_sandbox_requires_template_or_snapshot(
+        self, client: SandboxClient
+    ):
+        """Test that either template_name or snapshot_id is required."""
+        with pytest.raises(ValueError, match="Either template_name or snapshot_id"):
+            client.create_sandbox()
+
+    def test_create_sandbox_rejects_both_template_and_snapshot(
+        self, client: SandboxClient
+    ):
+        """Test that both template_name and snapshot_id are rejected."""
+        with pytest.raises(ValueError, match="Cannot specify both"):
+            client.create_sandbox(
+                template_name="my-template", snapshot_id="snap-1"
+            )

--- a/python/tests/unit_tests/sandbox/test_client.py
+++ b/python/tests/unit_tests/sandbox/test_client.py
@@ -1589,9 +1589,7 @@ class TestSnapshotOperations:
             },
         )
 
-        snapshot = client.create_snapshot(
-            "my-env", "python:3.12-slim", 4294967296
-        )
+        snapshot = client.create_snapshot("my-env", "python:3.12-slim", 4294967296)
 
         assert snapshot.id == "snap-1"
         assert snapshot.status == "ready"
@@ -1660,9 +1658,7 @@ class TestSnapshotOperations:
         assert snapshot.id == "snap-1"
         assert snapshot.name == "my-env"
 
-    def test_get_snapshot_not_found(
-        self, client: SandboxClient, httpx_mock: HTTPXMock
-    ):
+    def test_get_snapshot_not_found(self, client: SandboxClient, httpx_mock: HTTPXMock):
         """Test getting a non-existent snapshot."""
         httpx_mock.add_response(
             method="GET",
@@ -1823,9 +1819,7 @@ class TestStartStopOperations:
 
         client.stop_sandbox("my-vm")
 
-    def test_stop_sandbox_not_found(
-        self, client: SandboxClient, httpx_mock: HTTPXMock
-    ):
+    def test_stop_sandbox_not_found(self, client: SandboxClient, httpx_mock: HTTPXMock):
         """Test stopping a non-existent sandbox."""
         httpx_mock.add_response(
             method="POST",
@@ -1869,9 +1863,7 @@ class TestStartStopOperations:
         assert body["snapshot_id"] == "snap-1"
         assert "template_name" not in body
 
-    def test_create_sandbox_requires_template_or_snapshot(
-        self, client: SandboxClient
-    ):
+    def test_create_sandbox_requires_template_or_snapshot(self, client: SandboxClient):
         """Test that either template_name or snapshot_id is required."""
         with pytest.raises(ValueError, match="Either template_name or snapshot_id"):
             client.create_sandbox()
@@ -1881,6 +1873,4 @@ class TestStartStopOperations:
     ):
         """Test that both template_name and snapshot_id are rejected."""
         with pytest.raises(ValueError, match="Cannot specify both"):
-            client.create_sandbox(
-                template_name="my-template", snapshot_id="snap-1"
-            )
+            client.create_sandbox(template_name="my-template", snapshot_id="snap-1")

--- a/python/tests/unit_tests/sandbox/test_models.py
+++ b/python/tests/unit_tests/sandbox/test_models.py
@@ -12,6 +12,7 @@ from langsmith.sandbox import (
     ResourceStatus,
     SandboxTemplate,
     ServiceURL,
+    Snapshot,
     Volume,
     VolumeMountSpec,
 )
@@ -469,3 +470,73 @@ class TestAsyncServiceURL:
         svc = AsyncServiceURL.from_dict(data, _refresher=mock_refresher)
         token = await svc.get_token()
         assert token == "new-async-token"
+
+
+class TestSnapshot:
+    """Tests for Snapshot model."""
+
+    def test_from_dict_full(self):
+        """Test creating from full API response dict."""
+        data = {
+            "id": "550e8400-e29b-41d4-a716-446655440099",
+            "name": "my-python-env",
+            "status": "ready",
+            "fs_capacity_bytes": 4294967296,
+            "docker_image": "python:3.12-slim",
+            "image_digest": "sha256:abc123",
+            "source_sandbox_id": None,
+            "status_message": None,
+            "fs_used_bytes": 1073741824,
+            "created_by": "user@example.com",
+            "registry_id": "reg-123",
+            "created_at": "2025-06-01T00:00:00Z",
+            "updated_at": "2025-06-01T00:05:00Z",
+        }
+        snap = Snapshot.from_dict(data)
+
+        assert snap.id == "550e8400-e29b-41d4-a716-446655440099"
+        assert snap.name == "my-python-env"
+        assert snap.status == "ready"
+        assert snap.fs_capacity_bytes == 4294967296
+        assert snap.docker_image == "python:3.12-slim"
+        assert snap.image_digest == "sha256:abc123"
+        assert snap.fs_used_bytes == 1073741824
+        assert snap.created_by == "user@example.com"
+        assert snap.registry_id == "reg-123"
+        assert snap.created_at == "2025-06-01T00:00:00Z"
+        assert snap.updated_at == "2025-06-01T00:05:00Z"
+
+    def test_from_dict_minimal(self):
+        """Test creating from minimal dict with defaults."""
+        data = {
+            "id": "snap-1",
+            "name": "test",
+            "status": "building",
+            "fs_capacity_bytes": 1073741824,
+        }
+        snap = Snapshot.from_dict(data)
+
+        assert snap.id == "snap-1"
+        assert snap.name == "test"
+        assert snap.status == "building"
+        assert snap.fs_capacity_bytes == 1073741824
+        assert snap.docker_image is None
+        assert snap.image_digest is None
+        assert snap.source_sandbox_id is None
+        assert snap.status_message is None
+        assert snap.fs_used_bytes is None
+        assert snap.created_by is None
+
+    def test_from_dict_capture_snapshot(self):
+        """Test creating from a capture (has source_sandbox_id, no docker_image)."""
+        data = {
+            "id": "snap-2",
+            "name": "captured",
+            "status": "ready",
+            "fs_capacity_bytes": 4294967296,
+            "source_sandbox_id": "box-abc",
+        }
+        snap = Snapshot.from_dict(data)
+
+        assert snap.source_sandbox_id == "box-abc"
+        assert snap.docker_image is None


### PR DESCRIPTION
## Summary

- Add snapshot CRUD: `create_snapshot`, `capture_snapshot`, `get_snapshot`, `list_snapshots`, `delete_snapshot`, `wait_for_snapshot`
- Add sandbox start/stop: `start_sandbox`, `stop_sandbox` on client, plus `start()` / `stop()` convenience methods on `Sandbox` / `AsyncSandbox`
- Extend `create_sandbox` / `sandbox` to accept `snapshot_id` as an alternative to `template_name`, with `vcpus`, `mem_bytes`, `fs_capacity_bytes` resource params
- Add `Snapshot` model
- All methods implemented for both sync and async clients
- Backwards compatible — existing `template_name` callers are unchanged

## Test plan

- [x] 447 existing unit tests still pass
- [x] New tests for snapshot CRUD, start/stop, snapshot-based sandbox creation, validation errors
- [x] Ruff lint clean