### PR TITLE
feat(js): add agent/skill hub operations to Client

### DIFF
--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -52,6 +52,10 @@ import {
   AnnotationQueueWithDetails,
   AnnotationQueueRubricItem,
   FeedbackConfigSchema,
+  AgentContext,
+  SkillContext,
+  Entry,
+  DirectoryCommitResponse,
 } from "./schemas.js";
 import {
   convertLangChainMessageToExample,
@@ -6196,6 +6200,380 @@ export class Client implements LangSmithTracingClientInterface {
       description: options?.commitDescription,
     });
     return url;
+  }
+
+  /**
+   * Check if an agent repo exists.
+   */
+  public async agentExists(identifier: string): Promise<boolean> {
+    const [owner, name] = parsePromptIdentifier(identifier);
+    return this._repoExists(owner, name);
+  }
+
+  /**
+   * Check if a skill repo exists.
+   */
+  public async skillExists(identifier: string): Promise<boolean> {
+    const [owner, name] = parsePromptIdentifier(identifier);
+    return this._repoExists(owner, name);
+  }
+
+  /**
+   * Pull an agent directory from Hub.
+   * @param identifier The identifier (owner/name[:version]).
+   * @param options.version Commit hash or tag; overrides identifier's version.
+   */
+  public async pullAgent(
+    identifier: string,
+    options?: { version?: string }
+  ): Promise<AgentContext> {
+    return (await this._pullDirectory(
+      identifier,
+      options?.version
+    )) as AgentContext;
+  }
+
+  /**
+   * Pull a skill directory from Hub.
+   */
+  public async pullSkill(
+    identifier: string,
+    options?: { version?: string }
+  ): Promise<SkillContext> {
+    return (await this._pullDirectory(
+      identifier,
+      options?.version
+    )) as SkillContext;
+  }
+
+  /**
+   * Push an agent to Hub. Creates the repo if missing, patches metadata if
+   * provided, then commits the given files.
+   * @returns The URL of the resulting commit.
+   */
+  public async pushAgent(
+    identifier: string,
+    options: {
+      files: Record<string, Entry | null>;
+      parentCommit?: string;
+      description?: string;
+      readme?: string;
+      tags?: string[];
+      isPublic?: boolean;
+    }
+  ): Promise<string> {
+    return this._pushDirectory(identifier, "agent", options);
+  }
+
+  /**
+   * Push a skill to Hub.
+   */
+  public async pushSkill(
+    identifier: string,
+    options: {
+      files: Record<string, Entry | null>;
+      parentCommit?: string;
+      description?: string;
+      readme?: string;
+      tags?: string[];
+      isPublic?: boolean;
+    }
+  ): Promise<string> {
+    return this._pushDirectory(identifier, "skill", options);
+  }
+
+  /**
+   * Delete an agent and all its owned child file repos.
+   */
+  public async deleteAgent(identifier: string): Promise<void> {
+    return this._deleteDirectory(identifier);
+  }
+
+  /**
+   * Delete a skill and all its owned child file repos.
+   */
+  public async deleteSkill(identifier: string): Promise<void> {
+    return this._deleteDirectory(identifier);
+  }
+
+  /**
+   * List agent repos. Yields one at a time, auto-paginating.
+   */
+  public async *listAgents(options?: {
+    isPublic?: boolean;
+    isArchived?: boolean;
+    query?: string;
+  }): AsyncIterableIterator<Prompt> {
+    yield* this._listReposByType("agent", options);
+  }
+
+  /**
+   * List skill repos. Yields one at a time, auto-paginating.
+   */
+  public async *listSkills(options?: {
+    isPublic?: boolean;
+    isArchived?: boolean;
+    query?: string;
+  }): AsyncIterableIterator<Prompt> {
+    yield* this._listReposByType("skill", options);
+  }
+
+  private async *_listReposByType(
+    repoType: "agent" | "skill",
+    options?: { isPublic?: boolean; isArchived?: boolean; query?: string }
+  ): AsyncIterableIterator<Prompt> {
+    const params = new URLSearchParams();
+    params.append("repo_type", repoType);
+    params.append("is_archived", (!!options?.isArchived).toString());
+    if (options?.isPublic !== undefined) {
+      params.append("is_public", options.isPublic.toString());
+    }
+    if (options?.query) {
+      params.append("query", options.query);
+    }
+
+    for await (const repos of this._getPaginated<Prompt, ListPromptsResponse>(
+      "/repos",
+      params,
+      (res) => res.repos
+    )) {
+      yield* repos;
+    }
+  }
+
+  private async _pullDirectory(
+    identifier: string,
+    version?: string
+  ): Promise<AgentContext | SkillContext> {
+    const [owner, name, parsedVersion] = parsePromptIdentifier(identifier);
+    const resolvedVersion =
+      version ?? (parsedVersion !== "latest" ? parsedVersion : undefined);
+
+    const url = new URL(
+      `${this.apiUrl}/v1/platform/hub/repos/${owner}/${name}/directories`
+    );
+    if (resolvedVersion) {
+      url.searchParams.set("commit", resolvedVersion);
+    }
+
+    const response = await this.caller.call(async () => {
+      const res = await this._fetch(url.toString(), {
+        method: "GET",
+        headers: this._mergedHeaders,
+        signal: AbortSignal.timeout(this.timeout_ms),
+        ...this.fetchOptions,
+      });
+      await raiseForStatus(res, "pull directory");
+      return res;
+    });
+    const data = (await response.json()) as Partial<AgentContext> & {
+      files: Record<string, Entry>;
+      commit_hash: string;
+    };
+    return {
+      owner: data.owner ?? owner,
+      repo: data.repo ?? name,
+      commit_hash: data.commit_hash,
+      files: data.files,
+    };
+  }
+
+  private async _pushDirectory(
+    identifier: string,
+    repoType: "agent" | "skill",
+    options: {
+      files: Record<string, Entry | null>;
+      parentCommit?: string;
+      description?: string;
+      readme?: string;
+      tags?: string[];
+      isPublic?: boolean;
+    }
+  ): Promise<string> {
+    const fileCount = Object.keys(options.files).length;
+    if (fileCount > 500) {
+      throw new Error(`Too many files (${fileCount} > 500)`);
+    }
+    if (
+      options.parentCommit !== undefined &&
+      (options.parentCommit.length < 8 || options.parentCommit.length > 64)
+    ) {
+      throw new Error("parent_commit must be 8-64 characters");
+    }
+
+    const [owner, name] = parsePromptIdentifier(identifier);
+    if (!(await this._currentTenantIsOwner(owner))) {
+      throw await this._ownerConflictError(`push ${repoType}`, owner);
+    }
+
+    if (await this._repoExists(owner, name)) {
+      if (
+        options.description !== undefined ||
+        options.readme !== undefined ||
+        options.tags !== undefined ||
+        options.isPublic !== undefined
+      ) {
+        await this._updateRepoMetadata(owner, name, options);
+      }
+    } else {
+      if (!/^[a-z][a-z0-9-_]*$/.test(name)) {
+        throw new Error(
+          `Invalid repo_handle ${JSON.stringify(
+            name
+          )}: must match /^[a-z][a-z0-9-_]*$/`
+        );
+      }
+      await this._createRepo(name, repoType, options);
+    }
+
+    const body: Record<string, unknown> = { files: options.files };
+    if (options.parentCommit) {
+      body.parent_commit = options.parentCommit;
+    }
+
+    const response = await this.caller.call(async () => {
+      const res = await this._fetch(
+        `${this.apiUrl}/v1/platform/hub/repos/${owner}/${name}/directories/commits`,
+        {
+          method: "POST",
+          headers: {
+            ...this._mergedHeaders,
+            "Content-Type": "application/json",
+          },
+          signal: AbortSignal.timeout(this.timeout_ms),
+          ...this.fetchOptions,
+          body: JSON.stringify(body),
+        }
+      );
+      await raiseForStatus(res, `push ${repoType}`);
+      return res;
+    });
+    const data = (await response.json()) as DirectoryCommitResponse;
+    const commitHash = data.commit.commit_hash;
+    return `${this.getHostUrl()}/hub/${owner}/${name}:${commitHash.slice(
+      0,
+      8
+    )}`;
+  }
+
+  private async _deleteDirectory(identifier: string): Promise<void> {
+    const [owner, name] = parsePromptIdentifier(identifier);
+    await this.caller.call(async () => {
+      const res = await this._fetch(
+        `${this.apiUrl}/v1/platform/hub/repos/${owner}/${name}/directories`,
+        {
+          method: "DELETE",
+          headers: this._mergedHeaders,
+          signal: AbortSignal.timeout(this.timeout_ms),
+          ...this.fetchOptions,
+        }
+      );
+      await raiseForStatus(res, "delete directory");
+      return res;
+    });
+  }
+
+  private async _repoExists(owner: string, name: string): Promise<boolean> {
+    try {
+      await this.caller.call(async () => {
+        const res = await this._fetch(`${this.apiUrl}/repos/${owner}/${name}`, {
+          method: "GET",
+          headers: this._mergedHeaders,
+          signal: AbortSignal.timeout(this.timeout_ms),
+          ...this.fetchOptions,
+        });
+        await raiseForStatus(res, "check repo exists");
+        return res;
+      });
+      return true;
+    } catch (e) {
+      if (isLangSmithNotFoundError(e)) {
+        return false;
+      }
+      throw e;
+    }
+  }
+
+  private async _createRepo(
+    name: string,
+    repoType: "agent" | "skill",
+    options: {
+      description?: string;
+      readme?: string;
+      tags?: string[];
+      isPublic?: boolean;
+    }
+  ): Promise<void> {
+    const body: Record<string, unknown> = {
+      repo_handle: name,
+      repo_type: repoType,
+      is_public: !!options.isPublic,
+    };
+    if (options.description !== undefined)
+      body.description = options.description;
+    if (options.readme !== undefined) body.readme = options.readme;
+    if (options.tags !== undefined) body.tags = options.tags;
+
+    try {
+      await this.caller.call(async () => {
+        const res = await this._fetch(`${this.apiUrl}/repos/`, {
+          method: "POST",
+          headers: {
+            ...this._mergedHeaders,
+            "Content-Type": "application/json",
+          },
+          signal: AbortSignal.timeout(this.timeout_ms),
+          ...this.fetchOptions,
+          body: JSON.stringify(body),
+        });
+        await raiseForStatus(res, `create ${repoType}`);
+        return res;
+      });
+    } catch (e) {
+      if (
+        e != null &&
+        typeof e === "object" &&
+        "name" in e &&
+        (e as { name?: string }).name === "LangSmithConflictError"
+      ) {
+        return;
+      }
+      throw e;
+    }
+  }
+
+  private async _updateRepoMetadata(
+    owner: string,
+    name: string,
+    options: {
+      description?: string;
+      readme?: string;
+      tags?: string[];
+      isPublic?: boolean;
+    }
+  ): Promise<void> {
+    const body: Record<string, unknown> = {};
+    if (options.description !== undefined)
+      body.description = options.description;
+    if (options.readme !== undefined) body.readme = options.readme;
+    if (options.tags !== undefined) body.tags = options.tags;
+    if (options.isPublic !== undefined) body.is_public = options.isPublic;
+    if (Object.keys(body).length === 0) return;
+
+    await this.caller.call(async () => {
+      const res = await this._fetch(`${this.apiUrl}/repos/${owner}/${name}`, {
+        method: "PATCH",
+        headers: {
+          ...this._mergedHeaders,
+          "Content-Type": "application/json",
+        },
+        signal: AbortSignal.timeout(this.timeout_ms),
+        ...this.fetchOptions,
+        body: JSON.stringify(body),
+      });
+      await raiseForStatus(res, "update repo metadata");
+      return res;
+    });
   }
 
   /**

--- a/js/src/schemas.ts
+++ b/js/src/schemas.ts
@@ -543,6 +543,51 @@ export interface LikePromptResponse {
   likes: number;
 }
 
+export interface FileEntry {
+  type: "file";
+  content: string;
+}
+
+export interface AgentEntry {
+  type: "agent";
+  repo_handle: string;
+  commit_id?: string;
+  owner?: string;
+  commit_hash?: string;
+}
+
+export interface SkillEntry {
+  type: "skill";
+  repo_handle: string;
+  commit_id?: string;
+  owner?: string;
+  commit_hash?: string;
+}
+
+export type Entry = FileEntry | AgentEntry | SkillEntry;
+
+export interface AgentContext {
+  owner: string;
+  repo: string;
+  commit_hash: string;
+  files: Record<string, Entry>;
+}
+
+export interface SkillContext {
+  owner: string;
+  repo: string;
+  commit_hash: string;
+  files: Record<string, Entry>;
+}
+
+export interface DirectoryCommitResponse {
+  commit: {
+    id: string;
+    commit_hash: string;
+    created_at?: string;
+  };
+}
+
 export interface LangSmithSettings {
   id: string;
   display_name: string;

--- a/js/src/tests/context.int.test.ts
+++ b/js/src/tests/context.int.test.ts
@@ -1,0 +1,117 @@
+import { Client } from "../client.js";
+import { AgentContext, FileEntry, SkillContext } from "../schemas.js";
+
+function shortId(): string {
+  return Math.random().toString(36).slice(2, 10);
+}
+
+function agentIdentifier(): string {
+  return `-/ctx-test-js-agent-${shortId()}`;
+}
+
+function skillIdentifier(): string {
+  return `-/ctx-test-js-skill-${shortId()}`;
+}
+
+describe("Context integration (agent/skill)", () => {
+  const client = new Client();
+
+  async function cleanupAgent(identifier: string) {
+    try {
+      await client.deleteAgent(identifier);
+    } catch (_) {
+      /* best effort */
+    }
+  }
+
+  async function cleanupSkill(identifier: string) {
+    try {
+      await client.deleteSkill(identifier);
+    } catch (_) {
+      /* best effort */
+    }
+  }
+
+  test("pushAgent + pullAgent roundtrip", async () => {
+    const identifier = agentIdentifier();
+    try {
+      const url = await client.pushAgent(identifier, {
+        files: {
+          "AGENTS.md": { type: "file", content: "# Test Agent\n" },
+        },
+        description: "integration test agent (js)",
+      });
+      expect(url).toContain("/hub/");
+
+      const agent: AgentContext = await client.pullAgent(identifier);
+      expect(agent.files["AGENTS.md"]).toBeDefined();
+      const entry = agent.files["AGENTS.md"] as FileEntry;
+      expect(entry.type).toBe("file");
+      expect(entry.content).toBe("# Test Agent\n");
+    } finally {
+      await cleanupAgent(identifier);
+    }
+  });
+
+  test("pushSkill + pullSkill roundtrip", async () => {
+    const identifier = skillIdentifier();
+    try {
+      const url = await client.pushSkill(identifier, {
+        files: {
+          "SKILL.md": { type: "file", content: "# Test Skill\n" },
+        },
+        description: "integration test skill (js)",
+      });
+      expect(url).toContain("/hub/");
+
+      const skill: SkillContext = await client.pullSkill(identifier);
+      expect(skill.files["SKILL.md"]).toBeDefined();
+      const entry = skill.files["SKILL.md"] as FileEntry;
+      expect(entry.content).toBe("# Test Skill\n");
+    } finally {
+      await cleanupSkill(identifier);
+    }
+  });
+
+  test("pushAgent with null entry deletes that file", async () => {
+    const identifier = agentIdentifier();
+    try {
+      await client.pushAgent(identifier, {
+        files: {
+          "keep.md": { type: "file", content: "keep" },
+          "remove.md": { type: "file", content: "remove" },
+        },
+      });
+      let agent = await client.pullAgent(identifier);
+      expect(agent.files["keep.md"]).toBeDefined();
+      expect(agent.files["remove.md"]).toBeDefined();
+
+      await client.pushAgent(identifier, {
+        files: { "remove.md": null },
+      });
+      agent = await client.pullAgent(identifier);
+      expect(agent.files["keep.md"]).toBeDefined();
+      expect(agent.files["remove.md"]).toBeUndefined();
+    } finally {
+      await cleanupAgent(identifier);
+    }
+  });
+
+  test("pushAgent second commit updates file content", async () => {
+    const identifier = agentIdentifier();
+    try {
+      await client.pushAgent(identifier, {
+        files: { "AGENTS.md": { type: "file", content: "v1" } },
+      });
+      await client.pushAgent(identifier, {
+        files: { "AGENTS.md": { type: "file", content: "v2" } },
+      });
+
+      const agent = await client.pullAgent(identifier);
+      const entry = agent.files["AGENTS.md"] as FileEntry;
+      expect(entry.content).toBe("v2");
+    } finally {
+      await cleanupAgent(identifier);
+    }
+  });
+});

--- a/js/src/tests/context.test.ts
+++ b/js/src/tests/context.test.ts
@@ -1,0 +1,316 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { jest } from "@jest/globals";
+import { Client } from "../client.js";
+import { LangSmithConflictError } from "../utils/error.js";
+
+function _mockClient() {
+  const client = new Client({ apiKey: "test-api-key" });
+  jest.spyOn(client as any, "_currentTenantIsOwner").mockResolvedValue(true);
+  jest
+    .spyOn(client as any, "_ownerConflictError")
+    .mockImplementation(async () => new Error("owner mismatch"));
+  return client;
+}
+
+function _response(body: unknown, status = 200): any {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+    headers: new Headers(),
+  };
+}
+
+function _setFetchSequence(client: Client, responses: any[]): jest.Mock {
+  const spy = jest.spyOn(client as any, "_fetch");
+  for (const res of responses) {
+    spy.mockResolvedValueOnce(res);
+  }
+  return spy as unknown as jest.Mock;
+}
+
+describe("Context (agent/skill) on Client", () => {
+  describe("pullAgent", () => {
+    it("hits the directories GET URL and merges owner/repo into response", async () => {
+      const client = _mockClient();
+      const fetchSpy = _setFetchSequence(client, [
+        _response({
+          commit_id: "00000000-0000-0000-0000-000000000000",
+          commit_hash: "abc12345",
+          files: { "main.py": { type: "file", content: "print('hi')" } },
+        }),
+      ]);
+
+      const agent = await client.pullAgent("owner/my-agent");
+
+      const [url, init] = fetchSpy.mock.calls[0] as [string, any];
+      expect(url).toContain(
+        "/v1/platform/hub/repos/owner/my-agent/directories"
+      );
+      expect(init.method).toBe("GET");
+      expect(agent.owner).toBe("owner");
+      expect(agent.repo).toBe("my-agent");
+      expect(agent.commit_hash).toBe("abc12345");
+      expect(agent.files["main.py"]).toEqual({
+        type: "file",
+        content: "print('hi')",
+      });
+    });
+
+    it("passes commit query param when version is supplied", async () => {
+      const client = _mockClient();
+      const fetchSpy = _setFetchSequence(client, [
+        _response({ commit_hash: "abc12345", files: {} }),
+      ]);
+
+      await client.pullAgent("owner/my-agent", { version: "abc12345" });
+
+      const url = (fetchSpy.mock.calls[0] as [string, any])[0];
+      expect(url).toContain("commit=abc12345");
+    });
+  });
+
+  describe("pushAgent", () => {
+    it("rejects more than 500 files", async () => {
+      const client = _mockClient();
+      const tooMany: Record<string, any> = {};
+      for (let i = 0; i < 501; i++) {
+        tooMany[`p_${i}.py`] = { type: "file", content: "x" };
+      }
+      await expect(
+        client.pushAgent("-/repo", { files: tooMany })
+      ).rejects.toThrow(/Too many files/);
+    });
+
+    it("rejects short parentCommit", async () => {
+      const client = _mockClient();
+      await expect(
+        client.pushAgent("-/repo", { files: {}, parentCommit: "abc" })
+      ).rejects.toThrow(/8-64/);
+    });
+
+    it("rejects invalid repo_handle when creating", async () => {
+      const client = _mockClient();
+      _setFetchSequence(client, [
+        // GET /repos/-/BadName → 404 (doesn't exist)
+        _response({ detail: "Not Found" }, 404),
+      ]);
+      await expect(
+        client.pushAgent("-/BadName", {
+          files: { "main.py": { type: "file", content: "x" } },
+        })
+      ).rejects.toThrow(/Invalid repo_handle/);
+    });
+
+    it("creates new repo then commits files when repo does not exist", async () => {
+      const client = _mockClient();
+      const fetchSpy = _setFetchSequence(client, [
+        // _repoExists GET → 404
+        _response({ detail: "Not Found" }, 404),
+        // _createRepo POST → ok
+        _response({ repo: { id: "r1" } }),
+        // commit POST → ok
+        _response({
+          commit: {
+            id: "00000000-0000-0000-0000-000000000000",
+            commit_hash: "abc12345",
+          },
+        }),
+      ]);
+
+      const url = await client.pushAgent("-/my-agent", {
+        files: { "main.py": { type: "file", content: "x" } },
+      });
+      expect(url).toContain("/hub/-/my-agent:abc12345");
+
+      const calls = fetchSpy.mock.calls as [string, any][];
+      expect(calls).toHaveLength(3);
+      // 1. exists check
+      expect(calls[0][0]).toContain("/repos/-/my-agent");
+      expect(calls[0][1].method).toBe("GET");
+      // 2. create repo
+      expect(calls[1][0]).toContain("/repos/");
+      expect(calls[1][1].method).toBe("POST");
+      const createBody = JSON.parse(calls[1][1].body);
+      expect(createBody.repo_handle).toBe("my-agent");
+      expect(createBody.repo_type).toBe("agent");
+      // 3. commit
+      expect(calls[2][0]).toContain(
+        "/v1/platform/hub/repos/-/my-agent/directories/commits"
+      );
+      expect(calls[2][1].method).toBe("POST");
+      const commitBody = JSON.parse(calls[2][1].body);
+      expect(commitBody.files).toEqual({
+        "main.py": { type: "file", content: "x" },
+      });
+    });
+
+    it("patches metadata when repo exists and metadata fields are provided", async () => {
+      const client = _mockClient();
+      const fetchSpy = _setFetchSequence(client, [
+        // _repoExists → 200 (exists)
+        _response({ repo: { repo_handle: "my-agent" } }),
+        // _updateRepoMetadata PATCH
+        _response({}),
+        // commit
+        _response({
+          commit: {
+            id: "00000000-0000-0000-0000-000000000000",
+            commit_hash: "abc12345",
+          },
+        }),
+      ]);
+
+      await client.pushAgent("-/my-agent", {
+        files: { "main.py": { type: "file", content: "x" } },
+        description: "new desc",
+      });
+
+      const calls = fetchSpy.mock.calls as [string, any][];
+      expect(calls).toHaveLength(3);
+      expect(calls[1][0]).toContain("/repos/-/my-agent");
+      expect(calls[1][1].method).toBe("PATCH");
+      const patchBody = JSON.parse(calls[1][1].body);
+      expect(patchBody).toEqual({ description: "new desc" });
+    });
+
+    it("skips metadata patch when repo exists and no metadata fields given", async () => {
+      const client = _mockClient();
+      const fetchSpy = _setFetchSequence(client, [
+        _response({ repo: { repo_handle: "my-agent" } }),
+        _response({
+          commit: {
+            id: "00000000-0000-0000-0000-000000000000",
+            commit_hash: "abc12345",
+          },
+        }),
+      ]);
+
+      await client.pushAgent("-/my-agent", {
+        files: { "main.py": { type: "file", content: "x" } },
+      });
+
+      const calls = fetchSpy.mock.calls as [string, any][];
+      expect(calls).toHaveLength(2);
+      expect(calls[1][1].method).toBe("POST");
+    });
+
+    it("swallows 409 from _createRepo (repo already exists)", async () => {
+      const client = _mockClient();
+      _setFetchSequence(client, [
+        _response({ detail: "Not Found" }, 404),
+        // _createRepo POST → 409
+        _response({ detail: "already exists" }, 409),
+        // commit
+        _response({
+          commit: {
+            id: "00000000-0000-0000-0000-000000000000",
+            commit_hash: "abc12345",
+          },
+        }),
+      ]);
+
+      await expect(
+        client.pushAgent("-/my-agent", {
+          files: { "main.py": { type: "file", content: "x" } },
+        })
+      ).resolves.toContain("/hub/-/my-agent:abc12345");
+    });
+
+    it("serializes null entry for deletion", async () => {
+      const client = _mockClient();
+      const fetchSpy = _setFetchSequence(client, [
+        _response({ repo: { repo_handle: "my-agent" } }),
+        _response({
+          commit: {
+            id: "00000000-0000-0000-0000-000000000000",
+            commit_hash: "abc12345",
+          },
+        }),
+      ]);
+
+      await client.pushAgent("-/my-agent", {
+        files: { "gone.md": null },
+      });
+
+      const commitCall = (fetchSpy.mock.calls as [string, any][])[1];
+      const body = JSON.parse(commitCall[1].body);
+      expect(body.files).toEqual({ "gone.md": null });
+    });
+  });
+
+  describe("deleteAgent", () => {
+    it("hits DELETE on the directories URL", async () => {
+      const client = _mockClient();
+      const fetchSpy = _setFetchSequence(client, [_response({}, 204)]);
+      await client.deleteAgent("-/old-agent");
+      const [url, init] = fetchSpy.mock.calls[0] as [string, any];
+      expect(url).toContain("/v1/platform/hub/repos/-/old-agent/directories");
+      expect(init.method).toBe("DELETE");
+    });
+  });
+
+  describe("agentExists / skillExists", () => {
+    it("returns true on 200", async () => {
+      const client = _mockClient();
+      _setFetchSequence(client, [_response({ repo: { id: "r1" } })]);
+      expect(await client.agentExists("-/my-agent")).toBe(true);
+    });
+
+    it("returns false on 404", async () => {
+      const client = _mockClient();
+      _setFetchSequence(client, [_response({ detail: "Not Found" }, 404)]);
+      expect(await client.agentExists("-/nope")).toBe(false);
+    });
+  });
+
+  describe("listAgents", () => {
+    it("sends repo_type=agent and paginates", async () => {
+      const client = _mockClient();
+      const fetchSpy = _setFetchSequence(client, [
+        _response({
+          repos: [{ repo_handle: "a1" }, { repo_handle: "a2" }],
+          total: 2,
+        }),
+      ]);
+
+      const items: any[] = [];
+      for await (const item of client.listAgents()) {
+        items.push(item);
+      }
+
+      expect(items).toHaveLength(2);
+      const url = (fetchSpy.mock.calls[0] as [string, any])[0];
+      expect(url).toContain("/repos");
+      expect(url).toContain("repo_type=agent");
+    });
+
+    it("forwards isPublic and query params", async () => {
+      const client = _mockClient();
+      const fetchSpy = _setFetchSequence(client, [
+        _response({ repos: [], total: 0 }),
+      ]);
+
+      for await (const _ of client.listSkills({
+        isPublic: true,
+        query: "foo",
+      })) {
+        /* noop */
+      }
+
+      const url = (fetchSpy.mock.calls[0] as [string, any])[0];
+      expect(url).toContain("repo_type=skill");
+      expect(url).toContain("is_public=true");
+      expect(url).toContain("query=foo");
+    });
+  });
+
+  describe("LangSmithConflictError import", () => {
+    it("is an Error subclass", () => {
+      const e = new LangSmithConflictError("test");
+      expect(e).toBeInstanceOf(Error);
+      expect(e.name).toBe("LangSmithConflictError");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Ports the Python Context class (PR #2734) to JS/TS, following existing JS SDK conventions: methods directly on `Client` rather than a dedicated `Context` class (matches how `pullPrompt`, `pushPrompt`, etc. are exposed today).

## What's new

**Public methods on `Client`:**
- `pullAgent(identifier, { version? })` → `AgentContext`
- `pullSkill(identifier, { version? })` → `SkillContext`
- `pushAgent(identifier, { files, parentCommit?, description?, readme?, tags?, isPublic? })` → commit URL
- `pushSkill(identifier, …)` → commit URL
- `deleteAgent(identifier)` / `deleteSkill(identifier)`
- `listAgents({ isPublic?, isArchived?, query? })` / `listSkills(...)` → `AsyncIterableIterator<Prompt>` (mirrors `listPrompts`)
- `agentExists(identifier)` / `skillExists(identifier)` (mirrors `promptExists`)

**Schemas:** `FileEntry`, `AgentEntry`, `SkillEntry`, `Entry` (discriminated union), `AgentContext`, `SkillContext`, `DirectoryCommitResponse`.

**URL paths** — identical to the post-parity Python implementation:
- `POST /repos/` (create), `GET /repos/{o}/{n}` (exists), `PATCH /repos/{o}/{n}` (update) — smith-backend
- `GET|POST|DELETE /v1/platform/hub/repos/{o}/{n}/directories[/commits]` — smith-go

`_createRepo` swallows `LangSmithConflictError` (409) to stay idempotent against concurrent pushes — matches the pattern used by `smith-go/backfills/agent_store_to_hub`.

## Intentionally omitted

`pushFile` / `pullFile` / `deleteFile` — the backend's `/directories/commits` endpoint hard-rejects file-type repos today (`files endpoint only supports agent or skill repos`). Can be added once the backend gap closes.

## Test plan

- [x] 16 unit tests covering URL shape, validation (too many files, short parentCommit, invalid repo_handle), create/update flow, null-entry serialization, 409 idempotency, listing with `repo_type` param
- [x] 4 integration tests mirroring Python round-trip coverage: push+pull agent, push+pull skill, null-entry deletes, second-commit updates
- [x] `pnpm lint` — 0 errors (20 pre-existing warnings unrelated to this change)
- [x] `pnpm tsc --noEmit` — clean
- [ ] Integration tests against a live beta/prod backend — will run in CI

## Release Note

Adds `pullAgent` / `pushAgent` / `pullSkill` / `pushSkill` / `deleteAgent` / `deleteSkill` / `listAgents` / `listSkills` / `agentExists` / `skillExists` methods to `Client` for managing non-prompt hub repos.