### PR TITLE
test: integration tests for Context (python + js)

### DIFF
--- a/js/src/tests/context.int.test.ts
+++ b/js/src/tests/context.int.test.ts
@@ -1,0 +1,181 @@
+import { Client } from "../client.js";
+import { AgentContext, FileEntry, SkillContext } from "../schemas.js";
+
+function shortId(): string {
+  return Math.random().toString(36).slice(2, 10);
+}
+
+function agentIdentifier(): string {
+  return `-/ctx-test-js-agent-${shortId()}`;
+}
+
+function skillIdentifier(): string {
+  return `-/ctx-test-js-skill-${shortId()}`;
+}
+
+describe("Context integration (agent/skill)", () => {
+  const client = new Client();
+
+  async function cleanupAgent(identifier: string) {
+    try {
+      await client.deleteAgent(identifier);
+    } catch (_) {
+      /* best effort */
+    }
+  }
+
+  async function cleanupSkill(identifier: string) {
+    try {
+      await client.deleteSkill(identifier);
+    } catch (_) {
+      /* best effort */
+    }
+  }
+
+  test("pushAgent + pullAgent roundtrip", async () => {
+    const identifier = agentIdentifier();
+    try {
+      const url = await client.pushAgent(identifier, {
+        files: {
+          "AGENTS.md": { type: "file", content: "# Test Agent\n" },
+        },
+        description: "integration test agent (js)",
+      });
+      expect(url).toContain("/hub/");
+
+      const agent: AgentContext = await client.pullAgent(identifier);
+      expect(agent.files["AGENTS.md"]).toBeDefined();
+      const entry = agent.files["AGENTS.md"] as FileEntry;
+      expect(entry.type).toBe("file");
+      expect(entry.content).toBe("# Test Agent\n");
+    } finally {
+      await cleanupAgent(identifier);
+    }
+  });
+
+  test("pushSkill + pullSkill roundtrip", async () => {
+    const identifier = skillIdentifier();
+    try {
+      const url = await client.pushSkill(identifier, {
+        files: {
+          "SKILL.md": { type: "file", content: "# Test Skill\n" },
+        },
+        description: "integration test skill (js)",
+      });
+      expect(url).toContain("/hub/");
+
+      const skill: SkillContext = await client.pullSkill(identifier);
+      expect(skill.files["SKILL.md"]).toBeDefined();
+      const entry = skill.files["SKILL.md"] as FileEntry;
+      expect(entry.content).toBe("# Test Skill\n");
+    } finally {
+      await cleanupSkill(identifier);
+    }
+  });
+
+  test("pushAgent with null entry deletes that file", async () => {
+    const identifier = agentIdentifier();
+    try {
+      await client.pushAgent(identifier, {
+        files: {
+          "keep.md": { type: "file", content: "keep" },
+          "remove.md": { type: "file", content: "remove" },
+        },
+      });
+      let agent = await client.pullAgent(identifier);
+      expect(agent.files["keep.md"]).toBeDefined();
+      expect(agent.files["remove.md"]).toBeDefined();
+
+      await client.pushAgent(identifier, {
+        files: { "remove.md": null },
+      });
+      agent = await client.pullAgent(identifier);
+      expect(agent.files["keep.md"]).toBeDefined();
+      expect(agent.files["remove.md"]).toBeUndefined();
+    } finally {
+      await cleanupAgent(identifier);
+    }
+  });
+
+  test("pushAgent second commit updates file content", async () => {
+    const identifier = agentIdentifier();
+    try {
+      await client.pushAgent(identifier, {
+        files: { "AGENTS.md": { type: "file", content: "v1" } },
+      });
+      await client.pushAgent(identifier, {
+        files: { "AGENTS.md": { type: "file", content: "v2" } },
+      });
+
+      const agent = await client.pullAgent(identifier);
+      const entry = agent.files["AGENTS.md"] as FileEntry;
+      expect(entry.content).toBe("v2");
+    } finally {
+      await cleanupAgent(identifier);
+    }
+  });
+
+  test("deleteAgent removes the repo", async () => {
+    const identifier = agentIdentifier();
+    await client.pushAgent(identifier, {
+      files: { "AGENTS.md": { type: "file", content: "x" } },
+    });
+    await client.pullAgent(identifier);
+
+    await client.deleteAgent(identifier);
+
+    await expect(client.pullAgent(identifier)).rejects.toThrow();
+  });
+
+  test("listAgents returns pushed agent", async () => {
+    const identifier = agentIdentifier();
+    const handle = identifier.split("/")[1];
+    try {
+      await client.pushAgent(identifier, {
+        files: { "AGENTS.md": { type: "file", content: "x" } },
+      });
+      let found = false;
+      for await (const repo of client.listAgents({ query: handle })) {
+        if (repo.repo_handle === handle) {
+          found = true;
+          break;
+        }
+      }
+      expect(found).toBe(true);
+    } finally {
+      await cleanupAgent(identifier);
+    }
+  });
+
+  test("deleteSkill removes the repo", async () => {
+    const identifier = skillIdentifier();
+    await client.pushSkill(identifier, {
+      files: { "SKILL.md": { type: "file", content: "x" } },
+    });
+    await client.pullSkill(identifier);
+
+    await client.deleteSkill(identifier);
+
+    await expect(client.pullSkill(identifier)).rejects.toThrow();
+  });
+
+  test("listSkills returns pushed skill", async () => {
+    const identifier = skillIdentifier();
+    const handle = identifier.split("/")[1];
+    try {
+      await client.pushSkill(identifier, {
+        files: { "SKILL.md": { type: "file", content: "x" } },
+      });
+      let found = false;
+      for await (const repo of client.listSkills({ query: handle })) {
+        if (repo.repo_handle === handle) {
+          found = true;
+          break;
+        }
+      }
+      expect(found).toBe(true);
+    } finally {
+      await cleanupSkill(identifier);
+    }
+  });
+});

--- a/js/src/tests/context.int.test.ts
+++ b/js/src/tests/context.int.test.ts
@@ -1,16 +1,13 @@
+import { v4 as uuidv4 } from "uuid";
 import { Client } from "../client.js";
 import { AgentContext, FileEntry, SkillContext } from "../schemas.js";
 
-function shortId(): string {
-  return Math.random().toString(36).slice(2, 10);
-}
-
 function agentIdentifier(): string {
-  return `-/ctx-test-js-agent-${shortId()}`;
+  return `-/ctx-test-js-agent-${uuidv4().slice(0, 8)}`;
 }
 
 function skillIdentifier(): string {
-  return `-/ctx-test-js-skill-${shortId()}`;
+  return `-/ctx-test-js-skill-${uuidv4().slice(0, 8)}`;
 }
 
 describe("Context integration (agent/skill)", () => {

--- a/python/tests/integration_tests/test_context.py
+++ b/python/tests/integration_tests/test_context.py
@@ -1,0 +1,204 @@
+import uuid
+
+import pytest
+
+import langsmith.schemas as ls_schemas
+import langsmith.utils as ls_utils
+from langsmith.client import Client
+from tests.integration_tests.conftest import skip_if_rate_limited
+
+
+@pytest.fixture
+def langsmith_client() -> Client:
+    return Client(timeout_ms=(50_000, 90_000))
+
+
+@pytest.fixture
+def agent_identifier() -> str:
+    return f"-/ctx-test-agent-{uuid.uuid4().hex[:8]}"
+
+
+@pytest.fixture
+def skill_identifier() -> str:
+    return f"-/ctx-test-skill-{uuid.uuid4().hex[:8]}"
+
+
+@skip_if_rate_limited
+def test_push_and_pull_agent_roundtrip(
+    langsmith_client: Client, agent_identifier: str
+) -> None:
+    ctx = langsmith_client.context
+    try:
+        url = ctx.push_agent(
+            agent_identifier,
+            files={"AGENTS.md": ls_schemas.FileEntry(content="# Test Agent\n")},
+            description="integration test agent",
+        )
+        assert "/hub/" in url
+
+        agent = ctx.pull_agent(agent_identifier)
+        assert isinstance(agent, ls_schemas.AgentContext)
+        assert "AGENTS.md" in agent.files
+        entry = agent.files["AGENTS.md"]
+        assert isinstance(entry, ls_schemas.FileEntry)
+        assert entry.content == "# Test Agent\n"
+    finally:
+        try:
+            ctx.delete_agent(agent_identifier)
+        except Exception:
+            pass
+
+
+@skip_if_rate_limited
+def test_push_and_pull_skill_roundtrip(
+    langsmith_client: Client, skill_identifier: str
+) -> None:
+    ctx = langsmith_client.context
+    try:
+        url = ctx.push_skill(
+            skill_identifier,
+            files={"SKILL.md": ls_schemas.FileEntry(content="# Test Skill\n")},
+            description="integration test skill",
+        )
+        assert "/hub/" in url
+
+        skill = ctx.pull_skill(skill_identifier)
+        assert isinstance(skill, ls_schemas.SkillContext)
+        assert "SKILL.md" in skill.files
+        entry = skill.files["SKILL.md"]
+        assert isinstance(entry, ls_schemas.FileEntry)
+        assert entry.content == "# Test Skill\n"
+    finally:
+        try:
+            ctx.delete_skill(skill_identifier)
+        except Exception:
+            pass
+
+
+@skip_if_rate_limited
+def test_push_agent_null_entry_deletes_file(
+    langsmith_client: Client, agent_identifier: str
+) -> None:
+    ctx = langsmith_client.context
+    try:
+        ctx.push_agent(
+            agent_identifier,
+            files={
+                "keep.md": ls_schemas.FileEntry(content="keep"),
+                "remove.md": ls_schemas.FileEntry(content="remove"),
+            },
+        )
+        agent = ctx.pull_agent(agent_identifier)
+        assert "keep.md" in agent.files
+        assert "remove.md" in agent.files
+
+        ctx.push_agent(agent_identifier, files={"remove.md": None})
+        agent = ctx.pull_agent(agent_identifier)
+        assert "keep.md" in agent.files
+        assert "remove.md" not in agent.files
+    finally:
+        try:
+            ctx.delete_agent(agent_identifier)
+        except Exception:
+            pass
+
+
+@skip_if_rate_limited
+def test_push_agent_second_commit_updates_content(
+    langsmith_client: Client, agent_identifier: str
+) -> None:
+    ctx = langsmith_client.context
+    try:
+        ctx.push_agent(
+            agent_identifier,
+            files={"AGENTS.md": ls_schemas.FileEntry(content="v1")},
+        )
+        ctx.push_agent(
+            agent_identifier,
+            files={"AGENTS.md": ls_schemas.FileEntry(content="v2")},
+        )
+
+        agent = ctx.pull_agent(agent_identifier)
+        entry = agent.files["AGENTS.md"]
+        assert isinstance(entry, ls_schemas.FileEntry)
+        assert entry.content == "v2"
+    finally:
+        try:
+            ctx.delete_agent(agent_identifier)
+        except Exception:
+            pass
+
+
+@skip_if_rate_limited
+def test_delete_agent_removes_repo(
+    langsmith_client: Client, agent_identifier: str
+) -> None:
+    ctx = langsmith_client.context
+    ctx.push_agent(
+        agent_identifier,
+        files={"AGENTS.md": ls_schemas.FileEntry(content="x")},
+    )
+    # confirm it exists
+    ctx.pull_agent(agent_identifier)
+
+    ctx.delete_agent(agent_identifier)
+
+    with pytest.raises(ls_utils.LangSmithNotFoundError):
+        ctx.pull_agent(agent_identifier)
+
+
+@skip_if_rate_limited
+def test_list_agents_returns_pushed_agent(
+    langsmith_client: Client, agent_identifier: str
+) -> None:
+    ctx = langsmith_client.context
+    _, handle = agent_identifier.split("/", 1)
+    try:
+        ctx.push_agent(
+            agent_identifier,
+            files={"AGENTS.md": ls_schemas.FileEntry(content="x")},
+        )
+        response = ctx.list_agents(query=handle)
+        assert any(repo.repo_handle == handle for repo in response.repos)
+    finally:
+        try:
+            ctx.delete_agent(agent_identifier)
+        except Exception:
+            pass
+
+
+@skip_if_rate_limited
+def test_delete_skill_removes_repo(
+    langsmith_client: Client, skill_identifier: str
+) -> None:
+    ctx = langsmith_client.context
+    ctx.push_skill(
+        skill_identifier,
+        files={"SKILL.md": ls_schemas.FileEntry(content="x")},
+    )
+    ctx.pull_skill(skill_identifier)
+
+    ctx.delete_skill(skill_identifier)
+
+    with pytest.raises(ls_utils.LangSmithNotFoundError):
+        ctx.pull_skill(skill_identifier)
+
+
+@skip_if_rate_limited
+def test_list_skills_returns_pushed_skill(
+    langsmith_client: Client, skill_identifier: str
+) -> None:
+    ctx = langsmith_client.context
+    _, handle = skill_identifier.split("/", 1)
+    try:
+        ctx.push_skill(
+            skill_identifier,
+            files={"SKILL.md": ls_schemas.FileEntry(content="x")},
+        )
+        response = ctx.list_skills(query=handle)
+        assert any(repo.repo_handle == handle for repo in response.repos)
+    finally:
+        try:
+            ctx.delete_skill(skill_identifier)
+        except Exception:
+            pass

--- a/python/tests/integration_tests/test_context_async.py
+++ b/python/tests/integration_tests/test_context_async.py
@@ -1,0 +1,203 @@
+import uuid
+
+import pytest
+
+import langsmith.schemas as ls_schemas
+import langsmith.utils as ls_utils
+from langsmith.async_client import AsyncClient
+from tests.integration_tests.conftest import skip_if_rate_limited
+
+
+@pytest.fixture
+def langsmith_client() -> AsyncClient:
+    return AsyncClient(timeout_ms=(50_000, 90_000))
+
+
+@pytest.fixture
+def agent_identifier() -> str:
+    return f"-/ctx-test-async-agent-{uuid.uuid4().hex[:8]}"
+
+
+@pytest.fixture
+def skill_identifier() -> str:
+    return f"-/ctx-test-async-skill-{uuid.uuid4().hex[:8]}"
+
+
+@skip_if_rate_limited
+async def test_push_and_pull_agent_roundtrip(
+    langsmith_client: AsyncClient, agent_identifier: str
+) -> None:
+    ctx = langsmith_client.context
+    try:
+        url = await ctx.push_agent(
+            agent_identifier,
+            files={"AGENTS.md": ls_schemas.FileEntry(content="# Test Agent\n")},
+            description="integration test agent",
+        )
+        assert "/hub/" in url
+
+        agent = await ctx.pull_agent(agent_identifier)
+        assert isinstance(agent, ls_schemas.AgentContext)
+        assert "AGENTS.md" in agent.files
+        entry = agent.files["AGENTS.md"]
+        assert isinstance(entry, ls_schemas.FileEntry)
+        assert entry.content == "# Test Agent\n"
+    finally:
+        try:
+            await ctx.delete_agent(agent_identifier)
+        except Exception:
+            pass
+
+
+@skip_if_rate_limited
+async def test_push_and_pull_skill_roundtrip(
+    langsmith_client: AsyncClient, skill_identifier: str
+) -> None:
+    ctx = langsmith_client.context
+    try:
+        url = await ctx.push_skill(
+            skill_identifier,
+            files={"SKILL.md": ls_schemas.FileEntry(content="# Test Skill\n")},
+            description="integration test skill",
+        )
+        assert "/hub/" in url
+
+        skill = await ctx.pull_skill(skill_identifier)
+        assert isinstance(skill, ls_schemas.SkillContext)
+        assert "SKILL.md" in skill.files
+        entry = skill.files["SKILL.md"]
+        assert isinstance(entry, ls_schemas.FileEntry)
+        assert entry.content == "# Test Skill\n"
+    finally:
+        try:
+            await ctx.delete_skill(skill_identifier)
+        except Exception:
+            pass
+
+
+@skip_if_rate_limited
+async def test_push_agent_null_entry_deletes_file(
+    langsmith_client: AsyncClient, agent_identifier: str
+) -> None:
+    ctx = langsmith_client.context
+    try:
+        await ctx.push_agent(
+            agent_identifier,
+            files={
+                "keep.md": ls_schemas.FileEntry(content="keep"),
+                "remove.md": ls_schemas.FileEntry(content="remove"),
+            },
+        )
+        agent = await ctx.pull_agent(agent_identifier)
+        assert "keep.md" in agent.files
+        assert "remove.md" in agent.files
+
+        await ctx.push_agent(agent_identifier, files={"remove.md": None})
+        agent = await ctx.pull_agent(agent_identifier)
+        assert "keep.md" in agent.files
+        assert "remove.md" not in agent.files
+    finally:
+        try:
+            await ctx.delete_agent(agent_identifier)
+        except Exception:
+            pass
+
+
+@skip_if_rate_limited
+async def test_push_agent_second_commit_updates_content(
+    langsmith_client: AsyncClient, agent_identifier: str
+) -> None:
+    ctx = langsmith_client.context
+    try:
+        await ctx.push_agent(
+            agent_identifier,
+            files={"AGENTS.md": ls_schemas.FileEntry(content="v1")},
+        )
+        await ctx.push_agent(
+            agent_identifier,
+            files={"AGENTS.md": ls_schemas.FileEntry(content="v2")},
+        )
+
+        agent = await ctx.pull_agent(agent_identifier)
+        entry = agent.files["AGENTS.md"]
+        assert isinstance(entry, ls_schemas.FileEntry)
+        assert entry.content == "v2"
+    finally:
+        try:
+            await ctx.delete_agent(agent_identifier)
+        except Exception:
+            pass
+
+
+@skip_if_rate_limited
+async def test_delete_agent_removes_repo(
+    langsmith_client: AsyncClient, agent_identifier: str
+) -> None:
+    ctx = langsmith_client.context
+    await ctx.push_agent(
+        agent_identifier,
+        files={"AGENTS.md": ls_schemas.FileEntry(content="x")},
+    )
+    await ctx.pull_agent(agent_identifier)
+
+    await ctx.delete_agent(agent_identifier)
+
+    with pytest.raises(ls_utils.LangSmithNotFoundError):
+        await ctx.pull_agent(agent_identifier)
+
+
+@skip_if_rate_limited
+async def test_list_agents_returns_pushed_agent(
+    langsmith_client: AsyncClient, agent_identifier: str
+) -> None:
+    ctx = langsmith_client.context
+    _, handle = agent_identifier.split("/", 1)
+    try:
+        await ctx.push_agent(
+            agent_identifier,
+            files={"AGENTS.md": ls_schemas.FileEntry(content="x")},
+        )
+        response = await ctx.list_agents(query=handle)
+        assert any(repo.repo_handle == handle for repo in response.repos)
+    finally:
+        try:
+            await ctx.delete_agent(agent_identifier)
+        except Exception:
+            pass
+
+
+@skip_if_rate_limited
+async def test_delete_skill_removes_repo(
+    langsmith_client: AsyncClient, skill_identifier: str
+) -> None:
+    ctx = langsmith_client.context
+    await ctx.push_skill(
+        skill_identifier,
+        files={"SKILL.md": ls_schemas.FileEntry(content="x")},
+    )
+    await ctx.pull_skill(skill_identifier)
+
+    await ctx.delete_skill(skill_identifier)
+
+    with pytest.raises(ls_utils.LangSmithNotFoundError):
+        await ctx.pull_skill(skill_identifier)
+
+
+@skip_if_rate_limited
+async def test_list_skills_returns_pushed_skill(
+    langsmith_client: AsyncClient, skill_identifier: str
+) -> None:
+    ctx = langsmith_client.context
+    _, handle = skill_identifier.split("/", 1)
+    try:
+        await ctx.push_skill(
+            skill_identifier,
+            files={"SKILL.md": ls_schemas.FileEntry(content="x")},
+        )
+        response = await ctx.list_skills(query=handle)
+        assert any(repo.repo_handle == handle for repo in response.repos)
+    finally:
+        try:
+            await ctx.delete_skill(skill_identifier)
+        except Exception:
+            pass


### PR DESCRIPTION
## Summary

Adds live-backend round-trip integration tests for the Context hub surface, landing the test coverage that was held out of the impl PRs.

## Coverage

Each file runs 8 tests covering every public method — `push`, `pull`, `delete`, `list` — plus null-entry deletion and second-commit update. Agent and skill variants are tested symmetrically.

- **Python sync** (`python/tests/integration_tests/test_context.py`) — 8 tests against `Client.context`
- **Python async** (`python/tests/integration_tests/test_context_async.py`) — 8 tests against `AsyncClient.context`
- **JS** (`js/src/tests/context.int.test.ts`) — 8 tests against `Client`

## Stack

Top of the stack. Depends on:

1. #2745 — Context schemas (py + js)
2. #2746 — Python impl
3. #2747 — JS impl
4. **#2748 (this PR)** — integration tests

Upstream PRs must land before this is reviewable on its own.

## Release Note

none

## Test plan

- [x] Python tests collect cleanly via `uv run pytest --collect-only`
- [x] JS tests compile via `tsc --noEmit`
- [ ] Live backend run: Python sync 8/8 + async 8/8 pass against `beta.api.smith.langchain.com`
- [ ] Live backend run: JS 8/8 pass

