### PR TITLE
perf(js): Use estimator instead of serialization in hot path

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -192,6 +192,7 @@
     "eslint-plugin-prettier": "^4.2.1",
     "jest": "^29.5.0",
     "langchain": "^0.3.29",
+    "mongoose": "^9.5.0",
     "msw": "^2.11.2",
     "node-fetch": "^3.3.2",
     "openai": "^6.18.0",

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -138,6 +138,9 @@ importers:
       langchain:
         specifier: ^0.3.29
         version: 0.3.37(@langchain/core@0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.215.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.20.0)(zod@4.3.6)))(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.215.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(handlebars@4.7.9)(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
+      mongoose:
+        specifier: ^9.5.0
+        version: 9.5.0
       msw:
         specifier: ^2.11.2
         version: 2.13.4(@types/node@25.6.0)(typescript@5.9.3)
@@ -1366,6 +1369,9 @@ packages:
       '@cfworker/json-schema':
         optional: true
 
+  '@mongodb-js/saslprep@1.4.8':
+    resolution: {integrity: sha512-kpjr2jy2w71w0oqAMI8oibBmiF9lXxWkEQs5gMkW4hVE48bsqINGLxnCSYW62ck/NHXJQpQEfA9WlJ1sY0eqBg==}
+
   '@mswjs/interceptors@0.41.4':
     resolution: {integrity: sha512-3B9EinUkrdOUGYzHRzRWSXunQ4YFGboJnyLNRwEJWEde+j8fNhPUHvrN1E3g1DU/iS/s8JQrMNVe+S7AHHVs0w==}
     engines: {node: '>=18'}
@@ -2198,6 +2204,12 @@ packages:
   '@types/uuid@10.0.0':
     resolution: {integrity: sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==}
 
+  '@types/webidl-conversions@7.0.3':
+    resolution: {integrity: sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA==}
+
+  '@types/whatwg-url@13.0.0':
+    resolution: {integrity: sha512-N8WXpbE6Wgri7KUSvrmQcqrMllKZ9uxkYWMt+mCSGwNc0Hsw9VQTW7ApqI4XNrx6/SaM2QQJCzMPDEXE058s+Q==}
+
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
@@ -2532,6 +2544,10 @@ packages:
 
   bser@2.1.1:
     resolution: {integrity: sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==}
+
+  bson@7.2.0:
+    resolution: {integrity: sha512-YCEo7KjMlbNlyHhz7zAZNDpIpQbd+wOEHJYezv0nMYTn4x31eIUM2yomNNubclAt63dObUzKHWsBLJ9QcZNSnQ==}
+    engines: {node: '>=20.19.0'}
 
   buffer-equal-constant-time@1.0.1:
     resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
@@ -3709,6 +3725,10 @@ packages:
   jws@4.0.1:
     resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
 
+  kareem@3.3.0:
+    resolution: {integrity: sha512-kpSuLD3/7RenBnjnJdOHXCKC8dTd1JzeOiJhN0necWWci6cC+qX+VuwPnMVgb+a4+KNJSfgqahpnfWaeDXCimw==}
+    engines: {node: '>=18.0.0'}
+
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
@@ -3868,6 +3888,9 @@ packages:
     resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
     engines: {node: '>= 0.8'}
 
+  memory-pager@1.5.0:
+    resolution: {integrity: sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==}
+
   merge-descriptors@2.0.0:
     resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
     engines: {node: '>=18'}
@@ -3923,6 +3946,49 @@ packages:
 
   module-details-from-path@1.0.4:
     resolution: {integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==}
+
+  mongodb-connection-string-url@7.0.1:
+    resolution: {integrity: sha512-h0AZ9A7IDVwwHyMxmdMXKy+9oNlF0zFoahHiX3vQ8e3KFcSP3VmsmfvtRSuLPxmyv2vjIDxqty8smTgie/SNRQ==}
+    engines: {node: '>=20.19.0'}
+
+  mongodb@7.1.1:
+    resolution: {integrity: sha512-067DXiMjcpYQl6bGjWQoTUEE9UoRViTtKFcoqX7z08I+iDZv/emH1g8XEFiO3qiDfXAheT5ozl1VffDTKhIW/w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@aws-sdk/credential-providers': ^3.806.0
+      '@mongodb-js/zstd': ^7.0.0
+      gcp-metadata: ^7.0.1
+      kerberos: ^7.0.0
+      mongodb-client-encryption: '>=7.0.0 <7.1.0'
+      snappy: ^7.3.2
+      socks: ^2.8.6
+    peerDependenciesMeta:
+      '@aws-sdk/credential-providers':
+        optional: true
+      '@mongodb-js/zstd':
+        optional: true
+      gcp-metadata:
+        optional: true
+      kerberos:
+        optional: true
+      mongodb-client-encryption:
+        optional: true
+      snappy:
+        optional: true
+      socks:
+        optional: true
+
+  mongoose@9.5.0:
+    resolution: {integrity: sha512-B4blGFkFL1s0G24URuMvx0qTlx+gRVLmfO7WcSz8NcmW/XHEJ3G69capdyW1iRsGKiycp1tkwKHnxHbnwjwmPw==}
+    engines: {node: '>=20.19.0'}
+
+  mpath@0.9.0:
+    resolution: {integrity: sha512-ikJRQTk8hw5DEoFVxHG1Gn9T/xcjtdnOKIU1JTmGjZZlg9LST2mBLmcX3/ICIbgJydT2GOc15RnNy5mHmzfSew==}
+    engines: {node: '>=4.0.0'}
+
+  mquery@6.0.0:
+    resolution: {integrity: sha512-b2KQNsmgtkscfeDgkYMcWGn9vZI9YoXh802VDEwE6qc50zxBFQ0Oo8ROkawbPAsXCY1/Z1yp0MagqsZStPWJjw==}
+    engines: {node: '>=20.19.0'}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -4438,6 +4504,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  sift@17.1.3:
+    resolution: {integrity: sha512-Rtlj66/b0ICeFzYTuNvX/EF1igRbbnGSvEyT79McoZa/DeGhMyC5pWKOEsZKnpkqtSeovd5FL/bjHWC3CIIvCQ==}
+
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
@@ -4468,6 +4537,9 @@ packages:
   source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
+
+  sparse-bitfield@3.0.3:
+    resolution: {integrity: sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==}
 
   stack-utils@2.0.6:
     resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
@@ -4607,6 +4679,10 @@ packages:
   tough-cookie@6.0.1:
     resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
     engines: {node: '>=16'}
+
+  tr46@5.1.1:
+    resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
+    engines: {node: '>=18'}
 
   ts-algebra@2.0.0:
     resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
@@ -4873,6 +4949,14 @@ packages:
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
+
+  webidl-conversions@7.0.0:
+    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
+
+  whatwg-url@14.2.0:
+    resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
+    engines: {node: '>=18'}
 
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
@@ -6403,6 +6487,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@mongodb-js/saslprep@1.4.8':
+    dependencies:
+      sparse-bitfield: 3.0.3
+
   '@mswjs/interceptors@0.41.4':
     dependencies:
       '@open-draft/deferred-promise': 2.2.0
@@ -7432,6 +7520,12 @@ snapshots:
 
   '@types/uuid@10.0.0': {}
 
+  '@types/webidl-conversions@7.0.3': {}
+
+  '@types/whatwg-url@13.0.0':
+    dependencies:
+      '@types/webidl-conversions': 7.0.3
+
   '@types/ws@8.18.1':
     dependencies:
       '@types/node': 25.5.0
@@ -7875,6 +7969,8 @@ snapshots:
   bser@2.1.1:
     dependencies:
       node-int64: 0.4.0
+
+  bson@7.2.0: {}
 
   buffer-equal-constant-time@1.0.1: {}
 
@@ -9420,6 +9516,8 @@ snapshots:
       jwa: 2.0.1
       safe-buffer: 5.2.1
 
+  kareem@3.3.0: {}
+
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
@@ -9533,6 +9631,8 @@ snapshots:
 
   media-typer@1.1.0: {}
 
+  memory-pager@1.5.0: {}
+
   merge-descriptors@2.0.0: {}
 
   merge-stream@2.0.0: {}
@@ -9575,6 +9675,38 @@ snapshots:
   minipass@7.1.3: {}
 
   module-details-from-path@1.0.4: {}
+
+  mongodb-connection-string-url@7.0.1:
+    dependencies:
+      '@types/whatwg-url': 13.0.0
+      whatwg-url: 14.2.0
+
+  mongodb@7.1.1:
+    dependencies:
+      '@mongodb-js/saslprep': 1.4.8
+      bson: 7.2.0
+      mongodb-connection-string-url: 7.0.1
+
+  mongoose@9.5.0:
+    dependencies:
+      kareem: 3.3.0
+      mongodb: 7.1.1
+      mpath: 0.9.0
+      mquery: 6.0.0
+      ms: 2.1.3
+      sift: 17.1.3
+    transitivePeerDependencies:
+      - '@aws-sdk/credential-providers'
+      - '@mongodb-js/zstd'
+      - gcp-metadata
+      - kerberos
+      - mongodb-client-encryption
+      - snappy
+      - socks
+
+  mpath@0.9.0: {}
+
+  mquery@6.0.0: {}
 
   ms@2.1.3: {}
 
@@ -10145,6 +10277,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  sift@17.1.3: {}
+
   siginfo@2.0.0: {}
 
   signal-exit@3.0.7: {}
@@ -10165,6 +10299,10 @@ snapshots:
       source-map: 0.6.1
 
   source-map@0.6.1: {}
+
+  sparse-bitfield@3.0.3:
+    dependencies:
+      memory-pager: 1.5.0
 
   stack-utils@2.0.6:
     dependencies:
@@ -10295,6 +10433,10 @@ snapshots:
   tough-cookie@6.0.1:
     dependencies:
       tldts: 7.0.28
+
+  tr46@5.1.1:
+    dependencies:
+      punycode: 2.3.1
 
   ts-algebra@2.0.0: {}
 
@@ -10555,6 +10697,13 @@ snapshots:
       makeerror: 1.0.12
 
   web-streams-polyfill@3.3.3: {}
+
+  webidl-conversions@7.0.0: {}
+
+  whatwg-url@14.2.0:
+    dependencies:
+      tr46: 5.1.1
+      webidl-conversions: 7.0.0
 
   which-boxed-primitive@1.1.1:
     dependencies:

--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -82,7 +82,10 @@ import {
   _getFetchImplementation,
 } from "./singletons/fetch.js";
 
-import { serialize as serializePayloadForTracing } from "./utils/fast-safe-stringify/index.js";
+import {
+  serialize as serializePayloadForTracing,
+  estimateSerializedSize,
+} from "./utils/fast-safe-stringify/index.js";
 
 /**
  * Catches timestamps without a timezone suffix.
@@ -676,10 +679,23 @@ export class AutoBatchQueue {
       // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/Promise
       itemPromiseResolve = resolve;
     });
-    const size = serializePayloadForTracing(
-      item.item,
-      `Serializing run with id: ${item.item.id}`
-    ).length;
+    // By default we compute the exact serialized size here by stringifying
+    // the payload. This is expensive: JSON.stringify on large payloads
+    // blocks the event loop on the user's hot path.
+    //
+    // Opting into LANGSMITH_PERF_OPTIMIZATION=true switches to a cheap
+    // structural estimate instead. The estimate is only used for soft
+    // memory accounting (queue size limit and downstream async caller
+    // memory tracking), never for anything correctness-critical -- the
+    // real serialization still happens later, off the hot path, when the
+    // batch is assembled for sending.
+    const size =
+      getLangSmithEnvironmentVariable("PERF_OPTIMIZATION") === "true"
+        ? estimateSerializedSize(item.item)
+        : serializePayloadForTracing(
+            item.item,
+            `Serializing run with id: ${item.item.id}`
+          ).length;
 
     // Check if adding this item would exceed the size limit
     // Allow the run if the queue is empty (to support large single traces)

--- a/js/src/tests/perf.int.test.ts
+++ b/js/src/tests/perf.int.test.ts
@@ -127,7 +127,12 @@ benchIt(
     monitor.unref();
 
     const fetchImplementation: typeof fetch = async (input) => {
-      const url = typeof input === "string" ? input : input.url;
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+          ? input.toString()
+          : input.url;
       if (url.endsWith("/info")) {
         return new Response(
           JSON.stringify({

--- a/js/src/tests/perf.int.test.ts
+++ b/js/src/tests/perf.int.test.ts
@@ -1,5 +1,7 @@
+/* eslint-disable no-process-env */
 import { traceable } from "../traceable.js";
 import { Client } from "../client.js";
+import { v7 as uuidv7 } from "uuid";
 
 import * as fs from "fs";
 import path from "path";
@@ -17,7 +19,7 @@ test.skip("Test performance with large runs and concurrency", async () => {
     debug: true,
   });
   const largeTest = traceable(
-    async (foo: Record<string, any>) => {
+    async (foo: { bee: string }) => {
       await new Promise((resolve) => setTimeout(resolve, 100));
       return { reversebee: foo.bee.toString().split("").reverse().join("") };
     },
@@ -34,3 +36,204 @@ test.skip("Test performance with large runs and concurrency", async () => {
 
   await client.awaitPendingTraceBatches();
 });
+
+/**
+ * Benchmark event-loop blocking caused by tracing large payloads.
+ *
+ * This test measures how long the event loop is unable to run other work
+ * while the SDK performs end-to-end createRun/updateRun calls with large
+ * payloads. A monitor runs on a short timer and records the actual delay
+ * between ticks -- any delay beyond the target interval is time the event
+ * loop was blocked.
+ *
+ * The hot-path size estimation optimization is opt-in via
+ * LANGSMITH_PERF_OPTIMIZATION=true. Running the benchmark with and
+ * without that flag shows the before/after impact on the real public API
+ * path, not just the internal queue.
+ *
+ * Example (run both to compare):
+ *   # Default behavior (serialize on hot path)
+ *   LANGSMITH_TRACING=false pnpm test:integration src/tests/perf.int.test.ts \
+ *     -t "benchmark event loop"
+ *
+ *   # With opt-in optimization (estimator)
+ *   LANGSMITH_PERF_OPTIMIZATION=true LANGSMITH_TRACING=false \
+ *     pnpm test:integration src/tests/perf.int.test.ts -t "benchmark event loop"
+ */
+// Enabled by setting LANGSMITH_RUN_PERF_BENCH=true. Skipped in CI by default.
+const benchIt =
+  process.env.LANGSMITH_RUN_PERF_BENCH === "true" ? test : test.skip;
+benchIt(
+  "benchmark event loop blocking from tracing large payloads",
+  async () => {
+    const pathname = path.join(
+      path.dirname(fileURLToPath(import.meta.url)),
+      "test_data",
+      "beemovie.txt"
+    );
+
+    // Build a realistically large payload. beemovie.txt is ~50KB; nesting
+    // it a few times simulates a large model input/output.
+    const baseText = fs.readFileSync(pathname).toString();
+    const largeInputs = {
+      messages: Array.from({ length: 20 }, (_, i) => ({
+        role: i % 2 === 0 ? "user" : "assistant",
+        content: baseText,
+      })),
+      metadata: {
+        model: "gpt-4",
+        temperature: 0.7,
+        tools: Array.from({ length: 10 }, (_, i) => ({
+          name: `tool_${i}`,
+          description: baseText.slice(0, 500),
+        })),
+      },
+    };
+    const largeOutputs = {
+      generations: Array.from({ length: 8 }, () => ({
+        text: baseText,
+      })),
+      usage: {
+        prompt_tokens: 120000,
+        completion_tokens: 48000,
+      },
+    };
+
+    const inputJsonSize = JSON.stringify(largeInputs).length;
+    const outputJsonSize = JSON.stringify(largeOutputs).length;
+    const mode =
+      process.env.LANGSMITH_PERF_OPTIMIZATION === "true"
+        ? "ESTIMATE (opt-in optimization)"
+        : "EXACT (default, serialize on hot path)";
+
+    console.log(`\n=== Event loop benchmark ===`);
+    console.log(`Mode: ${mode}`);
+    console.log(
+      `Per-run create payload size: ${(inputJsonSize / 1024).toFixed(1)} KB`
+    );
+    console.log(
+      `Per-run update payload size: ${(outputJsonSize / 1024).toFixed(1)} KB`
+    );
+
+    const targetInterval = 1;
+    const lags: number[] = [];
+    let lastTick = performance.now();
+    const monitor = setInterval(() => {
+      const now = performance.now();
+      const lag = now - lastTick - targetInterval;
+      if (lag > 0) lags.push(lag);
+      lastTick = now;
+    }, targetInterval);
+    monitor.unref();
+
+    const fetchImplementation: typeof fetch = async (input) => {
+      const url = typeof input === "string" ? input : input.url;
+      if (url.endsWith("/info")) {
+        return new Response(
+          JSON.stringify({
+            batch_ingest_config: {
+              use_multipart_endpoint: true,
+              size_limit: 100,
+              size_limit_bytes: 20 * 1024 * 1024,
+            },
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          }
+        );
+      }
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 202,
+        headers: { "content-type": "application/json" },
+      });
+    };
+
+    const client = new Client({
+      autoBatchTracing: true,
+      fetchImplementation,
+      fetchOptions: {
+        signal: AbortSignal.timeout(30_000),
+      },
+    });
+
+    const NUM_RUNS = 100;
+    const createTimes: number[] = [];
+    const updateTimes: number[] = [];
+    const wallStart = performance.now();
+
+    for (let i = 0; i < NUM_RUNS; i++) {
+      const runId = uuidv7();
+
+      const createStart = performance.now();
+      await client.createRun({
+        id: runId,
+        trace_id: runId,
+        dotted_order: `${new Date().toISOString()}${runId}`,
+        name: "bench_run",
+        run_type: "llm",
+        inputs: largeInputs,
+        start_time: Date.now(),
+      });
+      createTimes.push(performance.now() - createStart);
+
+      await new Promise((resolve) => setImmediate(resolve));
+
+      const updateStart = performance.now();
+      await client.updateRun(runId, {
+        outputs: largeOutputs,
+        end_time: Date.now(),
+      });
+      updateTimes.push(performance.now() - updateStart);
+
+      await new Promise((resolve) => setImmediate(resolve));
+    }
+
+    await client.awaitPendingTraceBatches();
+
+    const wallEnd = performance.now();
+    clearInterval(monitor);
+
+    lags.sort((a, b) => a - b);
+    const percentile = (values: number[], p: number) =>
+      values.length === 0
+        ? 0
+        : values[
+            Math.min(values.length - 1, Math.floor(values.length * p))
+          ];
+    const totalLag = lags.reduce((a, b) => a + b, 0);
+    const maxLag = lags.length ? lags[lags.length - 1] : 0;
+
+    createTimes.sort((a, b) => a - b);
+    updateTimes.sort((a, b) => a - b);
+    const createTotal = createTimes.reduce((a, b) => a + b, 0);
+    const updateTotal = updateTimes.reduce((a, b) => a + b, 0);
+    const createMax = createTimes.length ? createTimes[createTimes.length - 1] : 0;
+    const updateMax = updateTimes.length ? updateTimes[updateTimes.length - 1] : 0;
+
+    console.log(`\nRuns traced: ${NUM_RUNS}`);
+    console.log(`Wall time (including batch drain): ${(wallEnd - wallStart).toFixed(1)}ms`);
+    console.log(`\ncreateRun sync time (ms):`);
+    console.log(`  total:       ${createTotal.toFixed(2)}ms`);
+    console.log(`  max:         ${createMax.toFixed(2)}ms`);
+    console.log(`  p50:         ${percentile(createTimes, 0.5).toFixed(2)}ms`);
+    console.log(`  p95:         ${percentile(createTimes, 0.95).toFixed(2)}ms`);
+    console.log(`  p99:         ${percentile(createTimes, 0.99).toFixed(2)}ms`);
+    console.log(`\nupdateRun sync time (ms):`);
+    console.log(`  total:       ${updateTotal.toFixed(2)}ms`);
+    console.log(`  max:         ${updateMax.toFixed(2)}ms`);
+    console.log(`  p50:         ${percentile(updateTimes, 0.5).toFixed(2)}ms`);
+    console.log(`  p95:         ${percentile(updateTimes, 0.95).toFixed(2)}ms`);
+    console.log(`  p99:         ${percentile(updateTimes, 0.99).toFixed(2)}ms`);
+    console.log(
+      `\nEvent loop lag (setInterval monitor, ${targetInterval}ms target):`
+    );
+    console.log(`  samples > 0: ${lags.length}`);
+    console.log(`  total:       ${totalLag.toFixed(2)}ms`);
+    console.log(`  max:         ${maxLag.toFixed(2)}ms`);
+    console.log(`  p50:         ${percentile(lags, 0.5).toFixed(2)}ms`);
+    console.log(`  p95:         ${percentile(lags, 0.95).toFixed(2)}ms`);
+    console.log(`  p99:         ${percentile(lags, 0.99).toFixed(2)}ms`);
+  },
+  120_000
+);

--- a/js/src/tests/perf.int.test.ts
+++ b/js/src/tests/perf.int.test.ts
@@ -198,9 +198,7 @@ benchIt(
     const percentile = (values: number[], p: number) =>
       values.length === 0
         ? 0
-        : values[
-            Math.min(values.length - 1, Math.floor(values.length * p))
-          ];
+        : values[Math.min(values.length - 1, Math.floor(values.length * p))];
     const totalLag = lags.reduce((a, b) => a + b, 0);
     const maxLag = lags.length ? lags[lags.length - 1] : 0;
 
@@ -208,11 +206,17 @@ benchIt(
     updateTimes.sort((a, b) => a - b);
     const createTotal = createTimes.reduce((a, b) => a + b, 0);
     const updateTotal = updateTimes.reduce((a, b) => a + b, 0);
-    const createMax = createTimes.length ? createTimes[createTimes.length - 1] : 0;
-    const updateMax = updateTimes.length ? updateTimes[updateTimes.length - 1] : 0;
+    const createMax = createTimes.length
+      ? createTimes[createTimes.length - 1]
+      : 0;
+    const updateMax = updateTimes.length
+      ? updateTimes[updateTimes.length - 1]
+      : 0;
 
     console.log(`\nRuns traced: ${NUM_RUNS}`);
-    console.log(`Wall time (including batch drain): ${(wallEnd - wallStart).toFixed(1)}ms`);
+    console.log(
+      `Wall time (including batch drain): ${(wallEnd - wallStart).toFixed(1)}ms`
+    );
     console.log(`\ncreateRun sync time (ms):`);
     console.log(`  total:       ${createTotal.toFixed(2)}ms`);
     console.log(`  max:         ${createMax.toFixed(2)}ms`);

--- a/js/src/tests/perf.int.test.ts
+++ b/js/src/tests/perf.int.test.ts
@@ -1,4 +1,4 @@
-/* eslint-disable no-process-env */
+/* eslint-disable no-process-env, no-instanceof/no-instanceof */
 import { traceable } from "../traceable.js";
 import { Client } from "../client.js";
 import { v7 as uuidv7 } from "uuid";

--- a/js/src/tests/serialize.test.ts
+++ b/js/src/tests/serialize.test.ts
@@ -5,6 +5,11 @@ import {
   serialize,
   estimateSerializedSize,
 } from "../utils/fast-safe-stringify/index.js";
+import {
+  HumanMessage,
+  SystemMessage,
+  AIMessage,
+} from "@langchain/core/messages";
 
 describe("serializeWellKnownTypes", () => {
   it("should handle Map objects", () => {
@@ -441,5 +446,32 @@ describe("estimateSerializedSize", () => {
     const real = serialize(v).length;
     const estimate = estimateSerializedSize(v);
     expect(estimate).toBeGreaterThan(real * 0.5);
+  });
+
+  it("handles LangChain message objects", () => {
+    // LangChain message classes have a toJSON() method that returns
+    // a serializable representation. The estimator must invoke it.
+    const messages = [
+      new SystemMessage("You are a helpful assistant."),
+      new HumanMessage("What is the capital of France?"),
+      new AIMessage("The capital of France is Paris."),
+    ];
+
+    expectClose({ messages }, { minRatio: 0.95, maxRatio: 1.1 });
+  });
+
+  it("handles LangChain message objects with complex content", () => {
+    // Multi-modal message with text and image
+    const message = new HumanMessage({
+      content: [
+        { type: "text", text: "What's in this image?" },
+        {
+          type: "image_url",
+          image_url: { url: "data:image/png;base64," + "x".repeat(1000) },
+        },
+      ],
+    });
+
+    expectClose({ message }, { minRatio: 0.95, maxRatio: 1.1 });
   });
 });

--- a/js/src/tests/serialize.test.ts
+++ b/js/src/tests/serialize.test.ts
@@ -1,6 +1,10 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, it, expect } from "@jest/globals";
-import { serialize } from "../utils/fast-safe-stringify/index.js";
+import mongoose from "mongoose";
+import {
+  serialize,
+  estimateSerializedSize,
+} from "../utils/fast-safe-stringify/index.js";
 
 describe("serializeWellKnownTypes", () => {
   it("should handle Map objects", () => {
@@ -187,5 +191,255 @@ describe("serializeWellKnownTypes", () => {
 
     expect(parsed.prop).toBe("value");
     expect(parsed.circular).toEqual({ result: "[Circular]" });
+  });
+});
+
+describe("estimateSerializedSize", () => {
+  // Helper: estimate must be within a tolerance of the real size.
+  // Direction matters: for soft limits on the ingest queue, over-estimating
+  // is safer than under-estimating (we may flush slightly earlier than we
+  // would otherwise). We allow a wide band here because the point of the
+  // estimator is speed, not precision.
+  function expectClose(
+    value: unknown,
+    opts: { minRatio?: number; maxRatio?: number } = {}
+  ) {
+    const { minRatio = 0.9, maxRatio = 3.0 } = opts;
+    const real = serialize(value).length;
+    const estimate = estimateSerializedSize(value);
+    const ratio = estimate / real;
+    if (ratio < minRatio || ratio > maxRatio) {
+      throw new Error(
+        `estimate out of range: real=${real}, estimate=${estimate}, ratio=${ratio.toFixed(
+          3
+        )} (expected between ${minRatio} and ${maxRatio})`
+      );
+    }
+  }
+
+  it("handles shared references without treating them as circular", () => {
+    // The repeated `shared` object is serialized twice by JSON.stringify,
+    // so the estimate should count it twice.
+    const shared = { text: "x".repeat(1000) };
+    const payload = { a: shared, b: shared };
+    expectClose(payload, { minRatio: 0.95, maxRatio: 1.05 });
+  });
+
+  it("handles deeply shared subtrees (system prompt pattern)", () => {
+    const systemPrompt = "You are a helpful assistant. ".repeat(100);
+    const payload = {
+      messages: [
+        { role: "system", content: systemPrompt },
+        { role: "user", content: "hi" },
+      ],
+      metadata: { systemPrompt },
+    };
+    expectClose(payload, { minRatio: 0.95, maxRatio: 1.05 });
+  });
+
+  it("counts Buffer by its JSON representation, not a constant", () => {
+    const buf = Buffer.alloc(10000, "x");
+    expectClose(buf, { minRatio: 0.95, maxRatio: 1.1 });
+  });
+
+  it("prefers Buffer's dedicated sizing path over generic toJSON duck-typing", () => {
+    const buf = Buffer.alloc(32, 7);
+    const originalToJSON = buf.toJSON.bind(buf);
+    let calls = 0;
+    buf.toJSON = (() => {
+      calls += 1;
+      return originalToJSON();
+    }) as typeof buf.toJSON;
+
+    const estimate = estimateSerializedSize(buf);
+    expect(estimate).toBeGreaterThan(0);
+    expect(calls).toBe(0);
+  });
+
+  it("counts typed arrays by their (expensive) JSON representation", () => {
+    // Uint8Array stringifies as {"0":v,"1":v,...}, not [v,v,...].
+    const arr = new Uint8Array(1000).fill(5);
+    expectClose(arr, { minRatio: 0.9, maxRatio: 2.0 });
+  });
+
+  it("counts ArrayBuffer as an empty object", () => {
+    // ArrayBuffer itself has no enumerable properties -> "{}"
+    const buf = new ArrayBuffer(1000);
+    expectClose(buf, { minRatio: 0.5, maxRatio: 1.5 });
+  });
+
+  it("invokes toJSON for custom types", () => {
+    class Money {
+      amount: number;
+      constructor(n: number) {
+        this.amount = n;
+      }
+      toJSON() {
+        return { amount: this.amount, currency: "USD" };
+      }
+    }
+    // Small object -> allow looser ratio for constant overheads.
+    expectClose(new Money(42), { minRatio: 0.5, maxRatio: 3.0 });
+  });
+
+  it("handles real mongoose documents via toJSON", () => {
+    // Mongoose documents carry extensive internal state ($__, $isNew,
+    // prototype methods, getters, etc.) but expose toJSON() for
+    // serialization. The estimator must invoke toJSON() to match
+    // JSON.stringify semantics.
+    const UserSchema = new mongoose.Schema({
+      name: String,
+      age: Number,
+      tags: [String],
+      nested: { city: String, active: Boolean },
+    });
+    const User =
+      mongoose.models.EstUser ?? mongoose.model("EstUser", UserSchema);
+
+    const doc = new User({
+      name: "Alice",
+      age: 30,
+      tags: ["admin", "beta"],
+      nested: { city: "SF", active: true },
+    });
+
+    expectClose(doc, { minRatio: 0.95, maxRatio: 1.1 });
+  });
+
+  it("handles real mongoose documents with nested subdocuments and arrays", () => {
+    const PostSchema = new mongoose.Schema({
+      title: String,
+      body: String,
+      comments: [{ text: String, votes: Number }],
+    });
+    const Post =
+      mongoose.models.EstPost ?? mongoose.model("EstPost", PostSchema);
+
+    const post = new Post({
+      title: "Hello",
+      body: "x".repeat(500),
+      comments: [
+        { text: "nice", votes: 3 },
+        { text: "ok", votes: 1 },
+      ],
+    });
+
+    expectClose(post, { minRatio: 0.95, maxRatio: 1.1 });
+  });
+
+  it("falls back to exact serialization if estimation throws", () => {
+    const originalKeys = Object.keys;
+    try {
+      // Simulate an unexpected edge case inside the estimator traversal.
+      Object.keys = ((obj: object) => {
+        if ((obj as any).__explode) {
+          throw new Error("boom");
+        }
+        return originalKeys(obj);
+      }) as typeof Object.keys;
+
+      const payload = {
+        ok: true,
+        nested: { __explode: true, value: "x".repeat(100) },
+      };
+
+      expect(estimateSerializedSize(payload)).toBe(serialize(payload).length);
+    } finally {
+      Object.keys = originalKeys;
+    }
+  });
+
+  it("falls back to exact serialization if byte-length calculation throws", () => {
+    if (typeof Buffer === "undefined") {
+      return;
+    }
+
+    const originalByteLength = Buffer.byteLength;
+    try {
+      Buffer.byteLength = ((str: string, encoding?: BufferEncoding) => {
+        if (str.includes("explode-byte-length")) {
+          throw new Error("boom");
+        }
+        return originalByteLength(str, encoding);
+      }) as typeof Buffer.byteLength;
+
+      const payload = { text: "explode-byte-length" };
+      expect(estimateSerializedSize(payload)).toBe(serialize(payload).length);
+    } finally {
+      Buffer.byteLength = originalByteLength;
+    }
+  });
+
+  it("counts UTF-8 byte length for non-ASCII strings", () => {
+    // Chinese: each character is 3 UTF-8 bytes but 1 code unit.
+    expectClose({ text: "你好世界".repeat(100) });
+    // Emoji outside BMP: 4 UTF-8 bytes, 2 code units.
+    expectClose({ text: "🎉".repeat(100) });
+  });
+
+  it("detects real cycles but not shared siblings", () => {
+    const shared = { x: 1 };
+    const cyc: any = { shared, other: shared };
+    cyc.self = cyc;
+    const real = serialize(cyc).length;
+    const estimate = estimateSerializedSize(cyc);
+    // Should be finite (no infinite recursion), and in the ballpark.
+    expect(Number.isFinite(estimate)).toBe(true);
+    expect(estimate).toBeGreaterThan(0);
+    // Cycle handling uses a placeholder; we just want sanity.
+    expect(estimate / real).toBeGreaterThan(0.5);
+    expect(estimate / real).toBeLessThan(3.0);
+  });
+
+  it("handles typical traced-run payloads accurately", () => {
+    const runish = {
+      id: "abc-123",
+      name: "test_run",
+      run_type: "llm",
+      inputs: {
+        messages: [{ role: "user", content: "hello " + "x".repeat(1000) }],
+      },
+      extra: { metadata: { model: "gpt-4", temperature: 0.7 } },
+    };
+    expectClose(runish, { minRatio: 0.95, maxRatio: 1.1 });
+  });
+
+  it("handles well-known types (Map, Set, Date, RegExp, Error)", () => {
+    expectClose(
+      new Map([
+        ["a", 1],
+        ["b", 2],
+      ]),
+      {
+        minRatio: 0.5,
+        maxRatio: 2.0,
+      }
+    );
+    expectClose(new Set([1, 2, 3, "hi"]), { minRatio: 0.5, maxRatio: 3.0 });
+    expectClose(new Date(), { minRatio: 0.9, maxRatio: 1.2 });
+    expectClose(/foo/g, { minRatio: 0.5, maxRatio: 2.0 });
+    expectClose(new Error("boom"), { minRatio: 0.5, maxRatio: 3.0 });
+  });
+
+  it("does not throw on BigInt", () => {
+    expect(() =>
+      estimateSerializedSize({ big: 123456789012345678901234567890n })
+    ).not.toThrow();
+  });
+
+  it("treats undefined/function/symbol as dropped in object properties", () => {
+    const v = { a: 1, b: undefined, c: () => 1, d: Symbol(), e: 2 };
+    const real = serialize(v).length;
+    const estimate = estimateSerializedSize(v);
+    // Dropped keys shouldn't blow up the estimate significantly.
+    expect(estimate).toBeLessThan(real * 6);
+  });
+
+  it("treats undefined/function/symbol as null inside arrays", () => {
+    // JSON.stringify renders these as "null" in arrays.
+    const v = [1, undefined, () => 1, Symbol(), 2];
+    const real = serialize(v).length;
+    const estimate = estimateSerializedSize(v);
+    expect(estimate).toBeGreaterThan(real * 0.5);
   });
 });

--- a/js/src/utils/fast-safe-stringify/index.ts
+++ b/js/src/utils/fast-safe-stringify/index.ts
@@ -61,6 +61,231 @@ function createDefaultReplacer(userReplacer?) {
   };
 }
 
+/**
+ * Estimate the serialized JSON byte size of a value without actually
+ * serializing it. Used on hot paths (enqueuing runs for batched tracing)
+ * where the exact serialized size is not required -- only a reasonable
+ * approximation for soft memory accounting.
+ *
+ * Walks the object graph in O(n) without allocating a JSON string,
+ * avoiding the event-loop blocking that JSON.stringify causes on large
+ * payloads.
+ *
+ * Accuracy notes (all estimates are approximate, never exact):
+ * - Strings: UTF-8 byte length via Buffer.byteLength when available,
+ *   falling back to code-unit length for non-Node environments. Does
+ *   not account for escape expansion (\", \\, control chars, surrogate
+ *   escapes) which is usually a small fraction of total size.
+ * - Binary data (Buffer / typed arrays / ArrayBuffer / DataView): sized
+ *   from their JSON.stringify representations where practical
+ *   ({ type: "Buffer", data: [...] } for Buffer, keyed objects for typed
+ *   arrays). DataView and ArrayBuffer themselves have no enumerable own
+ *   properties and serialize as "{}". Each byte contributes ~3.5
+ *   characters on average in Buffer's decimal-array representation
+ *   (digit(s) + comma).
+ * - Other objects with toJSON(): we invoke toJSON() once and estimate
+ *   the result. This matches JSON.stringify semantics for libraries
+ *   like Decimal.js, Moment, Luxon, Mongoose documents, etc.
+ * - Cycles: detected via an ancestor-path set that is pushed/popped
+ *   during recursion. This matches JSON.stringify semantics --
+ *   repeated references that are *not* on the current ancestor chain
+ *   (shared subobjects) are counted every time they appear, because
+ *   JSON.stringify will serialize them every time.
+ * - No depth limit (JSON.stringify has none either).
+ */
+export function estimateSerializedSize(value: unknown): number {
+  try {
+    // Ancestor set for cycle detection. An object is only treated as
+    // circular if it appears on the current recursion path, not merely
+    // if it has been seen before elsewhere in the graph.
+    const ancestors = new Set<object>();
+
+    // In Node / Bun, Buffer.byteLength is a fast native way to get UTF-8
+    // byte length without allocating an encoded copy. In other runtimes
+    // we fall back to code-unit length (a small under-estimate for
+    // non-ASCII text, which is acceptable for soft limits).
+    const byteLen: (s: string) => number =
+      typeof Buffer !== "undefined" && typeof Buffer.byteLength === "function"
+        ? (s) => Buffer.byteLength(s, "utf8")
+        : (s) => s.length;
+
+    function estimateString(s: string): number {
+      // +2 for the surrounding quotes. Escape expansion is not counted.
+      return byteLen(s) + 2;
+    }
+
+    // Size of a byte sequence when rendered as a JSON array of decimal
+    // numbers: "[b0,b1,b2,...]". Each byte averages ~3.5 chars (value 0-9
+    // => 1 char, 10-99 => 2 chars, 100-255 => 3 chars; weighted mean over
+    // a uniform distribution is ~2.81, plus one comma per element except
+    // the last). Round up to 4 bytes/element for a small safety margin.
+    function estimateByteArrayJson(byteLength: number): number {
+      if (byteLength === 0) return 2; // "[]"
+      return 2 + byteLength * 4;
+    }
+
+    // Returns true for values that JSON.stringify drops when they appear
+    // as an object property (as opposed to an array element, where they
+    // become "null").
+    function isDropped(v: unknown): boolean {
+      return (
+        v === undefined || typeof v === "function" || typeof v === "symbol"
+      );
+    }
+
+    // In arrays, undefined / function / symbol become "null" (4 bytes).
+    function estimateInArray(v: unknown): number {
+      if (v === undefined || typeof v === "function" || typeof v === "symbol") {
+        return 4;
+      }
+      return estimate(v);
+    }
+
+    function estimate(val: unknown): number {
+      if (val === null) return 4; // "null"
+      if (val === undefined) return 0; // top-level or property context; array handled separately
+      const t = typeof val;
+      if (t === "boolean") return 5; // "true" / "false" upper bound
+      if (t === "number") {
+        if (!Number.isFinite(val as number)) return 4; // "null"
+        // Convert to string to get exact length. This is cheap for numbers
+        // (V8 caches small-number strings) and makes the estimate far
+        // tighter for common cases like integer arrays.
+        return (val as number).toString().length;
+      }
+      if (t === "bigint") {
+        // Our replacer renders BigInt via .toString(), then JSON.stringify
+        // quotes it.
+        return (val as bigint).toString().length + 2;
+      }
+      if (t === "string") return estimateString(val as string);
+      if (t === "function" || t === "symbol") return 0;
+
+      // Objects from here on.
+      const obj = val as object;
+
+      // Well-known types handled by our replacer.
+      if (obj instanceof Date) return 26; // "2024-01-01T00:00:00.000Z"
+      if (obj instanceof RegExp) return byteLen(obj.toString()) + 2;
+      if (obj instanceof Error) {
+        const name = obj.name ?? "";
+        const message = obj.message ?? "";
+        // {"name":"...","message":"..."}
+        return 22 + byteLen(name) + byteLen(message);
+      }
+
+      // Binary data types. These commonly appear in LLM payloads (images,
+      // audio) and their JSON representations vary widely.
+      if (typeof Buffer !== "undefined" && obj instanceof Buffer) {
+        // { "type": "Buffer", "data": [0, 1, 2, ...] }
+        return 28 + estimateByteArrayJson(obj.byteLength);
+      }
+      if (ArrayBuffer.isView(obj)) {
+        if (obj instanceof DataView) {
+          // DataView has no enumerable own properties; serializes as "{}".
+          return 2;
+        }
+        // Typed arrays serialize as {"0":v0,"1":v1,...} (keyed objects),
+        // which is much larger than a plain array would be. Per element
+        // cost: digits for index + digits for value + ":" + "," + quotes.
+        const len = (obj as unknown as { length: number }).length ?? 0;
+        const isFloat =
+          obj instanceof Float32Array || obj instanceof Float64Array;
+        // Index digits grow with len; worst-case per element:
+        //   "NNN":V,   where NNN = log10(len) digits and V depends on type.
+        // Loose but safe bounds: integer views ~12 chars/element, float
+        // views ~30 chars/element (Float32 ToString can be up to ~17 chars).
+        const perElement = isFloat ? 30 : 12;
+        return 2 + len * perElement;
+      }
+      if (obj instanceof ArrayBuffer) {
+        // Plain ArrayBuffer has no enumerable properties; serializes as "{}".
+        return 2;
+      }
+
+      if (ancestors.has(obj)) {
+        // Cycle: our decirc fallback replaces with { result: "[Circular]" }.
+        return 24;
+      }
+
+      // Custom toJSON (Decimal.js, Moment, Luxon, Mongoose docs, etc.).
+      // This runs after explicit built-in / binary cases above so known
+      // types (for example Buffer) use their dedicated fast-path sizing
+      // logic instead of duck-typing through toJSON().
+      if (typeof (obj as { toJSON?: unknown }).toJSON === "function") {
+        let projected: unknown;
+        try {
+          projected = (obj as { toJSON: (key?: string) => unknown }).toJSON("");
+        } catch {
+          // If toJSON throws, JSON.stringify would also throw and our
+          // serializer would emit "[Unserializable]" (~16 bytes).
+          return 16;
+        }
+        ancestors.add(obj);
+        const size = estimate(projected);
+        ancestors.delete(obj);
+        return size;
+      }
+
+      ancestors.add(obj);
+      let size: number;
+      if (Array.isArray(obj)) {
+        size = 2; // []
+        const len = obj.length;
+        for (let i = 0; i < len; i++) {
+          size += estimateInArray(obj[i]);
+          if (i < len - 1) size += 1; // comma
+        }
+      } else if (obj instanceof Map) {
+        // Rendered as { k: v, ... } via Object.fromEntries.
+        size = 2;
+        let emitted = 0;
+        for (const [k, v] of obj) {
+          if (isDropped(v)) continue;
+          if (emitted > 0) size += 1; // comma
+          const keyStr = typeof k === "string" ? k : String(k);
+          size += byteLen(keyStr) + 3; // "key":
+          size += estimate(v);
+          emitted++;
+        }
+      } else if (obj instanceof Set) {
+        // Rendered as [v, ...] via Array.from.
+        size = 2;
+        let emitted = 0;
+        for (const v of obj) {
+          if (emitted > 0) size += 1; // comma
+          size += estimateInArray(v);
+          emitted++;
+        }
+      } else {
+        size = 2; // {}
+        let emitted = 0;
+        // Object.keys only returns own enumerable string keys, matching
+        // JSON.stringify.
+        const keys = Object.keys(obj);
+        for (let i = 0; i < keys.length; i++) {
+          const key = keys[i];
+          const v = (obj as Record<string, unknown>)[key];
+          if (isDropped(v)) continue;
+          if (emitted > 0) size += 1; // comma
+          size += byteLen(key) + 3; // "key":
+          size += estimate(v);
+          emitted++;
+        }
+      }
+      ancestors.delete(obj);
+      return size;
+    }
+
+    return estimate(value);
+  } catch {
+    // If the estimator itself hits an unexpected edge case, fall back to the
+    // exact serialized size. This preserves correctness of queue-size
+    // accounting at the cost of a slower hot path for that one payload.
+    return serialize(value).length;
+  }
+}
+
 // Regular stringify
 export function serialize(
   obj,


### PR DESCRIPTION
Metric | EXACT | ESTIMATE |
|---|---:|---:|
| Wall time incl. drain | 1088.7ms | 977.6ms |
| `createRun` total sync time | 290.46ms | 62.05ms |
| `createRun` max | 36.25ms | 21.69ms |
| `createRun` p50 | 1.95ms | 0.26ms |
| `createRun` p95 | 8.43ms | 0.92ms |
| `createRun` p99 | 36.25ms | 21.69ms |
| `updateRun` total sync time | 123.69ms | 147.36ms |
| `updateRun` max | 7.46ms | 12.80ms |
| `updateRun` p50 | 0.89ms | 0.96ms |
| `updateRun` p95 | 2.69ms | 3.23ms |
| `updateRun` p99 | 7.46ms | 12.80ms |
| Event-loop lag total | 666.38ms | 586.56ms |
| Event-loop lag max | 131.72ms | 104.75ms |
| Event-loop lag p50 | 0.20ms | 0.16ms |
| Event-loop lag p95 | 3.81ms | 3.69ms |
| Event-loop lag p99 | 48.27ms | 51.06ms