### PR TITLE
feat(py): Adds runtime overrides for updating internal methods

### DIFF
--- a/python/langsmith/__init__.py
+++ b/python/langsmith/__init__.py
@@ -156,6 +156,11 @@ def __getattr__(name: str) -> Any:
 
         return configure_global_async_prompt_cache
 
+    elif name == "set_runtime_overrides":
+        from langsmith._runtime_overrides import set_runtime_overrides
+
+        return set_runtime_overrides
+
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
@@ -190,4 +195,5 @@ __all__ = [
     "ContextThreadPoolExecutor",
     "uuid7",
     "uuid7_from_datetime",
+    "set_runtime_overrides",
 ]

--- a/python/langsmith/_internal/_aiter.py
+++ b/python/langsmith/_internal/_aiter.py
@@ -339,22 +339,26 @@ def accepts_context(callable: Callable[..., Any]) -> bool:
 
 # Ported from Python 3.9+ to support Python 3.8
 async def aio_to_thread(
-    func, /, *args, __ctx: Optional[contextvars.Context] = None, **kwargs
+    ctx: contextvars.Context,
+    func,
+    /,
+    *args,
+    **kwargs,
 ):
-    """Asynchronously run function *func* in a separate thread.
+    """Run ``func`` in a separate thread, inside ``ctx``.
 
-    Any *args and **kwargs supplied for this function are directly passed
-    to *func*. Also, the current :class:`contextvars.Context` is propagated,
-    allowing context variables from the main thread to be accessed in the
-    separate thread.
+    ``ctx`` is the :class:`~contextvars.Context` in which ``func`` is invoked.
+    Callers that want default isolation should pass
+    ``contextvars.copy_context()``; callers with a specific Context
+    (e.g. :func:`trace`) pass it directly so subsequent reads from that
+    Context see the mutations.
 
-    Return a coroutine that can be awaited to get the eventual result of *func*.
+    Return a coroutine that can be awaited to get the eventual result of ``func``.
     """
     overrides = get_runtime_overrides()
     if overrides.aio_to_thread is not None:
-        return await overrides.aio_to_thread(func, *args, __ctx=__ctx, **kwargs)
+        return await overrides.aio_to_thread(ctx, func, *args, **kwargs)
     loop = asyncio.get_running_loop()
-    ctx = __ctx or contextvars.copy_context()
     func_call = functools.partial(ctx.run, func, *args, **kwargs)
     return await loop.run_in_executor(None, func_call)
 

--- a/python/langsmith/_internal/_aiter.py
+++ b/python/langsmith/_internal/_aiter.py
@@ -357,7 +357,20 @@ async def aio_to_thread(
     """
     overrides = get_runtime_overrides()
     if overrides.aio_to_thread is not None:
-        return await overrides.aio_to_thread(ctx, func, *args, **kwargs)
+        return await overrides.aio_to_thread(
+            _default_aio_to_thread, ctx, func, *args, **kwargs
+        )
+    return await _default_aio_to_thread(ctx, func, *args, **kwargs)
+
+
+async def _default_aio_to_thread(
+    ctx: contextvars.Context,
+    func,
+    /,
+    *args,
+    **kwargs,
+):
+    """Default implementation of aio_to_thread using run_in_executor."""
     loop = asyncio.get_running_loop()
     func_call = functools.partial(ctx.run, func, *args, **kwargs)
     return await loop.run_in_executor(None, func_call)

--- a/python/langsmith/_internal/_aiter.py
+++ b/python/langsmith/_internal/_aiter.py
@@ -5,6 +5,8 @@ https://github.com/maxfischer2781/asyncstdlib/blob/master/asyncstdlib/itertools.
 MIT License
 """
 
+from __future__ import annotations
+
 import asyncio
 import contextvars
 import functools
@@ -30,6 +32,8 @@ from typing import (
     cast,
     overload,
 )
+
+from langsmith._runtime_overrides import get_runtime_overrides
 
 T = TypeVar("T")
 
@@ -197,7 +201,7 @@ class Tee(Generic[T]):
     def __iter__(self) -> Iterator[AsyncIterator[T]]:
         yield from self._children
 
-    async def __aenter__(self) -> "Tee[T]":
+    async def __aenter__(self) -> Tee[T]:
         return self
 
     async def __aexit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> bool:
@@ -346,6 +350,9 @@ async def aio_to_thread(
 
     Return a coroutine that can be awaited to get the eventual result of *func*.
     """
+    overrides = get_runtime_overrides()
+    if overrides.aio_to_thread is not None:
+        return await overrides.aio_to_thread(func, *args, __ctx=__ctx, **kwargs)
     loop = asyncio.get_running_loop()
     ctx = __ctx or contextvars.copy_context()
     func_call = functools.partial(ctx.run, func, *args, **kwargs)

--- a/python/langsmith/_runtime_overrides.py
+++ b/python/langsmith/_runtime_overrides.py
@@ -1,0 +1,98 @@
+"""Runtime overrides for LangSmith.
+
+This module provides hooks to override LangSmith's default runtime behavior,
+primarily for environments with constrained async runtimes (e.g., Temporal).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Callable, Optional
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable
+
+
+class RuntimeOverrides:
+    """Overrides for LangSmith runtime behavior.
+
+    This class allows overriding default async implementations for environments
+    that don't support certain asyncio features (e.g., Temporal doesn't support
+    run_in_executor).
+
+    Example:
+        import langsmith
+
+        # For Temporal or other constrained runtimes
+        async def my_aio_to_thread(func, /, *args, __ctx=None, **kwargs):
+            # Custom implementation
+            return await some_wrapper(func, *args, **kwargs)
+
+        langsmith.set_runtime_overrides(aio_to_thread=my_aio_to_thread)
+
+        # Reset to defaults
+        langsmith.set_runtime_overrides()
+    """
+
+    __slots__ = ("aio_to_thread",)
+
+    def __init__(
+        self,
+        aio_to_thread: Optional[Callable[..., Awaitable[Any]]] = None,
+    ):
+        """Initialize runtime overrides.
+
+        Args:
+            aio_to_thread: Custom async-to-thread implementation.
+                Used to run sync functions asynchronously. Override for runtimes
+                like Temporal that don't support asyncio.run_in_executor.
+        """
+        self.aio_to_thread = aio_to_thread
+
+
+# Global runtime overrides instance
+_runtime_overrides = RuntimeOverrides()
+
+
+def set_runtime_overrides(
+    aio_to_thread: Optional[Callable[..., Awaitable[Any]]] = None,
+) -> None:
+    """Set LangSmith runtime overrides.
+
+    This allows customizing LangSmith's async runtime behavior for environments
+    with constrained async runtimes (e.g., Temporal, which doesn't support
+    run_in_executor).
+
+    Args:
+        aio_to_thread: Custom async function to run sync functions
+            asynchronously. Should have signature:
+            async def aio_to_thread(func, /, *args, __ctx=None, **kwargs)
+            Pass None to use the default implementation.
+
+    Example:
+        For Temporal or similar runtimes:
+
+        ```python
+        import langsmith
+
+
+        async def temporal_aio_to_thread(func, /, *args, __ctx=None, **kwargs):
+            # Use Temporal's activity execution or similar
+            return await temporal_async_wrapper(func, *args, **kwargs)
+
+
+        langsmith.set_runtime_overrides(aio_to_thread=temporal_aio_to_thread)
+        ```
+
+        Reset to defaults:
+
+        ```python
+        langsmith.set_runtime_overrides()
+        ```
+    """
+    global _runtime_overrides
+    _runtime_overrides = RuntimeOverrides(aio_to_thread=aio_to_thread)
+
+
+def get_runtime_overrides() -> RuntimeOverrides:
+    """Get the current runtime overrides."""
+    return _runtime_overrides

--- a/python/langsmith/_runtime_overrides.py
+++ b/python/langsmith/_runtime_overrides.py
@@ -30,7 +30,9 @@ class RuntimeOverrides:
         import contextvars
 
 
-        async def my_aio_to_thread(ctx, func, /, *args, **kwargs):
+        async def my_aio_to_thread(
+            default_aio_to_thread, ctx, func, /, *args, **kwargs
+        ):
             # Custom implementation
             return ctx.run(func, *args, **kwargs)
 
@@ -51,7 +53,10 @@ class RuntimeOverrides:
 
         Args:
             aio_to_thread: Custom async-to-thread implementation, with signature
-                ``async def (ctx, func, /, *args, **kwargs)``. ``ctx`` is the
+                ``async def (default_aio_to_thread, ctx, func, /, *args, **kwargs)``.
+                ``default_aio_to_thread`` is LangSmith's default implementation, which
+                the override can call to fall back to default behavior (e.g., when
+                outside a constrained runtime context). ``ctx`` is the
                 ``contextvars.Context`` LangSmith wants ``func`` to run inside;
                 tracing state will be read back from this Context after the call.
                 Override for runtimes like Temporal that don't support
@@ -75,11 +80,15 @@ def set_runtime_overrides(
     Args:
         aio_to_thread: Custom async function to run sync functions
             asynchronously. Should have signature:
-            ``async def aio_to_thread(ctx, func, /, *args, **kwargs)``.
-            The implementation must invoke ``func`` inside ``ctx`` (e.g.
-            ``ctx.run(func, *args, **kwargs)``) so that LangSmith's tracing
-            state, which is read back from ``ctx`` after the call, is visible
-            to downstream code. Pass ``None`` to use the default implementation.
+            ``async def aio_to_thread(
+                default_aio_to_thread, ctx, func, /, *args, **kwargs
+            )``.
+            ``default_aio_to_thread`` is LangSmith's default implementation, which
+            the override can call to fall back to default behavior. The
+            implementation must invoke ``func`` inside ``ctx`` (e.g.
+            ``ctx.run(func, *args, **kwargs)``) so that LangSmith's tracing state,
+            which is read back from ``ctx`` after the call, is visible to downstream
+            code. Pass ``None`` to use the default implementation.
 
     Example:
         For Temporal or similar runtimes:
@@ -88,12 +97,12 @@ def set_runtime_overrides(
         import langsmith
 
 
-        async def temporal_aio_to_thread(ctx, func, /, *args, **kwargs):
+        async def temporal_aio_to_thread(
+            default_aio_to_thread, ctx, func, /, *args, **kwargs
+        ):
+            # Use the default implementation when not in a workflow
             if not temporalio.workflow.in_workflow():
-                loop = asyncio.get_running_loop()
-                return await loop.run_in_executor(
-                    None, functools.partial(ctx.run, func, *args, **kwargs)
-                )
+                return await default_aio_to_thread(ctx, func, *args, **kwargs)
             with temporalio.workflow.unsafe.sandbox_unrestricted():
                 return ctx.run(func, *args, **kwargs)
 

--- a/python/langsmith/_runtime_overrides.py
+++ b/python/langsmith/_runtime_overrides.py
@@ -12,20 +12,28 @@ if TYPE_CHECKING:
     from collections.abc import Awaitable
 
 
+AioToThread = Callable[
+    ...,  # (ctx: contextvars.Context, func, /, *args, **kwargs)
+    "Awaitable[Any]",
+]
+
+
 class RuntimeOverrides:
     """Overrides for LangSmith runtime behavior.
 
     This class allows overriding default async implementations for environments
     that don't support certain asyncio features (e.g., Temporal doesn't support
-    run_in_executor).
+    ``run_in_executor``).
 
     Example:
         import langsmith
+        import contextvars
 
-        # For Temporal or other constrained runtimes
-        async def my_aio_to_thread(func, /, *args, __ctx=None, **kwargs):
+
+        async def my_aio_to_thread(ctx, func, /, *args, **kwargs):
             # Custom implementation
-            return await some_wrapper(func, *args, **kwargs)
+            return ctx.run(func, *args, **kwargs)
+
 
         langsmith.set_runtime_overrides(aio_to_thread=my_aio_to_thread)
 
@@ -37,36 +45,41 @@ class RuntimeOverrides:
 
     def __init__(
         self,
-        aio_to_thread: Optional[Callable[..., Awaitable[Any]]] = None,
+        aio_to_thread: Optional[AioToThread] = None,
     ):
         """Initialize runtime overrides.
 
         Args:
-            aio_to_thread: Custom async-to-thread implementation.
-                Used to run sync functions asynchronously. Override for runtimes
-                like Temporal that don't support asyncio.run_in_executor.
+            aio_to_thread: Custom async-to-thread implementation, with signature
+                ``async def (ctx, func, /, *args, **kwargs)``. ``ctx`` is the
+                ``contextvars.Context`` LangSmith wants ``func`` to run inside;
+                tracing state will be read back from this Context after the call.
+                Override for runtimes like Temporal that don't support
+                ``asyncio.run_in_executor``.
         """
         self.aio_to_thread = aio_to_thread
 
 
-# Global runtime overrides instance
 _runtime_overrides = RuntimeOverrides()
 
 
 def set_runtime_overrides(
-    aio_to_thread: Optional[Callable[..., Awaitable[Any]]] = None,
+    aio_to_thread: Optional[AioToThread] = None,
 ) -> None:
     """Set LangSmith runtime overrides.
 
     This allows customizing LangSmith's async runtime behavior for environments
     with constrained async runtimes (e.g., Temporal, which doesn't support
-    run_in_executor).
+    ``run_in_executor``).
 
     Args:
         aio_to_thread: Custom async function to run sync functions
             asynchronously. Should have signature:
-            async def aio_to_thread(func, /, *args, __ctx=None, **kwargs)
-            Pass None to use the default implementation.
+            ``async def aio_to_thread(ctx, func, /, *args, **kwargs)``.
+            The implementation must invoke ``func`` inside ``ctx`` (e.g.
+            ``ctx.run(func, *args, **kwargs)``) so that LangSmith's tracing
+            state, which is read back from ``ctx`` after the call, is visible
+            to downstream code. Pass ``None`` to use the default implementation.
 
     Example:
         For Temporal or similar runtimes:
@@ -75,9 +88,14 @@ def set_runtime_overrides(
         import langsmith
 
 
-        async def temporal_aio_to_thread(func, /, *args, __ctx=None, **kwargs):
-            # Use Temporal's activity execution or similar
-            return await temporal_async_wrapper(func, *args, **kwargs)
+        async def temporal_aio_to_thread(ctx, func, /, *args, **kwargs):
+            if not temporalio.workflow.in_workflow():
+                loop = asyncio.get_running_loop()
+                return await loop.run_in_executor(
+                    None, functools.partial(ctx.run, func, *args, **kwargs)
+                )
+            with temporalio.workflow.unsafe.sandbox_unrestricted():
+                return ctx.run(func, *args, **kwargs)
 
 
         langsmith.set_runtime_overrides(aio_to_thread=temporal_aio_to_thread)
@@ -96,3 +114,15 @@ def set_runtime_overrides(
 def get_runtime_overrides() -> RuntimeOverrides:
     """Get the current runtime overrides."""
     return _runtime_overrides
+
+
+def _aio_to_thread_override_active() -> bool:
+    """Return True iff an ``aio_to_thread`` override is currently installed.
+
+    Callers use this to select a loop-behavior-independent path for
+    re-entering a LangSmith-mutated Context (the explicit
+    ``tracing_context(**get_tracing_context(ctx))`` fallback), rather than
+    relying on ``asyncio.create_task(coro, context=ctx)`` which some custom
+    event loops silently ignore.
+    """
+    return _runtime_overrides.aio_to_thread is not None

--- a/python/langsmith/evaluation/_arunner.py
+++ b/python/langsmith/evaluation/_arunner.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import concurrent.futures as cf
+import contextvars
 import io
 import logging
 import pathlib
@@ -437,12 +438,22 @@ async def aevaluate_existing(
     project = (
         experiment
         if isinstance(experiment, schemas.TracerSession)
-        else (await aitertools.aio_to_thread(_load_experiment, experiment, client))
+        else (
+            await aitertools.aio_to_thread(
+                contextvars.copy_context(), _load_experiment, experiment, client
+            )
+        )
     )
     runs = await aitertools.aio_to_thread(
-        _load_traces, experiment, client, load_nested=load_nested
+        contextvars.copy_context(),
+        _load_traces,
+        experiment,
+        client,
+        load_nested=load_nested,
     )
-    data_map = await aitertools.aio_to_thread(_load_examples_map, client, project)
+    data_map = await aitertools.aio_to_thread(
+        contextvars.copy_context(), _load_examples_map, client, project
+    )
     data = [data_map[run.reference_example_id] for run in runs]
     return await _aevaluate(
         runs,
@@ -482,6 +493,7 @@ async def _aevaluate(
     client = client or rt.get_cached_client()
     runs = None if is_async_target else cast(Iterable[schemas.Run], target)
     experiment_, runs = await aitertools.aio_to_thread(
+        contextvars.copy_context(),
         _resolve_experiment,
         experiment,
         runs,
@@ -1089,6 +1101,7 @@ class _AsyncExperimentManager(_ExperimentManagerMixin):
                             feedback = result.model_dump(exclude={"target_run_id"})
                             evaluator_info = feedback.pop("evaluator_info", None)
                             await aitertools.aio_to_thread(
+                                contextvars.copy_context(),
                                 self.client.create_feedback,
                                 **feedback,
                                 run_id=None,

--- a/python/langsmith/run_helpers.py
+++ b/python/langsmith/run_helpers.py
@@ -46,6 +46,9 @@ import langsmith._internal._context as _context
 from langsmith import client as ls_client
 from langsmith import run_trees, schemas, utils
 from langsmith._internal import _aiter as aitertools
+from langsmith._runtime_overrides import (
+    _aio_to_thread_override_active as _runtime_override_active,
+)
 from langsmith.env import _runtime_env
 from langsmith.run_trees import WriteReplica
 
@@ -602,6 +605,7 @@ def traceable(
             if not func_accepts_config:
                 kwargs.pop("config", None)
             run_container = await aitertools.aio_to_thread(
+                copy_context(),
                 _setup_run,
                 func,
                 container_input=container_input,
@@ -618,30 +622,29 @@ def traceable(
                 otel_context_manager = _maybe_create_otel_context(
                     run_container["new_run"]
                 )
+                use_ctx_task = accepts_context and not _runtime_override_active()
                 if otel_context_manager:
 
                     async def run_with_otel_context():
                         with otel_context_manager:
                             return await func(*args, **kwargs)
 
-                    if accepts_context:
+                    if use_ctx_task:
                         function_result = await asyncio.create_task(  # type: ignore[call-arg]
                             run_with_otel_context(), context=run_container["context"]
                         )
                     else:
-                        # Python < 3.11
                         with tracing_context(
                             **get_tracing_context(run_container["context"])
                         ):
                             function_result = await run_with_otel_context()
                 else:
                     fr_coro = func(*args, **kwargs)
-                    if accepts_context:
+                    if use_ctx_task:
                         function_result = await asyncio.create_task(  # type: ignore[call-arg]
                             fr_coro, context=run_container["context"]
                         )
                     else:
-                        # Python < 3.11
                         with tracing_context(
                             **get_tracing_context(run_container["context"])
                         ):
@@ -650,11 +653,13 @@ def traceable(
                 # shield from cancellation, given we're catching all exceptions
                 _cleanup_traceback(e)
                 await asyncio.shield(
-                    aitertools.aio_to_thread(_on_run_end, run_container, error=e)
+                    aitertools.aio_to_thread(
+                        copy_context(), _on_run_end, run_container, error=e
+                    )
                 )
                 raise
             await aitertools.aio_to_thread(
-                _on_run_end, run_container, outputs=function_result
+                copy_context(), _on_run_end, run_container, outputs=function_result
             )
             return function_result
 
@@ -665,6 +670,7 @@ def traceable(
             if not func_accepts_config:
                 kwargs.pop("config", None)
             run_container = await aitertools.aio_to_thread(
+                copy_context(),
                 _setup_run,
                 func,
                 container_input=container_input,
@@ -687,13 +693,13 @@ def traceable(
                 async_gen_result = func(*args, **kwargs)
                 # Can't iterate through if it's a coroutine
                 accepts_context = aitertools.asyncio_accepts_context()
+                use_ctx_task = accepts_context and not _runtime_override_active()
                 if inspect.iscoroutine(async_gen_result):
-                    if accepts_context:
+                    if use_ctx_task:
                         async_gen_result = await asyncio.create_task(
                             async_gen_result, context=run_container["context"]
                         )  # type: ignore
                     else:
-                        # Python < 3.11
                         with tracing_context(
                             **get_tracing_context(run_container["context"])
                         ):
@@ -707,7 +713,7 @@ def traceable(
                         if run_container["new_run"]
                         else False
                     ),
-                    accepts_context=accepts_context,
+                    accepts_context=use_ctx_task,
                     results=results,
                     process_chunk=container_input.get("process_chunk"),
                     otel_context_manager=otel_context_manager,
@@ -717,6 +723,7 @@ def traceable(
                 _cleanup_traceback(e)
                 await asyncio.shield(
                     aitertools.aio_to_thread(
+                        copy_context(),
                         _on_run_end,
                         run_container,
                         error=e,
@@ -725,6 +732,7 @@ def traceable(
                 )
                 raise
             await aitertools.aio_to_thread(
+                copy_context(),
                 _on_run_end,
                 run_container,
                 outputs=_get_function_result(results, reduce_fn),
@@ -872,6 +880,7 @@ def traceable(
             if not func_accepts_config:
                 kwargs.pop("config", None)
             trace_container = await aitertools.aio_to_thread(
+                copy_context(),
                 _setup_run,
                 func,
                 container_input=container_input,
@@ -885,7 +894,9 @@ def traceable(
                     kwargs["run_tree"] = trace_container["new_run"]
                 stream = await func(*args, **kwargs)
             except Exception as e:
-                await aitertools.aio_to_thread(_on_run_end, trace_container, error=e)
+                await aitertools.aio_to_thread(
+                    copy_context(), _on_run_end, trace_container, error=e
+                )
                 raise
 
             if hasattr(stream, "__aiter__"):
@@ -895,7 +906,9 @@ def traceable(
                 return _TracedStream(stream, trace_container, reduce_fn)
 
             # If it's not iterable, end the trace immediately
-            await aitertools.aio_to_thread(_on_run_end, trace_container, outputs=stream)
+            await aitertools.aio_to_thread(
+                copy_context(), _on_run_end, trace_container, outputs=stream
+            )
             return stream
 
         if inspect.isasyncgenfunction(func):
@@ -1208,7 +1221,7 @@ class trace:
             run_trees.RunTree: The newly created run.
         """
         ctx = copy_context()
-        result = await aitertools.aio_to_thread(self._setup, __ctx=ctx)
+        result = await aitertools.aio_to_thread(ctx, self._setup)
         # Set the context for the current thread
         _set_tracing_context(get_tracing_context(ctx))
         return result
@@ -1230,12 +1243,12 @@ class trace:
         if exc_type is not None:
             await asyncio.shield(
                 aitertools.aio_to_thread(
-                    self._teardown, exc_type, exc_value, traceback, __ctx=ctx
+                    ctx, self._teardown, exc_type, exc_value, traceback
                 )
             )
         else:
             await aitertools.aio_to_thread(
-                self._teardown, exc_type, exc_value, traceback, __ctx=ctx
+                ctx, self._teardown, exc_type, exc_value, traceback
             )
         _set_tracing_context(get_tracing_context(ctx))
 
@@ -2149,9 +2162,7 @@ class _TracedAsyncStream(_TracedStreamBase, Generic[T]):
 
     async def _aend_trace(self, error: Optional[BaseException] = None):
         ctx = copy_context()
-        await asyncio.shield(
-            aitertools.aio_to_thread(self._end_trace, error, __ctx=ctx)
-        )
+        await asyncio.shield(aitertools.aio_to_thread(ctx, self._end_trace, error))
         _set_tracing_context(get_tracing_context(ctx))
 
     async def __anext__(self) -> T:

--- a/python/tests/unit_tests/test_runtime_overrides.py
+++ b/python/tests/unit_tests/test_runtime_overrides.py
@@ -1,0 +1,188 @@
+"""Tests for langsmith runtime overrides."""
+
+import contextvars
+
+import pytest
+
+import langsmith
+from langsmith._internal import _aiter as aitertools
+from langsmith._runtime_overrides import (
+    RuntimeOverrides,
+    get_runtime_overrides,
+    set_runtime_overrides,
+)
+
+
+@pytest.fixture(autouse=True)
+def reset_overrides():
+    """Ensure overrides are reset before and after each test."""
+    set_runtime_overrides()
+    yield
+    set_runtime_overrides()
+
+
+async def test_default_aio_to_thread_runs_in_executor():
+    """Without any override, aio_to_thread should run func in a thread."""
+    import threading
+
+    main_thread_id = threading.get_ident()
+    captured_thread_id = None
+
+    def sync_func(x):
+        nonlocal captured_thread_id
+        captured_thread_id = threading.get_ident()
+        return x * 2
+
+    result = await aitertools.aio_to_thread(sync_func, 5)
+    assert result == 10
+    assert captured_thread_id is not None
+    assert captured_thread_id != main_thread_id
+
+
+async def test_override_is_invoked():
+    """When an override is set, it should be called instead of the default."""
+    calls = []
+
+    async def my_override(func, /, *args, __ctx=None, **kwargs):
+        calls.append((func, args, kwargs))
+        return func(*args, **kwargs)
+
+    set_runtime_overrides(aio_to_thread=my_override)
+
+    def sync_func(x, y=1):
+        return x + y
+
+    result = await aitertools.aio_to_thread(sync_func, 5, y=3)
+    assert result == 8
+    assert len(calls) == 1
+    assert calls[0][0] is sync_func
+    assert calls[0][1] == (5,)
+    assert calls[0][2] == {"y": 3}
+
+
+async def test_override_does_not_use_run_in_executor():
+    """Override should run in the calling thread (for runtimes like Temporal)."""
+    import threading
+
+    main_thread_id = threading.get_ident()
+    captured_thread_id = None
+
+    async def my_override(func, /, *args, __ctx=None, **kwargs):
+        # Run in the current thread, not a worker thread
+        return func(*args, **kwargs)
+
+    set_runtime_overrides(aio_to_thread=my_override)
+
+    def sync_func(x):
+        nonlocal captured_thread_id
+        captured_thread_id = threading.get_ident()
+        return x * 2
+
+    result = await aitertools.aio_to_thread(sync_func, 5)
+    assert result == 10
+    assert captured_thread_id == main_thread_id
+
+
+async def test_override_receives_ctx():
+    """Override should receive the __ctx kwarg when passed."""
+    received_ctx = None
+
+    async def my_override(func, /, *args, __ctx=None, **kwargs):
+        nonlocal received_ctx
+        received_ctx = __ctx
+        return func(*args, **kwargs)
+
+    set_runtime_overrides(aio_to_thread=my_override)
+
+    ctx = contextvars.copy_context()
+
+    def sync_func():
+        return "ok"
+
+    await aitertools.aio_to_thread(sync_func, __ctx=ctx)
+    assert received_ctx is ctx
+
+
+async def test_reset_to_default():
+    """Calling set_runtime_overrides() with no args resets to defaults."""
+
+    async def my_override(func, /, *args, __ctx=None, **kwargs):
+        return "overridden"
+
+    set_runtime_overrides(aio_to_thread=my_override)
+    result = await aitertools.aio_to_thread(lambda: "actual")
+    assert result == "overridden"
+
+    set_runtime_overrides()
+    result = await aitertools.aio_to_thread(lambda: "actual")
+    assert result == "actual"
+
+
+async def test_override_propagates_exceptions():
+    """Exceptions from the override should propagate."""
+
+    class MyError(Exception):
+        pass
+
+    async def my_override(func, /, *args, __ctx=None, **kwargs):
+        raise MyError("boom")
+
+    set_runtime_overrides(aio_to_thread=my_override)
+
+    with pytest.raises(MyError, match="boom"):
+        await aitertools.aio_to_thread(lambda: "never")
+
+
+def test_get_runtime_overrides_returns_instance():
+    """get_runtime_overrides should return a RuntimeOverrides instance."""
+    overrides = get_runtime_overrides()
+    assert isinstance(overrides, RuntimeOverrides)
+    assert overrides.aio_to_thread is None
+
+
+def test_set_runtime_overrides_updates_instance():
+    """set_runtime_overrides should update the global instance."""
+
+    async def my_override(func, /, *args, __ctx=None, **kwargs):
+        return func(*args, **kwargs)
+
+    set_runtime_overrides(aio_to_thread=my_override)
+    overrides = get_runtime_overrides()
+    assert overrides.aio_to_thread is my_override
+
+
+def test_set_runtime_overrides_exposed_at_top_level():
+    """set_runtime_overrides should be accessible via langsmith."""
+    assert langsmith.set_runtime_overrides is set_runtime_overrides
+
+
+async def test_traceable_uses_override():
+    """A traceable async function should route through the override."""
+    from unittest.mock import MagicMock
+
+    from langsmith import traceable
+
+    override_calls = 0
+
+    async def my_override(func, /, *args, __ctx=None, **kwargs):
+        nonlocal override_calls
+        override_calls += 1
+        ctx = __ctx or contextvars.copy_context()
+        return ctx.run(func, *args, **kwargs)
+
+    set_runtime_overrides(aio_to_thread=my_override)
+
+    mock_client = MagicMock()
+    mock_client.tracing_queue = None
+
+    @traceable(client=mock_client)
+    async def my_async_fn(x: int) -> int:
+        return x + 1
+
+    with langsmith.tracing_context(enabled=True):
+        result = await my_async_fn(1)
+
+    assert result == 2
+    # Verify the override was called at least once during traceable execution
+    # (traceable uses aio_to_thread for its setup/teardown work).
+    assert override_calls > 0

--- a/python/tests/unit_tests/test_runtime_overrides.py
+++ b/python/tests/unit_tests/test_runtime_overrides.py
@@ -15,7 +15,6 @@ from langsmith._runtime_overrides import (
 
 @pytest.fixture(autouse=True)
 def reset_overrides():
-    """Ensure overrides are reset before and after each test."""
     set_runtime_overrides()
     yield
     set_runtime_overrides()
@@ -33,7 +32,7 @@ async def test_default_aio_to_thread_runs_in_executor():
         captured_thread_id = threading.get_ident()
         return x * 2
 
-    result = await aitertools.aio_to_thread(sync_func, 5)
+    result = await aitertools.aio_to_thread(contextvars.copy_context(), sync_func, 5)
     assert result == 10
     assert captured_thread_id is not None
     assert captured_thread_id != main_thread_id
@@ -43,21 +42,23 @@ async def test_override_is_invoked():
     """When an override is set, it should be called instead of the default."""
     calls = []
 
-    async def my_override(func, /, *args, __ctx=None, **kwargs):
-        calls.append((func, args, kwargs))
-        return func(*args, **kwargs)
+    async def my_override(ctx, func, /, *args, **kwargs):
+        calls.append((ctx, func, args, kwargs))
+        return ctx.run(func, *args, **kwargs)
 
     set_runtime_overrides(aio_to_thread=my_override)
 
     def sync_func(x, y=1):
         return x + y
 
-    result = await aitertools.aio_to_thread(sync_func, 5, y=3)
+    ctx = contextvars.copy_context()
+    result = await aitertools.aio_to_thread(ctx, sync_func, 5, y=3)
     assert result == 8
     assert len(calls) == 1
-    assert calls[0][0] is sync_func
-    assert calls[0][1] == (5,)
-    assert calls[0][2] == {"y": 3}
+    assert calls[0][0] is ctx
+    assert calls[0][1] is sync_func
+    assert calls[0][2] == (5,)
+    assert calls[0][3] == {"y": 3}
 
 
 async def test_override_does_not_use_run_in_executor():
@@ -67,9 +68,8 @@ async def test_override_does_not_use_run_in_executor():
     main_thread_id = threading.get_ident()
     captured_thread_id = None
 
-    async def my_override(func, /, *args, __ctx=None, **kwargs):
-        # Run in the current thread, not a worker thread
-        return func(*args, **kwargs)
+    async def my_override(ctx, func, /, *args, **kwargs):
+        return ctx.run(func, *args, **kwargs)
 
     set_runtime_overrides(aio_to_thread=my_override)
 
@@ -78,19 +78,19 @@ async def test_override_does_not_use_run_in_executor():
         captured_thread_id = threading.get_ident()
         return x * 2
 
-    result = await aitertools.aio_to_thread(sync_func, 5)
+    result = await aitertools.aio_to_thread(contextvars.copy_context(), sync_func, 5)
     assert result == 10
     assert captured_thread_id == main_thread_id
 
 
-async def test_override_receives_ctx():
-    """Override should receive the __ctx kwarg when passed."""
+async def test_override_receives_explicit_ctx():
+    """Override should receive the Context passed through aio_to_thread."""
     received_ctx = None
 
-    async def my_override(func, /, *args, __ctx=None, **kwargs):
+    async def my_override(ctx, func, /, *args, **kwargs):
         nonlocal received_ctx
-        received_ctx = __ctx
-        return func(*args, **kwargs)
+        received_ctx = ctx
+        return ctx.run(func, *args, **kwargs)
 
     set_runtime_overrides(aio_to_thread=my_override)
 
@@ -99,23 +99,23 @@ async def test_override_receives_ctx():
     def sync_func():
         return "ok"
 
-    await aitertools.aio_to_thread(sync_func, __ctx=ctx)
+    await aitertools.aio_to_thread(ctx, sync_func)
     assert received_ctx is ctx
 
 
 async def test_reset_to_default():
     """Calling set_runtime_overrides() with no args resets to defaults."""
 
-    async def my_override(func, /, *args, __ctx=None, **kwargs):
+    async def my_override(ctx, func, /, *args, **kwargs):
         return "overridden"
 
     set_runtime_overrides(aio_to_thread=my_override)
-    result = await aitertools.aio_to_thread(lambda: "actual")
+    result = await aitertools.aio_to_thread(contextvars.copy_context(), lambda: "x")
     assert result == "overridden"
 
     set_runtime_overrides()
-    result = await aitertools.aio_to_thread(lambda: "actual")
-    assert result == "actual"
+    result = await aitertools.aio_to_thread(contextvars.copy_context(), lambda: "x")
+    assert result == "x"
 
 
 async def test_override_propagates_exceptions():
@@ -124,27 +124,24 @@ async def test_override_propagates_exceptions():
     class MyError(Exception):
         pass
 
-    async def my_override(func, /, *args, __ctx=None, **kwargs):
+    async def my_override(ctx, func, /, *args, **kwargs):
         raise MyError("boom")
 
     set_runtime_overrides(aio_to_thread=my_override)
 
     with pytest.raises(MyError, match="boom"):
-        await aitertools.aio_to_thread(lambda: "never")
+        await aitertools.aio_to_thread(contextvars.copy_context(), lambda: "never")
 
 
 def test_get_runtime_overrides_returns_instance():
-    """get_runtime_overrides should return a RuntimeOverrides instance."""
     overrides = get_runtime_overrides()
     assert isinstance(overrides, RuntimeOverrides)
     assert overrides.aio_to_thread is None
 
 
 def test_set_runtime_overrides_updates_instance():
-    """set_runtime_overrides should update the global instance."""
-
-    async def my_override(func, /, *args, __ctx=None, **kwargs):
-        return func(*args, **kwargs)
+    async def my_override(ctx, func, /, *args, **kwargs):
+        return ctx.run(func, *args, **kwargs)
 
     set_runtime_overrides(aio_to_thread=my_override)
     overrides = get_runtime_overrides()
@@ -152,8 +149,32 @@ def test_set_runtime_overrides_updates_instance():
 
 
 def test_set_runtime_overrides_exposed_at_top_level():
-    """set_runtime_overrides should be accessible via langsmith."""
     assert langsmith.set_runtime_overrides is set_runtime_overrides
+
+
+async def test_async_trace_context_propagates_under_override():
+    """End-to-end: with an override registered, async trace() still propagates
+    tracing context — i.e. the override's ctx.run invocation, plus the
+    run_helpers fallback that re-applies tracing state from ctx, together
+    produce correct parent/child linkage inside an async context manager."""
+    from langsmith import get_current_run_tree, trace, tracing_context
+
+    async def my_override(ctx, func, /, *args, **kwargs):
+        return ctx.run(func, *args, **kwargs)
+
+    set_runtime_overrides(aio_to_thread=my_override)
+
+    with tracing_context(enabled="local"):
+        assert get_current_run_tree() is None
+        async with trace(name="outer", inputs={"step": "outer"}) as outer:
+            assert get_current_run_tree() is not None
+            assert get_current_run_tree().id == outer.id
+            async with trace(name="inner", inputs={"step": "inner"}) as inner:
+                assert get_current_run_tree() is not None
+                assert get_current_run_tree().id == inner.id
+                assert inner.parent_run_id == outer.id
+            assert get_current_run_tree().id == outer.id
+        assert get_current_run_tree() is None
 
 
 async def test_traceable_uses_override():
@@ -164,10 +185,9 @@ async def test_traceable_uses_override():
 
     override_calls = 0
 
-    async def my_override(func, /, *args, __ctx=None, **kwargs):
+    async def my_override(ctx, func, /, *args, **kwargs):
         nonlocal override_calls
         override_calls += 1
-        ctx = __ctx or contextvars.copy_context()
         return ctx.run(func, *args, **kwargs)
 
     set_runtime_overrides(aio_to_thread=my_override)
@@ -183,6 +203,4 @@ async def test_traceable_uses_override():
         result = await my_async_fn(1)
 
     assert result == 2
-    # Verify the override was called at least once during traceable execution
-    # (traceable uses aio_to_thread for its setup/teardown work).
     assert override_calls > 0

--- a/python/tests/unit_tests/test_runtime_overrides.py
+++ b/python/tests/unit_tests/test_runtime_overrides.py
@@ -42,7 +42,7 @@ async def test_override_is_invoked():
     """When an override is set, it should be called instead of the default."""
     calls = []
 
-    async def my_override(ctx, func, /, *args, **kwargs):
+    async def my_override(default_aio_to_thread, ctx, func, /, *args, **kwargs):
         calls.append((ctx, func, args, kwargs))
         return ctx.run(func, *args, **kwargs)
 
@@ -68,7 +68,7 @@ async def test_override_does_not_use_run_in_executor():
     main_thread_id = threading.get_ident()
     captured_thread_id = None
 
-    async def my_override(ctx, func, /, *args, **kwargs):
+    async def my_override(default_aio_to_thread, ctx, func, /, *args, **kwargs):
         return ctx.run(func, *args, **kwargs)
 
     set_runtime_overrides(aio_to_thread=my_override)
@@ -87,7 +87,7 @@ async def test_override_receives_explicit_ctx():
     """Override should receive the Context passed through aio_to_thread."""
     received_ctx = None
 
-    async def my_override(ctx, func, /, *args, **kwargs):
+    async def my_override(default_aio_to_thread, ctx, func, /, *args, **kwargs):
         nonlocal received_ctx
         received_ctx = ctx
         return ctx.run(func, *args, **kwargs)
@@ -106,7 +106,7 @@ async def test_override_receives_explicit_ctx():
 async def test_reset_to_default():
     """Calling set_runtime_overrides() with no args resets to defaults."""
 
-    async def my_override(ctx, func, /, *args, **kwargs):
+    async def my_override(default_aio_to_thread, ctx, func, /, *args, **kwargs):
         return "overridden"
 
     set_runtime_overrides(aio_to_thread=my_override)
@@ -124,7 +124,7 @@ async def test_override_propagates_exceptions():
     class MyError(Exception):
         pass
 
-    async def my_override(ctx, func, /, *args, **kwargs):
+    async def my_override(default_aio_to_thread, ctx, func, /, *args, **kwargs):
         raise MyError("boom")
 
     set_runtime_overrides(aio_to_thread=my_override)
@@ -140,7 +140,7 @@ def test_get_runtime_overrides_returns_instance():
 
 
 def test_set_runtime_overrides_updates_instance():
-    async def my_override(ctx, func, /, *args, **kwargs):
+    async def my_override(default_aio_to_thread, ctx, func, /, *args, **kwargs):
         return ctx.run(func, *args, **kwargs)
 
     set_runtime_overrides(aio_to_thread=my_override)
@@ -159,7 +159,7 @@ async def test_async_trace_context_propagates_under_override():
     produce correct parent/child linkage inside an async context manager."""
     from langsmith import get_current_run_tree, trace, tracing_context
 
-    async def my_override(ctx, func, /, *args, **kwargs):
+    async def my_override(default_aio_to_thread, ctx, func, /, *args, **kwargs):
         return ctx.run(func, *args, **kwargs)
 
     set_runtime_overrides(aio_to_thread=my_override)
@@ -185,7 +185,7 @@ async def test_traceable_uses_override():
 
     override_calls = 0
 
-    async def my_override(ctx, func, /, *args, **kwargs):
+    async def my_override(default_aio_to_thread, ctx, func, /, *args, **kwargs):
         nonlocal override_calls
         override_calls += 1
         return ctx.run(func, *args, **kwargs)
@@ -204,3 +204,32 @@ async def test_traceable_uses_override():
 
     assert result == 2
     assert override_calls > 0
+
+
+async def test_override_can_delegate_to_default():
+    """Override can delegate to the default implementation for fallback."""
+    import threading
+
+    main_thread_id = threading.get_ident()
+    default_thread_id = None
+    received_default = None
+
+    async def my_override(default_aio_to_thread, ctx, func, /, *args, **kwargs):
+        nonlocal received_default
+        received_default = default_aio_to_thread
+        # Delegate to the default implementation
+        return await default_aio_to_thread(ctx, func, *args, **kwargs)
+
+    set_runtime_overrides(aio_to_thread=my_override)
+
+    def sync_func(x):
+        nonlocal default_thread_id
+        default_thread_id = threading.get_ident()
+        return x * 3
+
+    result = await aitertools.aio_to_thread(contextvars.copy_context(), sync_func, 5)
+    assert result == 15
+    assert received_default is not None
+    # Default implementation runs in a separate thread
+    assert default_thread_id is not None
+    assert default_thread_id != main_thread_id


### PR DESCRIPTION
Allows overriding certain internal asyncio methods, e.g.:

```py
async def my_override(ctx: contextvars.Context, func, /, *args, **kwargs):
    ...

set_runtime_overrides(aio_to_thread=my_override)
```