### PR TITLE
feat(sandbox): expose per-sandbox proxy_config in py + js clients

### DIFF
--- a/js/src/experimental/sandbox/client.ts
+++ b/js/src/experimental/sandbox/client.ts
@@ -745,6 +745,7 @@ export class SandboxClient {
       vCpus,
       memBytes,
       fsCapacityBytes,
+      proxyConfig,
     } = options;
 
     if (!templateName && !snapshotId) {
@@ -788,6 +789,9 @@ export class SandboxClient {
     }
     if (fsCapacityBytes !== undefined) {
       payload.fs_capacity_bytes = fsCapacityBytes;
+    }
+    if (proxyConfig !== undefined) {
+      payload.proxy_config = proxyConfig;
     }
 
     const httpTimeout = waitForReady ? (timeout + 30) * 1000 : 30 * 1000;

--- a/js/src/experimental/sandbox/index.ts
+++ b/js/src/experimental/sandbox/index.ts
@@ -45,6 +45,8 @@ export type {
   SandboxClientConfig,
   RunOptions,
   CreateSandboxOptions,
+  SandboxAccessControl,
+  SandboxProxyConfig,
   CreateSnapshotOptions,
   CaptureSnapshotOptions,
   WaitForSnapshotOptions,

--- a/js/src/experimental/sandbox/types.ts
+++ b/js/src/experimental/sandbox/types.ts
@@ -281,6 +281,35 @@ export interface RunOptions {
 }
 
 /**
+ * Network access-control rules for a sandbox's proxy sidecar.
+ *
+ * Supported pattern types: exact domains, globs (e.g. `*.example.com`),
+ * IPs, CIDR ranges (e.g. `10.0.0.0/8`), and regex (`~pattern`).
+ *
+ * Only one of `allow_list` and `deny_list` may be populated.
+ */
+export interface SandboxAccessControl {
+  /** Hosts the sandbox is allowed to reach. */
+  allow_list?: string[];
+  /** Hosts the sandbox is blocked from reaching. */
+  deny_list?: string[];
+}
+
+/**
+ * Full proxy configuration forwarded to the sandbox server as-is (snake_case
+ * so it's wire-compatible with the backend). Mirrors the server's
+ * `ProxyConfig` type.
+ */
+export interface SandboxProxyConfig {
+  /** Header-injection rules keyed by host pattern. */
+  rules?: unknown[];
+  /** Hosts that bypass the proxy entirely. */
+  no_proxy?: string[];
+  /** Allow/deny list enforced at the proxy sidecar. */
+  access_control?: SandboxAccessControl;
+}
+
+/**
  * Options for creating a sandbox.
  */
 export interface CreateSandboxOptions {
@@ -320,6 +349,13 @@ export interface CreateSandboxOptions {
   memBytes?: number;
   /** Root filesystem capacity in bytes. */
   fsCapacityBytes?: number;
+  /**
+   * Per-sandbox proxy configuration. Use
+   * `{ access_control: { allow_list: ["github.com", "*.example.com"] } }`
+   * to restrict outbound HTTPS to a set of host patterns. Forwarded to the
+   * server as-is on the wire.
+   */
+  proxyConfig?: SandboxProxyConfig;
 }
 
 /**

--- a/js/src/tests/sandbox.test.ts
+++ b/js/src/tests/sandbox.test.ts
@@ -363,6 +363,47 @@ describe("SandboxClient - createSandbox", () => {
     ).rejects.toThrow(LangSmithValidationError);
     expect(mockFetch).not.toHaveBeenCalled();
   });
+
+  it("should forward proxyConfig in the request body under proxy_config", async () => {
+    const mockFetch = jest.fn<typeof fetch>().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        name: "test-sb",
+        template_name: "python-sandbox",
+        status: "ready",
+      }),
+    } as Response);
+
+    const client = createClientWithMock(mockFetch);
+    const proxyConfig = {
+      access_control: {
+        allow_list: ["github.com", "*.example.com"],
+      },
+    };
+    await client.createSandbox("python-sandbox", { proxyConfig });
+
+    const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string);
+    expect(body.proxy_config).toEqual(proxyConfig);
+  });
+
+  it("should omit proxy_config from the request body when not provided", async () => {
+    const mockFetch = jest.fn<typeof fetch>().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        name: "test-sb",
+        template_name: "python-sandbox",
+        status: "ready",
+      }),
+    } as Response);
+
+    const client = createClientWithMock(mockFetch);
+    await client.createSandbox("python-sandbox");
+
+    const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string);
+    expect(body.proxy_config).toBeUndefined();
+  });
 });
 
 describe("validateTtl", () => {

--- a/python/langsmith/sandbox/_async_client.py
+++ b/python/langsmith/sandbox/_async_client.py
@@ -727,6 +727,7 @@ class AsyncSandboxClient:
         vcpus: Optional[int] = None,
         mem_bytes: Optional[int] = None,
         fs_capacity_bytes: Optional[int] = None,
+        proxy_config: Optional[dict[str, Any]] = None,
         headers: RequestHeaders = None,
     ) -> AsyncSandbox:
         """Create a sandbox and return an AsyncSandbox instance.
@@ -759,6 +760,14 @@ class AsyncSandboxClient:
             vcpus: Number of vCPUs.
             mem_bytes: Memory in bytes.
             fs_capacity_bytes: Root filesystem capacity in bytes.
+            proxy_config: Per-sandbox proxy configuration forwarded to the
+                server as-is. Shape matches the backend `proxy_config` field:
+                ``{"rules": [...], "no_proxy": [...], "access_control":
+                {"allow_list": [...]}}`` or ``{"access_control":
+                {"deny_list": [...]}}``. Use ``access_control.allow_list`` to
+                restrict outbound HTTPS to a set of host patterns (exact
+                domains, globs like ``*.example.com``, IPs, CIDRs, or
+                ``~regex``).
 
         Returns:
             AsyncSandbox instance.
@@ -780,6 +789,7 @@ class AsyncSandboxClient:
             vcpus=vcpus,
             mem_bytes=mem_bytes,
             fs_capacity_bytes=fs_capacity_bytes,
+            proxy_config=proxy_config,
             headers=headers,
         )
         sb._auto_delete = True
@@ -798,6 +808,7 @@ class AsyncSandboxClient:
         vcpus: Optional[int] = None,
         mem_bytes: Optional[int] = None,
         fs_capacity_bytes: Optional[int] = None,
+        proxy_config: Optional[dict[str, Any]] = None,
         headers: RequestHeaders = None,
     ) -> AsyncSandbox:
         """Create a new Sandbox.
@@ -825,6 +836,14 @@ class AsyncSandboxClient:
             vcpus: Number of vCPUs.
             mem_bytes: Memory in bytes.
             fs_capacity_bytes: Root filesystem capacity in bytes.
+            proxy_config: Per-sandbox proxy configuration forwarded to the
+                server as-is. Shape matches the backend `proxy_config` field:
+                ``{"rules": [...], "no_proxy": [...], "access_control":
+                {"allow_list": [...]}}`` or ``{"access_control":
+                {"deny_list": [...]}}``. Use ``access_control.allow_list`` to
+                restrict outbound HTTPS to a set of host patterns (exact
+                domains, globs like ``*.example.com``, IPs, CIDRs, or
+                ``~regex``).
 
         Returns:
             Created AsyncSandbox. When wait_for_ready=False, the sandbox will have
@@ -868,6 +887,8 @@ class AsyncSandboxClient:
             payload["mem_bytes"] = mem_bytes
         if fs_capacity_bytes is not None:
             payload["fs_capacity_bytes"] = fs_capacity_bytes
+        if proxy_config is not None:
+            payload["proxy_config"] = proxy_config
 
         http_timeout = (timeout + 30) if wait_for_ready else 30
 

--- a/python/langsmith/sandbox/_client.py
+++ b/python/langsmith/sandbox/_client.py
@@ -718,6 +718,7 @@ class SandboxClient:
         vcpus: Optional[int] = None,
         mem_bytes: Optional[int] = None,
         fs_capacity_bytes: Optional[int] = None,
+        proxy_config: Optional[dict[str, Any]] = None,
         headers: RequestHeaders = None,
     ) -> Sandbox:
         """Create a sandbox and return a Sandbox instance.
@@ -750,6 +751,14 @@ class SandboxClient:
             vcpus: Number of vCPUs.
             mem_bytes: Memory in bytes.
             fs_capacity_bytes: Root filesystem capacity in bytes.
+            proxy_config: Per-sandbox proxy configuration forwarded to the
+                server as-is. Shape matches the backend `proxy_config` field:
+                ``{"rules": [...], "no_proxy": [...], "access_control":
+                {"allow_list": [...]}}`` or ``{"access_control":
+                {"deny_list": [...]}}``. Use ``access_control.allow_list`` to
+                restrict outbound HTTPS to a set of host patterns (exact
+                domains, globs like ``*.example.com``, IPs, CIDRs, or
+                ``~regex``).
 
         Returns:
             Sandbox instance.
@@ -771,6 +780,7 @@ class SandboxClient:
             vcpus=vcpus,
             mem_bytes=mem_bytes,
             fs_capacity_bytes=fs_capacity_bytes,
+            proxy_config=proxy_config,
             headers=headers,
         )
         sb._auto_delete = True
@@ -789,6 +799,7 @@ class SandboxClient:
         vcpus: Optional[int] = None,
         mem_bytes: Optional[int] = None,
         fs_capacity_bytes: Optional[int] = None,
+        proxy_config: Optional[dict[str, Any]] = None,
         headers: RequestHeaders = None,
     ) -> Sandbox:
         """Create a new Sandbox.
@@ -816,6 +827,14 @@ class SandboxClient:
             vcpus: Number of vCPUs.
             mem_bytes: Memory in bytes.
             fs_capacity_bytes: Root filesystem capacity in bytes.
+            proxy_config: Per-sandbox proxy configuration forwarded to the
+                server as-is. Shape matches the backend `proxy_config` field:
+                ``{"rules": [...], "no_proxy": [...], "access_control":
+                {"allow_list": [...]}}`` or ``{"access_control":
+                {"deny_list": [...]}}``. Use ``access_control.allow_list`` to
+                restrict outbound HTTPS to a set of host patterns (exact
+                domains, globs like ``*.example.com``, IPs, CIDRs, or
+                ``~regex``).
 
         Returns:
             Created Sandbox. When wait_for_ready=False, the sandbox will have
@@ -859,6 +878,8 @@ class SandboxClient:
             payload["mem_bytes"] = mem_bytes
         if fs_capacity_bytes is not None:
             payload["fs_capacity_bytes"] = fs_capacity_bytes
+        if proxy_config is not None:
+            payload["proxy_config"] = proxy_config
 
         http_timeout = (timeout + 30) if wait_for_ready else 30
 

--- a/python/tests/unit_tests/sandbox/test_async_client.py
+++ b/python/tests/unit_tests/sandbox/test_async_client.py
@@ -368,6 +368,53 @@ class TestAsyncSandboxOperations:
             sandbox.dataplane_url == "https://sandbox-router.example.com/tenant/sb-123"
         )
 
+    async def test_create_sandbox_forwards_proxy_config(
+        self, client: AsyncSandboxClient, httpx_mock: HTTPXMock
+    ):
+        """proxy_config should appear verbatim in the POST body."""
+        import json
+
+        httpx_mock.add_response(
+            method="POST",
+            url="http://test-server:8080/boxes",
+            json={
+                "name": "test-sandbox",
+                "template_name": "python-sandbox",
+            },
+            status_code=201,
+        )
+
+        proxy_config = {
+            "access_control": {"allow_list": ["github.com", "*.example.com"]},
+        }
+        await client.create_sandbox(
+            template_name="python-sandbox",
+            proxy_config=proxy_config,
+        )
+
+        body = json.loads(httpx_mock.get_request().content)
+        assert body["proxy_config"] == proxy_config
+
+    async def test_create_sandbox_omits_proxy_config_when_none(
+        self, client: AsyncSandboxClient, httpx_mock: HTTPXMock
+    ):
+        """proxy_config must not appear in the payload when not provided."""
+        import json
+
+        httpx_mock.add_response(
+            method="POST",
+            url="http://test-server:8080/boxes",
+            json={
+                "name": "test-sandbox",
+                "template_name": "python-sandbox",
+            },
+            status_code=201,
+        )
+
+        await client.create_sandbox(template_name="python-sandbox")
+        body = json.loads(httpx_mock.get_request().content)
+        assert "proxy_config" not in body
+
     async def test_create_sandbox_merges_custom_headers(
         self, client: AsyncSandboxClient, httpx_mock: HTTPXMock
     ):

--- a/python/tests/unit_tests/sandbox/test_client.py
+++ b/python/tests/unit_tests/sandbox/test_client.py
@@ -357,6 +357,54 @@ class TestSandboxOperations:
         assert sandbox.id == "550e8400-e29b-41d4-a716-446655440003"
         assert sandbox.dataplane_url == "https://sandbox-router.example.com/sb-123"
 
+    def test_create_sandbox_forwards_proxy_config(
+        self, client: SandboxClient, httpx_mock: HTTPXMock
+    ):
+        """proxy_config should appear verbatim in the POST body."""
+        import json
+
+        httpx_mock.add_response(
+            method="POST",
+            url="http://test-server:8080/boxes",
+            json={
+                "name": "test-sandbox",
+                "template_name": "python-sandbox",
+            },
+            status_code=201,
+        )
+
+        proxy_config = {
+            "access_control": {"allow_list": ["github.com", "*.example.com"]},
+        }
+        client.create_sandbox(
+            template_name="python-sandbox",
+            proxy_config=proxy_config,
+        )
+
+        request = httpx_mock.get_request()
+        body = json.loads(request.content)
+        assert body["proxy_config"] == proxy_config
+
+    def test_create_sandbox_omits_proxy_config_when_none(
+        self, client: SandboxClient, httpx_mock: HTTPXMock
+    ):
+        """proxy_config must not appear in the payload when not provided."""
+        import json
+
+        httpx_mock.add_response(
+            method="POST",
+            url="http://test-server:8080/boxes",
+            json={
+                "name": "test-sandbox",
+                "template_name": "python-sandbox",
+            },
+            status_code=201,
+        )
+
+        client.create_sandbox(template_name="python-sandbox")
+        body = json.loads(httpx_mock.get_request().content)
+        assert "proxy_config" not in body
+
     def test_create_sandbox_merges_custom_headers(
         self, client: SandboxClient, httpx_mock: HTTPXMock
     ):


### PR DESCRIPTION
The server's CreateClaimPayload already accepts a proxy_config block (rules, no_proxy, access_control.allow_list/deny_list) enforced by the sandbox proxy sidecar, but neither SDK exposed it. Callers that want to restrict a sandbox's outbound traffic to a hostname allowlist had no way to do so short of crafting the raw HTTP request.

Python: add proxy_config: Optional[dict[str, Any]] to create_sandbox and the sandbox() context-manager wrapper on both SandboxClient and AsyncSandboxClient. Forwarded to the server as-is under the proxy_config key; omitted from the payload when None.

JS: add proxyConfig?: SandboxProxyConfig to CreateSandboxOptions, with SandboxProxyConfig / SandboxAccessControl interfaces exported from the sandbox module. Snake-case on the wire to match the server; forwarded as-is when provided.

Unit tests cover both "forwarded verbatim" and "omitted when unset" for all four client surfaces.