### PR TITLE
fix(js): honor numRepetitions when data is an Example[]

### DIFF
--- a/js/src/evaluation/_runner.ts
+++ b/js/src/evaluation/_runner.ts
@@ -1054,10 +1054,7 @@ async function _evaluate(
   );
 
   let manager = await new _ExperimentManager({
-    data: Array.isArray(standardFields.data) ? undefined : standardFields.data,
-    examples: Array.isArray(standardFields.data)
-      ? standardFields.data
-      : undefined,
+    data: standardFields.data,
     client,
     metadata: fields.metadata,
     experiment: experiment_ ?? fields.experimentPrefix,

--- a/js/src/tests/evaluate.int.test.ts
+++ b/js/src/tests/evaluate.int.test.ts
@@ -139,6 +139,7 @@ test("evaluate handles various data inputs and evaluator shapes", async () => {
 });
 
 test("evaluate can repeat", async () => {
+  const client = new Client();
   const targetFunc = (input: Record<string, any>) => {
     return {
       foo: input.input + 1,
@@ -163,6 +164,33 @@ test("evaluate can repeat", async () => {
 
     const firstRunResults = evalRes.results[i].evaluationResults;
     expect(firstRunResults.results).toHaveLength(0);
+  }
+
+  // numRepetitions should also be honored when data is a pre-fetched Example[].
+  const examples: Example[] = [];
+  for await (const example of client.listExamples({
+    datasetName: TESTING_DATASET_NAME,
+  })) {
+    examples.push(example);
+  }
+  const arrayRepeatRes = await evaluate(targetFunc, {
+    data: examples,
+    description: "numRepetitions honored with Example[] data",
+    numRepetitions: 3,
+  });
+  expect(arrayRepeatRes.results).toHaveLength(examples.length * 3);
+  const runCountByExampleId = new Map<string, number>();
+  for (const result of arrayRepeatRes.results) {
+    expect(result.run).toBeDefined();
+    expect(result.example).toBeDefined();
+    const exampleId = result.example.id;
+    runCountByExampleId.set(
+      exampleId,
+      (runCountByExampleId.get(exampleId) ?? 0) + 1
+    );
+  }
+  for (const example of examples) {
+    expect(runCountByExampleId.get(example.id)).toBe(3);
   }
 });
 


### PR DESCRIPTION
## Summary
- `evaluate()` was short-circuiting `Example[]` data into the manager's pre-resolved `examples` field (`js/src/evaluation/_runner.ts:1056-1060`), which bypassed the repetition logic in `getExamples()`. `numRepetitions` was silently dropped for array inputs while working for dataset names and async iterables.
- Route array data through `_data` like every other input shape so `numRepetitions` applies uniformly. This matches Python's behavior (`_resolve_data` already passes `Iterable[Example]` through as-is and repetitions apply in `examples`).
- The `DataT` type and `data` docstring already advertise `Example[]` as a valid input, and `numRepetitions` is documented as "Each example will be run this many times" with no carve-out — so this was always a bug, not a design choice.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `eslint` no new warnings/errors
- [x] `prettier --check` clean
- [x] Existing unit tests in `evaluate_runner.test.ts` pass
- [ ] Added integration test in `evaluate.int.test.ts`: pre-fetch examples, evaluate with `numRepetitions: 3`, assert each example runs exactly 3 times
