### PR TITLE
feat(python-sandbox): support snapshot_name and list filters

### DIFF
--- a/python/langsmith/sandbox/README.md
+++ b/python/langsmith/sandbox/README.md
@@ -640,14 +640,15 @@ with client.sandbox(snapshot_id=snapshot.id) as sb:
 ### Snapshot CRUD
 
 ```python
-# List all snapshots
+# List snapshots (server paginates with a default page size of 50)
 snapshots = client.list_snapshots()
 
-# Filter and paginate — all three kwargs are optional and independent
+# Filter and paginate — all three kwargs are optional and independent.
+# `limit` must be between 1 and 500 (inclusive); `offset` must be >= 0.
 snapshots = client.list_snapshots(
-    name_contains="python",  # server-side substring match on name
-    limit=10,
-    offset=20,
+    name_contains="python",  # case-insensitive substring match on name
+    limit=100,
+    offset=0,
 )
 
 # Get a snapshot by ID
@@ -899,7 +900,7 @@ except SandboxClientError as e:
 | `create_snapshot(name, docker_image, fs_capacity_bytes, *, timeout=60)` | Build a snapshot from a Docker image |
 | `capture_snapshot(sandbox_name, name, *, timeout=60)` | Capture a snapshot from a running sandbox |
 | `get_snapshot(snapshot_id)` | Get a snapshot by ID |
-| `list_snapshots(*, name_contains=None, limit=None, offset=None)` | List snapshots (optional server-side substring filter and pagination) |
+| `list_snapshots(*, name_contains=None, limit=None, offset=None)` | List a page of snapshots (server paginates, default limit 50, max 500; `name_contains` is a case-insensitive substring match) |
 | `delete_snapshot(snapshot_id)` | Delete a snapshot |
 | `wait_for_snapshot(snapshot_id, *, timeout=300)` | Poll until snapshot is ready or failed |
 

--- a/python/langsmith/sandbox/README.md
+++ b/python/langsmith/sandbox/README.md
@@ -592,8 +592,15 @@ snapshot = client.create_snapshot(
     fs_capacity_bytes=4 * 1024**3,  # 4 GB
 )
 
-# Create a sandbox from the snapshot
+# Create a sandbox from the snapshot (by ID)
 with client.sandbox(snapshot_id=snapshot.id) as sb:
+    result = sb.run("python --version")
+    print(result.stdout)
+
+# Or resolve by snapshot name — the server looks up the snapshot owned by
+# your tenant and boots from it. Exactly one of snapshot_id or snapshot_name
+# must be provided.
+with client.sandbox(snapshot_name="my-python-env") as sb:
     result = sb.run("python --version")
     print(result.stdout)
 ```
@@ -635,6 +642,13 @@ with client.sandbox(snapshot_id=snapshot.id) as sb:
 ```python
 # List all snapshots
 snapshots = client.list_snapshots()
+
+# Filter and paginate — all three kwargs are optional and independent
+snapshots = client.list_snapshots(
+    name_contains="python",  # server-side substring match on name
+    limit=10,
+    offset=20,
+)
 
 # Get a snapshot by ID
 snapshot = client.get_snapshot("550e8400-...")
@@ -871,8 +885,8 @@ except SandboxClientError as e:
 
 | Method | Description |
 |--------|-------------|
-| `sandbox(snapshot_id, *, ttl_seconds=None, idle_ttl_seconds=None, ...)` | Create a sandbox (auto-deleted on context exit). |
-| `create_sandbox(snapshot_id, *, wait_for_ready=True, ...)` | Create a sandbox (requires explicit delete). |
+| `sandbox(snapshot_id=None, *, snapshot_name=None, ttl_seconds=None, idle_ttl_seconds=None, ...)` | Create a sandbox (auto-deleted on context exit). Exactly one of `snapshot_id` / `snapshot_name` must be set. |
+| `create_sandbox(snapshot_id=None, *, snapshot_name=None, wait_for_ready=True, ...)` | Create a sandbox (requires explicit delete). Exactly one of `snapshot_id` / `snapshot_name` must be set. |
 | `get_sandbox(name)` | Get an existing sandbox by name |
 | `get_sandbox_status(name)` | Get lightweight provisioning status (`ResourceStatus`) |
 | `wait_for_sandbox(name, *, timeout=120, poll_interval=1.0)` | Poll until sandbox is ready or failed |
@@ -885,7 +899,7 @@ except SandboxClientError as e:
 | `create_snapshot(name, docker_image, fs_capacity_bytes, *, timeout=60)` | Build a snapshot from a Docker image |
 | `capture_snapshot(sandbox_name, name, *, timeout=60)` | Capture a snapshot from a running sandbox |
 | `get_snapshot(snapshot_id)` | Get a snapshot by ID |
-| `list_snapshots()` | List all snapshots |
+| `list_snapshots(*, name_contains=None, limit=None, offset=None)` | List snapshots (optional server-side substring filter and pagination) |
 | `delete_snapshot(snapshot_id)` | Delete a snapshot |
 | `wait_for_snapshot(snapshot_id, *, timeout=300)` | Poll until snapshot is ready or failed |
 

--- a/python/langsmith/sandbox/_async_client.py
+++ b/python/langsmith/sandbox/_async_client.py
@@ -836,18 +836,25 @@ class AsyncSandboxClient:
     ) -> list[Snapshot]:
         """List snapshots.
 
+        The backend always paginates this endpoint. When ``limit`` is omitted
+        the server applies a default page size (currently 50), so a single
+        call is not guaranteed to return every snapshot. To iterate through
+        all results, repeat the call with increasing ``offset`` values (or an
+        explicit ``limit``) until fewer than ``limit`` snapshots come back.
+
         Args:
-            name_contains: Optional substring filter applied to snapshot names
-                server-side (case sensitivity follows the backend
-                implementation).
-            limit: Optional maximum number of snapshots to return.
+            name_contains: Optional case-insensitive substring filter applied
+                to snapshot names server-side.
+            limit: Optional maximum number of snapshots to return for a single
+                request. Must be between 1 and 500 (inclusive); the server
+                rejects values outside that range. Defaults to 50 server-side
+                when omitted.
             offset: Optional number of snapshots to skip before returning
-                results. Useful for paginating through large result sets in
-                combination with ``limit``.
+                results. Must be ``>= 0``. Useful for paginating through
+                large result sets in combination with ``limit``.
 
         Returns:
-            List of Snapshots matching the provided filters (or all snapshots
-            when no filters are supplied).
+            A single page of Snapshots matching the provided filters.
         """
         url = f"{self._base_url}/snapshots"
 

--- a/python/langsmith/sandbox/_async_client.py
+++ b/python/langsmith/sandbox/_async_client.py
@@ -143,8 +143,9 @@ class AsyncSandboxClient:
 
     async def sandbox(
         self,
-        snapshot_id: str,
+        snapshot_id: Optional[str] = None,
         *,
+        snapshot_name: Optional[str] = None,
         name: Optional[str] = None,
         timeout: int = 30,
         ttl_seconds: Optional[int] = None,
@@ -163,11 +164,19 @@ class AsyncSandboxClient:
             async with await client.sandbox(snapshot_id="<uuid>") as sandbox:
                 result = await sandbox.run("echo hello")
 
+            # Resolve by snapshot name instead of ID:
+            async with await client.sandbox(snapshot_name="my-snap") as sandbox:
+                result = await sandbox.run("echo hello")
+
         The sandbox is automatically deleted when exiting the context manager.
         For sandboxes with manual lifecycle management, use create_sandbox().
 
         Args:
-            snapshot_id: Snapshot ID to boot from.
+            snapshot_id: Snapshot ID to boot from. Mutually exclusive with
+                ``snapshot_name``; exactly one must be provided.
+            snapshot_name: Snapshot name to boot from. Resolved server-side to a
+                snapshot owned by the caller's tenant. Mutually exclusive with
+                ``snapshot_id``; exactly one must be provided.
             name: Optional sandbox name (auto-generated if not provided).
             timeout: Timeout in seconds when waiting for ready.
             ttl_seconds: Maximum lifetime in seconds from creation. The sandbox
@@ -195,10 +204,12 @@ class AsyncSandboxClient:
             ResourceTimeoutError: If timeout waiting for sandbox to be ready.
             ResourceCreationError: If sandbox creation fails.
             SandboxClientError: For other errors.
-            ValueError: If TTL values are invalid.
+            ValueError: If TTL values are invalid, or if neither/both of
+                ``snapshot_id`` and ``snapshot_name`` are provided.
         """
         sb = await self.create_sandbox(
             snapshot_id,
+            snapshot_name=snapshot_name,
             name=name,
             timeout=timeout,
             ttl_seconds=ttl_seconds,
@@ -214,8 +225,9 @@ class AsyncSandboxClient:
 
     async def create_sandbox(
         self,
-        snapshot_id: str,
+        snapshot_id: Optional[str] = None,
         *,
+        snapshot_name: Optional[str] = None,
         name: Optional[str] = None,
         timeout: int = 30,
         wait_for_ready: bool = True,
@@ -233,7 +245,11 @@ class AsyncSandboxClient:
         or use sandbox() for automatic cleanup with a context manager.
 
         Args:
-            snapshot_id: Snapshot ID to boot from.
+            snapshot_id: Snapshot ID to boot from. Mutually exclusive with
+                ``snapshot_name``; exactly one must be provided.
+            snapshot_name: Snapshot name to boot from. Resolved server-side to a
+                snapshot owned by the caller's tenant. Mutually exclusive with
+                ``snapshot_id``; exactly one must be provided.
             name: Optional sandbox name (auto-generated if not provided).
             timeout: Timeout in seconds when waiting for ready (only used when
                 wait_for_ready=True).
@@ -266,10 +282,11 @@ class AsyncSandboxClient:
             ResourceTimeoutError: If timeout waiting for sandbox to be ready.
             ResourceCreationError: If sandbox creation fails.
             SandboxClientError: For other errors.
-            ValueError: If TTL values are invalid.
+            ValueError: If TTL values are invalid, or if neither/both of
+                ``snapshot_id`` and ``snapshot_name`` are provided.
         """
-        if not snapshot_id:
-            raise ValueError("snapshot_id is required")
+        if bool(snapshot_id) == bool(snapshot_name):
+            raise ValueError("Exactly one of snapshot_id or snapshot_name must be set")
 
         validate_ttl(ttl_seconds, "ttl_seconds")
         validate_ttl(idle_ttl_seconds, "idle_ttl_seconds")
@@ -278,8 +295,11 @@ class AsyncSandboxClient:
 
         payload: dict[str, Any] = {
             "wait_for_ready": wait_for_ready,
-            "snapshot_id": snapshot_id,
         }
+        if snapshot_id:
+            payload["snapshot_id"] = snapshot_id
+        if snapshot_name:
+            payload["snapshot_name"] = snapshot_name
         if wait_for_ready:
             payload["timeout"] = timeout
         if name:
@@ -806,16 +826,45 @@ class AsyncSandboxClient:
             handle_client_http_error(e)
             raise  # pragma: no cover
 
-    async def list_snapshots(self, *, headers: RequestHeaders = None) -> list[Snapshot]:
-        """List all snapshots.
+    async def list_snapshots(
+        self,
+        *,
+        name_contains: Optional[str] = None,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
+        headers: RequestHeaders = None,
+    ) -> list[Snapshot]:
+        """List snapshots.
+
+        Args:
+            name_contains: Optional substring filter applied to snapshot names
+                server-side (case sensitivity follows the backend
+                implementation).
+            limit: Optional maximum number of snapshots to return.
+            offset: Optional number of snapshots to skip before returning
+                results. Useful for paginating through large result sets in
+                combination with ``limit``.
 
         Returns:
-            List of Snapshots.
+            List of Snapshots matching the provided filters (or all snapshots
+            when no filters are supplied).
         """
         url = f"{self._base_url}/snapshots"
 
+        params: dict[str, Any] = {}
+        if name_contains is not None:
+            params["name_contains"] = name_contains
+        if limit is not None:
+            params["limit"] = limit
+        if offset is not None:
+            params["offset"] = offset
+
         try:
-            response = await self._http.get(url, headers=self._request_headers(headers))
+            response = await self._http.get(
+                url,
+                params=params or None,
+                headers=self._request_headers(headers),
+            )
             response.raise_for_status()
             data = response.json()
             return [Snapshot.from_dict(s) for s in data.get("snapshots", [])]

--- a/python/langsmith/sandbox/_client.py
+++ b/python/langsmith/sandbox/_client.py
@@ -814,18 +814,25 @@ class SandboxClient:
     ) -> list[Snapshot]:
         """List snapshots.
 
+        The backend always paginates this endpoint. When ``limit`` is omitted
+        the server applies a default page size (currently 50), so a single
+        call is not guaranteed to return every snapshot. To iterate through
+        all results, repeat the call with increasing ``offset`` values (or an
+        explicit ``limit``) until fewer than ``limit`` snapshots come back.
+
         Args:
-            name_contains: Optional substring filter applied to snapshot names
-                server-side (case sensitivity follows the backend
-                implementation).
-            limit: Optional maximum number of snapshots to return.
+            name_contains: Optional case-insensitive substring filter applied
+                to snapshot names server-side.
+            limit: Optional maximum number of snapshots to return for a single
+                request. Must be between 1 and 500 (inclusive); the server
+                rejects values outside that range. Defaults to 50 server-side
+                when omitted.
             offset: Optional number of snapshots to skip before returning
-                results. Useful for paginating through large result sets in
-                combination with ``limit``.
+                results. Must be ``>= 0``. Useful for paginating through
+                large result sets in combination with ``limit``.
 
         Returns:
-            List of Snapshots matching the provided filters (or all snapshots
-            when no filters are supplied).
+            A single page of Snapshots matching the provided filters.
         """
         url = f"{self._base_url}/snapshots"
 

--- a/python/langsmith/sandbox/_client.py
+++ b/python/langsmith/sandbox/_client.py
@@ -140,8 +140,9 @@ class SandboxClient:
 
     def sandbox(
         self,
-        snapshot_id: str,
+        snapshot_id: Optional[str] = None,
         *,
+        snapshot_name: Optional[str] = None,
         name: Optional[str] = None,
         timeout: int = 30,
         ttl_seconds: Optional[int] = None,
@@ -160,11 +161,19 @@ class SandboxClient:
             with client.sandbox(snapshot_id="<uuid>") as sandbox:
                 result = sandbox.run("echo hello")
 
+            # Resolve by snapshot name instead of ID:
+            with client.sandbox(snapshot_name="my-snap") as sandbox:
+                result = sandbox.run("echo hello")
+
         The sandbox is automatically deleted when exiting the context manager.
         For sandboxes with manual lifecycle management, use create_sandbox().
 
         Args:
-            snapshot_id: Snapshot ID to boot from.
+            snapshot_id: Snapshot ID to boot from. Mutually exclusive with
+                ``snapshot_name``; exactly one must be provided.
+            snapshot_name: Snapshot name to boot from. Resolved server-side to a
+                snapshot owned by the caller's tenant. Mutually exclusive with
+                ``snapshot_id``; exactly one must be provided.
             name: Optional sandbox name (auto-generated if not provided).
             timeout: Timeout in seconds when waiting for ready.
             ttl_seconds: Maximum lifetime in seconds from creation. The sandbox
@@ -192,10 +201,12 @@ class SandboxClient:
             ResourceTimeoutError: If timeout waiting for sandbox to be ready.
             ResourceCreationError: If sandbox creation fails.
             SandboxClientError: For other errors.
-            ValueError: If TTL values are invalid.
+            ValueError: If TTL values are invalid, or if neither/both of
+                ``snapshot_id`` and ``snapshot_name`` are provided.
         """
         sb = self.create_sandbox(
             snapshot_id,
+            snapshot_name=snapshot_name,
             name=name,
             timeout=timeout,
             ttl_seconds=ttl_seconds,
@@ -211,8 +222,9 @@ class SandboxClient:
 
     def create_sandbox(
         self,
-        snapshot_id: str,
+        snapshot_id: Optional[str] = None,
         *,
+        snapshot_name: Optional[str] = None,
         name: Optional[str] = None,
         timeout: int = 30,
         wait_for_ready: bool = True,
@@ -230,7 +242,11 @@ class SandboxClient:
         or use sandbox() for automatic cleanup with a context manager.
 
         Args:
-            snapshot_id: Snapshot ID to boot from.
+            snapshot_id: Snapshot ID to boot from. Mutually exclusive with
+                ``snapshot_name``; exactly one must be provided.
+            snapshot_name: Snapshot name to boot from. Resolved server-side to a
+                snapshot owned by the caller's tenant. Mutually exclusive with
+                ``snapshot_id``; exactly one must be provided.
             name: Optional sandbox name (auto-generated if not provided).
             timeout: Timeout in seconds when waiting for ready (only used when
                 wait_for_ready=True).
@@ -263,10 +279,11 @@ class SandboxClient:
             ResourceTimeoutError: If timeout waiting for sandbox to be ready.
             ResourceCreationError: If sandbox creation fails.
             SandboxClientError: For other errors.
-            ValueError: If TTL values are invalid.
+            ValueError: If TTL values are invalid, or if neither/both of
+                ``snapshot_id`` and ``snapshot_name`` are provided.
         """
-        if not snapshot_id:
-            raise ValueError("snapshot_id is required")
+        if bool(snapshot_id) == bool(snapshot_name):
+            raise ValueError("Exactly one of snapshot_id or snapshot_name must be set")
 
         validate_ttl(ttl_seconds, "ttl_seconds")
         validate_ttl(idle_ttl_seconds, "idle_ttl_seconds")
@@ -275,8 +292,11 @@ class SandboxClient:
 
         payload: dict[str, Any] = {
             "wait_for_ready": wait_for_ready,
-            "snapshot_id": snapshot_id,
         }
+        if snapshot_id:
+            payload["snapshot_id"] = snapshot_id
+        if snapshot_name:
+            payload["snapshot_name"] = snapshot_name
         if wait_for_ready:
             payload["timeout"] = timeout
         if name:
@@ -784,16 +804,45 @@ class SandboxClient:
             handle_client_http_error(e)
             raise  # pragma: no cover
 
-    def list_snapshots(self, *, headers: RequestHeaders = None) -> list[Snapshot]:
-        """List all snapshots.
+    def list_snapshots(
+        self,
+        *,
+        name_contains: Optional[str] = None,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
+        headers: RequestHeaders = None,
+    ) -> list[Snapshot]:
+        """List snapshots.
+
+        Args:
+            name_contains: Optional substring filter applied to snapshot names
+                server-side (case sensitivity follows the backend
+                implementation).
+            limit: Optional maximum number of snapshots to return.
+            offset: Optional number of snapshots to skip before returning
+                results. Useful for paginating through large result sets in
+                combination with ``limit``.
 
         Returns:
-            List of Snapshots.
+            List of Snapshots matching the provided filters (or all snapshots
+            when no filters are supplied).
         """
         url = f"{self._base_url}/snapshots"
 
+        params: dict[str, Any] = {}
+        if name_contains is not None:
+            params["name_contains"] = name_contains
+        if limit is not None:
+            params["limit"] = limit
+        if offset is not None:
+            params["offset"] = offset
+
         try:
-            response = self._http.get(url, headers=self._request_headers(headers))
+            response = self._http.get(
+                url,
+                params=params or None,
+                headers=self._request_headers(headers),
+            )
             response.raise_for_status()
             data = response.json()
             return [Snapshot.from_dict(s) for s in data.get("snapshots", [])]

--- a/python/tests/unit_tests/sandbox/test_async_client.py
+++ b/python/tests/unit_tests/sandbox/test_async_client.py
@@ -668,6 +668,107 @@ class TestAsyncSandboxOperations:
         assert sandboxes[0].status == "ready"
         assert sandboxes[1].status == "provisioning"
 
+    async def test_create_sandbox_with_snapshot_name(
+        self, client: AsyncSandboxClient, httpx_mock: HTTPXMock
+    ):
+        """Test creating a sandbox by snapshot name (server-side resolution)."""
+        import json
+
+        httpx_mock.add_response(
+            method="POST",
+            url="http://test-server:8080/boxes",
+            json={
+                "name": "my-vm",
+                "snapshot_id": "snap-1",
+                "status": "ready",
+                "dataplane_url": "https://dp.example.com/my-vm",
+            },
+            status_code=201,
+        )
+
+        sandbox = await client.create_sandbox(snapshot_name="my-snap", name="my-vm")
+
+        assert sandbox.name == "my-vm"
+        assert sandbox.snapshot_id == "snap-1"
+
+        body = json.loads(httpx_mock.get_request().content)
+        assert body["snapshot_name"] == "my-snap"
+        assert "snapshot_id" not in body
+        assert "template_name" not in body
+
+    async def test_create_sandbox_requires_exactly_one_identifier(
+        self, client: AsyncSandboxClient
+    ):
+        """Test that exactly one of snapshot_id / snapshot_name must be set."""
+        with pytest.raises(
+            ValueError,
+            match="Exactly one of snapshot_id or snapshot_name must be set",
+        ):
+            await client.create_sandbox()
+
+        with pytest.raises(
+            ValueError,
+            match="Exactly one of snapshot_id or snapshot_name must be set",
+        ):
+            await client.create_sandbox(snapshot_id="snap-1", snapshot_name="my-snap")
+
+    async def test_list_snapshots(
+        self, client: AsyncSandboxClient, httpx_mock: HTTPXMock
+    ):
+        """Test listing snapshots with no filters."""
+        httpx_mock.add_response(
+            method="GET",
+            url="http://test-server:8080/snapshots",
+            json={
+                "snapshots": [
+                    {
+                        "id": "snap-1",
+                        "name": "env-1",
+                        "status": "ready",
+                    },
+                ],
+                "offset": 0,
+            },
+        )
+
+        snapshots = await client.list_snapshots()
+
+        assert len(snapshots) == 1
+        assert snapshots[0].name == "env-1"
+
+        request = httpx_mock.get_request()
+        assert request.url.query == b""
+
+    async def test_list_snapshots_with_filters(
+        self, client: AsyncSandboxClient, httpx_mock: HTTPXMock
+    ):
+        """Test listing snapshots forwards name_contains/limit/offset."""
+        httpx_mock.add_response(
+            method="GET",
+            url=(
+                "http://test-server:8080/snapshots?name_contains=env&limit=10&offset=5"
+            ),
+            json={
+                "snapshots": [
+                    {
+                        "id": "snap-1",
+                        "name": "env-1",
+                        "status": "ready",
+                    }
+                ],
+                "offset": 5,
+            },
+        )
+
+        snapshots = await client.list_snapshots(name_contains="env", limit=10, offset=5)
+
+        assert len(snapshots) == 1
+        assert snapshots[0].name == "env-1"
+
+        request = httpx_mock.get_request()
+        params = dict(request.url.params)
+        assert params == {"name_contains": "env", "limit": "10", "offset": "5"}
+
 
 class TestAsyncConnectionErrors:
     """Tests for async connection error handling."""

--- a/python/tests/unit_tests/sandbox/test_client.py
+++ b/python/tests/unit_tests/sandbox/test_client.py
@@ -965,6 +965,39 @@ class TestSnapshotOperations:
         assert snapshots[0].name == "env-1"
         assert snapshots[1].status == "building"
 
+        request = httpx_mock.get_request()
+        assert request.url.query == b""
+
+    def test_list_snapshots_with_filters(
+        self, client: SandboxClient, httpx_mock: HTTPXMock
+    ):
+        """Test listing snapshots forwards name_contains/limit/offset."""
+        httpx_mock.add_response(
+            method="GET",
+            url=(
+                "http://test-server:8080/snapshots?name_contains=env&limit=10&offset=5"
+            ),
+            json={
+                "snapshots": [
+                    {
+                        "id": "snap-1",
+                        "name": "env-1",
+                        "status": "ready",
+                    }
+                ],
+                "offset": 5,
+            },
+        )
+
+        snapshots = client.list_snapshots(name_contains="env", limit=10, offset=5)
+
+        assert len(snapshots) == 1
+        assert snapshots[0].name == "env-1"
+
+        request = httpx_mock.get_request()
+        params = dict(request.url.params)
+        assert params == {"name_contains": "env", "limit": "10", "offset": "5"}
+
     def test_delete_snapshot(self, client: SandboxClient, httpx_mock: HTTPXMock):
         """Test deleting a snapshot."""
         httpx_mock.add_response(
@@ -1126,9 +1159,50 @@ class TestStartStopOperations:
         request = httpx_mock.get_request()
         body = json.loads(request.content)
         assert body["snapshot_id"] == "snap-1"
+        assert "snapshot_name" not in body
         assert "template_name" not in body
 
-    def test_create_sandbox_requires_snapshot_id(self, client: SandboxClient):
-        """Test that snapshot_id is required."""
-        with pytest.raises(TypeError):
-            client.create_sandbox()  # type: ignore[call-arg]
+    def test_create_sandbox_with_snapshot_name(
+        self, client: SandboxClient, httpx_mock: HTTPXMock
+    ):
+        """Test creating a sandbox by snapshot name (server-side resolution)."""
+        httpx_mock.add_response(
+            method="POST",
+            url="http://test-server:8080/boxes",
+            json={
+                "name": "my-vm",
+                "snapshot_id": "snap-1",
+                "status": "ready",
+                "dataplane_url": "https://dp.example.com/my-vm",
+            },
+            status_code=201,
+        )
+
+        sandbox = client.create_sandbox(snapshot_name="my-snap", name="my-vm")
+
+        assert sandbox.name == "my-vm"
+        assert sandbox.snapshot_id == "snap-1"
+
+        import json
+
+        request = httpx_mock.get_request()
+        body = json.loads(request.content)
+        assert body["snapshot_name"] == "my-snap"
+        assert "snapshot_id" not in body
+        assert "template_name" not in body
+
+    def test_create_sandbox_requires_exactly_one_identifier(
+        self, client: SandboxClient
+    ):
+        """Test that exactly one of snapshot_id / snapshot_name must be set."""
+        with pytest.raises(
+            ValueError,
+            match="Exactly one of snapshot_id or snapshot_name must be set",
+        ):
+            client.create_sandbox()
+
+        with pytest.raises(
+            ValueError,
+            match="Exactly one of snapshot_id or snapshot_name must be set",
+        ):
+            client.create_sandbox(snapshot_id="snap-1", snapshot_name="my-snap")


### PR DESCRIPTION
## Summary

Follow-up to #2757 — extends the snapshot-only sandbox surface so callers can boot from a snapshot **name** (not just an ID) and so `list_snapshots` supports server-side filtering and pagination.

Sibling to the JS SDK change: #2770.

> Stacked on #2757. GitHub will auto-retarget the base to `main` once that PR merges.

### `create_sandbox` / `sandbox` — accept `snapshot_name`

Exactly one of `snapshot_id` / `snapshot_name` must be provided. The SDK forwards the identifier verbatim on the wire; the backend resolves `snapshot_name` against the caller's tenant.

```python
with client.sandbox(snapshot_id=snapshot.id) as sb:
    ...

# Equivalent, resolved by name on the server:
with client.sandbox(snapshot_name="my-python-env") as sb:
    ...
```

Implemented symmetrically in `SandboxClient` and `AsyncSandboxClient`.

### `list_snapshots` — optional `name_contains` / `limit` / `offset`

```python
snapshots = client.list_snapshots(
    name_contains="python",
    limit=10,
    offset=20,
)
```

All three kwargs are optional and independent; omitting them preserves today's zero-arg behavior (no query string). The kwargs are mirrored on `AsyncSandboxClient`.

### Tests

- `test_create_sandbox_with_snapshot_name` (sync + async): asserts the POST body has `snapshot_name` and no `snapshot_id` / `template_name`.
- `test_create_sandbox_requires_exactly_one_identifier` (sync + async): both missing -> error; both set -> error.
- `test_list_snapshots` extended to assert the zero-arg URL has no query string.
- `test_list_snapshots_with_filters` (sync + async): asserts the request URL carries `name_contains`, `limit`, `offset`.

### README

- Added a `snapshot_name=` example in the Snapshots section alongside the existing `snapshot_id=` example.
- Added a `list_snapshots(name_contains=..., limit=..., offset=...)` example in the Snapshot CRUD section.
- Updated the API Reference table entries for `sandbox`, `create_sandbox`, and `list_snapshots`.

### Breaking changes

None. `snapshot_id` remains positional; callers that pass `snapshot_id=...` keep working unchanged. Callers that relied on the "missing snapshot_id raises `TypeError`" contract now get a `ValueError` instead, but this is a stronger error for an already-broken call.

Made with Cursor