### PR TITLE
fix(run-trees): coerce Pydantic BaseModel to dict in RunTree inputs/outputs

### DIFF
--- a/python/langsmith/run_trees.py
+++ b/python/langsmith/run_trees.py
@@ -92,6 +92,18 @@ _DISTRIBUTED_PARENT_ID = contextvars.ContextVar[Optional[str]](
 
 _SENTINEL = cast(None, object())
 
+
+def _coerce_to_dict(value):
+    if isinstance(value, dict):
+        return value
+    if (
+        not isinstance(value, type)
+        and hasattr(value, 'model_dump')
+        and callable(value.model_dump)
+    ):
+        return value.model_dump()
+    return dict(value)
+
 TIMESTAMP_LENGTH = 36
 
 
@@ -304,6 +316,10 @@ class RunTree(ls_schemas.RunBase):
             values["tags"] = []
         if values.get("outputs") is None:
             values["outputs"] = {}
+        for _key in ("inputs", "outputs"):
+            _val = values.get(_key)
+            if _val is not None and not isinstance(_val, dict):
+                values[_key] = _coerce_to_dict(_val)
         if values.get("attachments") is None:
             values["attachments"] = {}
         if values.get("replicas") is None:
@@ -392,13 +408,13 @@ class RunTree(ls_schemas.RunBase):
             if inputs is None:
                 self.inputs = {}
             else:
-                self.inputs = dict(inputs)
+                self.inputs = _coerce_to_dict(inputs)
         if outputs is not NOT_PROVIDED:
             self.extra[OVERRIDE_OUTPUTS] = True
             if outputs is None:
                 self.outputs = {}
             else:
-                self.outputs = dict(outputs)
+                self.outputs = _coerce_to_dict(outputs)
         if usage_metadata is not NOT_PROVIDED:
             self.extra.setdefault("metadata", {})["usage_metadata"] = (
                 validate_extracted_usage_metadata(usage_metadata)
@@ -491,10 +507,11 @@ class RunTree(ls_schemas.RunBase):
         # the ones that are automatically included
         if not self.extra.get(OVERRIDE_OUTPUTS):
             if outputs is not None:
+                dict_outputs = _coerce_to_dict(outputs)
                 if not self.outputs:
-                    self.outputs = outputs
+                    self.outputs = dict_outputs
                 else:
-                    self.outputs.update(outputs)
+                    self.outputs.update(dict_outputs)
         if error is not None:
             self.error = error
         if events is not None:

--- a/python/tests/unit_tests/test_run_trees.py
+++ b/python/tests/unit_tests/test_run_trees.py
@@ -550,3 +550,62 @@ def test_from_headers_filters_replica_credentials():
     assert "api_url" not in replica
     assert replica.get("project_name") == "legit-project"
     assert replica.get("updates") == {"reroot": True}
+
+
+# Tests for regression: RunTree should accept Pydantic BaseModel for inputs/outputs
+# https://github.com/langchain-ai/langsmith-sdk/issues/2765
+def test_runtree_accepts_pydantic_basemodel_as_constructor_inputs():
+    from pydantic import BaseModel as PydanticBaseModel
+
+    class MyInput(PydanticBaseModel):
+        query: str
+
+    rt = RunTree(name="test", run_type="chain", inputs=MyInput(query="hello"))
+    assert rt.inputs == {"query": "hello"}
+
+
+def test_runtree_accepts_pydantic_basemodel_as_constructor_outputs():
+    from pydantic import BaseModel as PydanticBaseModel
+
+    class MyOutput(PydanticBaseModel):
+        answer: str
+
+    rt = RunTree(name="test", run_type="chain", inputs={}, outputs=MyOutput(answer="hi"))
+    assert rt.outputs == {"answer": "hi"}
+
+
+def test_runtree_end_accepts_pydantic_basemodel_outputs():
+    from pydantic import BaseModel as PydanticBaseModel
+
+    class MyOutput(PydanticBaseModel):
+        answer: str
+
+    rt = RunTree(name="test", run_type="chain", inputs={})
+    rt.end(outputs=MyOutput(answer="goodbye"))
+    assert rt.outputs == {"answer": "goodbye"}
+
+
+def test_runtree_set_accepts_nested_pydantic_basemodel_inputs():
+    from pydantic import BaseModel as PydanticBaseModel
+
+    class Inner(PydanticBaseModel):
+        val: int
+
+    class MyNestedInput(PydanticBaseModel):
+        query: str
+        nested: Inner
+
+    rt = RunTree(name="test", run_type="chain", inputs={})
+    rt.set(inputs=MyNestedInput(query="hello", nested=Inner(val=42)))
+    assert rt.inputs == {"query": "hello", "nested": {"val": 42}}
+
+
+def test_runtree_set_accepts_pydantic_basemodel_outputs():
+    from pydantic import BaseModel as PydanticBaseModel
+
+    class MyOutput(PydanticBaseModel):
+        answer: str
+
+    rt = RunTree(name="test", run_type="chain", inputs={})
+    rt.set(outputs=MyOutput(answer="result"))
+    assert rt.outputs == {"answer": "result"}


### PR DESCRIPTION
## Summary

Fixes #2765

`RunTree` raised `ValidationError` when a Pydantic `BaseModel` instance was passed as `inputs` or `outputs`, because those fields are typed as `dict`. The `@traceable` decorator already handled this case via `model_dump()` in `_container_end`, but the `RunTree` direct API did not.

**Before:**
```python
RunTree(name="test", run_type="chain", inputs=MyInput(query="hello"))
# ValidationError: inputs - Input should be a valid dictionary
```

**After:**
```python
rt = RunTree(name="test", run_type="chain", inputs=MyInput(query="hello"))
rt.inputs  # {"query": "hello"}
```

## Changes

- Add a module-level `_coerce_to_dict(value)` helper that calls `.model_dump()` on Pydantic BaseModel instances, mirroring the logic in `_container_end`.
- Apply it in `RunTree.infer_defaults` (mode="before" validator) — covers constructor args
- Apply it in `RunTree.set()` — covers `set(inputs=..., outputs=...)`
- Apply it in `RunTree.end()` — covers `end(outputs=...)`

## Test plan

Added five unit tests in `tests/unit_tests/test_run_trees.py` covering:
- Constructor with `inputs=BaseModel`
- Constructor with `outputs=BaseModel`
- `end(outputs=BaseModel)` — verifies no silent storage of raw BaseModel
- `set(inputs=NestedBaseModel)` — verifies full recursive conversion via `model_dump()`
- `set(outputs=BaseModel)`