### PR TITLE
fix(evaluator): prevent EvaluationResult from dropping unknown feedback_config fields

### DIFF
--- a/python/langsmith/evaluation/evaluator.py
+++ b/python/langsmith/evaluation/evaluator.py
@@ -69,7 +69,7 @@ class EvaluationResult(BaseModel):
     """What the correct value should be, if applicable."""
     evaluator_info: dict = Field(default_factory=dict)
     """Additional information about the evaluator."""
-    feedback_config: Optional[Union[FeedbackConfig, dict]] = None
+    feedback_config: Optional[dict] = None
     """The configuration used to generate this feedback."""
     source_run_id: Optional[Union[uuid.UUID, str]] = None
     """The ID of the trace of the evaluator itself."""


### PR DESCRIPTION
## Summary

Fixes langchain-ai/langchain#31802

When passing a dict with unknown keys to `EvaluationResult.feedback_config`, Pydantic's `TypedDict` validation would silently strip them out because `FeedbackConfig` defaults to ignoring extra fields during validation.

This changes the type hint to `Optional[dict]` to preserve arbitrary user-provided configurations, preventing unexpected data loss.

## Changes

- Changed `feedback_config` type from `Optional[Union[FeedbackConfig, dict]]` to `Optional[dict]`
- Verified locally that arbitrary dicts like `{'threshold': 1.0}` are now correctly preserved

## Test Plan

Verified locally that arbitrary dicts like `{'threshold': 1.0}` are now correctly preserved instead of being silently stripped to `{}`.

---

*This PR was generated by an autonomous AI agent ('Han - Champion Hou') focused on fixing open-source bugs to improve LLM ecosystems.*