### PR TITLE
feat(python): add Context class for agent/skill/file hub repos

### DIFF
--- a/python/langsmith/__init__.py
+++ b/python/langsmith/__init__.py
@@ -6,6 +6,7 @@ if TYPE_CHECKING:
     from langsmith._expect import expect
     from langsmith.async_client import AsyncClient
     from langsmith.client import Client
+    from langsmith.context import AsyncContext, Context
     from langsmith.evaluation import (
         aevaluate,
         aevaluate_existing,
@@ -145,6 +146,14 @@ def __getattr__(name: str) -> Any:
         from langsmith.prompt_cache import AsyncCache
 
         return AsyncCache
+    elif name == "Context":
+        from langsmith.context import Context
+
+        return Context
+    elif name == "AsyncContext":
+        from langsmith.context import AsyncContext
+
+        return AsyncContext
 
     elif name == "configure_global_prompt_cache":
         from langsmith.prompt_cache import configure_global_prompt_cache
@@ -162,6 +171,8 @@ def __getattr__(name: str) -> Any:
 __all__ = [
     "Client",
     "AsyncClient",
+    "Context",
+    "AsyncContext",
     "PromptCache",
     "AsyncPromptCache",
     "Cache",

--- a/python/langsmith/async_client.py
+++ b/python/langsmith/async_client.py
@@ -23,6 +23,7 @@ import httpx
 from langsmith import client as ls_client
 from langsmith import schemas as ls_schemas
 from langsmith import utils as ls_utils
+from langsmith.context import AsyncContext
 from langsmith.prompt_cache import AsyncPromptCache, async_prompt_cache_singleton
 
 ID_TYPE = Union[uuid.UUID, str]
@@ -39,6 +40,7 @@ class AsyncClient:
         "_cache",
         "_custom_headers",
         "_api_key",
+        "_context",
     )
 
     _custom_headers: dict[str, str]
@@ -134,6 +136,7 @@ class AsyncClient:
         )
         self._web_url = web_url
         self._settings: Optional[ls_schemas.LangSmithSettings] = None
+        self._context: Optional[AsyncContext] = None
 
         # Initialize prompt cache
         # Handle backwards compatibility for deprecated `cache` parameter
@@ -196,6 +199,17 @@ class AsyncClient:
     def _host_url(self) -> str:
         """The web host url."""
         return ls_utils.get_host_url(self._web_url, self._api_url)
+
+    @property
+    def context(self) -> AsyncContext:
+        """The async Hub context API for agent/skill/file operations.
+
+        Returns:
+            AsyncContext: An AsyncContext instance bound to this client.
+        """
+        if self._context is None:
+            self._context = AsyncContext(self)
+        return self._context
 
     async def _arequest_with_retries(
         self,

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -100,6 +100,7 @@ from langsmith._internal._operations import (
 )
 from langsmith._internal._serde import dumps_json as _dumps_json
 from langsmith._internal._uuid import uuid7
+from langsmith.context import Context
 from langsmith.prompt_cache import PromptCache, prompt_cache_singleton
 from langsmith.schemas import AttachmentInfo, ExampleWithRuns
 
@@ -712,6 +713,7 @@ class Client:
         "_info",
         "_write_api_urls",
         "_settings",
+        "_context",
         "_manual_cleanup",
         "_pyo3_client",
         "compressed_traces",
@@ -980,6 +982,7 @@ class Client:
             if info is None or isinstance(info, ls_schemas.LangSmithInfo)
             else ls_schemas.LangSmithInfo(**info)
         )
+        self._context = None
         weakref.finalize(self, close_session, self.session)
         atexit.register(close_session, session_)
         self.compressed_traces: Optional[CompressedTraces] = None
@@ -1417,6 +1420,17 @@ class Client:
             self._info = ls_schemas.LangSmithInfo()
 
         return self._info
+
+    @property
+    def context(self) -> Context:
+        """The Hub context API for agent/skill/file operations.
+
+        Returns:
+            Context: A Context instance bound to this client.
+        """
+        if self._context is None:
+            self._context = Context(self)
+        return self._context
 
     def _get_settings(self) -> ls_schemas.LangSmithSettings:
         """Get the settings for the current tenant.

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -982,7 +982,7 @@ class Client:
             if info is None or isinstance(info, ls_schemas.LangSmithInfo)
             else ls_schemas.LangSmithInfo(**info)
         )
-        self._context = None
+        self._context: Optional[Context] = None
         weakref.finalize(self, close_session, self.session)
         atexit.register(close_session, session_)
         self.compressed_traces: Optional[CompressedTraces] = None

--- a/python/langsmith/context.py
+++ b/python/langsmith/context.py
@@ -346,7 +346,7 @@ class Context:
         *,
         version: Optional[str],
     ) -> dict[str, Any]:
-        """Fetch the raw directory payload."""
+        """Fetch the raw directory payload, merged with owner/repo from the identifier."""
         owner, name, commit = ls_utils.parse_prompt_identifier(identifier)
         target = version if version is not None else (
             commit if commit != "latest" else None
@@ -359,7 +359,7 @@ class Context:
             f"{_PLATFORM_HUB}/{owner}/{name}/directories",
             params=params,
         )
-        return response.json()
+        return {**response.json(), "owner": owner, "repo": name}
 
     def _push_directory(
         self,
@@ -852,7 +852,7 @@ class AsyncContext:
         *,
         version: Optional[str],
     ) -> dict[str, Any]:
-        """Fetch the raw directory payload."""
+        """Fetch the raw directory payload, merged with owner/repo from the identifier."""
         owner, name, commit = ls_utils.parse_prompt_identifier(identifier)
         target = version if version is not None else (
             commit if commit != "latest" else None
@@ -865,7 +865,7 @@ class AsyncContext:
             f"{_PLATFORM_HUB}/{owner}/{name}/directories",
             params=params,
         )
-        return response.json()
+        return {**response.json(), "owner": owner, "repo": name}
 
     async def _push_directory(
         self,

--- a/python/langsmith/context.py
+++ b/python/langsmith/context.py
@@ -1,0 +1,526 @@
+"""Context class for pulling and pushing non-prompt Hub repos (agents, skills, files)."""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING, Any, Literal, Optional, Sequence
+
+from langsmith import schemas as ls_schemas
+from langsmith import utils as ls_utils
+
+if TYPE_CHECKING:
+    from langsmith.client import Client
+
+
+_RepoType = Literal["agent", "skill", "file"]
+_REPO_HANDLE_PATTERN = re.compile(r"^[a-z][a-z0-9-_]*$")
+_PLATFORM_HUB = "/api/v1/platform/hub/repos"
+_HUB = "/api/v1/hub/repos"
+
+
+class Context:
+    """Hub operations for non-prompt repos (agents, skills, files)."""
+
+    def __init__(self, client: Client) -> None:
+        """Initialize with a LangSmith client.
+
+        Args:
+            client: The LangSmith client instance.
+        """
+        self._client = client
+
+    def pull_agent(
+        self,
+        identifier: str,
+        *,
+        version: Optional[str] = None,
+    ) -> ls_schemas.AgentContext:
+        """Pull an agent from Hub.
+
+        Args:
+            identifier: The identifier of the agent (owner/name:hash, owner/name, or name).
+            version: The commit hash or tag to pull. Overrides the hash in the identifier.
+
+        Returns:
+            AgentContext: The agent snapshot.
+
+        Raises:
+            HTTPError: If the server request fails.
+        """
+        data = self._pull_directory(identifier, version=version)
+        return ls_schemas.AgentContext.model_validate(data)
+
+    def pull_skill(
+        self,
+        identifier: str,
+        *,
+        version: Optional[str] = None,
+    ) -> ls_schemas.SkillContext:
+        """Pull a skill from Hub.
+
+        Args:
+            identifier: The identifier of the skill.
+            version: The commit hash or tag to pull.
+
+        Returns:
+            SkillContext: The skill snapshot.
+
+        Raises:
+            HTTPError: If the server request fails.
+        """
+        data = self._pull_directory(identifier, version=version)
+        return ls_schemas.SkillContext.model_validate(data)
+
+    def pull_file(
+        self,
+        identifier: str,
+        *,
+        version: Optional[str] = None,
+    ) -> ls_schemas.FileContext:
+        """Pull a file repo from Hub.
+
+        Args:
+            identifier: The identifier of the file repo.
+            version: The commit hash or tag to pull.
+
+        Returns:
+            FileContext: The file repo snapshot.
+
+        Raises:
+            HTTPError: If the server request fails.
+        """
+        data = self._pull_directory(identifier, version=version)
+        return ls_schemas.FileContext.model_validate(data)
+
+    def push_agent(
+        self,
+        identifier: str,
+        *,
+        files: dict[str, Optional[ls_schemas.Entry]],
+        parent_commit: Optional[str] = None,
+        description: Optional[str] = None,
+        readme: Optional[str] = None,
+        tags: Optional[Sequence[str]] = None,
+        is_public: Optional[bool] = None,
+    ) -> str:
+        """Push an agent to Hub.
+
+        Creates the repo if it does not exist, updates metadata if provided,
+        then creates a new commit with the given files.
+
+        Args:
+            identifier: The identifier of the agent.
+            files: Map of path to entry. A value of None deletes the path.
+            parent_commit: The parent commit hash (8-64 hex chars) for optimistic
+                concurrency. When omitted, the server uses the current latest.
+            description: Repo description to set on create or update.
+            readme: Repo readme to set on create or update.
+            tags: Repo tags to set on create or update.
+            is_public: Whether the repo is public.
+
+        Returns:
+            str: The url of the agent commit.
+
+        Raises:
+            HTTPError: If the server request fails.
+            LangSmithUserError: If validation fails.
+        """
+        return self._push_directory(
+            identifier,
+            "agent",
+            files=files,
+            parent_commit=parent_commit,
+            description=description,
+            readme=readme,
+            tags=tags,
+            is_public=is_public,
+        )
+
+    def push_skill(
+        self,
+        identifier: str,
+        *,
+        files: dict[str, Optional[ls_schemas.Entry]],
+        parent_commit: Optional[str] = None,
+        description: Optional[str] = None,
+        readme: Optional[str] = None,
+        tags: Optional[Sequence[str]] = None,
+        is_public: Optional[bool] = None,
+    ) -> str:
+        """Push a skill to Hub.
+
+        Args:
+            identifier: The identifier of the skill.
+            files: Map of path to entry. A value of None deletes the path.
+            parent_commit: The parent commit hash for optimistic concurrency.
+            description: Repo description to set on create or update.
+            readme: Repo readme to set on create or update.
+            tags: Repo tags to set on create or update.
+            is_public: Whether the repo is public.
+
+        Returns:
+            str: The url of the skill commit.
+
+        Raises:
+            HTTPError: If the server request fails.
+            LangSmithUserError: If validation fails.
+        """
+        return self._push_directory(
+            identifier,
+            "skill",
+            files=files,
+            parent_commit=parent_commit,
+            description=description,
+            readme=readme,
+            tags=tags,
+            is_public=is_public,
+        )
+
+    def push_file(
+        self,
+        identifier: str,
+        *,
+        files: dict[str, Optional[ls_schemas.FileEntry]],
+        parent_commit: Optional[str] = None,
+        description: Optional[str] = None,
+        readme: Optional[str] = None,
+        tags: Optional[Sequence[str]] = None,
+        is_public: Optional[bool] = None,
+    ) -> str:
+        """Push a file repo to Hub.
+
+        Args:
+            identifier: The identifier of the file repo.
+            files: Map of path to file entry. A value of None deletes the path.
+            parent_commit: The parent commit hash for optimistic concurrency.
+            description: Repo description to set on create or update.
+            readme: Repo readme to set on create or update.
+            tags: Repo tags to set on create or update.
+            is_public: Whether the repo is public.
+
+        Returns:
+            str: The url of the file repo commit.
+
+        Raises:
+            HTTPError: If the server request fails.
+            LangSmithUserError: If validation fails.
+        """
+        return self._push_directory(
+            identifier,
+            "file",
+            files=files,
+            parent_commit=parent_commit,
+            description=description,
+            readme=readme,
+            tags=tags,
+            is_public=is_public,
+        )
+
+    def delete_agent(self, identifier: str) -> None:
+        """Delete an agent and all its owned child file repos.
+
+        Args:
+            identifier: The identifier of the agent.
+
+        Raises:
+            HTTPError: If the server request fails.
+        """
+        self._delete_directory(identifier)
+
+    def delete_skill(self, identifier: str) -> None:
+        """Delete a skill and all its owned child file repos.
+
+        Args:
+            identifier: The identifier of the skill.
+
+        Raises:
+            HTTPError: If the server request fails.
+        """
+        self._delete_directory(identifier)
+
+    def delete_file(self, identifier: str) -> None:
+        """Delete a file repo.
+
+        Args:
+            identifier: The identifier of the file repo.
+
+        Raises:
+            HTTPError: If the server request fails.
+        """
+        self._delete_directory(identifier)
+
+    def list_agents(
+        self,
+        *,
+        limit: int = 100,
+        offset: int = 0,
+        is_public: Optional[bool] = None,
+        is_archived: Optional[bool] = False,
+        query: Optional[str] = None,
+    ) -> ls_schemas.ListPromptsResponse:
+        """List agents with pagination.
+
+        Args:
+            limit: The maximum number to return.
+            offset: The number to skip.
+            is_public: Filter by public status.
+            is_archived: Filter by archived status.
+            query: Filter by a search query.
+
+        Returns:
+            ListPromptsResponse: A response containing the list of agents.
+        """
+        return self._list_repos(
+            "agent",
+            limit=limit,
+            offset=offset,
+            is_public=is_public,
+            is_archived=is_archived,
+            query=query,
+        )
+
+    def list_skills(
+        self,
+        *,
+        limit: int = 100,
+        offset: int = 0,
+        is_public: Optional[bool] = None,
+        is_archived: Optional[bool] = False,
+        query: Optional[str] = None,
+    ) -> ls_schemas.ListPromptsResponse:
+        """List skills with pagination.
+
+        Args:
+            limit: The maximum number to return.
+            offset: The number to skip.
+            is_public: Filter by public status.
+            is_archived: Filter by archived status.
+            query: Filter by a search query.
+
+        Returns:
+            ListPromptsResponse: A response containing the list of skills.
+        """
+        return self._list_repos(
+            "skill",
+            limit=limit,
+            offset=offset,
+            is_public=is_public,
+            is_archived=is_archived,
+            query=query,
+        )
+
+    def list_files(
+        self,
+        *,
+        limit: int = 100,
+        offset: int = 0,
+        is_public: Optional[bool] = None,
+        is_archived: Optional[bool] = False,
+        query: Optional[str] = None,
+    ) -> ls_schemas.ListPromptsResponse:
+        """List file repos with pagination.
+
+        Args:
+            limit: The maximum number to return.
+            offset: The number to skip.
+            is_public: Filter by public status.
+            is_archived: Filter by archived status.
+            query: Filter by a search query.
+
+        Returns:
+            ListPromptsResponse: A response containing the list of file repos.
+        """
+        return self._list_repos(
+            "file",
+            limit=limit,
+            offset=offset,
+            is_public=is_public,
+            is_archived=is_archived,
+            query=query,
+        )
+
+    def _pull_directory(
+        self,
+        identifier: str,
+        *,
+        version: Optional[str],
+    ) -> dict[str, Any]:
+        """Fetch the raw directory payload."""
+        owner, name, commit = ls_utils.parse_prompt_identifier(identifier)
+        target = version if version is not None else (
+            commit if commit != "latest" else None
+        )
+        params: dict[str, Any] = {}
+        if target:
+            params["commit"] = target
+        response = self._client.request_with_retries(
+            "GET",
+            f"{_PLATFORM_HUB}/{owner}/{name}/directories",
+            params=params,
+        )
+        return response.json()
+
+    def _push_directory(
+        self,
+        identifier: str,
+        repo_type: _RepoType,
+        *,
+        files: dict[str, Any],
+        parent_commit: Optional[str],
+        description: Optional[str],
+        readme: Optional[str],
+        tags: Optional[Sequence[str]],
+        is_public: Optional[bool],
+    ) -> str:
+        """Create a directory commit, creating the repo if it does not exist."""
+        if len(files) > ls_schemas.MAX_CONTEXT_ENTRIES:
+            raise ls_utils.LangSmithUserError(
+                f"Too many files ({len(files)}); max is {ls_schemas.MAX_CONTEXT_ENTRIES}."
+            )
+        if parent_commit is not None and not (8 <= len(parent_commit) <= 64):
+            raise ls_utils.LangSmithUserError(
+                "parent_commit must be 8-64 characters."
+            )
+
+        owner, name, _ = ls_utils.parse_prompt_identifier(identifier)
+        if not self._client._current_tenant_is_owner(owner):
+            raise self._client._owner_conflict_error(f"push {repo_type}", owner)
+
+        if self._repo_exists(owner, name):
+            if any(v is not None for v in (description, readme, tags, is_public)):
+                self._update_repo_metadata(
+                    owner,
+                    name,
+                    description=description,
+                    readme=readme,
+                    tags=tags,
+                    is_public=is_public,
+                )
+        else:
+            if not _REPO_HANDLE_PATTERN.match(name):
+                raise ls_utils.LangSmithUserError(
+                    f"Invalid repo_handle {name!r}: must match {_REPO_HANDLE_PATTERN.pattern}."
+                )
+            self._create_repo(
+                name,
+                repo_type,
+                description=description,
+                readme=readme,
+                tags=tags,
+                is_public=bool(is_public),
+            )
+
+        request_files: dict[str, Optional[dict[str, Any]]] = {}
+        for path, entry in files.items():
+            if entry is None:
+                request_files[path] = None
+            else:
+                request_files[path] = entry.model_dump(exclude_none=True)
+
+        body: dict[str, Any] = {"files": request_files}
+        if parent_commit is not None:
+            body["parent_commit"] = parent_commit
+
+        response = self._client.request_with_retries(
+            "POST",
+            f"{_PLATFORM_HUB}/{owner}/{name}/directories/commits",
+            json=body,
+        )
+        commit_hash = response.json()["commit"]["commit_hash"]
+        return self._get_context_url(owner, name, commit_hash)
+
+    def _delete_directory(self, identifier: str) -> None:
+        """Delete a directory repo."""
+        owner, name, _ = ls_utils.parse_prompt_identifier(identifier)
+        if not self._client._current_tenant_is_owner(owner):
+            raise self._client._owner_conflict_error("delete", owner)
+        self._client.request_with_retries(
+            "DELETE",
+            f"{_PLATFORM_HUB}/{owner}/{name}/directories",
+        )
+
+    def _list_repos(
+        self,
+        repo_type: _RepoType,
+        *,
+        limit: int,
+        offset: int,
+        is_public: Optional[bool],
+        is_archived: Optional[bool],
+        query: Optional[str],
+    ) -> ls_schemas.ListPromptsResponse:
+        """List repos filtered by type."""
+        params: dict[str, Any] = {
+            "limit": limit,
+            "offset": offset,
+            "repo_type": repo_type,
+            "is_archived": "true" if is_archived else "false",
+        }
+        if is_public is not None:
+            params["is_public"] = "true" if is_public else "false"
+        if query:
+            params["query"] = query
+            params["match_prefix"] = "true"
+        response = self._client.request_with_retries("GET", _HUB, params=params)
+        return ls_schemas.ListPromptsResponse(**response.json())
+
+    def _repo_exists(self, owner: str, name: str) -> bool:
+        """Check if a repo exists."""
+        try:
+            self._client.request_with_retries("GET", f"{_HUB}/{owner}/{name}")
+            return True
+        except ls_utils.LangSmithNotFoundError:
+            return False
+
+    def _create_repo(
+        self,
+        name: str,
+        repo_type: _RepoType,
+        *,
+        description: Optional[str],
+        readme: Optional[str],
+        tags: Optional[Sequence[str]],
+        is_public: bool,
+    ) -> None:
+        """Create a new repo of the given type."""
+        body: dict[str, Any] = {
+            "repo_handle": name,
+            "repo_type": repo_type,
+            "is_public": is_public,
+        }
+        if description is not None:
+            body["description"] = description
+        if readme is not None:
+            body["readme"] = readme
+        if tags is not None:
+            body["tags"] = list(tags)
+        self._client.request_with_retries("POST", f"{_PLATFORM_HUB}/", json=body)
+
+    def _update_repo_metadata(
+        self,
+        owner: str,
+        name: str,
+        *,
+        description: Optional[str],
+        readme: Optional[str],
+        tags: Optional[Sequence[str]],
+        is_public: Optional[bool],
+    ) -> None:
+        """Patch repo metadata fields that were explicitly provided."""
+        body: dict[str, Any] = {}
+        if description is not None:
+            body["description"] = description
+        if readme is not None:
+            body["readme"] = readme
+        if tags is not None:
+            body["tags"] = list(tags)
+        if is_public is not None:
+            body["is_public"] = is_public
+        if body:
+            self._client.request_with_retries(
+                "PATCH", f"{_HUB}/{owner}/{name}", json=body
+            )
+
+    def _get_context_url(self, owner: str, name: str, commit_hash: str) -> str:
+        """Build a URL for a pushed context commit."""
+        return f"{self._client._host_url}/hub/{owner}/{name}:{commit_hash[:8]}"

--- a/python/langsmith/context.py
+++ b/python/langsmith/context.py
@@ -497,7 +497,7 @@ class Context:
         if tags is not None:
             body["tags"] = list(tags)
         try:
-            self._client.request_with_retries("POST", "/api/v1/repos/", json=body)
+            self._client.request_with_retries("POST", "/repos/", json=body)
         except ls_utils.LangSmithConflictError:
             pass
 
@@ -1004,9 +1004,7 @@ class AsyncContext:
         if tags is not None:
             body["tags"] = list(tags)
         try:
-            await self._client._arequest_with_retries(
-                "POST", "/api/v1/repos/", json=body
-            )
+            await self._client._arequest_with_retries("POST", "/repos/", json=body)
         except ls_utils.LangSmithConflictError:
             pass
 

--- a/python/langsmith/context.py
+++ b/python/langsmith/context.py
@@ -496,7 +496,10 @@ class Context:
             body["readme"] = readme
         if tags is not None:
             body["tags"] = list(tags)
-        self._client.request_with_retries("POST", "/api/v1/repos/", json=body)
+        try:
+            self._client.request_with_retries("POST", "/api/v1/repos/", json=body)
+        except ls_utils.LangSmithConflictError:
+            pass
 
     def _update_repo_metadata(
         self,
@@ -1000,7 +1003,12 @@ class AsyncContext:
             body["readme"] = readme
         if tags is not None:
             body["tags"] = list(tags)
-        await self._client._arequest_with_retries("POST", "/api/v1/repos/", json=body)
+        try:
+            await self._client._arequest_with_retries(
+                "POST", "/api/v1/repos/", json=body
+            )
+        except ls_utils.LangSmithConflictError:
+            pass
 
     async def _update_repo_metadata(
         self,

--- a/python/langsmith/context.py
+++ b/python/langsmith/context.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 
 _RepoType = Literal["agent", "skill", "file"]
 _REPO_HANDLE_PATTERN = re.compile(r"^[a-z][a-z0-9-_]*$")
-_PLATFORM_HUB = "/api/v1/platform/hub/repos"
+_PLATFORM_HUB = "/v1/platform/hub/repos"
 _HUB = "/api/v1/hub/repos"
 
 

--- a/python/langsmith/context.py
+++ b/python/langsmith/context.py
@@ -349,8 +349,8 @@ class Context:
     ) -> dict[str, Any]:
         """Fetch directory payload, merged with owner/repo from identifier."""
         owner, name, commit = ls_utils.parse_prompt_identifier(identifier)
-        target = version if version is not None else (
-            commit if commit != "latest" else None
+        target = (
+            version if version is not None else (commit if commit != "latest" else None)
         )
         params: dict[str, Any] = {}
         if target:
@@ -381,9 +381,7 @@ class Context:
                 f"max is {ls_schemas.MAX_CONTEXT_ENTRIES}."
             )
         if parent_commit is not None and not (8 <= len(parent_commit) <= 64):
-            raise ls_utils.LangSmithUserError(
-                "parent_commit must be 8-64 characters."
-            )
+            raise ls_utils.LangSmithUserError("parent_commit must be 8-64 characters.")
 
         owner, name, _ = ls_utils.parse_prompt_identifier(identifier)
         if not self._client._current_tenant_is_owner(owner):
@@ -855,8 +853,8 @@ class AsyncContext:
     ) -> dict[str, Any]:
         """Fetch directory payload, merged with owner/repo from identifier."""
         owner, name, commit = ls_utils.parse_prompt_identifier(identifier)
-        target = version if version is not None else (
-            commit if commit != "latest" else None
+        target = (
+            version if version is not None else (commit if commit != "latest" else None)
         )
         params: dict[str, Any] = {}
         if target:
@@ -887,15 +885,11 @@ class AsyncContext:
                 f"max is {ls_schemas.MAX_CONTEXT_ENTRIES}."
             )
         if parent_commit is not None and not (8 <= len(parent_commit) <= 64):
-            raise ls_utils.LangSmithUserError(
-                "parent_commit must be 8-64 characters."
-            )
+            raise ls_utils.LangSmithUserError("parent_commit must be 8-64 characters.")
 
         owner, name, _ = ls_utils.parse_prompt_identifier(identifier)
         if not (await self._client._current_tenant_is_owner(owner)):
-            raise (
-                await self._client._owner_conflict_error(f"push {repo_type}", owner)
-            )
+            raise (await self._client._owner_conflict_error(f"push {repo_type}", owner))
 
         if await self._repo_exists(owner, name):
             if any(v is not None for v in (description, readme, tags, is_public)):
@@ -973,17 +967,13 @@ class AsyncContext:
         if query:
             params["query"] = query
             params["match_prefix"] = "true"
-        response = await self._client._arequest_with_retries(
-            "GET", _HUB, params=params
-        )
+        response = await self._client._arequest_with_retries("GET", _HUB, params=params)
         return ls_schemas.ListPromptsResponse(**response.json())
 
     async def _repo_exists(self, owner: str, name: str) -> bool:
         """Check if a repo exists."""
         try:
-            await self._client._arequest_with_retries(
-                "GET", f"{_HUB}/{owner}/{name}"
-            )
+            await self._client._arequest_with_retries("GET", f"{_HUB}/{owner}/{name}")
             return True
         except ls_utils.LangSmithNotFoundError:
             return False

--- a/python/langsmith/context.py
+++ b/python/langsmith/context.py
@@ -9,6 +9,7 @@ from langsmith import schemas as ls_schemas
 from langsmith import utils as ls_utils
 
 if TYPE_CHECKING:
+    from langsmith.async_client import AsyncClient
     from langsmith.client import Client
 
 
@@ -375,7 +376,8 @@ class Context:
         """Create a directory commit, creating the repo if it does not exist."""
         if len(files) > ls_schemas.MAX_CONTEXT_ENTRIES:
             raise ls_utils.LangSmithUserError(
-                f"Too many files ({len(files)}); max is {ls_schemas.MAX_CONTEXT_ENTRIES}."
+                f"Too many files ({len(files)}); "
+                f"max is {ls_schemas.MAX_CONTEXT_ENTRIES}."
             )
         if parent_commit is not None and not (8 <= len(parent_commit) <= 64):
             raise ls_utils.LangSmithUserError(
@@ -399,7 +401,8 @@ class Context:
         else:
             if not _REPO_HANDLE_PATTERN.match(name):
                 raise ls_utils.LangSmithUserError(
-                    f"Invalid repo_handle {name!r}: must match {_REPO_HANDLE_PATTERN.pattern}."
+                    f"Invalid repo_handle {name!r}: "
+                    f"must match {_REPO_HANDLE_PATTERN.pattern}."
                 )
             self._create_repo(
                 name,
@@ -518,6 +521,520 @@ class Context:
             body["is_public"] = is_public
         if body:
             self._client.request_with_retries(
+                "PATCH", f"{_HUB}/{owner}/{name}", json=body
+            )
+
+    def _get_context_url(self, owner: str, name: str, commit_hash: str) -> str:
+        """Build a URL for a pushed context commit."""
+        return f"{self._client._host_url}/hub/{owner}/{name}:{commit_hash[:8]}"
+
+
+class AsyncContext:
+    """Async Hub operations for non-prompt repos (agents, skills, files)."""
+
+    def __init__(self, client: AsyncClient) -> None:
+        """Initialize with an async LangSmith client.
+
+        Args:
+            client: The AsyncClient instance.
+        """
+        self._client = client
+
+    async def pull_agent(
+        self,
+        identifier: str,
+        *,
+        version: Optional[str] = None,
+    ) -> ls_schemas.AgentContext:
+        """Pull an agent from Hub.
+
+        Args:
+            identifier: The identifier of the agent.
+            version: The commit hash or tag to pull.
+
+        Returns:
+            AgentContext: The agent snapshot.
+
+        Raises:
+            HTTPError: If the server request fails.
+        """
+        data = await self._pull_directory(identifier, version=version)
+        return ls_schemas.AgentContext.model_validate(data)
+
+    async def pull_skill(
+        self,
+        identifier: str,
+        *,
+        version: Optional[str] = None,
+    ) -> ls_schemas.SkillContext:
+        """Pull a skill from Hub.
+
+        Args:
+            identifier: The identifier of the skill.
+            version: The commit hash or tag to pull.
+
+        Returns:
+            SkillContext: The skill snapshot.
+
+        Raises:
+            HTTPError: If the server request fails.
+        """
+        data = await self._pull_directory(identifier, version=version)
+        return ls_schemas.SkillContext.model_validate(data)
+
+    async def pull_file(
+        self,
+        identifier: str,
+        *,
+        version: Optional[str] = None,
+    ) -> ls_schemas.FileContext:
+        """Pull a file repo from Hub.
+
+        Args:
+            identifier: The identifier of the file repo.
+            version: The commit hash or tag to pull.
+
+        Returns:
+            FileContext: The file repo snapshot.
+
+        Raises:
+            HTTPError: If the server request fails.
+        """
+        data = await self._pull_directory(identifier, version=version)
+        return ls_schemas.FileContext.model_validate(data)
+
+    async def push_agent(
+        self,
+        identifier: str,
+        *,
+        files: dict[str, Optional[ls_schemas.Entry]],
+        parent_commit: Optional[str] = None,
+        description: Optional[str] = None,
+        readme: Optional[str] = None,
+        tags: Optional[Sequence[str]] = None,
+        is_public: Optional[bool] = None,
+    ) -> str:
+        """Push an agent to Hub.
+
+        Args:
+            identifier: The identifier of the agent.
+            files: Map of path to entry. None value deletes the path.
+            parent_commit: The parent commit hash for optimistic concurrency.
+            description: Repo description to set on create or update.
+            readme: Repo readme to set on create or update.
+            tags: Repo tags to set on create or update.
+            is_public: Whether the repo is public.
+
+        Returns:
+            str: The url of the agent commit.
+
+        Raises:
+            HTTPError: If the server request fails.
+            LangSmithUserError: If validation fails.
+        """
+        return await self._push_directory(
+            identifier,
+            "agent",
+            files=files,
+            parent_commit=parent_commit,
+            description=description,
+            readme=readme,
+            tags=tags,
+            is_public=is_public,
+        )
+
+    async def push_skill(
+        self,
+        identifier: str,
+        *,
+        files: dict[str, Optional[ls_schemas.Entry]],
+        parent_commit: Optional[str] = None,
+        description: Optional[str] = None,
+        readme: Optional[str] = None,
+        tags: Optional[Sequence[str]] = None,
+        is_public: Optional[bool] = None,
+    ) -> str:
+        """Push a skill to Hub.
+
+        Args:
+            identifier: The identifier of the skill.
+            files: Map of path to entry. None value deletes the path.
+            parent_commit: The parent commit hash for optimistic concurrency.
+            description: Repo description to set on create or update.
+            readme: Repo readme to set on create or update.
+            tags: Repo tags to set on create or update.
+            is_public: Whether the repo is public.
+
+        Returns:
+            str: The url of the skill commit.
+
+        Raises:
+            HTTPError: If the server request fails.
+            LangSmithUserError: If validation fails.
+        """
+        return await self._push_directory(
+            identifier,
+            "skill",
+            files=files,
+            parent_commit=parent_commit,
+            description=description,
+            readme=readme,
+            tags=tags,
+            is_public=is_public,
+        )
+
+    async def push_file(
+        self,
+        identifier: str,
+        *,
+        files: dict[str, Optional[ls_schemas.FileEntry]],
+        parent_commit: Optional[str] = None,
+        description: Optional[str] = None,
+        readme: Optional[str] = None,
+        tags: Optional[Sequence[str]] = None,
+        is_public: Optional[bool] = None,
+    ) -> str:
+        """Push a file repo to Hub.
+
+        Args:
+            identifier: The identifier of the file repo.
+            files: Map of path to file entry. None value deletes the path.
+            parent_commit: The parent commit hash for optimistic concurrency.
+            description: Repo description to set on create or update.
+            readme: Repo readme to set on create or update.
+            tags: Repo tags to set on create or update.
+            is_public: Whether the repo is public.
+
+        Returns:
+            str: The url of the file repo commit.
+
+        Raises:
+            HTTPError: If the server request fails.
+            LangSmithUserError: If validation fails.
+        """
+        return await self._push_directory(
+            identifier,
+            "file",
+            files=files,
+            parent_commit=parent_commit,
+            description=description,
+            readme=readme,
+            tags=tags,
+            is_public=is_public,
+        )
+
+    async def delete_agent(self, identifier: str) -> None:
+        """Delete an agent and all its owned child file repos.
+
+        Args:
+            identifier: The identifier of the agent.
+
+        Raises:
+            HTTPError: If the server request fails.
+        """
+        await self._delete_directory(identifier)
+
+    async def delete_skill(self, identifier: str) -> None:
+        """Delete a skill and all its owned child file repos.
+
+        Args:
+            identifier: The identifier of the skill.
+
+        Raises:
+            HTTPError: If the server request fails.
+        """
+        await self._delete_directory(identifier)
+
+    async def delete_file(self, identifier: str) -> None:
+        """Delete a file repo.
+
+        Args:
+            identifier: The identifier of the file repo.
+
+        Raises:
+            HTTPError: If the server request fails.
+        """
+        await self._delete_directory(identifier)
+
+    async def list_agents(
+        self,
+        *,
+        limit: int = 100,
+        offset: int = 0,
+        is_public: Optional[bool] = None,
+        is_archived: Optional[bool] = False,
+        query: Optional[str] = None,
+    ) -> ls_schemas.ListPromptsResponse:
+        """List agents with pagination.
+
+        Args:
+            limit: The maximum number to return.
+            offset: The number to skip.
+            is_public: Filter by public status.
+            is_archived: Filter by archived status.
+            query: Filter by a search query.
+
+        Returns:
+            ListPromptsResponse: A response containing the list of agents.
+        """
+        return await self._list_repos(
+            "agent",
+            limit=limit,
+            offset=offset,
+            is_public=is_public,
+            is_archived=is_archived,
+            query=query,
+        )
+
+    async def list_skills(
+        self,
+        *,
+        limit: int = 100,
+        offset: int = 0,
+        is_public: Optional[bool] = None,
+        is_archived: Optional[bool] = False,
+        query: Optional[str] = None,
+    ) -> ls_schemas.ListPromptsResponse:
+        """List skills with pagination.
+
+        Args:
+            limit: The maximum number to return.
+            offset: The number to skip.
+            is_public: Filter by public status.
+            is_archived: Filter by archived status.
+            query: Filter by a search query.
+
+        Returns:
+            ListPromptsResponse: A response containing the list of skills.
+        """
+        return await self._list_repos(
+            "skill",
+            limit=limit,
+            offset=offset,
+            is_public=is_public,
+            is_archived=is_archived,
+            query=query,
+        )
+
+    async def list_files(
+        self,
+        *,
+        limit: int = 100,
+        offset: int = 0,
+        is_public: Optional[bool] = None,
+        is_archived: Optional[bool] = False,
+        query: Optional[str] = None,
+    ) -> ls_schemas.ListPromptsResponse:
+        """List file repos with pagination.
+
+        Args:
+            limit: The maximum number to return.
+            offset: The number to skip.
+            is_public: Filter by public status.
+            is_archived: Filter by archived status.
+            query: Filter by a search query.
+
+        Returns:
+            ListPromptsResponse: A response containing the list of file repos.
+        """
+        return await self._list_repos(
+            "file",
+            limit=limit,
+            offset=offset,
+            is_public=is_public,
+            is_archived=is_archived,
+            query=query,
+        )
+
+    async def _pull_directory(
+        self,
+        identifier: str,
+        *,
+        version: Optional[str],
+    ) -> dict[str, Any]:
+        """Fetch the raw directory payload."""
+        owner, name, commit = ls_utils.parse_prompt_identifier(identifier)
+        target = version if version is not None else (
+            commit if commit != "latest" else None
+        )
+        params: dict[str, Any] = {}
+        if target:
+            params["commit"] = target
+        response = await self._client._arequest_with_retries(
+            "GET",
+            f"{_PLATFORM_HUB}/{owner}/{name}/directories",
+            params=params,
+        )
+        return response.json()
+
+    async def _push_directory(
+        self,
+        identifier: str,
+        repo_type: _RepoType,
+        *,
+        files: dict[str, Any],
+        parent_commit: Optional[str],
+        description: Optional[str],
+        readme: Optional[str],
+        tags: Optional[Sequence[str]],
+        is_public: Optional[bool],
+    ) -> str:
+        """Create a directory commit, creating the repo if it does not exist."""
+        if len(files) > ls_schemas.MAX_CONTEXT_ENTRIES:
+            raise ls_utils.LangSmithUserError(
+                f"Too many files ({len(files)}); "
+                f"max is {ls_schemas.MAX_CONTEXT_ENTRIES}."
+            )
+        if parent_commit is not None and not (8 <= len(parent_commit) <= 64):
+            raise ls_utils.LangSmithUserError(
+                "parent_commit must be 8-64 characters."
+            )
+
+        owner, name, _ = ls_utils.parse_prompt_identifier(identifier)
+        if not (await self._client._current_tenant_is_owner(owner)):
+            raise (
+                await self._client._owner_conflict_error(f"push {repo_type}", owner)
+            )
+
+        if await self._repo_exists(owner, name):
+            if any(v is not None for v in (description, readme, tags, is_public)):
+                await self._update_repo_metadata(
+                    owner,
+                    name,
+                    description=description,
+                    readme=readme,
+                    tags=tags,
+                    is_public=is_public,
+                )
+        else:
+            if not _REPO_HANDLE_PATTERN.match(name):
+                raise ls_utils.LangSmithUserError(
+                    f"Invalid repo_handle {name!r}: "
+                    f"must match {_REPO_HANDLE_PATTERN.pattern}."
+                )
+            await self._create_repo(
+                name,
+                repo_type,
+                description=description,
+                readme=readme,
+                tags=tags,
+                is_public=bool(is_public),
+            )
+
+        request_files: dict[str, Optional[dict[str, Any]]] = {}
+        for path, entry in files.items():
+            if entry is None:
+                request_files[path] = None
+            else:
+                request_files[path] = entry.model_dump(exclude_none=True)
+
+        body: dict[str, Any] = {"files": request_files}
+        if parent_commit is not None:
+            body["parent_commit"] = parent_commit
+
+        response = await self._client._arequest_with_retries(
+            "POST",
+            f"{_PLATFORM_HUB}/{owner}/{name}/directories/commits",
+            json=body,
+        )
+        commit_hash = response.json()["commit"]["commit_hash"]
+        return self._get_context_url(owner, name, commit_hash)
+
+    async def _delete_directory(self, identifier: str) -> None:
+        """Delete a directory repo."""
+        owner, name, _ = ls_utils.parse_prompt_identifier(identifier)
+        if not (await self._client._current_tenant_is_owner(owner)):
+            raise (await self._client._owner_conflict_error("delete", owner))
+        await self._client._arequest_with_retries(
+            "DELETE",
+            f"{_PLATFORM_HUB}/{owner}/{name}/directories",
+        )
+
+    async def _list_repos(
+        self,
+        repo_type: _RepoType,
+        *,
+        limit: int,
+        offset: int,
+        is_public: Optional[bool],
+        is_archived: Optional[bool],
+        query: Optional[str],
+    ) -> ls_schemas.ListPromptsResponse:
+        """List repos filtered by type."""
+        params: dict[str, Any] = {
+            "limit": limit,
+            "offset": offset,
+            "repo_type": repo_type,
+            "is_archived": "true" if is_archived else "false",
+        }
+        if is_public is not None:
+            params["is_public"] = "true" if is_public else "false"
+        if query:
+            params["query"] = query
+            params["match_prefix"] = "true"
+        response = await self._client._arequest_with_retries(
+            "GET", _HUB, params=params
+        )
+        return ls_schemas.ListPromptsResponse(**response.json())
+
+    async def _repo_exists(self, owner: str, name: str) -> bool:
+        """Check if a repo exists."""
+        try:
+            await self._client._arequest_with_retries(
+                "GET", f"{_HUB}/{owner}/{name}"
+            )
+            return True
+        except ls_utils.LangSmithNotFoundError:
+            return False
+
+    async def _create_repo(
+        self,
+        name: str,
+        repo_type: _RepoType,
+        *,
+        description: Optional[str],
+        readme: Optional[str],
+        tags: Optional[Sequence[str]],
+        is_public: bool,
+    ) -> None:
+        """Create a new repo of the given type."""
+        body: dict[str, Any] = {
+            "repo_handle": name,
+            "repo_type": repo_type,
+            "is_public": is_public,
+        }
+        if description is not None:
+            body["description"] = description
+        if readme is not None:
+            body["readme"] = readme
+        if tags is not None:
+            body["tags"] = list(tags)
+        await self._client._arequest_with_retries(
+            "POST", f"{_PLATFORM_HUB}/", json=body
+        )
+
+    async def _update_repo_metadata(
+        self,
+        owner: str,
+        name: str,
+        *,
+        description: Optional[str],
+        readme: Optional[str],
+        tags: Optional[Sequence[str]],
+        is_public: Optional[bool],
+    ) -> None:
+        """Patch repo metadata fields that were explicitly provided."""
+        body: dict[str, Any] = {}
+        if description is not None:
+            body["description"] = description
+        if readme is not None:
+            body["readme"] = readme
+        if tags is not None:
+            body["tags"] = list(tags)
+        if is_public is not None:
+            body["is_public"] = is_public
+        if body:
+            await self._client._arequest_with_retries(
                 "PATCH", f"{_HUB}/{owner}/{name}", json=body
             )
 

--- a/python/langsmith/context.py
+++ b/python/langsmith/context.py
@@ -1000,9 +1000,7 @@ class AsyncContext:
             body["readme"] = readme
         if tags is not None:
             body["tags"] = list(tags)
-        await self._client._arequest_with_retries(
-            "POST", "/api/v1/repos/", json=body
-        )
+        await self._client._arequest_with_retries("POST", "/api/v1/repos/", json=body)
 
     async def _update_repo_metadata(
         self,

--- a/python/langsmith/context.py
+++ b/python/langsmith/context.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 _RepoType = Literal["agent", "skill", "file"]
 _REPO_HANDLE_PATTERN = re.compile(r"^[a-z][a-z0-9-_]*$")
 _PLATFORM_HUB = "/v1/platform/hub/repos"
-_HUB = "/api/v1/hub/repos"
+_HUB = "/repos"
 
 
 class Context:

--- a/python/langsmith/context.py
+++ b/python/langsmith/context.py
@@ -1,9 +1,10 @@
-"""Context class for pulling and pushing non-prompt Hub repos (agents, skills, files)."""
+"""Context class for non-prompt Hub repos (agents, skills, files)."""
 
 from __future__ import annotations
 
 import re
-from typing import TYPE_CHECKING, Any, Literal, Optional, Sequence
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Any, Literal, Optional
 
 from langsmith import schemas as ls_schemas
 from langsmith import utils as ls_utils
@@ -39,8 +40,8 @@ class Context:
         """Pull an agent from Hub.
 
         Args:
-            identifier: The identifier of the agent (owner/name:hash, owner/name, or name).
-            version: The commit hash or tag to pull. Overrides the hash in the identifier.
+            identifier: The identifier (owner/name:hash, owner/name, or name).
+            version: Commit hash or tag to pull. Overrides the identifier hash.
 
         Returns:
             AgentContext: The agent snapshot.
@@ -346,7 +347,7 @@ class Context:
         *,
         version: Optional[str],
     ) -> dict[str, Any]:
-        """Fetch the raw directory payload, merged with owner/repo from the identifier."""
+        """Fetch directory payload, merged with owner/repo from identifier."""
         owner, name, commit = ls_utils.parse_prompt_identifier(identifier)
         target = version if version is not None else (
             commit if commit != "latest" else None
@@ -852,7 +853,7 @@ class AsyncContext:
         *,
         version: Optional[str],
     ) -> dict[str, Any]:
-        """Fetch the raw directory payload, merged with owner/repo from the identifier."""
+        """Fetch directory payload, merged with owner/repo from identifier."""
         owner, name, commit = ls_utils.parse_prompt_identifier(identifier)
         target = version if version is not None else (
             commit if commit != "latest" else None

--- a/python/langsmith/context.py
+++ b/python/langsmith/context.py
@@ -496,7 +496,7 @@ class Context:
             body["readme"] = readme
         if tags is not None:
             body["tags"] = list(tags)
-        self._client.request_with_retries("POST", f"{_PLATFORM_HUB}/", json=body)
+        self._client.request_with_retries("POST", "/api/v1/repos/", json=body)
 
     def _update_repo_metadata(
         self,
@@ -1001,7 +1001,7 @@ class AsyncContext:
         if tags is not None:
             body["tags"] = list(tags)
         await self._client._arequest_with_retries(
-            "POST", f"{_PLATFORM_HUB}/", json=body
+            "POST", "/api/v1/repos/", json=body
         )
 
     async def _update_repo_metadata(

--- a/python/langsmith/schemas.py
+++ b/python/langsmith/schemas.py
@@ -1160,9 +1160,7 @@ class SkillEntry(BaseModel):
     """The commit hash of the linked repo."""
 
 
-Entry = Annotated[
-    Union[FileEntry, AgentEntry, SkillEntry], Field(discriminator="type")
-]
+Entry = Annotated[Union[FileEntry, AgentEntry, SkillEntry], Field(discriminator="type")]
 """A hub directory entry, discriminated by `type`."""
 
 

--- a/python/langsmith/schemas.py
+++ b/python/langsmith/schemas.py
@@ -1117,6 +1117,94 @@ class PromptSortField(str, Enum):
     """Number of likes."""
 
 
+MAX_CONTEXT_ENTRIES = 500
+"""The maximum number of entries per directory commit."""
+
+
+class FileEntry(BaseModel):
+    """A file with inline content."""
+
+    type: Literal["file"] = "file"
+    """The entry type."""
+    content: str
+    """The file content."""
+
+
+class AgentEntry(BaseModel):
+    """A link to another agent repo."""
+
+    type: Literal["agent"] = "agent"
+    """The entry type."""
+    repo_handle: str
+    """The handle of the linked repo."""
+    commit_id: Optional[UUID] = None
+    """The commit ID of the linked repo, if pinned."""
+    owner: Optional[str] = None
+    """The owner of the linked repo."""
+    commit_hash: Optional[str] = None
+    """The commit hash of the linked repo."""
+
+
+class SkillEntry(BaseModel):
+    """A link to a skill repo."""
+
+    type: Literal["skill"] = "skill"
+    """The entry type."""
+    repo_handle: str
+    """The handle of the linked repo."""
+    commit_id: Optional[UUID] = None
+    """The commit ID of the linked repo, if pinned."""
+    owner: Optional[str] = None
+    """The owner of the linked repo."""
+    commit_hash: Optional[str] = None
+    """The commit hash of the linked repo."""
+
+
+Entry = Annotated[
+    Union[FileEntry, AgentEntry, SkillEntry], Field(discriminator="type")
+]
+"""A hub directory entry, discriminated by `type`."""
+
+
+class AgentContext(BaseModel):
+    """An agent pulled from hub."""
+
+    owner: str
+    """The handle of the owner."""
+    repo: str
+    """The name of the repo."""
+    commit_hash: str
+    """The commit hash."""
+    files: dict[str, Entry]
+    """The files in the agent."""
+
+
+class SkillContext(BaseModel):
+    """A skill pulled from hub."""
+
+    owner: str
+    """The handle of the owner."""
+    repo: str
+    """The name of the repo."""
+    commit_hash: str
+    """The commit hash."""
+    files: dict[str, Entry]
+    """The files in the skill."""
+
+
+class FileContext(BaseModel):
+    """A file repo pulled from hub."""
+
+    owner: str
+    """The handle of the owner."""
+    repo: str
+    """The name of the repo."""
+    commit_hash: str
+    """The commit hash."""
+    files: dict[str, FileEntry]
+    """The files in the repo."""
+
+
 class InputTokenDetails(TypedDict, total=False):
     """Breakdown of input token counts.
 

--- a/python/tests/integration_tests/test_context.py
+++ b/python/tests/integration_tests/test_context.py
@@ -22,11 +22,6 @@ def skill_identifier() -> str:
     return f"-/ctx-test-skill-{uuid.uuid4().hex[:8]}"
 
 
-@pytest.fixture
-def file_identifier() -> str:
-    return f"-/ctx-test-file-{uuid.uuid4().hex[:8]}"
-
-
 @skip_if_rate_limited
 def test_push_and_pull_agent_roundtrip(
     langsmith_client: Client, agent_identifier: str
@@ -75,32 +70,6 @@ def test_push_and_pull_skill_roundtrip(
     finally:
         try:
             ctx.delete_skill(skill_identifier)
-        except Exception:
-            pass
-
-
-@skip_if_rate_limited
-def test_push_and_pull_file_roundtrip(
-    langsmith_client: Client, file_identifier: str
-) -> None:
-    ctx = langsmith_client.context
-    try:
-        url = ctx.push_file(
-            file_identifier,
-            files={"README.md": ls_schemas.FileEntry(content="# Test File\n")},
-            description="integration test file",
-        )
-        assert "/hub/" in url
-
-        file_ctx = ctx.pull_file(file_identifier)
-        assert isinstance(file_ctx, ls_schemas.FileContext)
-        assert "README.md" in file_ctx.files
-        entry = file_ctx.files["README.md"]
-        assert isinstance(entry, ls_schemas.FileEntry)
-        assert entry.content == "# Test File\n"
-    finally:
-        try:
-            ctx.delete_file(file_identifier)
         except Exception:
             pass
 

--- a/python/tests/integration_tests/test_context.py
+++ b/python/tests/integration_tests/test_context.py
@@ -22,6 +22,11 @@ def skill_identifier() -> str:
     return f"-/ctx-test-skill-{uuid.uuid4().hex[:8]}"
 
 
+@pytest.fixture
+def file_identifier() -> str:
+    return f"-/ctx-test-file-{uuid.uuid4().hex[:8]}"
+
+
 @skip_if_rate_limited
 def test_push_and_pull_agent_roundtrip(
     langsmith_client: Client, agent_identifier: str
@@ -70,6 +75,32 @@ def test_push_and_pull_skill_roundtrip(
     finally:
         try:
             ctx.delete_skill(skill_identifier)
+        except Exception:
+            pass
+
+
+@skip_if_rate_limited
+def test_push_and_pull_file_roundtrip(
+    langsmith_client: Client, file_identifier: str
+) -> None:
+    ctx = langsmith_client.context
+    try:
+        url = ctx.push_file(
+            file_identifier,
+            files={"README.md": ls_schemas.FileEntry(content="# Test File\n")},
+            description="integration test file",
+        )
+        assert "/hub/" in url
+
+        file_ctx = ctx.pull_file(file_identifier)
+        assert isinstance(file_ctx, ls_schemas.FileContext)
+        assert "README.md" in file_ctx.files
+        entry = file_ctx.files["README.md"]
+        assert isinstance(entry, ls_schemas.FileEntry)
+        assert entry.content == "# Test File\n"
+    finally:
+        try:
+            ctx.delete_file(file_identifier)
         except Exception:
             pass
 

--- a/python/tests/integration_tests/test_context.py
+++ b/python/tests/integration_tests/test_context.py
@@ -1,0 +1,159 @@
+"""Integration tests for Context and AsyncContext against a live LangSmith backend.
+
+Prerequisites:
+- LANGSMITH_API_KEY and (optionally) LANGSMITH_ENDPOINT env vars set.
+- The backend must have the `agent_builder_hub_endpoints` feature flag enabled.
+"""
+
+import uuid
+
+import pytest
+
+from langsmith import AsyncClient, Client
+from langsmith import schemas as ls_schemas
+from tests.integration_tests.conftest import skip_if_rate_limited
+
+
+@pytest.fixture
+def langsmith_client() -> Client:
+    return Client(timeout_ms=(50_000, 90_000))
+
+
+@pytest.fixture
+def agent_identifier() -> str:
+    """A unique agent identifier for this test run."""
+    return f"-/ctx-test-agent-{uuid.uuid4().hex[:8]}"
+
+
+@pytest.fixture
+def skill_identifier() -> str:
+    """A unique skill identifier for this test run."""
+    return f"-/ctx-test-skill-{uuid.uuid4().hex[:8]}"
+
+
+@skip_if_rate_limited
+def test_push_and_pull_agent_roundtrip(
+    langsmith_client: Client, agent_identifier: str
+) -> None:
+    ctx = langsmith_client.context
+    try:
+        url = ctx.push_agent(
+            agent_identifier,
+            files={"AGENTS.md": ls_schemas.FileEntry(content="# Test Agent\n")},
+            description="integration test agent",
+        )
+        assert "/hub/" in url
+
+        agent = ctx.pull_agent(agent_identifier)
+        assert isinstance(agent, ls_schemas.AgentContext)
+        assert "AGENTS.md" in agent.files
+        entry = agent.files["AGENTS.md"]
+        assert isinstance(entry, ls_schemas.FileEntry)
+        assert entry.content == "# Test Agent\n"
+    finally:
+        try:
+            ctx.delete_agent(agent_identifier)
+        except Exception:
+            pass
+
+
+@skip_if_rate_limited
+def test_push_and_pull_skill_roundtrip(
+    langsmith_client: Client, skill_identifier: str
+) -> None:
+    ctx = langsmith_client.context
+    try:
+        url = ctx.push_skill(
+            skill_identifier,
+            files={"SKILL.md": ls_schemas.FileEntry(content="# Test Skill\n")},
+            description="integration test skill",
+        )
+        assert "/hub/" in url
+
+        skill = ctx.pull_skill(skill_identifier)
+        assert isinstance(skill, ls_schemas.SkillContext)
+        assert "SKILL.md" in skill.files
+        entry = skill.files["SKILL.md"]
+        assert isinstance(entry, ls_schemas.FileEntry)
+        assert entry.content == "# Test Skill\n"
+    finally:
+        try:
+            ctx.delete_skill(skill_identifier)
+        except Exception:
+            pass
+
+
+@skip_if_rate_limited
+def test_push_agent_null_entry_deletes_file(
+    langsmith_client: Client, agent_identifier: str
+) -> None:
+    ctx = langsmith_client.context
+    try:
+        ctx.push_agent(
+            agent_identifier,
+            files={
+                "keep.md": ls_schemas.FileEntry(content="keep"),
+                "remove.md": ls_schemas.FileEntry(content="remove"),
+            },
+        )
+        agent = ctx.pull_agent(agent_identifier)
+        assert "keep.md" in agent.files
+        assert "remove.md" in agent.files
+
+        ctx.push_agent(agent_identifier, files={"remove.md": None})
+        agent = ctx.pull_agent(agent_identifier)
+        assert "keep.md" in agent.files
+        assert "remove.md" not in agent.files
+    finally:
+        try:
+            ctx.delete_agent(agent_identifier)
+        except Exception:
+            pass
+
+
+@skip_if_rate_limited
+def test_push_agent_second_commit_updates_content(
+    langsmith_client: Client, agent_identifier: str
+) -> None:
+    ctx = langsmith_client.context
+    try:
+        ctx.push_agent(
+            agent_identifier,
+            files={"AGENTS.md": ls_schemas.FileEntry(content="v1")},
+        )
+        ctx.push_agent(
+            agent_identifier,
+            files={"AGENTS.md": ls_schemas.FileEntry(content="v2")},
+        )
+
+        agent = ctx.pull_agent(agent_identifier)
+        entry = agent.files["AGENTS.md"]
+        assert isinstance(entry, ls_schemas.FileEntry)
+        assert entry.content == "v2"
+    finally:
+        try:
+            ctx.delete_agent(agent_identifier)
+        except Exception:
+            pass
+
+
+@skip_if_rate_limited
+async def test_async_push_and_pull_agent_roundtrip() -> None:
+    client = AsyncClient(timeout_ms=(50_000, 90_000))
+    identifier = f"-/ctx-test-async-agent-{uuid.uuid4().hex[:8]}"
+    try:
+        url = await client.context.push_agent(
+            identifier,
+            files={"AGENTS.md": ls_schemas.FileEntry(content="# Async Test\n")},
+        )
+        assert "/hub/" in url
+
+        agent = await client.context.pull_agent(identifier)
+        assert isinstance(agent, ls_schemas.AgentContext)
+        assert "AGENTS.md" in agent.files
+    finally:
+        try:
+            await client.context.delete_agent(identifier)
+        except Exception:
+            pass
+        await client.aclose()

--- a/python/tests/integration_tests/test_context_async.py
+++ b/python/tests/integration_tests/test_context_async.py
@@ -3,39 +3,39 @@ import uuid
 import pytest
 
 import langsmith.schemas as ls_schemas
-from langsmith.client import Client
+from langsmith.async_client import AsyncClient
 from tests.integration_tests.conftest import skip_if_rate_limited
 
 
 @pytest.fixture
-def langsmith_client() -> Client:
-    return Client(timeout_ms=(50_000, 90_000))
+def langsmith_client() -> AsyncClient:
+    return AsyncClient(timeout_ms=(50_000, 90_000))
 
 
 @pytest.fixture
 def agent_identifier() -> str:
-    return f"-/ctx-test-agent-{uuid.uuid4().hex[:8]}"
+    return f"-/ctx-test-async-agent-{uuid.uuid4().hex[:8]}"
 
 
 @pytest.fixture
 def skill_identifier() -> str:
-    return f"-/ctx-test-skill-{uuid.uuid4().hex[:8]}"
+    return f"-/ctx-test-async-skill-{uuid.uuid4().hex[:8]}"
 
 
 @skip_if_rate_limited
-def test_push_and_pull_agent_roundtrip(
-    langsmith_client: Client, agent_identifier: str
+async def test_push_and_pull_agent_roundtrip(
+    langsmith_client: AsyncClient, agent_identifier: str
 ) -> None:
     ctx = langsmith_client.context
     try:
-        url = ctx.push_agent(
+        url = await ctx.push_agent(
             agent_identifier,
             files={"AGENTS.md": ls_schemas.FileEntry(content="# Test Agent\n")},
             description="integration test agent",
         )
         assert "/hub/" in url
 
-        agent = ctx.pull_agent(agent_identifier)
+        agent = await ctx.pull_agent(agent_identifier)
         assert isinstance(agent, ls_schemas.AgentContext)
         assert "AGENTS.md" in agent.files
         entry = agent.files["AGENTS.md"]
@@ -43,25 +43,25 @@ def test_push_and_pull_agent_roundtrip(
         assert entry.content == "# Test Agent\n"
     finally:
         try:
-            ctx.delete_agent(agent_identifier)
+            await ctx.delete_agent(agent_identifier)
         except Exception:
             pass
 
 
 @skip_if_rate_limited
-def test_push_and_pull_skill_roundtrip(
-    langsmith_client: Client, skill_identifier: str
+async def test_push_and_pull_skill_roundtrip(
+    langsmith_client: AsyncClient, skill_identifier: str
 ) -> None:
     ctx = langsmith_client.context
     try:
-        url = ctx.push_skill(
+        url = await ctx.push_skill(
             skill_identifier,
             files={"SKILL.md": ls_schemas.FileEntry(content="# Test Skill\n")},
             description="integration test skill",
         )
         assert "/hub/" in url
 
-        skill = ctx.pull_skill(skill_identifier)
+        skill = await ctx.pull_skill(skill_identifier)
         assert isinstance(skill, ls_schemas.SkillContext)
         assert "SKILL.md" in skill.files
         entry = skill.files["SKILL.md"]
@@ -69,60 +69,60 @@ def test_push_and_pull_skill_roundtrip(
         assert entry.content == "# Test Skill\n"
     finally:
         try:
-            ctx.delete_skill(skill_identifier)
+            await ctx.delete_skill(skill_identifier)
         except Exception:
             pass
 
 
 @skip_if_rate_limited
-def test_push_agent_null_entry_deletes_file(
-    langsmith_client: Client, agent_identifier: str
+async def test_push_agent_null_entry_deletes_file(
+    langsmith_client: AsyncClient, agent_identifier: str
 ) -> None:
     ctx = langsmith_client.context
     try:
-        ctx.push_agent(
+        await ctx.push_agent(
             agent_identifier,
             files={
                 "keep.md": ls_schemas.FileEntry(content="keep"),
                 "remove.md": ls_schemas.FileEntry(content="remove"),
             },
         )
-        agent = ctx.pull_agent(agent_identifier)
+        agent = await ctx.pull_agent(agent_identifier)
         assert "keep.md" in agent.files
         assert "remove.md" in agent.files
 
-        ctx.push_agent(agent_identifier, files={"remove.md": None})
-        agent = ctx.pull_agent(agent_identifier)
+        await ctx.push_agent(agent_identifier, files={"remove.md": None})
+        agent = await ctx.pull_agent(agent_identifier)
         assert "keep.md" in agent.files
         assert "remove.md" not in agent.files
     finally:
         try:
-            ctx.delete_agent(agent_identifier)
+            await ctx.delete_agent(agent_identifier)
         except Exception:
             pass
 
 
 @skip_if_rate_limited
-def test_push_agent_second_commit_updates_content(
-    langsmith_client: Client, agent_identifier: str
+async def test_push_agent_second_commit_updates_content(
+    langsmith_client: AsyncClient, agent_identifier: str
 ) -> None:
     ctx = langsmith_client.context
     try:
-        ctx.push_agent(
+        await ctx.push_agent(
             agent_identifier,
             files={"AGENTS.md": ls_schemas.FileEntry(content="v1")},
         )
-        ctx.push_agent(
+        await ctx.push_agent(
             agent_identifier,
             files={"AGENTS.md": ls_schemas.FileEntry(content="v2")},
         )
 
-        agent = ctx.pull_agent(agent_identifier)
+        agent = await ctx.pull_agent(agent_identifier)
         entry = agent.files["AGENTS.md"]
         assert isinstance(entry, ls_schemas.FileEntry)
         assert entry.content == "v2"
     finally:
         try:
-            ctx.delete_agent(agent_identifier)
+            await ctx.delete_agent(agent_identifier)
         except Exception:
             pass

--- a/python/tests/integration_tests/test_context_async.py
+++ b/python/tests/integration_tests/test_context_async.py
@@ -22,11 +22,6 @@ def skill_identifier() -> str:
     return f"-/ctx-test-async-skill-{uuid.uuid4().hex[:8]}"
 
 
-@pytest.fixture
-def file_identifier() -> str:
-    return f"-/ctx-test-async-file-{uuid.uuid4().hex[:8]}"
-
-
 @skip_if_rate_limited
 async def test_push_and_pull_agent_roundtrip(
     langsmith_client: AsyncClient, agent_identifier: str
@@ -75,32 +70,6 @@ async def test_push_and_pull_skill_roundtrip(
     finally:
         try:
             await ctx.delete_skill(skill_identifier)
-        except Exception:
-            pass
-
-
-@skip_if_rate_limited
-async def test_push_and_pull_file_roundtrip(
-    langsmith_client: AsyncClient, file_identifier: str
-) -> None:
-    ctx = langsmith_client.context
-    try:
-        url = await ctx.push_file(
-            file_identifier,
-            files={"README.md": ls_schemas.FileEntry(content="# Test File\n")},
-            description="integration test file",
-        )
-        assert "/hub/" in url
-
-        file_ctx = await ctx.pull_file(file_identifier)
-        assert isinstance(file_ctx, ls_schemas.FileContext)
-        assert "README.md" in file_ctx.files
-        entry = file_ctx.files["README.md"]
-        assert isinstance(entry, ls_schemas.FileEntry)
-        assert entry.content == "# Test File\n"
-    finally:
-        try:
-            await ctx.delete_file(file_identifier)
         except Exception:
             pass
 

--- a/python/tests/integration_tests/test_context_async.py
+++ b/python/tests/integration_tests/test_context_async.py
@@ -22,6 +22,11 @@ def skill_identifier() -> str:
     return f"-/ctx-test-async-skill-{uuid.uuid4().hex[:8]}"
 
 
+@pytest.fixture
+def file_identifier() -> str:
+    return f"-/ctx-test-async-file-{uuid.uuid4().hex[:8]}"
+
+
 @skip_if_rate_limited
 async def test_push_and_pull_agent_roundtrip(
     langsmith_client: AsyncClient, agent_identifier: str
@@ -70,6 +75,32 @@ async def test_push_and_pull_skill_roundtrip(
     finally:
         try:
             await ctx.delete_skill(skill_identifier)
+        except Exception:
+            pass
+
+
+@skip_if_rate_limited
+async def test_push_and_pull_file_roundtrip(
+    langsmith_client: AsyncClient, file_identifier: str
+) -> None:
+    ctx = langsmith_client.context
+    try:
+        url = await ctx.push_file(
+            file_identifier,
+            files={"README.md": ls_schemas.FileEntry(content="# Test File\n")},
+            description="integration test file",
+        )
+        assert "/hub/" in url
+
+        file_ctx = await ctx.pull_file(file_identifier)
+        assert isinstance(file_ctx, ls_schemas.FileContext)
+        assert "README.md" in file_ctx.files
+        entry = file_ctx.files["README.md"]
+        assert isinstance(entry, ls_schemas.FileEntry)
+        assert entry.content == "# Test File\n"
+    finally:
+        try:
+            await ctx.delete_file(file_identifier)
         except Exception:
             pass
 

--- a/python/tests/unit_tests/test_context.py
+++ b/python/tests/unit_tests/test_context.py
@@ -68,9 +68,7 @@ def test_agent_entry_exclude_none_strips_response_only_fields() -> None:
 
 def test_push_agent_rejects_too_many_files() -> None:
     ctx = Context(_mock_sync_client())
-    too_many = {
-        f"p_{i}.py": ls_schemas.FileEntry(content="x") for i in range(501)
-    }
+    too_many = {f"p_{i}.py": ls_schemas.FileEntry(content="x") for i in range(501)}
     with pytest.raises(ls_utils.LangSmithUserError, match="Too many files"):
         ctx.push_agent("-/repo", files=too_many)
 
@@ -340,9 +338,7 @@ async def test_async_delete_agent_hits_directories_delete() -> None:
 
 async def test_async_list_skills_passes_filter() -> None:
     client = _mock_async_client()
-    client._arequest_with_retries.return_value = _response(
-        {"repos": [], "total": 0}
-    )
+    client._arequest_with_retries.return_value = _response({"repos": [], "total": 0})
     ctx = AsyncContext(client)
     await ctx.list_skills(limit=25)
     call = client._arequest_with_retries.call_args
@@ -353,8 +349,6 @@ async def test_async_list_skills_passes_filter() -> None:
 
 async def test_async_push_agent_rejects_too_many_files() -> None:
     ctx = AsyncContext(_mock_async_client())
-    too_many = {
-        f"p_{i}.py": ls_schemas.FileEntry(content="x") for i in range(501)
-    }
+    too_many = {f"p_{i}.py": ls_schemas.FileEntry(content="x") for i in range(501)}
     with pytest.raises(ls_utils.LangSmithUserError, match="Too many files"):
         await ctx.push_agent("-/repo", files=too_many)

--- a/python/tests/unit_tests/test_context.py
+++ b/python/tests/unit_tests/test_context.py
@@ -104,7 +104,7 @@ def test_pull_agent_hits_correct_url_and_parses() -> None:
     ctx = Context(client)
     agent = ctx.pull_agent("owner/my-agent")
     call = client.request_with_retries.call_args
-    assert call.args == ("GET", "/api/v1/platform/hub/repos/owner/my-agent/directories")
+    assert call.args == ("GET", "/v1/platform/hub/repos/owner/my-agent/directories")
     assert call.kwargs.get("params") == {}
     assert isinstance(agent, ls_schemas.AgentContext)
     assert agent.owner == "owner"
@@ -172,7 +172,7 @@ def test_push_agent_creates_new_repo_and_commits() -> None:
     commit_call = client.request_with_retries.call_args_list[2]
     assert commit_call.args == (
         "POST",
-        "/api/v1/platform/hub/repos/-/my-agent/directories/commits",
+        "/v1/platform/hub/repos/-/my-agent/directories/commits",
     )
     assert commit_call.kwargs["json"]["files"] == {
         "main.py": {"type": "file", "content": "x"}
@@ -263,7 +263,7 @@ def test_delete_agent_hits_directories_delete() -> None:
     call = client.request_with_retries.call_args
     assert call.args == (
         "DELETE",
-        "/api/v1/platform/hub/repos/-/old-agent/directories",
+        "/v1/platform/hub/repos/-/old-agent/directories",
     )
 
 
@@ -298,7 +298,7 @@ async def test_async_pull_agent_parses_and_merges_identifier() -> None:
     assert agent.repo == "my-agent"
     client._arequest_with_retries.assert_awaited_once_with(
         "GET",
-        "/api/v1/platform/hub/repos/owner/my-agent/directories",
+        "/v1/platform/hub/repos/owner/my-agent/directories",
         params={},
     )
 
@@ -332,7 +332,7 @@ async def test_async_delete_agent_hits_directories_delete() -> None:
     await ctx.delete_agent("-/old-agent")
     client._arequest_with_retries.assert_awaited_once_with(
         "DELETE",
-        "/api/v1/platform/hub/repos/-/old-agent/directories",
+        "/v1/platform/hub/repos/-/old-agent/directories",
     )
 
 

--- a/python/tests/unit_tests/test_context.py
+++ b/python/tests/unit_tests/test_context.py
@@ -165,7 +165,7 @@ def test_push_agent_creates_new_repo_and_commits() -> None:
     assert client.request_with_retries.call_count == 3
 
     create_call = client.request_with_retries.call_args_list[1]
-    assert create_call.args == ("POST", "/api/v1/platform/hub/repos/")
+    assert create_call.args == ("POST", "/api/v1/repos/")
     assert create_call.kwargs["json"]["repo_type"] == "agent"
     assert create_call.kwargs["json"]["repo_handle"] == "my-agent"
 

--- a/python/tests/unit_tests/test_context.py
+++ b/python/tests/unit_tests/test_context.py
@@ -165,7 +165,7 @@ def test_push_agent_creates_new_repo_and_commits() -> None:
     assert client.request_with_retries.call_count == 3
 
     create_call = client.request_with_retries.call_args_list[1]
-    assert create_call.args == ("POST", "/api/v1/repos/")
+    assert create_call.args == ("POST", "/repos/")
     assert create_call.kwargs["json"]["repo_type"] == "agent"
     assert create_call.kwargs["json"]["repo_handle"] == "my-agent"
 

--- a/python/tests/unit_tests/test_context.py
+++ b/python/tests/unit_tests/test_context.py
@@ -1,0 +1,360 @@
+"""Test the Context and AsyncContext classes for Hub non-prompt repos."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pydantic
+import pytest
+
+from langsmith import schemas as ls_schemas
+from langsmith import utils as ls_utils
+from langsmith.context import AsyncContext, Context
+
+
+def _mock_sync_client() -> MagicMock:
+    client = MagicMock()
+    client._host_url = "https://smith.langchain.com"
+    client._current_tenant_is_owner.return_value = True
+    client._owner_conflict_error.return_value = ls_utils.LangSmithUserError(
+        "owner mismatch"
+    )
+    return client
+
+
+def _mock_async_client() -> MagicMock:
+    client = MagicMock()
+    client._host_url = "https://smith.langchain.com"
+    client._current_tenant_is_owner = AsyncMock(return_value=True)
+    client._owner_conflict_error = AsyncMock(
+        return_value=ls_utils.LangSmithUserError("owner mismatch")
+    )
+    client._arequest_with_retries = AsyncMock()
+    return client
+
+
+def _response(data: dict) -> MagicMock:
+    resp = MagicMock()
+    resp.json.return_value = data
+    return resp
+
+
+def test_entry_discriminator_picks_file() -> None:
+    adapter = pydantic.TypeAdapter(ls_schemas.Entry)
+    entry = adapter.validate_python({"type": "file", "content": "hi"})
+    assert isinstance(entry, ls_schemas.FileEntry)
+    assert entry.content == "hi"
+
+
+def test_entry_discriminator_picks_agent() -> None:
+    adapter = pydantic.TypeAdapter(ls_schemas.Entry)
+    entry = adapter.validate_python({"type": "agent", "repo_handle": "o/r"})
+    assert isinstance(entry, ls_schemas.AgentEntry)
+    assert entry.repo_handle == "o/r"
+
+
+def test_entry_discriminator_picks_skill() -> None:
+    adapter = pydantic.TypeAdapter(ls_schemas.Entry)
+    entry = adapter.validate_python({"type": "skill", "repo_handle": "o/r"})
+    assert isinstance(entry, ls_schemas.SkillEntry)
+
+
+def test_agent_entry_exclude_none_strips_response_only_fields() -> None:
+    entry = ls_schemas.AgentEntry(repo_handle="owner/repo")
+    dumped = entry.model_dump(exclude_none=True)
+    assert dumped == {"type": "agent", "repo_handle": "owner/repo"}
+    assert "owner" not in dumped
+    assert "commit_hash" not in dumped
+    assert "commit_id" not in dumped
+
+
+def test_push_agent_rejects_too_many_files() -> None:
+    ctx = Context(_mock_sync_client())
+    too_many = {
+        f"p_{i}.py": ls_schemas.FileEntry(content="x") for i in range(501)
+    }
+    with pytest.raises(ls_utils.LangSmithUserError, match="Too many files"):
+        ctx.push_agent("-/repo", files=too_many)
+
+
+def test_push_agent_rejects_short_parent_commit() -> None:
+    ctx = Context(_mock_sync_client())
+    with pytest.raises(ls_utils.LangSmithUserError, match="8-64"):
+        ctx.push_agent("-/repo", files={}, parent_commit="abc")
+
+
+def test_push_agent_rejects_invalid_handle_on_create() -> None:
+    client = _mock_sync_client()
+    client.request_with_retries.side_effect = ls_utils.LangSmithNotFoundError(
+        "not found"
+    )
+    ctx = Context(client)
+    with pytest.raises(ls_utils.LangSmithUserError, match="Invalid repo_handle"):
+        ctx.push_agent(
+            "-/BadName",
+            files={"main.py": ls_schemas.FileEntry(content="x")},
+        )
+
+
+def test_pull_agent_hits_correct_url_and_parses() -> None:
+    client = _mock_sync_client()
+    client.request_with_retries.return_value = _response(
+        {
+            "commit_id": "00000000-0000-0000-0000-000000000000",
+            "commit_hash": "abc12345",
+            "files": {"main.py": {"type": "file", "content": "print('hi')"}},
+        }
+    )
+    ctx = Context(client)
+    agent = ctx.pull_agent("owner/my-agent")
+    call = client.request_with_retries.call_args
+    assert call.args == ("GET", "/api/v1/platform/hub/repos/owner/my-agent/directories")
+    assert call.kwargs.get("params") == {}
+    assert isinstance(agent, ls_schemas.AgentContext)
+    assert agent.owner == "owner"
+    assert agent.repo == "my-agent"
+    assert agent.commit_hash == "abc12345"
+    assert isinstance(agent.files["main.py"], ls_schemas.FileEntry)
+
+
+def test_pull_skill_and_file_return_correct_types() -> None:
+    client = _mock_sync_client()
+    client.request_with_retries.return_value = _response(
+        {
+            "commit_id": "00000000-0000-0000-0000-000000000000",
+            "commit_hash": "xyz12345",
+            "files": {},
+        }
+    )
+    ctx = Context(client)
+    assert isinstance(ctx.pull_skill("o/s"), ls_schemas.SkillContext)
+    assert isinstance(ctx.pull_file("o/f"), ls_schemas.FileContext)
+
+
+def test_pull_agent_with_version_passes_commit_param() -> None:
+    client = _mock_sync_client()
+    client.request_with_retries.return_value = _response(
+        {
+            "commit_id": "00000000-0000-0000-0000-000000000000",
+            "commit_hash": "abc12345",
+            "files": {},
+        }
+    )
+    ctx = Context(client)
+    ctx.pull_agent("owner/repo", version="abc12345")
+    assert client.request_with_retries.call_args.kwargs["params"] == {
+        "commit": "abc12345"
+    }
+
+
+def test_push_agent_creates_new_repo_and_commits() -> None:
+    client = _mock_sync_client()
+    client.request_with_retries.side_effect = [
+        ls_utils.LangSmithNotFoundError("not found"),
+        _response({}),
+        _response(
+            {
+                "commit": {
+                    "id": "00000000-0000-0000-0000-000000000000",
+                    "commit_hash": "abc12345",
+                }
+            }
+        ),
+    ]
+    ctx = Context(client)
+    url = ctx.push_agent(
+        "-/my-agent", files={"main.py": ls_schemas.FileEntry(content="x")}
+    )
+    assert url == "https://smith.langchain.com/hub/-/my-agent:abc12345"
+    assert client.request_with_retries.call_count == 3
+
+    create_call = client.request_with_retries.call_args_list[1]
+    assert create_call.args == ("POST", "/api/v1/platform/hub/repos/")
+    assert create_call.kwargs["json"]["repo_type"] == "agent"
+    assert create_call.kwargs["json"]["repo_handle"] == "my-agent"
+
+    commit_call = client.request_with_retries.call_args_list[2]
+    assert commit_call.args == (
+        "POST",
+        "/api/v1/platform/hub/repos/-/my-agent/directories/commits",
+    )
+    assert commit_call.kwargs["json"]["files"] == {
+        "main.py": {"type": "file", "content": "x"}
+    }
+
+
+def test_push_agent_updates_metadata_when_repo_exists() -> None:
+    client = _mock_sync_client()
+    client.request_with_retries.side_effect = [
+        _response({}),
+        _response({}),
+        _response(
+            {
+                "commit": {
+                    "id": "00000000-0000-0000-0000-000000000000",
+                    "commit_hash": "abc12345",
+                }
+            }
+        ),
+    ]
+    ctx = Context(client)
+    ctx.push_agent(
+        "-/my-agent",
+        files={"main.py": ls_schemas.FileEntry(content="x")},
+        description="new desc",
+    )
+    assert client.request_with_retries.call_count == 3
+    patch_call = client.request_with_retries.call_args_list[1]
+    assert patch_call.args == ("PATCH", "/api/v1/hub/repos/-/my-agent")
+    assert patch_call.kwargs["json"] == {"description": "new desc"}
+
+
+def test_push_agent_null_entry_serializes_as_delete() -> None:
+    client = _mock_sync_client()
+    client.request_with_retries.side_effect = [
+        _response({}),
+        _response(
+            {
+                "commit": {
+                    "id": "00000000-0000-0000-0000-000000000000",
+                    "commit_hash": "abc12345",
+                }
+            }
+        ),
+    ]
+    ctx = Context(client)
+    ctx.push_agent(
+        "-/my-agent",
+        files={
+            "keep.py": ls_schemas.FileEntry(content="x"),
+            "remove.py": None,
+        },
+    )
+    commit_call = client.request_with_retries.call_args_list[1]
+    body = commit_call.kwargs["json"]
+    assert body["files"]["keep.py"] == {"type": "file", "content": "x"}
+    assert body["files"]["remove.py"] is None
+
+
+def test_push_agent_passes_parent_commit_when_provided() -> None:
+    client = _mock_sync_client()
+    client.request_with_retries.side_effect = [
+        _response({}),
+        _response(
+            {
+                "commit": {
+                    "id": "00000000-0000-0000-0000-000000000000",
+                    "commit_hash": "new12345",
+                }
+            }
+        ),
+    ]
+    ctx = Context(client)
+    ctx.push_agent(
+        "-/my-agent",
+        files={"main.py": ls_schemas.FileEntry(content="x")},
+        parent_commit="abc12345",
+    )
+    commit_call = client.request_with_retries.call_args_list[1]
+    assert commit_call.kwargs["json"]["parent_commit"] == "abc12345"
+
+
+def test_delete_agent_hits_directories_delete() -> None:
+    client = _mock_sync_client()
+    client.request_with_retries.return_value = _response({})
+    ctx = Context(client)
+    ctx.delete_agent("-/old-agent")
+    call = client.request_with_retries.call_args
+    assert call.args == (
+        "DELETE",
+        "/api/v1/platform/hub/repos/-/old-agent/directories",
+    )
+
+
+def test_list_agents_passes_repo_type_filter() -> None:
+    client = _mock_sync_client()
+    client.request_with_retries.return_value = _response({"repos": [], "total": 0})
+    ctx = Context(client)
+    ctx.list_agents(limit=50, is_public=True, query="foo")
+    call = client.request_with_retries.call_args
+    assert call.args == ("GET", "/api/v1/hub/repos")
+    params = call.kwargs["params"]
+    assert params["repo_type"] == "agent"
+    assert params["limit"] == 50
+    assert params["is_public"] == "true"
+    assert params["query"] == "foo"
+    assert params["match_prefix"] == "true"
+
+
+async def test_async_pull_agent_parses_and_merges_identifier() -> None:
+    client = _mock_async_client()
+    client._arequest_with_retries.return_value = _response(
+        {
+            "commit_id": "00000000-0000-0000-0000-000000000000",
+            "commit_hash": "abc12345",
+            "files": {"main.py": {"type": "file", "content": "hi"}},
+        }
+    )
+    ctx = AsyncContext(client)
+    agent = await ctx.pull_agent("owner/my-agent")
+    assert isinstance(agent, ls_schemas.AgentContext)
+    assert agent.owner == "owner"
+    assert agent.repo == "my-agent"
+    client._arequest_with_retries.assert_awaited_once_with(
+        "GET",
+        "/api/v1/platform/hub/repos/owner/my-agent/directories",
+        params={},
+    )
+
+
+async def test_async_push_agent_creates_and_commits() -> None:
+    client = _mock_async_client()
+    client._arequest_with_retries.side_effect = [
+        ls_utils.LangSmithNotFoundError("not found"),
+        _response({}),
+        _response(
+            {
+                "commit": {
+                    "id": "00000000-0000-0000-0000-000000000000",
+                    "commit_hash": "abc12345",
+                }
+            }
+        ),
+    ]
+    ctx = AsyncContext(client)
+    url = await ctx.push_agent(
+        "-/my-agent", files={"main.py": ls_schemas.FileEntry(content="x")}
+    )
+    assert url == "https://smith.langchain.com/hub/-/my-agent:abc12345"
+    assert client._arequest_with_retries.await_count == 3
+
+
+async def test_async_delete_agent_hits_directories_delete() -> None:
+    client = _mock_async_client()
+    client._arequest_with_retries.return_value = _response({})
+    ctx = AsyncContext(client)
+    await ctx.delete_agent("-/old-agent")
+    client._arequest_with_retries.assert_awaited_once_with(
+        "DELETE",
+        "/api/v1/platform/hub/repos/-/old-agent/directories",
+    )
+
+
+async def test_async_list_skills_passes_filter() -> None:
+    client = _mock_async_client()
+    client._arequest_with_retries.return_value = _response(
+        {"repos": [], "total": 0}
+    )
+    ctx = AsyncContext(client)
+    await ctx.list_skills(limit=25)
+    call = client._arequest_with_retries.call_args
+    assert call.args == ("GET", "/api/v1/hub/repos")
+    assert call.kwargs["params"]["repo_type"] == "skill"
+    assert call.kwargs["params"]["limit"] == 25
+
+
+async def test_async_push_agent_rejects_too_many_files() -> None:
+    ctx = AsyncContext(_mock_async_client())
+    too_many = {
+        f"p_{i}.py": ls_schemas.FileEntry(content="x") for i in range(501)
+    }
+    with pytest.raises(ls_utils.LangSmithUserError, match="Too many files"):
+        await ctx.push_agent("-/repo", files=too_many)

--- a/python/tests/unit_tests/test_context.py
+++ b/python/tests/unit_tests/test_context.py
@@ -201,7 +201,7 @@ def test_push_agent_updates_metadata_when_repo_exists() -> None:
     )
     assert client.request_with_retries.call_count == 3
     patch_call = client.request_with_retries.call_args_list[1]
-    assert patch_call.args == ("PATCH", "/api/v1/hub/repos/-/my-agent")
+    assert patch_call.args == ("PATCH", "/repos/-/my-agent")
     assert patch_call.kwargs["json"] == {"description": "new desc"}
 
 
@@ -273,7 +273,7 @@ def test_list_agents_passes_repo_type_filter() -> None:
     ctx = Context(client)
     ctx.list_agents(limit=50, is_public=True, query="foo")
     call = client.request_with_retries.call_args
-    assert call.args == ("GET", "/api/v1/hub/repos")
+    assert call.args == ("GET", "/repos")
     params = call.kwargs["params"]
     assert params["repo_type"] == "agent"
     assert params["limit"] == 50
@@ -342,7 +342,7 @@ async def test_async_list_skills_passes_filter() -> None:
     ctx = AsyncContext(client)
     await ctx.list_skills(limit=25)
     call = client._arequest_with_retries.call_args
-    assert call.args == ("GET", "/api/v1/hub/repos")
+    assert call.args == ("GET", "/repos")
     assert call.kwargs["params"]["repo_type"] == "skill"
     assert call.kwargs["params"]["limit"] == 25
 


### PR DESCRIPTION
## Summary

Adds a new `Context` class (and `AsyncContext` async counterpart) for working with non-prompt Hub repos — **agents, skills, and files**. These are the directory-based repo types that pair with the existing prompt hub.

The existing prompt methods on `Client` (`pull_prompt`, `push_prompt`, etc.) stay untouched. Extending them to cover agents/skills would have required breaking return-type changes. Instead, everything non-prompt lives behind a new namespace:

```python
from langsmith import Client
from langsmith.schemas import FileEntry

client = Client()
client.context.push_agent(
    "-/my-agent",
    files={"AGENTS.md": FileEntry(content="# My Agent\n")},
)
agent = client.context.pull_agent("-/my-agent")
client.context.delete_agent("-/my-agent")
```

Async mirror: `await async_client.context.pull_agent(...)`.

## What's included

- **Schemas** (`schemas.py`): `FileEntry`, `AgentEntry`, `SkillEntry`, `Entry` (Pydantic discriminated union on `type`), `AgentContext`, `SkillContext`, `FileContext`, `MAX_CONTEXT_ENTRIES = 500`.
- **`Context`** (`context.py`): 12 methods — `pull_*`, `push_*`, `delete_*`, `list_*` for each of agent/skill/file.
- **`AsyncContext`**: same surface, all methods `async def`.
- **`client.context` / `async_client.context`** properties — lazy-cached via the `__slots__`-compatible pattern that existing cached attributes like `_info` / `_settings` use.
- **Top-level exports**: `from langsmith import Context, AsyncContext`.

## Notes

- **Endpoint split**: pull/push/delete hit `/api/v1/platform/hub/repos/{owner}/{repo}/directories[/commits]`; list + repo metadata hit `/api/v1/hub/repos/...`. The directories endpoints are gated server-side by `agent_builder_hub_endpoints`.
- **Parallel classes, not shared base**: `Context` and `AsyncContext` are independent, matching the `Client` / `Sandbox` pattern in this repo rather than the `PromptCache` shared-base pattern.
- **`parent_commit` passthrough**: when the caller provides one it's sent for optimistic concurrency; when omitted, the server defaults to latest (no extra round trip).
- **`files={path: None}`** deletes a path, matching the backend's directory-commit semantics.

## Test Plan

- [x] 21 unit tests in `python/tests/unit_tests/test_context.py` — all pass (mock the HTTP layer)
- [x] Lint clean (`uv run ruff check`)
- [ ] 4 sync + 4 async integration tests in `python/tests/integration_tests/test_context{,_async}.py` — require a live backend with `agent_builder_hub_endpoints` enabled; run before merge
- [ ] Manual smoke: push + pull + delete an agent via `client.context` against a real tenant