### PR TITLE
feat(py): Allow more granular concurrency config, give evaluators their own concurrency pool

### DIFF
--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -9224,6 +9224,9 @@ class Client:
         blocking: bool = True,
         experiment: Optional[EXPERIMENT_T] = None,
         upload_results: bool = True,
+        error_handling: Literal["log", "ignore"] = "log",
+        target_concurrency: Optional[int] = None,
+        evaluation_concurrency: Optional[int] = None,
         **kwargs: Any,
     ) -> ExperimentResults: ...
 
@@ -9243,6 +9246,9 @@ class Client:
         blocking: bool = True,
         experiment: Optional[EXPERIMENT_T] = None,
         upload_results: bool = True,
+        error_handling: Literal["log", "ignore"] = "log",
+        target_concurrency: Optional[int] = None,
+        evaluation_concurrency: Optional[int] = None,
         **kwargs: Any,
     ) -> ComparativeExperimentResults: ...
 
@@ -9266,6 +9272,8 @@ class Client:
         experiment: Optional[EXPERIMENT_T] = None,
         upload_results: bool = True,
         error_handling: Literal["log", "ignore"] = "log",
+        target_concurrency: Optional[int] = None,
+        evaluation_concurrency: Optional[int] = None,
         **kwargs: Any,
     ) -> Union[ExperimentResults, ComparativeExperimentResults]:
         r"""Evaluate a target system on a given dataset.
@@ -9471,6 +9479,8 @@ class Client:
             experiment=experiment,
             upload_results=upload_results,
             error_handling=error_handling,
+            target_concurrency=target_concurrency,
+            evaluation_concurrency=evaluation_concurrency,
             **kwargs,
         )
 
@@ -9499,6 +9509,8 @@ class Client:
         experiment: Optional[Union[schemas.TracerSession, str, uuid.UUID]] = None,
         upload_results: bool = True,
         error_handling: Literal["log", "ignore"] = "log",
+        target_concurrency: Optional[int] = None,
+        evaluation_concurrency: Optional[int] = None,
         **kwargs: Any,
     ) -> AsyncExperimentResults:
         r"""Evaluate an async target system on a given dataset.
@@ -9722,6 +9734,8 @@ class Client:
             experiment=experiment,
             upload_results=upload_results,
             error_handling=error_handling,
+            target_concurrency=target_concurrency,
+            evaluation_concurrency=evaluation_concurrency,
             **kwargs,
         )
 

--- a/python/langsmith/evaluation/_arunner.py
+++ b/python/langsmith/evaluation/_arunner.py
@@ -91,6 +91,8 @@ async def aevaluate(
     experiment: Optional[Union[schemas.TracerSession, str, uuid.UUID]] = None,
     upload_results: bool = True,
     error_handling: Literal["log", "ignore"] = "log",
+    target_concurrency: Optional[int] = None,
+    evaluation_concurrency: Optional[int] = None,
     **kwargs: Any,
 ) -> AsyncExperimentResults:
     r"""Evaluate an async target system on a given dataset.
@@ -115,6 +117,20 @@ async def aevaluate(
             evaluations to run.
 
             If `None` then no limit is set. If `0` then no concurrency.
+        target_concurrency (int | None): The maximum number of concurrent
+            predictions to run. If not provided, defaults to `max_concurrency`.
+            When set, predictions and evaluations are pipelined so
+            evaluations can start before all predictions complete.
+
+            If `None` then no limit is set. If `0` then no concurrency
+            (fully sequential end-to-end).
+        evaluation_concurrency (int | None): The maximum number of concurrent
+            evaluators to run. If not provided, defaults to `max_concurrency`.
+            When set, predictions and evaluations are pipelined so
+            evaluations can start before all predictions complete.
+
+            If `None` then no limit is set. If `0` then no concurrency
+            (fully sequential end-to-end).
         num_repetitions (int): The number of times to run the evaluation.
             Each item in the dataset will be run and evaluated this many times.
         client (Optional[langsmith.Client]): The LangSmith client to use.
@@ -241,6 +257,19 @@ async def aevaluate(
         ... )  # doctest: +ELLIPSIS
         View the evaluation results for experiment:...
 
+        Setting separate concurrency limits for predictions and evaluators:
+
+        >>> results = asyncio.run(
+        ...     aevaluate(
+        ...         apredict,
+        ...         data=dataset_name,
+        ...         evaluators=[accuracy],
+        ...         target_concurrency=2,
+        ...         evaluation_concurrency=4,
+        ...     )
+        ... )  # doctest: +ELLIPSIS
+        View the evaluation results for experiment:...
+
         Using Async evaluators:
 
         >>> async def helpfulness(run: Run, example: Example):
@@ -335,6 +364,8 @@ async def aevaluate(
             experiment=experiment,
             upload_results=upload_results,
             error_handling=error_handling,
+            target_concurrency=target_concurrency,
+            evaluation_concurrency=evaluation_concurrency,
         )
 
 
@@ -473,6 +504,8 @@ async def _aevaluate(
     experiment: Optional[Union[schemas.TracerSession, str, uuid.UUID]] = None,
     upload_results: bool = True,
     error_handling: Literal["log", "ignore"] = "log",
+    target_concurrency: Optional[int] = None,
+    evaluation_concurrency: Optional[int] = None,
 ) -> AsyncExperimentResults:
     is_async_target = (
         asyncio.iscoroutinefunction(target)
@@ -512,20 +545,33 @@ async def _aevaluate(
     with ls_utils.with_optional_cache(cache_path, ignore_hosts=[client.api_url]):
         if is_async_target:
             if evaluators:
-                # Run predictions and evaluations in a single pipeline
                 manager = await manager.awith_predictions_and_evaluators(
-                    cast(ATARGET_T, target), evaluators, max_concurrency=max_concurrency
+                    cast(ATARGET_T, target),
+                    evaluators,
+                    max_concurrency=max_concurrency,
+                    target_concurrency=target_concurrency,
+                    evaluation_concurrency=evaluation_concurrency,
                 )
             else:
                 manager = await manager.awith_predictions(
-                    cast(ATARGET_T, target), max_concurrency=max_concurrency
+                    cast(ATARGET_T, target),
+                    max_concurrency=(
+                        target_concurrency
+                        if target_concurrency is not None
+                        else max_concurrency
+                    ),
                 )
             if summary_evaluators:
                 manager = await manager.awith_summary_evaluators(summary_evaluators)
         else:
             if evaluators:
                 manager = await manager.awith_evaluators(
-                    evaluators, max_concurrency=max_concurrency
+                    evaluators,
+                    max_concurrency=(
+                        evaluation_concurrency
+                        if evaluation_concurrency is not None
+                        else max_concurrency
+                    ),
                 )
             if summary_evaluators:
                 manager = await manager.awith_summary_evaluators(summary_evaluators)
@@ -782,6 +828,8 @@ class _AsyncExperimentManager(_ExperimentManagerMixin):
         evaluators: Sequence[Union[EVALUATOR_T, AEVALUATOR_T]],
         /,
         max_concurrency: Optional[int] = None,
+        target_concurrency: Optional[int] = None,
+        evaluation_concurrency: Optional[int] = None,
     ) -> _AsyncExperimentManager:
         """Run predictions and evaluations in a single pipeline.
 
@@ -795,28 +843,114 @@ class _AsyncExperimentManager(_ExperimentManagerMixin):
 
         traceable_target = _ensure_async_traceable(target)
 
-        async def process_example(example: schemas.Example):
-            # Yield the coroutine to be awaited later
-            pred = await _aforward(
-                traceable_target,
-                self._get_example_with_readers(example),
-                self.experiment_name,
-                self._metadata,
-                self.client,
-                _target_include_attachments(target),
-                self._error_handling,
-            )
-            example, run = pred["example"], pred["run"]
-            result = await self._arun_evaluators(
-                evaluators,
-                {
-                    "run": run,
-                    "example": example,
-                    "evaluation_results": {"results": []},
-                },
-                feedback_executor=self._evaluation_feedback_executor,
-            )
-            return result
+        # Determine whether the caller requested per-stage concurrency
+        # controls.  When neither override is provided we preserve the
+        # legacy single-semaphore behaviour (outer limiter = max_concurrency,
+        # no inner semaphores).
+        _has_explicit = (
+            target_concurrency is not None or evaluation_concurrency is not None
+        )
+
+        # Resolve per-stage values, falling back to max_concurrency.
+        _target_conc = (
+            target_concurrency if target_concurrency is not None else max_concurrency
+        )
+        _eval_conc = (
+            evaluation_concurrency
+            if evaluation_concurrency is not None
+            else max_concurrency
+        )
+
+        if _has_explicit and _target_conc != 0 and _eval_conc != 0:
+            # Per-stage semaphores throttle predictions and evaluations
+            # independently within the same pipeline.  The outer limiter
+            # bounds total in-flight tasks to avoid unbounded memory growth.
+            def _make_sem(
+                n: Optional[int],
+            ) -> asyncio.Semaphore | aitertools.NoLock:
+                if n is None:
+                    return aitertools.NoLock()
+                return asyncio.Semaphore(max(n, 1))
+
+            _target_sem = _make_sem(_target_conc)
+            _eval_sem = _make_sem(_eval_conc)
+
+            async def process_example(example: schemas.Example):
+                async with _target_sem:
+                    pred = await _aforward(
+                        traceable_target,
+                        self._get_example_with_readers(example),
+                        self.experiment_name,
+                        self._metadata,
+                        self.client,
+                        _target_include_attachments(target),
+                        self._error_handling,
+                    )
+                example, run = pred["example"], pred["run"]
+                async with _eval_sem:
+                    result = await self._arun_evaluators(
+                        evaluators,
+                        {
+                            "run": run,
+                            "example": example,
+                            "evaluation_results": {"results": []},
+                        },
+                        feedback_executor=self._evaluation_feedback_executor,
+                    )
+                return result
+
+            # Compute a bounded outer concurrency window.  This limits the
+            # total number of in-flight tasks (and therefore memory) while
+            # still allowing prediction/evaluation overlap across examples.
+            # Note: _has_explicit guarantees at least one of _target_conc /
+            # _eval_conc is an explicit int (not inherited None), so the
+            # outer window is always bounded when we reach this branch.
+            if _target_conc is not None and _eval_conc is not None:
+                _outer_concurrency: Optional[int] = _target_conc + _eval_conc
+            elif _target_conc is not None:
+                _outer_concurrency = _target_conc
+            else:
+                # _eval_conc must be not-None here (at least one explicit).
+                _outer_concurrency = _eval_conc
+        else:
+            # TODO: Deprecate this legacy path in favour of always using
+            # per-stage semaphores.  Keeping it for now to preserve the
+            # exact old behaviour when callers only set max_concurrency.
+            #
+            # Legacy path: a single outer semaphore governs the whole
+            # predict-then-evaluate coroutine per example.  No inner
+            # semaphores — concurrency is controlled entirely by the
+            # outer aiter_with_concurrency call.  This is also the
+            # fallback when either stage is set to 0 (true sequential),
+            # which maps to aiter_with_concurrency(0, ...) for genuine
+            # no-task-spawn sequential execution.
+            if not _has_explicit:
+                _outer_concurrency = max_concurrency
+            else:
+                # At least one stage is explicitly 0 — run fully sequential.
+                _outer_concurrency = 0
+
+            async def process_example(example: schemas.Example):
+                pred = await _aforward(
+                    traceable_target,
+                    self._get_example_with_readers(example),
+                    self.experiment_name,
+                    self._metadata,
+                    self.client,
+                    _target_include_attachments(target),
+                    self._error_handling,
+                )
+                example, run = pred["example"], pred["run"]
+                result = await self._arun_evaluators(
+                    evaluators,
+                    {
+                        "run": run,
+                        "example": example,
+                        "evaluation_results": {"results": []},
+                    },
+                    feedback_executor=self._evaluation_feedback_executor,
+                )
+                return result
 
         async def process_examples():
             """Create a single task per example.
@@ -829,11 +963,8 @@ class _AsyncExperimentManager(_ExperimentManagerMixin):
 
             await self._aend()
 
-        # Run the per-example tasks with max-concurrency
-        # This guarantees that max_concurrency is the upper limit
-        # for the number of target/evaluators that can be run in parallel
         experiment_results = aitertools.aiter_with_concurrency(
-            max_concurrency,
+            _outer_concurrency,
             process_examples(),
             _eager_consumption_timeout=0.001,
         )

--- a/python/langsmith/evaluation/_runner.py
+++ b/python/langsmith/evaluation/_runner.py
@@ -110,6 +110,9 @@ def evaluate(
     blocking: bool = True,
     experiment: Optional[EXPERIMENT_T] = None,
     upload_results: bool = True,
+    error_handling: Literal["log", "ignore"] = "log",
+    target_concurrency: Optional[int] = None,
+    evaluation_concurrency: Optional[int] = None,
     **kwargs: Any,
 ) -> ExperimentResults: ...
 
@@ -130,6 +133,9 @@ def evaluate(
     blocking: bool = True,
     experiment: Optional[EXPERIMENT_T] = None,
     upload_results: bool = True,
+    error_handling: Literal["log", "ignore"] = "log",
+    target_concurrency: Optional[int] = None,
+    evaluation_concurrency: Optional[int] = None,
     **kwargs: Any,
 ) -> ComparativeExperimentResults: ...
 
@@ -152,6 +158,8 @@ def evaluate(
     experiment: Optional[EXPERIMENT_T] = None,
     upload_results: bool = True,
     error_handling: Literal["log", "ignore"] = "log",
+    target_concurrency: Optional[int] = None,
+    evaluation_concurrency: Optional[int] = None,
     **kwargs: Any,
 ) -> Union[ExperimentResults, ComparativeExperimentResults]:
     r"""Evaluate a target system on a given dataset.
@@ -177,6 +185,18 @@ def evaluate(
         description (str | None): A free-form text description for the experiment.
         max_concurrency (int | None): The maximum number of concurrent
             evaluations to run.
+
+            If `None` then no limit is set. If `0` then no concurrency.
+        target_concurrency (int | None): The maximum number of concurrent
+            predictions to run. If not provided, defaults to `max_concurrency`.
+            Note: in sync mode, predictions run to completion before
+            evaluations begin (no pipelining).
+
+            If `None` then no limit is set. If `0` then no concurrency.
+        evaluation_concurrency (int | None): The maximum number of concurrent
+            evaluators to run. If not provided, defaults to `max_concurrency`.
+            Note: in sync mode, evaluations run after all predictions
+            complete.
 
             If `None` then no limit is set. If `0` then no concurrency.
         client (langsmith.Client | None): The LangSmith client to use.
@@ -273,7 +293,16 @@ def evaluate(
         >>> for i, result in enumerate(results):  # doctest: +ELLIPSIS
         ...     pass
 
+        Setting separate concurrency limits for predictions and evaluators:
 
+        >>> results = evaluate(
+        ...     predict,
+        ...     data=dataset_name,
+        ...     evaluators=[accuracy],
+        ...     target_concurrency=2,
+        ...     evaluation_concurrency=4,
+        ... )  # doctest: +ELLIPSIS
+        View the evaluation results for experiment:...
 
         Evaluating a LangChain object:
 
@@ -412,6 +441,8 @@ def evaluate(
             experiment=experiment,
             upload_results=upload_results,
             error_handling=error_handling,
+            target_concurrency=target_concurrency,
+            evaluation_concurrency=evaluation_concurrency,
         )
 
 
@@ -1077,11 +1108,23 @@ def _evaluate(
     experiment: Optional[Union[schemas.TracerSession, str, uuid.UUID]] = None,
     upload_results: bool = True,
     error_handling: Literal["log", "ignore"] = "log",
+    target_concurrency: Optional[int] = None,
+    evaluation_concurrency: Optional[int] = None,
 ) -> ExperimentResults:
     # Initialize the experiment manager.
     client = client or rt.get_cached_client()
     runs = None if _is_callable(target) else cast(Iterable[schemas.Run], target)
     experiment_, runs = _resolve_experiment(experiment, runs, client)
+
+    # Resolve concurrency settings: specific overrides general
+    target_concurrency = (
+        target_concurrency if target_concurrency is not None else max_concurrency
+    )
+    evaluation_concurrency = (
+        evaluation_concurrency
+        if evaluation_concurrency is not None
+        else max_concurrency
+    )
 
     manager = _ExperimentManager(
         data,
@@ -1101,16 +1144,19 @@ def _evaluate(
         cache_path = pathlib.Path(cache_dir) / f"{manager.dataset_id}.yaml"
     else:
         cache_path = None
+    # TODO: Consider pipelining predictions and evaluations in the sync path
+    # (like the async awith_predictions_and_evaluators) so evaluators can run
+    # as predictions stream in, rather than waiting for all predictions first.
     with ls_utils.with_optional_cache(cache_path, ignore_hosts=[client.api_url]):
         if _is_callable(target):
             # Add predictions to the experiment.
             manager = manager.with_predictions(
-                cast(TARGET_T, target), max_concurrency=max_concurrency
+                cast(TARGET_T, target), max_concurrency=target_concurrency
             )
         if evaluators:
             # Apply evaluators to the predictions.
             manager = manager.with_evaluators(
-                evaluators, max_concurrency=max_concurrency
+                evaluators, max_concurrency=evaluation_concurrency
             )
         if summary_evaluators:
             # Apply the experiment-level summary evaluators.

--- a/python/tests/unit_tests/evaluation/test_runner.py
+++ b/python/tests/unit_tests/evaluation/test_runner.py
@@ -1299,3 +1299,269 @@ async def test_invalid_aevaluate_args() -> None:
 
     with pytest.raises(ValueError, match="Received unsupported arguments"):
         await aevaluate((lambda x: x), data="data", load_nested=True)
+
+
+# ---------------------------------------------------------------------------
+# Separate target / evaluation concurrency tests
+# ---------------------------------------------------------------------------
+
+
+def _make_concurrency_client(
+    num_examples: int = 6,
+) -> tuple:
+    """Create a mock client and example list for concurrency tests."""
+    session = mock.Mock()
+    ds_name = "my-dataset"
+    ds_id = "00886375-eb2a-4038-9032-efff60309896"
+    ds_example_responses = [_create_example(i) for i in range(10)]
+    tenant_id = str(uuid.uuid4())
+    fake_request = FakeRequest(
+        ds_id, ds_name, [e[1] for e in ds_example_responses], tenant_id
+    )
+    session.request = fake_request.request
+    client = Client(
+        api_url="http://localhost:1984",
+        api_key="123",
+        session=session,
+        info=ls_schemas.LangSmithInfo(
+            batch_ingest_config=ls_schemas.BatchIngestConfig(
+                size_limit_bytes=None,
+                size_limit=100,
+                scale_up_nthreads_limit=16,
+                scale_up_qsize_trigger=1000,
+                scale_down_nempty_trigger=4,
+            )
+        ),
+    )
+    client._tenant_id = tenant_id  # type: ignore
+    ds_examples = [e[0] for e in ds_example_responses]
+    return client, ds_examples[:num_examples]
+
+
+@pytest.mark.skipif(sys.version_info < (3, 9), reason="requires python3.9 or higher")
+@pytest.mark.parametrize(
+    "max_conc, target_conc, eval_conc, expect_max_target, expect_max_eval",
+    [
+        # Both explicit: target=1, eval=2
+        (None, 1, 2, 1, 2),
+        # Only target_concurrency set; eval falls back to max_concurrency=3
+        (3, 1, None, 1, 3),
+        # Only max_concurrency set; both stages use it
+        (2, None, None, 2, 2),
+        # target_concurrency=0 means fully sequential
+        (None, 0, None, 1, 1),
+    ],
+    ids=[
+        "both_explicit",
+        "one_override_target",
+        "fallback_to_max",
+        "zero_sequential",
+    ],
+)
+def test_evaluate_concurrency_limits(
+    max_conc: int,
+    target_conc: int,
+    eval_conc: int,
+    expect_max_target: int,
+    expect_max_eval: int,
+) -> None:
+    """Sync evaluate respects separate concurrency limits."""
+    import threading
+
+    client, dev_split = _make_concurrency_client()
+
+    max_target_active = 0
+    current_target_active = 0
+    max_eval_active = 0
+    current_eval_active = 0
+    target_lock = threading.Lock()
+    eval_lock = threading.Lock()
+
+    def predict(inputs: dict) -> dict:
+        nonlocal max_target_active, current_target_active
+        with target_lock:
+            current_target_active += 1
+            max_target_active = max(max_target_active, current_target_active)
+        time.sleep(0.02)
+        with target_lock:
+            current_target_active -= 1
+        return {"output": 1}
+
+    def evaluator(run, example):
+        nonlocal max_eval_active, current_eval_active
+        with eval_lock:
+            current_eval_active += 1
+            max_eval_active = max(max_eval_active, current_eval_active)
+        time.sleep(0.02)
+        with eval_lock:
+            current_eval_active -= 1
+        return {"score": 1}
+
+    kwargs: dict = {}
+    if max_conc is not None:
+        kwargs["max_concurrency"] = max_conc
+    if target_conc is not None:
+        kwargs["target_concurrency"] = target_conc
+    if eval_conc is not None:
+        kwargs["evaluation_concurrency"] = eval_conc
+
+    results = evaluate(
+        predict,
+        client=client,
+        data=dev_split,
+        evaluators=[evaluator],
+        **kwargs,
+    )
+    list(results)
+
+    assert max_target_active <= expect_max_target, (
+        f"Expected max_target_active<={expect_max_target}, got {max_target_active}"
+    )
+    assert max_eval_active <= expect_max_eval, (
+        f"Expected max_eval_active<={expect_max_eval}, got {max_eval_active}"
+    )
+
+
+@pytest.mark.skipif(sys.version_info < (3, 9), reason="requires python3.9 or higher")
+@pytest.mark.parametrize(
+    "max_conc, target_conc, eval_conc, expect_max_target, expect_max_eval",
+    [
+        # Both explicit: target=1, eval=2
+        (None, 1, 2, 1, 2),
+        # Only eval_concurrency set; target falls back to max_concurrency=3
+        (3, None, 1, 3, 1),
+        # Only max_concurrency set; both stages use it
+        (2, None, None, 2, 2),
+        # target_concurrency=0 means fully sequential end-to-end
+        (None, 0, None, 1, 1),
+    ],
+    ids=[
+        "both_explicit",
+        "one_override_eval",
+        "fallback_to_max",
+        "zero_sequential",
+    ],
+)
+async def test_aevaluate_concurrency_limits(
+    max_conc: int,
+    target_conc: int,
+    eval_conc: int,
+    expect_max_target: int,
+    expect_max_eval: int,
+) -> None:
+    """Async evaluate respects separate concurrency limits."""
+    client, dev_split = _make_concurrency_client()
+
+    max_target_active = 0
+    current_target_active = 0
+    max_eval_active = 0
+    current_eval_active = 0
+    target_lock = asyncio.Lock()
+    eval_lock = asyncio.Lock()
+
+    async def predict(inputs: dict) -> dict:
+        nonlocal max_target_active, current_target_active
+        async with target_lock:
+            current_target_active += 1
+            max_target_active = max(max_target_active, current_target_active)
+        await asyncio.sleep(0.02)
+        async with target_lock:
+            current_target_active -= 1
+        return {"output": 1}
+
+    async def evaluator(run, example):
+        nonlocal max_eval_active, current_eval_active
+        async with eval_lock:
+            current_eval_active += 1
+            max_eval_active = max(max_eval_active, current_eval_active)
+        await asyncio.sleep(0.02)
+        async with eval_lock:
+            current_eval_active -= 1
+        return {"score": 1}
+
+    kwargs: dict = {}
+    if max_conc is not None:
+        kwargs["max_concurrency"] = max_conc
+    if target_conc is not None:
+        kwargs["target_concurrency"] = target_conc
+    if eval_conc is not None:
+        kwargs["evaluation_concurrency"] = eval_conc
+
+    results = await aevaluate(
+        predict,
+        client=client,
+        data=dev_split,
+        evaluators=[evaluator],
+        **kwargs,
+    )
+    async for _ in results:
+        pass
+
+    assert max_target_active <= expect_max_target, (
+        f"Expected max_target_active<={expect_max_target}, got {max_target_active}"
+    )
+    assert max_eval_active <= expect_max_eval, (
+        f"Expected max_eval_active<={expect_max_eval}, got {max_eval_active}"
+    )
+
+
+@pytest.mark.skipif(sys.version_info < (3, 9), reason="requires python3.9 or higher")
+async def test_aevaluate_pipelining() -> None:
+    """Evaluations on fast predictions run before slow predictions finish.
+
+    With separate concurrency, the pipeline should not wait for all
+    predictions to complete before starting evaluations.
+    """
+    client, _ = _make_concurrency_client(num_examples=3)
+    ds_example_responses = [_create_example(i) for i in range(10)]
+    examples = [e[0] for e in ds_example_responses[:3]]
+
+    prediction_times: dict = {}
+    evaluation_times: dict = {}
+    start = time.monotonic()
+
+    # Example 0 is slow (1 s), examples 1-2 are fast (10 ms).
+    delays = {0: 1.0, 1: 0.01, 2: 0.01}
+
+    async def predict(inputs: dict) -> dict:
+        idx = inputs.get("in", 0)
+        await asyncio.sleep(delays.get(idx, 0.01))
+        prediction_times[idx] = time.monotonic() - start
+        return {"output": idx}
+
+    async def evaluator(run, example):
+        idx = example.inputs.get("in", 0)
+        evaluation_times[idx] = time.monotonic() - start
+        return {"score": 1}
+
+    results = await aevaluate(
+        predict,
+        client=client,
+        data=examples,
+        evaluators=[evaluator],
+        target_concurrency=3,
+        evaluation_concurrency=3,
+    )
+    async for _ in results:
+        pass
+
+    # Fast predictions (1, 2) should complete before the slow one (0).
+    assert prediction_times[1] < prediction_times[0], (
+        f"Fast prediction 1 ({prediction_times[1]:.3f}s) should finish "
+        f"before slow prediction 0 ({prediction_times[0]:.3f}s)"
+    )
+    assert prediction_times[2] < prediction_times[0], (
+        f"Fast prediction 2 ({prediction_times[2]:.3f}s) should finish "
+        f"before slow prediction 0 ({prediction_times[0]:.3f}s)"
+    )
+
+    # Fast predictions should be *evaluated* before the slow prediction
+    # even finishes predicting — this proves pipelining is working.
+    assert evaluation_times[1] < prediction_times[0], (
+        f"Evaluation of example 1 ({evaluation_times[1]:.3f}s) should run "
+        f"before slow prediction 0 finishes ({prediction_times[0]:.3f}s)"
+    )
+    assert evaluation_times[2] < prediction_times[0], (
+        f"Evaluation of example 2 ({evaluation_times[2]:.3f}s) should run "
+        f"before slow prediction 0 finishes ({prediction_times[0]:.3f}s)"
+    )


### PR DESCRIPTION
Python version of:

https://github.com/langchain-ai/langsmith-sdk/pull/2349
https://github.com/langchain-ai/langsmith-sdk/pull/2385
