### PR TITLE
feat(js-sandbox): support snapshotName and list filters

### DIFF
--- a/js/src/experimental/sandbox/README.md
+++ b/js/src/experimental/sandbox/README.md
@@ -396,11 +396,14 @@ const byName = await client.createSandbox(undefined, {
 });
 
 // List / fetch / delete snapshots. listSnapshots() accepts optional
-// server-side filters and pagination; omit them to return everything.
-const snapshots = await client.listSnapshots();
+// server-side filters and pagination; when omitted the server applies a
+// default page size of 50, so calling it once will not necessarily return
+// every snapshot. `limit` must be between 1 and 500 and `offset` must be
+// >= 0.
+const firstPage = await client.listSnapshots();
 const firstPython = await client.listSnapshots({
   nameContains: "python",
-  limit: 10,
+  limit: 100,
   offset: 0,
 });
 const loaded = await client.getSnapshot(snapshot.id);
@@ -495,7 +498,7 @@ try {
 | `createSnapshot(name, dockerImage, fsCapacityBytes, options?)` | Build a snapshot from a Docker image |
 | `captureSnapshot(sandboxName, name, options?)` | Capture a snapshot from a running sandbox |
 | `getSnapshot(snapshotId)` | Get a snapshot by ID |
-| `listSnapshots(options?)` | List snapshots with optional server-side filters and pagination (`nameContains`, `limit`, `offset`). |
+| `listSnapshots(options?)` | List a page of snapshots with optional server-side filters and pagination (server paginates, default limit 50, max 500). |
 | `deleteSnapshot(snapshotId)` | Delete a snapshot |
 | `waitForSnapshot(snapshotId, options?)` | Poll until a snapshot becomes ready |
 
@@ -561,9 +564,9 @@ try {
 
 | Property | Description |
 |----------|-------------|
-| `nameContains?` | Server-side substring filter applied to snapshot names |
-| `limit?` | Maximum number of snapshots to return |
-| `offset?` | Number of snapshots to skip before returning results (pairs with `limit`) |
+| `nameContains?` | Case-insensitive substring filter applied server-side to snapshot names |
+| `limit?` | Page size; must be in `[1, 500]`. Server defaults to 50 when omitted |
+| `offset?` | Number of snapshots to skip before returning results (must be `>= 0`, pairs with `limit`) |
 | `signal?` | `AbortSignal` for cancellation |
 
 ### CreateSnapshotOptions

--- a/js/src/experimental/sandbox/README.md
+++ b/js/src/experimental/sandbox/README.md
@@ -388,8 +388,21 @@ console.log(captured.id, captured.source_sandbox_id);
 // Boot a new sandbox from the captured snapshot
 const resumed = await client.createSandbox(captured.id);
 
-// List / fetch / delete snapshots
+// Or resolve by snapshot name instead of ID — the server looks up the
+// snapshot owned by your tenant. Exactly one of the positional `snapshotId`
+// or `options.snapshotName` must be provided.
+const byName = await client.createSandbox(undefined, {
+  snapshotName: "with-data",
+});
+
+// List / fetch / delete snapshots. listSnapshots() accepts optional
+// server-side filters and pagination; omit them to return everything.
 const snapshots = await client.listSnapshots();
+const firstPython = await client.listSnapshots({
+  nameContains: "python",
+  limit: 10,
+  offset: 0,
+});
 const loaded = await client.getSnapshot(snapshot.id);
 await client.deleteSnapshot(snapshot.id);
 ```
@@ -470,7 +483,7 @@ try {
 
 | Method | Description |
 |--------|-------------|
-| `createSandbox(snapshotId, options?)` | Create a sandbox from a snapshot |
+| `createSandbox(snapshotId?, options?)` | Create a sandbox from a snapshot. Exactly one of the positional `snapshotId` or `options.snapshotName` must be provided. |
 | `getSandbox(name)` | Get an existing sandbox by name |
 | `listSandboxes()` | List all sandboxes |
 | `updateSandbox(name, options)` | Rename or adjust TTLs on a sandbox |
@@ -482,7 +495,7 @@ try {
 | `createSnapshot(name, dockerImage, fsCapacityBytes, options?)` | Build a snapshot from a Docker image |
 | `captureSnapshot(sandboxName, name, options?)` | Capture a snapshot from a running sandbox |
 | `getSnapshot(snapshotId)` | Get a snapshot by ID |
-| `listSnapshots()` | List all snapshots |
+| `listSnapshots(options?)` | List snapshots with optional server-side filters and pagination (`nameContains`, `limit`, `offset`). |
 | `deleteSnapshot(snapshotId)` | Delete a snapshot |
 | `waitForSnapshot(snapshotId, options?)` | Poll until a snapshot becomes ready |
 
@@ -533,6 +546,7 @@ try {
 
 | Property | Description |
 |----------|-------------|
+| `snapshotName?` | Snapshot name to boot from. Mutually exclusive with the positional `snapshotId` argument on `createSandbox`; exactly one must be set. |
 | `name?` | Custom sandbox name |
 | `timeout?` | Wait timeout in seconds |
 | `waitForReady?` | Wait for the sandbox to be ready before returning (default: `true`) |
@@ -542,6 +556,15 @@ try {
 | `memBytes?` | Memory allocation in bytes |
 | `fsCapacityBytes?` | Root filesystem capacity in bytes |
 | `proxyConfig?` | Per-sandbox proxy configuration (access control, rules, `no_proxy`) |
+
+### ListSnapshotsOptions
+
+| Property | Description |
+|----------|-------------|
+| `nameContains?` | Server-side substring filter applied to snapshot names |
+| `limit?` | Maximum number of snapshots to return |
+| `offset?` | Number of snapshots to skip before returning results (pairs with `limit`) |
+| `signal?` | `AbortSignal` for cancellation |
 
 ### CreateSnapshotOptions
 

--- a/js/src/experimental/sandbox/client.ts
+++ b/js/src/experimental/sandbox/client.ts
@@ -697,17 +697,28 @@ export class SandboxClient {
   /**
    * List snapshots, optionally filtered and paginated server-side.
    *
-   * @param options - Optional filter/pagination options. When omitted,
-   *   returns all snapshots visible to the caller's tenant.
-   * @returns List of Snapshots.
+   * The backend always paginates this endpoint. When `limit` is omitted the
+   * server applies a default page size (currently 50), so a single call is
+   * not guaranteed to return every snapshot visible to the tenant. To iterate
+   * through all results, repeat the call with increasing `offset` values (or
+   * an explicit `limit`) until fewer than `limit` snapshots come back.
+   *
+   * @param options - Optional filter/pagination options.
+   *   - `nameContains`: case-insensitive substring match on snapshot name.
+   *   - `limit`: page size; must be between 1 and 500 (inclusive). Defaults
+   *     to 50 server-side when omitted.
+   *   - `offset`: number of snapshots to skip; must be `>= 0`.
+   *
+   *   Values outside those ranges are rejected by the server.
+   * @returns A single page of Snapshots matching the provided filters.
    *
    * @example
    * ```typescript
-   * const all = await client.listSnapshots();
+   * const firstPage = await client.listSnapshots();
    * const page = await client.listSnapshots({
    *   nameContains: "python",
-   *   limit: 10,
-   *   offset: 20,
+   *   limit: 100,
+   *   offset: 0,
    * });
    * ```
    */

--- a/js/src/experimental/sandbox/client.ts
+++ b/js/src/experimental/sandbox/client.ts
@@ -9,6 +9,7 @@ import type {
   CaptureSnapshotOptions,
   CreateSandboxOptions,
   CreateSnapshotOptions,
+  ListSnapshotsOptions,
   ResourceStatus,
   SandboxClientConfig,
   SandboxData,
@@ -25,6 +26,7 @@ import {
   LangSmithResourceNotFoundError,
   LangSmithResourceTimeoutError,
   LangSmithSandboxAPIError,
+  LangSmithValidationError,
 } from "./errors.js";
 import {
   handleClientHttpError,
@@ -189,13 +191,20 @@ export class SandboxClient {
    *
    * Remember to call `sandbox.delete()` when done to clean up resources.
    *
+   * Exactly one of `snapshotId` (positional) or `options.snapshotName` must
+   * be provided. When `snapshotName` is used, the server resolves it to a
+   * snapshot owned by the caller's tenant.
+   *
    * @param snapshotId - ID of the snapshot to boot from. Create one with
    *   `createSnapshot()` or `captureSnapshot()`, or pass an existing snapshot ID.
-   * @param options - Creation options.
+   *   Pass `undefined` when booting by name via `options.snapshotName`.
+   * @param options - Creation options. Use `options.snapshotName` to boot
+   *   by snapshot name instead of ID.
    * @returns Created Sandbox.
    * @throws ResourceTimeoutError if timeout waiting for sandbox to be ready.
    * @throws SandboxCreationError if sandbox creation fails.
-   * @throws LangSmithValidationError if TTL values are invalid.
+   * @throws LangSmithValidationError if TTL values are invalid, or if neither
+   *   (or both) of `snapshotId` / `options.snapshotName` are provided.
    *
    * @example
    * ```typescript
@@ -205,6 +214,10 @@ export class SandboxClient {
    *   1_073_741_824
    * );
    * const sandbox = await client.createSandbox(snapshot.id);
+   * // Or, resolve by snapshot name:
+   * const sandbox = await client.createSandbox(undefined, {
+   *   snapshotName: "python",
+   * });
    * try {
    *   const result = await sandbox.run("echo hello");
    *   console.log(result.stdout);
@@ -214,10 +227,11 @@ export class SandboxClient {
    * ```
    */
   async createSandbox(
-    snapshotId: string,
+    snapshotId?: string,
     options: CreateSandboxOptions = {}
   ): Promise<Sandbox> {
     const {
+      snapshotName,
       name,
       timeout = 30,
       waitForReady = true,
@@ -229,15 +243,27 @@ export class SandboxClient {
       proxyConfig,
     } = options;
 
+    if (!!snapshotId === !!snapshotName) {
+      throw new LangSmithValidationError(
+        "Exactly one of snapshotId or options.snapshotName must be set",
+        "snapshotId"
+      );
+    }
+
     validateTtl(ttlSeconds, "ttlSeconds");
     validateTtl(idleTtlSeconds, "idleTtlSeconds");
 
     const url = `${this._baseUrl}/boxes`;
 
     const payload: Record<string, unknown> = {
-      snapshot_id: snapshotId,
       wait_for_ready: waitForReady,
     };
+    if (snapshotId) {
+      payload.snapshot_id = snapshotId;
+    }
+    if (snapshotName) {
+      payload.snapshot_name = snapshotName;
+    }
     if (waitForReady) {
       payload.timeout = timeout;
     }
@@ -669,14 +695,42 @@ export class SandboxClient {
   }
 
   /**
-   * List all snapshots.
+   * List snapshots, optionally filtered and paginated server-side.
    *
+   * @param options - Optional filter/pagination options. When omitted,
+   *   returns all snapshots visible to the caller's tenant.
    * @returns List of Snapshots.
+   *
+   * @example
+   * ```typescript
+   * const all = await client.listSnapshots();
+   * const page = await client.listSnapshots({
+   *   nameContains: "python",
+   *   limit: 10,
+   *   offset: 20,
+   * });
+   * ```
    */
-  async listSnapshots(): Promise<Snapshot[]> {
-    const url = `${this._baseUrl}/snapshots`;
+  async listSnapshots(options: ListSnapshotsOptions = {}): Promise<Snapshot[]> {
+    const { nameContains, limit, offset, signal } = options;
 
-    const response = await this._fetch(url);
+    const params = new URLSearchParams();
+    if (nameContains !== undefined) {
+      params.set("name_contains", nameContains);
+    }
+    if (limit !== undefined) {
+      params.set("limit", String(limit));
+    }
+    if (offset !== undefined) {
+      params.set("offset", String(offset));
+    }
+
+    const query = params.toString();
+    const url = query
+      ? `${this._baseUrl}/snapshots?${query}`
+      : `${this._baseUrl}/snapshots`;
+
+    const response = await this._fetch(url, { signal });
 
     if (!response.ok) {
       await handleClientHttpError(response);

--- a/js/src/experimental/sandbox/index.ts
+++ b/js/src/experimental/sandbox/index.ts
@@ -49,6 +49,7 @@ export type {
   SandboxProxyConfig,
   CreateSnapshotOptions,
   CaptureSnapshotOptions,
+  ListSnapshotsOptions,
   WaitForSnapshotOptions,
   StartSandboxOptions,
   UpdateSandboxOptions,

--- a/js/src/experimental/sandbox/types.ts
+++ b/js/src/experimental/sandbox/types.ts
@@ -255,6 +255,12 @@ export interface SandboxProxyConfig {
  */
 export interface CreateSandboxOptions {
   /**
+   * Snapshot name to boot from. Mutually exclusive with the positional
+   * `snapshotId` argument on `createSandbox`; exactly one must be provided.
+   * Resolved server-side to a snapshot owned by the caller's tenant.
+   */
+  snapshotName?: string;
+  /**
    * Optional sandbox name (auto-generated if not provided).
    */
   name?: string;
@@ -318,6 +324,28 @@ export interface CreateSnapshotOptions {
 export interface CaptureSnapshotOptions {
   /** Timeout in seconds when waiting for ready. Default: 60. */
   timeout?: number;
+  /** AbortSignal for cancellation. */
+  signal?: AbortSignal;
+}
+
+/**
+ * Options for listing snapshots. All fields are optional and independent;
+ * omitting them returns all snapshots visible to the caller's tenant.
+ */
+export interface ListSnapshotsOptions {
+  /**
+   * Server-side substring filter applied to snapshot names.
+   */
+  nameContains?: string;
+  /**
+   * Maximum number of snapshots to return.
+   */
+  limit?: number;
+  /**
+   * Number of snapshots to skip before returning results. Useful for
+   * paginating through large result sets in combination with `limit`.
+   */
+  offset?: number;
   /** AbortSignal for cancellation. */
   signal?: AbortSignal;
 }

--- a/js/src/experimental/sandbox/types.ts
+++ b/js/src/experimental/sandbox/types.ts
@@ -329,21 +329,28 @@ export interface CaptureSnapshotOptions {
 }
 
 /**
- * Options for listing snapshots. All fields are optional and independent;
- * omitting them returns all snapshots visible to the caller's tenant.
+ * Options for listing snapshots. All fields are optional and independent.
+ *
+ * The backend always paginates: when `limit` is omitted the server applies
+ * a default page size (currently 50), so a single call will not necessarily
+ * return every snapshot visible to the caller's tenant.
  */
 export interface ListSnapshotsOptions {
   /**
-   * Server-side substring filter applied to snapshot names.
+   * Case-insensitive substring filter applied server-side to snapshot
+   * names.
    */
   nameContains?: string;
   /**
-   * Maximum number of snapshots to return.
+   * Maximum number of snapshots to return for a single request. Must be
+   * between 1 and 500 (inclusive); the server rejects values outside that
+   * range. Defaults to 50 server-side when omitted.
    */
   limit?: number;
   /**
-   * Number of snapshots to skip before returning results. Useful for
-   * paginating through large result sets in combination with `limit`.
+   * Number of snapshots to skip before returning results. Must be `>= 0`.
+   * Useful for paginating through large result sets in combination with
+   * `limit`.
    */
   offset?: number;
   /** AbortSignal for cancellation. */

--- a/js/src/tests/sandbox.test.ts
+++ b/js/src/tests/sandbox.test.ts
@@ -1095,6 +1095,53 @@ describe("SandboxClient - createSandbox (snapshotId)", () => {
     expect(sandbox.vCpus).toBe(4);
     expect(sandbox.mem_bytes).toBe(1073741824);
   });
+
+  it("should send snapshot_name (and no snapshot_id) when resolved by name", async () => {
+    const mockFetch = jest.fn<typeof fetch>().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        name: "test-sb",
+        snapshot_id: "snap-1",
+        dataplane_url: "https://dp.example.com",
+        status: "ready",
+      }),
+    } as Response);
+
+    const client = createClientWithMock(mockFetch);
+    const sandbox = await client.createSandbox(undefined, {
+      snapshotName: "my-snap",
+    });
+
+    const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string);
+    expect(body.snapshot_name).toBe("my-snap");
+    expect(body.snapshot_id).toBeUndefined();
+    expect(body.template_name).toBeUndefined();
+    expect(sandbox.snapshot_id).toBe("snap-1");
+  });
+
+  it("should throw when neither snapshotId nor snapshotName is provided", async () => {
+    const mockFetch = jest.fn<typeof fetch>();
+    const client = createClientWithMock(mockFetch);
+
+    await expect(client.createSandbox()).rejects.toThrow(
+      LangSmithValidationError
+    );
+    await expect(client.createSandbox()).rejects.toThrow(
+      /Exactly one of snapshotId or options\.snapshotName must be set/
+    );
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("should throw when both snapshotId and snapshotName are provided", async () => {
+    const mockFetch = jest.fn<typeof fetch>();
+    const client = createClientWithMock(mockFetch);
+
+    await expect(
+      client.createSandbox("snap-1", { snapshotName: "my-snap" })
+    ).rejects.toThrow(LangSmithValidationError);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
 });
 
 describe("SandboxClient - snapshot operations", () => {
@@ -1236,6 +1283,42 @@ describe("SandboxClient - snapshot operations", () => {
     expect(snapshots).toHaveLength(2);
     expect(snapshots[0].name).toBe("env-1");
     expect(snapshots[1].status).toBe("building");
+
+    const [url] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(new URL(url).search).toBe("");
+  });
+
+  it("listSnapshots should forward nameContains, limit, and offset as query params", async () => {
+    const mockFetch = jest.fn<typeof fetch>().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        snapshots: [
+          {
+            id: "snap-1",
+            name: "env-1",
+            status: "ready",
+          },
+        ],
+        offset: 5,
+      }),
+    } as Response);
+
+    const client = createClientWithMock(mockFetch);
+    const snapshots = await client.listSnapshots({
+      nameContains: "env",
+      limit: 10,
+      offset: 5,
+    });
+
+    expect(snapshots).toHaveLength(1);
+    expect(snapshots[0].name).toBe("env-1");
+
+    const [url] = mockFetch.mock.calls[0] as [string, RequestInit];
+    const parsed = new URL(url);
+    expect(parsed.pathname.endsWith("/snapshots")).toBe(true);
+    expect(parsed.searchParams.get("name_contains")).toBe("env");
+    expect(parsed.searchParams.get("limit")).toBe("10");
+    expect(parsed.searchParams.get("offset")).toBe("5");
   });
 
   it("deleteSnapshot should send DELETE request", async () => {


### PR DESCRIPTION
## Summary

Follow-up to #2758 — extends the snapshot-only sandbox surface so callers can boot from a snapshot **name** (not just an ID) and so `listSnapshots` supports server-side filtering and pagination.

Sibling to the Python SDK change: #2769.

> Stacked on #2758. GitHub will auto-retarget the base to `main` once that PR merges.

### `createSandbox` — accept `snapshotName`

`snapshotId` becomes optional (positional) and a new `snapshotName` field is added to `CreateSandboxOptions`. Exactly one must be provided. To avoid confusion, `snapshotId` is intentionally not duplicated on the options object.

```ts
// By ID (unchanged):
const sandbox = await client.createSandbox(snapshot.id);

// By name — server resolves the snapshot against the caller's tenant:
const sandbox = await client.createSandbox(undefined, {
  snapshotName: "my-snap",
});
```

Validation throws a `LangSmithValidationError` if neither (or both) is provided.

### `listSnapshots` — add `ListSnapshotsOptions`

```ts
const all = await client.listSnapshots();
const page = await client.listSnapshots({
  nameContains: "python",
  limit: 10,
  offset: 20,
});
```

All three options are optional and independent. Omitting them keeps today's zero-arg behavior — the request URL has no query string. The new type is re-exported from the sandbox public index.

### Tests (`src/tests/sandbox.test.ts`)

- createSandbox: new \`snapshot_name\` payload test + zero-identifier and both-identifier rejection tests.
- listSnapshots: existing zero-arg test extended to assert an empty query string; new test asserts \`name_contains\`, \`limit\`, \`offset\` appear on the request URL.

All 80 sandbox tests pass locally.

### README

- Added a \`snapshotName\` example in the Snapshots section alongside the existing \`snapshotId\` example.
- Added a \`listSnapshots({ nameContains, limit, offset })\` example.
- Updated the API Reference rows for \`createSandbox\` and \`listSnapshots\`.
- Added a \`snapshotName\` row to the \`CreateSandboxOptions\` table.
- Added a new \`ListSnapshotsOptions\` table.

### Breaking changes

None. \`createSandbox(snapshotId)\` calls keep working unchanged; the positional arg is now optional, but the payload behavior is identical when it is provided.

Made with [Cursor](https://cursor.com)