### PR TITLE
draft

### DIFF
--- a/python/langsmith/run_trees.py
+++ b/python/langsmith/run_trees.py
@@ -58,6 +58,9 @@ class WriteReplica(TypedDict, total=False):
     auth: AuthHeaders
     project_name: Optional[str]
     updates: Optional[dict]
+    client: Any  # Optional Client override — if set, uses this client for
+    # create_run/update_run instead of the parent RunTree's client.
+    # Useful when replicas need different hide_inputs/hide_outputs settings.
 
 
 _HEADER_SAFE_REPLICA_FIELDS: frozenset[str] = frozenset({"project_name", "updates"})
@@ -678,7 +681,8 @@ class RunTree(ls_schemas.RunBase):
                 api_url, api_key, service_key, tenant_id, authorization, cookie = (
                     _extract_replica_auth(replica)
                 )
-                self.client.create_run(
+                replica_client = replica.get("client") or self.client
+                replica_client.create_run(
                     **run_dict,
                     api_key=api_key,
                     api_url=api_url,
@@ -741,7 +745,8 @@ class RunTree(ls_schemas.RunBase):
                 api_url, api_key, service_key, tenant_id, authorization, cookie = (
                     _extract_replica_auth(replica)
                 )
-                self.client.update_run(
+                replica_client = replica.get("client") or self.client
+                replica_client.update_run(
                     name=run_dict["name"],
                     run_id=run_dict["id"],
                     run_type=run_dict.get("run_type"),

--- a/python/langsmith/run_trees.py
+++ b/python/langsmith/run_trees.py
@@ -11,7 +11,7 @@ import threading
 import urllib.parse
 from collections.abc import Mapping, Sequence
 from datetime import datetime, timezone
-from typing import Any, NamedTuple, Optional, Union, cast
+from typing import Any, Callable, NamedTuple, Optional, Union, cast
 from uuid import UUID
 
 from pydantic import ConfigDict, Field, model_validator
@@ -58,6 +58,14 @@ class WriteReplica(TypedDict, total=False):
     auth: AuthHeaders
     project_name: Optional[str]
     updates: Optional[dict]
+    process_run: NotRequired[Callable[[dict], Optional[dict]]]
+    # Optional pre-send processor. Receives the run-like dict that would be
+    # sent (post-remap, pre-auth merge — shape follows `RunLikeDict`: name,
+    # id, inputs, outputs, trace_id, session_name, etc.) and returns a
+    # transformed dict, or None to skip this replica for this event. Applied
+    # to both create and update events. Enables per-replica redaction,
+    # tagging, or selective routing when different replicas need different
+    # data-handling policies.
 
 
 _HEADER_SAFE_REPLICA_FIELDS: frozenset[str] = frozenset({"project_name", "updates"})
@@ -675,11 +683,14 @@ class RunTree(ls_schemas.RunBase):
                 project_name = replica.get("project_name") or self.session_name
                 updates = replica.get("updates")
                 run_dict = self._remap_for_project(project_name, updates)
+                processed = _apply_replica_process_run(replica, run_dict)
+                if processed is None:
+                    continue
                 api_url, api_key, service_key, tenant_id, authorization, cookie = (
                     _extract_replica_auth(replica)
                 )
                 self.client.create_run(
-                    **run_dict,
+                    **processed,
                     api_key=api_key,
                     api_url=api_url,
                     service_key=service_key,
@@ -738,26 +749,29 @@ class RunTree(ls_schemas.RunBase):
                 project_name = replica.get("project_name") or self.session_name
                 updates = replica.get("updates")
                 run_dict = self._remap_for_project(project_name, updates)
+                processed = _apply_replica_process_run(replica, run_dict)
+                if processed is None:
+                    continue
                 api_url, api_key, service_key, tenant_id, authorization, cookie = (
                     _extract_replica_auth(replica)
                 )
                 self.client.update_run(
-                    name=run_dict["name"],
-                    run_id=run_dict["id"],
-                    run_type=run_dict.get("run_type"),
-                    start_time=run_dict.get("start_time"),
-                    inputs=None if exclude_inputs else run_dict["inputs"],
-                    outputs=run_dict["outputs"],
-                    error=run_dict.get("error"),
-                    parent_run_id=run_dict.get("parent_run_id"),
-                    session_name=run_dict.get("session_name"),
-                    reference_example_id=run_dict.get("reference_example_id"),
-                    end_time=run_dict.get("end_time"),
-                    dotted_order=run_dict.get("dotted_order"),
-                    trace_id=run_dict.get("trace_id"),
-                    events=run_dict.get("events"),
-                    tags=run_dict.get("tags"),
-                    extra=run_dict.get("extra"),
+                    name=processed["name"],
+                    run_id=processed["id"],
+                    run_type=processed.get("run_type"),
+                    start_time=processed.get("start_time"),
+                    inputs=None if exclude_inputs else processed.get("inputs"),
+                    outputs=processed.get("outputs"),
+                    error=processed.get("error"),
+                    parent_run_id=processed.get("parent_run_id"),
+                    session_name=processed.get("session_name"),
+                    reference_example_id=processed.get("reference_example_id"),
+                    end_time=processed.get("end_time"),
+                    dotted_order=processed.get("dotted_order"),
+                    trace_id=processed.get("trace_id"),
+                    events=processed.get("events"),
+                    tags=processed.get("tags"),
+                    extra=processed.get("extra"),
                     attachments=attachments,
                     api_key=api_key,
                     api_url=api_url,
@@ -1249,3 +1263,26 @@ def _extract_replica_auth(
         authorization=None,
         cookie=None,
     )
+
+
+def _apply_replica_process_run(
+    replica: WriteReplica,
+    run_dict: dict,
+) -> Optional[dict]:
+    """Apply a replica's process_run callback, if any.
+
+    Returns the transformed run dict, or None to skip this replica. If the
+    callback raises, the replica is skipped and a warning is logged — a bad
+    processor shouldn't take down tracing for other replicas.
+    """
+    processor = replica.get("process_run")
+    if processor is None:
+        return run_dict
+    try:
+        return processor(run_dict)
+    except Exception:
+        logger.warning(
+            "Replica process_run callback raised; skipping replica",
+            exc_info=True,
+        )
+        return None

--- a/python/tests/unit_tests/test_replica_endpoints.py
+++ b/python/tests/unit_tests/test_replica_endpoints.py
@@ -1120,3 +1120,198 @@ class TestTracingContextReplicas:
         # This should not raise a type error
         with tracing_context(replicas=replicas):
             pass  # Just testing that the context manager works
+
+
+class TestReplicaProcessCallback:
+    """Tests for the per-replica ``process`` pre-send callback."""
+
+    def test_process_transforms_payload_per_replica(self):
+        """Each replica's process callback sees and can mutate its own payload."""
+        client = Mock()
+
+        def redact(run_dict: dict) -> dict:
+            return {**run_dict, "inputs": {}, "outputs": {}}
+
+        def passthrough(run_dict: dict) -> dict:
+            return run_dict
+
+        replicas = [
+            WriteReplica(
+                api_url="https://primary.example.com",
+                auth=ApiKeyAuth(api_key="primary-key"),
+                project_name="primary",
+                process_run=redact,
+            ),
+            WriteReplica(
+                api_url="https://debug.example.com",
+                auth=ApiKeyAuth(api_key="debug-key"),
+                project_name="debug-unredacted",
+                process_run=passthrough,
+            ),
+        ]
+
+        run_tree = RunTree(
+            name="test_run",
+            inputs={"secret": "sensitive"},
+            outputs={"answer": "also sensitive"},
+            client=client,
+            project_name="default",
+            replicas=replicas,
+        )
+        run_tree.post()
+
+        assert client.create_run.call_count == 2
+        first, second = client.create_run.call_args_list
+        assert first.kwargs["inputs"] == {}
+        assert first.kwargs["outputs"] == {}
+        assert second.kwargs["inputs"] == {"secret": "sensitive"}
+        assert second.kwargs["outputs"] == {"answer": "also sensitive"}
+
+    def test_process_returning_none_skips_replica(self):
+        """Returning None from process suppresses the write for that replica only."""
+        client = Mock()
+
+        replicas = [
+            WriteReplica(
+                api_url="https://drop.example.com",
+                auth=ApiKeyAuth(api_key="drop-key"),
+                project_name="drop",
+                process_run=lambda _d: None,
+            ),
+            WriteReplica(
+                api_url="https://keep.example.com",
+                auth=ApiKeyAuth(api_key="keep-key"),
+                project_name="keep",
+            ),
+        ]
+
+        run_tree = RunTree(
+            name="test_run",
+            inputs={"x": 1},
+            client=client,
+            project_name="default",
+            replicas=replicas,
+        )
+        run_tree.post()
+
+        assert client.create_run.call_count == 1
+        assert client.create_run.call_args.kwargs["api_key"] == "keep-key"
+
+    def test_process_applied_on_patch(self):
+        """process runs on update_run as well as create_run."""
+        client = Mock()
+
+        seen: list[dict] = []
+
+        def record_and_redact(run_dict: dict) -> dict:
+            seen.append(run_dict)
+            return {**run_dict, "outputs": {}}
+
+        run_tree = RunTree(
+            name="test_run",
+            inputs={"x": 1},
+            outputs={"y": 2},
+            client=client,
+            project_name="default",
+            replicas=[
+                WriteReplica(
+                    project_name="primary",
+                    process_run=record_and_redact,
+                )
+            ],
+        )
+        run_tree.patch()
+
+        assert client.update_run.call_count == 1
+        assert client.update_run.call_args.kwargs["outputs"] == {}
+        assert len(seen) == 1
+
+    def test_process_exception_skips_replica_without_breaking_others(self):
+        """A raising processor is isolated; other replicas still receive their write."""
+        client = Mock()
+
+        def blow_up(_d: dict) -> dict:
+            raise RuntimeError("bad processor")
+
+        replicas = [
+            WriteReplica(
+                api_url="https://bad.example.com",
+                auth=ApiKeyAuth(api_key="bad-key"),
+                project_name="bad",
+                process_run=blow_up,
+            ),
+            WriteReplica(
+                api_url="https://good.example.com",
+                auth=ApiKeyAuth(api_key="good-key"),
+                project_name="good",
+            ),
+        ]
+
+        run_tree = RunTree(
+            name="test_run",
+            inputs={"x": 1},
+            client=client,
+            project_name="default",
+            replicas=replicas,
+        )
+        run_tree.post()
+
+        assert client.create_run.call_count == 1
+        assert client.create_run.call_args.kwargs["api_key"] == "good-key"
+
+    def test_process_run_receives_run_like_dict(self):
+        """process_run is invoked with a RunLikeDict-shaped payload."""
+        client = Mock()
+        captured: list[dict] = []
+
+        def capture(run_dict: dict) -> dict:
+            captured.append(run_dict)
+            return run_dict
+
+        run_tree = RunTree(
+            name="my_run",
+            run_type="chain",
+            inputs={"x": 1},
+            outputs={"y": 2},
+            tags=["a", "b"],
+            client=client,
+            project_name="default",
+            replicas=[
+                WriteReplica(project_name="target", process_run=capture),
+            ],
+        )
+        run_tree.post()
+
+        assert len(captured) == 1
+        payload = captured[0]
+        # Core RunLikeDict fields the processor should see.
+        assert payload["name"] == "my_run"
+        assert payload["run_type"] == "chain"
+        assert payload["inputs"] == {"x": 1}
+        assert payload["outputs"] == {"y": 2}
+        assert payload["tags"] == ["a", "b"]
+        assert payload["session_name"] == "target"
+        assert "id" in payload
+        assert "trace_id" in payload
+
+    def test_exclude_inputs_wins_over_process_run_on_patch(self):
+        """patch(exclude_inputs=True) must drop inputs even if process_run sets them."""
+        client = Mock()
+
+        def revive_inputs(run_dict: dict) -> dict:
+            return {**run_dict, "inputs": {"sneaky": "value"}}
+
+        run_tree = RunTree(
+            name="test_run",
+            inputs={"x": 1},
+            outputs={"y": 2},
+            client=client,
+            project_name="default",
+            replicas=[
+                WriteReplica(project_name="primary", process_run=revive_inputs),
+            ],
+        )
+        run_tree.patch(exclude_inputs=True)
+
+        assert client.update_run.call_count == 1
+        assert client.update_run.call_args.kwargs["inputs"] is None


### PR DESCRIPTION
Adds optional `process_run` to `WriteReplica`: called with the run payload before each replica's `create_run`/`update_run`. Return a modified dict to send; return `None` to skip the replica.

Today, replicas share the parent RunTree's client, so `hide_inputs`/`hide_outputs` apply uniformly. `process_run` lets each replica redact (or tag, or drop) independently without a second `Client` in the queue.

The callback receives a run-like dict shaped per `RunLikeDict` (name, id, inputs, outputs, trace_id, session_name, etc.) — documented in the field comment.

```python
def redact(r): return {**r, "inputs": {}, "outputs": {}}

tracing_context(replicas=[
    {"api_key": primary, "process_run": redact},
    {"api_key": debug},  # pass-through
])
```

Additive field, no behavior change for existing replicas. Exceptions in `process_run` are caught and logged — bad processors skip their own replica without breaking others.

## Test plan

- [x] `process_run` transforms per replica independently
- [x] Returning `None` skips only that replica
- [x] Runs on both `post()` and `patch()`
- [x] Raising processor is isolated
- [x] Processor receives the documented RunLikeDict shape
- [x] `exclude_inputs` still takes precedence over processor output on patch