### PR TITLE
feat: runtime selection of tracing destination

### DIFF
--- a/python/langsmith/_internal/_background_thread.py
+++ b/python/langsmith/_internal/_background_thread.py
@@ -87,6 +87,12 @@ class TracingQueueItem:
     authorization: Optional[str]
     cookie: Optional[str]
     otel_context: Optional[Context]
+    destination: Optional[str]
+    """Per-run routing override: one of ``"langsmith"``, ``"otel"``, ``"hybrid"``.
+
+    ``None`` means "use the global tracing mode" (see :func:`get_tracing_mode`),
+    preserving legacy behaviour for every item not carrying a per-run override.
+    """
 
     __slots__ = (
         "priority",
@@ -98,6 +104,7 @@ class TracingQueueItem:
         "authorization",
         "cookie",
         "otel_context",
+        "destination",
     )
 
     def __init__(
@@ -111,6 +118,7 @@ class TracingQueueItem:
         authorization: Optional[str] = None,
         cookie: Optional[str] = None,
         otel_context: Optional[Context] = None,
+        destination: Optional[str] = None,
     ) -> None:
         self.priority = priority
         self.item = item
@@ -121,6 +129,7 @@ class TracingQueueItem:
         self.authorization = authorization
         self.cookie = cookie
         self.otel_context = otel_context
+        self.destination = destination
 
     def __lt__(self, other: TracingQueueItem) -> bool:
         return (self.priority, self.item.__class__) < (
@@ -594,6 +603,60 @@ def get_tracing_mode() -> tuple[bool, bool]:
     return hybrid_otel_and_langsmith, is_otel_only
 
 
+def _dispatch_batch(
+    client: Client,
+    tracing_queue: Queue,
+    batch: list[TracingQueueItem],
+    use_multipart: bool,
+) -> None:
+    """Dispatch a batch, honouring per-item ``destination`` overrides.
+
+    Items with ``destination=None`` follow the global :func:`get_tracing_mode`
+    result, so callers that never set an override get exactly the pre-feature
+    behaviour. When every item agrees on a destination (the common case) this
+    collapses to a single handler call with no grouping overhead.
+    """
+    hybrid_mode, otel_only = get_tracing_mode()
+
+    # Fast path: no per-run overrides anywhere in the batch.
+    if all(item.destination is None for item in batch):
+        if hybrid_mode:
+            _hybrid_tracing_thread_handle_batch(
+                client, tracing_queue, batch, use_multipart
+            )
+        elif otel_only:
+            _otel_tracing_thread_handle_batch(client, tracing_queue, batch)
+        else:
+            _tracing_thread_handle_batch(client, tracing_queue, batch, use_multipart)
+        return
+
+    # Slow path: partition by resolved destination.
+    default = "hybrid" if hybrid_mode else "otel" if otel_only else "langsmith"
+    ls_items: list[TracingQueueItem] = []
+    otel_items: list[TracingQueueItem] = []
+    hybrid_items: list[TracingQueueItem] = []
+    for item in batch:
+        dest = item.destination or default
+        if dest == "otel":
+            otel_items.append(item)
+        elif dest == "hybrid":
+            hybrid_items.append(item)
+        else:
+            # Anything unrecognised falls back to LangSmith-only; the client
+            # validates overrides before stamping them, so this is defence
+            # in depth for the background thread.
+            ls_items.append(item)
+
+    if ls_items:
+        _tracing_thread_handle_batch(client, tracing_queue, ls_items, use_multipart)
+    if otel_items:
+        _otel_tracing_thread_handle_batch(client, tracing_queue, otel_items)
+    if hybrid_items:
+        _hybrid_tracing_thread_handle_batch(
+            client, tracing_queue, hybrid_items, use_multipart
+        )
+
+
 def tracing_control_thread_func(client_ref: weakref.ref[Client]) -> None:
     client = client_ref()
     if client is None:
@@ -692,7 +755,6 @@ def tracing_control_thread_func(client_ref: weakref.ref[Client]) -> None:
             sub_threads.append(new_thread)
             new_thread.start()
 
-        hybrid_otel_and_langsmith, is_otel_only = get_tracing_mode()
         max_batch_size = (
             client._max_batch_size_bytes
             or batch_ingest_config.get("size_limit_bytes")
@@ -701,48 +763,20 @@ def tracing_control_thread_func(client_ref: weakref.ref[Client]) -> None:
         if next_batch := _tracing_thread_drain_queue(
             tracing_queue, limit=size_limit, max_size_bytes=max_batch_size
         ):
-            if hybrid_otel_and_langsmith:
-                # Hybrid mode: both OTEL and LangSmith
-                _hybrid_tracing_thread_handle_batch(
-                    client, tracing_queue, next_batch, use_multipart
-                )
-            elif is_otel_only:
-                # OTEL-only mode
-                _otel_tracing_thread_handle_batch(client, tracing_queue, next_batch)
-            else:
-                # LangSmith-only mode
-                _tracing_thread_handle_batch(
-                    client, tracing_queue, next_batch, use_multipart
-                )
+            _dispatch_batch(client, tracing_queue, next_batch, use_multipart)
 
     # drain the queue on exit - apply same logic
     logger.debug(
         "Tracing thread draining queue on exit: qsize=%d",
         tracing_queue.qsize(),
     )
-    hybrid_otel_and_langsmith, is_otel_only = get_tracing_mode()
     max_batch_size = (
         client._max_batch_size_bytes or batch_ingest_config.get("size_limit_bytes") or 0
     )
     while next_batch := _tracing_thread_drain_queue(
         tracing_queue, limit=size_limit, block=False, max_size_bytes=max_batch_size
     ):
-        if hybrid_otel_and_langsmith:
-            # Hybrid mode cleanup
-            logger.debug("Hybrid mode cleanup")
-            _hybrid_tracing_thread_handle_batch(
-                client, tracing_queue, next_batch, use_multipart
-            )
-        elif is_otel_only:
-            # OTEL-only cleanup
-            logger.debug("OTEL-only cleanup")
-            _otel_tracing_thread_handle_batch(client, tracing_queue, next_batch)
-        else:
-            # LangSmith-only cleanup
-            logger.debug("LangSmith-only cleanup")
-            _tracing_thread_handle_batch(
-                client, tracing_queue, next_batch, use_multipart
-            )
+        _dispatch_batch(client, tracing_queue, next_batch, use_multipart)
     logger.debug("Tracing control thread is shutting down")
 
 
@@ -953,44 +987,16 @@ def _tracing_sub_thread_func(
         ):
             seen_successive_empty_queues = 0
 
-            hybrid_otel_and_langsmith, is_otel_only = get_tracing_mode()
-            if hybrid_otel_and_langsmith:
-                # Hybrid mode: both OTEL and LangSmith
-                _hybrid_tracing_thread_handle_batch(
-                    client, tracing_queue, next_batch, use_multipart
-                )
-            elif is_otel_only:
-                # OTEL-only mode
-                _otel_tracing_thread_handle_batch(client, tracing_queue, next_batch)
-            else:
-                # LangSmith-only mode
-                _tracing_thread_handle_batch(
-                    client, tracing_queue, next_batch, use_multipart
-                )
+            _dispatch_batch(client, tracing_queue, next_batch, use_multipart)
         else:
             seen_successive_empty_queues += 1
 
     # drain the queue on exit - apply same logic
-    hybrid_otel_and_langsmith, is_otel_only = get_tracing_mode()
     max_batch_size = (
         client._max_batch_size_bytes or batch_ingest_config.get("size_limit_bytes") or 0
     )
     while next_batch := _tracing_thread_drain_queue(
         tracing_queue, limit=size_limit, block=False, max_size_bytes=max_batch_size
     ):
-        if hybrid_otel_and_langsmith:
-            # Hybrid mode cleanup
-            _hybrid_tracing_thread_handle_batch(
-                client, tracing_queue, next_batch, use_multipart
-            )
-        elif is_otel_only:
-            # OTEL-only cleanup
-            logger.debug("OTEL-only cleanup")
-            _otel_tracing_thread_handle_batch(client, tracing_queue, next_batch)
-        else:
-            # LangSmith-only cleanup
-            logger.debug("LangSmith-only cleanup")
-            _tracing_thread_handle_batch(
-                client, tracing_queue, next_batch, use_multipart
-            )
+        _dispatch_batch(client, tracing_queue, next_batch, use_multipart)
     logger.debug("Tracing control sub-thread is shutting down")

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -729,6 +729,7 @@ class Client:
         "_cache",
         "_failed_traces_dir",
         "_failed_traces_max_bytes",
+        "_otel_missing_warned",
     ]
 
     _api_key: Optional[str]
@@ -1036,6 +1037,8 @@ class Client:
                 self.otel_exporter = None
         else:
             self.otel_exporter = None
+
+        self._otel_missing_warned: bool = False
 
         # Initialize auto batching
         if auto_batch_tracing:
@@ -2036,6 +2039,47 @@ class Client:
                     sampled.append(run)
             return sampled
 
+    _VALID_TRACING_DESTINATIONS = frozenset({"langsmith", "otel", "hybrid"})
+
+    def _resolve_tracing_destination(
+        self,
+        tracing_destinations: Optional[str],
+    ) -> Optional[str]:
+        """Validate and resolve a per-run tracing destination override.
+
+        Returns the destination to stamp onto the outgoing
+        :class:`TracingQueueItem`, or ``None`` if no per-run override applies
+        (in which case the background thread's global
+        :func:`langsmith._internal._background_thread.get_tracing_mode` kicks
+        in, exactly as before this feature existed).
+
+        ``"otel"`` / ``"hybrid"`` require an OTEL exporter on the client; if
+        none is configured, we warn once per client and fall back to ``None``
+        so the item routes via the client's default mode. A bogus value raises
+        ``ValueError`` synchronously so typos never make it onto the queue.
+        """
+        if tracing_destinations is None:
+            return None
+        if tracing_destinations not in self._VALID_TRACING_DESTINATIONS:
+            raise ValueError(
+                f"Invalid tracing_destinations value "
+                f"{tracing_destinations!r}; expected one of "
+                f"{sorted(self._VALID_TRACING_DESTINATIONS)}."
+            )
+        if tracing_destinations in ("otel", "hybrid") and self.otel_exporter is None:
+            if not self._otel_missing_warned:
+                logger.warning(
+                    "langsmith_extra['tracing_destinations']=%r was requested "
+                    "for a run, but this client has no OpenTelemetry exporter "
+                    "configured; falling back to the client's default mode. "
+                    "Pass `otel_enabled=True` (or set LANGSMITH_OTEL_ENABLED=true) "
+                    "and install `langsmith[otel]` to enable OTEL export.",
+                    tracing_destinations,
+                )
+                self._otel_missing_warned = True
+            return None
+        return tracing_destinations
+
     def _put_tracing_queue(self, item: TracingQueueItem) -> None:
         """Put an item on the tracing queue, dropping if full."""
         assert self.tracing_queue is not None
@@ -2109,6 +2153,7 @@ class Client:
         tenant_id: str | None = kwargs.pop("tenant_id", None)
         authorization: str | None = kwargs.pop("authorization", None)
         cookie: str | None = kwargs.pop("cookie", None)
+        tracing_destinations: Optional[str] = kwargs.pop("tracing_destinations", None)
         project_name = project_name or kwargs.pop(
             "session_name",
             # if the project is not provided, use the environment's project
@@ -2152,6 +2197,7 @@ class Client:
                             "tenant_id": tenant_id,
                             "authorization": authorization,
                             "cookie": cookie,
+                            "tracing_destinations": tracing_destinations,
                         },
                     )
                 )
@@ -2168,6 +2214,7 @@ class Client:
                 tenant_id=tenant_id,
                 authorization=authorization,
                 cookie=cookie,
+                tracing_destinations=tracing_destinations,
             )
 
     def _create_run(
@@ -2180,6 +2227,7 @@ class Client:
         tenant_id: Optional[str] = None,
         authorization: Optional[str] = None,
         cookie: Optional[str] = None,
+        tracing_destinations: Optional[str] = None,
     ) -> None:
         if (
             # batch ingest requires trace_id and dotted_order to be set
@@ -2232,6 +2280,9 @@ class Client:
                     serialized_op.trace_id,
                     serialized_op.id,
                 )
+                resolved_destination = self._resolve_tracing_destination(
+                    tracing_destinations
+                )
                 if self.otel_exporter is not None:
                     self._put_tracing_queue(
                         TracingQueueItem(
@@ -2246,6 +2297,7 @@ class Client:
                             otel_context=self._set_span_in_context(
                                 self._otel_trace.get_current_span()
                             ),
+                            destination=resolved_destination,
                         )
                     )
                 else:
@@ -2259,6 +2311,7 @@ class Client:
                             tenant_id=tenant_id,
                             authorization=authorization,
                             cookie=cookie,
+                            destination=resolved_destination,
                         )
                     )
             else:
@@ -3323,6 +3376,8 @@ class Client:
         if reference_example_id is not None:
             data["reference_example_id"] = reference_example_id
 
+        tracing_destinations: Optional[str] = kwargs.pop("tracing_destinations", None)
+
         # If process_buffered_run_ops is enabled, collect runs in batches
         if self._process_buffered_run_ops and not kwargs.get("is_run_ops_buffer_flush"):
             with self._run_ops_buffer_lock:
@@ -3337,6 +3392,7 @@ class Client:
                             "tenant_id": tenant_id,
                             "authorization": authorization,
                             "cookie": cookie,
+                            "tracing_destinations": tracing_destinations,
                         },
                     )
                 )
@@ -3353,6 +3409,7 @@ class Client:
                 tenant_id=tenant_id,
                 authorization=authorization,
                 cookie=cookie,
+                tracing_destinations=tracing_destinations,
             )
 
     def _update_run(
@@ -3365,6 +3422,7 @@ class Client:
         tenant_id: Optional[str] = None,
         authorization: Optional[str] = None,
         cookie: Optional[str] = None,
+        tracing_destinations: Optional[str] = None,
     ):
         use_multipart = (
             (self.tracing_queue is not None or self.compressed_traces is not None)
@@ -3417,6 +3475,9 @@ class Client:
                     serialized_op.trace_id,
                     serialized_op.id,
                 )
+                resolved_destination = self._resolve_tracing_destination(
+                    tracing_destinations
+                )
                 if self.otel_exporter is not None:
                     self._put_tracing_queue(
                         TracingQueueItem(
@@ -3431,6 +3492,7 @@ class Client:
                             otel_context=self._set_span_in_context(
                                 self._otel_trace.get_current_span()
                             ),
+                            destination=resolved_destination,
                         )
                     )
                 else:
@@ -3444,6 +3506,7 @@ class Client:
                             tenant_id=tenant_id,
                             authorization=authorization,
                             cookie=cookie,
+                            destination=resolved_destination,
                         )
                     )
         else:

--- a/python/langsmith/run_helpers.py
+++ b/python/langsmith/run_helpers.py
@@ -278,6 +278,17 @@ class LangSmithExtra(TypedDict, total=False):
     """Optional ID for the run."""
     client: Optional[ls_client.Client]
     """Optional LangSmith client."""
+    tracing_destinations: Optional[Literal["langsmith", "otel", "hybrid"]]
+    """Route this run (and its descendants) to a specific destination.
+
+    One of ``"langsmith"``, ``"otel"``, or ``"hybrid"``. When unset the run
+    follows the client's default tracing mode (driven by
+    ``LANGSMITH_OTEL_ENABLED`` / ``LANGSMITH_OTEL_ONLY`` env vars). Set on a
+    root ``@traceable`` call, the override propagates to child runs created
+    via :meth:`RunTree.create_child`. If ``"otel"``/``"hybrid"`` is requested
+    on a client with no OpenTelemetry exporter configured, the override is
+    silently ignored after a one-time warning per client.
+    """
     # Optional callback function to be called if the run succeeds and before it is sent.
     _on_success: Optional[Callable[[run_trees.RunTree], None]]
     on_end: Optional[Callable[[run_trees.RunTree], Any]]
@@ -1642,6 +1653,7 @@ def _setup_run(
     tags_ = (langsmith_extra.get("tags") or []) + (outer_tags or [])
     context.run(_context._TAGS.set, tags_)
     tags_ += tags or []
+    tracing_destinations_override = langsmith_extra.get("tracing_destinations")
     if parent_run_ is not None:
         new_run = parent_run_.create_child(
             name=name_,
@@ -1652,6 +1664,9 @@ def _setup_run(
             run_id=id_,
             attachments=attachments,
         )
+        # Per-call override beats any value inherited from the parent.
+        if tracing_destinations_override is not None:
+            new_run.tracing_destinations = tracing_destinations_override
     else:
         # Create RunTree kwargs conditionally to let RunTree generate id from start_time
         run_tree_kwargs = {
@@ -1669,6 +1684,8 @@ def _setup_run(
             "attachments": attachments,
             "dangerously_allow_filesystem": dangerously_allow_filesystem,
         }
+        if tracing_destinations_override is not None:
+            run_tree_kwargs["tracing_destinations"] = tracing_destinations_override
         # Only pass id if user explicitly provided one
         if id_ is not None:
             run_tree_kwargs["id"] = ls_client._ensure_uuid(id_)

--- a/python/langsmith/run_trees.py
+++ b/python/langsmith/run_trees.py
@@ -257,6 +257,14 @@ class RunTree(ls_schemas.RunBase):
         default=None,
         description="Projects to replicate this run to with optional updates.",
     )
+    tracing_destinations: Optional[str] = Field(
+        default=None,
+        exclude=True,
+        description=(
+            "Per-run routing override: one of 'langsmith', 'otel', 'hybrid'. "
+            "Propagated to descendants via create_child. Excluded from API payloads."
+        ),
+    )
 
     model_config = ConfigDict(
         arbitrary_types_allowed=True,
@@ -559,6 +567,7 @@ class RunTree(ls_schemas.RunBase):
             tags=tags,
             attachments=attachments or {},  # type: ignore
             dangerously_allow_filesystem=self.dangerously_allow_filesystem,
+            tracing_destinations=self.tracing_destinations,
         )
 
         return run
@@ -686,10 +695,13 @@ class RunTree(ls_schemas.RunBase):
                     tenant_id=tenant_id,
                     authorization=authorization,
                     cookie=cookie,
+                    tracing_destinations=self.tracing_destinations,
                 )
         else:
             kwargs = self._get_dicts_safe()
-            self.client.create_run(**kwargs)
+            self.client.create_run(
+                **kwargs, tracing_destinations=self.tracing_destinations
+            )
         if self.attachments:
             keys = [str(name) for name in self.attachments]
             self.events.append(
@@ -765,6 +777,7 @@ class RunTree(ls_schemas.RunBase):
                     tenant_id=tenant_id,
                     authorization=authorization,
                     cookie=cookie,
+                    tracing_destinations=self.tracing_destinations,
                 )
         else:
             self.client.update_run(
@@ -789,6 +802,7 @@ class RunTree(ls_schemas.RunBase):
                 tags=self.tags,
                 extra=self.extra,
                 attachments=attachments,
+                tracing_destinations=self.tracing_destinations,
             )
 
     def wait(self) -> None:

--- a/python/tests/unit_tests/test_tracing_destinations.py
+++ b/python/tests/unit_tests/test_tracing_destinations.py
@@ -1,0 +1,333 @@
+"""Per-run tracing destination override via ``langsmith_extra``.
+
+The feature under test is deliberately narrow: setting
+``langsmith_extra={"tracing_destinations": "langsmith" | "otel" | "hybrid"}``
+on a ``@traceable`` call routes that run (and any descendants created via
+``RunTree.create_child``) to the requested destination. No client-level
+default, no env var changes, no decorator kwarg.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from queue import Queue
+from typing import Iterator
+from unittest import mock
+
+import pytest
+
+from langsmith import Client, run_helpers, run_trees
+from langsmith._internal._background_thread import (
+    TracingQueueItem,
+    _dispatch_batch,
+)
+from langsmith._internal._operations import SerializedRunOperation
+from langsmith.utils import get_env_var
+
+
+@pytest.fixture(autouse=True)
+def _clear_env_cache() -> Iterator[None]:
+    """Neutralise :func:`langsmith.utils.get_env_var`'s lru_cache between tests."""
+    get_env_var.cache_clear()
+    yield
+    get_env_var.cache_clear()
+
+
+# ---------------------------------------------------------------------------
+# RunTree field + propagation
+# ---------------------------------------------------------------------------
+
+
+class TestRunTreeField:
+    def test_field_excluded_from_serialization(self) -> None:
+        run = run_trees.RunTree(name="r", inputs={}, tracing_destinations="otel")
+        assert "tracing_destinations" not in run.model_dump()
+        assert "tracing_destinations" not in run.model_dump(exclude_none=True)
+
+    def test_legacy_default_is_none(self) -> None:
+        assert run_trees.RunTree(name="r", inputs={}).tracing_destinations is None
+
+    def test_create_child_inherits(self) -> None:
+        parent = run_trees.RunTree(name="p", inputs={}, tracing_destinations="hybrid")
+        assert parent.create_child(name="c").tracing_destinations == "hybrid"
+
+    def test_create_child_inherits_none(self) -> None:
+        parent = run_trees.RunTree(name="p", inputs={})
+        assert parent.create_child(name="c").tracing_destinations is None
+
+
+# ---------------------------------------------------------------------------
+# Client._resolve_tracing_destination
+# ---------------------------------------------------------------------------
+
+
+def _make_client() -> Client:
+    return Client(
+        api_url="http://localhost:1984",
+        api_key="test",
+        auto_batch_tracing=False,
+    )
+
+
+class TestResolveTracingDestination:
+    def test_none_passes_through(self) -> None:
+        assert _make_client()._resolve_tracing_destination(None) is None
+
+    def test_langsmith_never_needs_otel(self) -> None:
+        # No exporter; "langsmith" is always fine.
+        client = _make_client()
+        assert client.otel_exporter is None
+        assert client._resolve_tracing_destination("langsmith") == "langsmith"
+
+    def test_bogus_value_raises_synchronously(self) -> None:
+        # Typos must be caught at the caller, not later on the bg thread.
+        client = _make_client()
+        with pytest.raises(ValueError, match="Invalid tracing_destinations"):
+            client._resolve_tracing_destination("OTEL")
+
+    def test_otel_without_exporter_warns_once_and_downgrades(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        client = _make_client()
+        assert client.otel_exporter is None
+        caplog.set_level(logging.WARNING, logger="langsmith.client")
+
+        for _ in range(4):
+            assert client._resolve_tracing_destination("otel") is None
+            assert client._resolve_tracing_destination("hybrid") is None
+
+        downgrade_records = [
+            r
+            for r in caplog.records
+            if r.levelno == logging.WARNING
+            and "no OpenTelemetry exporter" in r.getMessage()
+        ]
+        assert len(downgrade_records) == 1
+
+    def test_with_exporter_returns_value(self) -> None:
+        client = _make_client()
+        client.otel_exporter = mock.Mock()
+        assert client._resolve_tracing_destination("otel") == "otel"
+        assert client._resolve_tracing_destination("hybrid") == "hybrid"
+
+
+# ---------------------------------------------------------------------------
+# Dispatcher: per-item destination partitioning
+# ---------------------------------------------------------------------------
+
+
+def _make_queue_item(destination: object = None) -> TracingQueueItem:
+    op = SerializedRunOperation(
+        operation="post",
+        id=uuid.uuid4(),
+        trace_id=uuid.uuid4(),
+        _none=b"{}",
+        inputs=None,
+        outputs=None,
+        events=None,
+        attachments=None,
+    )
+    return TracingQueueItem(priority="0", item=op, destination=destination)
+
+
+class TestDispatchBatch:
+    def test_fast_path_when_no_overrides(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """No item carries a destination → single-handler call, matching
+        today's behaviour exactly."""
+        monkeypatch.delenv("LANGSMITH_OTEL_ENABLED", raising=False)
+        monkeypatch.delenv("LANGCHAIN_OTEL_ENABLED", raising=False)
+        client = _make_client()
+        batch = [_make_queue_item(), _make_queue_item()]
+        queue: Queue = Queue()
+
+        with (
+            mock.patch(
+                "langsmith._internal._background_thread._tracing_thread_handle_batch"
+            ) as ls_h,
+            mock.patch(
+                "langsmith._internal._background_thread._otel_tracing_thread_handle_batch"
+            ) as otel_h,
+            mock.patch(
+                "langsmith._internal._background_thread._hybrid_tracing_thread_handle_batch"
+            ) as hybrid_h,
+        ):
+            _dispatch_batch(client, queue, batch, use_multipart=True)
+
+        ls_h.assert_called_once()
+        otel_h.assert_not_called()
+        hybrid_h.assert_not_called()
+        # Exactly today's shape: one call with the full batch.
+        assert list(ls_h.call_args.args[2]) == batch
+
+    def test_fast_path_respects_global_hybrid_mode(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("LANGSMITH_OTEL_ENABLED", "true")
+        monkeypatch.delenv("LANGSMITH_OTEL_ONLY", raising=False)
+        monkeypatch.delenv("LANGCHAIN_OTEL_ONLY", raising=False)
+        get_env_var.cache_clear()
+        client = _make_client()
+        batch = [_make_queue_item()]
+        queue: Queue = Queue()
+
+        with (
+            mock.patch(
+                "langsmith._internal._background_thread._tracing_thread_handle_batch"
+            ) as ls_h,
+            mock.patch(
+                "langsmith._internal._background_thread._otel_tracing_thread_handle_batch"
+            ) as otel_h,
+            mock.patch(
+                "langsmith._internal._background_thread._hybrid_tracing_thread_handle_batch"
+            ) as hybrid_h,
+        ):
+            _dispatch_batch(client, queue, batch, use_multipart=True)
+
+        ls_h.assert_not_called()
+        otel_h.assert_not_called()
+        hybrid_h.assert_called_once()
+
+    def test_mixed_batch_is_partitioned(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("LANGSMITH_OTEL_ENABLED", raising=False)
+        client = _make_client()
+        items = [
+            _make_queue_item("langsmith"),
+            _make_queue_item("otel"),
+            _make_queue_item("hybrid"),
+            _make_queue_item("langsmith"),
+            _make_queue_item(None),  # falls back to default → "langsmith"
+        ]
+        queue: Queue = Queue()
+
+        with (
+            mock.patch(
+                "langsmith._internal._background_thread._tracing_thread_handle_batch"
+            ) as ls_h,
+            mock.patch(
+                "langsmith._internal._background_thread._otel_tracing_thread_handle_batch"
+            ) as otel_h,
+            mock.patch(
+                "langsmith._internal._background_thread._hybrid_tracing_thread_handle_batch"
+            ) as hybrid_h,
+        ):
+            _dispatch_batch(client, queue, items, use_multipart=True)
+
+        ls_h.assert_called_once()
+        otel_h.assert_called_once()
+        hybrid_h.assert_called_once()
+        assert len(ls_h.call_args.args[2]) == 3
+        assert len(otel_h.call_args.args[2]) == 1
+        assert len(hybrid_h.call_args.args[2]) == 1
+
+    def test_unknown_destination_routes_to_langsmith(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Defence-in-depth: a queue item with an unrecognised destination
+        must not crash the background thread."""
+        monkeypatch.delenv("LANGSMITH_OTEL_ENABLED", raising=False)
+        client = _make_client()
+        items = [_make_queue_item("garbage")]
+        queue: Queue = Queue()
+
+        with (
+            mock.patch(
+                "langsmith._internal._background_thread._tracing_thread_handle_batch"
+            ) as ls_h,
+            mock.patch(
+                "langsmith._internal._background_thread._otel_tracing_thread_handle_batch"
+            ) as otel_h,
+        ):
+            _dispatch_batch(client, queue, items, use_multipart=True)
+
+        ls_h.assert_called_once()
+        otel_h.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: @traceable + langsmith_extra → TracingQueueItem.destination
+# ---------------------------------------------------------------------------
+
+
+def _patched_client(monkeypatch: pytest.MonkeyPatch, seen: list) -> Client:
+    """Return a Client whose ``create_run`` records ``tracing_destinations``.
+
+    Patches at the *class* level to satisfy ``__slots__``.
+    """
+    monkeypatch.setenv("LANGSMITH_TRACING", "true")
+    client = _make_client()
+    client.otel_exporter = mock.Mock()
+
+    def _record(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+        seen.append(kwargs.get("tracing_destinations"))
+
+    def _noop(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+        pass
+
+    monkeypatch.setattr(Client, "create_run", _record)
+    monkeypatch.setattr(Client, "update_run", _noop)
+    return client
+
+
+class TestTraceableIntegration:
+    def test_langsmith_extra_sets_destination_on_outgoing_run(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        seen: list = []
+        client = _patched_client(monkeypatch, seen)
+
+        @run_helpers.traceable(client=client)
+        def f() -> int:
+            return 1
+
+        f(langsmith_extra={"tracing_destinations": "otel"})
+        assert seen == ["otel"]
+
+    def test_override_propagates_to_child_runs(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        seen: list = []
+        client = _patched_client(monkeypatch, seen)
+
+        @run_helpers.traceable(client=client)
+        def inner() -> int:
+            return 2
+
+        @run_helpers.traceable(client=client)
+        def outer() -> int:
+            return inner()
+
+        outer(langsmith_extra={"tracing_destinations": "hybrid"})
+        assert seen == ["hybrid", "hybrid"]
+
+    def test_sibling_traces_do_not_share_override(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An override on one top-level trace must not leak to a sibling."""
+        seen: list = []
+        client = _patched_client(monkeypatch, seen)
+
+        @run_helpers.traceable(client=client)
+        def a() -> int:
+            return 1
+
+        @run_helpers.traceable(client=client)
+        def b() -> int:
+            return 2
+
+        a(langsmith_extra={"tracing_destinations": "otel"})
+        b()
+        assert seen == ["otel", None]
+
+    def test_no_override_leaves_destination_as_none(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        seen: list = []
+        client = _patched_client(monkeypatch, seen)
+
+        @run_helpers.traceable(client=client)
+        def f() -> int:
+            return 1
+
+        f()
+        assert seen == [None]


### PR DESCRIPTION
## Problem

The LangSmith SDK supports exporting traces to three destinations: **LangSmith** (the default), **OpenTelemetry** (a third-party OTEL endpoint), or **both** (hybrid). Today, this is configured globally via environment variables (`LANGSMITH_OTEL_ENABLED` + `LANGSMITH_OTEL_ONLY`), which means every trace from a given process goes to the same place.

Users sometimes need to route individual traces to different destinations at runtime - for example, sending most traces to LangSmith but selectively exporting specific workflows to an OTEL collector only. The only way to achieve this before our change was monkey-patching internal SDK functions between calls, which is fragile and breaks across SDK versions.

## Solution

We add a single new key to the existing `langsmith_extra` dict: `tracing_destinations`. It accepts `"langsmith"`, `"otel"`, or `"hybrid"`. When set for a `@traceable` call, it overrides the global tracing mode for that run and all its descendants (child runs created via `create_child`). When not set, behavior is identical to before

## Test plan
See comments