### PR TITLE
release(py,js): py 0.7.33, js 0.5.21

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langsmith",
-  "version": "0.5.20",
+  "version": "0.5.21",
   "description": "Client library to connect to the LangSmith Observability and Evaluation Platform.",
   "packageManager": "pnpm@10.33.0",
   "files": [

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -32,4 +32,4 @@ export {
 } from "./utils/prompt_cache/index.js";
 
 // Update using pnpm bump-version
-export const __version__ = "0.5.20";
+export const __version__ = "0.5.21";

--- a/python/.bumpversion.cfg
+++ b/python/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.7.32
+current_version = 0.7.33
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
 serialize = {major}.{minor}.{patch}
 search = {current_version}

--- a/python/langsmith/__init__.py
+++ b/python/langsmith/__init__.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
 
 # Avoid calling into importlib on every call to __version__
 
-__version__ = "0.7.32"
+__version__ = "0.7.33"
 version = __version__  # for backwards compatibility
 
 


### PR DESCRIPTION
Bump Python SDK to 0.7.33 and JS SDK to 0.5.21.

Releases the `proxy_config` kwarg on `create_sandbox` (py + js) added in #2742 so downstream callers (issues-board agent / `smith-issues-agent`) can pin against it.