### PR TITLE
chore(js): remove templates, pools, and volumes from sandbox SDK

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,7 +40,7 @@ repos:
       # JS - auto-format with prettier
       - id: js-format
         name: JS Prettier Format
-        entry: bash -c 'cd js && yarn run format'
+        entry: bash -c 'cd js && pnpm run format'
         language: system
         files: ^js/src/.*\.(ts|tsx|mts)$
         pass_filenames: false
@@ -48,7 +48,7 @@ repos:
       # JS - lint and auto-fix with eslint
       - id: js-lint
         name: JS ESLint
-        entry: bash -c 'cd js && yarn run lint:fix'
+        entry: bash -c 'cd js && pnpm run lint:fix'
         language: system
         files: ^js/src/.*\.(ts|js)$
         pass_filenames: false
@@ -56,7 +56,7 @@ repos:
       # JS - type check with TypeScript (cannot auto-fix)
       - id: js-typecheck
         name: JS TypeScript Type Check
-        entry: bash -c 'cd js && yarn run check:types'
+        entry: bash -c 'cd js && pnpm run check:types'
         language: system
         files: ^js/src/.*\.(ts|tsx|mts)$
         pass_filenames: false

--- a/js/src/experimental/sandbox/README.md
+++ b/js/src/experimental/sandbox/README.md
@@ -372,10 +372,18 @@ const privateSnapshot = await client.createSnapshot(
   },
 );
 
-// Capture the state of a running sandbox for later reuse
+// Capture the state of a running sandbox for later reuse. Persistent paths
+// (`/usr/local`, `/root`, `/opt`, the home directory, etc.) are preserved;
+// `/tmp` is a tmpfs and is NOT part of the capture.
 const running = await client.createSandbox(snapshot.id);
-await running.write("/data/prepared.txt", "preloaded");
-const captured = await client.captureSnapshot(running.name, "with-data");
+await running.run("pip install --quiet requests", { timeout: 180 });
+await running.write("/opt/prepared.txt", "preloaded");
+
+// Either form works; the instance method just forwards to the client.
+const captured = await running.captureSnapshot("with-data", { timeout: 300 });
+// const captured = await client.captureSnapshot(running.name, "with-data");
+
+console.log(captured.id, captured.source_sandbox_id);
 
 // Boot a new sandbox from the captured snapshot
 const resumed = await client.createSandbox(captured.id);
@@ -385,6 +393,10 @@ const snapshots = await client.listSnapshots();
 const loaded = await client.getSnapshot(snapshot.id);
 await client.deleteSnapshot(snapshot.id);
 ```
+
+> **Note:** `captureSnapshot` preserves only the persistent filesystem. Running
+> processes, open sockets, in-memory state, and anything under `/tmp` are not
+> carried over — restart the processes you need in the new sandbox.
 
 ### Sizing and Resources
 

--- a/js/src/experimental/sandbox/README.md
+++ b/js/src/experimental/sandbox/README.md
@@ -6,29 +6,41 @@ Sandboxed code execution for LangSmith. Run untrusted code safely in isolated co
 
 ## Quick Start
 
+Sandboxes are created from **snapshots**. A snapshot is a filesystem image you
+build once from a Docker image (or capture from a running sandbox) and then
+reuse to boot as many sandboxes as you need.
+
 ```typescript
 import { SandboxClient } from "langsmith/experimental/sandbox";
 
 // Client uses LANGSMITH_ENDPOINT and LANGSMITH_API_KEY from environment
 const client = new SandboxClient();
 
-// First, create a template (defines the container image)
-await client.createTemplate("python-sandbox", { image: "python:3.12-slim" });
+// Build a snapshot from a Docker image (do this once)
+const snapshot = await client.createSnapshot(
+  "python",
+  "python:3.12-slim",
+  1_073_741_824, // 1 GiB filesystem
+);
 
-// Now create a sandbox from the template and run code
-const sandbox = await client.createSandbox("python-sandbox");
+// Create a sandbox from the snapshot and run code
+const sandbox = await client.createSandbox(snapshot.id);
 try {
   const result = await sandbox.run("python -c 'print(2 + 2)'");
-  console.log(result.stdout);    // "4\n"
+  console.log(result.stdout); // "4\n"
   console.log(result.exit_code); // 0
 } finally {
   await sandbox.delete();
 }
 
-// Or use an existing sandbox by name
+// Or reuse an existing sandbox by name
 const existingSb = await client.getSandbox("your-sandbox");
 const res = await existingSb.run("python -c 'print(2 + 2)'");
 ```
+
+If you already have a snapshot ID (for example, listed with
+`client.listSnapshots()`), you can skip the `createSnapshot` step and call
+`client.createSandbox(snapshotId)` directly.
 
 ## Configuration
 
@@ -52,8 +64,7 @@ const client = new SandboxClient({
 ## Running Commands
 
 ```typescript
-// Assuming you've created a template called "my-sandbox"
-const sandbox = await client.createSandbox("my-sandbox");
+const sandbox = await client.createSandbox(snapshot.id);
 try {
   // Run a command
   const result = await sandbox.run("echo 'Hello, World!'");
@@ -173,7 +184,7 @@ period. During this window you can still reconnect to retrieve output. After the
 TTL expires, the session is cleaned up and `reconnect()` will throw an error.
 
 ```typescript
-const sandbox = await client.createSandbox("my-sandbox");
+const sandbox = await client.createSandbox(snapshot.id);
 try {
   const handle = await sandbox.run("make build", { wait: false });
   const commandId = handle.commandId;
@@ -200,7 +211,7 @@ Set to `-1` for no idle timeout (the command runs indefinitely until explicitly
 killed or it exits on its own).
 
 ```typescript
-const sandbox = await client.createSandbox("my-sandbox");
+const sandbox = await client.createSandbox(snapshot.id);
 try {
   // Start a long-running command with a 30-minute idle timeout
   const handle = await sandbox.run("python server.py", {
@@ -229,7 +240,7 @@ reconnected to later. Set `killOnDisconnect: true` to kill the command
 immediately when the last client disconnects:
 
 ```typescript
-const sandbox = await client.createSandbox("my-sandbox");
+const sandbox = await client.createSandbox(snapshot.id);
 try {
   // Command is killed as soon as the client disconnects
   const handle = await sandbox.run("python server.py", {
@@ -252,7 +263,7 @@ try {
 All lifecycle options can be combined:
 
 ```typescript
-const sandbox = await client.createSandbox("my-sandbox");
+const sandbox = await client.createSandbox(snapshot.id);
 try {
   // Long-running task: 30-min idle timeout, 1-hour session TTL
   const handle = await sandbox.run("python train.py", {
@@ -280,7 +291,7 @@ Set `pty: true` to allocate a pseudo-terminal for the command. This is useful
 for interactive programs and commands that detect terminal capabilities:
 
 ```typescript
-const sandbox = await client.createSandbox("my-sandbox");
+const sandbox = await client.createSandbox(snapshot.id);
 try {
   // Run an interactive Python REPL with PTY
   const handle = await sandbox.run("python", { pty: true, wait: false });
@@ -316,8 +327,7 @@ try {
 Read and write files in the sandbox:
 
 ```typescript
-// Assuming you've created a Python template
-const sandbox = await client.createSandbox("my-python");
+const sandbox = await client.createSandbox(snapshot.id);
 try {
   // Write a file (string content)
   await sandbox.write("/app/script.py", "print('Hello from file!')");
@@ -337,121 +347,58 @@ try {
 }
 ```
 
-## Templates
+## Snapshots
 
-Templates define the container image and resources for sandboxes. **You must create a template before you can create sandboxes.**
+Snapshots are the filesystem images sandboxes boot from. You can build one from
+a Docker image or capture the state of a running sandbox.
 
 ```typescript
-// Create a template (required before creating sandboxes)
-const template = await client.createTemplate("my-python-env", {
-  image: "python:3.12-slim",  // Any Docker image
-  cpu: "1",        // CPU limit (default: "500m")
-  memory: "1Gi",   // Memory limit (default: "512Mi")
+// Build a snapshot from a public Docker image
+const snapshot = await client.createSnapshot(
+  "python",
+  "python:3.12-slim",
+  1_073_741_824, // 1 GiB
+);
+
+// Build from a private registry (use registryId or explicit credentials)
+const privateSnapshot = await client.createSnapshot(
+  "internal-python",
+  "registry.example.com/internal/python:3.12",
+  2_147_483_648,
+  {
+    registryUrl: "https://registry.example.com",
+    registryUsername: "me",
+    registryPassword: process.env.REGISTRY_PASSWORD,
+  },
+);
+
+// Capture the state of a running sandbox for later reuse
+const running = await client.createSandbox(snapshot.id);
+await running.write("/data/prepared.txt", "preloaded");
+const captured = await client.captureSnapshot(running.name, "with-data");
+
+// Boot a new sandbox from the captured snapshot
+const resumed = await client.createSandbox(captured.id);
+
+// List / fetch / delete snapshots
+const snapshots = await client.listSnapshots();
+const loaded = await client.getSnapshot(snapshot.id);
+await client.deleteSnapshot(snapshot.id);
+```
+
+### Sizing and Resources
+
+`createSandbox` accepts optional per-sandbox resource limits. If omitted, the
+server-side defaults are used. `fsCapacityBytes` defaults to the snapshot's
+size.
+
+```typescript
+const sandbox = await client.createSandbox(snapshot.id, {
+  vCpus: 2,
+  memBytes: 2_147_483_648,        // 2 GiB
+  fsCapacityBytes: 5_368_709_120, // 5 GiB
 });
-
-// Now you can create sandboxes from this template
-const sandbox = await client.createSandbox("my-python-env");
-try {
-  const result = await sandbox.run("python --version");
-} finally {
-  await sandbox.delete();
-}
-
-// List all templates
-const templates = await client.listTemplates();
-
-// Get a specific template
-const tmpl = await client.getTemplate("my-python-env");
-
-// Update a template's name
-await client.updateTemplate("my-python-env", { newName: "python-env-v2" });
-
-// Delete a template (fails if sandboxes or pools are using it)
-await client.deleteTemplate("my-python-env");
 ```
-
-### Common Template Images
-
-```typescript
-// Python
-await client.createTemplate("python", { image: "python:3.12-slim" });
-
-// Node.js
-await client.createTemplate("node", { image: "node:20-slim" });
-
-// Ubuntu (general purpose)
-await client.createTemplate("ubuntu", { image: "ubuntu:24.04" });
-```
-
-## Persistent Volumes
-
-Use volumes to persist data across sandbox sessions:
-
-```typescript
-import { SandboxClient } from "langsmith/experimental/sandbox";
-import type { VolumeMountSpec } from "langsmith/experimental/sandbox";
-
-const client = new SandboxClient();
-
-// Create a volume
-const volume = await client.createVolume("my-data", { size: "1Gi" });
-
-// Create a template with the volume mounted
-const volumeMounts: VolumeMountSpec[] = [
-  { volume_name: "my-data", mount_path: "/data" }
-];
-
-const template = await client.createTemplate("stateful-sandbox", {
-  image: "python:3.12-slim",
-  volumeMounts,
-});
-
-// Data written to /data persists across sandbox sessions
-{
-  const sandbox = await client.createSandbox("stateful-sandbox");
-  await sandbox.write("/data/state.txt", "persistent data");
-  await sandbox.delete();
-}
-
-// Later, in a new sandbox...
-{
-  const sandbox = await client.createSandbox("stateful-sandbox");
-  const content = await sandbox.read("/data/state.txt");
-  console.log(new TextDecoder().decode(content));  // "persistent data"
-  await sandbox.delete();
-}
-```
-
-## Pools (Pre-warmed Sandboxes)
-
-Pools pre-provision sandboxes for faster startup:
-
-```typescript
-// First create a template (without volumes - pools don't support volumes)
-await client.createTemplate("fast-python", { image: "python:3.12-slim" });
-
-// Create a pool with 2 warm sandboxes
-const pool = await client.createPool("python-pool", {
-  templateName: "fast-python",
-  replicas: 2,
-});
-
-// Sandboxes from pooled templates start faster
-const sandbox = await client.createSandbox("fast-python");
-try {
-  const result = await sandbox.run("python --version");
-} finally {
-  await sandbox.delete();
-}
-
-// Scale the pool
-await client.updatePool("python-pool", { replicas: 3 });
-
-// Delete the pool
-await client.deletePool("python-pool");
-```
-
-> **Note:** Templates with volume mounts cannot be used in pools.
 
 ## Reusing Existing Sandboxes
 
@@ -459,7 +406,7 @@ Get a sandbox that's already running:
 
 ```typescript
 // Create a sandbox (requires explicit cleanup)
-const sb = await client.createSandbox("my-template");
+const sb = await client.createSandbox(snapshot.id);
 console.log(sb.name);  // e.g., "sandbox-abc123"
 
 // Later, get the same sandbox
@@ -490,12 +437,12 @@ import {
 const client = new SandboxClient();
 
 try {
-  // This will fail if "nonexistent" template doesn't exist
+  // This will fail if the snapshot doesn't exist
   const sandbox = await client.createSandbox("nonexistent");
   await sandbox.delete();
 } catch (e) {
   if (e instanceof LangSmithResourceNotFoundError) {
-    // e.resourceType tells you what wasn't found: "sandbox", "template", "volume", etc.
+    // e.resourceType tells you what wasn't found: "sandbox", "snapshot", "file"
     console.log(`${e.resourceType} not found: ${e.message}`);
   } else if (e instanceof LangSmithResourceTimeoutError) {
     console.log(`Timeout waiting for ${e.resourceType}: ${e.message}`);
@@ -511,25 +458,21 @@ try {
 
 | Method | Description |
 |--------|-------------|
-| `createSandbox(templateName, options?)` | Create a sandbox |
+| `createSandbox(snapshotId, options?)` | Create a sandbox from a snapshot |
 | `getSandbox(name)` | Get an existing sandbox by name |
 | `listSandboxes()` | List all sandboxes |
+| `updateSandbox(name, options)` | Rename or adjust TTLs on a sandbox |
 | `deleteSandbox(name)` | Delete a sandbox |
-| `createTemplate(name, options)` | Create a template |
-| `listTemplates()` | List all templates |
-| `getTemplate(name)` | Get template by name |
-| `updateTemplate(name, options)` | Update a template |
-| `deleteTemplate(name)` | Delete a template |
-| `createVolume(name, options)` | Create a persistent volume |
-| `listVolumes()` | List all volumes |
-| `getVolume(name)` | Get volume by name |
-| `updateVolume(name, options)` | Update a volume |
-| `deleteVolume(name)` | Delete a volume |
-| `createPool(name, options)` | Create a pool |
-| `listPools()` | List all pools |
-| `getPool(name)` | Get pool by name |
-| `updatePool(name, options)` | Update pool (rename or scale) |
-| `deletePool(name)` | Delete a pool |
+| `startSandbox(name, options?)` | Start a stopped sandbox and wait until ready |
+| `stopSandbox(name)` | Stop a running sandbox (preserves files) |
+| `getSandboxStatus(name)` | Lightweight status poll for async creation |
+| `waitForSandbox(name, options?)` | Poll until a sandbox becomes ready |
+| `createSnapshot(name, dockerImage, fsCapacityBytes, options?)` | Build a snapshot from a Docker image |
+| `captureSnapshot(sandboxName, name, options?)` | Capture a snapshot from a running sandbox |
+| `getSnapshot(snapshotId)` | Get a snapshot by ID |
+| `listSnapshots()` | List all snapshots |
+| `deleteSnapshot(snapshotId)` | Delete a snapshot |
+| `waitForSnapshot(snapshotId, options?)` | Poll until a snapshot becomes ready |
 
 ### Sandbox
 
@@ -539,6 +482,9 @@ try {
 | `reconnect(commandId, options?)` | Reconnect to a running command by ID |
 | `write(path, content, timeout?)` | Write file (string or Uint8Array) |
 | `read(path, timeout?)` | Read file (returns Uint8Array) |
+| `start(options?)` | Start this sandbox (if stopped) |
+| `stop()` | Stop this sandbox |
+| `captureSnapshot(name, options?)` | Capture a snapshot from this sandbox |
 | `delete()` | Delete the sandbox |
 
 ### CommandHandle
@@ -577,44 +523,32 @@ try {
 |----------|-------------|
 | `name?` | Custom sandbox name |
 | `timeout?` | Wait timeout in seconds |
+| `waitForReady?` | Wait for the sandbox to be ready before returning (default: `true`) |
+| `ttlSeconds?` | Maximum lifetime in seconds (multiple of 60; `0` disables) |
+| `idleTtlSeconds?` | Idle timeout in seconds (multiple of 60; `0` disables) |
+| `vCpus?` | Number of vCPUs |
+| `memBytes?` | Memory allocation in bytes |
+| `fsCapacityBytes?` | Root filesystem capacity in bytes |
+| `proxyConfig?` | Per-sandbox proxy configuration (access control, rules, `no_proxy`) |
 
-### CreateVolumeOptions
+### CreateSnapshotOptions
 
 | Property | Description |
 |----------|-------------|
-| `size` | Storage size (e.g., "1Gi") |
+| `registryId?` | Private registry ID |
+| `registryUrl?` | Registry URL for private images |
+| `registryUsername?` | Registry username |
+| `registryPassword?` | Registry password |
 | `timeout?` | Wait timeout in seconds (default: 60) |
+| `signal?` | `AbortSignal` for cancellation |
 
-### CreateTemplateOptions
-
-| Property | Description |
-|----------|-------------|
-| `image` | Container image (e.g., "python:3.12-slim") |
-| `cpu?` | CPU limit (default: "500m") |
-| `memory?` | Memory limit (default: "512Mi") |
-| `storage?` | Storage size |
-| `volumeMounts?` | Array of volume mount specs |
-
-### UpdateTemplateOptions
+### UpdateSandboxOptions
 
 | Property | Description |
 |----------|-------------|
-| `newName?` | New template name |
-
-### CreatePoolOptions
-
-| Property | Description |
-|----------|-------------|
-| `templateName` | Template to use for sandboxes |
-| `replicas` | Number of pre-warmed sandboxes (1-100) |
-| `timeout?` | Wait timeout in seconds (default: 30) |
-
-### UpdatePoolOptions
-
-| Property | Description |
-|----------|-------------|
-| `newName?` | New pool name |
-| `replicas?` | New replica count |
+| `newName?` | New display name |
+| `ttlSeconds?` | Maximum lifetime in seconds (multiple of 60; `0` disables) |
+| `idleTtlSeconds?` | Idle timeout in seconds (multiple of 60; `0` disables) |
 
 ### RunOptions
 

--- a/js/src/experimental/sandbox/client.ts
+++ b/js/src/experimental/sandbox/client.ts
@@ -7,23 +7,14 @@ import { _getFetchImplementation } from "../../singletons/fetch.js";
 import { AsyncCaller } from "../../utils/async_caller.js";
 import type {
   CaptureSnapshotOptions,
-  CreatePoolOptions,
   CreateSandboxOptions,
   CreateSnapshotOptions,
-  CreateTemplateOptions,
-  CreateVolumeOptions,
-  Pool,
   ResourceStatus,
   SandboxClientConfig,
   SandboxData,
-  SandboxTemplate,
   Snapshot,
   StartSandboxOptions,
-  UpdatePoolOptions,
   UpdateSandboxOptions,
-  UpdateTemplateOptions,
-  UpdateVolumeOptions,
-  Volume,
   WaitForSandboxOptions,
   WaitForSnapshotOptions,
 } from "./types.js";
@@ -37,11 +28,7 @@ import {
 } from "./errors.js";
 import {
   handleClientHttpError,
-  handleConflictError,
-  handlePoolError,
-  handleResourceInUseError,
   handleSandboxCreationError,
-  handleVolumeCreationError,
   validateTtl,
 } from "./helpers.js";
 
@@ -89,7 +76,7 @@ function getDefaultApiKey(): string | undefined {
 /**
  * Client for interacting with the Sandbox Server API.
  *
- * This client provides a simple interface for managing sandboxes and templates.
+ * This client provides a simple interface for managing sandboxes and snapshots.
  *
  * @example
  * ```typescript
@@ -104,8 +91,13 @@ function getDefaultApiKey(): string | undefined {
  *   apiKey: "your-api-key",
  * });
  *
- * // Create a sandbox and run commands
- * const sandbox = await client.createSandbox("python-sandbox");
+ * // Build a snapshot, then create a sandbox from it
+ * const snapshot = await client.createSnapshot(
+ *   "python",
+ *   "python:3.12-slim",
+ *   1_073_741_824 // 1 GiB
+ * );
+ * const sandbox = await client.createSandbox(snapshot.id);
  * try {
  *   const result = await sandbox.run("python --version");
  *   console.log(result.stdout);
@@ -189,531 +181,16 @@ export class SandboxClient {
   }
 
   // =========================================================================
-  // Volume Operations
-  // =========================================================================
-
-  /**
-   * Create a new persistent volume.
-   *
-   * Creates a persistent storage volume that can be referenced in templates.
-   *
-   * @param name - Volume name.
-   * @param options - Creation options including size and optional timeout.
-   * @returns Created Volume.
-   * @throws SandboxCreationError if volume provisioning fails.
-   * @throws ResourceTimeoutError if volume doesn't become ready within timeout.
-   */
-  async createVolume(
-    name: string,
-    options: CreateVolumeOptions
-  ): Promise<Volume> {
-    const { size, timeout = 60 } = options;
-    const url = `${this._baseUrl}/volumes`;
-    const payload = {
-      name,
-      size,
-      wait_for_ready: true,
-      timeout,
-    };
-
-    const response = await this._fetch(url, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(payload),
-      signal: AbortSignal.timeout((timeout + 30) * 1000),
-    });
-
-    if (!response.ok) {
-      await handleVolumeCreationError(response);
-    }
-
-    return (await response.json()) as Volume;
-  }
-
-  /**
-   * Get a volume by name.
-   *
-   * @param name - Volume name.
-   * @returns Volume.
-   * @throws LangSmithResourceNotFoundError if volume not found.
-   */
-  async getVolume(name: string): Promise<Volume> {
-    const url = `${this._baseUrl}/volumes/${encodeURIComponent(name)}`;
-
-    const response = await this._fetch(url);
-
-    if (!response.ok) {
-      if (response.status === 404) {
-        throw new LangSmithResourceNotFoundError(
-          `Volume '${name}' not found`,
-          "volume"
-        );
-      }
-      await handleClientHttpError(response);
-    }
-
-    return (await response.json()) as Volume;
-  }
-
-  /**
-   * List all volumes.
-   *
-   * @returns List of Volumes.
-   */
-  async listVolumes(): Promise<Volume[]> {
-    const url = `${this._baseUrl}/volumes`;
-
-    const response = await this._fetch(url);
-
-    if (!response.ok) {
-      if (response.status === 404) {
-        throw new LangSmithSandboxAPIError(
-          `API endpoint not found: ${url}. Check that apiEndpoint is correct.`
-        );
-      }
-      await handleClientHttpError(response);
-    }
-
-    const data = await response.json();
-    return (data.volumes ?? []) as Volume[];
-  }
-
-  /**
-   * Delete a volume.
-   *
-   * @param name - Volume name.
-   * @throws LangSmithResourceNotFoundError if volume not found.
-   * @throws ResourceInUseError if volume is referenced by templates.
-   */
-  async deleteVolume(name: string): Promise<void> {
-    const url = `${this._baseUrl}/volumes/${encodeURIComponent(name)}`;
-
-    const response = await this._fetch(url, { method: "DELETE" });
-
-    if (!response.ok) {
-      if (response.status === 404) {
-        throw new LangSmithResourceNotFoundError(
-          `Volume '${name}' not found`,
-          "volume"
-        );
-      }
-      if (response.status === 409) {
-        await handleResourceInUseError(response, "volume");
-      }
-      await handleClientHttpError(response);
-    }
-  }
-
-  /**
-   * Update a volume's name and/or size.
-   *
-   * You can update the display name, size, or both in a single request.
-   * Only storage size increases are allowed (storage backend limitation).
-   *
-   * @param name - Current volume name.
-   * @param options - Update options.
-   * @returns Updated Volume.
-   * @throws LangSmithResourceNotFoundError if volume not found.
-   * @throws ValidationError if storage decrease attempted.
-   * @throws LangSmithResourceNameConflictError if newName is already in use.
-   */
-  async updateVolume(
-    name: string,
-    options: UpdateVolumeOptions
-  ): Promise<Volume> {
-    const { newName, size } = options;
-
-    if (newName === undefined && size === undefined) {
-      // Nothing to update, just return the current volume
-      return this.getVolume(name);
-    }
-
-    const url = `${this._baseUrl}/volumes/${encodeURIComponent(name)}`;
-    const payload: Record<string, unknown> = {};
-    if (newName !== undefined) {
-      payload.name = newName;
-    }
-    if (size !== undefined) {
-      payload.size = size;
-    }
-
-    const response = await this._fetch(url, {
-      method: "PATCH",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(payload),
-    });
-
-    if (!response.ok) {
-      if (response.status === 404) {
-        throw new LangSmithResourceNotFoundError(
-          `Volume '${name}' not found`,
-          "volume"
-        );
-      }
-      if (response.status === 409) {
-        await handleConflictError(response, "volume");
-      }
-      await handleClientHttpError(response);
-    }
-
-    return (await response.json()) as Volume;
-  }
-
-  // =========================================================================
-  // Template Operations
-  // =========================================================================
-
-  /**
-   * Create a new SandboxTemplate.
-   *
-   * Only the container image, resource limits, and volume mounts can be
-   * configured. All other container details are handled by the server.
-   *
-   * @param name - Template name.
-   * @param options - Creation options including image and resource limits.
-   * @returns Created SandboxTemplate.
-   */
-  async createTemplate(
-    name: string,
-    options: CreateTemplateOptions
-  ): Promise<SandboxTemplate> {
-    const {
-      image,
-      cpu = "500m",
-      memory = "512Mi",
-      storage,
-      volumeMounts,
-    } = options;
-    const url = `${this._baseUrl}/templates`;
-
-    const payload: Record<string, unknown> = {
-      name,
-      image,
-      resources: {
-        cpu,
-        memory,
-      },
-    };
-    if (storage) {
-      (payload.resources as Record<string, unknown>).storage = storage;
-    }
-    if (volumeMounts && volumeMounts.length > 0) {
-      payload.volume_mounts = volumeMounts.map((vm) => ({
-        volume_name: vm.volume_name,
-        mount_path: vm.mount_path,
-      }));
-    }
-
-    const response = await this._fetch(url, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(payload),
-    });
-
-    if (!response.ok) {
-      await handleClientHttpError(response);
-    }
-
-    return (await response.json()) as SandboxTemplate;
-  }
-
-  /**
-   * Get a SandboxTemplate by name.
-   *
-   * @param name - Template name.
-   * @returns SandboxTemplate.
-   * @throws LangSmithResourceNotFoundError if template not found.
-   */
-  async getTemplate(name: string): Promise<SandboxTemplate> {
-    const url = `${this._baseUrl}/templates/${encodeURIComponent(name)}`;
-
-    const response = await this._fetch(url);
-
-    if (!response.ok) {
-      if (response.status === 404) {
-        throw new LangSmithResourceNotFoundError(
-          `Template '${name}' not found`,
-          "template"
-        );
-      }
-      await handleClientHttpError(response);
-    }
-
-    return (await response.json()) as SandboxTemplate;
-  }
-
-  /**
-   * List all SandboxTemplates.
-   *
-   * @returns List of SandboxTemplates.
-   */
-  async listTemplates(): Promise<SandboxTemplate[]> {
-    const url = `${this._baseUrl}/templates`;
-
-    const response = await this._fetch(url);
-
-    if (!response.ok) {
-      if (response.status === 404) {
-        throw new LangSmithSandboxAPIError(
-          `API endpoint not found: ${url}. Check that apiEndpoint is correct.`
-        );
-      }
-      await handleClientHttpError(response);
-    }
-
-    const data = await response.json();
-    return (data.templates ?? []) as SandboxTemplate[];
-  }
-
-  /**
-   * Update a template.
-   *
-   * @param name - Current template name.
-   * @param options - Update options (e.g., newName).
-   * @returns Updated SandboxTemplate.
-   * @throws LangSmithResourceNotFoundError if template not found.
-   * @throws LangSmithResourceNameConflictError if newName is already in use.
-   */
-  async updateTemplate(
-    name: string,
-    options: UpdateTemplateOptions
-  ): Promise<SandboxTemplate> {
-    const { newName } = options;
-
-    if (newName === undefined) {
-      // Nothing to update, just return the current template
-      return this.getTemplate(name);
-    }
-
-    const url = `${this._baseUrl}/templates/${encodeURIComponent(name)}`;
-    const payload = { name: newName };
-
-    const response = await this._fetch(url, {
-      method: "PATCH",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(payload),
-    });
-
-    if (!response.ok) {
-      if (response.status === 404) {
-        throw new LangSmithResourceNotFoundError(
-          `Template '${name}' not found`,
-          "template"
-        );
-      }
-      if (response.status === 409) {
-        await handleConflictError(response, "template");
-      }
-      await handleClientHttpError(response);
-    }
-
-    return (await response.json()) as SandboxTemplate;
-  }
-
-  /**
-   * Delete a SandboxTemplate.
-   *
-   * @param name - Template name.
-   * @throws LangSmithResourceNotFoundError if template not found.
-   * @throws ResourceInUseError if template is referenced by sandboxes or pools.
-   */
-  async deleteTemplate(name: string): Promise<void> {
-    const url = `${this._baseUrl}/templates/${encodeURIComponent(name)}`;
-
-    const response = await this._fetch(url, { method: "DELETE" });
-
-    if (!response.ok) {
-      if (response.status === 404) {
-        throw new LangSmithResourceNotFoundError(
-          `Template '${name}' not found`,
-          "template"
-        );
-      }
-      if (response.status === 409) {
-        await handleResourceInUseError(response, "template");
-      }
-      await handleClientHttpError(response);
-    }
-  }
-
-  // =========================================================================
-  // Pool Operations
-  // =========================================================================
-
-  /**
-   * Create a new Sandbox Pool.
-   *
-   * Pools pre-provision sandboxes from a template for faster startup.
-   *
-   * @param name - Pool name (lowercase letters, numbers, hyphens; max 63 chars).
-   * @param options - Creation options including templateName, replicas, and optional timeout.
-   * @returns Created Pool.
-   * @throws LangSmithResourceNotFoundError if template not found.
-   * @throws ValidationError if template has volumes attached.
-   * @throws ResourceAlreadyExistsError if pool with this name already exists.
-   * @throws ResourceTimeoutError if pool doesn't reach ready state within timeout.
-   * @throws QuotaExceededError if organization quota is exceeded.
-   */
-  async createPool(name: string, options: CreatePoolOptions): Promise<Pool> {
-    const { templateName, replicas, timeout = 30 } = options;
-    const url = `${this._baseUrl}/pools`;
-    const payload = {
-      name,
-      template_name: templateName,
-      replicas,
-      wait_for_ready: true,
-      timeout,
-    };
-
-    const response = await this._fetch(url, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(payload),
-      signal: AbortSignal.timeout((timeout + 30) * 1000),
-    });
-
-    if (!response.ok) {
-      await handlePoolError(response);
-    }
-
-    return (await response.json()) as Pool;
-  }
-
-  /**
-   * Get a Pool by name.
-   *
-   * @param name - Pool name.
-   * @returns Pool.
-   * @throws LangSmithResourceNotFoundError if pool not found.
-   */
-  async getPool(name: string): Promise<Pool> {
-    const url = `${this._baseUrl}/pools/${encodeURIComponent(name)}`;
-
-    const response = await this._fetch(url);
-
-    if (!response.ok) {
-      if (response.status === 404) {
-        throw new LangSmithResourceNotFoundError(
-          `Pool '${name}' not found`,
-          "pool"
-        );
-      }
-      await handleClientHttpError(response);
-    }
-
-    return (await response.json()) as Pool;
-  }
-
-  /**
-   * List all Pools.
-   *
-   * @returns List of Pools.
-   */
-  async listPools(): Promise<Pool[]> {
-    const url = `${this._baseUrl}/pools`;
-
-    const response = await this._fetch(url);
-
-    if (!response.ok) {
-      if (response.status === 404) {
-        throw new LangSmithSandboxAPIError(
-          `API endpoint not found: ${url}. Check that apiEndpoint is correct.`
-        );
-      }
-      await handleClientHttpError(response);
-    }
-
-    const data = await response.json();
-    return (data.pools ?? []) as Pool[];
-  }
-
-  /**
-   * Update a Pool's name and/or replica count.
-   *
-   * You can update the display name, replica count, or both.
-   * The template reference cannot be changed after creation.
-   *
-   * @param name - Current pool name.
-   * @param options - Update options.
-   * @returns Updated Pool.
-   * @throws LangSmithResourceNotFoundError if pool not found.
-   * @throws ValidationError if template was deleted.
-   * @throws LangSmithResourceNameConflictError if newName is already in use.
-   * @throws QuotaExceededError if quota exceeded when scaling up.
-   */
-  async updatePool(name: string, options: UpdatePoolOptions): Promise<Pool> {
-    const { newName, replicas } = options;
-
-    if (newName === undefined && replicas === undefined) {
-      // Nothing to update, just return the current pool
-      return this.getPool(name);
-    }
-
-    const url = `${this._baseUrl}/pools/${encodeURIComponent(name)}`;
-    const payload: Record<string, unknown> = {};
-    if (newName !== undefined) {
-      payload.name = newName;
-    }
-    if (replicas !== undefined) {
-      payload.replicas = replicas;
-    }
-
-    const response = await this._fetch(url, {
-      method: "PATCH",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(payload),
-    });
-
-    if (!response.ok) {
-      if (response.status === 404) {
-        throw new LangSmithResourceNotFoundError(
-          `Pool '${name}' not found`,
-          "pool"
-        );
-      }
-      if (response.status === 409) {
-        await handleConflictError(response, "pool");
-      }
-      await handlePoolError(response);
-    }
-
-    return (await response.json()) as Pool;
-  }
-
-  /**
-   * Delete a Pool.
-   *
-   * This will terminate all sandboxes in the pool.
-   *
-   * @param name - Pool name.
-   * @throws LangSmithResourceNotFoundError if pool not found.
-   */
-  async deletePool(name: string): Promise<void> {
-    const url = `${this._baseUrl}/pools/${encodeURIComponent(name)}`;
-
-    const response = await this._fetch(url, { method: "DELETE" });
-
-    if (!response.ok) {
-      if (response.status === 404) {
-        throw new LangSmithResourceNotFoundError(
-          `Pool '${name}' not found`,
-          "pool"
-        );
-      }
-      await handleClientHttpError(response);
-    }
-  }
-
-  // =========================================================================
   // Sandbox Operations
   // =========================================================================
 
   /**
-   * Create a new Sandbox.
+   * Create a new Sandbox from a snapshot.
    *
    * Remember to call `sandbox.delete()` when done to clean up resources.
    *
-   * @param templateName - Name of the SandboxTemplate to use.
+   * @param snapshotId - ID of the snapshot to boot from. Create one with
+   *   `createSnapshot()` or `captureSnapshot()`, or pass an existing snapshot ID.
    * @param options - Creation options.
    * @returns Created Sandbox.
    * @throws ResourceTimeoutError if timeout waiting for sandbox to be ready.
@@ -722,7 +199,12 @@ export class SandboxClient {
    *
    * @example
    * ```typescript
-   * const sandbox = await client.createSandbox("python-sandbox");
+   * const snapshot = await client.createSnapshot(
+   *   "python",
+   *   "python:3.12-slim",
+   *   1_073_741_824
+   * );
+   * const sandbox = await client.createSandbox(snapshot.id);
    * try {
    *   const result = await sandbox.run("echo hello");
    *   console.log(result.stdout);
@@ -732,11 +214,10 @@ export class SandboxClient {
    * ```
    */
   async createSandbox(
-    templateName?: string,
+    snapshotId: string,
     options: CreateSandboxOptions = {}
   ): Promise<Sandbox> {
     const {
-      snapshotId,
       name,
       timeout = 30,
       waitForReady = true,
@@ -748,27 +229,15 @@ export class SandboxClient {
       proxyConfig,
     } = options;
 
-    if (!templateName && !snapshotId) {
-      throw new Error("Either templateName or snapshotId is required");
-    }
-    if (templateName && snapshotId) {
-      throw new Error("Cannot specify both templateName and snapshotId");
-    }
-
     validateTtl(ttlSeconds, "ttlSeconds");
     validateTtl(idleTtlSeconds, "idleTtlSeconds");
 
     const url = `${this._baseUrl}/boxes`;
 
     const payload: Record<string, unknown> = {
+      snapshot_id: snapshotId,
       wait_for_ready: waitForReady,
     };
-    if (templateName) {
-      payload.template_name = templateName;
-    }
-    if (snapshotId) {
-      payload.snapshot_id = snapshotId;
-    }
     if (waitForReady) {
       payload.timeout = timeout;
     }
@@ -1017,7 +486,7 @@ export class SandboxClient {
    *
    * @example
    * ```typescript
-   * const sandbox = await client.createSandbox("python-sandbox", { waitForReady: false });
+   * const sandbox = await client.createSandbox(snapshot.id, { waitForReady: false });
    * // ... do other work ...
    * const readySandbox = await client.waitForSandbox(sandbox.name);
    * ```

--- a/js/src/experimental/sandbox/client.ts
+++ b/js/src/experimental/sandbox/client.ts
@@ -621,7 +621,7 @@ export class SandboxClient {
    *
    * @param sandboxName - Name of the sandbox to capture from.
    * @param name - Snapshot name.
-   * @param options - Capture options (checkpoint, timeout).
+   * @param options - Capture options (timeout).
    * @returns Snapshot in "ready" status.
    */
   async captureSnapshot(
@@ -629,15 +629,12 @@ export class SandboxClient {
     name: string,
     options: CaptureSnapshotOptions = {}
   ): Promise<Snapshot> {
-    const { checkpoint, timeout = 60, signal } = options;
+    const { timeout = 60, signal } = options;
     const url = `${this._baseUrl}/boxes/${encodeURIComponent(
       sandboxName
     )}/snapshot`;
 
     const payload: Record<string, unknown> = { name };
-    if (checkpoint !== undefined) {
-      payload.checkpoint = checkpoint;
-    }
 
     const response = await this._postJson(url, payload, { signal });
     const snapshot = (await response.json()) as Snapshot;

--- a/js/src/experimental/sandbox/errors.ts
+++ b/js/src/experimental/sandbox/errors.ts
@@ -142,7 +142,6 @@ export class LangSmithResourceNameConflictError extends LangSmithSandboxError {
  * - Resource values exceeding server-defined limits (CPU, memory, storage)
  * - Invalid resource units
  * - Invalid name formats
- * - Pool validation failures (e.g., template has volumes)
  */
 export class LangSmithValidationError extends LangSmithSandboxError {
   field?: string;
@@ -187,7 +186,7 @@ export class LangSmithQuotaExceededError extends LangSmithSandboxError {
  */
 export class LangSmithResourceCreationError extends LangSmithSandboxError {
   /**
-   * Type of resource that failed (e.g., "sandbox", "volume").
+   * Type of resource that failed (e.g., "sandbox", "snapshot").
    */
   resourceType?: string;
   /**

--- a/js/src/experimental/sandbox/helpers.ts
+++ b/js/src/experimental/sandbox/helpers.ts
@@ -7,9 +7,6 @@
 
 import {
   LangSmithQuotaExceededError,
-  LangSmithResourceAlreadyExistsError,
-  LangSmithResourceInUseError,
-  LangSmithResourceNameConflictError,
   LangSmithResourceNotFoundError,
   LangSmithResourceTimeoutError,
   LangSmithSandboxAPIError,
@@ -154,13 +151,6 @@ export function extractQuotaType(message: string): string | undefined {
     return "cpu";
   } else if (messageLower.includes("memory")) {
     return "memory";
-  }
-  // Check for volume count quota
-  else if (
-    messageLower.includes("volume") &&
-    (messageLower.includes("count") || messageLower.includes("limit"))
-  ) {
-    return "volume_count";
   } else if (messageLower.includes("storage")) {
     return "storage";
   }
@@ -212,80 +202,6 @@ export async function handleSandboxCreationError(
       data.message,
       data.errorType || "Unschedulable"
     );
-  }
-  // Fall through to generic handling
-  return handleClientHttpError(response);
-}
-
-/**
- * Handle HTTP errors specific to volume creation.
- *
- * Maps API error responses to specific exception types:
- * - 429: LangSmithQuotaExceededError (org limits exceeded)
- * - 503: LangSmithSandboxCreationError (provisioning failed)
- * - 504: LangSmithResourceTimeoutError (volume didn't become ready in time)
- * - Other: Falls through to generic error handling
- */
-export async function handleVolumeCreationError(
-  response: Response
-): Promise<never> {
-  const status = response.status;
-  const data = await parseErrorResponse(response);
-
-  if (status === 429) {
-    // Organization quota exceeded - extract type or default to volume_count
-    const quotaType = extractQuotaType(data.message) ?? "unknown";
-    throw new LangSmithQuotaExceededError(data.message, quotaType);
-  } else if (status === 503) {
-    // Provisioning failed (invalid storage class, quota exceeded)
-    throw new LangSmithSandboxCreationError(data.message, "VolumeProvisioning");
-  } else if (status === 504) {
-    // Timeout - volume didn't become ready in time
-    throw new LangSmithResourceTimeoutError(data.message, "volume");
-  }
-  // Fall through to generic handling
-  return handleClientHttpError(response);
-}
-
-/**
- * Handle HTTP errors specific to pool creation/update.
- *
- * Maps API error responses to specific exception types:
- * - 400: LangSmithResourceNotFoundError or LangSmithValidationError (template has volumes)
- * - 409: LangSmithResourceAlreadyExistsError
- * - 429: LangSmithQuotaExceededError (org limits exceeded)
- * - 504: LangSmithResourceTimeoutError (timeout waiting for ready replicas)
- * - Other: Falls through to generic error handling
- */
-export async function handlePoolError(response: Response): Promise<never> {
-  const status = response.status;
-  const data = await parseErrorResponse(response);
-  const errorType = data.errorType;
-
-  if (status === 400) {
-    // Check the error type to determine the specific exception
-    if (errorType === "TemplateNotFound") {
-      throw new LangSmithResourceNotFoundError(data.message, "template");
-    } else if (errorType === "LangSmithValidationError") {
-      // Template has volumes attached
-      throw new LangSmithValidationError(
-        data.message,
-        undefined,
-        undefined,
-        errorType
-      );
-    }
-    // Generic bad request - fall through to generic handling
-  } else if (status === 409) {
-    // Pool already exists
-    throw new LangSmithResourceAlreadyExistsError(data.message, "pool");
-  } else if (status === 429) {
-    // Organization quota exceeded - extract type or default to pool_count
-    const quotaType = extractQuotaType(data.message) ?? "unknown";
-    throw new LangSmithQuotaExceededError(data.message, quotaType);
-  } else if (status === 504) {
-    // Timeout waiting for pool to be ready
-    throw new LangSmithResourceTimeoutError(data.message, "pool");
   }
   // Fall through to generic handling
   return handleClientHttpError(response);
@@ -390,26 +306,4 @@ export async function handleSandboxHttpError(
   }
 
   throw new LangSmithSandboxError(message);
-}
-
-/**
- * Handle 409 Conflict errors for resource name conflicts.
- */
-export async function handleConflictError(
-  response: Response,
-  resourceType: string
-): Promise<never> {
-  const data = await parseErrorResponse(response);
-  throw new LangSmithResourceNameConflictError(data.message, resourceType);
-}
-
-/**
- * Handle 409 Conflict errors for resources in use.
- */
-export async function handleResourceInUseError(
-  response: Response,
-  resourceType: string
-): Promise<never> {
-  const data = await parseErrorResponse(response);
-  throw new LangSmithResourceInUseError(data.message, resourceType);
 }

--- a/js/src/experimental/sandbox/index.ts
+++ b/js/src/experimental/sandbox/index.ts
@@ -11,7 +11,12 @@
  * // Uses LANGSMITH_ENDPOINT and LANGSMITH_API_KEY from environment
  * const client = new SandboxClient();
  *
- * const sandbox = await client.createSandbox("python-sandbox");
+ * const snapshot = await client.createSnapshot(
+ *   "python",
+ *   "python:3.12-slim",
+ *   1_073_741_824
+ * );
+ * const sandbox = await client.createSandbox(snapshot.id);
  * try {
  *   const result = await sandbox.run("python --version");
  *   console.log(result.stdout);
@@ -34,13 +39,8 @@ export type {
   OutputChunk,
   WsMessage,
   WsRunOptions,
-  ResourceSpec,
   ResourceStatus,
   Snapshot,
-  VolumeMountSpec,
-  Volume,
-  SandboxTemplate,
-  Pool,
   SandboxData,
   SandboxClientConfig,
   RunOptions,
@@ -53,12 +53,6 @@ export type {
   StartSandboxOptions,
   UpdateSandboxOptions,
   WaitForSandboxOptions,
-  CreateVolumeOptions,
-  CreateTemplateOptions,
-  UpdateTemplateOptions,
-  CreatePoolOptions,
-  UpdateVolumeOptions,
-  UpdatePoolOptions,
 } from "./types.js";
 
 // Errors

--- a/js/src/experimental/sandbox/sandbox.ts
+++ b/js/src/experimental/sandbox/sandbox.ts
@@ -455,7 +455,7 @@ export class Sandbox {
    * Capture a snapshot from this sandbox.
    *
    * @param name - Snapshot name.
-   * @param options - Capture options (checkpoint, timeout).
+   * @param options - Capture options (timeout).
    * @returns Snapshot in "ready" status.
    */
   async captureSnapshot(

--- a/js/src/experimental/sandbox/sandbox.ts
+++ b/js/src/experimental/sandbox/sandbox.ts
@@ -28,7 +28,7 @@ import { reconnectWsStream, runWsStream } from "./ws_execute.js";
  *
  * @example
  * ```typescript
- * const sandbox = await client.createSandbox("python-sandbox");
+ * const sandbox = await client.createSandbox(snapshot.id);
  * try {
  *   const result = await sandbox.run("python --version");
  *   console.log(result.stdout);
@@ -42,8 +42,6 @@ import { reconnectWsStream, runWsStream } from "./ws_execute.js";
 export class Sandbox {
   /** Display name (can be updated). */
   readonly name: string;
-  /** Name of the template used to create this sandbox. */
-  readonly template_name?: string;
   /** URL for data plane operations (file I/O, command execution). */
   dataplane_url?: string;
   /** Provisioning status ("provisioning", "ready", "failed", "stopped"). */
@@ -76,7 +74,6 @@ export class Sandbox {
   /** @internal */
   constructor(data: SandboxData, client: SandboxClient) {
     this.name = data.name;
-    this.template_name = data.template_name;
     this.dataplane_url = data.dataplane_url;
     this.status = data.status;
     this.status_message = data.status_message;
@@ -420,7 +417,7 @@ export class Sandbox {
    *
    * @example
    * ```typescript
-   * const sandbox = await client.createSandbox("python-sandbox");
+   * const sandbox = await client.createSandbox(snapshot.id);
    * try {
    *   await sandbox.run("echo hello");
    * } finally {

--- a/js/src/experimental/sandbox/types.ts
+++ b/js/src/experimental/sandbox/types.ts
@@ -14,64 +14,6 @@ export interface ExecutionResult {
 }
 
 /**
- * Resource specification for a sandbox.
- */
-export interface ResourceSpec {
-  cpu?: string;
-  memory?: string;
-  storage?: string;
-}
-
-/**
- * Specification for mounting a volume in a sandbox template.
- */
-export interface VolumeMountSpec {
-  volume_name: string;
-  mount_path: string;
-}
-
-/**
- * Represents a persistent volume.
- */
-export interface Volume {
-  id?: string;
-  name: string;
-  size: string;
-  storage_class: string;
-  created_at?: string;
-  updated_at?: string;
-}
-
-/**
- * Represents a SandboxTemplate.
- *
- * Templates define the image, resource limits, and volume mounts for sandboxes.
- */
-export interface SandboxTemplate {
-  id?: string;
-  name: string;
-  image: string;
-  resources: ResourceSpec;
-  volume_mounts?: VolumeMountSpec[];
-  created_at?: string;
-  updated_at?: string;
-}
-
-/**
- * Represents a Sandbox Pool for pre-provisioned sandboxes.
- *
- * Pools pre-provision sandboxes from a template for faster startup.
- */
-export interface Pool {
-  id?: string;
-  name: string;
-  template_name: string;
-  replicas: number;
-  created_at?: string;
-  updated_at?: string;
-}
-
-/**
  * Lightweight provisioning status for any async-created resource.
  */
 export interface ResourceStatus {
@@ -110,7 +52,6 @@ export interface Snapshot {
 export interface SandboxData {
   id?: string;
   name: string;
-  template_name?: string;
   dataplane_url?: string;
   status?: string;
   status_message?: string;
@@ -314,11 +255,6 @@ export interface SandboxProxyConfig {
  */
 export interface CreateSandboxOptions {
   /**
-   * Snapshot ID to boot from.
-   * Mutually exclusive with the `templateName` positional arg.
-   */
-  snapshotId?: string;
-  /**
    * Optional sandbox name (auto-generated if not provided).
    */
   name?: string;
@@ -443,100 +379,4 @@ export interface WaitForSandboxOptions {
   pollInterval?: number;
   /** AbortSignal for cancellation. */
   signal?: AbortSignal;
-}
-
-/**
- * Options for creating a volume.
- */
-export interface CreateVolumeOptions {
-  /**
-   * Storage size (e.g., "1Gi", "10Gi").
-   */
-  size: string;
-  /**
-   * Timeout in seconds when waiting for volume to be ready. Default: 60.
-   */
-  timeout?: number;
-}
-
-/**
- * Options for creating a template.
- */
-export interface CreateTemplateOptions {
-  /**
-   * Container image (e.g., "python:3.12-slim", "node:20-slim").
-   */
-  image: string;
-  /**
-   * CPU limit (e.g., "500m", "1", "2"). Default: "500m".
-   */
-  cpu?: string;
-  /**
-   * Memory limit (e.g., "256Mi", "1Gi"). Default: "512Mi".
-   */
-  memory?: string;
-  /**
-   * Ephemeral storage limit (e.g., "1Gi"). Optional.
-   */
-  storage?: string;
-  /**
-   * List of volumes to mount in the sandbox. Optional.
-   */
-  volumeMounts?: VolumeMountSpec[];
-}
-
-/**
- * Options for updating a template.
- */
-export interface UpdateTemplateOptions {
-  /**
-   * New display name (optional).
-   */
-  newName?: string;
-}
-
-/**
- * Options for creating a pool.
- */
-export interface CreatePoolOptions {
-  /**
-   * Name of the template to use for sandboxes in this pool.
-   */
-  templateName: string;
-  /**
-   * Number of pre-warmed sandboxes to maintain (0-100).
-   */
-  replicas: number;
-  /**
-   * Timeout in seconds when waiting for pool to be ready. Default: 30.
-   */
-  timeout?: number;
-}
-
-/**
- * Options for updating a volume.
- */
-export interface UpdateVolumeOptions {
-  /**
-   * New display name (optional).
-   */
-  newName?: string;
-  /**
-   * New storage size (must be >= current size). Optional.
-   */
-  size?: string;
-}
-
-/**
- * Options for updating a pool.
- */
-export interface UpdatePoolOptions {
-  /**
-   * New display name (optional).
-   */
-  newName?: string;
-  /**
-   * New number of replicas (0-100). Set to 0 to pause.
-   */
-  replicas?: number;
 }

--- a/js/src/experimental/sandbox/types.ts
+++ b/js/src/experimental/sandbox/types.ts
@@ -316,8 +316,6 @@ export interface CreateSnapshotOptions {
  * Options for capturing a snapshot from a running sandbox.
  */
 export interface CaptureSnapshotOptions {
-  /** Checkpoint timestamp to use. If omitted, creates a fresh checkpoint. */
-  checkpoint?: string;
   /** Timeout in seconds when waiting for ready. Default: 60. */
   timeout?: number;
   /** AbortSignal for cancellation. */

--- a/js/src/tests/sandbox.test.ts
+++ b/js/src/tests/sandbox.test.ts
@@ -67,7 +67,6 @@ describe("Sandbox", () => {
         {
           id: "sandbox-123",
           name: "test-sandbox",
-          template_name: "python-sandbox",
           // No dataplane_url
         },
         createMockClient(),
@@ -95,7 +94,6 @@ describe("Sandbox", () => {
         {
           id: "sandbox-123",
           name: "test-sandbox",
-          template_name: "python-sandbox",
           dataplane_url: "https://dataplane.example.com",
         },
         mockClient,
@@ -126,7 +124,6 @@ describe("Sandbox", () => {
         {
           id: "sandbox-123",
           name: "test-sandbox",
-          template_name: "python-sandbox",
           dataplane_url: "https://dataplane.example.com",
         },
         mockClient,
@@ -158,7 +155,6 @@ describe("Sandbox", () => {
         {
           id: "sandbox-123",
           name: "test-sandbox",
-          template_name: "python-sandbox",
           dataplane_url: "https://dataplane.example.com",
         },
         mockClient,
@@ -184,7 +180,6 @@ describe("Sandbox", () => {
         {
           id: "sandbox-123",
           name: "test-sandbox",
-          template_name: "python-sandbox",
           dataplane_url: "https://dataplane.example.com",
         },
         mockClient,
@@ -212,7 +207,6 @@ describe("Sandbox", () => {
         {
           id: "sandbox-123",
           name: "test-sandbox",
-          template_name: "python-sandbox",
           dataplane_url: "https://dataplane.example.com",
         },
         mockClient,
@@ -240,7 +234,6 @@ describe("Sandbox", () => {
         {
           id: "sandbox-123",
           name: "test-sandbox",
-          template_name: "python-sandbox",
           dataplane_url: "https://dataplane.example.com",
         },
         mockClient
@@ -270,14 +263,13 @@ describe("SandboxClient - createSandbox", () => {
       ok: true,
       json: async () => ({
         name: "test-sb",
-        template_name: "python-sandbox",
         dataplane_url: "https://dp.example.com",
         status: "ready",
       }),
     } as Response);
 
     const client = createClientWithMock(mockFetch);
-    await client.createSandbox("python-sandbox");
+    await client.createSandbox("snap-123");
 
     const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
     const body = JSON.parse(init.body as string);
@@ -290,13 +282,12 @@ describe("SandboxClient - createSandbox", () => {
       ok: true,
       json: async () => ({
         name: "test-sb",
-        template_name: "python-sandbox",
         status: "provisioning",
       }),
     } as Response);
 
     const client = createClientWithMock(mockFetch);
-    const sandbox = await client.createSandbox("python-sandbox", {
+    const sandbox = await client.createSandbox("snap-123", {
       waitForReady: false,
     });
 
@@ -312,13 +303,12 @@ describe("SandboxClient - createSandbox", () => {
       ok: true,
       json: async () => ({
         name: "test-sb",
-        template_name: "python-sandbox",
         status: "provisioning",
       }),
     } as Response);
 
     const client = createClientWithMock(mockFetch);
-    await client.createSandbox("python-sandbox", { waitForReady: false });
+    await client.createSandbox("snap-123", { waitForReady: false });
 
     const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
     // The signal should be an AbortSignal with 30s timeout
@@ -330,7 +320,6 @@ describe("SandboxClient - createSandbox", () => {
       ok: true,
       json: async () => ({
         name: "test-sb",
-        template_name: "python-sandbox",
         dataplane_url: "https://dp.example.com",
         status: "ready",
         ttl_seconds: 3600,
@@ -340,7 +329,7 @@ describe("SandboxClient - createSandbox", () => {
     } as Response);
 
     const client = createClientWithMock(mockFetch);
-    const sandbox = await client.createSandbox("python-sandbox", {
+    const sandbox = await client.createSandbox("snap-123", {
       ttlSeconds: 3600,
       idleTtlSeconds: 600,
     });
@@ -359,7 +348,7 @@ describe("SandboxClient - createSandbox", () => {
     const client = createClientWithMock(mockFetch);
 
     await expect(
-      client.createSandbox("python-sandbox", { ttlSeconds: 61 })
+      client.createSandbox("snap-123", { ttlSeconds: 61 })
     ).rejects.toThrow(LangSmithValidationError);
     expect(mockFetch).not.toHaveBeenCalled();
   });
@@ -369,7 +358,6 @@ describe("SandboxClient - createSandbox", () => {
       ok: true,
       json: async () => ({
         name: "test-sb",
-        template_name: "python-sandbox",
         status: "ready",
       }),
     } as Response);
@@ -380,7 +368,7 @@ describe("SandboxClient - createSandbox", () => {
         allow_list: ["github.com", "*.example.com"],
       },
     };
-    await client.createSandbox("python-sandbox", { proxyConfig });
+    await client.createSandbox("snap-123", { proxyConfig });
 
     const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
     const body = JSON.parse(init.body as string);
@@ -392,13 +380,12 @@ describe("SandboxClient - createSandbox", () => {
       ok: true,
       json: async () => ({
         name: "test-sb",
-        template_name: "python-sandbox",
         status: "ready",
       }),
     } as Response);
 
     const client = createClientWithMock(mockFetch);
-    await client.createSandbox("python-sandbox");
+    await client.createSandbox("snap-123");
 
     const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
     const body = JSON.parse(init.body as string);
@@ -443,7 +430,6 @@ describe("SandboxClient - updateSandbox", () => {
       ok: true,
       json: async () => ({
         name: "sb-1",
-        template_name: "python-sandbox",
         status: "ready",
         ttl_seconds: 0,
         idle_ttl_seconds: 1800,
@@ -469,7 +455,6 @@ describe("SandboxClient - updateSandbox", () => {
       ok: true,
       json: async () => ({
         name: "sb-renamed",
-        template_name: "python-sandbox",
         status: "ready",
       }),
     } as Response);
@@ -487,7 +472,6 @@ describe("SandboxClient - updateSandbox", () => {
       ok: true,
       json: async () => ({
         name: "sb-1",
-        template_name: "python-sandbox",
         status: "ready",
       }),
     } as Response);
@@ -574,7 +558,6 @@ describe("SandboxClient - waitForSandbox", () => {
           ok: true,
           json: async () => ({
             name: "test-sb",
-            template_name: "python-sandbox",
             dataplane_url: "https://dp.example.com",
             status: "ready",
           }),
@@ -626,7 +609,6 @@ describe("Sandbox - status fields and not-ready guard", () => {
     const sandbox = new (Sandbox as any)(
       {
         name: "test-sandbox",
-        template_name: "python-sandbox",
         status: "provisioning",
         status_message: "Waiting for resources",
       },
@@ -641,7 +623,6 @@ describe("Sandbox - status fields and not-ready guard", () => {
     const sandbox = new (Sandbox as any)(
       {
         name: "test-sandbox",
-        template_name: "python-sandbox",
         dataplane_url: "https://dp.example.com",
         status: "provisioning",
       },
@@ -666,7 +647,6 @@ describe("Sandbox - status fields and not-ready guard", () => {
     const sandbox = new (Sandbox as any)(
       {
         name: "test-sandbox",
-        template_name: "python-sandbox",
         dataplane_url: "https://dp.example.com",
         status: "ready",
       },
@@ -1055,7 +1035,7 @@ describe("CommandHandle", () => {
   });
 });
 
-describe("SandboxClient - createSandbox with snapshotId", () => {
+describe("SandboxClient - createSandbox (snapshotId)", () => {
   const createClientWithMock = (mockFetch: any) => {
     const client = new SandboxClient({
       apiEndpoint: "https://api.example.com/v2/sandboxes",
@@ -1066,7 +1046,7 @@ describe("SandboxClient - createSandbox with snapshotId", () => {
     return client;
   };
 
-  it("should send snapshot_id instead of template_name", async () => {
+  it("should send snapshot_id in the request body", async () => {
     const mockFetch = jest.fn<typeof fetch>().mockResolvedValue({
       ok: true,
       json: async () => ({
@@ -1078,9 +1058,7 @@ describe("SandboxClient - createSandbox with snapshotId", () => {
     } as Response);
 
     const client = createClientWithMock(mockFetch);
-    const sandbox = await client.createSandbox(undefined, {
-      snapshotId: "snap-1",
-    });
+    const sandbox = await client.createSandbox("snap-1");
 
     const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
     const body = JSON.parse(init.body as string);
@@ -1103,8 +1081,7 @@ describe("SandboxClient - createSandbox with snapshotId", () => {
     } as Response);
 
     const client = createClientWithMock(mockFetch);
-    const sandbox = await client.createSandbox(undefined, {
-      snapshotId: "snap-1",
+    const sandbox = await client.createSandbox("snap-1", {
       vCpus: 4,
       memBytes: 1073741824,
       fsCapacityBytes: 4294967296,
@@ -1117,26 +1094,6 @@ describe("SandboxClient - createSandbox with snapshotId", () => {
     expect(body.fs_capacity_bytes).toBe(4294967296);
     expect(sandbox.vCpus).toBe(4);
     expect(sandbox.mem_bytes).toBe(1073741824);
-  });
-
-  it("should reject when neither templateName nor snapshotId is provided", async () => {
-    const mockFetch = jest.fn<typeof fetch>();
-    const client = createClientWithMock(mockFetch);
-
-    await expect(client.createSandbox()).rejects.toThrow(
-      "Either templateName or snapshotId is required"
-    );
-    expect(mockFetch).not.toHaveBeenCalled();
-  });
-
-  it("should reject when both templateName and snapshotId are provided", async () => {
-    const mockFetch = jest.fn<typeof fetch>();
-    const client = createClientWithMock(mockFetch);
-
-    await expect(
-      client.createSandbox("my-template", { snapshotId: "snap-1" })
-    ).rejects.toThrow("Cannot specify both templateName and snapshotId");
-    expect(mockFetch).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Summary

JS counterpart of #2757 (Python) — mirrors the same cleanup (plus the backend/frontend deprecations) in the JavaScript sandbox SDK. Template, pool, and volume concepts are gone from the backend, so the JS client now exposes only the snapshot-based surface.

### What changed

- `types.ts`: removed `ResourceSpec`, `VolumeMountSpec`, `Volume`, `SandboxTemplate`, `Pool`, and all `Create/Update {Volume,Template,Pool}Options`. Dropped `template_name` from `SandboxData` and `snapshotId` from `CreateSandboxOptions` (now a positional argument).
- `client.ts`: deleted every volume/template/pool CRUD method. `createSandbox` now takes `snapshotId` as a required positional argument followed by the options object, matching the shape of other sandbox methods (e.g. `getSandbox`, `stopSandbox`).
- `sandbox.ts`: removed the `template_name` field/JSDoc from the `Sandbox` class and refreshed the class-level example to use snapshots.
- `helpers.ts`: deleted `handleVolumeCreationError`, `handlePoolError`, `handleConflictError`, and `handleResourceInUseError`; dropped the `volume_count` branch in `extractQuotaType`.
- `errors.ts`: scrubbed template/pool/volume references from the JSDoc comments.
- `index.ts`: stopped re-exporting the deleted types and refreshed the module-level example.
- `README.md`: rewritten to be snapshot-only — quick start, snapshots workflow, API reference, and error handling — with no template/volume/pool sections.
- `src/tests/sandbox.test.ts`: stripped `template_name` from mocks, rewrote the `createSandbox` tests to use the new positional `snapshotId` argument, and removed the template/snapshot mutual-exclusion cases.

### Drive-by fix

`js/package.json` has pinned `packageManager` to `pnpm@10.33.0` since #2635, but `.pre-commit-config.yaml` was still calling `yarn run …` for the JS hooks. Yarn 1.x refuses to run in a project whose `packageManager` names a different manager, so the hooks always failed locally. This PR flips the three JS hooks to `pnpm run …` so they match the pinned package manager.

### Breaking changes

This is a breaking change for any consumer still using template/pool/volume APIs. The backend has already removed these endpoints, so those consumers are already broken; this PR just brings the types into line with reality. `createSandbox` callers will need to migrate from `createSandbox({ templateName: "…" })` (or `createSandbox({ snapshotId: "…" })`) to `createSandbox(snapshotId, options)`.

Made with [Cursor](https://cursor.com)