### PR TITLE
fix(wrappers): suppress Pydantic serialization warnings for ParsedBetaMessage in wrap_anthropic

### DIFF
--- a/python/langsmith/wrappers/_anthropic.py
+++ b/python/langsmith/wrappers/_anthropic.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import functools
 import logging
+import warnings
 from collections.abc import AsyncIterator, Mapping, Sequence
 from typing import (
     TYPE_CHECKING,
@@ -146,7 +147,16 @@ def _create_usage_metadata(anthropic_token_usage: dict) -> UsageMetadata:
 
 def _message_to_outputs(message: Any) -> dict:
     """Convert an Anthropic Message to a flat outputs dict with usage_metadata."""
-    outputs = message.model_dump()
+    # ParsedBetaMessage/ParsedMessage (from beta.messages.parse()) carry user-defined
+    # Pydantic models in parsed_output and ParsedBetaTextBlock in content. These trigger
+    # PydanticSerializationUnexpectedValue warnings because the values do not match the
+    # declared union types in the base BetaMessage schema. Suppress for parsed types.
+    if hasattr(message, "parsed_output"):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            outputs = message.model_dump()
+    else:
+        outputs = message.model_dump()
     anthropic_token_usage = outputs.pop("usage", None)
     if anthropic_token_usage:
         outputs["usage_metadata"] = _create_usage_metadata(anthropic_token_usage)

--- a/python/tests/unit_tests/wrappers/test_anthropic_processing.py
+++ b/python/tests/unit_tests/wrappers/test_anthropic_processing.py
@@ -1,5 +1,6 @@
 """Unit tests for Anthropic wrapper processing functions."""
 
+import warnings
 from unittest.mock import MagicMock
 
 from langsmith._internal._orjson import loads as _loads
@@ -180,3 +181,65 @@ class TestMessageToOutputsToolCalls:
         assert result["tool_calls"][1]["index"] == 1
         assert result["tool_calls"][0]["function"]["name"] == "get_weather"
         assert result["tool_calls"][1]["function"]["name"] == "get_stock"
+
+
+class TestMessageToOutputsParsedMessage:
+    """Test that _message_to_outputs suppresses Pydantic warnings for parsed messages."""
+
+    def test_no_pydantic_warning_for_parsed_beta_message(self):
+        """ParsedBetaMessage triggers PydanticSerializationUnexpectedValue when
+        model_dump() is called directly. Verify no warnings leak out."""
+        msg = MagicMock()
+        # Simulate ParsedBetaMessage: has parsed_output and emits warning on model_dump
+        msg.parsed_output = MagicMock()
+
+        def _model_dump_with_warning():
+            warnings.warn(
+                "PydanticSerializationUnexpectedValue: serialized value may not be as expected",
+                UserWarning,
+                stacklevel=2,
+            )
+            return {
+                "id": "msg_beta_123",
+                "role": "assistant",
+                "content": [{"type": "text", "text": "Hello"}],
+                "model": "claude-sonnet-4-20250514",
+                "stop_reason": "end_turn",
+                "type": "message",
+                "usage": {"input_tokens": 10, "output_tokens": 5},
+            }
+
+        msg.model_dump.side_effect = _model_dump_with_warning
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            result = _message_to_outputs(msg)
+
+        assert len(caught) == 0, f"Expected no warnings, got: {[str(w.message) for w in caught]}"
+        assert result["content"] == [{"type": "text", "text": "Hello"}]
+
+    def test_regular_message_warnings_not_suppressed(self):
+        """For regular (non-parsed) messages, warnings from model_dump are not suppressed."""
+        msg = MagicMock()
+        del msg.parsed_output  # ensure attribute does not exist
+
+        def _model_dump_with_warning():
+            warnings.warn("some other warning", UserWarning, stacklevel=2)
+            return {
+                "id": "msg_123",
+                "role": "assistant",
+                "content": "Hello",
+                "model": "claude-sonnet-4-20250514",
+                "stop_reason": "end_turn",
+                "type": "message",
+                "usage": {"input_tokens": 10, "output_tokens": 5},
+            }
+
+        msg.model_dump.side_effect = _model_dump_with_warning
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            result = _message_to_outputs(msg)
+
+        assert len(caught) == 1
+        assert "some other warning" in str(caught[0].message)


### PR DESCRIPTION
## Summary

Fixes #2737.

When `beta.messages.parse()` is called on a `wrap_anthropic`-wrapped client, the `_message_to_outputs` function receives a `ParsedBetaMessage`. Calling `.model_dump()` on it emits `PydanticSerializationUnexpectedValue` warnings because:

- `parsed_output` holds a user-defined Pydantic model (e.g. `WeatherResponse`) that doesn't match the `None` type declared in the base `BetaMessage` schema.
- `content` contains `ParsedBetaTextBlock[T]` instances where `BetaTextBlock` is expected.

**Fix:** guard the `model_dump()` call with `warnings.catch_warnings(simplefilter("ignore"))` only when `parsed_output` is present on the message (the reliable indicator of a parsed type). Regular `Message`/`BetaMessage` objects remain unaffected.

## Changes

- `python/langsmith/wrappers/_anthropic.py`: Add `import warnings`; in `_message_to_outputs`, suppress warnings for parsed message types via `warnings.catch_warnings()`.
- `python/tests/unit_tests/wrappers/test_anthropic_processing.py`: Add `TestMessageToOutputsParsedMessage` with two tests verifying (a) no warnings emitted for parsed messages and (b) warnings are still raised for regular messages.

## Test plan

- [ ] `pytest python/tests/unit_tests/wrappers/test_anthropic_processing.py -v` — all existing + new tests pass.
- [ ] Manually call `wrap_anthropic(Anthropic()).beta.messages.parse(...)` and confirm no Pydantic serialization warnings in output.