### PR TITLE
chore(python): remove templates, pools, and volumes

### DIFF
--- a/python/langsmith/sandbox/README.md
+++ b/python/langsmith/sandbox/README.md
@@ -600,21 +600,35 @@ with client.sandbox(snapshot_id=snapshot.id) as sb:
 
 ### Capture a Running Sandbox
 
-Install packages or configure state, then capture it as a reusable snapshot:
+Install packages or prepare files on a running sandbox, then capture the
+result as a reusable snapshot. The returned snapshot has `source_sandbox_id`
+set to the sandbox it was captured from, and can be used as the
+`snapshot_id` for any later `create_sandbox` / `sandbox(...)` call.
 
 ```python
 sb = client.create_sandbox(snapshot_id=base_snapshot_id, name="setup-box")
-sb.run("pip install numpy pandas scikit-learn")
+sb.run("pip install numpy pandas scikit-learn", timeout=180)
+sb.write("/opt/config.yaml", "model: gpt-5\n")
 
-# Capture current state as a new snapshot
-snapshot = sb.capture_snapshot("ml-ready")
+# Either form works; the instance method just forwards to the client.
+snapshot = sb.capture_snapshot("ml-ready", timeout=300)
+# snapshot = client.capture_snapshot(sb.name, "ml-ready", timeout=300)
+print(snapshot.id, snapshot.source_sandbox_id)
 
 sb.delete()
 
 # Later: spin up sandboxes from the captured snapshot
 with client.sandbox(snapshot_id=snapshot.id) as sb:
     sb.run("python -c 'import numpy; print(numpy.__version__)'")
+    assert sb.read("/opt/config.yaml") == b"model: gpt-5\n"
 ```
+
+> **Note:** `capture_snapshot` preserves only the **persistent filesystem**.
+> Installed packages (under `/usr/local`, `/root`, `/opt`, the home
+> directory, etc.) and files you wrote to those paths are kept. Running
+> processes, open sockets, in-memory state, and anything under `/tmp`
+> (which is a tmpfs) are **not** carried over — restart the processes you
+> need in the new sandbox.
 
 ### Snapshot CRUD
 

--- a/python/langsmith/sandbox/README.md
+++ b/python/langsmith/sandbox/README.md
@@ -12,27 +12,33 @@ from langsmith.sandbox import SandboxClient
 # Client uses LANGSMITH_ENDPOINT and LANGSMITH_API_KEY from environment
 client = SandboxClient()
 
-# First, create a template (defines the container image)
-client.create_template(
-    name="python-sandbox",
-    image="python:3.12-slim",
+# First, build a snapshot (defines the container image and root filesystem)
+snapshot = client.create_snapshot(
+    "python-snapshot",
+    docker_image="python:3.12-slim",
+    fs_capacity_bytes=4 * 1024**3,  # 4 GB
 )
 
-# Now create a sandbox from the template and run code
-with client.sandbox(template_name="python-sandbox") as sb:
+# Now create a sandbox from the snapshot and run code
+with client.sandbox(snapshot_id=snapshot.id) as sb:
     result = sb.run("python -c 'print(2 + 2)'")
     print(result.stdout)  # "4\n"
     print(result.success)  # True
 
 # Or create a sandbox to keep
-sb = client.create_sandbox(template_name="python-sandbox")
+sb = client.create_sandbox(snapshot_id=snapshot.id)
 result = sb.run("python -c 'print(2 + 2)'")
 client.delete_sandbox(sb.name)  # Don't forget to clean up when done
 
-# Or use an existing sandbox by ID
+# Or use an existing sandbox by name
 sb = client.get_sandbox(name="your-sandbox")
 result = sb.run("python -c 'print(2 + 2)'")
 ```
+
+The examples below assume `snapshot_id` is bound to a snapshot UUID obtained
+from `client.create_snapshot(...)` (or `client.list_snapshots()` /
+`client.get_snapshot(...)`). You only need to build a snapshot once; many
+sandboxes can be created from the same `snapshot_id`.
 
 ## Installation
 
@@ -68,8 +74,7 @@ client = SandboxClient(
 ## Running Commands
 
 ```python
-# Assuming you've created a template called "my-sandbox"
-with client.sandbox(template_name="my-sandbox") as sb:
+with client.sandbox(snapshot_id=snapshot_id) as sb:
     # Run a command
     result = sb.run("echo 'Hello, World!'")
 
@@ -96,7 +101,7 @@ The simplest way to get real-time output. Blocks until the command completes.
 ```python
 import sys
 
-with client.sandbox(template_name="my-sandbox") as sb:
+with client.sandbox(snapshot_id=snapshot_id) as sb:
     result = sb.run(
         "make build",
         timeout=600,
@@ -112,7 +117,7 @@ For full control — access to the process handle, stream identity, kill, and
 reconnection.
 
 ```python
-with client.sandbox(template_name="my-sandbox") as sb:
+with client.sandbox(snapshot_id=snapshot_id) as sb:
     handle = sb.run("make build", timeout=600, wait=False)
 
     print(f"Command ID: {handle.command_id}")
@@ -131,7 +136,7 @@ with client.sandbox(template_name="my-sandbox") as sb:
 import threading
 import time
 
-with client.sandbox(template_name="my-sandbox") as sb:
+with client.sandbox(snapshot_id=snapshot_id) as sb:
     handle = sb.run("sleep 3600", timeout=7200, wait=False)
 
     # Kill after 10 seconds from another thread
@@ -151,7 +156,7 @@ with client.sandbox(template_name="my-sandbox") as sb:
 ### Sending Stdin Input
 
 ```python
-with client.sandbox(template_name="my-sandbox") as sb:
+with client.sandbox(snapshot_id=snapshot_id) as sb:
     handle = sb.run(
         "python -c 'name = input(\"Name: \"); print(f\"Hello {name}\")'",
         timeout=30,
@@ -173,7 +178,7 @@ reconnects on transient disconnects — hot-reloads, network blips, etc. No user
 code needed:
 
 ```python
-with client.sandbox(template_name="my-sandbox") as sb:
+with client.sandbox(snapshot_id=snapshot_id) as sb:
     handle = sb.run("make build", timeout=600, wait=False)
 
     # Auto-reconnects on transient errors (hot-reload, network blips)
@@ -186,7 +191,7 @@ with client.sandbox(template_name="my-sandbox") as sb:
 For manual reconnection across process restarts:
 
 ```python
-with client.sandbox(template_name="my-sandbox") as sb:
+with client.sandbox(snapshot_id=snapshot_id) as sb:
     handle = sb.run("make build", timeout=600, wait=False)
     command_id = handle.command_id
 
@@ -206,7 +211,7 @@ and callbacks. Useful for long-lived processes like dev servers, file watchers,
 or background tasks that you control via `kill()`.
 
 ```python
-with client.sandbox(template_name="my-sandbox") as sb:
+with client.sandbox(snapshot_id=snapshot_id) as sb:
     handle = sb.run("python server.py", timeout=0, wait=False)
 
     for chunk in handle:
@@ -233,7 +238,7 @@ period. During this window you can still reconnect to retrieve output. After the
 TTL expires, the session is cleaned up and `reconnect()` will raise an error.
 
 ```python
-with client.sandbox(template_name="my-sandbox") as sb:
+with client.sandbox(snapshot_id=snapshot_id) as sb:
     handle = sb.run("make build", wait=False)
     command_id = handle.command_id
 
@@ -256,7 +261,7 @@ Set to `-1` for no idle timeout (the command runs indefinitely until explicitly
 killed or it exits on its own).
 
 ```python
-with client.sandbox(template_name="my-sandbox") as sb:
+with client.sandbox(snapshot_id=snapshot_id) as sb:
     # Start a long-running command with a 30-minute idle timeout
     handle = sb.run(
         "python server.py",
@@ -282,7 +287,7 @@ reconnected to later. Set `kill_on_disconnect=True` to kill the command
 immediately when the last client disconnects:
 
 ```python
-with client.sandbox(template_name="my-sandbox") as sb:
+with client.sandbox(snapshot_id=snapshot_id) as sb:
     # Command is killed as soon as the client disconnects
     handle = sb.run(
         "python server.py",
@@ -302,7 +307,7 @@ with client.sandbox(template_name="my-sandbox") as sb:
 All lifecycle parameters can be combined:
 
 ```python
-with client.sandbox(template_name="my-sandbox") as sb:
+with client.sandbox(snapshot_id=snapshot_id) as sb:
     # Long-running task: 30-min idle timeout, 1-hour session TTL
     handle = sb.run(
         "python train.py",
@@ -328,7 +333,7 @@ Set `pty=True` to allocate a pseudo-terminal for the command. This is useful
 for interactive programs and commands that detect terminal capabilities:
 
 ```python
-with client.sandbox(template_name="my-sandbox") as sb:
+with client.sandbox(snapshot_id=snapshot_id) as sb:
     # Run an interactive Python REPL with PTY
     handle = sb.run("python", pty=True, wait=False)
 
@@ -356,8 +361,7 @@ with client.sandbox(template_name="my-sandbox") as sb:
 Read and write files in the sandbox:
 
 ```python
-# Assuming you've created a Python template
-with client.sandbox(template_name="my-python") as sb:
+with client.sandbox(snapshot_id=snapshot_id) as sb:
     # Write a file
     sb.write("/app/script.py", "print('Hello from file!')")
 
@@ -384,14 +388,19 @@ Requires the `websockets` package (`pip install 'langsmith[sandbox]'`).
 
 ### Basic Usage — PostgreSQL
 
-Use a template with the `postgres:16` image. The entrypoint initializes and
+Build a snapshot from the `postgres:16` image. The entrypoint initializes and
 starts Postgres automatically:
 
 ```python
 import psycopg2
 
-# Template uses the official postgres:16 image
-sb = client.create_sandbox(template_name="my-postgres")
+postgres_snapshot = client.create_snapshot(
+    "postgres-snapshot",
+    docker_image="postgres:16",
+    fs_capacity_bytes=4 * 1024**3,
+)
+
+sb = client.create_sandbox(snapshot_id=postgres_snapshot.id)
 pg_handle = sb.run(
     "POSTGRES_HOST_AUTH_METHOD=trust docker-entrypoint.sh postgres",
     timeout=0,
@@ -417,12 +426,18 @@ finally:
 
 ### Basic Usage — Redis
 
-Use a template with the `redis:7` image. Redis self-daemonizes:
+Build a snapshot from the `redis:7` image. Redis self-daemonizes:
 
 ```python
 import redis
 
-with client.sandbox(template_name="my-redis") as sb:
+redis_snapshot = client.create_snapshot(
+    "redis-snapshot",
+    docker_image="redis:7",
+    fs_capacity_bytes=2 * 1024**3,
+)
+
+with client.sandbox(snapshot_id=redis_snapshot.id) as sb:
     sb.run("redis-server --daemonize yes", timeout=10)
 
     with sb.tunnel(remote_port=6379, local_port=26379) as t:
@@ -437,7 +452,7 @@ Works with any TCP service. Start long-running services with `wait=False` and
 `timeout=0` so they stay alive across commands:
 
 ```python
-sb = client.create_sandbox(template_name="my-sandbox")
+sb = client.create_sandbox(snapshot_id=snapshot_id)
 http_handle = sb.run("python3 -m http.server 3000", timeout=0, wait=False)
 import time; time.sleep(2)
 
@@ -483,7 +498,7 @@ t.close()
 ### Async Usage
 
 ```python
-async with await client.sandbox(template_name="my-sandbox") as sb:
+async with await client.sandbox(snapshot_id=snapshot_id) as sb:
     async with await sb.tunnel(remote_port=5432) as t:
         conn = await asyncpg.connect(host="127.0.0.1", port=t.local_port)
 ```
@@ -498,7 +513,7 @@ for you.
 ### Basic Usage
 
 ```python
-with client.sandbox(template_name="my-sandbox") as sb:
+with client.sandbox(snapshot_id=snapshot_id) as sb:
     # Start a web server inside the sandbox
     handle = sb.run("python -m http.server 3000", timeout=0, wait=False)
     import time; time.sleep(2)
@@ -546,7 +561,7 @@ resp = svc.get("/api/status")
 ### Async Usage
 
 ```python
-async with await client.sandbox(template_name="my-sandbox") as sb:
+async with await client.sandbox(snapshot_id=snapshot_id) as sb:
     svc = await sb.service(port=3000)
 
     # Async HTTP helpers
@@ -559,8 +574,9 @@ async with await client.sandbox(template_name="my-sandbox") as sb:
 
 ## Snapshots
 
-Snapshots are built from Docker images or captured from running sandboxes.
-Use snapshots to create sandboxes with persistent state.
+Snapshots are the starting point for every sandbox. They're built from Docker
+images or captured from running sandboxes, and many sandboxes can share the
+same snapshot.
 
 ### Build a Snapshot from a Docker Image
 
@@ -647,106 +663,6 @@ client.stop_sandbox("my-vm")
 sandbox = client.start_sandbox("my-vm")
 ```
 
-## Templates
-
-Templates define the container image and resources for sandboxes. **You must create a template before you can create sandboxes.**
-
-```python
-# Create a template (required before creating sandboxes)
-template = client.create_template(
-    name="my-python-env",
-    image="python:3.12-slim",  # Any Docker image
-    cpu="1",        # CPU limit (default: "500m")
-    memory="1Gi",   # Memory limit (default: "512Mi")
-)
-
-# Now you can create sandboxes from this template
-with client.sandbox(template_name="my-python-env") as sb:
-    result = sb.run("python --version")
-
-# List all templates
-templates = client.list_templates()
-
-# Get a specific template
-template = client.get_template("my-python-env")
-
-# Update a template's name
-client.update_template("my-python-env", new_name="python-env-v2")
-
-# Delete a template (fails if sandboxes or pools are using it)
-client.delete_template("my-python-env")
-```
-
-### Common Template Images
-
-```python
-# Python
-client.create_template(name="python", image="python:3.12-slim")
-
-# Node.js
-client.create_template(name="node", image="node:20-slim")
-
-# Ubuntu (general purpose)
-client.create_template(name="ubuntu", image="ubuntu:24.04")
-```
-
-## Persistent Volumes
-
-Use volumes to persist data across sandbox sessions:
-
-```python
-from langsmith.sandbox import VolumeMountSpec
-
-# Create a volume
-volume = client.create_volume(name="my-data", size="1Gi")
-
-# Create a template with the volume mounted
-template = client.create_template(
-    name="stateful-sandbox",
-    image="python:3.12-slim",
-    volume_mounts=[
-        VolumeMountSpec(volume_name="my-data", mount_path="/data")
-    ],
-)
-
-# Data written to /data persists across sandbox sessions
-with client.sandbox(template_name="stateful-sandbox") as sb:
-    sb.write("/data/state.txt", "persistent data")
-
-# Later, in a new sandbox...
-with client.sandbox(template_name="stateful-sandbox") as sb:
-    content = sb.read("/data/state.txt")
-    print(content.decode())  # "persistent data"
-```
-
-## Pools (Pre-warmed Sandboxes)
-
-Pools pre-provision sandboxes for faster startup:
-
-```python
-# First create a template (without volumes - pools don't support volumes)
-client.create_template(name="fast-python", image="python:3.12-slim")
-
-# Create a pool with 5 warm sandboxes
-pool = client.create_pool(
-    name="python-pool",
-    template_name="fast-python",
-    replicas=2,
-)
-
-# Sandboxes from pooled templates start faster
-with client.sandbox(template_name="fast-python") as sb:
-    result = sb.run("python --version")
-
-# Scale the pool
-client.update_pool("python-pool", replicas=3)
-
-# Delete the pool
-client.delete_pool("python-pool")
-```
-
-> **Note:** Templates with volume mounts cannot be used in pools.
-
 ## Sandbox Lifetime & TTL
 
 Control how long a sandbox stays alive with two optional TTL parameters:
@@ -763,20 +679,20 @@ disable a TTL. When both are set, whichever deadline comes first wins.
 ```python
 # Create a sandbox that expires after 1 hour
 with client.sandbox(
-    template_name="my-sandbox",
+    snapshot_id=snapshot_id,
     ttl_seconds=3600,
 ) as sb:
     result = sb.run("echo hello")
 
 # Create a sandbox that expires after 10 min of inactivity
 sb = client.create_sandbox(
-    template_name="my-sandbox",
+    snapshot_id=snapshot_id,
     idle_ttl_seconds=600,
 )
 
 # Combine both: 2-hour max lifetime, 15-min idle timeout
 sb = client.create_sandbox(
-    template_name="my-sandbox",
+    snapshot_id=snapshot_id,
     ttl_seconds=7200,
     idle_ttl_seconds=900,
 )
@@ -812,7 +728,7 @@ Get a sandbox that's already running:
 
 ```python
 # Create a sandbox (requires explicit cleanup)
-sb = client.create_sandbox(template_name="my-template")
+sb = client.create_sandbox(snapshot_id=snapshot_id)
 print(sb.name)  # e.g., "sandbox-abc123"
 
 # Later, get the same sandbox
@@ -830,7 +746,7 @@ non-blocking creation, pass `wait_for_ready=False`:
 
 ```python
 # Returns immediately with status="provisioning"
-sb = client.create_sandbox(template_name="my-template", wait_for_ready=False)
+sb = client.create_sandbox(snapshot_id=snapshot_id, wait_for_ready=False)
 print(sb.status)  # "provisioning"
 
 # Poll until ready using the lightweight status endpoint
@@ -844,7 +760,7 @@ result = sb.run("echo hello")
 You can also poll manually for more control:
 
 ```python
-sb = client.create_sandbox(template_name="my-template", wait_for_ready=False)
+sb = client.create_sandbox(snapshot_id=snapshot_id, wait_for_ready=False)
 
 while True:
     status = client.get_sandbox_status(sb.name)
@@ -869,11 +785,15 @@ from langsmith.sandbox import AsyncSandboxClient
 
 async def main():
     async with AsyncSandboxClient() as client:
-        # Create a template first
-        await client.create_template(name="async-python", image="python:3.12-slim")
+        # Build a snapshot first
+        snapshot = await client.create_snapshot(
+            "async-python",
+            docker_image="python:3.12-slim",
+            fs_capacity_bytes=4 * 1024**3,
+        )
 
-        # Use the template
-        async with await client.sandbox(template_name="async-python") as sb:
+        # Use the snapshot
+        async with await client.sandbox(snapshot_id=snapshot.id) as sb:
             result = await sb.run("python -c 'print(1 + 1)'")
             print(result.stdout)  # "2\n"
 
@@ -885,7 +805,7 @@ async def main():
 ### Async Streaming
 
 ```python
-async with await client.sandbox(template_name="async-python") as sb:
+async with await client.sandbox(snapshot_id=snapshot_id) as sb:
     handle = await sb.run("make build", timeout=600, wait=False)
 
     async for chunk in handle:
@@ -915,7 +835,7 @@ from langsmith.sandbox import (
 )
 
 try:
-    with client.sandbox(template_name="my-sandbox") as sb:
+    with client.sandbox(snapshot_id=snapshot_id) as sb:
         result = sb.run("sleep 999", timeout=10)
 except CommandTimeoutError as e:
     print(f"Command timed out: {e}")
@@ -937,8 +857,8 @@ except SandboxClientError as e:
 
 | Method | Description |
 |--------|-------------|
-| `sandbox(template_name=None, *, snapshot_id=None, ttl_seconds=None, idle_ttl_seconds=None, ...)` | Create a sandbox (auto-deleted on context exit). Provide `template_name` or `snapshot_id`. |
-| `create_sandbox(template_name=None, *, snapshot_id=None, wait_for_ready=True, ...)` | Create a sandbox (requires explicit delete). Provide `template_name` or `snapshot_id`. |
+| `sandbox(snapshot_id, *, ttl_seconds=None, idle_ttl_seconds=None, ...)` | Create a sandbox (auto-deleted on context exit). |
+| `create_sandbox(snapshot_id, *, wait_for_ready=True, ...)` | Create a sandbox (requires explicit delete). |
 | `get_sandbox(name)` | Get an existing sandbox by name |
 | `get_sandbox_status(name)` | Get lightweight provisioning status (`ResourceStatus`) |
 | `wait_for_sandbox(name, *, timeout=120, poll_interval=1.0)` | Poll until sandbox is ready or failed |
@@ -954,26 +874,12 @@ except SandboxClientError as e:
 | `list_snapshots()` | List all snapshots |
 | `delete_snapshot(snapshot_id)` | Delete a snapshot |
 | `wait_for_snapshot(snapshot_id, *, timeout=300)` | Poll until snapshot is ready or failed |
-| `create_template(name, image, ...)` | Create a template |
-| `list_templates()` | List all templates |
-| `get_template(name)` | Get template by name |
-| `update_template(name, *, new_name)` | Update a template's display name |
-| `delete_template(name)` | Delete a template |
-| `create_volume(name, size)` | Create a persistent volume |
-| `list_volumes()` | List all volumes |
-| `update_volume(name, *, new_name, size)` | Update a volume's name or size |
-| `delete_volume(name)` | Delete a volume |
-| `create_pool(name, template_name, replicas)` | Create a pool |
-| `list_pools()` | List all pools |
-| `update_pool(name, *, replicas, new_name)` | Update pool replicas or name |
-| `delete_pool(name)` | Delete a pool |
 
 ### Sandbox
 
 | Property | Description |
 |----------|-------------|
 | `name` | Display name |
-| `template_name` | Template used to create this sandbox |
 | `snapshot_id` | Snapshot ID used to create this sandbox |
 | `status` | Lifecycle status: `"provisioning"`, `"ready"`, `"failed"`, or `"stopped"` |
 | `status_message` | Human-readable details when status is `"failed"`, `None` otherwise |

--- a/python/langsmith/sandbox/__init__.py
+++ b/python/langsmith/sandbox/__init__.py
@@ -9,7 +9,10 @@ Example:
     # Uses LANGSMITH_ENDPOINT and LANGSMITH_API_KEY from environment
     client = SandboxClient()
 
-    with client.sandbox(template_name="python-sandbox") as sb:
+    snapshot = client.create_snapshot(
+        docker_image="python:3.12-slim", name="python-snapshot"
+    )
+    with client.sandbox(snapshot_id=snapshot.id) as sb:
         result = sb.run("python --version")
         print(result.stdout)
 
@@ -17,7 +20,10 @@ Example:
     from langsmith.sandbox import AsyncSandboxClient
 
     async with AsyncSandboxClient() as client:
-        async with await client.sandbox(template_name="python-sandbox") as sb:
+        snapshot = await client.create_snapshot(
+            docker_image="python:3.12-slim", name="python-snapshot"
+        )
+        async with await client.sandbox(snapshot_id=snapshot.id) as sb:
             result = await sb.run("python --version")
             print(result.stdout)
 """
@@ -54,14 +60,9 @@ from langsmith.sandbox._models import (
     CommandHandle,
     ExecutionResult,
     OutputChunk,
-    Pool,
-    ResourceSpec,
     ResourceStatus,
-    SandboxTemplate,
     ServiceURL,
     Snapshot,
-    Volume,
-    VolumeMountSpec,
 )
 from langsmith.sandbox._sandbox import Sandbox
 from langsmith.sandbox._tunnel import AsyncTunnel, Tunnel
@@ -73,13 +74,8 @@ __all__ = [
     "Sandbox",
     "AsyncSandbox",
     # Models
-    "SandboxTemplate",
     "ResourceStatus",
-    "ResourceSpec",
     "ExecutionResult",
-    "Volume",
-    "VolumeMountSpec",
-    "Pool",
     "Snapshot",
     "ServiceURL",
     "AsyncServiceURL",

--- a/python/langsmith/sandbox/_async_client.py
+++ b/python/langsmith/sandbox/_async_client.py
@@ -12,31 +12,22 @@ from langsmith import utils as ls_utils
 from langsmith.sandbox._async_sandbox import AsyncSandbox
 from langsmith.sandbox._exceptions import (
     ResourceCreationError,
-    ResourceInUseError,
     ResourceNameConflictError,
     ResourceNotFoundError,
     ResourceTimeoutError,
     SandboxAPIError,
-    ValidationError,
 )
 from langsmith.sandbox._helpers import (
     handle_client_http_error,
-    handle_pool_error,
     handle_sandbox_creation_error,
-    handle_volume_creation_error,
     merge_headers,
-    parse_error_response,
     validate_service_params,
     validate_ttl,
 )
 from langsmith.sandbox._models import (
     AsyncServiceURL,
-    Pool,
     ResourceStatus,
-    SandboxTemplate,
     Snapshot,
-    Volume,
-    VolumeMountSpec,
 )
 from langsmith.sandbox._transport import AsyncRetryTransport
 
@@ -61,13 +52,15 @@ RequestHeaders = Optional[Mapping[str, str]]
 class AsyncSandboxClient:
     """Async client for interacting with the Sandbox Server API.
 
-    This client provides an async interface for managing sandboxes and templates.
+    This client provides an async interface for managing sandboxes and snapshots.
 
     Example:
         # Uses LANGSMITH_ENDPOINT and LANGSMITH_API_KEY from environment
         async with AsyncSandboxClient() as client:
-            # Create a sandbox and run commands
-            async with await client.sandbox(template_name="python-sandbox") as sandbox:
+            # Create a sandbox from a snapshot and run commands
+            async with await client.sandbox(
+                snapshot_id="<snapshot-uuid>"
+            ) as sandbox:
                 result = await sandbox.run("python --version")
                 print(result.stdout)
     """
@@ -145,581 +138,13 @@ class AsyncSandboxClient:
         await self.aclose()
 
     # ========================================================================
-    # Volume Operations
-    # ========================================================================
-
-    async def create_volume(
-        self,
-        name: str,
-        size: str,
-        *,
-        timeout: int = 60,
-        headers: RequestHeaders = None,
-    ) -> Volume:
-        """Create a new persistent volume.
-
-        Creates a persistent storage volume that can be referenced in templates.
-
-        Args:
-            name: Volume name.
-            size: Storage size (e.g., "1Gi", "10Gi").
-            timeout: Timeout in seconds when waiting for ready (min: 5, max: 300).
-
-        Returns:
-            Created Volume.
-
-        Raises:
-            VolumeProvisioningError: If volume provisioning fails.
-            ResourceTimeoutError: If volume doesn't become ready within timeout.
-            SandboxClientError: For other errors.
-        """
-        url = f"{self._base_url}/volumes"
-
-        payload = {
-            "name": name,
-            "size": size,
-            "wait_for_ready": True,
-            "timeout": timeout,
-        }
-
-        try:
-            response = await self._http.post(
-                url,
-                json=payload,
-                timeout=timeout + 30,
-                headers=self._request_headers(headers),
-            )
-            response.raise_for_status()
-            return Volume.from_dict(response.json())
-        except httpx.HTTPStatusError as e:
-            handle_volume_creation_error(e)
-            raise  # pragma: no cover
-
-    async def get_volume(self, name: str, *, headers: RequestHeaders = None) -> Volume:
-        """Get a volume by name.
-
-        Args:
-            name: Volume name.
-
-        Returns:
-            Volume.
-
-        Raises:
-            ResourceNotFoundError: If volume not found.
-            SandboxClientError: For other errors.
-        """
-        url = f"{self._base_url}/volumes/{name}"
-
-        try:
-            response = await self._http.get(url, headers=self._request_headers(headers))
-            response.raise_for_status()
-            return Volume.from_dict(response.json())
-        except httpx.HTTPStatusError as e:
-            if e.response.status_code == 404:
-                raise ResourceNotFoundError(
-                    f"Volume '{name}' not found", resource_type="volume"
-                ) from e
-            handle_client_http_error(e)
-            raise  # pragma: no cover
-
-    async def list_volumes(self, *, headers: RequestHeaders = None) -> list[Volume]:
-        """List all volumes.
-
-        Returns:
-            List of Volumes.
-        """
-        url = f"{self._base_url}/volumes"
-
-        try:
-            response = await self._http.get(url, headers=self._request_headers(headers))
-            response.raise_for_status()
-            data = response.json()
-            return [Volume.from_dict(v) for v in data.get("volumes", [])]
-        except httpx.HTTPStatusError as e:
-            if e.response.status_code == 404:
-                raise SandboxAPIError(
-                    f"API endpoint not found: {url}. "
-                    f"Check that api_endpoint is correct."
-                ) from e
-            handle_client_http_error(e)
-            raise  # pragma: no cover
-
-    async def delete_volume(self, name: str, *, headers: RequestHeaders = None) -> None:
-        """Delete a volume.
-
-        Args:
-            name: Volume name.
-
-        Raises:
-            ResourceNotFoundError: If volume not found.
-            ResourceInUseError: If volume is referenced by templates.
-            SandboxClientError: For other errors.
-        """
-        url = f"{self._base_url}/volumes/{name}"
-
-        try:
-            response = await self._http.delete(
-                url, headers=self._request_headers(headers)
-            )
-            response.raise_for_status()
-        except httpx.HTTPStatusError as e:
-            if e.response.status_code == 404:
-                raise ResourceNotFoundError(
-                    f"Volume '{name}' not found", resource_type="volume"
-                ) from e
-            if e.response.status_code == 409:
-                data = parse_error_response(e)
-                raise ResourceInUseError(data["message"], resource_type="volume") from e
-            handle_client_http_error(e)
-
-    async def update_volume(
-        self,
-        name: str,
-        *,
-        new_name: Optional[str] = None,
-        size: Optional[str] = None,
-        headers: RequestHeaders = None,
-    ) -> Volume:
-        """Update a volume's name and/or size.
-
-        You can update the display name, size, or both in a single request.
-        Only storage size increases are allowed (storage backend limitation).
-
-        Args:
-            name: Current volume name.
-            new_name: New display name (optional).
-            size: New storage size (must be >= current size). Optional.
-
-        Returns:
-            Updated Volume.
-
-        Raises:
-            ResourceNotFoundError: If volume not found.
-            VolumeResizeError: If storage decrease attempted.
-            ResourceNameConflictError: If new_name is already in use.
-            SandboxQuotaExceededError: If storage quota would be exceeded.
-            SandboxClientError: For other errors.
-        """
-        url = f"{self._base_url}/volumes/{name}"
-        payload: dict[str, Any] = {}
-        if new_name is not None:
-            payload["name"] = new_name
-        if size is not None:
-            payload["size"] = size
-
-        if not payload:
-            # Nothing to update, just return the current volume
-            return await self.get_volume(name, headers=headers)
-
-        try:
-            response = await self._http.patch(
-                url, json=payload, headers=self._request_headers(headers)
-            )
-            response.raise_for_status()
-            return Volume.from_dict(response.json())
-        except httpx.HTTPStatusError as e:
-            if e.response.status_code == 404:
-                raise ResourceNotFoundError(
-                    f"Volume '{name}' not found", resource_type="volume"
-                ) from e
-            if e.response.status_code == 400:
-                data = parse_error_response(e)
-                raise ValidationError(data["message"], error_type="VolumeResize") from e
-            if e.response.status_code == 409:
-                data = parse_error_response(e)
-                raise ResourceNameConflictError(
-                    data["message"], resource_type="volume"
-                ) from e
-            handle_client_http_error(e)
-            raise  # pragma: no cover
-
-    # ========================================================================
-    # Template Operations
-    # ========================================================================
-
-    async def create_template(
-        self,
-        name: str,
-        image: str,
-        *,
-        cpu: str = "500m",
-        memory: str = "512Mi",
-        storage: Optional[str] = None,
-        volume_mounts: Optional[list[VolumeMountSpec]] = None,
-        headers: RequestHeaders = None,
-    ) -> SandboxTemplate:
-        """Create a new SandboxTemplate.
-
-        Only the container image, resource limits, and volume mounts can be
-        configured. All other container details are handled by the server.
-
-        Args:
-            name: Template name.
-            image: Container image (e.g., "python:3.12-slim").
-            cpu: CPU limit (e.g., "500m", "1", "2"). Default: "500m".
-            memory: Memory limit (e.g., "256Mi", "1Gi"). Default: "512Mi".
-            storage: Ephemeral storage limit (e.g., "1Gi"). Optional.
-            volume_mounts: List of volumes to mount in the sandbox. Optional.
-
-        Returns:
-            Created SandboxTemplate.
-
-        Raises:
-            SandboxClientError: If creation fails.
-        """
-        url = f"{self._base_url}/templates"
-
-        payload: dict[str, Any] = {
-            "name": name,
-            "image": image,
-            "resources": {
-                "cpu": cpu,
-                "memory": memory,
-            },
-        }
-        if storage:
-            payload["resources"]["storage"] = storage
-        if volume_mounts:
-            payload["volume_mounts"] = [
-                {"volume_name": vm.volume_name, "mount_path": vm.mount_path}
-                for vm in volume_mounts
-            ]
-
-        try:
-            response = await self._http.post(
-                url, json=payload, headers=self._request_headers(headers)
-            )
-            response.raise_for_status()
-            return SandboxTemplate.from_dict(response.json())
-        except httpx.HTTPStatusError as e:
-            handle_client_http_error(e)
-            raise  # pragma: no cover
-
-    async def get_template(
-        self, name: str, *, headers: RequestHeaders = None
-    ) -> SandboxTemplate:
-        """Get a SandboxTemplate by name.
-
-        Args:
-            name: Template name.
-
-        Returns:
-            SandboxTemplate.
-
-        Raises:
-            ResourceNotFoundError: If template not found.
-            SandboxClientError: For other errors.
-        """
-        url = f"{self._base_url}/templates/{name}"
-
-        try:
-            response = await self._http.get(url, headers=self._request_headers(headers))
-            response.raise_for_status()
-            return SandboxTemplate.from_dict(response.json())
-        except httpx.HTTPStatusError as e:
-            if e.response.status_code == 404:
-                raise ResourceNotFoundError(
-                    f"Template '{name}' not found", resource_type="template"
-                ) from e
-            handle_client_http_error(e)
-            raise  # pragma: no cover
-
-    async def list_templates(
-        self, *, headers: RequestHeaders = None
-    ) -> list[SandboxTemplate]:
-        """List all SandboxTemplates.
-
-        Returns:
-            List of SandboxTemplates.
-        """
-        url = f"{self._base_url}/templates"
-
-        try:
-            response = await self._http.get(url, headers=self._request_headers(headers))
-            response.raise_for_status()
-            data = response.json()
-            return [SandboxTemplate.from_dict(t) for t in data.get("templates", [])]
-        except httpx.HTTPStatusError as e:
-            if e.response.status_code == 404:
-                raise SandboxAPIError(
-                    f"API endpoint not found: {url}. "
-                    f"Check that api_endpoint is correct."
-                ) from e
-            handle_client_http_error(e)
-            raise  # pragma: no cover
-
-    async def update_template(
-        self, name: str, *, new_name: str, headers: RequestHeaders = None
-    ) -> SandboxTemplate:
-        """Update a template's display name.
-
-        Args:
-            name: Current template name.
-            new_name: New display name.
-
-        Returns:
-            Updated SandboxTemplate.
-
-        Raises:
-            ResourceNotFoundError: If template not found.
-            ResourceNameConflictError: If new_name is already in use.
-            SandboxClientError: For other errors.
-        """
-        url = f"{self._base_url}/templates/{name}"
-        payload = {"name": new_name}
-
-        try:
-            response = await self._http.patch(
-                url, json=payload, headers=self._request_headers(headers)
-            )
-            response.raise_for_status()
-            return SandboxTemplate.from_dict(response.json())
-        except httpx.HTTPStatusError as e:
-            if e.response.status_code == 404:
-                raise ResourceNotFoundError(
-                    f"Template '{name}' not found", resource_type="template"
-                ) from e
-            if e.response.status_code == 409:
-                data = parse_error_response(e)
-                raise ResourceNameConflictError(
-                    data["message"], resource_type="template"
-                ) from e
-            handle_client_http_error(e)
-            raise  # pragma: no cover
-
-    async def delete_template(
-        self, name: str, *, headers: RequestHeaders = None
-    ) -> None:
-        """Delete a SandboxTemplate.
-
-        Args:
-            name: Template name.
-
-        Raises:
-            ResourceNotFoundError: If template not found.
-            ResourceInUseError: If template is referenced by sandboxes or pools.
-            SandboxClientError: For other errors.
-        """
-        url = f"{self._base_url}/templates/{name}"
-
-        try:
-            response = await self._http.delete(
-                url, headers=self._request_headers(headers)
-            )
-            response.raise_for_status()
-        except httpx.HTTPStatusError as e:
-            if e.response.status_code == 404:
-                raise ResourceNotFoundError(
-                    f"Template '{name}' not found", resource_type="template"
-                ) from e
-            if e.response.status_code == 409:
-                data = parse_error_response(e)
-                raise ResourceInUseError(
-                    data["message"], resource_type="template"
-                ) from e
-            handle_client_http_error(e)
-
-    # ========================================================================
-    # Pool Operations
-    # ========================================================================
-
-    async def create_pool(
-        self,
-        name: str,
-        template_name: str,
-        replicas: int,
-        *,
-        timeout: int = 30,
-        headers: RequestHeaders = None,
-    ) -> Pool:
-        """Create a new Sandbox Pool.
-
-        Pools pre-provision sandboxes from a template for faster startup.
-
-        Args:
-            name: Pool name (lowercase letters, numbers, hyphens; max 63 chars).
-            template_name: Name of the SandboxTemplate to use (no volume mounts).
-            replicas: Number of sandboxes to pre-provision (1-100).
-            timeout: Timeout in seconds when waiting for ready (10-600).
-
-        Returns:
-            Created Pool.
-
-        Raises:
-            ResourceNotFoundError: If template not found.
-            ValidationError: If template has volumes attached.
-            ResourceAlreadyExistsError: If pool with this name already exists.
-            ResourceTimeoutError: If pool doesn't reach ready state within timeout.
-            SandboxQuotaExceededError: If organization quota is exceeded.
-            SandboxClientError: For other errors.
-        """
-        url = f"{self._base_url}/pools"
-
-        payload: dict[str, Any] = {
-            "name": name,
-            "template_name": template_name,
-            "replicas": replicas,
-            "wait_for_ready": True,
-            "timeout": timeout,
-        }
-
-        try:
-            http_timeout = timeout + 30
-            response = await self._http.post(
-                url,
-                json=payload,
-                timeout=http_timeout,
-                headers=self._request_headers(headers),
-            )
-            response.raise_for_status()
-            return Pool.from_dict(response.json())
-        except httpx.HTTPStatusError as e:
-            handle_pool_error(e)
-            raise  # pragma: no cover
-
-    async def get_pool(self, name: str, *, headers: RequestHeaders = None) -> Pool:
-        """Get a Pool by name.
-
-        Args:
-            name: Pool name.
-
-        Returns:
-            Pool.
-
-        Raises:
-            ResourceNotFoundError: If pool not found.
-            SandboxClientError: For other errors.
-        """
-        url = f"{self._base_url}/pools/{name}"
-
-        try:
-            response = await self._http.get(url, headers=self._request_headers(headers))
-            response.raise_for_status()
-            return Pool.from_dict(response.json())
-        except httpx.HTTPStatusError as e:
-            if e.response.status_code == 404:
-                raise ResourceNotFoundError(
-                    f"Pool '{name}' not found", resource_type="pool"
-                ) from e
-            handle_client_http_error(e)
-            raise  # pragma: no cover
-
-    async def list_pools(self, *, headers: RequestHeaders = None) -> list[Pool]:
-        """List all Pools.
-
-        Returns:
-            List of Pools.
-        """
-        url = f"{self._base_url}/pools"
-
-        try:
-            response = await self._http.get(url, headers=self._request_headers(headers))
-            response.raise_for_status()
-            data = response.json()
-            return [Pool.from_dict(p) for p in data.get("pools", [])]
-        except httpx.HTTPStatusError as e:
-            if e.response.status_code == 404:
-                raise SandboxAPIError(
-                    f"API endpoint not found: {url}. "
-                    f"Check that api_endpoint is correct."
-                ) from e
-            handle_client_http_error(e)
-            raise  # pragma: no cover
-
-    async def update_pool(
-        self,
-        name: str,
-        *,
-        new_name: Optional[str] = None,
-        replicas: Optional[int] = None,
-        headers: RequestHeaders = None,
-    ) -> Pool:
-        """Update a Pool's name and/or replica count.
-
-        You can update the display name, replica count, or both.
-        The template reference cannot be changed after creation.
-
-        Args:
-            name: Current pool name.
-            new_name: New display name (optional).
-            replicas: New number of replicas (0-100). Set to 0 to pause.
-
-        Returns:
-            Updated Pool.
-
-        Raises:
-            ResourceNotFoundError: If pool not found.
-            ValidationError: If template was deleted.
-            ResourceNameConflictError: If new_name is already in use.
-            SandboxQuotaExceededError: If quota exceeded when scaling up.
-            SandboxClientError: For other errors.
-        """
-        url = f"{self._base_url}/pools/{name}"
-
-        payload: dict[str, Any] = {}
-        if new_name is not None:
-            payload["name"] = new_name
-        if replicas is not None:
-            payload["replicas"] = replicas
-
-        if not payload:
-            # Nothing to update, just return the current pool
-            return await self.get_pool(name, headers=headers)
-
-        try:
-            response = await self._http.patch(
-                url, json=payload, headers=self._request_headers(headers)
-            )
-            response.raise_for_status()
-            return Pool.from_dict(response.json())
-        except httpx.HTTPStatusError as e:
-            if e.response.status_code == 404:
-                raise ResourceNotFoundError(
-                    f"Pool '{name}' not found", resource_type="pool"
-                ) from e
-            if e.response.status_code == 409:
-                data = parse_error_response(e)
-                raise ResourceNameConflictError(
-                    data["message"], resource_type="pool"
-                ) from e
-            handle_pool_error(e)
-            raise  # pragma: no cover
-
-    async def delete_pool(self, name: str, *, headers: RequestHeaders = None) -> None:
-        """Delete a Pool.
-
-        This will terminate all sandboxes in the pool.
-
-        Args:
-            name: Pool name.
-
-        Raises:
-            ResourceNotFoundError: If pool not found.
-            SandboxClientError: For other errors.
-        """
-        url = f"{self._base_url}/pools/{name}"
-
-        try:
-            response = await self._http.delete(
-                url, headers=self._request_headers(headers)
-            )
-            response.raise_for_status()
-        except httpx.HTTPStatusError as e:
-            if e.response.status_code == 404:
-                raise ResourceNotFoundError(
-                    f"Pool '{name}' not found", resource_type="pool"
-                ) from e
-            handle_client_http_error(e)
-
-    # ========================================================================
     # Sandbox Operations
     # ========================================================================
 
     async def sandbox(
         self,
-        template_name: Optional[str] = None,
+        snapshot_id: str,
         *,
-        snapshot_id: Optional[str] = None,
         name: Optional[str] = None,
         timeout: int = 30,
         ttl_seconds: Optional[int] = None,
@@ -735,9 +160,6 @@ class AsyncSandboxClient:
         This is the primary method for creating sandboxes. Use it as an
         async context manager for automatic cleanup:
 
-            async with await client.sandbox(template_name="my-template") as sandbox:
-                result = await sandbox.run("echo hello")
-
             async with await client.sandbox(snapshot_id="<uuid>") as sandbox:
                 result = await sandbox.run("echo hello")
 
@@ -745,10 +167,7 @@ class AsyncSandboxClient:
         For sandboxes with manual lifecycle management, use create_sandbox().
 
         Args:
-            template_name: Name of the SandboxTemplate to use.
-                Mutually exclusive with snapshot_id.
             snapshot_id: Snapshot ID to boot from.
-                Mutually exclusive with template_name.
             name: Optional sandbox name (auto-generated if not provided).
             timeout: Timeout in seconds when waiting for ready.
             ttl_seconds: Maximum lifetime in seconds from creation. The sandbox
@@ -776,12 +195,10 @@ class AsyncSandboxClient:
             ResourceTimeoutError: If timeout waiting for sandbox to be ready.
             ResourceCreationError: If sandbox creation fails.
             SandboxClientError: For other errors.
-            ValueError: If TTL values are invalid or neither template_name
-                nor snapshot_id is provided.
+            ValueError: If TTL values are invalid.
         """
         sb = await self.create_sandbox(
-            template_name=template_name,
-            snapshot_id=snapshot_id,
+            snapshot_id,
             name=name,
             timeout=timeout,
             ttl_seconds=ttl_seconds,
@@ -797,9 +214,8 @@ class AsyncSandboxClient:
 
     async def create_sandbox(
         self,
-        template_name: Optional[str] = None,
+        snapshot_id: str,
         *,
-        snapshot_id: Optional[str] = None,
         name: Optional[str] = None,
         timeout: int = 30,
         wait_for_ready: bool = True,
@@ -817,10 +233,7 @@ class AsyncSandboxClient:
         or use sandbox() for automatic cleanup with a context manager.
 
         Args:
-            template_name: Name of the SandboxTemplate to use.
-                Mutually exclusive with snapshot_id.
             snapshot_id: Snapshot ID to boot from.
-                Mutually exclusive with template_name.
             name: Optional sandbox name (auto-generated if not provided).
             timeout: Timeout in seconds when waiting for ready (only used when
                 wait_for_ready=True).
@@ -853,13 +266,10 @@ class AsyncSandboxClient:
             ResourceTimeoutError: If timeout waiting for sandbox to be ready.
             ResourceCreationError: If sandbox creation fails.
             SandboxClientError: For other errors.
-            ValueError: If TTL values are invalid or neither template_name
-                nor snapshot_id is provided.
+            ValueError: If TTL values are invalid.
         """
-        if not template_name and not snapshot_id:
-            raise ValueError("Either template_name or snapshot_id is required")
-        if template_name and snapshot_id:
-            raise ValueError("Cannot specify both template_name and snapshot_id")
+        if not snapshot_id:
+            raise ValueError("snapshot_id is required")
 
         validate_ttl(ttl_seconds, "ttl_seconds")
         validate_ttl(idle_ttl_seconds, "idle_ttl_seconds")
@@ -868,11 +278,8 @@ class AsyncSandboxClient:
 
         payload: dict[str, Any] = {
             "wait_for_ready": wait_for_ready,
+            "snapshot_id": snapshot_id,
         }
-        if template_name:
-            payload["template_name"] = template_name
-        if snapshot_id:
-            payload["snapshot_id"] = snapshot_id
         if wait_for_ready:
             payload["timeout"] = timeout
         if name:

--- a/python/langsmith/sandbox/_async_client.py
+++ b/python/langsmith/sandbox/_async_client.py
@@ -734,7 +734,6 @@ class AsyncSandboxClient:
         sandbox_name: str,
         name: str,
         *,
-        checkpoint: Optional[str] = None,
         timeout: int = 60,
         headers: RequestHeaders = None,
     ) -> Snapshot:
@@ -745,8 +744,6 @@ class AsyncSandboxClient:
         Args:
             sandbox_name: Name of the sandbox to capture from.
             name: Snapshot name.
-            checkpoint: Checkpoint timestamp to use. If omitted, creates a
-                fresh checkpoint from the running VM's current state.
             timeout: Timeout in seconds when waiting for ready.
 
         Returns:
@@ -761,8 +758,6 @@ class AsyncSandboxClient:
         url = f"{self._base_url}/boxes/{sandbox_name}/snapshot"
 
         payload: dict[str, Any] = {"name": name}
-        if checkpoint is not None:
-            payload["checkpoint"] = checkpoint
 
         try:
             response = await self._http.post(

--- a/python/langsmith/sandbox/_async_sandbox.py
+++ b/python/langsmith/sandbox/_async_sandbox.py
@@ -695,7 +695,6 @@ class AsyncSandbox:
         self,
         name: str,
         *,
-        checkpoint: Optional[str] = None,
         timeout: int = 60,
         headers: RequestHeaders = None,
     ) -> Snapshot:
@@ -703,8 +702,6 @@ class AsyncSandbox:
 
         Args:
             name: Snapshot name.
-            checkpoint: Checkpoint timestamp to use. If omitted, creates a
-                fresh checkpoint from the current state.
             timeout: Timeout in seconds when waiting for ready.
             headers: Optional per-request header overrides.
 
@@ -720,7 +717,6 @@ class AsyncSandbox:
         return await self._client.capture_snapshot(
             self.name,
             name,
-            checkpoint=checkpoint,
             timeout=timeout,
             headers=headers,
         )

--- a/python/langsmith/sandbox/_async_sandbox.py
+++ b/python/langsmith/sandbox/_async_sandbox.py
@@ -40,7 +40,6 @@ class AsyncSandbox:
 
     Attributes:
         name: Display name (can be updated).
-        template_name: Name of the template used to create this sandbox.
         dataplane_url: URL for data plane operations (file I/O, command execution).
             Only functional when status is "ready".
         id: Unique identifier (UUID). Remains constant even if name changes.
@@ -59,14 +58,15 @@ class AsyncSandbox:
         fs_capacity_bytes: Root filesystem capacity in bytes.
 
     Example:
-        async with await client.sandbox(template_name="python-sandbox") as sandbox:
+        async with await client.sandbox(
+            snapshot_id="<snapshot-uuid>"
+        ) as sandbox:
             result = await sandbox.run("python --version")
             print(result.stdout)
     """
 
     # Data fields (from API response)
     name: str
-    template_name: Optional[str] = None
     dataplane_url: Optional[str] = None
     id: Optional[str] = None
     status: str = "ready"
@@ -104,7 +104,6 @@ class AsyncSandbox:
         """
         return cls(
             name=data.get("name", ""),
-            template_name=data.get("template_name"),
             dataplane_url=data.get("dataplane_url"),
             id=data.get("id"),
             status=data.get("status", "ready"),

--- a/python/langsmith/sandbox/_client.py
+++ b/python/langsmith/sandbox/_client.py
@@ -10,31 +10,22 @@ import httpx
 from langsmith import utils as ls_utils
 from langsmith.sandbox._exceptions import (
     ResourceCreationError,
-    ResourceInUseError,
     ResourceNameConflictError,
     ResourceNotFoundError,
     ResourceTimeoutError,
     SandboxAPIError,
-    ValidationError,
 )
 from langsmith.sandbox._helpers import (
     handle_client_http_error,
-    handle_pool_error,
     handle_sandbox_creation_error,
-    handle_volume_creation_error,
     merge_headers,
-    parse_error_response,
     validate_service_params,
     validate_ttl,
 )
 from langsmith.sandbox._models import (
-    Pool,
     ResourceStatus,
-    SandboxTemplate,
     ServiceURL,
     Snapshot,
-    Volume,
-    VolumeMountSpec,
 )
 from langsmith.sandbox._sandbox import Sandbox
 from langsmith.sandbox._transport import RetryTransport
@@ -60,7 +51,7 @@ RequestHeaders = Optional[Mapping[str, str]]
 class SandboxClient:
     """Client for interacting with the Sandbox Server API.
 
-    This client provides a simple interface for managing sandboxes and templates.
+    This client provides a simple interface for managing sandboxes and snapshots.
 
     Example:
         # Uses LANGSMITH_ENDPOINT and LANGSMITH_API_KEY from environment
@@ -72,8 +63,8 @@ class SandboxClient:
             api_key="your-api-key",
         )
 
-        # Create a sandbox and run commands
-        with client.sandbox(template_name="python-sandbox") as sandbox:
+        # Create a sandbox from a snapshot and run commands
+        with client.sandbox(snapshot_id="<snapshot-uuid>") as sandbox:
             result = sandbox.run("python --version")
             print(result.stdout)
     """
@@ -144,573 +135,13 @@ class SandboxClient:
         self.close()
 
     # ========================================================================
-    # Volume Operations
-    # ========================================================================
-
-    def create_volume(
-        self,
-        name: str,
-        size: str,
-        *,
-        timeout: int = 60,
-        headers: RequestHeaders = None,
-    ) -> Volume:
-        """Create a new persistent volume.
-
-        Creates a persistent storage volume that can be referenced in templates.
-
-        Args:
-            name: Volume name.
-            size: Storage size (e.g., "1Gi", "10Gi").
-            timeout: Timeout in seconds when waiting for ready (min: 5, max: 300).
-
-        Returns:
-            Created Volume.
-
-        Raises:
-            VolumeProvisioningError: If volume provisioning fails.
-            ResourceTimeoutError: If volume doesn't become ready within timeout.
-            SandboxClientError: For other errors.
-        """
-        url = f"{self._base_url}/volumes"
-
-        payload = {
-            "name": name,
-            "size": size,
-            "wait_for_ready": True,
-            "timeout": timeout,
-        }
-
-        try:
-            response = self._http.post(
-                url,
-                json=payload,
-                timeout=timeout + 30,
-                headers=self._request_headers(headers),
-            )
-            response.raise_for_status()
-            return Volume.from_dict(response.json())
-        except httpx.HTTPStatusError as e:
-            handle_volume_creation_error(e)
-            raise  # pragma: no cover
-
-    def get_volume(self, name: str, *, headers: RequestHeaders = None) -> Volume:
-        """Get a volume by name.
-
-        Args:
-            name: Volume name.
-
-        Returns:
-            Volume.
-
-        Raises:
-            ResourceNotFoundError: If volume not found.
-            SandboxClientError: For other errors.
-        """
-        url = f"{self._base_url}/volumes/{name}"
-
-        try:
-            response = self._http.get(url, headers=self._request_headers(headers))
-            response.raise_for_status()
-            return Volume.from_dict(response.json())
-        except httpx.HTTPStatusError as e:
-            if e.response.status_code == 404:
-                raise ResourceNotFoundError(
-                    f"Volume '{name}' not found", resource_type="volume"
-                ) from e
-            handle_client_http_error(e)
-            raise  # pragma: no cover
-
-    def list_volumes(self, *, headers: RequestHeaders = None) -> list[Volume]:
-        """List all volumes.
-
-        Returns:
-            List of Volumes.
-        """
-        url = f"{self._base_url}/volumes"
-
-        try:
-            response = self._http.get(url, headers=self._request_headers(headers))
-            response.raise_for_status()
-            data = response.json()
-            return [Volume.from_dict(v) for v in data.get("volumes", [])]
-        except httpx.HTTPStatusError as e:
-            if e.response.status_code == 404:
-                raise SandboxAPIError(
-                    f"API endpoint not found: {url}. "
-                    f"Check that api_endpoint is correct."
-                ) from e
-            handle_client_http_error(e)
-            raise  # pragma: no cover
-
-    def delete_volume(self, name: str, *, headers: RequestHeaders = None) -> None:
-        """Delete a volume.
-
-        Args:
-            name: Volume name.
-
-        Raises:
-            ResourceNotFoundError: If volume not found.
-            ResourceInUseError: If volume is referenced by templates.
-            SandboxClientError: For other errors.
-        """
-        url = f"{self._base_url}/volumes/{name}"
-
-        try:
-            response = self._http.delete(url, headers=self._request_headers(headers))
-            response.raise_for_status()
-        except httpx.HTTPStatusError as e:
-            if e.response.status_code == 404:
-                raise ResourceNotFoundError(
-                    f"Volume '{name}' not found", resource_type="volume"
-                ) from e
-            if e.response.status_code == 409:
-                data = parse_error_response(e)
-                raise ResourceInUseError(data["message"], resource_type="volume") from e
-            handle_client_http_error(e)
-
-    def update_volume(
-        self,
-        name: str,
-        *,
-        new_name: Optional[str] = None,
-        size: Optional[str] = None,
-        headers: RequestHeaders = None,
-    ) -> Volume:
-        """Update a volume's name and/or size.
-
-        You can update the display name, size, or both in a single request.
-        Only storage size increases are allowed (storage backend limitation).
-
-        Args:
-            name: Current volume name.
-            new_name: New display name (optional).
-            size: New storage size (must be >= current size). Optional.
-
-        Returns:
-            Updated Volume.
-
-        Raises:
-            ResourceNotFoundError: If volume not found.
-            VolumeResizeError: If storage decrease attempted.
-            ResourceNameConflictError: If new_name is already in use.
-            SandboxQuotaExceededError: If storage quota would be exceeded.
-            SandboxClientError: For other errors.
-        """
-        url = f"{self._base_url}/volumes/{name}"
-        payload: dict[str, Any] = {}
-        if new_name is not None:
-            payload["name"] = new_name
-        if size is not None:
-            payload["size"] = size
-
-        if not payload:
-            # Nothing to update, just return the current volume
-            return self.get_volume(name, headers=headers)
-
-        try:
-            response = self._http.patch(
-                url, json=payload, headers=self._request_headers(headers)
-            )
-            response.raise_for_status()
-            return Volume.from_dict(response.json())
-        except httpx.HTTPStatusError as e:
-            if e.response.status_code == 404:
-                raise ResourceNotFoundError(
-                    f"Volume '{name}' not found", resource_type="volume"
-                ) from e
-            if e.response.status_code == 400:
-                data = parse_error_response(e)
-                raise ValidationError(data["message"], error_type="VolumeResize") from e
-            if e.response.status_code == 409:
-                data = parse_error_response(e)
-                raise ResourceNameConflictError(
-                    data["message"], resource_type="volume"
-                ) from e
-            handle_client_http_error(e)
-            raise  # pragma: no cover
-
-    # ========================================================================
-    # Template Operations
-    # ========================================================================
-
-    def create_template(
-        self,
-        name: str,
-        image: str,
-        *,
-        cpu: str = "500m",
-        memory: str = "512Mi",
-        storage: Optional[str] = None,
-        volume_mounts: Optional[list[VolumeMountSpec]] = None,
-        headers: RequestHeaders = None,
-    ) -> SandboxTemplate:
-        """Create a new SandboxTemplate.
-
-        Only the container image, resource limits, and volume mounts can be
-        configured. All other container details are handled by the server.
-
-        Args:
-            name: Template name.
-            image: Container image (e.g., "python:3.12-slim").
-            cpu: CPU limit (e.g., "500m", "1", "2"). Default: "500m".
-            memory: Memory limit (e.g., "256Mi", "1Gi"). Default: "512Mi".
-            storage: Ephemeral storage limit (e.g., "1Gi"). Optional.
-            volume_mounts: List of volumes to mount in the sandbox. Optional.
-
-        Returns:
-            Created SandboxTemplate.
-
-        Raises:
-            SandboxClientError: If creation fails.
-        """
-        url = f"{self._base_url}/templates"
-
-        payload: dict[str, Any] = {
-            "name": name,
-            "image": image,
-            "resources": {
-                "cpu": cpu,
-                "memory": memory,
-            },
-        }
-        if storage:
-            payload["resources"]["storage"] = storage
-        if volume_mounts:
-            payload["volume_mounts"] = [
-                {"volume_name": vm.volume_name, "mount_path": vm.mount_path}
-                for vm in volume_mounts
-            ]
-
-        try:
-            response = self._http.post(
-                url, json=payload, headers=self._request_headers(headers)
-            )
-            response.raise_for_status()
-            return SandboxTemplate.from_dict(response.json())
-        except httpx.HTTPStatusError as e:
-            handle_client_http_error(e)
-            raise  # pragma: no cover
-
-    def get_template(
-        self, name: str, *, headers: RequestHeaders = None
-    ) -> SandboxTemplate:
-        """Get a SandboxTemplate by name.
-
-        Args:
-            name: Template name.
-
-        Returns:
-            SandboxTemplate.
-
-        Raises:
-            ResourceNotFoundError: If template not found.
-            SandboxClientError: For other errors.
-        """
-        url = f"{self._base_url}/templates/{name}"
-
-        try:
-            response = self._http.get(url, headers=self._request_headers(headers))
-            response.raise_for_status()
-            return SandboxTemplate.from_dict(response.json())
-        except httpx.HTTPStatusError as e:
-            if e.response.status_code == 404:
-                raise ResourceNotFoundError(
-                    f"Template '{name}' not found", resource_type="template"
-                ) from e
-            handle_client_http_error(e)
-            raise  # pragma: no cover
-
-    def list_templates(
-        self, *, headers: RequestHeaders = None
-    ) -> list[SandboxTemplate]:
-        """List all SandboxTemplates.
-
-        Returns:
-            List of SandboxTemplates.
-        """
-        url = f"{self._base_url}/templates"
-
-        try:
-            response = self._http.get(url, headers=self._request_headers(headers))
-            response.raise_for_status()
-            data = response.json()
-            return [SandboxTemplate.from_dict(t) for t in data.get("templates", [])]
-        except httpx.HTTPStatusError as e:
-            if e.response.status_code == 404:
-                raise SandboxAPIError(
-                    f"API endpoint not found: {url}. "
-                    f"Check that api_endpoint is correct."
-                ) from e
-            handle_client_http_error(e)
-            raise  # pragma: no cover
-
-    def update_template(
-        self, name: str, *, new_name: str, headers: RequestHeaders = None
-    ) -> SandboxTemplate:
-        """Update a template's display name.
-
-        Args:
-            name: Current template name.
-            new_name: New display name.
-
-        Returns:
-            Updated SandboxTemplate.
-
-        Raises:
-            ResourceNotFoundError: If template not found.
-            ResourceNameConflictError: If new_name is already in use.
-            SandboxClientError: For other errors.
-        """
-        url = f"{self._base_url}/templates/{name}"
-        payload = {"name": new_name}
-
-        try:
-            response = self._http.patch(
-                url, json=payload, headers=self._request_headers(headers)
-            )
-            response.raise_for_status()
-            return SandboxTemplate.from_dict(response.json())
-        except httpx.HTTPStatusError as e:
-            if e.response.status_code == 404:
-                raise ResourceNotFoundError(
-                    f"Template '{name}' not found", resource_type="template"
-                ) from e
-            if e.response.status_code == 409:
-                data = parse_error_response(e)
-                raise ResourceNameConflictError(
-                    data["message"], resource_type="template"
-                ) from e
-            handle_client_http_error(e)
-            raise  # pragma: no cover
-
-    def delete_template(self, name: str, *, headers: RequestHeaders = None) -> None:
-        """Delete a SandboxTemplate.
-
-        Args:
-            name: Template name.
-
-        Raises:
-            ResourceNotFoundError: If template not found.
-            ResourceInUseError: If template is referenced by sandboxes or pools.
-            SandboxClientError: For other errors.
-        """
-        url = f"{self._base_url}/templates/{name}"
-
-        try:
-            response = self._http.delete(url, headers=self._request_headers(headers))
-            response.raise_for_status()
-        except httpx.HTTPStatusError as e:
-            if e.response.status_code == 404:
-                raise ResourceNotFoundError(
-                    f"Template '{name}' not found", resource_type="template"
-                ) from e
-            if e.response.status_code == 409:
-                data = parse_error_response(e)
-                raise ResourceInUseError(
-                    data["message"], resource_type="template"
-                ) from e
-            handle_client_http_error(e)
-
-    # ========================================================================
-    # Pool Operations
-    # ========================================================================
-
-    def create_pool(
-        self,
-        name: str,
-        template_name: str,
-        replicas: int,
-        *,
-        timeout: int = 30,
-        headers: RequestHeaders = None,
-    ) -> Pool:
-        """Create a new Sandbox Pool.
-
-        Pools pre-provision sandboxes from a template for faster startup.
-
-        Args:
-            name: Pool name (lowercase letters, numbers, hyphens; max 63 chars).
-            template_name: Name of the SandboxTemplate to use (no volume mounts).
-            replicas: Number of sandboxes to pre-provision (1-100).
-            timeout: Timeout in seconds when waiting for ready (10-600).
-
-        Returns:
-            Created Pool.
-
-        Raises:
-            ResourceNotFoundError: If template not found.
-            ValidationError: If template has volumes attached.
-            ResourceAlreadyExistsError: If pool with this name already exists.
-            ResourceTimeoutError: If pool doesn't reach ready state within timeout.
-            SandboxQuotaExceededError: If organization quota is exceeded.
-            SandboxClientError: For other errors.
-        """
-        url = f"{self._base_url}/pools"
-
-        payload: dict[str, Any] = {
-            "name": name,
-            "template_name": template_name,
-            "replicas": replicas,
-            "wait_for_ready": True,
-            "timeout": timeout,
-        }
-
-        try:
-            http_timeout = timeout + 30
-            response = self._http.post(
-                url,
-                json=payload,
-                timeout=http_timeout,
-                headers=self._request_headers(headers),
-            )
-            response.raise_for_status()
-            return Pool.from_dict(response.json())
-        except httpx.HTTPStatusError as e:
-            handle_pool_error(e)
-            raise  # pragma: no cover
-
-    def get_pool(self, name: str, *, headers: RequestHeaders = None) -> Pool:
-        """Get a Pool by name.
-
-        Args:
-            name: Pool name.
-
-        Returns:
-            Pool.
-
-        Raises:
-            ResourceNotFoundError: If pool not found.
-            SandboxClientError: For other errors.
-        """
-        url = f"{self._base_url}/pools/{name}"
-
-        try:
-            response = self._http.get(url, headers=self._request_headers(headers))
-            response.raise_for_status()
-            return Pool.from_dict(response.json())
-        except httpx.HTTPStatusError as e:
-            if e.response.status_code == 404:
-                raise ResourceNotFoundError(
-                    f"Pool '{name}' not found", resource_type="pool"
-                ) from e
-            handle_client_http_error(e)
-            raise  # pragma: no cover
-
-    def list_pools(self, *, headers: RequestHeaders = None) -> list[Pool]:
-        """List all Pools.
-
-        Returns:
-            List of Pools.
-        """
-        url = f"{self._base_url}/pools"
-
-        try:
-            response = self._http.get(url, headers=self._request_headers(headers))
-            response.raise_for_status()
-            data = response.json()
-            return [Pool.from_dict(p) for p in data.get("pools", [])]
-        except httpx.HTTPStatusError as e:
-            if e.response.status_code == 404:
-                raise SandboxAPIError(
-                    f"API endpoint not found: {url}. "
-                    f"Check that api_endpoint is correct."
-                ) from e
-            handle_client_http_error(e)
-            raise  # pragma: no cover
-
-    def update_pool(
-        self,
-        name: str,
-        *,
-        new_name: Optional[str] = None,
-        replicas: Optional[int] = None,
-        headers: RequestHeaders = None,
-    ) -> Pool:
-        """Update a Pool's name and/or replica count.
-
-        You can update the display name, replica count, or both.
-        The template reference cannot be changed after creation.
-
-        Args:
-            name: Current pool name.
-            new_name: New display name (optional).
-            replicas: New number of replicas (0-100). Set to 0 to pause.
-
-        Returns:
-            Updated Pool.
-
-        Raises:
-            ResourceNotFoundError: If pool not found.
-            ValidationError: If template was deleted.
-            ResourceNameConflictError: If new_name is already in use.
-            SandboxQuotaExceededError: If quota exceeded when scaling up.
-            SandboxClientError: For other errors.
-        """
-        url = f"{self._base_url}/pools/{name}"
-
-        payload: dict[str, Any] = {}
-        if new_name is not None:
-            payload["name"] = new_name
-        if replicas is not None:
-            payload["replicas"] = replicas
-
-        if not payload:
-            # Nothing to update, just return the current pool
-            return self.get_pool(name, headers=headers)
-
-        try:
-            response = self._http.patch(
-                url, json=payload, headers=self._request_headers(headers)
-            )
-            response.raise_for_status()
-            return Pool.from_dict(response.json())
-        except httpx.HTTPStatusError as e:
-            if e.response.status_code == 404:
-                raise ResourceNotFoundError(
-                    f"Pool '{name}' not found", resource_type="pool"
-                ) from e
-            if e.response.status_code == 409:
-                data = parse_error_response(e)
-                raise ResourceNameConflictError(
-                    data["message"], resource_type="pool"
-                ) from e
-            handle_pool_error(e)
-            raise  # pragma: no cover
-
-    def delete_pool(self, name: str, *, headers: RequestHeaders = None) -> None:
-        """Delete a Pool.
-
-        This will terminate all sandboxes in the pool.
-
-        Args:
-            name: Pool name.
-
-        Raises:
-            ResourceNotFoundError: If pool not found.
-            SandboxClientError: For other errors.
-        """
-        url = f"{self._base_url}/pools/{name}"
-
-        try:
-            response = self._http.delete(url, headers=self._request_headers(headers))
-            response.raise_for_status()
-        except httpx.HTTPStatusError as e:
-            if e.response.status_code == 404:
-                raise ResourceNotFoundError(
-                    f"Pool '{name}' not found", resource_type="pool"
-                ) from e
-            handle_client_http_error(e)
-
-    # ========================================================================
     # Sandbox Operations
     # ========================================================================
 
     def sandbox(
         self,
-        template_name: Optional[str] = None,
+        snapshot_id: str,
         *,
-        snapshot_id: Optional[str] = None,
         name: Optional[str] = None,
         timeout: int = 30,
         ttl_seconds: Optional[int] = None,
@@ -726,9 +157,6 @@ class SandboxClient:
         This is the primary method for creating sandboxes. Use it as a
         context manager for automatic cleanup:
 
-            with client.sandbox(template_name="my-template") as sandbox:
-                result = sandbox.run("echo hello")
-
             with client.sandbox(snapshot_id="<uuid>") as sandbox:
                 result = sandbox.run("echo hello")
 
@@ -736,10 +164,7 @@ class SandboxClient:
         For sandboxes with manual lifecycle management, use create_sandbox().
 
         Args:
-            template_name: Name of the SandboxTemplate to use.
-                Mutually exclusive with snapshot_id.
             snapshot_id: Snapshot ID to boot from.
-                Mutually exclusive with template_name.
             name: Optional sandbox name (auto-generated if not provided).
             timeout: Timeout in seconds when waiting for ready.
             ttl_seconds: Maximum lifetime in seconds from creation. The sandbox
@@ -767,12 +192,10 @@ class SandboxClient:
             ResourceTimeoutError: If timeout waiting for sandbox to be ready.
             ResourceCreationError: If sandbox creation fails.
             SandboxClientError: For other errors.
-            ValueError: If TTL values are invalid or neither template_name
-                nor snapshot_id is provided.
+            ValueError: If TTL values are invalid.
         """
         sb = self.create_sandbox(
-            template_name=template_name,
-            snapshot_id=snapshot_id,
+            snapshot_id,
             name=name,
             timeout=timeout,
             ttl_seconds=ttl_seconds,
@@ -788,9 +211,8 @@ class SandboxClient:
 
     def create_sandbox(
         self,
-        template_name: Optional[str] = None,
+        snapshot_id: str,
         *,
-        snapshot_id: Optional[str] = None,
         name: Optional[str] = None,
         timeout: int = 30,
         wait_for_ready: bool = True,
@@ -808,10 +230,7 @@ class SandboxClient:
         or use sandbox() for automatic cleanup with a context manager.
 
         Args:
-            template_name: Name of the SandboxTemplate to use.
-                Mutually exclusive with snapshot_id.
             snapshot_id: Snapshot ID to boot from.
-                Mutually exclusive with template_name.
             name: Optional sandbox name (auto-generated if not provided).
             timeout: Timeout in seconds when waiting for ready (only used when
                 wait_for_ready=True).
@@ -844,13 +263,10 @@ class SandboxClient:
             ResourceTimeoutError: If timeout waiting for sandbox to be ready.
             ResourceCreationError: If sandbox creation fails.
             SandboxClientError: For other errors.
-            ValueError: If TTL values are invalid or neither template_name
-                nor snapshot_id is provided.
+            ValueError: If TTL values are invalid.
         """
-        if not template_name and not snapshot_id:
-            raise ValueError("Either template_name or snapshot_id is required")
-        if template_name and snapshot_id:
-            raise ValueError("Cannot specify both template_name and snapshot_id")
+        if not snapshot_id:
+            raise ValueError("snapshot_id is required")
 
         validate_ttl(ttl_seconds, "ttl_seconds")
         validate_ttl(idle_ttl_seconds, "idle_ttl_seconds")
@@ -859,11 +275,8 @@ class SandboxClient:
 
         payload: dict[str, Any] = {
             "wait_for_ready": wait_for_ready,
+            "snapshot_id": snapshot_id,
         }
-        if template_name:
-            payload["template_name"] = template_name
-        if snapshot_id:
-            payload["snapshot_id"] = snapshot_id
         if wait_for_ready:
             payload["timeout"] = timeout
         if name:

--- a/python/langsmith/sandbox/_client.py
+++ b/python/langsmith/sandbox/_client.py
@@ -714,7 +714,6 @@ class SandboxClient:
         sandbox_name: str,
         name: str,
         *,
-        checkpoint: Optional[str] = None,
         timeout: int = 60,
         headers: RequestHeaders = None,
     ) -> Snapshot:
@@ -725,8 +724,6 @@ class SandboxClient:
         Args:
             sandbox_name: Name of the sandbox to capture from.
             name: Snapshot name.
-            checkpoint: Checkpoint timestamp to use. If omitted, creates a
-                fresh checkpoint from the running VM's current state.
             timeout: Timeout in seconds when waiting for ready.
 
         Returns:
@@ -741,8 +738,6 @@ class SandboxClient:
         url = f"{self._base_url}/boxes/{sandbox_name}/snapshot"
 
         payload: dict[str, Any] = {"name": name}
-        if checkpoint is not None:
-            payload["checkpoint"] = checkpoint
 
         try:
             response = self._http.post(

--- a/python/langsmith/sandbox/_exceptions.py
+++ b/python/langsmith/sandbox/_exceptions.py
@@ -71,7 +71,7 @@ class ResourceNotFoundError(SandboxClientError):
     """Raised when a resource is not found.
 
     Attributes:
-        resource_type: Type of resource (sandbox, template, volume, pool, file).
+        resource_type: Type of resource (sandbox, snapshot, file).
     """
 
     def __init__(self, message: str, resource_type: Optional[str] = None):
@@ -84,7 +84,7 @@ class ResourceTimeoutError(SandboxClientError):
     """Raised when an operation times out.
 
     Attributes:
-        resource_type: Type of resource (sandbox, volume, pool).
+        resource_type: Type of resource (sandbox, snapshot).
         last_status: The last known status before timeout (for sandboxes).
     """
 
@@ -111,7 +111,7 @@ class ResourceInUseError(SandboxClientError):
     """Raised when deleting a resource that is still in use.
 
     Attributes:
-        resource_type: Type of resource (template, volume).
+        resource_type: Type of resource (snapshot).
     """
 
     def __init__(self, message: str, resource_type: Optional[str] = None):
@@ -124,7 +124,7 @@ class ResourceAlreadyExistsError(SandboxClientError):
     """Raised when creating a resource that already exists.
 
     Attributes:
-        resource_type: Type of resource (e.g., pool).
+        resource_type: Type of resource (e.g., snapshot).
     """
 
     def __init__(self, message: str, resource_type: Optional[str] = None):
@@ -137,7 +137,7 @@ class ResourceNameConflictError(SandboxClientError):
     """Raised when updating a resource name to one that already exists.
 
     Attributes:
-        resource_type: Type of resource (volume, template, pool, sandbox).
+        resource_type: Type of resource (sandbox, snapshot).
     """
 
     def __init__(self, message: str, resource_type: Optional[str] = None):
@@ -158,7 +158,6 @@ class ValidationError(SandboxClientError):
     - Resource values exceeding server-defined limits (CPU, memory, storage)
     - Invalid resource units
     - Invalid name formats
-    - Pool validation failures (e.g., template has volumes)
 
     Attributes:
         field: The field that failed validation (e.g., "cpu", "memory").
@@ -204,9 +203,9 @@ class ResourceCreationError(SandboxClientError):
     """Raised when resource provisioning fails.
 
     Attributes:
-        resource_type: Type of resource (sandbox, volume, pool).
+        resource_type: Type of resource (sandbox, snapshot).
         error_type: Machine-readable error type (ImagePull, CrashLoop,
-            SandboxConfig, Unschedulable, VolumeProvisioning).
+            SandboxConfig, Unschedulable).
     """
 
     def __init__(

--- a/python/langsmith/sandbox/_helpers.py
+++ b/python/langsmith/sandbox/_helpers.py
@@ -13,7 +13,6 @@ import httpx
 
 from langsmith.sandbox._exceptions import (
     QuotaExceededError,
-    ResourceAlreadyExistsError,
     ResourceCreationError,
     ResourceNotFoundError,
     ResourceTimeoutError,
@@ -168,8 +167,7 @@ def parse_validation_error(error: httpx.HTTPStatusError) -> list[dict]:
 def extract_quota_type(message: str) -> Optional[str]:
     """Extract quota type from error message.
 
-    Returns one of: "sandbox_count", "cpu", "memory", "volume_count",
-    "storage", or None.
+    Returns one of: "sandbox_count", "cpu", "memory", "storage", or None.
     """
     message_lower = message.lower()
     # Check for sandbox count quota
@@ -181,11 +179,6 @@ def extract_quota_type(message: str) -> Optional[str]:
         return "cpu"
     elif "memory" in message_lower:
         return "memory"
-    # Check for volume count quota
-    elif "volume" in message_lower and (
-        "count" in message_lower or "limit" in message_lower
-    ):
-        return "volume_count"
     elif "storage" in message_lower:
         return "storage"
     return None
@@ -260,78 +253,6 @@ def handle_sandbox_creation_error(error: httpx.HTTPStatusError) -> None:
             resource_type="sandbox",
             error_type=data.get("error_type") or "Unschedulable",
         ) from error
-    else:
-        # Fall through to generic handling
-        handle_client_http_error(error)
-
-
-def handle_volume_creation_error(error: httpx.HTTPStatusError) -> None:
-    """Handle HTTP errors specific to volume creation.
-
-    Maps API error responses to specific exception types:
-    - 503: ResourceCreationError (provisioning failed)
-    - 504: ResourceTimeoutError (volume didn't become ready in time)
-    - Other: Falls through to generic error handling
-    """
-    status = error.response.status_code
-    data = parse_error_response(error)
-
-    if status == 503:
-        # Provisioning failed (invalid storage class, quota exceeded)
-        raise ResourceCreationError(
-            data["message"],
-            resource_type="volume",
-            error_type="VolumeProvisioning",
-        ) from error
-    elif status == 504:
-        # Timeout - volume didn't become ready in time
-        raise ResourceTimeoutError(data["message"], resource_type="volume") from error
-    else:
-        # Fall through to generic handling
-        handle_client_http_error(error)
-
-
-def handle_pool_error(error: httpx.HTTPStatusError) -> None:
-    """Handle HTTP errors specific to pool creation/update.
-
-    Maps API error responses to specific exception types:
-    - 400: ResourceNotFoundError or ValidationError (template has volumes)
-    - 409: ResourceAlreadyExistsError
-    - 429: QuotaExceededError (org limits exceeded)
-    - 504: ResourceTimeoutError (timeout waiting for ready replicas)
-    - Other: Falls through to generic error handling
-    """
-    status = error.response.status_code
-    data = parse_error_response(error)
-    error_type = data.get("error_type")
-
-    if status == 400:
-        # Check the error type to determine the specific exception
-        if error_type == "TemplateNotFound":
-            raise ResourceNotFoundError(
-                data["message"], resource_type="template"
-            ) from error
-        elif error_type == "ValidationError":
-            # Template has volumes attached
-            raise ValidationError(data["message"], error_type=error_type) from error
-        else:
-            # Generic bad request
-            handle_client_http_error(error)
-    elif status == 409:
-        # Pool already exists
-        raise ResourceAlreadyExistsError(
-            data["message"], resource_type="pool"
-        ) from error
-    elif status == 429:
-        # Organization quota exceeded
-        quota_type = extract_quota_type(data["message"])
-        raise QuotaExceededError(
-            message=data["message"],
-            quota_type=quota_type,
-        ) from error
-    elif status == 504:
-        # Timeout waiting for pool to be ready
-        raise ResourceTimeoutError(data["message"], resource_type="pool") from error
     else:
         # Fall through to generic handling
         handle_client_http_error(error)

--- a/python/langsmith/sandbox/_models.py
+++ b/python/langsmith/sandbox/_models.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import AsyncIterator, Awaitable, Callable, Iterator
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Optional
 
@@ -39,102 +39,6 @@ class ExecutionResult:
 
 
 @dataclass
-class ResourceSpec:
-    """Resource specification for a sandbox."""
-
-    cpu: str = "500m"
-    memory: str = "512Mi"
-    storage: Optional[str] = None
-
-
-@dataclass
-class Volume:
-    """Represents a persistent volume.
-
-    Volumes are persistent storage that can be mounted in sandboxes.
-
-    Attributes:
-        id: Unique identifier (UUID). Remains constant even if name changes.
-            May be None for resources created before ID support was added.
-        name: Display name (can be updated).
-    """
-
-    name: str
-    size: str
-    storage_class: str
-    id: Optional[str] = None
-    created_at: Optional[str] = None
-    updated_at: Optional[str] = None
-
-    @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> Volume:
-        """Create a Volume from API response dict."""
-        return cls(
-            name=data.get("name", ""),
-            size=data.get("size", "unknown"),
-            storage_class=data.get("storage_class", "default"),
-            id=data.get("id"),
-            created_at=data.get("created_at"),
-            updated_at=data.get("updated_at"),
-        )
-
-
-@dataclass
-class VolumeMountSpec:
-    """Specification for mounting a volume in a sandbox template."""
-
-    volume_name: str
-    mount_path: str
-
-
-@dataclass
-class SandboxTemplate:
-    """Represents a SandboxTemplate.
-
-    Templates define the image, resource limits, and volume mounts for sandboxes.
-    All other container details are handled by the server with secure defaults.
-
-    Attributes:
-        id: Unique identifier (UUID). Remains constant even if name changes.
-            May be None for resources created before ID support was added.
-        name: Display name (can be updated).
-    """
-
-    name: str
-    image: str
-    resources: ResourceSpec
-    volume_mounts: list[VolumeMountSpec] = field(default_factory=list)
-    id: Optional[str] = None
-    created_at: Optional[str] = None
-    updated_at: Optional[str] = None
-
-    @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> SandboxTemplate:
-        """Create a SandboxTemplate from API response dict."""
-        resources_data = data.get("resources", {})
-        volume_mounts_data = data.get("volume_mounts", [])
-        return cls(
-            name=data.get("name", ""),
-            image=data.get("image", "unknown"),
-            resources=ResourceSpec(
-                cpu=resources_data.get("cpu", "500m"),
-                memory=resources_data.get("memory", "512Mi"),
-                storage=resources_data.get("storage"),
-            ),
-            volume_mounts=[
-                VolumeMountSpec(
-                    volume_name=vm.get("volume_name", ""),
-                    mount_path=vm.get("mount_path", ""),
-                )
-                for vm in volume_mounts_data
-            ],
-            id=data.get("id"),
-            created_at=data.get("created_at"),
-            updated_at=data.get("updated_at"),
-        )
-
-
-@dataclass
 class ResourceStatus:
     """Lightweight provisioning status for any async-created resource.
 
@@ -152,42 +56,6 @@ class ResourceStatus:
         return cls(
             status=data.get("status", "provisioning"),
             status_message=data.get("status_message"),
-        )
-
-
-@dataclass
-class Pool:
-    """Represents a Sandbox Pool for pre-provisioned sandboxes.
-
-    Pools pre-provision sandboxes from a template for faster startup.
-    Instead of waiting for a new sandbox to be created, sandboxes can
-    be served from a pre-warmed pool.
-
-    Note: Templates with volume mounts cannot be used in pools.
-
-    Attributes:
-        id: Unique identifier (UUID). Remains constant even if name changes.
-            May be None for resources created before ID support was added.
-        name: Display name (can be updated).
-    """
-
-    name: str
-    template_name: str
-    replicas: int  # Desired replicas
-    id: Optional[str] = None
-    created_at: Optional[str] = None
-    updated_at: Optional[str] = None
-
-    @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> Pool:
-        """Create a Pool from API response dict."""
-        return cls(
-            name=data.get("name", ""),
-            template_name=data.get("template_name", ""),
-            replicas=data.get("replicas", 0),
-            id=data.get("id"),
-            created_at=data.get("created_at"),
-            updated_at=data.get("updated_at"),
         )
 
 

--- a/python/langsmith/sandbox/_sandbox.py
+++ b/python/langsmith/sandbox/_sandbox.py
@@ -39,7 +39,6 @@ class Sandbox:
 
     Attributes:
         name: Display name (can be updated).
-        template_name: Name of the template used to create this sandbox.
         dataplane_url: URL for data plane operations (file I/O, command execution).
             Only functional when status is "ready".
         id: Unique identifier (UUID). Remains constant even if name changes.
@@ -58,14 +57,13 @@ class Sandbox:
         fs_capacity_bytes: Root filesystem capacity in bytes.
 
     Example:
-        with client.sandbox(template_name="python-sandbox") as sandbox:
+        with client.sandbox(snapshot_id="<snapshot-uuid>") as sandbox:
             result = sandbox.run("python --version")
             print(result.stdout)
     """
 
     # Data fields (from API response)
     name: str
-    template_name: Optional[str] = None
     dataplane_url: Optional[str] = None
     id: Optional[str] = None
     status: str = "ready"
@@ -103,7 +101,6 @@ class Sandbox:
         """
         return cls(
             name=data.get("name", ""),
-            template_name=data.get("template_name"),
             dataplane_url=data.get("dataplane_url"),
             id=data.get("id"),
             status=data.get("status", "ready"),

--- a/python/langsmith/sandbox/_sandbox.py
+++ b/python/langsmith/sandbox/_sandbox.py
@@ -698,7 +698,6 @@ class Sandbox:
         self,
         name: str,
         *,
-        checkpoint: Optional[str] = None,
         timeout: int = 60,
         headers: RequestHeaders = None,
     ) -> Snapshot:
@@ -706,8 +705,6 @@ class Sandbox:
 
         Args:
             name: Snapshot name.
-            checkpoint: Checkpoint timestamp to use. If omitted, creates a
-                fresh checkpoint from the current state.
             timeout: Timeout in seconds when waiting for ready.
             headers: Optional per-request header overrides.
 
@@ -723,7 +720,6 @@ class Sandbox:
         return self._client.capture_snapshot(
             self.name,
             name,
-            checkpoint=checkpoint,
             timeout=timeout,
             headers=headers,
         )

--- a/python/tests/unit_tests/sandbox/test_async_client.py
+++ b/python/tests/unit_tests/sandbox/test_async_client.py
@@ -8,16 +8,12 @@ from pytest_httpx import HTTPXMock
 from langsmith.sandbox import (
     AsyncSandboxClient,
     AsyncServiceURL,
-    QuotaExceededError,
-    ResourceAlreadyExistsError,
     ResourceCreationError,
-    ResourceInUseError,
     ResourceNameConflictError,
     ResourceNotFoundError,
     ResourceStatus,
     ResourceTimeoutError,
     SandboxConnectionError,
-    ValidationError,
 )
 
 
@@ -133,214 +129,6 @@ class TestAsyncSandboxClientInit:
         await client.aclose()
 
 
-class TestAsyncTemplateOperations:
-    """Tests for async template operations."""
-
-    async def test_create_template(
-        self, client: AsyncSandboxClient, httpx_mock: HTTPXMock
-    ):
-        """Test creating a template."""
-        httpx_mock.add_response(
-            method="POST",
-            url="http://test-server:8080/templates",
-            json={
-                "name": "python-sandbox",
-                "image": "python:3.12-slim",
-                "resources": {"cpu": "500m", "memory": "512Mi"},
-            },
-            status_code=201,
-        )
-
-        template = await client.create_template(
-            name="python-sandbox",
-            image="python:3.12-slim",
-        )
-
-        assert template.name == "python-sandbox"
-        assert template.image == "python:3.12-slim"
-
-    async def test_create_template_with_resources(
-        self, client: AsyncSandboxClient, httpx_mock: HTTPXMock
-    ):
-        """Test creating a template with custom resources."""
-        httpx_mock.add_response(
-            method="POST",
-            url="http://test-server:8080/templates",
-            json={
-                "name": "python-sandbox",
-                "image": "python:3.12-slim",
-                "resources": {"cpu": "2", "memory": "4Gi", "storage": "10Gi"},
-            },
-            status_code=201,
-        )
-
-        template = await client.create_template(
-            name="python-sandbox",
-            image="python:3.12-slim",
-            cpu="2",
-            memory="4Gi",
-            storage="10Gi",
-        )
-
-        assert template.resources.cpu == "2"
-        assert template.resources.memory == "4Gi"
-        assert template.resources.storage == "10Gi"
-
-    async def test_list_templates(
-        self, client: AsyncSandboxClient, httpx_mock: HTTPXMock
-    ):
-        """Test listing templates."""
-        httpx_mock.add_response(
-            method="GET",
-            url="http://test-server:8080/templates",
-            json={
-                "templates": [
-                    {
-                        "name": "template-1",
-                        "image": "python:3.12",
-                        "resources": {"cpu": "500m", "memory": "512Mi"},
-                    },
-                    {
-                        "name": "template-2",
-                        "image": "node:20",
-                        "resources": {"cpu": "1", "memory": "1Gi"},
-                    },
-                ]
-            },
-        )
-
-        templates = await client.list_templates()
-
-        assert len(templates) == 2
-        assert templates[0].name == "template-1"
-        assert templates[1].name == "template-2"
-
-    async def test_get_template(
-        self, client: AsyncSandboxClient, httpx_mock: HTTPXMock
-    ):
-        """Test getting a template."""
-        httpx_mock.add_response(
-            method="GET",
-            url="http://test-server:8080/templates/python-sandbox",
-            json={
-                "name": "python-sandbox",
-                "image": "python:3.12-slim",
-                "resources": {"cpu": "500m", "memory": "512Mi"},
-            },
-        )
-
-        template = await client.get_template("python-sandbox")
-
-        assert template.name == "python-sandbox"
-
-    async def test_get_template_not_found(
-        self, client: AsyncSandboxClient, httpx_mock: HTTPXMock
-    ):
-        """Test getting non-existent template."""
-        httpx_mock.add_response(
-            method="GET",
-            url="http://test-server:8080/templates/nonexistent",
-            json={"detail": "Template 'nonexistent' not found"},
-            status_code=404,
-        )
-
-        with pytest.raises(ResourceNotFoundError):
-            await client.get_template("nonexistent")
-
-    async def test_update_template(
-        self, client: AsyncSandboxClient, httpx_mock: HTTPXMock
-    ):
-        """Test updating a template's name."""
-        httpx_mock.add_response(
-            method="PATCH",
-            url="http://test-server:8080/templates/python-sandbox",
-            json={
-                "id": "550e8400-e29b-41d4-a716-446655440001",
-                "name": "python-sandbox-renamed",
-                "image": "python:3.12-slim",
-                "resources": {"cpu": "500m", "memory": "512Mi"},
-                "updated_at": "2026-01-19T14:00:00Z",
-            },
-        )
-
-        template = await client.update_template(
-            "python-sandbox", new_name="python-sandbox-renamed"
-        )
-
-        assert template.name == "python-sandbox-renamed"
-        assert template.id == "550e8400-e29b-41d4-a716-446655440001"
-        assert template.updated_at == "2026-01-19T14:00:00Z"
-
-    async def test_update_template_not_found(
-        self, client: AsyncSandboxClient, httpx_mock: HTTPXMock
-    ):
-        """Test updating a non-existent template."""
-        httpx_mock.add_response(
-            method="PATCH",
-            url="http://test-server:8080/templates/nonexistent",
-            json={"detail": "Template 'nonexistent' not found"},
-            status_code=404,
-        )
-
-        with pytest.raises(ResourceNotFoundError):
-            await client.update_template("nonexistent", new_name="new-name")
-
-    async def test_update_template_name_conflict(
-        self, client: AsyncSandboxClient, httpx_mock: HTTPXMock
-    ):
-        """Test updating a template to a name that already exists."""
-        httpx_mock.add_response(
-            method="PATCH",
-            url="http://test-server:8080/templates/python-sandbox",
-            json={
-                "detail": {
-                    "error": "Conflict",
-                    "message": "Template name 'existing-template' is already in use",
-                }
-            },
-            status_code=409,
-        )
-
-        with pytest.raises(ResourceNameConflictError) as exc_info:
-            await client.update_template("python-sandbox", new_name="existing-template")
-        assert exc_info.value.resource_type == "template"
-
-    async def test_delete_template(
-        self, client: AsyncSandboxClient, httpx_mock: HTTPXMock
-    ):
-        """Test deleting a template."""
-        httpx_mock.add_response(
-            method="DELETE",
-            url="http://test-server:8080/templates/python-sandbox",
-            status_code=204,
-        )
-
-        # Should not raise
-        await client.delete_template("python-sandbox")
-
-    async def test_delete_template_in_use(
-        self, client: AsyncSandboxClient, httpx_mock: HTTPXMock
-    ):
-        """Test deleting a template that is in use by sandboxes or pools."""
-        httpx_mock.add_response(
-            method="DELETE",
-            url="http://test-server:8080/templates/python-sandbox",
-            json={
-                "detail": {
-                    "error": "Conflict",
-                    "message": (
-                        "Template 'python-sandbox' is in use by sandboxes: sandbox-1; "
-                        "pools: pool-1. Delete the dependent resources first."
-                    ),
-                }
-            },
-            status_code=409,
-        )
-
-        with pytest.raises(ResourceInUseError):
-            await client.delete_template("python-sandbox")
-
-
 class TestAsyncSandboxOperations:
     """Tests for async sandbox operations."""
 
@@ -354,13 +142,12 @@ class TestAsyncSandboxOperations:
             json={
                 "id": "550e8400-e29b-41d4-a716-446655440003",
                 "name": "test-sandbox",
-                "template_name": "python-sandbox",
                 "dataplane_url": "https://sandbox-router.example.com/tenant/sb-123",
             },
             status_code=201,
         )
 
-        sandbox = await client.create_sandbox(template_name="python-sandbox")
+        sandbox = await client.create_sandbox(snapshot_id="snap-1")
 
         assert sandbox.name == "test-sandbox"
         assert sandbox.id == "550e8400-e29b-41d4-a716-446655440003"
@@ -379,7 +166,6 @@ class TestAsyncSandboxOperations:
             url="http://test-server:8080/boxes",
             json={
                 "name": "test-sandbox",
-                "template_name": "python-sandbox",
             },
             status_code=201,
         )
@@ -388,7 +174,7 @@ class TestAsyncSandboxOperations:
             "access_control": {"allow_list": ["github.com", "*.example.com"]},
         }
         await client.create_sandbox(
-            template_name="python-sandbox",
+            snapshot_id="snap-1",
             proxy_config=proxy_config,
         )
 
@@ -406,12 +192,11 @@ class TestAsyncSandboxOperations:
             url="http://test-server:8080/boxes",
             json={
                 "name": "test-sandbox",
-                "template_name": "python-sandbox",
             },
             status_code=201,
         )
 
-        await client.create_sandbox(template_name="python-sandbox")
+        await client.create_sandbox(snapshot_id="snap-1")
         body = json.loads(httpx_mock.get_request().content)
         assert "proxy_config" not in body
 
@@ -424,14 +209,13 @@ class TestAsyncSandboxOperations:
             url="http://test-server:8080/boxes",
             json={
                 "name": "test-sandbox",
-                "template_name": "python-sandbox",
                 "dataplane_url": "https://sandbox-router.example.com/tenant/sb-123",
             },
             status_code=201,
         )
 
         await client.create_sandbox(
-            template_name="python-sandbox",
+            snapshot_id="snap-1",
             headers={
                 "X-Api-Key": "override-key",
                 "X-Test-Header": "sandbox-client",
@@ -451,7 +235,6 @@ class TestAsyncSandboxOperations:
             url="http://test-server:8080/boxes",
             json={
                 "name": "test-sandbox",
-                "template_name": "python-sandbox",
             },
             status_code=201,
         )
@@ -461,7 +244,7 @@ class TestAsyncSandboxOperations:
             status_code=204,
         )
 
-        async with await client.sandbox(template_name="python-sandbox") as sandbox:
+        async with await client.sandbox(snapshot_id="snap-1") as sandbox:
             assert sandbox.name == "test-sandbox"
 
         # Verify delete was called
@@ -480,7 +263,7 @@ class TestAsyncSandboxOperations:
         )
 
         with pytest.raises(ResourceTimeoutError):
-            await client.create_sandbox(template_name="python-sandbox")
+            await client.create_sandbox(snapshot_id="snap-1")
 
     async def test_list_sandboxes(
         self, client: AsyncSandboxClient, httpx_mock: HTTPXMock
@@ -493,7 +276,6 @@ class TestAsyncSandboxOperations:
                 "sandboxes": [
                     {
                         "name": "sandbox-1",
-                        "template_name": "template-1",
                     },
                 ]
             },
@@ -527,7 +309,6 @@ class TestAsyncSandboxOperations:
             json={
                 "id": "550e8400-e29b-41d4-a716-446655440003",
                 "name": "my-sandbox-renamed",
-                "template_name": "python-sandbox",
                 "dataplane_url": "https://sandbox-router.example.com/tenant/sb-123",
             },
         )
@@ -579,7 +360,6 @@ class TestAsyncSandboxOperations:
             json={
                 "id": "550e8400-e29b-41d4-a716-446655440003",
                 "name": "test-sandbox",
-                "template_name": "python-sandbox",
                 "status": "provisioning",
                 "status_message": None,
                 "dataplane_url": "https://sandbox-router.example.com/tenant/sb-123",
@@ -588,7 +368,7 @@ class TestAsyncSandboxOperations:
         )
 
         sandbox = await client.create_sandbox(
-            template_name="python-sandbox", wait_for_ready=False
+            snapshot_id="snap-1", wait_for_ready=False
         )
 
         assert sandbox.name == "test-sandbox"
@@ -651,7 +431,6 @@ class TestAsyncSandboxOperations:
             url="http://test-server:8080/boxes/my-sandbox",
             json={
                 "name": "my-sandbox",
-                "template_name": "python-sandbox",
                 "status": "ready",
                 "dataplane_url": "https://sandbox-router.example.com/tenant/sb-123",
             },
@@ -706,7 +485,6 @@ class TestAsyncSandboxOperations:
             url="http://test-server:8080/boxes",
             json={
                 "name": "test-sandbox",
-                "template_name": "python-sandbox",
                 "ttl_seconds": 3600,
                 "idle_ttl_seconds": 600,
                 "expires_at": "2026-03-24T12:00:00Z",
@@ -716,7 +494,7 @@ class TestAsyncSandboxOperations:
         )
 
         sandbox = await client.create_sandbox(
-            template_name="python-sandbox",
+            snapshot_id="snap-1",
             ttl_seconds=3600,
             idle_ttl_seconds=600,
         )
@@ -741,13 +519,12 @@ class TestAsyncSandboxOperations:
             url="http://test-server:8080/boxes",
             json={
                 "name": "test-sandbox",
-                "template_name": "python-sandbox",
                 "dataplane_url": "https://sandbox-router.example.com/tenant/sb-123",
             },
             status_code=201,
         )
 
-        await client.create_sandbox(template_name="python-sandbox")
+        await client.create_sandbox(snapshot_id="snap-1")
 
         import json
 
@@ -761,14 +538,14 @@ class TestAsyncSandboxOperations:
     ):
         """Test that negative TTL values raise ValueError."""
         with pytest.raises(ValueError, match="must be >= 0"):
-            await client.create_sandbox(template_name="python-sandbox", ttl_seconds=-1)
+            await client.create_sandbox(snapshot_id="snap-1", ttl_seconds=-1)
 
     async def test_create_sandbox_ttl_validation_not_multiple_of_60(
         self, client: AsyncSandboxClient
     ):
         """Test that non-multiple-of-60 TTL values raise ValueError."""
         with pytest.raises(ValueError, match="must be a multiple of 60"):
-            await client.create_sandbox(template_name="python-sandbox", ttl_seconds=90)
+            await client.create_sandbox(snapshot_id="snap-1", ttl_seconds=90)
 
     async def test_create_sandbox_ttl_zero_allowed(
         self, client: AsyncSandboxClient, httpx_mock: HTTPXMock
@@ -779,7 +556,6 @@ class TestAsyncSandboxOperations:
             url="http://test-server:8080/boxes",
             json={
                 "name": "test-sandbox",
-                "template_name": "python-sandbox",
                 "ttl_seconds": 0,
                 "idle_ttl_seconds": 0,
                 "dataplane_url": "https://sandbox-router.example.com/tenant/sb-123",
@@ -788,7 +564,7 @@ class TestAsyncSandboxOperations:
         )
 
         sandbox = await client.create_sandbox(
-            template_name="python-sandbox",
+            snapshot_id="snap-1",
             ttl_seconds=0,
             idle_ttl_seconds=0,
         )
@@ -805,7 +581,6 @@ class TestAsyncSandboxOperations:
             url="http://test-server:8080/boxes/my-sandbox",
             json={
                 "name": "my-sandbox",
-                "template_name": "python-sandbox",
                 "ttl_seconds": 7200,
                 "idle_ttl_seconds": 1200,
                 "expires_at": "2026-03-24T14:00:00Z",
@@ -845,7 +620,6 @@ class TestAsyncSandboxOperations:
             url="http://test-server:8080/boxes/my-sandbox",
             json={
                 "name": "my-sandbox-renamed",
-                "template_name": "python-sandbox",
                 "ttl_seconds": 3600,
                 "dataplane_url": "https://sandbox-router.example.com/tenant/sb-123",
             },
@@ -878,12 +652,10 @@ class TestAsyncSandboxOperations:
                 "sandboxes": [
                     {
                         "name": "sandbox-ready",
-                        "template_name": "template-1",
                         "status": "ready",
                     },
                     {
                         "name": "sandbox-provisioning",
-                        "template_name": "template-1",
                         "status": "provisioning",
                     },
                 ]
@@ -897,430 +669,8 @@ class TestAsyncSandboxOperations:
         assert sandboxes[1].status == "provisioning"
 
 
-class TestAsyncPoolOperations:
-    """Tests for async pool operations."""
-
-    async def test_create_pool(self, client: AsyncSandboxClient, httpx_mock: HTTPXMock):
-        """Test creating a pool."""
-        httpx_mock.add_response(
-            method="POST",
-            url="http://test-server:8080/pools",
-            json={
-                "name": "python-pool",
-                "template_name": "python-sandbox",
-                "replicas": 5,
-                "created_at": "2026-01-16T12:00:00Z",
-            },
-            status_code=201,
-        )
-
-        pool = await client.create_pool(
-            name="python-pool",
-            template_name="python-sandbox",
-            replicas=5,
-        )
-
-        assert pool.name == "python-pool"
-        assert pool.template_name == "python-sandbox"
-        assert pool.replicas == 5
-
-    async def test_create_pool_template_not_found(
-        self, client: AsyncSandboxClient, httpx_mock: HTTPXMock
-    ):
-        """Test creating pool with non-existent template."""
-        httpx_mock.add_response(
-            method="POST",
-            url="http://test-server:8080/pools",
-            json={
-                "detail": {
-                    "error": "TemplateNotFound",
-                    "message": "Template 'nonexistent' not found.",
-                }
-            },
-            status_code=400,
-        )
-
-        with pytest.raises(ResourceNotFoundError):
-            await client.create_pool(
-                name="python-pool",
-                template_name="nonexistent",
-                replicas=5,
-            )
-
-    async def test_create_pool_template_has_volumes(
-        self, client: AsyncSandboxClient, httpx_mock: HTTPXMock
-    ):
-        """Test creating pool with template that has volumes."""
-        httpx_mock.add_response(
-            method="POST",
-            url="http://test-server:8080/pools",
-            json={
-                "detail": {
-                    "error": "ValidationError",
-                    "message": (
-                        "Template 'stateful-template' has volumes attached. "
-                        "Pools only support stateless templates."
-                    ),
-                }
-            },
-            status_code=400,
-        )
-
-        with pytest.raises(ValidationError) as exc_info:
-            await client.create_pool(
-                name="python-pool",
-                template_name="stateful-template",
-                replicas=5,
-            )
-        assert exc_info.value.error_type == "ValidationError"
-
-    async def test_create_pool_already_exists(
-        self, client: AsyncSandboxClient, httpx_mock: HTTPXMock
-    ):
-        """Test creating pool that already exists."""
-        httpx_mock.add_response(
-            method="POST",
-            url="http://test-server:8080/pools",
-            json={"detail": "Pool 'python-pool' already exists"},
-            status_code=409,
-        )
-
-        with pytest.raises(ResourceAlreadyExistsError):
-            await client.create_pool(
-                name="python-pool",
-                template_name="python-sandbox",
-                replicas=5,
-            )
-
-    async def test_create_pool_quota_exceeded(
-        self, client: AsyncSandboxClient, httpx_mock: HTTPXMock
-    ):
-        """Test creating pool when quota is exceeded."""
-        httpx_mock.add_response(
-            method="POST",
-            url="http://test-server:8080/pools",
-            json={
-                "detail": (
-                    "Limit of 10 sandbox(es) per organization exceeded. "
-                    "Current usage: 8 sandboxes, Requested: 5 additional."
-                )
-            },
-            status_code=429,
-        )
-
-        with pytest.raises(QuotaExceededError) as exc_info:
-            await client.create_pool(
-                name="python-pool",
-                template_name="python-sandbox",
-                replicas=5,
-            )
-        assert exc_info.value.quota_type == "sandbox_count"
-
-    async def test_create_pool_with_timeout(
-        self, client: AsyncSandboxClient, httpx_mock: HTTPXMock
-    ):
-        """Test creating pool sends wait_for_ready and timeout in payload."""
-        httpx_mock.add_response(
-            method="POST",
-            url="http://test-server:8080/pools",
-            json={
-                "name": "python-pool",
-                "template_name": "python-sandbox",
-                "replicas": 5,
-                "created_at": "2026-01-16T12:00:00Z",
-            },
-            status_code=201,
-        )
-
-        pool = await client.create_pool(
-            name="python-pool",
-            template_name="python-sandbox",
-            replicas=5,
-            timeout=60,
-        )
-
-        assert pool.name == "python-pool"
-        assert pool.replicas == 5
-
-        # Verify the request payload includes wait_for_ready (hardcoded) and timeout
-        request = httpx_mock.get_request()
-        import json
-
-        body = json.loads(request.content)
-        assert body["wait_for_ready"] is True
-        assert body["timeout"] == 60
-
-    async def test_create_pool_timeout(
-        self, client: AsyncSandboxClient, httpx_mock: HTTPXMock
-    ):
-        """Test creating pool timeout when waiting for ready."""
-        httpx_mock.add_response(
-            method="POST",
-            url="http://test-server:8080/pools",
-            json={
-                "detail": {
-                    "error": "Timeout",
-                    "message": (
-                        "Pool 'python-pool' did not reach 1 ready replica(s) "
-                        "within 30 seconds"
-                    ),
-                }
-            },
-            status_code=504,
-        )
-
-        with pytest.raises(ResourceTimeoutError):
-            await client.create_pool(
-                name="python-pool",
-                template_name="python-sandbox",
-                replicas=5,
-            )
-
-    async def test_get_pool(self, client: AsyncSandboxClient, httpx_mock: HTTPXMock):
-        """Test getting a pool."""
-        httpx_mock.add_response(
-            method="GET",
-            url="http://test-server:8080/pools/python-pool",
-            json={
-                "name": "python-pool",
-                "template_name": "python-sandbox",
-                "replicas": 5,
-                "created_at": "2026-01-16T12:00:00Z",
-            },
-        )
-
-        pool = await client.get_pool("python-pool")
-
-        assert pool.name == "python-pool"
-        assert pool.replicas == 5
-
-    async def test_get_pool_not_found(
-        self, client: AsyncSandboxClient, httpx_mock: HTTPXMock
-    ):
-        """Test getting non-existent pool."""
-        httpx_mock.add_response(
-            method="GET",
-            url="http://test-server:8080/pools/nonexistent",
-            json={"detail": "Pool 'nonexistent' not found"},
-            status_code=404,
-        )
-
-        with pytest.raises(ResourceNotFoundError):
-            await client.get_pool("nonexistent")
-
-    async def test_list_pools(self, client: AsyncSandboxClient, httpx_mock: HTTPXMock):
-        """Test listing pools."""
-        httpx_mock.add_response(
-            method="GET",
-            url="http://test-server:8080/pools",
-            json={
-                "pools": [
-                    {
-                        "name": "pool-1",
-                        "template_name": "python-sandbox",
-                        "replicas": 5,
-                    },
-                    {
-                        "name": "pool-2",
-                        "template_name": "node-sandbox",
-                        "replicas": 3,
-                    },
-                ]
-            },
-        )
-
-        pools = await client.list_pools()
-
-        assert len(pools) == 2
-        assert pools[0].name == "pool-1"
-        assert pools[1].name == "pool-2"
-
-    async def test_list_pools_empty(
-        self, client: AsyncSandboxClient, httpx_mock: HTTPXMock
-    ):
-        """Test listing pools when none exist."""
-        httpx_mock.add_response(
-            method="GET",
-            url="http://test-server:8080/pools",
-            json={"pools": []},
-        )
-
-        pools = await client.list_pools()
-
-        assert len(pools) == 0
-
-    async def test_update_pool_replicas(
-        self, client: AsyncSandboxClient, httpx_mock: HTTPXMock
-    ):
-        """Test updating pool replicas."""
-        httpx_mock.add_response(
-            method="PATCH",
-            url="http://test-server:8080/pools/python-pool",
-            json={
-                "id": "550e8400-e29b-41d4-a716-446655440002",
-                "name": "python-pool",
-                "template_name": "python-sandbox",
-                "replicas": 10,
-                "created_at": "2026-01-16T12:00:00Z",
-            },
-        )
-
-        pool = await client.update_pool("python-pool", replicas=10)
-
-        assert pool.name == "python-pool"
-        assert pool.replicas == 10
-
-    async def test_update_pool_name(
-        self, client: AsyncSandboxClient, httpx_mock: HTTPXMock
-    ):
-        """Test updating pool name."""
-        httpx_mock.add_response(
-            method="PATCH",
-            url="http://test-server:8080/pools/python-pool",
-            json={
-                "id": "550e8400-e29b-41d4-a716-446655440002",
-                "name": "python-pool-renamed",
-                "template_name": "python-sandbox",
-                "replicas": 5,
-                "created_at": "2026-01-16T12:00:00Z",
-                "updated_at": "2026-01-19T14:00:00Z",
-            },
-        )
-
-        pool = await client.update_pool("python-pool", new_name="python-pool-renamed")
-
-        assert pool.name == "python-pool-renamed"
-        assert pool.id == "550e8400-e29b-41d4-a716-446655440002"
-
-    async def test_update_pool_name_and_replicas(
-        self, client: AsyncSandboxClient, httpx_mock: HTTPXMock
-    ):
-        """Test updating pool name and replicas in a single request."""
-        httpx_mock.add_response(
-            method="PATCH",
-            url="http://test-server:8080/pools/python-pool",
-            json={
-                "id": "550e8400-e29b-41d4-a716-446655440002",
-                "name": "python-pool-renamed",
-                "template_name": "python-sandbox",
-                "replicas": 10,
-                "created_at": "2026-01-16T12:00:00Z",
-                "updated_at": "2026-01-19T14:00:00Z",
-            },
-        )
-
-        pool = await client.update_pool(
-            "python-pool", new_name="python-pool-renamed", replicas=10
-        )
-
-        assert pool.name == "python-pool-renamed"
-        assert pool.replicas == 10
-
-    async def test_update_pool_not_found(
-        self, client: AsyncSandboxClient, httpx_mock: HTTPXMock
-    ):
-        """Test updating non-existent pool."""
-        httpx_mock.add_response(
-            method="PATCH",
-            url="http://test-server:8080/pools/nonexistent",
-            json={"detail": "Pool 'nonexistent' not found"},
-            status_code=404,
-        )
-
-        with pytest.raises(ResourceNotFoundError):
-            await client.update_pool("nonexistent", replicas=10)
-
-    async def test_update_pool_quota_exceeded(
-        self, client: AsyncSandboxClient, httpx_mock: HTTPXMock
-    ):
-        """Test updating pool when scaling up exceeds quota."""
-        httpx_mock.add_response(
-            method="PATCH",
-            url="http://test-server:8080/pools/python-pool",
-            json={"detail": "Limit of 10 sandbox(es) per organization exceeded."},
-            status_code=429,
-        )
-
-        with pytest.raises(QuotaExceededError):
-            await client.update_pool("python-pool", replicas=20)
-
-    async def test_update_pool_pause(
-        self, client: AsyncSandboxClient, httpx_mock: HTTPXMock
-    ):
-        """Test pausing pool by setting replicas to 0."""
-        httpx_mock.add_response(
-            method="PATCH",
-            url="http://test-server:8080/pools/python-pool",
-            json={
-                "name": "python-pool",
-                "template_name": "python-sandbox",
-                "replicas": 0,
-            },
-        )
-
-        pool = await client.update_pool("python-pool", replicas=0)
-
-        assert pool.replicas == 0
-
-    async def test_update_pool_name_conflict(
-        self, client: AsyncSandboxClient, httpx_mock: HTTPXMock
-    ):
-        """Test updating a pool to a name that already exists."""
-        httpx_mock.add_response(
-            method="PATCH",
-            url="http://test-server:8080/pools/python-pool",
-            json={
-                "detail": {
-                    "error": "Conflict",
-                    "message": "Pool name 'existing-pool' is already in use",
-                }
-            },
-            status_code=409,
-        )
-
-        with pytest.raises(ResourceNameConflictError) as exc_info:
-            await client.update_pool("python-pool", new_name="existing-pool")
-        assert exc_info.value.resource_type == "pool"
-
-    async def test_delete_pool(self, client: AsyncSandboxClient, httpx_mock: HTTPXMock):
-        """Test deleting a pool."""
-        httpx_mock.add_response(
-            method="DELETE",
-            url="http://test-server:8080/pools/python-pool",
-            status_code=204,
-        )
-
-        # Should not raise
-        await client.delete_pool("python-pool")
-
-    async def test_delete_pool_not_found(
-        self, client: AsyncSandboxClient, httpx_mock: HTTPXMock
-    ):
-        """Test deleting non-existent pool."""
-        httpx_mock.add_response(
-            method="DELETE",
-            url="http://test-server:8080/pools/nonexistent",
-            json={"detail": "Pool 'nonexistent' not found"},
-            status_code=404,
-        )
-
-        with pytest.raises(ResourceNotFoundError):
-            await client.delete_pool("nonexistent")
-
-
 class TestAsyncConnectionErrors:
     """Tests for async connection error handling."""
-
-    async def test_connection_error_on_template_create(
-        self, client: AsyncSandboxClient, httpx_mock: HTTPXMock
-    ):
-        """Test connection error when creating template."""
-        import httpx
-
-        httpx_mock.add_exception(httpx.ConnectError("Connection refused"))
-
-        with pytest.raises(SandboxConnectionError):
-            await client.create_template(name="test", image="python:3.12")
 
     async def test_connection_error_on_sandbox_create(
         self, client: AsyncSandboxClient, httpx_mock: HTTPXMock
@@ -1331,173 +681,7 @@ class TestAsyncConnectionErrors:
         httpx_mock.add_exception(httpx.ConnectError("Connection refused"))
 
         with pytest.raises(SandboxConnectionError):
-            await client.create_sandbox(template_name="test")
-
-    async def test_connection_error_on_pool_create(
-        self, client: AsyncSandboxClient, httpx_mock: HTTPXMock
-    ):
-        """Test connection error when creating pool."""
-        import httpx
-
-        httpx_mock.add_exception(httpx.ConnectError("Connection refused"))
-
-        with pytest.raises(SandboxConnectionError):
-            await client.create_pool(
-                name="python-pool",
-                template_name="python-sandbox",
-                replicas=5,
-            )
-
-
-class TestAsyncVolumeOperations:
-    """Tests for async volume operations."""
-
-    async def test_update_volume_size(
-        self, client: AsyncSandboxClient, httpx_mock: HTTPXMock
-    ):
-        """Test updating a volume's size."""
-        httpx_mock.add_response(
-            method="PATCH",
-            url="http://test-server:8080/volumes/my-volume",
-            json={
-                "id": "550e8400-e29b-41d4-a716-446655440000",
-                "name": "my-volume",
-                "size": "20Gi",
-                "storage_class": "standard",
-                "created_at": "2026-01-19T12:00:00Z",
-                "updated_at": "2026-01-19T14:00:00Z",
-            },
-        )
-
-        volume = await client.update_volume("my-volume", size="20Gi")
-
-        assert volume.name == "my-volume"
-        assert volume.size == "20Gi"
-        assert volume.updated_at == "2026-01-19T14:00:00Z"
-
-    async def test_update_volume_name(
-        self, client: AsyncSandboxClient, httpx_mock: HTTPXMock
-    ):
-        """Test updating a volume's name."""
-        httpx_mock.add_response(
-            method="PATCH",
-            url="http://test-server:8080/volumes/my-volume",
-            json={
-                "id": "550e8400-e29b-41d4-a716-446655440000",
-                "name": "my-volume-renamed",
-                "size": "10Gi",
-                "storage_class": "standard",
-                "created_at": "2026-01-19T12:00:00Z",
-                "updated_at": "2026-01-19T14:00:00Z",
-            },
-        )
-
-        volume = await client.update_volume("my-volume", new_name="my-volume-renamed")
-
-        assert volume.name == "my-volume-renamed"
-        assert volume.id == "550e8400-e29b-41d4-a716-446655440000"
-
-    async def test_update_volume_name_and_size(
-        self, client: AsyncSandboxClient, httpx_mock: HTTPXMock
-    ):
-        """Test updating both volume name and size in a single request."""
-        httpx_mock.add_response(
-            method="PATCH",
-            url="http://test-server:8080/volumes/my-volume",
-            json={
-                "id": "550e8400-e29b-41d4-a716-446655440000",
-                "name": "my-volume-renamed",
-                "size": "20Gi",
-                "storage_class": "standard",
-                "created_at": "2026-01-19T12:00:00Z",
-                "updated_at": "2026-01-19T14:00:00Z",
-            },
-        )
-
-        volume = await client.update_volume(
-            "my-volume", new_name="my-volume-renamed", size="20Gi"
-        )
-
-        assert volume.name == "my-volume-renamed"
-        assert volume.size == "20Gi"
-
-    async def test_update_volume_not_found(
-        self, client: AsyncSandboxClient, httpx_mock: HTTPXMock
-    ):
-        """Test updating a non-existent volume."""
-        httpx_mock.add_response(
-            method="PATCH",
-            url="http://test-server:8080/volumes/nonexistent",
-            json={"detail": "Volume 'nonexistent' not found"},
-            status_code=404,
-        )
-
-        with pytest.raises(ResourceNotFoundError):
-            await client.update_volume("nonexistent", size="20Gi")
-
-    async def test_update_volume_resize_error(
-        self, client: AsyncSandboxClient, httpx_mock: HTTPXMock
-    ):
-        """Test updating a volume with size decrease."""
-        httpx_mock.add_response(
-            method="PATCH",
-            url="http://test-server:8080/volumes/my-volume",
-            json={
-                "detail": {
-                    "error": "ResizeError",
-                    "message": (
-                        "Volume 'my-volume' resize failed: Storage cannot be "
-                        "decreased. Current: 10.00Gi, Requested: 5.00Gi"
-                    ),
-                }
-            },
-            status_code=400,
-        )
-
-        with pytest.raises(ValidationError):
-            await client.update_volume("my-volume", size="5Gi")
-
-    async def test_update_volume_name_conflict(
-        self, client: AsyncSandboxClient, httpx_mock: HTTPXMock
-    ):
-        """Test updating a volume to a name that already exists."""
-        httpx_mock.add_response(
-            method="PATCH",
-            url="http://test-server:8080/volumes/my-volume",
-            json={
-                "detail": {
-                    "error": "Conflict",
-                    "message": "Volume name 'existing-volume' is already in use",
-                }
-            },
-            status_code=409,
-        )
-
-        with pytest.raises(ResourceNameConflictError) as exc_info:
-            await client.update_volume("my-volume", new_name="existing-volume")
-        assert exc_info.value.resource_type == "volume"
-
-    async def test_delete_volume_in_use(
-        self, client: AsyncSandboxClient, httpx_mock: HTTPXMock
-    ):
-        """Test deleting a volume that is in use by templates."""
-        httpx_mock.add_response(
-            method="DELETE",
-            url="http://test-server:8080/volumes/my-volume",
-            json={
-                "detail": {
-                    "error": "Conflict",
-                    "message": (
-                        "Volume 'my-volume' is in use by templates: template-1, "
-                        "template-2. Delete or update the templates first."
-                    ),
-                }
-            },
-            status_code=409,
-        )
-
-        with pytest.raises(ResourceInUseError):
-            await client.delete_volume("my-volume")
+            await client.create_sandbox(snapshot_id="snap-1")
 
 
 class TestService:

--- a/python/tests/unit_tests/sandbox/test_async_sandbox.py
+++ b/python/tests/unit_tests/sandbox/test_async_sandbox.py
@@ -31,7 +31,6 @@ def sandbox(client: AsyncSandboxClient):
     return AsyncSandbox.from_dict(
         data={
             "name": "test-sandbox",
-            "template_name": "test-template",
             "dataplane_url": "https://sandbox-router.example.com/sb-123",
         },
         client=client,
@@ -46,10 +45,6 @@ class TestAsyncSandboxProperties:
         """Test name property."""
         assert sandbox.name == "test-sandbox"
 
-    def test_template_name_property(self, sandbox):
-        """Test template_name property."""
-        assert sandbox.template_name == "test-template"
-
     def test_dataplane_url_property(self, sandbox):
         """Test dataplane_url property."""
         assert sandbox.dataplane_url == "https://sandbox-router.example.com/sb-123"
@@ -63,7 +58,6 @@ class TestAsyncSandboxTTLFields:
         sb = AsyncSandbox.from_dict(
             data={
                 "name": "test-sandbox",
-                "template_name": "test-template",
                 "ttl_seconds": 3600,
                 "idle_ttl_seconds": 600,
                 "expires_at": "2026-03-24T12:00:00Z",
@@ -80,7 +74,6 @@ class TestAsyncSandboxTTLFields:
         sb = AsyncSandbox.from_dict(
             data={
                 "name": "test-sandbox",
-                "template_name": "test-template",
             },
             client=client,
             auto_delete=False,
@@ -94,7 +87,6 @@ class TestAsyncSandboxTTLFields:
         sb = AsyncSandbox.from_dict(
             data={
                 "name": "test-sandbox",
-                "template_name": "test-template",
                 "ttl_seconds": 0,
                 "idle_ttl_seconds": 0,
                 "expires_at": None,
@@ -115,7 +107,6 @@ class TestAsyncSandboxStatusFields:
         sb = AsyncSandbox.from_dict(
             data={
                 "name": "test-sandbox",
-                "template_name": "test-template",
                 "status": "provisioning",
                 "status_message": None,
                 "dataplane_url": "https://sandbox-router.example.com/sb-123",
@@ -131,7 +122,6 @@ class TestAsyncSandboxStatusFields:
         sb = AsyncSandbox.from_dict(
             data={
                 "name": "test-sandbox",
-                "template_name": "test-template",
             },
             client=client,
             auto_delete=False,
@@ -144,7 +134,6 @@ class TestAsyncSandboxStatusFields:
         sb = AsyncSandbox.from_dict(
             data={
                 "name": "test-sandbox",
-                "template_name": "test-template",
                 "status": "provisioning",
                 "dataplane_url": "https://sandbox-router.example.com/sb-123",
             },
@@ -159,7 +148,6 @@ class TestAsyncSandboxStatusFields:
         sb = AsyncSandbox.from_dict(
             data={
                 "name": "test-sandbox",
-                "template_name": "test-template",
                 "status": "provisioning",
                 "dataplane_url": "https://sandbox-router.example.com/sb-123",
             },
@@ -174,7 +162,6 @@ class TestAsyncSandboxStatusFields:
         sb = AsyncSandbox.from_dict(
             data={
                 "name": "test-sandbox",
-                "template_name": "test-template",
                 "status": "provisioning",
                 "dataplane_url": "https://sandbox-router.example.com/sb-123",
             },
@@ -238,7 +225,6 @@ class TestAsyncSandboxRun:
         sandbox = AsyncSandbox.from_dict(
             data={
                 "name": "test-sandbox",
-                "template_name": "test-template",
                 "dataplane_url": None,
             },
             client=client,
@@ -418,7 +404,6 @@ class TestAsyncSandboxWrite:
         sandbox = AsyncSandbox.from_dict(
             data={
                 "name": "test-sandbox",
-                "template_name": "test-template",
                 "dataplane_url": None,
             },
             client=client,
@@ -480,7 +465,6 @@ class TestAsyncSandboxRead:
         sandbox = AsyncSandbox.from_dict(
             data={
                 "name": "test-sandbox",
-                "template_name": "test-template",
                 "dataplane_url": None,
             },
             client=client,
@@ -509,7 +493,6 @@ class TestAsyncSandboxContextManager:
         sandbox = AsyncSandbox.from_dict(
             data={
                 "name": "test-sandbox",
-                "template_name": "test-template",
             },
             client=client,
             auto_delete=True,
@@ -530,7 +513,6 @@ class TestAsyncSandboxContextManager:
         sandbox = AsyncSandbox.from_dict(
             data={
                 "name": "test-sandbox",
-                "template_name": "test-template",
             },
             client=client,
             auto_delete=False,
@@ -560,7 +542,6 @@ class TestAsyncSandboxService:
         sb = AsyncSandbox.from_dict(
             data={
                 "name": "test-sandbox",
-                "template_name": "test-template",
                 "dataplane_url": "https://sandbox-router.example.com/sb-123",
             },
             client=client,

--- a/python/tests/unit_tests/sandbox/test_async_ws_execute.py
+++ b/python/tests/unit_tests/sandbox/test_async_ws_execute.py
@@ -593,7 +593,6 @@ class TestAsyncSandboxRunWs:
         return AsyncSandbox.from_dict(
             data={
                 "name": "test-sb",
-                "template_name": "test-tmpl",
                 "dataplane_url": "https://router.example.com/sb-123",
             },
             client=client,
@@ -788,7 +787,6 @@ class TestAsyncSandboxReconnect:
         return AsyncSandbox.from_dict(
             data={
                 "name": "test-sb",
-                "template_name": "test-tmpl",
                 "dataplane_url": "https://router.example.com/sb-123",
             },
             client=client,

--- a/python/tests/unit_tests/sandbox/test_client.py
+++ b/python/tests/unit_tests/sandbox/test_client.py
@@ -6,10 +6,7 @@ import pytest
 from pytest_httpx import HTTPXMock
 
 from langsmith.sandbox import (
-    QuotaExceededError,
-    ResourceAlreadyExistsError,
     ResourceCreationError,
-    ResourceInUseError,
     ResourceNameConflictError,
     ResourceNotFoundError,
     ResourceStatus,
@@ -17,7 +14,6 @@ from langsmith.sandbox import (
     SandboxClient,
     SandboxConnectionError,
     ServiceURL,
-    ValidationError,
 )
 
 
@@ -140,200 +136,6 @@ class TestSandboxClientInit:
         client.close()
 
 
-class TestTemplateOperations:
-    """Tests for template operations."""
-
-    def test_create_template(self, client: SandboxClient, httpx_mock: HTTPXMock):
-        """Test creating a template."""
-        httpx_mock.add_response(
-            method="POST",
-            url="http://test-server:8080/templates",
-            json={
-                "name": "python-sandbox",
-                "image": "python:3.12-slim",
-                "resources": {"cpu": "500m", "memory": "512Mi"},
-            },
-            status_code=201,
-        )
-
-        template = client.create_template(
-            name="python-sandbox",
-            image="python:3.12-slim",
-        )
-
-        assert template.name == "python-sandbox"
-        assert template.image == "python:3.12-slim"
-
-    def test_create_template_with_resources(
-        self, client: SandboxClient, httpx_mock: HTTPXMock
-    ):
-        """Test creating a template with custom resources."""
-        httpx_mock.add_response(
-            method="POST",
-            url="http://test-server:8080/templates",
-            json={
-                "name": "python-sandbox",
-                "image": "python:3.12-slim",
-                "resources": {"cpu": "2", "memory": "4Gi", "storage": "10Gi"},
-            },
-            status_code=201,
-        )
-
-        template = client.create_template(
-            name="python-sandbox",
-            image="python:3.12-slim",
-            cpu="2",
-            memory="4Gi",
-            storage="10Gi",
-        )
-
-        assert template.resources.cpu == "2"
-        assert template.resources.memory == "4Gi"
-        assert template.resources.storage == "10Gi"
-
-    def test_list_templates(self, client: SandboxClient, httpx_mock: HTTPXMock):
-        """Test listing templates."""
-        httpx_mock.add_response(
-            method="GET",
-            url="http://test-server:8080/templates",
-            json={
-                "templates": [
-                    {
-                        "name": "template-1",
-                        "image": "python:3.12",
-                        "resources": {"cpu": "500m", "memory": "512Mi"},
-                    },
-                    {
-                        "name": "template-2",
-                        "image": "node:20",
-                        "resources": {"cpu": "1", "memory": "1Gi"},
-                    },
-                ]
-            },
-        )
-
-        templates = client.list_templates()
-
-        assert len(templates) == 2
-        assert templates[0].name == "template-1"
-        assert templates[1].name == "template-2"
-
-    def test_get_template(self, client: SandboxClient, httpx_mock: HTTPXMock):
-        """Test getting a template."""
-        httpx_mock.add_response(
-            method="GET",
-            url="http://test-server:8080/templates/python-sandbox",
-            json={
-                "name": "python-sandbox",
-                "image": "python:3.12-slim",
-                "resources": {"cpu": "500m", "memory": "512Mi"},
-            },
-        )
-
-        template = client.get_template("python-sandbox")
-
-        assert template.name == "python-sandbox"
-
-    def test_get_template_not_found(self, client: SandboxClient, httpx_mock: HTTPXMock):
-        """Test getting non-existent template."""
-        httpx_mock.add_response(
-            method="GET",
-            url="http://test-server:8080/templates/nonexistent",
-            json={"detail": "Template 'nonexistent' not found"},
-            status_code=404,
-        )
-
-        with pytest.raises(ResourceNotFoundError):
-            client.get_template("nonexistent")
-
-    def test_update_template(self, client: SandboxClient, httpx_mock: HTTPXMock):
-        """Test updating a template's name."""
-        httpx_mock.add_response(
-            method="PATCH",
-            url="http://test-server:8080/templates/python-sandbox",
-            json={
-                "id": "550e8400-e29b-41d4-a716-446655440001",
-                "name": "python-sandbox-renamed",
-                "image": "python:3.12-slim",
-                "resources": {"cpu": "500m", "memory": "512Mi"},
-                "updated_at": "2026-01-19T14:00:00Z",
-            },
-        )
-
-        template = client.update_template(
-            "python-sandbox", new_name="python-sandbox-renamed"
-        )
-
-        assert template.name == "python-sandbox-renamed"
-        assert template.id == "550e8400-e29b-41d4-a716-446655440001"
-        assert template.updated_at == "2026-01-19T14:00:00Z"
-
-    def test_update_template_not_found(
-        self, client: SandboxClient, httpx_mock: HTTPXMock
-    ):
-        """Test updating a non-existent template."""
-        httpx_mock.add_response(
-            method="PATCH",
-            url="http://test-server:8080/templates/nonexistent",
-            json={"detail": "Template 'nonexistent' not found"},
-            status_code=404,
-        )
-
-        with pytest.raises(ResourceNotFoundError):
-            client.update_template("nonexistent", new_name="new-name")
-
-    def test_update_template_name_conflict(
-        self, client: SandboxClient, httpx_mock: HTTPXMock
-    ):
-        """Test updating a template to a name that already exists."""
-        httpx_mock.add_response(
-            method="PATCH",
-            url="http://test-server:8080/templates/python-sandbox",
-            json={
-                "detail": {
-                    "error": "Conflict",
-                    "message": "Template name 'existing-template' is already in use",
-                }
-            },
-            status_code=409,
-        )
-
-        with pytest.raises(ResourceNameConflictError) as exc_info:
-            client.update_template("python-sandbox", new_name="existing-template")
-        assert exc_info.value.resource_type == "template"
-
-    def test_delete_template(self, client: SandboxClient, httpx_mock: HTTPXMock):
-        """Test deleting a template."""
-        httpx_mock.add_response(
-            method="DELETE",
-            url="http://test-server:8080/templates/python-sandbox",
-            status_code=204,
-        )
-
-        # Should not raise
-        client.delete_template("python-sandbox")
-
-    def test_delete_template_in_use(self, client: SandboxClient, httpx_mock: HTTPXMock):
-        """Test deleting a template that is in use by sandboxes or pools."""
-        httpx_mock.add_response(
-            method="DELETE",
-            url="http://test-server:8080/templates/python-sandbox",
-            json={
-                "detail": {
-                    "error": "Conflict",
-                    "message": (
-                        "Template 'python-sandbox' is in use by sandboxes: sandbox-1; "
-                        "pools: pool-1. Delete the dependent resources first."
-                    ),
-                }
-            },
-            status_code=409,
-        )
-
-        with pytest.raises(ResourceInUseError):
-            client.delete_template("python-sandbox")
-
-
 class TestSandboxOperations:
     """Tests for sandbox operations."""
 
@@ -345,13 +147,12 @@ class TestSandboxOperations:
             json={
                 "id": "550e8400-e29b-41d4-a716-446655440003",
                 "name": "test-sandbox",
-                "template_name": "python-sandbox",
                 "dataplane_url": "https://sandbox-router.example.com/sb-123",
             },
             status_code=201,
         )
 
-        sandbox = client.create_sandbox(template_name="python-sandbox")
+        sandbox = client.create_sandbox(snapshot_id="snap-1")
 
         assert sandbox.name == "test-sandbox"
         assert sandbox.id == "550e8400-e29b-41d4-a716-446655440003"
@@ -368,7 +169,6 @@ class TestSandboxOperations:
             url="http://test-server:8080/boxes",
             json={
                 "name": "test-sandbox",
-                "template_name": "python-sandbox",
             },
             status_code=201,
         )
@@ -377,7 +177,7 @@ class TestSandboxOperations:
             "access_control": {"allow_list": ["github.com", "*.example.com"]},
         }
         client.create_sandbox(
-            template_name="python-sandbox",
+            snapshot_id="snap-1",
             proxy_config=proxy_config,
         )
 
@@ -396,12 +196,11 @@ class TestSandboxOperations:
             url="http://test-server:8080/boxes",
             json={
                 "name": "test-sandbox",
-                "template_name": "python-sandbox",
             },
             status_code=201,
         )
 
-        client.create_sandbox(template_name="python-sandbox")
+        client.create_sandbox(snapshot_id="snap-1")
         body = json.loads(httpx_mock.get_request().content)
         assert "proxy_config" not in body
 
@@ -414,14 +213,13 @@ class TestSandboxOperations:
             url="http://test-server:8080/boxes",
             json={
                 "name": "test-sandbox",
-                "template_name": "python-sandbox",
                 "dataplane_url": "https://sandbox-router.example.com/sb-123",
             },
             status_code=201,
         )
 
         client.create_sandbox(
-            template_name="python-sandbox",
+            snapshot_id="snap-1",
             headers={
                 "X-Api-Key": "override-key",
                 "X-Test-Header": "sandbox-client",
@@ -441,7 +239,6 @@ class TestSandboxOperations:
             url="http://test-server:8080/boxes",
             json={
                 "name": "test-sandbox",
-                "template_name": "python-sandbox",
             },
             status_code=201,
         )
@@ -451,7 +248,7 @@ class TestSandboxOperations:
             status_code=204,
         )
 
-        with client.sandbox(template_name="python-sandbox") as sandbox:
+        with client.sandbox(snapshot_id="snap-1") as sandbox:
             assert sandbox.name == "test-sandbox"
 
         # Verify delete was called
@@ -468,7 +265,7 @@ class TestSandboxOperations:
         )
 
         with pytest.raises(ResourceTimeoutError):
-            client.create_sandbox(template_name="python-sandbox")
+            client.create_sandbox(snapshot_id="snap-1")
 
     def test_list_sandboxes(self, client: SandboxClient, httpx_mock: HTTPXMock):
         """Test listing sandboxes."""
@@ -479,7 +276,6 @@ class TestSandboxOperations:
                 "sandboxes": [
                     {
                         "name": "sandbox-1",
-                        "template_name": "template-1",
                     },
                 ]
             },
@@ -509,7 +305,6 @@ class TestSandboxOperations:
             json={
                 "id": "550e8400-e29b-41d4-a716-446655440003",
                 "name": "my-sandbox-renamed",
-                "template_name": "python-sandbox",
                 "dataplane_url": "https://sandbox-router.example.com/sb-123",
             },
         )
@@ -559,7 +354,6 @@ class TestSandboxOperations:
             json={
                 "id": "550e8400-e29b-41d4-a716-446655440003",
                 "name": "test-sandbox",
-                "template_name": "python-sandbox",
                 "status": "provisioning",
                 "status_message": None,
                 "dataplane_url": "https://sandbox-router.example.com/sb-123",
@@ -567,9 +361,7 @@ class TestSandboxOperations:
             status_code=201,
         )
 
-        sandbox = client.create_sandbox(
-            template_name="python-sandbox", wait_for_ready=False
-        )
+        sandbox = client.create_sandbox(snapshot_id="snap-1", wait_for_ready=False)
 
         assert sandbox.name == "test-sandbox"
         assert sandbox.status == "provisioning"
@@ -592,7 +384,6 @@ class TestSandboxOperations:
             url="http://test-server:8080/boxes",
             json={
                 "name": "test-sandbox",
-                "template_name": "python-sandbox",
                 "status": "ready",
                 "status_message": None,
                 "dataplane_url": "https://sandbox-router.example.com/sb-123",
@@ -600,7 +391,7 @@ class TestSandboxOperations:
             status_code=201,
         )
 
-        sandbox = client.create_sandbox(template_name="python-sandbox")
+        sandbox = client.create_sandbox(snapshot_id="snap-1")
 
         assert sandbox.status == "ready"
         assert sandbox.status_message is None
@@ -668,7 +459,6 @@ class TestSandboxOperations:
             url="http://test-server:8080/boxes/my-sandbox",
             json={
                 "name": "my-sandbox",
-                "template_name": "python-sandbox",
                 "status": "ready",
                 "dataplane_url": "https://sandbox-router.example.com/sb-123",
             },
@@ -723,7 +513,6 @@ class TestSandboxOperations:
             url="http://test-server:8080/boxes",
             json={
                 "name": "test-sandbox",
-                "template_name": "python-sandbox",
                 "ttl_seconds": 3600,
                 "idle_ttl_seconds": 600,
                 "expires_at": "2026-03-24T12:00:00Z",
@@ -733,7 +522,7 @@ class TestSandboxOperations:
         )
 
         sandbox = client.create_sandbox(
-            template_name="python-sandbox",
+            snapshot_id="snap-1",
             ttl_seconds=3600,
             idle_ttl_seconds=600,
         )
@@ -758,13 +547,12 @@ class TestSandboxOperations:
             url="http://test-server:8080/boxes",
             json={
                 "name": "test-sandbox",
-                "template_name": "python-sandbox",
                 "dataplane_url": "https://sandbox-router.example.com/sb-123",
             },
             status_code=201,
         )
 
-        client.create_sandbox(template_name="python-sandbox")
+        client.create_sandbox(snapshot_id="snap-1")
 
         import json
 
@@ -776,14 +564,14 @@ class TestSandboxOperations:
     def test_create_sandbox_ttl_validation_negative(self, client: SandboxClient):
         """Test that negative TTL values raise ValueError."""
         with pytest.raises(ValueError, match="must be >= 0"):
-            client.create_sandbox(template_name="python-sandbox", ttl_seconds=-1)
+            client.create_sandbox(snapshot_id="snap-1", ttl_seconds=-1)
 
     def test_create_sandbox_ttl_validation_not_multiple_of_60(
         self, client: SandboxClient
     ):
         """Test that non-multiple-of-60 TTL values raise ValueError."""
         with pytest.raises(ValueError, match="must be a multiple of 60"):
-            client.create_sandbox(template_name="python-sandbox", ttl_seconds=90)
+            client.create_sandbox(snapshot_id="snap-1", ttl_seconds=90)
 
     def test_create_sandbox_ttl_zero_allowed(
         self, client: SandboxClient, httpx_mock: HTTPXMock
@@ -794,7 +582,6 @@ class TestSandboxOperations:
             url="http://test-server:8080/boxes",
             json={
                 "name": "test-sandbox",
-                "template_name": "python-sandbox",
                 "ttl_seconds": 0,
                 "idle_ttl_seconds": 0,
                 "dataplane_url": "https://sandbox-router.example.com/sb-123",
@@ -803,7 +590,7 @@ class TestSandboxOperations:
         )
 
         sandbox = client.create_sandbox(
-            template_name="python-sandbox",
+            snapshot_id="snap-1",
             ttl_seconds=0,
             idle_ttl_seconds=0,
         )
@@ -820,7 +607,6 @@ class TestSandboxOperations:
             url="http://test-server:8080/boxes/my-sandbox",
             json={
                 "name": "my-sandbox",
-                "template_name": "python-sandbox",
                 "ttl_seconds": 7200,
                 "idle_ttl_seconds": 1200,
                 "expires_at": "2026-03-24T14:00:00Z",
@@ -860,7 +646,6 @@ class TestSandboxOperations:
             url="http://test-server:8080/boxes/my-sandbox",
             json={
                 "name": "my-sandbox-renamed",
-                "template_name": "python-sandbox",
                 "ttl_seconds": 3600,
                 "dataplane_url": "https://sandbox-router.example.com/sb-123",
             },
@@ -893,12 +678,10 @@ class TestSandboxOperations:
                 "sandboxes": [
                     {
                         "name": "sandbox-ready",
-                        "template_name": "template-1",
                         "status": "ready",
                     },
                     {
                         "name": "sandbox-provisioning",
-                        "template_name": "template-1",
                         "status": "provisioning",
                     },
                 ]
@@ -912,414 +695,8 @@ class TestSandboxOperations:
         assert sandboxes[1].status == "provisioning"
 
 
-class TestPoolOperations:
-    """Tests for pool operations."""
-
-    def test_create_pool(self, client: SandboxClient, httpx_mock: HTTPXMock):
-        """Test creating a pool."""
-        httpx_mock.add_response(
-            method="POST",
-            url="http://test-server:8080/pools",
-            json={
-                "name": "python-pool",
-                "template_name": "python-sandbox",
-                "replicas": 5,
-                "created_at": "2026-01-16T12:00:00Z",
-            },
-            status_code=201,
-        )
-
-        pool = client.create_pool(
-            name="python-pool",
-            template_name="python-sandbox",
-            replicas=5,
-        )
-
-        assert pool.name == "python-pool"
-        assert pool.template_name == "python-sandbox"
-        assert pool.replicas == 5
-
-    def test_create_pool_template_not_found(
-        self, client: SandboxClient, httpx_mock: HTTPXMock
-    ):
-        """Test creating pool with non-existent template."""
-        httpx_mock.add_response(
-            method="POST",
-            url="http://test-server:8080/pools",
-            json={
-                "detail": {
-                    "error": "TemplateNotFound",
-                    "message": "Template 'nonexistent' not found.",
-                }
-            },
-            status_code=400,
-        )
-
-        with pytest.raises(ResourceNotFoundError):
-            client.create_pool(
-                name="python-pool",
-                template_name="nonexistent",
-                replicas=5,
-            )
-
-    def test_create_pool_template_has_volumes(
-        self, client: SandboxClient, httpx_mock: HTTPXMock
-    ):
-        """Test creating pool with template that has volumes."""
-        httpx_mock.add_response(
-            method="POST",
-            url="http://test-server:8080/pools",
-            json={
-                "detail": {
-                    "error": "ValidationError",
-                    "message": (
-                        "Template 'stateful-template' has volumes attached. "
-                        "Pools only support stateless templates."
-                    ),
-                }
-            },
-            status_code=400,
-        )
-
-        with pytest.raises(ValidationError) as exc_info:
-            client.create_pool(
-                name="python-pool",
-                template_name="stateful-template",
-                replicas=5,
-            )
-        assert exc_info.value.error_type == "ValidationError"
-
-    def test_create_pool_already_exists(
-        self, client: SandboxClient, httpx_mock: HTTPXMock
-    ):
-        """Test creating pool that already exists."""
-        httpx_mock.add_response(
-            method="POST",
-            url="http://test-server:8080/pools",
-            json={"detail": "Pool 'python-pool' already exists"},
-            status_code=409,
-        )
-
-        with pytest.raises(ResourceAlreadyExistsError):
-            client.create_pool(
-                name="python-pool",
-                template_name="python-sandbox",
-                replicas=5,
-            )
-
-    def test_create_pool_quota_exceeded(
-        self, client: SandboxClient, httpx_mock: HTTPXMock
-    ):
-        """Test creating pool when quota is exceeded."""
-        httpx_mock.add_response(
-            method="POST",
-            url="http://test-server:8080/pools",
-            json={
-                "detail": (
-                    "Limit of 10 sandbox(es) per organization exceeded. "
-                    "Current usage: 8 sandboxes, Requested: 5 additional."
-                )
-            },
-            status_code=429,
-        )
-
-        with pytest.raises(QuotaExceededError) as exc_info:
-            client.create_pool(
-                name="python-pool",
-                template_name="python-sandbox",
-                replicas=5,
-            )
-        assert exc_info.value.quota_type == "sandbox_count"
-
-    def test_create_pool_with_timeout(
-        self, client: SandboxClient, httpx_mock: HTTPXMock
-    ):
-        """Test creating pool sends wait_for_ready and timeout in payload."""
-        httpx_mock.add_response(
-            method="POST",
-            url="http://test-server:8080/pools",
-            json={
-                "name": "python-pool",
-                "template_name": "python-sandbox",
-                "replicas": 5,
-                "created_at": "2026-01-16T12:00:00Z",
-            },
-            status_code=201,
-        )
-
-        pool = client.create_pool(
-            name="python-pool",
-            template_name="python-sandbox",
-            replicas=5,
-            timeout=60,
-        )
-
-        assert pool.name == "python-pool"
-        assert pool.replicas == 5
-
-        # Verify the request payload includes wait_for_ready (hardcoded) and timeout
-        request = httpx_mock.get_request()
-        import json
-
-        body = json.loads(request.content)
-        assert body["wait_for_ready"] is True
-        assert body["timeout"] == 60
-
-    def test_create_pool_timeout(self, client: SandboxClient, httpx_mock: HTTPXMock):
-        """Test creating pool timeout when waiting for ready."""
-        httpx_mock.add_response(
-            method="POST",
-            url="http://test-server:8080/pools",
-            json={
-                "detail": {
-                    "error": "Timeout",
-                    "message": (
-                        "Pool 'python-pool' did not reach 1 ready replica(s) "
-                        "within 30 seconds"
-                    ),
-                }
-            },
-            status_code=504,
-        )
-
-        with pytest.raises(ResourceTimeoutError):
-            client.create_pool(
-                name="python-pool",
-                template_name="python-sandbox",
-                replicas=5,
-            )
-
-    def test_get_pool(self, client: SandboxClient, httpx_mock: HTTPXMock):
-        """Test getting a pool."""
-        httpx_mock.add_response(
-            method="GET",
-            url="http://test-server:8080/pools/python-pool",
-            json={
-                "name": "python-pool",
-                "template_name": "python-sandbox",
-                "replicas": 5,
-                "created_at": "2026-01-16T12:00:00Z",
-            },
-        )
-
-        pool = client.get_pool("python-pool")
-
-        assert pool.name == "python-pool"
-        assert pool.replicas == 5
-
-    def test_get_pool_not_found(self, client: SandboxClient, httpx_mock: HTTPXMock):
-        """Test getting non-existent pool."""
-        httpx_mock.add_response(
-            method="GET",
-            url="http://test-server:8080/pools/nonexistent",
-            json={"detail": "Pool 'nonexistent' not found"},
-            status_code=404,
-        )
-
-        with pytest.raises(ResourceNotFoundError):
-            client.get_pool("nonexistent")
-
-    def test_list_pools(self, client: SandboxClient, httpx_mock: HTTPXMock):
-        """Test listing pools."""
-        httpx_mock.add_response(
-            method="GET",
-            url="http://test-server:8080/pools",
-            json={
-                "pools": [
-                    {
-                        "name": "pool-1",
-                        "template_name": "python-sandbox",
-                        "replicas": 5,
-                    },
-                    {
-                        "name": "pool-2",
-                        "template_name": "node-sandbox",
-                        "replicas": 3,
-                    },
-                ]
-            },
-        )
-
-        pools = client.list_pools()
-
-        assert len(pools) == 2
-        assert pools[0].name == "pool-1"
-        assert pools[1].name == "pool-2"
-
-    def test_list_pools_empty(self, client: SandboxClient, httpx_mock: HTTPXMock):
-        """Test listing pools when none exist."""
-        httpx_mock.add_response(
-            method="GET",
-            url="http://test-server:8080/pools",
-            json={"pools": []},
-        )
-
-        pools = client.list_pools()
-
-        assert len(pools) == 0
-
-    def test_update_pool_replicas(self, client: SandboxClient, httpx_mock: HTTPXMock):
-        """Test updating pool replicas."""
-        httpx_mock.add_response(
-            method="PATCH",
-            url="http://test-server:8080/pools/python-pool",
-            json={
-                "id": "550e8400-e29b-41d4-a716-446655440002",
-                "name": "python-pool",
-                "template_name": "python-sandbox",
-                "replicas": 10,
-                "created_at": "2026-01-16T12:00:00Z",
-            },
-        )
-
-        pool = client.update_pool("python-pool", replicas=10)
-
-        assert pool.name == "python-pool"
-        assert pool.replicas == 10
-
-    def test_update_pool_name(self, client: SandboxClient, httpx_mock: HTTPXMock):
-        """Test updating pool name."""
-        httpx_mock.add_response(
-            method="PATCH",
-            url="http://test-server:8080/pools/python-pool",
-            json={
-                "id": "550e8400-e29b-41d4-a716-446655440002",
-                "name": "python-pool-renamed",
-                "template_name": "python-sandbox",
-                "replicas": 5,
-                "created_at": "2026-01-16T12:00:00Z",
-                "updated_at": "2026-01-19T14:00:00Z",
-            },
-        )
-
-        pool = client.update_pool("python-pool", new_name="python-pool-renamed")
-
-        assert pool.name == "python-pool-renamed"
-        assert pool.id == "550e8400-e29b-41d4-a716-446655440002"
-
-    def test_update_pool_name_and_replicas(
-        self, client: SandboxClient, httpx_mock: HTTPXMock
-    ):
-        """Test updating pool name and replicas in a single request."""
-        httpx_mock.add_response(
-            method="PATCH",
-            url="http://test-server:8080/pools/python-pool",
-            json={
-                "id": "550e8400-e29b-41d4-a716-446655440002",
-                "name": "python-pool-renamed",
-                "template_name": "python-sandbox",
-                "replicas": 10,
-                "created_at": "2026-01-16T12:00:00Z",
-                "updated_at": "2026-01-19T14:00:00Z",
-            },
-        )
-
-        pool = client.update_pool(
-            "python-pool", new_name="python-pool-renamed", replicas=10
-        )
-
-        assert pool.name == "python-pool-renamed"
-        assert pool.replicas == 10
-
-    def test_update_pool_not_found(self, client: SandboxClient, httpx_mock: HTTPXMock):
-        """Test updating non-existent pool."""
-        httpx_mock.add_response(
-            method="PATCH",
-            url="http://test-server:8080/pools/nonexistent",
-            json={"detail": "Pool 'nonexistent' not found"},
-            status_code=404,
-        )
-
-        with pytest.raises(ResourceNotFoundError):
-            client.update_pool("nonexistent", replicas=10)
-
-    def test_update_pool_quota_exceeded(
-        self, client: SandboxClient, httpx_mock: HTTPXMock
-    ):
-        """Test updating pool when scaling up exceeds quota."""
-        httpx_mock.add_response(
-            method="PATCH",
-            url="http://test-server:8080/pools/python-pool",
-            json={"detail": "Limit of 10 sandbox(es) per organization exceeded."},
-            status_code=429,
-        )
-
-        with pytest.raises(QuotaExceededError):
-            client.update_pool("python-pool", replicas=20)
-
-    def test_update_pool_pause(self, client: SandboxClient, httpx_mock: HTTPXMock):
-        """Test pausing pool by setting replicas to 0."""
-        httpx_mock.add_response(
-            method="PATCH",
-            url="http://test-server:8080/pools/python-pool",
-            json={
-                "name": "python-pool",
-                "template_name": "python-sandbox",
-                "replicas": 0,
-            },
-        )
-
-        pool = client.update_pool("python-pool", replicas=0)
-
-        assert pool.replicas == 0
-
-    def test_update_pool_name_conflict(
-        self, client: SandboxClient, httpx_mock: HTTPXMock
-    ):
-        """Test updating a pool to a name that already exists."""
-        httpx_mock.add_response(
-            method="PATCH",
-            url="http://test-server:8080/pools/python-pool",
-            json={
-                "detail": {
-                    "error": "Conflict",
-                    "message": "Pool name 'existing-pool' is already in use",
-                }
-            },
-            status_code=409,
-        )
-
-        with pytest.raises(ResourceNameConflictError) as exc_info:
-            client.update_pool("python-pool", new_name="existing-pool")
-        assert exc_info.value.resource_type == "pool"
-
-    def test_delete_pool(self, client: SandboxClient, httpx_mock: HTTPXMock):
-        """Test deleting a pool."""
-        httpx_mock.add_response(
-            method="DELETE",
-            url="http://test-server:8080/pools/python-pool",
-            status_code=204,
-        )
-
-        # Should not raise
-        client.delete_pool("python-pool")
-
-    def test_delete_pool_not_found(self, client: SandboxClient, httpx_mock: HTTPXMock):
-        """Test deleting non-existent pool."""
-        httpx_mock.add_response(
-            method="DELETE",
-            url="http://test-server:8080/pools/nonexistent",
-            json={"detail": "Pool 'nonexistent' not found"},
-            status_code=404,
-        )
-
-        with pytest.raises(ResourceNotFoundError):
-            client.delete_pool("nonexistent")
-
-
 class TestConnectionErrors:
     """Tests for connection error handling."""
-
-    def test_connection_error_on_template_create(
-        self, client: SandboxClient, httpx_mock: HTTPXMock
-    ):
-        """Test connection error when creating template."""
-        import httpx
-
-        httpx_mock.add_exception(httpx.ConnectError("Connection refused"))
-
-        with pytest.raises(SandboxConnectionError):
-            client.create_template(name="test", image="python:3.12")
 
     def test_connection_error_on_sandbox_create(
         self, client: SandboxClient, httpx_mock: HTTPXMock
@@ -1330,167 +707,7 @@ class TestConnectionErrors:
         httpx_mock.add_exception(httpx.ConnectError("Connection refused"))
 
         with pytest.raises(SandboxConnectionError):
-            client.create_sandbox(template_name="test")
-
-    def test_connection_error_on_pool_create(
-        self, client: SandboxClient, httpx_mock: HTTPXMock
-    ):
-        """Test connection error when creating pool."""
-        import httpx
-
-        httpx_mock.add_exception(httpx.ConnectError("Connection refused"))
-
-        with pytest.raises(SandboxConnectionError):
-            client.create_pool(
-                name="python-pool",
-                template_name="python-sandbox",
-                replicas=5,
-            )
-
-
-class TestVolumeOperations:
-    """Tests for volume operations."""
-
-    def test_update_volume_size(self, client: SandboxClient, httpx_mock: HTTPXMock):
-        """Test updating a volume's size."""
-        httpx_mock.add_response(
-            method="PATCH",
-            url="http://test-server:8080/volumes/my-volume",
-            json={
-                "id": "550e8400-e29b-41d4-a716-446655440000",
-                "name": "my-volume",
-                "size": "20Gi",
-                "storage_class": "standard",
-                "created_at": "2026-01-19T12:00:00Z",
-                "updated_at": "2026-01-19T14:00:00Z",
-            },
-        )
-
-        volume = client.update_volume("my-volume", size="20Gi")
-
-        assert volume.name == "my-volume"
-        assert volume.size == "20Gi"
-        assert volume.updated_at == "2026-01-19T14:00:00Z"
-
-    def test_update_volume_name(self, client: SandboxClient, httpx_mock: HTTPXMock):
-        """Test updating a volume's name."""
-        httpx_mock.add_response(
-            method="PATCH",
-            url="http://test-server:8080/volumes/my-volume",
-            json={
-                "id": "550e8400-e29b-41d4-a716-446655440000",
-                "name": "my-volume-renamed",
-                "size": "10Gi",
-                "storage_class": "standard",
-                "created_at": "2026-01-19T12:00:00Z",
-                "updated_at": "2026-01-19T14:00:00Z",
-            },
-        )
-
-        volume = client.update_volume("my-volume", new_name="my-volume-renamed")
-
-        assert volume.name == "my-volume-renamed"
-        assert volume.id == "550e8400-e29b-41d4-a716-446655440000"
-
-    def test_update_volume_name_and_size(
-        self, client: SandboxClient, httpx_mock: HTTPXMock
-    ):
-        """Test updating both volume name and size in a single request."""
-        httpx_mock.add_response(
-            method="PATCH",
-            url="http://test-server:8080/volumes/my-volume",
-            json={
-                "id": "550e8400-e29b-41d4-a716-446655440000",
-                "name": "my-volume-renamed",
-                "size": "20Gi",
-                "storage_class": "standard",
-                "created_at": "2026-01-19T12:00:00Z",
-                "updated_at": "2026-01-19T14:00:00Z",
-            },
-        )
-
-        volume = client.update_volume(
-            "my-volume", new_name="my-volume-renamed", size="20Gi"
-        )
-
-        assert volume.name == "my-volume-renamed"
-        assert volume.size == "20Gi"
-
-    def test_update_volume_not_found(
-        self, client: SandboxClient, httpx_mock: HTTPXMock
-    ):
-        """Test updating a non-existent volume."""
-        httpx_mock.add_response(
-            method="PATCH",
-            url="http://test-server:8080/volumes/nonexistent",
-            json={"detail": "Volume 'nonexistent' not found"},
-            status_code=404,
-        )
-
-        with pytest.raises(ResourceNotFoundError):
-            client.update_volume("nonexistent", size="20Gi")
-
-    def test_update_volume_resize_error(
-        self, client: SandboxClient, httpx_mock: HTTPXMock
-    ):
-        """Test updating a volume with size decrease."""
-        httpx_mock.add_response(
-            method="PATCH",
-            url="http://test-server:8080/volumes/my-volume",
-            json={
-                "detail": {
-                    "error": "ResizeError",
-                    "message": (
-                        "Volume 'my-volume' resize failed: Storage cannot be "
-                        "decreased. Current: 10.00Gi, Requested: 5.00Gi"
-                    ),
-                }
-            },
-            status_code=400,
-        )
-
-        with pytest.raises(ValidationError):
-            client.update_volume("my-volume", size="5Gi")
-
-    def test_update_volume_name_conflict(
-        self, client: SandboxClient, httpx_mock: HTTPXMock
-    ):
-        """Test updating a volume to a name that already exists."""
-        httpx_mock.add_response(
-            method="PATCH",
-            url="http://test-server:8080/volumes/my-volume",
-            json={
-                "detail": {
-                    "error": "Conflict",
-                    "message": "Volume name 'existing-volume' is already in use",
-                }
-            },
-            status_code=409,
-        )
-
-        with pytest.raises(ResourceNameConflictError) as exc_info:
-            client.update_volume("my-volume", new_name="existing-volume")
-        assert exc_info.value.resource_type == "volume"
-
-    def test_delete_volume_in_use(self, client: SandboxClient, httpx_mock: HTTPXMock):
-        """Test deleting a volume that is in use by templates."""
-        httpx_mock.add_response(
-            method="DELETE",
-            url="http://test-server:8080/volumes/my-volume",
-            json={
-                "detail": {
-                    "error": "Conflict",
-                    "message": (
-                        "Volume 'my-volume' is in use by templates: template-1, "
-                        "template-2. Delete or update the templates first."
-                    ),
-                }
-            },
-            status_code=409,
-        )
-
-        with pytest.raises(ResourceInUseError):
-            client.delete_volume("my-volume")
+            client.create_sandbox(snapshot_id="snap-1")
 
 
 class TestService:
@@ -1911,14 +1128,7 @@ class TestStartStopOperations:
         assert body["snapshot_id"] == "snap-1"
         assert "template_name" not in body
 
-    def test_create_sandbox_requires_template_or_snapshot(self, client: SandboxClient):
-        """Test that either template_name or snapshot_id is required."""
-        with pytest.raises(ValueError, match="Either template_name or snapshot_id"):
-            client.create_sandbox()
-
-    def test_create_sandbox_rejects_both_template_and_snapshot(
-        self, client: SandboxClient
-    ):
-        """Test that both template_name and snapshot_id are rejected."""
-        with pytest.raises(ValueError, match="Cannot specify both"):
-            client.create_sandbox(template_name="my-template", snapshot_id="snap-1")
+    def test_create_sandbox_requires_snapshot_id(self, client: SandboxClient):
+        """Test that snapshot_id is required."""
+        with pytest.raises(TypeError):
+            client.create_sandbox()  # type: ignore[call-arg]

--- a/python/tests/unit_tests/sandbox/test_exceptions.py
+++ b/python/tests/unit_tests/sandbox/test_exceptions.py
@@ -67,8 +67,8 @@ class TestResourceNotFoundError:
 
     def test_with_resource_type(self):
         """Test error with resource_type."""
-        error = ResourceNotFoundError("Template not found", resource_type="template")
-        assert error.resource_type == "template"
+        error = ResourceNotFoundError("Snapshot not found", resource_type="snapshot")
+        assert error.resource_type == "snapshot"
 
 
 class TestValidationError:
@@ -128,11 +128,11 @@ class TestResourceCreationError:
         """Test error with resource_type."""
         error = ResourceCreationError(
             "Provisioning failed",
-            resource_type="volume",
-            error_type="VolumeProvisioning",
+            resource_type="sandbox",
+            error_type="ImagePull",
         )
-        assert error.resource_type == "volume"
-        assert error.error_type == "VolumeProvisioning"
+        assert error.resource_type == "sandbox"
+        assert error.error_type == "ImagePull"
 
 
 class TestSandboxOperationError:
@@ -169,8 +169,10 @@ class TestResourceNameConflictError:
 
     def test_with_resource_type(self):
         """Test error with resource_type."""
-        error = ResourceNameConflictError("Name already exists", resource_type="volume")
-        assert error.resource_type == "volume"
+        error = ResourceNameConflictError(
+            "Name already exists", resource_type="snapshot"
+        )
+        assert error.resource_type == "snapshot"
 
 
 class TestCommandTimeoutError:

--- a/python/tests/unit_tests/sandbox/test_models.py
+++ b/python/tests/unit_tests/sandbox/test_models.py
@@ -7,14 +7,9 @@ from langsmith.sandbox import (
     AsyncServiceURL,
     ExecutionResult,
     OutputChunk,
-    Pool,
-    ResourceSpec,
     ResourceStatus,
-    SandboxTemplate,
     ServiceURL,
     Snapshot,
-    Volume,
-    VolumeMountSpec,
 )
 
 
@@ -46,154 +41,6 @@ class TestExecutionResult:
         """Test success is False when exit_code is negative."""
         result = ExecutionResult(stdout="", stderr="", exit_code=-1)
         assert result.success is False
-
-
-class TestResourceSpec:
-    """Tests for ResourceSpec."""
-
-    def test_default_values(self):
-        """Test default values."""
-        spec = ResourceSpec()
-        assert spec.cpu == "500m"
-        assert spec.memory == "512Mi"
-        assert spec.storage is None
-
-    def test_custom_values(self):
-        """Test custom values."""
-        spec = ResourceSpec(cpu="1", memory="1Gi", storage="5Gi")
-        assert spec.cpu == "1"
-        assert spec.memory == "1Gi"
-        assert spec.storage == "5Gi"
-
-
-class TestVolume:
-    """Tests for Volume."""
-
-    def test_from_dict(self):
-        """Test creating from dict."""
-        data = {
-            "id": "550e8400-e29b-41d4-a716-446655440000",
-            "name": "test-volume",
-            "size": "1Gi",
-            "storage_class": "hostpath",
-            "created_at": "2025-01-01T00:00:00Z",
-            "updated_at": "2025-01-02T00:00:00Z",
-        }
-        volume = Volume.from_dict(data)
-
-        assert volume.id == "550e8400-e29b-41d4-a716-446655440000"
-        assert volume.name == "test-volume"
-        assert volume.size == "1Gi"
-        assert volume.storage_class == "hostpath"
-        assert volume.created_at == "2025-01-01T00:00:00Z"
-        assert volume.updated_at == "2025-01-02T00:00:00Z"
-
-    def test_from_dict_minimal(self):
-        """Test creating from minimal dict."""
-        data = {
-            "name": "test-volume",
-            "size": "5Gi",
-        }
-        volume = Volume.from_dict(data)
-
-        assert volume.id is None
-        assert volume.name == "test-volume"
-        assert volume.size == "5Gi"
-        assert volume.storage_class == "default"
-        assert volume.created_at is None
-        assert volume.updated_at is None
-
-
-class TestVolumeMountSpec:
-    """Tests for VolumeMountSpec."""
-
-    def test_creation(self):
-        """Test creating a volume mount spec."""
-        mount = VolumeMountSpec(volume_name="my-volume", mount_path="/data")
-        assert mount.volume_name == "my-volume"
-        assert mount.mount_path == "/data"
-
-
-class TestSandboxTemplate:
-    """Tests for SandboxTemplate."""
-
-    def test_from_dict_minimal(self):
-        """Test creating from minimal dict."""
-        data = {
-            "name": "test-template",
-            "image": "python:3.12",
-        }
-        template = SandboxTemplate.from_dict(data)
-
-        assert template.id is None
-        assert template.name == "test-template"
-        assert template.image == "python:3.12"
-        assert template.resources.cpu == "500m"
-        assert template.updated_at is None
-
-    def test_from_dict_full(self):
-        """Test creating from full dict."""
-        data = {
-            "id": "550e8400-e29b-41d4-a716-446655440001",
-            "name": "test-template",
-            "image": "node:20",
-            "resources": {
-                "cpu": "2",
-                "memory": "4Gi",
-                "storage": "10Gi",
-            },
-            "created_at": "2025-01-01T00:00:00Z",
-            "updated_at": "2025-01-02T00:00:00Z",
-        }
-        template = SandboxTemplate.from_dict(data)
-
-        assert template.id == "550e8400-e29b-41d4-a716-446655440001"
-        assert template.name == "test-template"
-        assert template.image == "node:20"
-        assert template.resources.cpu == "2"
-        assert template.resources.memory == "4Gi"
-        assert template.resources.storage == "10Gi"
-        assert template.created_at == "2025-01-01T00:00:00Z"
-        assert template.updated_at == "2025-01-02T00:00:00Z"
-
-    def test_from_dict_with_volume_mounts(self):
-        """Test creating from dict with volume mounts."""
-        data = {
-            "name": "test-template",
-            "image": "python:3.12",
-            "volume_mounts": [
-                {"volume_name": "data-volume", "mount_path": "/data"},
-                {"volume_name": "cache-volume", "mount_path": "/cache"},
-            ],
-        }
-        template = SandboxTemplate.from_dict(data)
-
-        assert len(template.volume_mounts) == 2
-        assert template.volume_mounts[0].volume_name == "data-volume"
-        assert template.volume_mounts[0].mount_path == "/data"
-        assert template.volume_mounts[1].volume_name == "cache-volume"
-        assert template.volume_mounts[1].mount_path == "/cache"
-
-    def test_from_dict_empty_volume_mounts(self):
-        """Test creating from dict with empty volume mounts."""
-        data = {
-            "name": "test-template",
-            "image": "python:3.12",
-            "volume_mounts": [],
-        }
-        template = SandboxTemplate.from_dict(data)
-
-        assert template.volume_mounts == []
-
-    def test_from_dict_no_volume_mounts_key(self):
-        """Test creating from dict without volume_mounts key."""
-        data = {
-            "name": "test-template",
-            "image": "python:3.12",
-        }
-        template = SandboxTemplate.from_dict(data)
-
-        assert template.volume_mounts == []
 
 
 class TestResourceStatus:
@@ -228,56 +75,6 @@ class TestResourceStatus:
         status = ResourceStatus.from_dict({})
         assert status.status == "provisioning"
         assert status.status_message is None
-
-
-class TestPool:
-    """Tests for Pool."""
-
-    def test_from_dict_full(self):
-        """Test creating from full dict."""
-        data = {
-            "id": "550e8400-e29b-41d4-a716-446655440002",
-            "name": "python-pool",
-            "template_name": "python-sandbox",
-            "replicas": 5,
-            "created_at": "2026-01-16T12:00:00Z",
-            "updated_at": "2026-01-16T14:30:00Z",
-        }
-        pool = Pool.from_dict(data)
-
-        assert pool.id == "550e8400-e29b-41d4-a716-446655440002"
-        assert pool.name == "python-pool"
-        assert pool.template_name == "python-sandbox"
-        assert pool.replicas == 5
-        assert pool.created_at == "2026-01-16T12:00:00Z"
-        assert pool.updated_at == "2026-01-16T14:30:00Z"
-
-    def test_from_dict_minimal(self):
-        """Test creating from minimal dict."""
-        data = {
-            "name": "python-pool",
-            "template_name": "python-sandbox",
-            "replicas": 3,
-        }
-        pool = Pool.from_dict(data)
-
-        assert pool.id is None
-        assert pool.name == "python-pool"
-        assert pool.template_name == "python-sandbox"
-        assert pool.replicas == 3
-        assert pool.created_at is None
-        assert pool.updated_at is None
-
-    def test_from_dict_paused(self):
-        """Test creating from dict for paused pool."""
-        data = {
-            "name": "paused-pool",
-            "template_name": "python-sandbox",
-            "replicas": 0,
-        }
-        pool = Pool.from_dict(data)
-
-        assert pool.replicas == 0
 
 
 _SAMPLE_SERVICE_URL_DATA = {

--- a/python/tests/unit_tests/sandbox/test_sandbox.py
+++ b/python/tests/unit_tests/sandbox/test_sandbox.py
@@ -28,7 +28,6 @@ def sandbox(client: SandboxClient):
     return Sandbox.from_dict(
         data={
             "name": "test-sandbox",
-            "template_name": "test-template",
             "dataplane_url": "https://sandbox-router.example.com/sb-123",
         },
         client=client,
@@ -43,10 +42,6 @@ class TestSandboxProperties:
         """Test name property."""
         assert sandbox.name == "test-sandbox"
 
-    def test_template_name_property(self, sandbox):
-        """Test template_name property."""
-        assert sandbox.template_name == "test-template"
-
     def test_dataplane_url_property(self, sandbox):
         """Test dataplane_url property."""
         assert sandbox.dataplane_url == "https://sandbox-router.example.com/sb-123"
@@ -60,7 +55,6 @@ class TestSandboxTTLFields:
         sb = Sandbox.from_dict(
             data={
                 "name": "test-sandbox",
-                "template_name": "test-template",
                 "ttl_seconds": 3600,
                 "idle_ttl_seconds": 600,
                 "expires_at": "2026-03-24T12:00:00Z",
@@ -77,7 +71,6 @@ class TestSandboxTTLFields:
         sb = Sandbox.from_dict(
             data={
                 "name": "test-sandbox",
-                "template_name": "test-template",
             },
             client=client,
             auto_delete=False,
@@ -91,7 +84,6 @@ class TestSandboxTTLFields:
         sb = Sandbox.from_dict(
             data={
                 "name": "test-sandbox",
-                "template_name": "test-template",
                 "ttl_seconds": 0,
                 "idle_ttl_seconds": 0,
                 "expires_at": None,
@@ -112,7 +104,6 @@ class TestSandboxStatusFields:
         sb = Sandbox.from_dict(
             data={
                 "name": "test-sandbox",
-                "template_name": "test-template",
                 "status": "provisioning",
                 "status_message": None,
                 "dataplane_url": "https://sandbox-router.example.com/sb-123",
@@ -128,7 +119,6 @@ class TestSandboxStatusFields:
         sb = Sandbox.from_dict(
             data={
                 "name": "test-sandbox",
-                "template_name": "test-template",
                 "status": "failed",
                 "status_message": "No capacity available",
             },
@@ -143,7 +133,6 @@ class TestSandboxStatusFields:
         sb = Sandbox.from_dict(
             data={
                 "name": "test-sandbox",
-                "template_name": "test-template",
             },
             client=client,
             auto_delete=False,
@@ -156,7 +145,6 @@ class TestSandboxStatusFields:
         sb = Sandbox.from_dict(
             data={
                 "name": "test-sandbox",
-                "template_name": "test-template",
                 "status": "provisioning",
                 "dataplane_url": "https://sandbox-router.example.com/sb-123",
             },
@@ -171,7 +159,6 @@ class TestSandboxStatusFields:
         sb = Sandbox.from_dict(
             data={
                 "name": "test-sandbox",
-                "template_name": "test-template",
                 "status": "failed",
                 "status_message": "No capacity",
                 "dataplane_url": "https://sandbox-router.example.com/sb-123",
@@ -187,7 +174,6 @@ class TestSandboxStatusFields:
         sb = Sandbox.from_dict(
             data={
                 "name": "test-sandbox",
-                "template_name": "test-template",
                 "status": "provisioning",
                 "dataplane_url": "https://sandbox-router.example.com/sb-123",
             },
@@ -202,7 +188,6 @@ class TestSandboxStatusFields:
         sb = Sandbox.from_dict(
             data={
                 "name": "test-sandbox",
-                "template_name": "test-template",
                 "status": "provisioning",
                 "dataplane_url": "https://sandbox-router.example.com/sb-123",
             },
@@ -266,7 +251,6 @@ class TestSandboxRun:
         sandbox = Sandbox.from_dict(
             data={
                 "name": "test-sandbox",
-                "template_name": "test-template",
                 "dataplane_url": None,
             },
             client=client,
@@ -446,7 +430,6 @@ class TestSandboxWrite:
         sandbox = Sandbox.from_dict(
             data={
                 "name": "test-sandbox",
-                "template_name": "test-template",
                 "dataplane_url": None,
             },
             client=client,
@@ -508,7 +491,6 @@ class TestSandboxRead:
         sandbox = Sandbox.from_dict(
             data={
                 "name": "test-sandbox",
-                "template_name": "test-template",
                 "dataplane_url": None,
             },
             client=client,
@@ -535,7 +517,6 @@ class TestSandboxContextManager:
         sandbox = Sandbox.from_dict(
             data={
                 "name": "test-sandbox",
-                "template_name": "test-template",
             },
             client=client,
             auto_delete=True,
@@ -556,7 +537,6 @@ class TestSandboxContextManager:
         sandbox = Sandbox.from_dict(
             data={
                 "name": "test-sandbox",
-                "template_name": "test-template",
             },
             client=client,
             auto_delete=False,
@@ -586,7 +566,6 @@ class TestSandboxService:
         sb = Sandbox.from_dict(
             data={
                 "name": "test-sandbox",
-                "template_name": "test-template",
                 "dataplane_url": "https://sandbox-router.example.com/sb-123",
             },
             client=client,

--- a/python/tests/unit_tests/sandbox/test_tunnel.py
+++ b/python/tests/unit_tests/sandbox/test_tunnel.py
@@ -250,7 +250,6 @@ def mock_sandbox():
 
     sb = Sandbox(
         name="test",
-        template_name="t",
         dataplane_url="http://x",
         status="ready",
     )

--- a/python/tests/unit_tests/sandbox/test_ws_execute.py
+++ b/python/tests/unit_tests/sandbox/test_ws_execute.py
@@ -568,7 +568,6 @@ class TestSandboxRunWs:
         return Sandbox.from_dict(
             data={
                 "name": "test-sb",
-                "template_name": "test-tmpl",
                 "dataplane_url": "https://router.example.com/sb-123",
             },
             client=client,
@@ -739,7 +738,6 @@ class TestSandboxReconnect:
         return Sandbox.from_dict(
             data={
                 "name": "test-sb",
-                "template_name": "test-tmpl",
                 "dataplane_url": "https://router.example.com/sb-123",
             },
             client=client,


### PR DESCRIPTION
## Summary

Removes the template/pool/volume surface from the Python sandbox SDK so it matches the backend, which no longer wires volume routes and whose `CreateClaimPayload` only accepts `snapshot_id`. Sandbox creation is now snapshot-only — `template_name` is gone and `snapshot_id` is the required positional argument for `client.sandbox` / `client.create_sandbox`.

Highlights:
- Deletes `ResourceSpec`, `Volume`, `VolumeMountSpec`, `SandboxTemplate`, and `Pool` models plus every template/pool/volume CRUD method on `SandboxClient` and `AsyncSandboxClient`.
- Rewrites the sandbox README to use `snapshot_id` throughout and drops the Templates, Pools, and Volumes sections (including their API reference rows).
- Scrubs `template_name` from the `Sandbox` dataclass, exception docstrings, and helper error paths; removes `handle_pool_error` / `handle_volume_creation_error`.
- Unit tests: deletes template/pool/volume suites, rewrites sandbox-creation tests to use `snapshot_id`, and strips stale `template_name` fixtures from the ws / tunnel / exceptions suites. 398 tests passing locally.

This is a clean breaking removal — no deprecation shims.

Made with [Cursor](https://cursor.com)