### PR TITLE
fix: patch 2 security alerts (high severity)

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -452,7 +452,8 @@
   },
   "pnpm": {
     "overrides": {
-      "js-yaml": "^4.1.1"
+      "js-yaml": "^4.1.1",
+      "vite": "^7.3.2"
     }
   },
   "browser": {

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   js-yaml: ^4.1.1
+  vite: ^7.3.2
 
 importers:
 
@@ -2253,7 +2254,7 @@ packages:
     resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
     peerDependencies:
       msw: ^2.4.9
-      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+      vite: ^7.3.2
     peerDependenciesMeta:
       msw:
         optional: true
@@ -4773,8 +4774,8 @@ packages:
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
 
-  vite@7.3.1:
-    resolution: {integrity: sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==}
+  vite@7.3.2:
+    resolution: {integrity: sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -7458,14 +7459,14 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(msw@2.13.4(@types/node@25.6.0)(typescript@5.9.3))(vite@7.3.1(@types/node@25.6.0)(yaml@2.8.3))':
+  '@vitest/mocker@3.2.4(msw@2.13.4(@types/node@25.6.0)(typescript@5.9.3))(vite@7.3.2(@types/node@25.6.0)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       msw: 2.13.4(@types/node@25.6.0)(typescript@5.9.3)
-      vite: 7.3.1(@types/node@25.6.0)(yaml@2.8.3)
+      vite: 7.3.2(@types/node@25.6.0)(yaml@2.8.3)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -10401,7 +10402,7 @@ snapshots:
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.3.1(@types/node@25.6.0)(yaml@2.8.3)
+      vite: 7.3.2(@types/node@25.6.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -10416,7 +10417,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@7.3.1(@types/node@25.6.0)(yaml@2.8.3):
+  vite@7.3.2(@types/node@25.6.0)(yaml@2.8.3):
     dependencies:
       esbuild: 0.27.4
       fdir: 6.5.0(picomatch@4.0.4)
@@ -10433,7 +10434,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(msw@2.13.4(@types/node@25.6.0)(typescript@5.9.3))(vite@7.3.1(@types/node@25.6.0)(yaml@2.8.3))
+      '@vitest/mocker': 3.2.4(msw@2.13.4(@types/node@25.6.0)(typescript@5.9.3))(vite@7.3.2(@types/node@25.6.0)(yaml@2.8.3))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -10451,7 +10452,7 @@ snapshots:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.3.1(@types/node@25.6.0)(yaml@2.8.3)
+      vite: 7.3.2(@types/node@25.6.0)(yaml@2.8.3)
       vite-node: 3.2.4(@types/node@25.6.0)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:


### PR DESCRIPTION
## Security Alert Patch

Resolves 2 Dependabot security alerts in the high severity tier (and incidentally 1 medium with the same patched version).

### Packages Updated

| Package | Old Constraint | New Constraint | Strategy | Scope | CVEs Resolved |
|---------|---------------|----------------|----------|-------|---------------|
| `vite` (via `vitest` peer dep) | resolved to 7.3.1 | `^7.3.2` override in `pnpm.overrides` | C (override) | dev-only | CVE-2026-39363, CVE-2026-39364, CVE-2026-39365 |

Strategy: C = override (valid because vite is dev-only via vitest in devDependencies).
Why override over lockfile-only update: `pnpm update vite` also bumped ~15 unrelated devDeps; the pinned override scopes the diff to vite only. `^7.3.2` restricts to the 7.x minor/patch range to stay within the minimum safe version (avoiding vite 8 major).

### Upstream Issues

None. vite 7.3.2 is fully released and compatible with the pinned vitest version.

### CVE Details

- **[CVE-2026-39363 / GHSA-p9ff-h696-f583](https://github.com/advisories/GHSA-p9ff-h696-f583)** (high) — Vite vulnerable to arbitrary file read via dev server WebSocket. Alert #157.
- **[CVE-2026-39364 / GHSA-v2wj-q39q-566r](https://github.com/advisories/GHSA-v2wj-q39q-566r)** (high) — \`server.fs.deny\` bypassed with queries. Alert #155.
- **[CVE-2026-39365 / GHSA-4w7w-66w2-5vf9](https://github.com/advisories/GHSA-4w7w-66w2-5vf9)** (medium, same patched version — incidentally resolved) — Path traversal in optimized deps \`.map\` handling. Alert #156.

### Linear Tickets

Linear ticket lookup skipped — CLI not authenticated.

### Verification

- [x] \`js/pnpm-lock.yaml\` regenerated (only vite entries changed)
- [x] Linters pass (\`pnpm lint\` — 0 errors)
- [x] Formatter passes (\`pnpm format:check\`)
- [x] Type check passes (\`pnpm check:types\`)
- [x] Tests pass (\`pnpm test:vitest\` — 64 pass, 1 skipped; directly exercises vite 7.3.2)

Submitted by langster-patch.