### PR TITLE
fix(js): move jest retry config to runtime setup file

### DIFF
--- a/js/jest.config.cjs
+++ b/js/jest.config.cjs
@@ -23,9 +23,10 @@ module.exports = {
     ],
   },
   setupFiles: ["dotenv/config"],
+  // Retry flaky integration tests up to 3 times. `jest.retryTimes` is a
+  // runtime API, not a config option, so it must be called from a file
+  // loaded after the test framework is installed.
+  setupFilesAfterEnv: ["<rootDir>/jest.setup.cjs"],
   testTimeout: 20_000,
   maxConcurrency: 2,
-  // Retry flaky integration tests up to 3 times
-  retryTimes: 3,
-  retryImmediately: false,
 };

--- a/js/jest.setup.cjs
+++ b/js/jest.setup.cjs
@@ -1,0 +1,1 @@
+jest.retryTimes(3, { logErrorsBeforeRetry: true });


### PR DESCRIPTION
## Summary

- Main went red after the integration test run in #2721 hit a transient 429 from the API and didn't retry.
- Jest was printing validation warnings (`Unknown option "retryTimes"`, `Unknown option "retryImmediately"`) because these were added to `jest.config.cjs` but aren't valid Jest 29 config options:
  - `retryTimes` is a runtime API (`jest.retryTimes(n)`), not a config key.
  - `retryImmediately` is a Vitest option and doesn't exist in Jest at all.
  - Jest silently ignored both, so integration tests never retried.
- Move the retry setup into a new `js/jest.setup.cjs` wired via `setupFilesAfterEnv`, calling `jest.retryTimes(3, { logErrorsBeforeRetry: true })`. `retryImmediately: false` is dropped — it has no Jest equivalent and was already a no-op.

## Test plan

- [x] Running jest against a no-match pattern no longer emits the two `Validation Warning: Unknown option` blocks.
- [x] CI integration test run on this PR completes without the validation warnings and retries a flaky rate-limited test.