### PR TITLE
release(py): 0.7.34

### DIFF
--- a/python/.bumpversion.cfg
+++ b/python/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.7.33
+current_version = 0.7.34
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
 serialize = {major}.{minor}.{patch}
 search = {current_version}

--- a/python/langsmith/__init__.py
+++ b/python/langsmith/__init__.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
 
 # Avoid calling into importlib on every call to __version__
 
-__version__ = "0.7.33"
+__version__ = "0.7.34"
 version = __version__  # for backwards compatibility
 
 


### PR DESCRIPTION
Bumps Python SDK to `0.7.34`.

Ships the snapshot-based sandbox provisioning API added in #2769:

- `SandboxClient.create_sandbox(..., snapshot_name=...)` and the async equivalent on `AsyncSandboxClient`
- `list_snapshots(name_contains=..., limit=..., offset=...)` on both sync and async clients (server-side name filter + pagination)

### Why now

Downstream consumer [`langchain-ai/deepagents#2888`](https://github.com/langchain-ai/deepagents/pull/2888) is migrating the LangSmith harbor environment + CLI integration test from the deprecated template API to shared-per-image snapshots. It pins `langsmith>=0.7.34` and drops the two `# ty: ignore[unknown-argument]` suppressions on `snapshot_name=` / `name_contains=`. That PR is currently held in draft until this release is on PyPI.

### Scope

Python-only bump. JS parity (#2770) already shipped in `langsmith@0.5.22` via #2774.

### How did you verify your code works?

- Pre-commit: ruff format/lint + mypy passed locally
- Behavioral verification was done in the source PR (#2769); this PR is purely a version bump — no runtime changes

---

_Used Cursor (Claude Opus 4.7) to draft this release PR._

Made with Cursor

Made with [Cursor](https://cursor.com)