### PR TITLE
python: pass OTEL config directly to exporter instead of setting env vars

### DIFF
--- a/python/langsmith/_internal/otel/_otel_client.py
+++ b/python/langsmith/_internal/otel/_otel_client.py
@@ -53,7 +53,8 @@ def get_otlp_tracer_provider() -> "TracerProvider":
       Langsmith-Project header if project is configured
 
     These defaults can be overridden by setting the environment variables before
-    calling this function.
+    calling this function. Values are passed directly to the exporter constructor
+    rather than written to os.environ.
 
     Returns:
         TracerProvider: The OTLP tracer provider.
@@ -73,20 +74,28 @@ def get_otlp_tracer_provider() -> "TracerProvider":
         BatchSpanProcessor,
     ) = otel_imports
 
-    if "OTEL_EXPORTER_OTLP_ENDPOINT" not in os.environ:
+    endpoint = os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT")
+    if not endpoint:
         ls_endpoint = ls_utils.get_api_url(None)
-        os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"] = f"{ls_endpoint}/otel"
+        endpoint = f"{ls_endpoint}/otel"
 
-    # Configure headers with API key and project if available
-    if "OTEL_EXPORTER_OTLP_HEADERS" not in os.environ:
-        api_key = ls_utils.get_api_key(None)
-        headers = f"x-api-key={api_key}"
+    # Configure headers with API key and project if available.
+    # Build a dict because OTLPSpanExporter expects a mapping, not a string.
+    headers_env = os.environ.get("OTEL_EXPORTER_OTLP_HEADERS")
+    if headers_env:
+        headers = {
+            k.strip(): v.strip()
+            for k, v in (
+                pair.split("=", 1) for pair in headers_env.split(",") if "=" in pair
+            )
+        }
+    else:
+        api_key = ls_utils.get_api_key(None) or ""
+        headers = {"x-api-key": api_key}
 
         project = ls_utils.get_tracer_project()
         if project:
-            headers += f",Langsmith-Project={project}"
-
-        os.environ["OTEL_EXPORTER_OTLP_HEADERS"] = headers
+            headers["Langsmith-Project"] = project
 
     service_name = os.environ.get("OTEL_SERVICE_NAME", "langsmith")
     resource = Resource(
@@ -99,7 +108,7 @@ def get_otlp_tracer_provider() -> "TracerProvider":
 
     tracer_provider = TracerProvider(resource=resource)
 
-    otlp_exporter = OTLPSpanExporter()
+    otlp_exporter = OTLPSpanExporter(endpoint=endpoint, headers=headers)
     span_processor = BatchSpanProcessor(otlp_exporter)
     tracer_provider.add_span_processor(span_processor)
 

--- a/python/tests/unit_tests/test_otel_exporter.py
+++ b/python/tests/unit_tests/test_otel_exporter.py
@@ -1,5 +1,6 @@
 """Unit tests for OTEL exporter and span processor."""
 
+import os
 import time
 import uuid
 from unittest.mock import MagicMock, patch
@@ -101,3 +102,118 @@ def test_set_metadata_propagates_to_spans(mock_exporter_cls):
     span.set_attribute.assert_any_call("langsmith.metadata.thread_id", "t-123")
     span.set_attribute.assert_any_call("langsmith.metadata.session_id", "s-456")
     mock_inner_processor.on_start.assert_called_once_with(span, None)
+
+
+# --- Tests for get_otlp_tracer_provider ---
+
+
+def _make_mock_otel_imports():
+    """Build mock return value for _import_otel_client."""
+    MockExporter = MagicMock(name="OTLPSpanExporter")
+    MockSERVICE_NAME = "service.name"
+    MockResource = MagicMock(name="Resource")
+    MockTracerProvider = MagicMock(name="TracerProvider")
+    MockBatchSpanProcessor = MagicMock(name="BatchSpanProcessor")
+    return (
+        MockExporter,
+        MockSERVICE_NAME,
+        MockResource,
+        MockTracerProvider,
+        MockBatchSpanProcessor,
+    )
+
+
+@patch("langsmith._internal.otel._otel_client._import_otel_client")
+@patch("langsmith._internal.otel._otel_client.ls_utils")
+def test_get_otlp_tracer_provider_does_not_mutate_env(mock_utils, mock_import):
+    """Env vars must not be written by get_otlp_tracer_provider."""
+    mock_import.return_value = _make_mock_otel_imports()
+    mock_utils.get_api_url.return_value = "https://api.smith.langchain.com"
+    mock_utils.get_api_key.return_value = "lsv2_pt_test123"
+    mock_utils.get_tracer_project.return_value = "my-project"
+
+    # Snapshot env before
+    env_before = dict(os.environ)
+
+    from langsmith._internal.otel._otel_client import get_otlp_tracer_provider
+
+    get_otlp_tracer_provider()
+
+    # These specific keys must not have been added
+    assert "OTEL_EXPORTER_OTLP_ENDPOINT" not in os.environ
+    assert "OTEL_EXPORTER_OTLP_HEADERS" not in os.environ
+
+    # Restore env (safety)
+    os.environ.clear()
+    os.environ.update(env_before)
+
+
+@patch("langsmith._internal.otel._otel_client._import_otel_client")
+@patch("langsmith._internal.otel._otel_client.ls_utils")
+def test_get_otlp_tracer_provider_passes_defaults_to_exporter(mock_utils, mock_import):
+    """Default endpoint and headers are passed directly to OTLPSpanExporter."""
+    mocks = _make_mock_otel_imports()
+    mock_import.return_value = mocks
+    MockExporter = mocks[0]
+
+    mock_utils.get_api_url.return_value = "https://api.smith.langchain.com"
+    mock_utils.get_api_key.return_value = "lsv2_pt_test123"
+    mock_utils.get_tracer_project.return_value = "my-project"
+
+    from langsmith._internal.otel._otel_client import get_otlp_tracer_provider
+
+    get_otlp_tracer_provider()
+
+    MockExporter.assert_called_once_with(
+        endpoint="https://api.smith.langchain.com/otel",
+        headers={"x-api-key": "lsv2_pt_test123", "Langsmith-Project": "my-project"},
+    )
+
+
+@patch("langsmith._internal.otel._otel_client._import_otel_client")
+@patch("langsmith._internal.otel._otel_client.ls_utils")
+def test_get_otlp_tracer_provider_honors_env_overrides(mock_utils, mock_import):
+    """User-set OTEL env vars are read and passed through to the exporter."""
+    mocks = _make_mock_otel_imports()
+    mock_import.return_value = mocks
+    MockExporter = mocks[0]
+
+    env_patch = {
+        "OTEL_EXPORTER_OTLP_ENDPOINT": "https://custom-collector:4318",
+        "OTEL_EXPORTER_OTLP_HEADERS": "Authorization=Bearer custom-token",
+    }
+
+    from langsmith._internal.otel._otel_client import get_otlp_tracer_provider
+
+    with patch.dict(os.environ, env_patch):
+        get_otlp_tracer_provider()
+
+    MockExporter.assert_called_once_with(
+        endpoint="https://custom-collector:4318",
+        headers={"Authorization": "Bearer custom-token"},
+    )
+    # LangSmith utils should NOT have been called for key/endpoint
+    mock_utils.get_api_key.assert_not_called()
+    mock_utils.get_api_url.assert_not_called()
+
+
+@patch("langsmith._internal.otel._otel_client._import_otel_client")
+@patch("langsmith._internal.otel._otel_client.ls_utils")
+def test_get_otlp_tracer_provider_no_project(mock_utils, mock_import):
+    """When no project is configured, headers contain only the API key."""
+    mocks = _make_mock_otel_imports()
+    mock_import.return_value = mocks
+    MockExporter = mocks[0]
+
+    mock_utils.get_api_url.return_value = "https://api.smith.langchain.com"
+    mock_utils.get_api_key.return_value = "lsv2_pt_test123"
+    mock_utils.get_tracer_project.return_value = None
+
+    from langsmith._internal.otel._otel_client import get_otlp_tracer_provider
+
+    get_otlp_tracer_provider()
+
+    MockExporter.assert_called_once_with(
+        endpoint="https://api.smith.langchain.com/otel",
+        headers={"x-api-key": "lsv2_pt_test123"},
+    )


### PR DESCRIPTION
## Summary

- `get_otlp_tracer_provider()` was writing the LangSmith API key into `os.environ["OTEL_EXPORTER_OTLP_HEADERS"]` and the endpoint into `os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"]`, causing credential-scope pollution for other OTLP exporters in the same process
- Pass `endpoint` and `headers` directly to the `OTLPSpanExporter` constructor instead of mutating process-wide env vars
- User-set env var overrides are still honored (read, not written)

## Test plan

- [x] 4 new unit tests covering: no env mutation, default config passthrough, env var override honoring, no-project header case
- [x] Existing unit tests pass (`test_otel_exporter.py` — 8/8)
- [x] CI integration tests for OTEL tracing

Thanks @OneThing4101 for bringing this bug to our attention!