### PR TITLE
perf(js): Offload serialize to worker thread at flush time

### DIFF
--- a/.github/workflows/js-perf.yml
+++ b/.github/workflows/js-perf.yml
@@ -1,0 +1,207 @@
+name: js-perf
+
+on:
+  pull_request:
+    paths:
+      - "js/src/**"
+      - "js/package.json"
+      - ".github/workflows/js-perf.yml"
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR HEAD
+        uses: actions/checkout@v6
+        with:
+          path: pr
+
+      - name: Checkout main
+        uses: actions/checkout@v6
+        with:
+          ref: main
+          path: base
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20
+
+      - name: Setup pnpm via corepack
+        run: |
+          corepack enable
+          corepack prepare pnpm@10.33.0 --activate
+          pnpm --version
+
+      - name: Install deps (main)
+        working-directory: base/js
+        run: pnpm install --frozen-lockfile
+
+      - name: Run benchmark (main)
+        working-directory: base/js
+        env:
+          LANGSMITH_RUN_PERF_BENCH: "true"
+          LANGSMITH_TRACING: "false"
+        run: |
+          set -o pipefail
+          pnpm test:integration src/tests/perf.int.test.ts \
+            -t "benchmark event loop" 2>&1 | tee "$GITHUB_WORKSPACE/base-bench.log"
+
+      - name: Install deps (PR)
+        working-directory: pr/js
+        run: pnpm install --frozen-lockfile
+
+      - name: Run benchmark (PR)
+        working-directory: pr/js
+        env:
+          LANGSMITH_RUN_PERF_BENCH: "true"
+          LANGSMITH_TRACING: "false"
+        run: |
+          set -o pipefail
+          pnpm test:integration src/tests/perf.int.test.ts \
+            -t "benchmark event loop" 2>&1 | tee "$GITHUB_WORKSPACE/pr-bench.log"
+
+      - name: Compare and post PR comment
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const fs = require("fs");
+            const path = require("path");
+            const readLog = (name) => {
+              try {
+                return fs.readFileSync(
+                  path.join(process.env.GITHUB_WORKSPACE, name),
+                  "utf8"
+                );
+              } catch {
+                return "";
+              }
+            };
+            const baseLog = readLog("base-bench.log");
+            const prLog   = readLog("pr-bench.log");
+
+            const extract = (log) => {
+              const m = log.match(/<<PERF_BENCH_JSON>>(.*?)<<END_PERF_BENCH_JSON>>/s);
+              if (!m) return null;
+              try { return JSON.parse(m[1]); } catch { return null; }
+            };
+
+            const base = extract(baseLog);
+            const pr   = extract(prLog);
+
+            if (!base || !pr) {
+              core.setFailed(
+                `Failed to parse benchmark output.\n` +
+                `base parsed: ${!!base}, pr parsed: ${!!pr}`
+              );
+              return;
+            }
+
+            const fmt = (n) => (typeof n === "number" ? n.toFixed(2) : String(n));
+            const delta = (a, b) => {
+              if (!a) return "n/a";
+              const pct = ((b - a) / a) * 100;
+              const sign = pct >= 0 ? "+" : "";
+              return `${sign}${pct.toFixed(1)}%`;
+            };
+
+            const row = (label, path) => {
+              const get = (obj) => path.reduce((o, k) => (o ? o[k] : undefined), obj);
+              const a = get(base);
+              const b = get(pr);
+              return `| ${label} | ${fmt(a)} | ${fmt(b)} | ${delta(a, b)} |`;
+            };
+
+            const metrics = [
+              ["Wall time (ms)",          ["wallMs"]],
+              ["createRun total (ms)",    ["createRun", "total"]],
+              ["createRun p50 (ms)",      ["createRun", "p50"]],
+              ["createRun p95 (ms)",      ["createRun", "p95"]],
+              ["createRun p99 (ms)",      ["createRun", "p99"]],
+              ["createRun max (ms)",      ["createRun", "max"]],
+              ["updateRun total (ms)",    ["updateRun", "total"]],
+              ["updateRun p95 (ms)",      ["updateRun", "p95"]],
+              ["loop lag total (ms)",     ["loopLag", "total"]],
+              ["loop lag p50 (ms)",       ["loopLag", "p50"]],
+              ["loop lag p95 (ms)",       ["loopLag", "p95"]],
+              ["loop lag p99 (ms)",       ["loopLag", "p99"]],
+              ["loop lag max (ms)",       ["loopLag", "max"]],
+            ];
+
+            // Only include the tail of each log — the useful part is the
+            // human-readable table jest prints near the end.
+            const tail = (s, n = 2500) =>
+              s.length > n ? "…\n" + s.slice(-n) : s;
+            const safe = (s) => s.replace(/```/g, "``\u200b`").trim();
+
+            const body = [
+              `### JS perf benchmark`,
+              ``,
+              `Event-loop blocking benchmark (large base64-heavy payload, ${pr.runs} runs).`,
+              `Lower is better. Noisy on shared runners — treat as a signal, not a gate.`,
+              ``,
+              `| metric | main | this PR | delta |`,
+              `| --- | ---: | ---: | ---: |`,
+              ...metrics.map(([label, path]) => row(label, path)),
+              ``,
+              `<details><summary>Raw output (PR)</summary>`,
+              ``,
+              "```",
+              safe(tail(prLog)),
+              "```",
+              ``,
+              `</details>`,
+              ``,
+              `<details><summary>Raw output (main)</summary>`,
+              ``,
+              "```",
+              safe(tail(baseLog)),
+              "```",
+              ``,
+              `</details>`,
+            ].join("\n");
+
+            // PR comments have a 65536-char limit; leave headroom.
+            const MAX = 60000;
+            const trimmed =
+              body.length > MAX ? body.slice(0, MAX) + "\n\n…truncated" : body;
+
+            // Sticky upsert: find our previous comment by a hidden marker
+            // and update it in place, else create a new one. Avoids
+            // depending on a third-party sticky-comment action.
+            const MARKER = "<!-- js-perf-bench -->";
+            const message = `${MARKER}\n${trimmed}`;
+
+            const pr_number = context.payload.pull_request?.number;
+            if (!pr_number) {
+              core.info("Not a pull_request event; skipping comment.");
+              return;
+            }
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr_number,
+              per_page: 100,
+            });
+            const existing = comments.find((c) => c.body?.includes(MARKER));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body: message,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr_number,
+                body: message,
+              });
+            }

--- a/.github/workflows/js-perf.yml
+++ b/.github/workflows/js-perf.yml
@@ -46,8 +46,10 @@ jobs:
         env:
           LANGSMITH_RUN_PERF_BENCH: "true"
           LANGSMITH_TRACING: "false"
+          LANGSMITH_PERF_BENCH_DIR: ${{ github.workspace }}/base-results
         run: |
           set -o pipefail
+          mkdir -p "$LANGSMITH_PERF_BENCH_DIR"
           pnpm test:integration src/tests/perf.int.test.ts \
             -t "benchmark event loop" 2>&1 | tee "$GITHUB_WORKSPACE/base-bench.log"
 
@@ -60,8 +62,10 @@ jobs:
         env:
           LANGSMITH_RUN_PERF_BENCH: "true"
           LANGSMITH_TRACING: "false"
+          LANGSMITH_PERF_BENCH_DIR: ${{ github.workspace }}/pr-results
         run: |
           set -o pipefail
+          mkdir -p "$LANGSMITH_PERF_BENCH_DIR"
           pnpm test:integration src/tests/perf.int.test.ts \
             -t "benchmark event loop" 2>&1 | tee "$GITHUB_WORKSPACE/pr-bench.log"
 
@@ -71,35 +75,34 @@ jobs:
           script: |
             const fs = require("fs");
             const path = require("path");
-            const readLog = (name) => {
+
+            const readJson = (dir, file) => {
               try {
-                return fs.readFileSync(
-                  path.join(process.env.GITHUB_WORKSPACE, name),
-                  "utf8"
+                return JSON.parse(
+                  fs.readFileSync(path.join(dir, file), "utf8")
                 );
               } catch {
-                return "";
+                return null;
               }
             };
-            const baseLog = readLog("base-bench.log");
-            const prLog   = readLog("pr-bench.log");
 
-            const extract = (log) => {
-              const m = log.match(/<<PERF_BENCH_JSON>>(.*?)<<END_PERF_BENCH_JSON>>/s);
-              if (!m) return null;
-              try { return JSON.parse(m[1]); } catch { return null; }
-            };
+            const baseDir = path.join(process.env.GITHUB_WORKSPACE, "base-results");
+            const prDir   = path.join(process.env.GITHUB_WORKSPACE, "pr-results");
 
-            const base = extract(baseLog);
-            const pr   = extract(prLog);
-
-            if (!base || !pr) {
-              core.setFailed(
-                `Failed to parse benchmark output.\n` +
-                `base parsed: ${!!base}, pr parsed: ${!!pr}`
-              );
-              return;
-            }
+            const cases = [
+              {
+                title: "Base64-heavy payload",
+                description:
+                  "Single large base64 string per message — the shape the worker-offload path is optimized for.",
+                file: "bench-base64.json",
+              },
+              {
+                title: "Structural payload",
+                description:
+                  "Many small strings across a wide/nested object graph. Should bypass worker offload and use sync flush.",
+                file: "bench-structural.json",
+              },
+            ];
 
             const fmt = (n) => (typeof n === "number" ? n.toFixed(2) : String(n));
             const delta = (a, b) => {
@@ -107,13 +110,6 @@ jobs:
               const pct = ((b - a) / a) * 100;
               const sign = pct >= 0 ? "+" : "";
               return `${sign}${pct.toFixed(1)}%`;
-            };
-
-            const row = (label, path) => {
-              const get = (obj) => path.reduce((o, k) => (o ? o[k] : undefined), obj);
-              const a = get(base);
-              const b = get(pr);
-              return `| ${label} | ${fmt(a)} | ${fmt(b)} | ${delta(a, b)} |`;
             };
 
             const metrics = [
@@ -132,37 +128,44 @@ jobs:
               ["loop lag max (ms)",       ["loopLag", "max"]],
             ];
 
-            // Only include the tail of each log — the useful part is the
-            // human-readable table jest prints near the end.
-            const tail = (s, n = 2500) =>
-              s.length > n ? "…\n" + s.slice(-n) : s;
-            const safe = (s) => s.replace(/```/g, "``\u200b`").trim();
+            const renderCase = ({ title, description, file }) => {
+              const base = readJson(baseDir, file);
+              const pr   = readJson(prDir, file);
+              if (!base || !pr) {
+                return [
+                  `#### ${title}`,
+                  ``,
+                  `_Missing results_: base=${!!base}, pr=${!!pr}`,
+                ];
+              }
+              const get = (obj, p) =>
+                p.reduce((o, k) => (o ? o[k] : undefined), obj);
+              const rows = metrics.map(([label, p]) => {
+                const a = get(base, p);
+                const b = get(pr, p);
+                return `| ${label} | ${fmt(a)} | ${fmt(b)} | ${delta(a, b)} |`;
+              });
+              return [
+                `#### ${title}`,
+                ``,
+                description,
+                `Payload: ${(pr.inputBytes / 1024).toFixed(1)} KB in / ${(
+                  pr.outputBytes / 1024
+                ).toFixed(1)} KB out, ${pr.runs} runs.`,
+                ``,
+                `| metric | main | this PR | delta |`,
+                `| --- | ---: | ---: | ---: |`,
+                ...rows,
+                ``,
+              ];
+            };
 
             const body = [
               `### JS perf benchmark`,
               ``,
-              `Event-loop blocking benchmark (large base64-heavy payload, ${pr.runs} runs).`,
               `Lower is better. Noisy on shared runners — treat as a signal, not a gate.`,
               ``,
-              `| metric | main | this PR | delta |`,
-              `| --- | ---: | ---: | ---: |`,
-              ...metrics.map(([label, path]) => row(label, path)),
-              ``,
-              `<details><summary>Raw output (PR)</summary>`,
-              ``,
-              "```",
-              safe(tail(prLog)),
-              "```",
-              ``,
-              `</details>`,
-              ``,
-              `<details><summary>Raw output (main)</summary>`,
-              ``,
-              "```",
-              safe(tail(baseLog)),
-              "```",
-              ``,
-              `</details>`,
+              ...cases.flatMap(renderCase),
             ].join("\n");
 
             // PR comments have a 65536-char limit; leave headroom.

--- a/js/package.json
+++ b/js/package.json
@@ -192,6 +192,7 @@
     "eslint-plugin-prettier": "^4.2.1",
     "jest": "^29.5.0",
     "langchain": "^0.3.29",
+    "mongoose": "^9.5.0",
     "msw": "^2.11.2",
     "node-fetch": "^3.3.2",
     "openai": "^6.18.0",

--- a/js/package.json
+++ b/js/package.json
@@ -471,6 +471,7 @@
     }
   },
   "browser": {
-    "./dist/utils/fs.js": "./dist/utils/fs.browser.js"
+    "./dist/utils/fs.js": "./dist/utils/fs.browser.js",
+    "./dist/utils/worker_threads.js": "./dist/utils/worker_threads.browser.js"
   }
 }

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -138,6 +138,9 @@ importers:
       langchain:
         specifier: ^0.3.29
         version: 0.3.37(@langchain/core@0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.215.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.20.0)(zod@4.3.6)))(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.215.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(handlebars@4.7.9)(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
+      mongoose:
+        specifier: ^9.5.0
+        version: 9.5.0
       msw:
         specifier: ^2.11.2
         version: 2.13.4(@types/node@25.6.0)(typescript@5.9.3)
@@ -1366,6 +1369,9 @@ packages:
       '@cfworker/json-schema':
         optional: true
 
+  '@mongodb-js/saslprep@1.4.8':
+    resolution: {integrity: sha512-kpjr2jy2w71w0oqAMI8oibBmiF9lXxWkEQs5gMkW4hVE48bsqINGLxnCSYW62ck/NHXJQpQEfA9WlJ1sY0eqBg==}
+
   '@mswjs/interceptors@0.41.4':
     resolution: {integrity: sha512-3B9EinUkrdOUGYzHRzRWSXunQ4YFGboJnyLNRwEJWEde+j8fNhPUHvrN1E3g1DU/iS/s8JQrMNVe+S7AHHVs0w==}
     engines: {node: '>=18'}
@@ -2198,6 +2204,12 @@ packages:
   '@types/uuid@10.0.0':
     resolution: {integrity: sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==}
 
+  '@types/webidl-conversions@7.0.3':
+    resolution: {integrity: sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA==}
+
+  '@types/whatwg-url@13.0.0':
+    resolution: {integrity: sha512-N8WXpbE6Wgri7KUSvrmQcqrMllKZ9uxkYWMt+mCSGwNc0Hsw9VQTW7ApqI4XNrx6/SaM2QQJCzMPDEXE058s+Q==}
+
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
@@ -2532,6 +2544,10 @@ packages:
 
   bser@2.1.1:
     resolution: {integrity: sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==}
+
+  bson@7.2.0:
+    resolution: {integrity: sha512-YCEo7KjMlbNlyHhz7zAZNDpIpQbd+wOEHJYezv0nMYTn4x31eIUM2yomNNubclAt63dObUzKHWsBLJ9QcZNSnQ==}
+    engines: {node: '>=20.19.0'}
 
   buffer-equal-constant-time@1.0.1:
     resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
@@ -3709,6 +3725,10 @@ packages:
   jws@4.0.1:
     resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
 
+  kareem@3.3.0:
+    resolution: {integrity: sha512-kpSuLD3/7RenBnjnJdOHXCKC8dTd1JzeOiJhN0necWWci6cC+qX+VuwPnMVgb+a4+KNJSfgqahpnfWaeDXCimw==}
+    engines: {node: '>=18.0.0'}
+
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
@@ -3868,6 +3888,9 @@ packages:
     resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
     engines: {node: '>= 0.8'}
 
+  memory-pager@1.5.0:
+    resolution: {integrity: sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==}
+
   merge-descriptors@2.0.0:
     resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
     engines: {node: '>=18'}
@@ -3923,6 +3946,49 @@ packages:
 
   module-details-from-path@1.0.4:
     resolution: {integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==}
+
+  mongodb-connection-string-url@7.0.1:
+    resolution: {integrity: sha512-h0AZ9A7IDVwwHyMxmdMXKy+9oNlF0zFoahHiX3vQ8e3KFcSP3VmsmfvtRSuLPxmyv2vjIDxqty8smTgie/SNRQ==}
+    engines: {node: '>=20.19.0'}
+
+  mongodb@7.1.1:
+    resolution: {integrity: sha512-067DXiMjcpYQl6bGjWQoTUEE9UoRViTtKFcoqX7z08I+iDZv/emH1g8XEFiO3qiDfXAheT5ozl1VffDTKhIW/w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@aws-sdk/credential-providers': ^3.806.0
+      '@mongodb-js/zstd': ^7.0.0
+      gcp-metadata: ^7.0.1
+      kerberos: ^7.0.0
+      mongodb-client-encryption: '>=7.0.0 <7.1.0'
+      snappy: ^7.3.2
+      socks: ^2.8.6
+    peerDependenciesMeta:
+      '@aws-sdk/credential-providers':
+        optional: true
+      '@mongodb-js/zstd':
+        optional: true
+      gcp-metadata:
+        optional: true
+      kerberos:
+        optional: true
+      mongodb-client-encryption:
+        optional: true
+      snappy:
+        optional: true
+      socks:
+        optional: true
+
+  mongoose@9.5.0:
+    resolution: {integrity: sha512-B4blGFkFL1s0G24URuMvx0qTlx+gRVLmfO7WcSz8NcmW/XHEJ3G69capdyW1iRsGKiycp1tkwKHnxHbnwjwmPw==}
+    engines: {node: '>=20.19.0'}
+
+  mpath@0.9.0:
+    resolution: {integrity: sha512-ikJRQTk8hw5DEoFVxHG1Gn9T/xcjtdnOKIU1JTmGjZZlg9LST2mBLmcX3/ICIbgJydT2GOc15RnNy5mHmzfSew==}
+    engines: {node: '>=4.0.0'}
+
+  mquery@6.0.0:
+    resolution: {integrity: sha512-b2KQNsmgtkscfeDgkYMcWGn9vZI9YoXh802VDEwE6qc50zxBFQ0Oo8ROkawbPAsXCY1/Z1yp0MagqsZStPWJjw==}
+    engines: {node: '>=20.19.0'}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -4438,6 +4504,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  sift@17.1.3:
+    resolution: {integrity: sha512-Rtlj66/b0ICeFzYTuNvX/EF1igRbbnGSvEyT79McoZa/DeGhMyC5pWKOEsZKnpkqtSeovd5FL/bjHWC3CIIvCQ==}
+
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
@@ -4468,6 +4537,9 @@ packages:
   source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
+
+  sparse-bitfield@3.0.3:
+    resolution: {integrity: sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==}
 
   stack-utils@2.0.6:
     resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
@@ -4607,6 +4679,10 @@ packages:
   tough-cookie@6.0.1:
     resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
     engines: {node: '>=16'}
+
+  tr46@5.1.1:
+    resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
+    engines: {node: '>=18'}
 
   ts-algebra@2.0.0:
     resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
@@ -4873,6 +4949,14 @@ packages:
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
+
+  webidl-conversions@7.0.0:
+    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
+
+  whatwg-url@14.2.0:
+    resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
+    engines: {node: '>=18'}
 
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
@@ -6403,6 +6487,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@mongodb-js/saslprep@1.4.8':
+    dependencies:
+      sparse-bitfield: 3.0.3
+
   '@mswjs/interceptors@0.41.4':
     dependencies:
       '@open-draft/deferred-promise': 2.2.0
@@ -7432,6 +7520,12 @@ snapshots:
 
   '@types/uuid@10.0.0': {}
 
+  '@types/webidl-conversions@7.0.3': {}
+
+  '@types/whatwg-url@13.0.0':
+    dependencies:
+      '@types/webidl-conversions': 7.0.3
+
   '@types/ws@8.18.1':
     dependencies:
       '@types/node': 25.5.0
@@ -7875,6 +7969,8 @@ snapshots:
   bser@2.1.1:
     dependencies:
       node-int64: 0.4.0
+
+  bson@7.2.0: {}
 
   buffer-equal-constant-time@1.0.1: {}
 
@@ -9420,6 +9516,8 @@ snapshots:
       jwa: 2.0.1
       safe-buffer: 5.2.1
 
+  kareem@3.3.0: {}
+
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
@@ -9533,6 +9631,8 @@ snapshots:
 
   media-typer@1.1.0: {}
 
+  memory-pager@1.5.0: {}
+
   merge-descriptors@2.0.0: {}
 
   merge-stream@2.0.0: {}
@@ -9575,6 +9675,38 @@ snapshots:
   minipass@7.1.3: {}
 
   module-details-from-path@1.0.4: {}
+
+  mongodb-connection-string-url@7.0.1:
+    dependencies:
+      '@types/whatwg-url': 13.0.0
+      whatwg-url: 14.2.0
+
+  mongodb@7.1.1:
+    dependencies:
+      '@mongodb-js/saslprep': 1.4.8
+      bson: 7.2.0
+      mongodb-connection-string-url: 7.0.1
+
+  mongoose@9.5.0:
+    dependencies:
+      kareem: 3.3.0
+      mongodb: 7.1.1
+      mpath: 0.9.0
+      mquery: 6.0.0
+      ms: 2.1.3
+      sift: 17.1.3
+    transitivePeerDependencies:
+      - '@aws-sdk/credential-providers'
+      - '@mongodb-js/zstd'
+      - gcp-metadata
+      - kerberos
+      - mongodb-client-encryption
+      - snappy
+      - socks
+
+  mpath@0.9.0: {}
+
+  mquery@6.0.0: {}
 
   ms@2.1.3: {}
 
@@ -10145,6 +10277,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  sift@17.1.3: {}
+
   siginfo@2.0.0: {}
 
   signal-exit@3.0.7: {}
@@ -10165,6 +10299,10 @@ snapshots:
       source-map: 0.6.1
 
   source-map@0.6.1: {}
+
+  sparse-bitfield@3.0.3:
+    dependencies:
+      memory-pager: 1.5.0
 
   stack-utils@2.0.6:
     dependencies:
@@ -10295,6 +10433,10 @@ snapshots:
   tough-cookie@6.0.1:
     dependencies:
       tldts: 7.0.28
+
+  tr46@5.1.1:
+    dependencies:
+      punycode: 2.3.1
 
   ts-algebra@2.0.0: {}
 
@@ -10555,6 +10697,13 @@ snapshots:
       makeerror: 1.0.12
 
   web-streams-polyfill@3.3.3: {}
+
+  webidl-conversions@7.0.0: {}
+
+  whatwg-url@14.2.0:
+    dependencies:
+      tr46: 5.1.1
+      webidl-conversions: 7.0.0
 
   which-boxed-primitive@1.1.1:
     dependencies:

--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -88,6 +88,7 @@ import {
 } from "./utils/fast-safe-stringify/index.js";
 import {
   getSharedSerializeWorker,
+  hasLargeString,
   SerializeWorker,
 } from "./utils/serialize_worker.js";
 
@@ -695,7 +696,7 @@ export class AutoBatchQueue {
     // batch is assembled for sending.
     const size =
       getLangSmithEnvironmentVariable("PERF_OPTIMIZATION") === "true"
-        ? estimateSerializedSize(item.item)
+        ? estimateSerializedSize(item.item).size
         : serializePayloadForTracing(
             item.item,
             `Serializing run with id: ${item.item.id}`
@@ -884,6 +885,15 @@ export class Client implements LangSmithTracingClientInterface {
     const perfOptIn =
       getLangSmithEnvironmentVariable("PERF_OPTIMIZATION") === "true";
     if (!perfOptIn || this.manualFlushMode) {
+      return serializePayloadForTracing(payload, errorContext);
+    }
+    // Shape-aware gate: worker offload pays for itself only when the
+    // payload is dominated by one or more large strings (V8 can refcount
+    // those across isolates instead of copying). For structure-heavy
+    // payloads -- many keys, deep nesting, lots of small strings -- the
+    // structuredClone walk plus thread-hop cost exceeds the JSON.stringify
+    // cost we would pay inline, so we fall through to sync serialize.
+    if (!hasLargeString(payload)) {
       return serializePayloadForTracing(payload, errorContext);
     }
     if (this._serializeWorker === undefined) {

--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -82,7 +82,10 @@ import {
   _getFetchImplementation,
 } from "./singletons/fetch.js";
 
-import { serialize as serializePayloadForTracing } from "./utils/fast-safe-stringify/index.js";
+import {
+  serialize as serializePayloadForTracing,
+  estimateSerializedSize,
+} from "./utils/fast-safe-stringify/index.js";
 
 /**
  * Catches timestamps without a timezone suffix.
@@ -676,10 +679,23 @@ export class AutoBatchQueue {
       // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/Promise
       itemPromiseResolve = resolve;
     });
-    const size = serializePayloadForTracing(
-      item.item,
-      `Serializing run with id: ${item.item.id}`
-    ).length;
+    // By default we compute the exact serialized size here by stringifying
+    // the payload. This is expensive: JSON.stringify on large payloads
+    // blocks the event loop on the user's hot path.
+    //
+    // Opting into LANGSMITH_PERF_OPTIMIZATION=true switches to a cheap
+    // structural estimate instead. The estimate is only used for soft
+    // memory accounting (queue size limit and downstream async caller
+    // memory tracking), never for anything correctness-critical -- the
+    // real serialization still happens later, off the hot path, when the
+    // batch is assembled for sending.
+    const size =
+      getLangSmithEnvironmentVariable("PERF_OPTIMIZATION") === "true"
+        ? estimateSerializedSize(item.item)
+        : serializePayloadForTracing(
+            item.item,
+            `Serializing run with id: ${item.item.id}`
+          ).length;
 
     // Check if adding this item would exceed the size limit
     // Allow the run if the queue is empty (to support large single traces)

--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -86,6 +86,10 @@ import {
   serialize as serializePayloadForTracing,
   estimateSerializedSize,
 } from "./utils/fast-safe-stringify/index.js";
+import {
+  getSharedSerializeWorker,
+  SerializeWorker,
+} from "./utils/serialize_worker.js";
 
 /**
  * Catches timestamps without a timezone suffix.
@@ -830,6 +834,15 @@ export class Client implements LangSmithTracingClientInterface {
 
   private manualFlushMode = false;
 
+  private _serializeWorker?: SerializeWorker | null;
+
+  /**
+   * Tracks in-flight drainAutoBatchQueue promises so awaitPendingTraceBatches
+   * can wait on them even if the flush involves async work (worker-thread
+   * serialize) that hasn't yet registered with batchIngestCaller.queue.
+   */
+  private _pendingDrains = new Set<Promise<unknown>>();
+
   private langSmithToOTELTranslator?: LangSmithToOTELTranslator;
 
   private fetchImplementation?: typeof fetch;
@@ -840,6 +853,57 @@ export class Client implements LangSmithTracingClientInterface {
 
   private get _fetch(): typeof fetch {
     return this.fetchImplementation || _getFetchImplementation(this.debug);
+  }
+
+  /**
+   * Serialize a payload for tracing, optionally offloading the work to a
+   * Node worker thread when LANGSMITH_PERF_OPTIMIZATION=true and the runtime
+   * supports worker_threads.
+   *
+   * Falls back to synchronous serialization when:
+   *  - the perf flag is off
+   *  - manualFlushMode is enabled (serverless: worker boot cost > benefit)
+   *  - worker_threads is unavailable (non-Node runtimes)
+   *  - the payload contains values that can't be structured-cloned across
+   *    threads (functions, non-cloneable class instances, streams, etc.)
+   *  - the worker throws for any other reason
+   *
+   * In all fallback cases the returned bytes are identical to the sync path.
+   */
+  private _trackDrain(promise: Promise<unknown>): void {
+    this._pendingDrains.add(promise);
+    promise.finally(() => {
+      this._pendingDrains.delete(promise);
+    });
+  }
+
+  private async _serializeBody(
+    payload: unknown,
+    errorContext: string
+  ): Promise<Uint8Array<ArrayBuffer>> {
+    const perfOptIn =
+      getLangSmithEnvironmentVariable("PERF_OPTIMIZATION") === "true";
+    if (!perfOptIn || this.manualFlushMode) {
+      return serializePayloadForTracing(payload, errorContext);
+    }
+    if (this._serializeWorker === undefined) {
+      this._serializeWorker = getSharedSerializeWorker();
+    }
+    if (this._serializeWorker === null) {
+      return serializePayloadForTracing(payload, errorContext);
+    }
+    try {
+      const bytes = await this._serializeWorker.serialize(payload);
+      if (bytes === null) {
+        // Worker subsystem unavailable; cache the null to skip re-entry.
+        this._serializeWorker = null;
+        return serializePayloadForTracing(payload, errorContext);
+      }
+      return bytes;
+    } catch {
+      // DataCloneError, worker crash, etc. Fall back silently.
+      return serializePayloadForTracing(payload, errorContext);
+    }
   }
 
   private multipartStreamingDisabled = false;
@@ -1575,18 +1639,22 @@ export class Client implements LangSmithTracingClientInterface {
       this.autoBatchQueue.sizeBytes > sizeLimitBytes ||
       this.autoBatchQueue.items.length > sizeLimit
     ) {
-      void this.drainAutoBatchQueue({
-        batchSizeLimitBytes: sizeLimitBytes,
-        batchSizeLimit: sizeLimit,
-      });
+      this._trackDrain(
+        this.drainAutoBatchQueue({
+          batchSizeLimitBytes: sizeLimitBytes,
+          batchSizeLimit: sizeLimit,
+        })
+      );
     }
     if (this.autoBatchQueue.items.length > 0) {
       this.autoBatchTimeout = setTimeout(() => {
         this.autoBatchTimeout = undefined;
-        void this.drainAutoBatchQueue({
-          batchSizeLimitBytes: sizeLimitBytes,
-          batchSizeLimit: sizeLimit,
-        });
+        this._trackDrain(
+          this.drainAutoBatchQueue({
+            batchSizeLimitBytes: sizeLimitBytes,
+            batchSizeLimit: sizeLimit,
+          })
+        );
       }, this.autoBatchAggregationDelayMs);
     }
     return itemPromise;
@@ -1813,7 +1881,7 @@ export class Client implements LangSmithTracingClientInterface {
         .concat(batchChunks.patch.map((item) => item.id))
         .join(",");
       await this._postBatchIngestRuns(
-        serializePayloadForTracing(
+        await this._serializeBody(
           batchChunks,
           `Ingesting runs with ids: ${runIds}`
         ),
@@ -1971,7 +2039,7 @@ export class Client implements LangSmithTracingClientInterface {
         } = originalPayload;
         const fields = { inputs, outputs, events, extra, error, serialized };
         // encode the main run payload
-        const stringifiedPayload = serializePayloadForTracing(
+        const stringifiedPayload = await this._serializeBody(
           payload,
           `Serializing for multipart ingestion of run with id: ${payload.id}`
         );
@@ -1986,7 +2054,7 @@ export class Client implements LangSmithTracingClientInterface {
           if (value === undefined) {
             continue;
           }
-          const stringifiedValue = serializePayloadForTracing(
+          const stringifiedValue = await this._serializeBody(
             value,
             `Serializing ${key} for multipart ingestion of run with id: ${payload.id}`
           );
@@ -6404,6 +6472,12 @@ export class Client implements LangSmithTracingClientInterface {
      * ```
      */
     await new Promise((resolve) => setTimeout(resolve, 1));
+    // Wait for any in-flight drains (whose serialize work may still be
+    // in-progress on a worker thread and not yet registered with the
+    // batchIngestCaller queue) before checking queue idleness.
+    while (this._pendingDrains.size > 0) {
+      await Promise.all([...this._pendingDrains]);
+    }
     await Promise.all([
       ...this.autoBatchQueue.items.map(({ itemPromise }) => itemPromise),
       this.batchIngestCaller.queue.onIdle(),

--- a/js/src/tests/perf.int.test.ts
+++ b/js/src/tests/perf.int.test.ts
@@ -127,7 +127,12 @@ benchIt(
     monitor.unref();
 
     const fetchImplementation: typeof fetch = async (input) => {
-      const url = typeof input === "string" ? input : input.url;
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+          ? input.toString()
+          : input.url;
       if (url.endsWith("/info")) {
         return new Response(
           JSON.stringify({

--- a/js/src/tests/perf.int.test.ts
+++ b/js/src/tests/perf.int.test.ts
@@ -1,5 +1,7 @@
+/* eslint-disable no-process-env */
 import { traceable } from "../traceable.js";
 import { Client } from "../client.js";
+import { v7 as uuidv7 } from "uuid";
 
 import * as fs from "fs";
 import path from "path";
@@ -17,7 +19,7 @@ test.skip("Test performance with large runs and concurrency", async () => {
     debug: true,
   });
   const largeTest = traceable(
-    async (foo: Record<string, any>) => {
+    async (foo: { bee: string }) => {
       await new Promise((resolve) => setTimeout(resolve, 100));
       return { reversebee: foo.bee.toString().split("").reverse().join("") };
     },
@@ -34,3 +36,204 @@ test.skip("Test performance with large runs and concurrency", async () => {
 
   await client.awaitPendingTraceBatches();
 });
+
+/**
+ * Benchmark event-loop blocking caused by tracing large payloads.
+ *
+ * This test measures how long the event loop is unable to run other work
+ * while the SDK performs end-to-end createRun/updateRun calls with large
+ * payloads. A monitor runs on a short timer and records the actual delay
+ * between ticks -- any delay beyond the target interval is time the event
+ * loop was blocked.
+ *
+ * The hot-path size estimation optimization is opt-in via
+ * LANGSMITH_PERF_OPTIMIZATION=true. Running the benchmark with and
+ * without that flag shows the before/after impact on the real public API
+ * path, not just the internal queue.
+ *
+ * Example (run both to compare):
+ *   # Default behavior (serialize on hot path)
+ *   LANGSMITH_TRACING=false pnpm test:integration src/tests/perf.int.test.ts \
+ *     -t "benchmark event loop"
+ *
+ *   # With opt-in optimization (estimator)
+ *   LANGSMITH_PERF_OPTIMIZATION=true LANGSMITH_TRACING=false \
+ *     pnpm test:integration src/tests/perf.int.test.ts -t "benchmark event loop"
+ */
+// Enabled by setting LANGSMITH_RUN_PERF_BENCH=true. Skipped in CI by default.
+const benchIt =
+  process.env.LANGSMITH_RUN_PERF_BENCH === "true" ? test : test.skip;
+benchIt(
+  "benchmark event loop blocking from tracing large payloads",
+  async () => {
+    const pathname = path.join(
+      path.dirname(fileURLToPath(import.meta.url)),
+      "test_data",
+      "beemovie.txt"
+    );
+
+    // Build a realistically large payload. beemovie.txt is ~50KB; nesting
+    // it a few times simulates a large model input/output.
+    const baseText = fs.readFileSync(pathname).toString();
+    const largeInputs = {
+      messages: Array.from({ length: 20 }, (_, i) => ({
+        role: i % 2 === 0 ? "user" : "assistant",
+        content: baseText,
+      })),
+      metadata: {
+        model: "gpt-4",
+        temperature: 0.7,
+        tools: Array.from({ length: 10 }, (_, i) => ({
+          name: `tool_${i}`,
+          description: baseText.slice(0, 500),
+        })),
+      },
+    };
+    const largeOutputs = {
+      generations: Array.from({ length: 8 }, () => ({
+        text: baseText,
+      })),
+      usage: {
+        prompt_tokens: 120000,
+        completion_tokens: 48000,
+      },
+    };
+
+    const inputJsonSize = JSON.stringify(largeInputs).length;
+    const outputJsonSize = JSON.stringify(largeOutputs).length;
+    const mode =
+      process.env.LANGSMITH_PERF_OPTIMIZATION === "true"
+        ? "ESTIMATE (opt-in optimization)"
+        : "EXACT (default, serialize on hot path)";
+
+    console.log(`\n=== Event loop benchmark ===`);
+    console.log(`Mode: ${mode}`);
+    console.log(
+      `Per-run create payload size: ${(inputJsonSize / 1024).toFixed(1)} KB`
+    );
+    console.log(
+      `Per-run update payload size: ${(outputJsonSize / 1024).toFixed(1)} KB`
+    );
+
+    const targetInterval = 1;
+    const lags: number[] = [];
+    let lastTick = performance.now();
+    const monitor = setInterval(() => {
+      const now = performance.now();
+      const lag = now - lastTick - targetInterval;
+      if (lag > 0) lags.push(lag);
+      lastTick = now;
+    }, targetInterval);
+    monitor.unref();
+
+    const fetchImplementation: typeof fetch = async (input) => {
+      const url = typeof input === "string" ? input : input.url;
+      if (url.endsWith("/info")) {
+        return new Response(
+          JSON.stringify({
+            batch_ingest_config: {
+              use_multipart_endpoint: true,
+              size_limit: 100,
+              size_limit_bytes: 20 * 1024 * 1024,
+            },
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          }
+        );
+      }
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 202,
+        headers: { "content-type": "application/json" },
+      });
+    };
+
+    const client = new Client({
+      autoBatchTracing: true,
+      fetchImplementation,
+      fetchOptions: {
+        signal: AbortSignal.timeout(30_000),
+      },
+    });
+
+    const NUM_RUNS = 100;
+    const createTimes: number[] = [];
+    const updateTimes: number[] = [];
+    const wallStart = performance.now();
+
+    for (let i = 0; i < NUM_RUNS; i++) {
+      const runId = uuidv7();
+
+      const createStart = performance.now();
+      await client.createRun({
+        id: runId,
+        trace_id: runId,
+        dotted_order: `${new Date().toISOString()}${runId}`,
+        name: "bench_run",
+        run_type: "llm",
+        inputs: largeInputs,
+        start_time: Date.now(),
+      });
+      createTimes.push(performance.now() - createStart);
+
+      await new Promise((resolve) => setImmediate(resolve));
+
+      const updateStart = performance.now();
+      await client.updateRun(runId, {
+        outputs: largeOutputs,
+        end_time: Date.now(),
+      });
+      updateTimes.push(performance.now() - updateStart);
+
+      await new Promise((resolve) => setImmediate(resolve));
+    }
+
+    await client.awaitPendingTraceBatches();
+
+    const wallEnd = performance.now();
+    clearInterval(monitor);
+
+    lags.sort((a, b) => a - b);
+    const percentile = (values: number[], p: number) =>
+      values.length === 0
+        ? 0
+        : values[
+            Math.min(values.length - 1, Math.floor(values.length * p))
+          ];
+    const totalLag = lags.reduce((a, b) => a + b, 0);
+    const maxLag = lags.length ? lags[lags.length - 1] : 0;
+
+    createTimes.sort((a, b) => a - b);
+    updateTimes.sort((a, b) => a - b);
+    const createTotal = createTimes.reduce((a, b) => a + b, 0);
+    const updateTotal = updateTimes.reduce((a, b) => a + b, 0);
+    const createMax = createTimes.length ? createTimes[createTimes.length - 1] : 0;
+    const updateMax = updateTimes.length ? updateTimes[updateTimes.length - 1] : 0;
+
+    console.log(`\nRuns traced: ${NUM_RUNS}`);
+    console.log(`Wall time (including batch drain): ${(wallEnd - wallStart).toFixed(1)}ms`);
+    console.log(`\ncreateRun sync time (ms):`);
+    console.log(`  total:       ${createTotal.toFixed(2)}ms`);
+    console.log(`  max:         ${createMax.toFixed(2)}ms`);
+    console.log(`  p50:         ${percentile(createTimes, 0.5).toFixed(2)}ms`);
+    console.log(`  p95:         ${percentile(createTimes, 0.95).toFixed(2)}ms`);
+    console.log(`  p99:         ${percentile(createTimes, 0.99).toFixed(2)}ms`);
+    console.log(`\nupdateRun sync time (ms):`);
+    console.log(`  total:       ${updateTotal.toFixed(2)}ms`);
+    console.log(`  max:         ${updateMax.toFixed(2)}ms`);
+    console.log(`  p50:         ${percentile(updateTimes, 0.5).toFixed(2)}ms`);
+    console.log(`  p95:         ${percentile(updateTimes, 0.95).toFixed(2)}ms`);
+    console.log(`  p99:         ${percentile(updateTimes, 0.99).toFixed(2)}ms`);
+    console.log(
+      `\nEvent loop lag (setInterval monitor, ${targetInterval}ms target):`
+    );
+    console.log(`  samples > 0: ${lags.length}`);
+    console.log(`  total:       ${totalLag.toFixed(2)}ms`);
+    console.log(`  max:         ${maxLag.toFixed(2)}ms`);
+    console.log(`  p50:         ${percentile(lags, 0.5).toFixed(2)}ms`);
+    console.log(`  p95:         ${percentile(lags, 0.95).toFixed(2)}ms`);
+    console.log(`  p99:         ${percentile(lags, 0.99).toFixed(2)}ms`);
+  },
+  120_000
+);

--- a/js/src/tests/perf.int.test.ts
+++ b/js/src/tests/perf.int.test.ts
@@ -38,26 +38,27 @@ test("Test performance with large runs and concurrency", async () => {
 });
 
 /**
- * Benchmark event-loop blocking caused by tracing large payloads.
+ * Benchmarks event-loop blocking caused by tracing large payloads.
  *
- * This test measures how long the event loop is unable to run other work
- * while the SDK performs end-to-end createRun/updateRun calls with large
- * payloads. A monitor runs on a short timer and records the actual delay
- * between ticks -- any delay beyond the target interval is time the event
- * loop was blocked.
+ * Two payload shapes are measured:
+ *   1. Large-string ("base64"): payload dominated by a few multi-hundred-KB
+ *      strings. This is the shape the worker-offload path is optimized for.
+ *   2. Structural: payload whose bulk is many small strings across a wide /
+ *      nested object graph. `hasLargeString` should return false here and
+ *      the client should fall back to synchronous serialize at flush. This
+ *      bench protects against regressions in that non-offloaded path.
  *
- * The hot-path size estimator is assumed to be enabled (it landed
- * separately and is now the standard hot-path behavior). The flush-time
- * worker offload is force-enabled inside the test, so the result reflects
- * the full perf optimization stack.
+ * Each bench writes its machine-readable results to a JSON file under
+ * `$LANGSMITH_PERF_BENCH_DIR` (defaults to the repo-local `js/` directory).
+ * The js-perf CI workflow reads those files from both `main` and PR HEAD
+ * and posts a comparison comment.
  *
- * The benchmark is skipped by default and runs only when
- * LANGSMITH_RUN_PERF_BENCH=true. The js-perf CI workflow sets that flag
- * and runs the bench on both `main` and PR HEAD to produce a PR comment.
+ * Benchmarks are skipped by default and run only when
+ * LANGSMITH_RUN_PERF_BENCH=true.
  *
  * Manual run:
  *   LANGSMITH_RUN_PERF_BENCH=true LANGSMITH_TRACING=false \
- *     pnpm test:integration src/tests/perf.int.test.ts -t "benchmark event loop"
+ *     pnpm test:integration src/tests/perf.int.test.ts -t "benchmark"
  */
 // Force the perf optimization on for benchmark runs so results reflect
 // the shipped perf behavior regardless of the invoker's env.
@@ -66,8 +67,186 @@ process.env.LANGSMITH_PERF_OPTIMIZATION = "true";
 // Enabled by setting LANGSMITH_RUN_PERF_BENCH=true. Skipped in CI by default.
 const benchIt =
   process.env.LANGSMITH_RUN_PERF_BENCH === "true" ? test : test.skip;
+
+interface BenchStats {
+  total: number;
+  max: number;
+  p50: number;
+  p95: number;
+  p99: number;
+}
+
+interface BenchResult {
+  name: string;
+  runs: number;
+  inputBytes: number;
+  outputBytes: number;
+  wallMs: number;
+  createRun: BenchStats;
+  updateRun: BenchStats;
+  loopLag: BenchStats & { samples: number };
+}
+
+function percentile(values: number[], p: number): number {
+  if (values.length === 0) return 0;
+  return values[Math.min(values.length - 1, Math.floor(values.length * p))];
+}
+
+function stats(values: number[]): BenchStats {
+  return {
+    total: values.reduce((a, b) => a + b, 0),
+    max: values.length ? values[values.length - 1] : 0,
+    p50: percentile(values, 0.5),
+    p95: percentile(values, 0.95),
+    p99: percentile(values, 0.99),
+  };
+}
+
+function benchOutputPath(filename: string): string {
+  const dir = process.env.LANGSMITH_PERF_BENCH_DIR ?? process.cwd();
+  return path.join(dir, filename);
+}
+
+// Shared mock fetch: /info returns a batch-ingest config; everything else
+// returns an empty 202. Keeps the bench end-to-end without hitting network.
+const benchFetch: typeof fetch = async (input) => {
+  const url =
+    typeof input === "string"
+      ? input
+      : input instanceof URL
+      ? input.toString()
+      : input.url;
+  if (url.endsWith("/info")) {
+    return new Response(
+      JSON.stringify({
+        batch_ingest_config: {
+          use_multipart_endpoint: true,
+          size_limit: 100,
+          size_limit_bytes: 20 * 1024 * 1024,
+        },
+      }),
+      { status: 200, headers: { "content-type": "application/json" } }
+    );
+  }
+  return new Response(JSON.stringify({ ok: true }), {
+    status: 202,
+    headers: { "content-type": "application/json" },
+  });
+};
+
+async function runBench(opts: {
+  name: string;
+  inputs: unknown;
+  outputs: unknown;
+  numRuns: number;
+  outFile: string;
+}): Promise<BenchResult> {
+  const { name, inputs, outputs, numRuns, outFile } = opts;
+  const inputJsonSize = JSON.stringify(inputs).length;
+  const outputJsonSize = JSON.stringify(outputs).length;
+
+  const targetInterval = 1;
+  const lags: number[] = [];
+  let lastTick = performance.now();
+  const monitor = setInterval(() => {
+    const now = performance.now();
+    const lag = now - lastTick - targetInterval;
+    if (lag > 0) lags.push(lag);
+    lastTick = now;
+  }, targetInterval);
+  monitor.unref();
+
+  const client = new Client({
+    autoBatchTracing: true,
+    fetchImplementation: benchFetch,
+    fetchOptions: { signal: AbortSignal.timeout(30_000) },
+  });
+
+  const createTimes: number[] = [];
+  const updateTimes: number[] = [];
+  const wallStart = performance.now();
+
+  for (let i = 0; i < numRuns; i++) {
+    const runId = uuidv7();
+
+    const createStart = performance.now();
+    await client.createRun({
+      id: runId,
+      trace_id: runId,
+      dotted_order: `${new Date().toISOString()}${runId}`,
+      name: "bench_run",
+      run_type: "llm",
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      inputs: inputs as any,
+      start_time: Date.now(),
+    });
+    createTimes.push(performance.now() - createStart);
+
+    await new Promise((resolve) => setImmediate(resolve));
+
+    const updateStart = performance.now();
+    await client.updateRun(runId, {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      outputs: outputs as any,
+      end_time: Date.now(),
+    });
+    updateTimes.push(performance.now() - updateStart);
+
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+
+  await client.awaitPendingTraceBatches();
+
+  const wallEnd = performance.now();
+  clearInterval(monitor);
+
+  lags.sort((a, b) => a - b);
+  createTimes.sort((a, b) => a - b);
+  updateTimes.sort((a, b) => a - b);
+
+  const createStats = stats(createTimes);
+  const updateStats = stats(updateTimes);
+  const lagStats = stats(lags);
+  const result: BenchResult = {
+    name,
+    runs: numRuns,
+    inputBytes: inputJsonSize,
+    outputBytes: outputJsonSize,
+    wallMs: wallEnd - wallStart,
+    createRun: createStats,
+    updateRun: updateStats,
+    loopLag: { ...lagStats, samples: lags.length },
+  };
+
+  const fmt = (n: number) => n.toFixed(2).padStart(9);
+  const humanReadable = [
+    ``,
+    `=== Event loop benchmark: ${name} ===`,
+    `Runs traced:                 ${numRuns}`,
+    `Per-run create payload:      ${(inputJsonSize / 1024).toFixed(1)} KB`,
+    `Per-run update payload:      ${(outputJsonSize / 1024).toFixed(1)} KB`,
+    `Wall time (incl. drain):     ${(wallEnd - wallStart).toFixed(1)} ms`,
+    ``,
+    `                 total       max       p50       p95       p99`,
+    `createRun   ${fmt(createStats.total)} ${fmt(createStats.max)} ${fmt(
+      createStats.p50
+    )} ${fmt(createStats.p95)} ${fmt(createStats.p99)}`,
+    `updateRun   ${fmt(updateStats.total)} ${fmt(updateStats.max)} ${fmt(
+      updateStats.p50
+    )} ${fmt(updateStats.p95)} ${fmt(updateStats.p99)}`,
+    `loop lag    ${fmt(lagStats.total)} ${fmt(lagStats.max)} ${fmt(
+      lagStats.p50
+    )} ${fmt(lagStats.p95)} ${fmt(lagStats.p99)}`,
+    `(loop lag monitor: ${targetInterval}ms target, ${lags.length} samples > 0)`,
+  ].join("\n");
+  console.log(humanReadable);
+
+  fs.writeFileSync(benchOutputPath(outFile), JSON.stringify(result, null, 2));
+  return result;
+}
+
 benchIt(
-  "benchmark event loop blocking from tracing large payloads",
+  "benchmark event loop blocking from tracing large base64-heavy payloads",
   async () => {
     const pathname = path.join(
       path.dirname(fileURLToPath(import.meta.url)),
@@ -115,149 +294,105 @@ benchIt(
       },
     };
 
-    const inputJsonSize = JSON.stringify(largeInputs).length;
-    const outputJsonSize = JSON.stringify(largeOutputs).length;
+    await runBench({
+      name: "base64",
+      inputs: largeInputs,
+      outputs: largeOutputs,
+      numRuns: 100,
+      outFile: "bench-base64.json",
+    });
+  },
+  120_000
+);
 
-    const targetInterval = 1;
-    const lags: number[] = [];
-    let lastTick = performance.now();
-    const monitor = setInterval(() => {
-      const now = performance.now();
-      const lag = now - lastTick - targetInterval;
-      if (lag > 0) lags.push(lag);
-      lastTick = now;
-    }, targetInterval);
-    monitor.unref();
+benchIt(
+  "benchmark event loop blocking from tracing structural large payloads",
+  async () => {
+    // Structural-large payload: large total JSON size, but made up of many
+    // small-to-medium strings across a wide/nested object graph. No single
+    // string exceeds the worker-offload threshold, so this exercises the
+    // *non-offloaded* flush path (sync serialize on the main thread) even
+    // when LANGSMITH_PERF_OPTIMIZATION is on. Guards against regressions in
+    // the fallback path and confirms hasLargeString correctly filters this
+    // shape out.
+    const NUM_MESSAGES = 200;
+    const PER_MESSAGE_CHARS = 6_000; // well below the 64KB worker threshold
 
-    const fetchImplementation: typeof fetch = async (input) => {
-      const url =
-        typeof input === "string"
-          ? input
-          : input instanceof URL
-          ? input.toString()
-          : input.url;
-      if (url.endsWith("/info")) {
-        return new Response(
-          JSON.stringify({
-            batch_ingest_config: {
-              use_multipart_endpoint: true,
-              size_limit: 100,
-              size_limit_bytes: 20 * 1024 * 1024,
-            },
-          }),
-          {
-            status: 200,
-            headers: { "content-type": "application/json" },
-          }
-        );
-      }
-      return new Response(JSON.stringify({ ok: true }), {
-        status: 202,
-        headers: { "content-type": "application/json" },
-      });
+    // Distinct-ish content per message so V8 can't aggressively dedupe.
+    const makeText = (seed: number, chars: number) => {
+      const base = `msg-${seed} ` + "lorem ipsum dolor sit amet ".repeat(40);
+      return base.repeat(Math.ceil(chars / base.length)).slice(0, chars);
     };
 
-    const client = new Client({
-      autoBatchTracing: true,
-      fetchImplementation,
-      fetchOptions: {
-        signal: AbortSignal.timeout(30_000),
-      },
+    const structuralInputs = {
+      messages: Array.from({ length: NUM_MESSAGES }, (_, i) => ({
+        role: i % 2 === 0 ? "user" : "assistant",
+        name: `speaker_${i}`,
+        timestamp: new Date(
+          Date.now() - (NUM_MESSAGES - i) * 1000
+        ).toISOString(),
+        metadata: {
+          turn: i,
+          tokens: 200 + (i % 50),
+          tags: [`tag-${i % 7}`, `tag-${i % 11}`, `tag-${i % 13}`],
+          nested: {
+            score: (i * 0.017) % 1,
+            flags: { a: i % 2 === 0, b: i % 3 === 0, c: i % 5 === 0 },
+          },
+        },
+        content: makeText(i, PER_MESSAGE_CHARS),
+      })),
+      tools: Array.from({ length: 20 }, (_, i) => ({
+        name: `tool_${i}`,
+        description: makeText(10000 + i, 400),
+        parameters: {
+          type: "object",
+          properties: Object.fromEntries(
+            Array.from({ length: 8 }, (_, j) => [
+              `param_${j}`,
+              {
+                type: j % 2 === 0 ? "string" : "number",
+                description: `description of param ${j} for tool ${i}`,
+              },
+            ])
+          ),
+        },
+      })),
+      model: "gpt-4o",
+      temperature: 0.7,
+    };
+
+    const structuralOutputs = {
+      choices: [
+        {
+          message: {
+            role: "assistant",
+            content: makeText(999999, 8_000),
+            tool_calls: Array.from({ length: 10 }, (_, i) => ({
+              id: `call_${i}`,
+              type: "function",
+              function: {
+                name: `tool_${i}`,
+                arguments: JSON.stringify({
+                  query: makeText(20000 + i, 400),
+                  filters: { k1: `v${i}`, k2: i, k3: i % 2 === 0 },
+                }),
+              },
+            })),
+          },
+          finish_reason: "stop",
+        },
+      ],
+      usage: { prompt_tokens: 120000, completion_tokens: 48000 },
+    };
+
+    await runBench({
+      name: "structural",
+      inputs: structuralInputs,
+      outputs: structuralOutputs,
+      numRuns: 100,
+      outFile: "bench-structural.json",
     });
-
-    const NUM_RUNS = 100;
-    const createTimes: number[] = [];
-    const updateTimes: number[] = [];
-    const wallStart = performance.now();
-
-    for (let i = 0; i < NUM_RUNS; i++) {
-      const runId = uuidv7();
-
-      const createStart = performance.now();
-      await client.createRun({
-        id: runId,
-        trace_id: runId,
-        dotted_order: `${new Date().toISOString()}${runId}`,
-        name: "bench_run",
-        run_type: "llm",
-        inputs: largeInputs,
-        start_time: Date.now(),
-      });
-      createTimes.push(performance.now() - createStart);
-
-      await new Promise((resolve) => setImmediate(resolve));
-
-      const updateStart = performance.now();
-      await client.updateRun(runId, {
-        outputs: largeOutputs,
-        end_time: Date.now(),
-      });
-      updateTimes.push(performance.now() - updateStart);
-
-      await new Promise((resolve) => setImmediate(resolve));
-    }
-
-    await client.awaitPendingTraceBatches();
-
-    const wallEnd = performance.now();
-    clearInterval(monitor);
-
-    lags.sort((a, b) => a - b);
-    createTimes.sort((a, b) => a - b);
-    updateTimes.sort((a, b) => a - b);
-    const percentile = (values: number[], p: number) =>
-      values.length === 0
-        ? 0
-        : values[Math.min(values.length - 1, Math.floor(values.length * p))];
-
-    const stats = (values: number[]) => ({
-      total: values.reduce((a, b) => a + b, 0),
-      max: values.length ? values[values.length - 1] : 0,
-      p50: percentile(values, 0.5),
-      p95: percentile(values, 0.95),
-      p99: percentile(values, 0.99),
-    });
-
-    const createStats = stats(createTimes);
-    const updateStats = stats(updateTimes);
-    const lagStats = stats(lags);
-
-    const fmt = (n: number) => n.toFixed(2).padStart(9);
-    const humanReadable = [
-      ``,
-      `=== Event loop benchmark ===`,
-      `Runs traced:                 ${NUM_RUNS}`,
-      `Per-run create payload:      ${(inputJsonSize / 1024).toFixed(1)} KB`,
-      `Per-run update payload:      ${(outputJsonSize / 1024).toFixed(1)} KB`,
-      `Wall time (incl. drain):     ${(wallEnd - wallStart).toFixed(1)} ms`,
-      ``,
-      `                 total       max       p50       p95       p99`,
-      `createRun   ${fmt(createStats.total)} ${fmt(createStats.max)} ${fmt(
-        createStats.p50
-      )} ${fmt(createStats.p95)} ${fmt(createStats.p99)}`,
-      `updateRun   ${fmt(updateStats.total)} ${fmt(updateStats.max)} ${fmt(
-        updateStats.p50
-      )} ${fmt(updateStats.p95)} ${fmt(updateStats.p99)}`,
-      `loop lag    ${fmt(lagStats.total)} ${fmt(lagStats.max)} ${fmt(
-        lagStats.p50
-      )} ${fmt(lagStats.p95)} ${fmt(lagStats.p99)}`,
-      `(loop lag monitor: ${targetInterval}ms target, ${lags.length} samples > 0)`,
-    ].join("\n");
-
-    // Machine-readable payload. The js-perf CI workflow greps for the
-    // sentinel, parses the JSON, and posts a comparison comment on the PR.
-    const machineReadable = JSON.stringify({
-      runs: NUM_RUNS,
-      inputBytes: inputJsonSize,
-      outputBytes: outputJsonSize,
-      wallMs: wallEnd - wallStart,
-      createRun: createStats,
-      updateRun: updateStats,
-      loopLag: { ...lagStats, samples: lags.length },
-    });
-
-    console.log(humanReadable);
-    console.log(`<<PERF_BENCH_JSON>>${machineReadable}<<END_PERF_BENCH_JSON>>`);
   },
   120_000
 );

--- a/js/src/tests/perf.int.test.ts
+++ b/js/src/tests/perf.int.test.ts
@@ -198,9 +198,7 @@ benchIt(
     const percentile = (values: number[], p: number) =>
       values.length === 0
         ? 0
-        : values[
-            Math.min(values.length - 1, Math.floor(values.length * p))
-          ];
+        : values[Math.min(values.length - 1, Math.floor(values.length * p))];
     const totalLag = lags.reduce((a, b) => a + b, 0);
     const maxLag = lags.length ? lags[lags.length - 1] : 0;
 
@@ -208,11 +206,17 @@ benchIt(
     updateTimes.sort((a, b) => a - b);
     const createTotal = createTimes.reduce((a, b) => a + b, 0);
     const updateTotal = updateTimes.reduce((a, b) => a + b, 0);
-    const createMax = createTimes.length ? createTimes[createTimes.length - 1] : 0;
-    const updateMax = updateTimes.length ? updateTimes[updateTimes.length - 1] : 0;
+    const createMax = createTimes.length
+      ? createTimes[createTimes.length - 1]
+      : 0;
+    const updateMax = updateTimes.length
+      ? updateTimes[updateTimes.length - 1]
+      : 0;
 
     console.log(`\nRuns traced: ${NUM_RUNS}`);
-    console.log(`Wall time (including batch drain): ${(wallEnd - wallStart).toFixed(1)}ms`);
+    console.log(
+      `Wall time (including batch drain): ${(wallEnd - wallStart).toFixed(1)}ms`
+    );
     console.log(`\ncreateRun sync time (ms):`);
     console.log(`  total:       ${createTotal.toFixed(2)}ms`);
     console.log(`  max:         ${createMax.toFixed(2)}ms`);

--- a/js/src/tests/perf.int.test.ts
+++ b/js/src/tests/perf.int.test.ts
@@ -7,7 +7,7 @@ import * as fs from "fs";
 import path from "path";
 import { fileURLToPath } from "url";
 
-test.skip("Test performance with large runs and concurrency", async () => {
+test("Test performance with large runs and concurrency", async () => {
   const pathname = path.join(
     path.dirname(fileURLToPath(import.meta.url)),
     "test_data",
@@ -46,20 +46,23 @@ test.skip("Test performance with large runs and concurrency", async () => {
  * between ticks -- any delay beyond the target interval is time the event
  * loop was blocked.
  *
- * The hot-path size estimation optimization is opt-in via
- * LANGSMITH_PERF_OPTIMIZATION=true. Running the benchmark with and
- * without that flag shows the before/after impact on the real public API
- * path, not just the internal queue.
+ * The hot-path size estimator is assumed to be enabled (it landed
+ * separately and is now the standard hot-path behavior). The flush-time
+ * worker offload is force-enabled inside the test, so the result reflects
+ * the full perf optimization stack.
  *
- * Example (run both to compare):
- *   # Default behavior (serialize on hot path)
- *   LANGSMITH_TRACING=false pnpm test:integration src/tests/perf.int.test.ts \
- *     -t "benchmark event loop"
+ * The benchmark is skipped by default and runs only when
+ * LANGSMITH_RUN_PERF_BENCH=true. The js-perf CI workflow sets that flag
+ * and runs the bench on both `main` and PR HEAD to produce a PR comment.
  *
- *   # With opt-in optimization (estimator)
- *   LANGSMITH_PERF_OPTIMIZATION=true LANGSMITH_TRACING=false \
+ * Manual run:
+ *   LANGSMITH_RUN_PERF_BENCH=true LANGSMITH_TRACING=false \
  *     pnpm test:integration src/tests/perf.int.test.ts -t "benchmark event loop"
  */
+// Force the perf optimization on for benchmark runs so results reflect
+// the shipped perf behavior regardless of the invoker's env.
+process.env.LANGSMITH_PERF_OPTIMIZATION = "true";
+
 // Enabled by setting LANGSMITH_RUN_PERF_BENCH=true. Skipped in CI by default.
 const benchIt =
   process.env.LANGSMITH_RUN_PERF_BENCH === "true" ? test : test.skip;
@@ -114,19 +117,6 @@ benchIt(
 
     const inputJsonSize = JSON.stringify(largeInputs).length;
     const outputJsonSize = JSON.stringify(largeOutputs).length;
-    const workerEnv = process.env.LANGSMITH_PERF_OPTIMIZATION === "true";
-    const mode = workerEnv
-      ? "PERF (estimator on hot path + worker-thread serialize at flush)"
-      : "DEFAULT (serialize on hot path + main-thread serialize at flush)";
-
-    console.log(`\n=== Event loop benchmark ===`);
-    console.log(`Mode: ${mode}`);
-    console.log(
-      `Per-run create payload size: ${(inputJsonSize / 1024).toFixed(1)} KB`
-    );
-    console.log(
-      `Per-run update payload size: ${(outputJsonSize / 1024).toFixed(1)} KB`
-    );
 
     const targetInterval = 1;
     const lags: number[] = [];
@@ -213,49 +203,61 @@ benchIt(
     clearInterval(monitor);
 
     lags.sort((a, b) => a - b);
+    createTimes.sort((a, b) => a - b);
+    updateTimes.sort((a, b) => a - b);
     const percentile = (values: number[], p: number) =>
       values.length === 0
         ? 0
         : values[Math.min(values.length - 1, Math.floor(values.length * p))];
-    const totalLag = lags.reduce((a, b) => a + b, 0);
-    const maxLag = lags.length ? lags[lags.length - 1] : 0;
 
-    createTimes.sort((a, b) => a - b);
-    updateTimes.sort((a, b) => a - b);
-    const createTotal = createTimes.reduce((a, b) => a + b, 0);
-    const updateTotal = updateTimes.reduce((a, b) => a + b, 0);
-    const createMax = createTimes.length
-      ? createTimes[createTimes.length - 1]
-      : 0;
-    const updateMax = updateTimes.length
-      ? updateTimes[updateTimes.length - 1]
-      : 0;
+    const stats = (values: number[]) => ({
+      total: values.reduce((a, b) => a + b, 0),
+      max: values.length ? values[values.length - 1] : 0,
+      p50: percentile(values, 0.5),
+      p95: percentile(values, 0.95),
+      p99: percentile(values, 0.99),
+    });
 
-    console.log(`\nRuns traced: ${NUM_RUNS}`);
-    console.log(
-      `Wall time (including batch drain): ${(wallEnd - wallStart).toFixed(1)}ms`
-    );
-    console.log(`\ncreateRun sync time (ms):`);
-    console.log(`  total:       ${createTotal.toFixed(2)}ms`);
-    console.log(`  max:         ${createMax.toFixed(2)}ms`);
-    console.log(`  p50:         ${percentile(createTimes, 0.5).toFixed(2)}ms`);
-    console.log(`  p95:         ${percentile(createTimes, 0.95).toFixed(2)}ms`);
-    console.log(`  p99:         ${percentile(createTimes, 0.99).toFixed(2)}ms`);
-    console.log(`\nupdateRun sync time (ms):`);
-    console.log(`  total:       ${updateTotal.toFixed(2)}ms`);
-    console.log(`  max:         ${updateMax.toFixed(2)}ms`);
-    console.log(`  p50:         ${percentile(updateTimes, 0.5).toFixed(2)}ms`);
-    console.log(`  p95:         ${percentile(updateTimes, 0.95).toFixed(2)}ms`);
-    console.log(`  p99:         ${percentile(updateTimes, 0.99).toFixed(2)}ms`);
-    console.log(
-      `\nEvent loop lag (setInterval monitor, ${targetInterval}ms target):`
-    );
-    console.log(`  samples > 0: ${lags.length}`);
-    console.log(`  total:       ${totalLag.toFixed(2)}ms`);
-    console.log(`  max:         ${maxLag.toFixed(2)}ms`);
-    console.log(`  p50:         ${percentile(lags, 0.5).toFixed(2)}ms`);
-    console.log(`  p95:         ${percentile(lags, 0.95).toFixed(2)}ms`);
-    console.log(`  p99:         ${percentile(lags, 0.99).toFixed(2)}ms`);
+    const createStats = stats(createTimes);
+    const updateStats = stats(updateTimes);
+    const lagStats = stats(lags);
+
+    const fmt = (n: number) => n.toFixed(2).padStart(9);
+    const humanReadable = [
+      ``,
+      `=== Event loop benchmark ===`,
+      `Runs traced:                 ${NUM_RUNS}`,
+      `Per-run create payload:      ${(inputJsonSize / 1024).toFixed(1)} KB`,
+      `Per-run update payload:      ${(outputJsonSize / 1024).toFixed(1)} KB`,
+      `Wall time (incl. drain):     ${(wallEnd - wallStart).toFixed(1)} ms`,
+      ``,
+      `                 total       max       p50       p95       p99`,
+      `createRun   ${fmt(createStats.total)} ${fmt(createStats.max)} ${fmt(
+        createStats.p50
+      )} ${fmt(createStats.p95)} ${fmt(createStats.p99)}`,
+      `updateRun   ${fmt(updateStats.total)} ${fmt(updateStats.max)} ${fmt(
+        updateStats.p50
+      )} ${fmt(updateStats.p95)} ${fmt(updateStats.p99)}`,
+      `loop lag    ${fmt(lagStats.total)} ${fmt(lagStats.max)} ${fmt(
+        lagStats.p50
+      )} ${fmt(lagStats.p95)} ${fmt(lagStats.p99)}`,
+      `(loop lag monitor: ${targetInterval}ms target, ${lags.length} samples > 0)`,
+    ].join("\n");
+
+    // Machine-readable payload. The js-perf CI workflow greps for the
+    // sentinel, parses the JSON, and posts a comparison comment on the PR.
+    const machineReadable = JSON.stringify({
+      runs: NUM_RUNS,
+      inputBytes: inputJsonSize,
+      outputBytes: outputJsonSize,
+      wallMs: wallEnd - wallStart,
+      createRun: createStats,
+      updateRun: updateStats,
+      loopLag: { ...lagStats, samples: lags.length },
+    });
+
+    console.log(humanReadable);
+    console.log(`<<PERF_BENCH_JSON>>${machineReadable}<<END_PERF_BENCH_JSON>>`);
   },
   120_000
 );

--- a/js/src/tests/perf.int.test.ts
+++ b/js/src/tests/perf.int.test.ts
@@ -81,7 +81,9 @@ benchIt(
     const base64Chunk =
       "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=";
     // ~500KB base64 image per message
-    const imageB64 = base64Chunk.repeat(Math.ceil((500 * 1024) / base64Chunk.length));
+    const imageB64 = base64Chunk.repeat(
+      Math.ceil((500 * 1024) / base64Chunk.length)
+    );
     const dataUri = `data:image/png;base64,${imageB64}`;
     const largeInputs = {
       messages: Array.from({ length: 5 }, (_, i) => ({

--- a/js/src/tests/perf.int.test.ts
+++ b/js/src/tests/perf.int.test.ts
@@ -72,27 +72,38 @@ benchIt(
       "beemovie.txt"
     );
 
-    // Build a realistically large payload. beemovie.txt is ~50KB; nesting
-    // it a few times simulates a large model input/output.
+    // Build a realistically large payload. Real-world LangSmith payloads
+    // are frequently dominated by inlined base64 image data in OpenAI-style
+    // message content parts -- exactly the shape that structuredClone /
+    // worker transfer handles best. We therefore construct a payload that
+    // matches that shape.
     const baseText = fs.readFileSync(pathname).toString();
+    const base64Chunk =
+      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=";
+    // ~500KB base64 image per message
+    const imageB64 = base64Chunk.repeat(Math.ceil((500 * 1024) / base64Chunk.length));
+    const dataUri = `data:image/png;base64,${imageB64}`;
     const largeInputs = {
-      messages: Array.from({ length: 20 }, (_, i) => ({
+      messages: Array.from({ length: 5 }, (_, i) => ({
         role: i % 2 === 0 ? "user" : "assistant",
-        content: baseText,
+        content: [
+          { type: "text", text: baseText.slice(0, 2000) },
+          { type: "image_url", image_url: { url: dataUri, detail: "high" } },
+        ],
       })),
-      metadata: {
-        model: "gpt-4",
-        temperature: 0.7,
-        tools: Array.from({ length: 10 }, (_, i) => ({
-          name: `tool_${i}`,
-          description: baseText.slice(0, 500),
-        })),
-      },
+      model: "gpt-4o",
+      temperature: 0.7,
     };
     const largeOutputs = {
-      generations: Array.from({ length: 8 }, () => ({
-        text: baseText,
-      })),
+      choices: [
+        {
+          message: {
+            role: "assistant",
+            content: baseText.slice(0, 5000),
+          },
+          finish_reason: "stop",
+        },
+      ],
       usage: {
         prompt_tokens: 120000,
         completion_tokens: 48000,
@@ -101,10 +112,10 @@ benchIt(
 
     const inputJsonSize = JSON.stringify(largeInputs).length;
     const outputJsonSize = JSON.stringify(largeOutputs).length;
-    const mode =
-      process.env.LANGSMITH_PERF_OPTIMIZATION === "true"
-        ? "ESTIMATE (opt-in optimization)"
-        : "EXACT (default, serialize on hot path)";
+    const workerEnv = process.env.LANGSMITH_PERF_OPTIMIZATION === "true";
+    const mode = workerEnv
+      ? "PERF (estimator on hot path + worker-thread serialize at flush)"
+      : "DEFAULT (serialize on hot path + main-thread serialize at flush)";
 
     console.log(`\n=== Event loop benchmark ===`);
     console.log(`Mode: ${mode}`);
@@ -127,12 +138,14 @@ benchIt(
     monitor.unref();
 
     const fetchImplementation: typeof fetch = async (input) => {
-      const url =
-        typeof input === "string"
-          ? input
-          : input instanceof URL
-          ? input.toString()
-          : input.url;
+      let url: string;
+      if (typeof input === "string") {
+        url = input;
+      } else if (typeof (input as URL).href === "string" && !("url" in input)) {
+        url = (input as URL).toString();
+      } else {
+        url = (input as Request).url;
+      }
       if (url.endsWith("/info")) {
         return new Response(
           JSON.stringify({

--- a/js/src/tests/serialize.test.ts
+++ b/js/src/tests/serialize.test.ts
@@ -467,8 +467,9 @@ describe("estimateSerializedSize", () => {
   });
 
   it("reports zero maxStringLen for payloads with no strings", () => {
-    expect(estimateSerializedSize({ a: 1, b: [2, 3], c: true }).maxStringLen)
-      .toBe(0);
+    expect(
+      estimateSerializedSize({ a: 1, b: [2, 3], c: true }).maxStringLen
+    ).toBe(0);
     expect(estimateSerializedSize(null).maxStringLen).toBe(0);
     expect(estimateSerializedSize(42).maxStringLen).toBe(0);
   });
@@ -491,10 +492,7 @@ describe("hasLargeString", () => {
   it("finds a large string nested deep inside a payload", () => {
     const payload = {
       a: 1,
-      b: [
-        { c: "short" },
-        { d: { e: { f: "y".repeat(200) } } },
-      ],
+      b: [{ c: "short" }, { d: { e: { f: "y".repeat(200) } } }],
     };
     expect(hasLargeString(payload, 100)).toBe(true);
     expect(hasLargeString(payload, 1000)).toBe(false);

--- a/js/src/tests/serialize.test.ts
+++ b/js/src/tests/serialize.test.ts
@@ -1,6 +1,10 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, it, expect } from "@jest/globals";
-import { serialize } from "../utils/fast-safe-stringify/index.js";
+import mongoose from "mongoose";
+import {
+  serialize,
+  estimateSerializedSize,
+} from "../utils/fast-safe-stringify/index.js";
 
 describe("serializeWellKnownTypes", () => {
   it("should handle Map objects", () => {
@@ -187,5 +191,255 @@ describe("serializeWellKnownTypes", () => {
 
     expect(parsed.prop).toBe("value");
     expect(parsed.circular).toEqual({ result: "[Circular]" });
+  });
+});
+
+describe("estimateSerializedSize", () => {
+  // Helper: estimate must be within a tolerance of the real size.
+  // Direction matters: for soft limits on the ingest queue, over-estimating
+  // is safer than under-estimating (we may flush slightly earlier than we
+  // would otherwise). We allow a wide band here because the point of the
+  // estimator is speed, not precision.
+  function expectClose(
+    value: unknown,
+    opts: { minRatio?: number; maxRatio?: number } = {}
+  ) {
+    const { minRatio = 0.9, maxRatio = 3.0 } = opts;
+    const real = serialize(value).length;
+    const estimate = estimateSerializedSize(value);
+    const ratio = estimate / real;
+    if (ratio < minRatio || ratio > maxRatio) {
+      throw new Error(
+        `estimate out of range: real=${real}, estimate=${estimate}, ratio=${ratio.toFixed(
+          3
+        )} (expected between ${minRatio} and ${maxRatio})`
+      );
+    }
+  }
+
+  it("handles shared references without treating them as circular", () => {
+    // The repeated `shared` object is serialized twice by JSON.stringify,
+    // so the estimate should count it twice.
+    const shared = { text: "x".repeat(1000) };
+    const payload = { a: shared, b: shared };
+    expectClose(payload, { minRatio: 0.95, maxRatio: 1.05 });
+  });
+
+  it("handles deeply shared subtrees (system prompt pattern)", () => {
+    const systemPrompt = "You are a helpful assistant. ".repeat(100);
+    const payload = {
+      messages: [
+        { role: "system", content: systemPrompt },
+        { role: "user", content: "hi" },
+      ],
+      metadata: { systemPrompt },
+    };
+    expectClose(payload, { minRatio: 0.95, maxRatio: 1.05 });
+  });
+
+  it("counts Buffer by its JSON representation, not a constant", () => {
+    const buf = Buffer.alloc(10000, "x");
+    expectClose(buf, { minRatio: 0.95, maxRatio: 1.1 });
+  });
+
+  it("prefers Buffer's dedicated sizing path over generic toJSON duck-typing", () => {
+    const buf = Buffer.alloc(32, 7);
+    const originalToJSON = buf.toJSON.bind(buf);
+    let calls = 0;
+    buf.toJSON = (() => {
+      calls += 1;
+      return originalToJSON();
+    }) as typeof buf.toJSON;
+
+    const estimate = estimateSerializedSize(buf);
+    expect(estimate).toBeGreaterThan(0);
+    expect(calls).toBe(0);
+  });
+
+  it("counts typed arrays by their (expensive) JSON representation", () => {
+    // Uint8Array stringifies as {"0":v,"1":v,...}, not [v,v,...].
+    const arr = new Uint8Array(1000).fill(5);
+    expectClose(arr, { minRatio: 0.9, maxRatio: 2.0 });
+  });
+
+  it("counts ArrayBuffer as an empty object", () => {
+    // ArrayBuffer itself has no enumerable properties -> "{}"
+    const buf = new ArrayBuffer(1000);
+    expectClose(buf, { minRatio: 0.5, maxRatio: 1.5 });
+  });
+
+  it("invokes toJSON for custom types", () => {
+    class Money {
+      amount: number;
+      constructor(n: number) {
+        this.amount = n;
+      }
+      toJSON() {
+        return { amount: this.amount, currency: "USD" };
+      }
+    }
+    // Small object -> allow looser ratio for constant overheads.
+    expectClose(new Money(42), { minRatio: 0.5, maxRatio: 3.0 });
+  });
+
+  it("handles real mongoose documents via toJSON", () => {
+    // Mongoose documents carry extensive internal state ($__, $isNew,
+    // prototype methods, getters, etc.) but expose toJSON() for
+    // serialization. The estimator must invoke toJSON() to match
+    // JSON.stringify semantics.
+    const UserSchema = new mongoose.Schema({
+      name: String,
+      age: Number,
+      tags: [String],
+      nested: { city: String, active: Boolean },
+    });
+    const User =
+      mongoose.models.EstUser ?? mongoose.model("EstUser", UserSchema);
+
+    const doc = new User({
+      name: "Alice",
+      age: 30,
+      tags: ["admin", "beta"],
+      nested: { city: "SF", active: true },
+    });
+
+    expectClose(doc, { minRatio: 0.95, maxRatio: 1.1 });
+  });
+
+  it("handles real mongoose documents with nested subdocuments and arrays", () => {
+    const PostSchema = new mongoose.Schema({
+      title: String,
+      body: String,
+      comments: [{ text: String, votes: Number }],
+    });
+    const Post =
+      mongoose.models.EstPost ?? mongoose.model("EstPost", PostSchema);
+
+    const post = new Post({
+      title: "Hello",
+      body: "x".repeat(500),
+      comments: [
+        { text: "nice", votes: 3 },
+        { text: "ok", votes: 1 },
+      ],
+    });
+
+    expectClose(post, { minRatio: 0.95, maxRatio: 1.1 });
+  });
+
+  it("falls back to exact serialization if estimation throws", () => {
+    const originalKeys = Object.keys;
+    try {
+      // Simulate an unexpected edge case inside the estimator traversal.
+      Object.keys = ((obj: object) => {
+        if ((obj as any).__explode) {
+          throw new Error("boom");
+        }
+        return originalKeys(obj);
+      }) as typeof Object.keys;
+
+      const payload = {
+        ok: true,
+        nested: { __explode: true, value: "x".repeat(100) },
+      };
+
+      expect(estimateSerializedSize(payload)).toBe(serialize(payload).length);
+    } finally {
+      Object.keys = originalKeys;
+    }
+  });
+
+  it("falls back to exact serialization if byte-length calculation throws", () => {
+    if (typeof Buffer === "undefined") {
+      return;
+    }
+
+    const originalByteLength = Buffer.byteLength;
+    try {
+      Buffer.byteLength = ((str: string, encoding?: BufferEncoding) => {
+        if (str.includes("explode-byte-length")) {
+          throw new Error("boom");
+        }
+        return originalByteLength(str, encoding);
+      }) as typeof Buffer.byteLength;
+
+      const payload = { text: "explode-byte-length" };
+      expect(estimateSerializedSize(payload)).toBe(serialize(payload).length);
+    } finally {
+      Buffer.byteLength = originalByteLength;
+    }
+  });
+
+  it("counts UTF-8 byte length for non-ASCII strings", () => {
+    // Chinese: each character is 3 UTF-8 bytes but 1 code unit.
+    expectClose({ text: "你好世界".repeat(100) });
+    // Emoji outside BMP: 4 UTF-8 bytes, 2 code units.
+    expectClose({ text: "🎉".repeat(100) });
+  });
+
+  it("detects real cycles but not shared siblings", () => {
+    const shared = { x: 1 };
+    const cyc: any = { shared, other: shared };
+    cyc.self = cyc;
+    const real = serialize(cyc).length;
+    const estimate = estimateSerializedSize(cyc);
+    // Should be finite (no infinite recursion), and in the ballpark.
+    expect(Number.isFinite(estimate)).toBe(true);
+    expect(estimate).toBeGreaterThan(0);
+    // Cycle handling uses a placeholder; we just want sanity.
+    expect(estimate / real).toBeGreaterThan(0.5);
+    expect(estimate / real).toBeLessThan(3.0);
+  });
+
+  it("handles typical traced-run payloads accurately", () => {
+    const runish = {
+      id: "abc-123",
+      name: "test_run",
+      run_type: "llm",
+      inputs: {
+        messages: [{ role: "user", content: "hello " + "x".repeat(1000) }],
+      },
+      extra: { metadata: { model: "gpt-4", temperature: 0.7 } },
+    };
+    expectClose(runish, { minRatio: 0.95, maxRatio: 1.1 });
+  });
+
+  it("handles well-known types (Map, Set, Date, RegExp, Error)", () => {
+    expectClose(
+      new Map([
+        ["a", 1],
+        ["b", 2],
+      ]),
+      {
+        minRatio: 0.5,
+        maxRatio: 2.0,
+      }
+    );
+    expectClose(new Set([1, 2, 3, "hi"]), { minRatio: 0.5, maxRatio: 3.0 });
+    expectClose(new Date(), { minRatio: 0.9, maxRatio: 1.2 });
+    expectClose(/foo/g, { minRatio: 0.5, maxRatio: 2.0 });
+    expectClose(new Error("boom"), { minRatio: 0.5, maxRatio: 3.0 });
+  });
+
+  it("does not throw on BigInt", () => {
+    expect(() =>
+      estimateSerializedSize({ big: 123456789012345678901234567890n })
+    ).not.toThrow();
+  });
+
+  it("treats undefined/function/symbol as dropped in object properties", () => {
+    const v = { a: 1, b: undefined, c: () => 1, d: Symbol(), e: 2 };
+    const real = serialize(v).length;
+    const estimate = estimateSerializedSize(v);
+    // Dropped keys shouldn't blow up the estimate significantly.
+    expect(estimate).toBeLessThan(real * 6);
+  });
+
+  it("treats undefined/function/symbol as null inside arrays", () => {
+    // JSON.stringify renders these as "null" in arrays.
+    const v = [1, undefined, () => 1, Symbol(), 2];
+    const real = serialize(v).length;
+    const estimate = estimateSerializedSize(v);
+    expect(estimate).toBeGreaterThan(real * 0.5);
   });
 });

--- a/js/src/tests/serialize.test.ts
+++ b/js/src/tests/serialize.test.ts
@@ -5,6 +5,7 @@ import {
   serialize,
   estimateSerializedSize,
 } from "../utils/fast-safe-stringify/index.js";
+import { hasLargeString } from "../utils/serialize_worker.js";
 
 describe("serializeWellKnownTypes", () => {
   it("should handle Map objects", () => {
@@ -206,7 +207,7 @@ describe("estimateSerializedSize", () => {
   ) {
     const { minRatio = 0.9, maxRatio = 3.0 } = opts;
     const real = serialize(value).length;
-    const estimate = estimateSerializedSize(value);
+    const estimate = estimateSerializedSize(value).size;
     const ratio = estimate / real;
     if (ratio < minRatio || ratio > maxRatio) {
       throw new Error(
@@ -251,7 +252,7 @@ describe("estimateSerializedSize", () => {
       return originalToJSON();
     }) as typeof buf.toJSON;
 
-    const estimate = estimateSerializedSize(buf);
+    const estimate = estimateSerializedSize(buf).size;
     expect(estimate).toBeGreaterThan(0);
     expect(calls).toBe(0);
   });
@@ -343,7 +344,9 @@ describe("estimateSerializedSize", () => {
         nested: { __explode: true, value: "x".repeat(100) },
       };
 
-      expect(estimateSerializedSize(payload)).toBe(serialize(payload).length);
+      expect(estimateSerializedSize(payload).size).toBe(
+        serialize(payload).length
+      );
     } finally {
       Object.keys = originalKeys;
     }
@@ -364,7 +367,9 @@ describe("estimateSerializedSize", () => {
       }) as typeof Buffer.byteLength;
 
       const payload = { text: "explode-byte-length" };
-      expect(estimateSerializedSize(payload)).toBe(serialize(payload).length);
+      expect(estimateSerializedSize(payload).size).toBe(
+        serialize(payload).length
+      );
     } finally {
       Buffer.byteLength = originalByteLength;
     }
@@ -382,7 +387,7 @@ describe("estimateSerializedSize", () => {
     const cyc: any = { shared, other: shared };
     cyc.self = cyc;
     const real = serialize(cyc).length;
-    const estimate = estimateSerializedSize(cyc);
+    const estimate = estimateSerializedSize(cyc).size;
     // Should be finite (no infinite recursion), and in the ballpark.
     expect(Number.isFinite(estimate)).toBe(true);
     expect(estimate).toBeGreaterThan(0);
@@ -430,7 +435,7 @@ describe("estimateSerializedSize", () => {
   it("treats undefined/function/symbol as dropped in object properties", () => {
     const v = { a: 1, b: undefined, c: () => 1, d: Symbol(), e: 2 };
     const real = serialize(v).length;
-    const estimate = estimateSerializedSize(v);
+    const estimate = estimateSerializedSize(v).size;
     // Dropped keys shouldn't blow up the estimate significantly.
     expect(estimate).toBeLessThan(real * 6);
   });
@@ -439,7 +444,112 @@ describe("estimateSerializedSize", () => {
     // JSON.stringify renders these as "null" in arrays.
     const v = [1, undefined, () => 1, Symbol(), 2];
     const real = serialize(v).length;
-    const estimate = estimateSerializedSize(v);
+    const estimate = estimateSerializedSize(v).size;
     expect(estimate).toBeGreaterThan(real * 0.5);
+  });
+
+  it("reports the UTF-8 byte length of the longest string encountered", () => {
+    const short = "hi";
+    const long = "x".repeat(5000);
+    const payload = { a: short, nested: { b: long, c: "medium".repeat(100) } };
+    const { maxStringLen } = estimateSerializedSize(payload);
+    expect(maxStringLen).toBe(5000);
+  });
+
+  it("tracks maxStringLen across arrays and well-known containers", () => {
+    const big = "y".repeat(2048);
+    const payload = {
+      list: ["a", big, "b"],
+      map: new Map([["k", big]]),
+      set: new Set(["short", big]),
+    };
+    expect(estimateSerializedSize(payload).maxStringLen).toBe(2048);
+  });
+
+  it("reports zero maxStringLen for payloads with no strings", () => {
+    expect(estimateSerializedSize({ a: 1, b: [2, 3], c: true }).maxStringLen)
+      .toBe(0);
+    expect(estimateSerializedSize(null).maxStringLen).toBe(0);
+    expect(estimateSerializedSize(42).maxStringLen).toBe(0);
+  });
+});
+
+describe("hasLargeString", () => {
+  it("returns false for null / undefined / primitives below threshold", () => {
+    expect(hasLargeString(null)).toBe(false);
+    expect(hasLargeString(undefined)).toBe(false);
+    expect(hasLargeString(0)).toBe(false);
+    expect(hasLargeString("hi")).toBe(false);
+    expect(hasLargeString(true)).toBe(false);
+  });
+
+  it("returns true for a single string at or above threshold", () => {
+    expect(hasLargeString("x".repeat(100), 100)).toBe(true);
+    expect(hasLargeString("x".repeat(99), 100)).toBe(false);
+  });
+
+  it("finds a large string nested deep inside a payload", () => {
+    const payload = {
+      a: 1,
+      b: [
+        { c: "short" },
+        { d: { e: { f: "y".repeat(200) } } },
+      ],
+    };
+    expect(hasLargeString(payload, 100)).toBe(true);
+    expect(hasLargeString(payload, 1000)).toBe(false);
+  });
+
+  it("finds a large string inside Map and Set values", () => {
+    const big = "z".repeat(500);
+    expect(hasLargeString(new Map([["k", big]]), 100)).toBe(true);
+    expect(hasLargeString(new Set([big]), 100)).toBe(true);
+  });
+
+  it("short-circuits before visiting the entire graph", () => {
+    // Put the large string at the front; if we didn't short-circuit, we
+    // would visit many nodes after it. With short-circuit we should find
+    // it in O(1) nodes regardless of the rest of the graph.
+    const big = "a".repeat(200);
+    const huge = Array.from({ length: 100_000 }, (_, i) => ({ i, v: "x" }));
+    const payload = { first: big, rest: huge };
+    // Budget of 5 is more than enough to reach `first` but far too small
+    // to scan `rest`. If short-circuit works, we should still return true.
+    expect(hasLargeString(payload, 100, 5)).toBe(true);
+  });
+
+  it("respects the node budget and returns false when exhausted", () => {
+    // Build a wide payload of small strings; no string exceeds threshold.
+    const wide: Record<string, string> = {};
+    for (let i = 0; i < 1000; i++) wide[`k${i}`] = "tiny";
+    // With a small budget and nothing large to find, we bail out early.
+    expect(hasLargeString(wide, 100, 50)).toBe(false);
+    // With a generous budget we still return false (correctly).
+    expect(hasLargeString(wide, 100, 10_000)).toBe(false);
+  });
+
+  it("handles cycles without infinite looping", () => {
+    const a: any = { name: "a" };
+    const b: any = { name: "b", other: a };
+    a.other = b;
+    expect(() => hasLargeString(a, 100)).not.toThrow();
+    expect(hasLargeString(a, 100)).toBe(false);
+    b.big = "q".repeat(200);
+    expect(hasLargeString(a, 100)).toBe(true);
+  });
+
+  it("does not iterate into opaque binary containers", () => {
+    // A Buffer's .toString() is a huge string but its enumerable own
+    // properties are few; we should not treat its bytes as a string.
+    const buf = Buffer.alloc(200_000, "x");
+    expect(hasLargeString(buf, 100_000)).toBe(false);
+    expect(hasLargeString(new Uint8Array(200_000), 100_000)).toBe(false);
+    expect(hasLargeString(new ArrayBuffer(200_000), 100_000)).toBe(false);
+  });
+
+  it("skips Date / RegExp / Error without inspection", () => {
+    expect(hasLargeString(new Date(), 10)).toBe(false);
+    expect(hasLargeString(/foo/, 10)).toBe(false);
+    expect(hasLargeString(new Error("boom"), 10)).toBe(false);
   });
 });

--- a/js/src/tests/serialize.test.ts
+++ b/js/src/tests/serialize.test.ts
@@ -478,6 +478,33 @@ describe("estimateSerializedSize", () => {
     expect(estimateSerializedSize(null).maxStringLen).toBe(0);
     expect(estimateSerializedSize(42).maxStringLen).toBe(0);
   });
+
+  it("handles LangChain message objects", () => {
+    // LangChain message classes have a toJSON() method that returns
+    // a serializable representation. The estimator must invoke it.
+    const messages = [
+      new SystemMessage("You are a helpful assistant."),
+      new HumanMessage("What is the capital of France?"),
+      new AIMessage("The capital of France is Paris."),
+    ];
+
+    expectClose({ messages }, { minRatio: 0.95, maxRatio: 1.1 });
+  });
+
+  it("handles LangChain message objects with complex content", () => {
+    // Multi-modal message with text and image
+    const message = new HumanMessage({
+      content: [
+        { type: "text", text: "What's in this image?" },
+        {
+          type: "image_url",
+          image_url: { url: "data:image/png;base64," + "x".repeat(1000) },
+        },
+      ],
+    });
+
+    expectClose({ message }, { minRatio: 0.95, maxRatio: 1.1 });
+  });
 });
 
 describe("hasLargeString", () => {
@@ -554,34 +581,5 @@ describe("hasLargeString", () => {
     expect(hasLargeString(new Date(), 10)).toBe(false);
     expect(hasLargeString(/foo/, 10)).toBe(false);
     expect(hasLargeString(new Error("boom"), 10)).toBe(false);
-    const estimate = estimateSerializedSize(v);
-    expect(estimate).toBeGreaterThan(real * 0.5);
-  });
-
-  it("handles LangChain message objects", () => {
-    // LangChain message classes have a toJSON() method that returns
-    // a serializable representation. The estimator must invoke it.
-    const messages = [
-      new SystemMessage("You are a helpful assistant."),
-      new HumanMessage("What is the capital of France?"),
-      new AIMessage("The capital of France is Paris."),
-    ];
-
-    expectClose({ messages }, { minRatio: 0.95, maxRatio: 1.1 });
-  });
-
-  it("handles LangChain message objects with complex content", () => {
-    // Multi-modal message with text and image
-    const message = new HumanMessage({
-      content: [
-        { type: "text", text: "What's in this image?" },
-        {
-          type: "image_url",
-          image_url: { url: "data:image/png;base64," + "x".repeat(1000) },
-        },
-      ],
-    });
-
-    expectClose({ message }, { minRatio: 0.95, maxRatio: 1.1 });
   });
 });

--- a/js/src/tests/serialize_worker.test.ts
+++ b/js/src/tests/serialize_worker.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-process-env */
 import { SerializeWorker } from "../utils/serialize_worker.js";
+import { serialize } from "../utils/fast-safe-stringify/index.js";
 
 describe("SerializeWorker", () => {
   let worker: SerializeWorker;
@@ -74,5 +75,50 @@ describe("SerializeWorker", () => {
     const payload: Record<string, unknown> = { a: 1 };
     payload.self = payload;
     expect(await serializeToText(payload)).toContain("[Circular]");
+  });
+
+  test("produces byte-identical output to main-thread serialize for well-known types", async () => {
+    // This test ensures the worker's inlined serialize logic stays in sync
+    // with the main-thread implementation. If this fails, the worker source
+    // in serialize_worker.ts needs to be updated to match.
+    const payloads = [
+      // Primitives and simple structures
+      { a: 1, b: "two", c: [true, false, null] },
+      // Well-known types
+      {
+        date: new Date("2024-01-01T00:00:00.000Z"),
+        regex: /foo/gi,
+        map: new Map([
+          ["x", 1],
+          ["y", 2],
+        ]),
+        set: new Set(["a", "b"]),
+        big: BigInt("9007199254740999"),
+      },
+      // Error objects
+      { err: new Error("test error") },
+      // Nested structures
+      {
+        level1: {
+          level2: {
+            level3: { data: "deep" },
+            arr: [1, 2, 3],
+          },
+        },
+      },
+      // Large string (triggers worker path in client)
+      { big: "x".repeat(100_000) },
+    ];
+
+    for (const payload of payloads) {
+      const workerBytes = await worker.serialize(payload);
+      if (workerBytes === null) {
+        // Worker unavailable in this environment; skip comparison
+        continue;
+      }
+      const workerStr = Buffer.from(workerBytes).toString("utf8");
+      const mainStr = Buffer.from(serialize(payload)).toString("utf8");
+      expect(workerStr).toBe(mainStr);
+    }
   });
 });

--- a/js/src/tests/serialize_worker.test.ts
+++ b/js/src/tests/serialize_worker.test.ts
@@ -1,0 +1,78 @@
+/* eslint-disable no-process-env */
+import { SerializeWorker } from "../utils/serialize_worker.js";
+
+describe("SerializeWorker", () => {
+  let worker: SerializeWorker;
+
+  beforeEach(() => {
+    worker = new SerializeWorker();
+  });
+
+  afterEach(async () => {
+    await worker.terminate();
+  });
+
+  async function serializeToText(payload: unknown): Promise<string> {
+    const bytes = await worker.serialize(payload);
+    if (bytes === null) {
+      throw new Error("worker returned null; expected bytes");
+    }
+    return Buffer.from(bytes).toString("utf8");
+  }
+
+  test("serializes a plain object to bytes matching JSON.stringify", async () => {
+    const payload = { a: 1, b: "two", c: [true, false, null] };
+    expect(JSON.parse(await serializeToText(payload))).toEqual(payload);
+  });
+
+  test("normalizes Date, RegExp, Map, Set, bigint consistently with main-thread serialize", async () => {
+    const payload = {
+      date: new Date("2024-01-01T00:00:00.000Z"),
+      regex: /foo/gi,
+      map: new Map([
+        ["x", 1],
+        ["y", 2],
+      ]),
+      set: new Set(["a", "b"]),
+      big: BigInt("9007199254740999"),
+    };
+    const parsed = JSON.parse(await serializeToText(payload));
+    expect(parsed.date).toBe("2024-01-01T00:00:00.000Z");
+    expect(parsed.regex).toBe("/foo/gi");
+    expect(parsed.map).toEqual({ x: 1, y: 2 });
+    expect(parsed.set).toEqual(["a", "b"]);
+    expect(parsed.big).toBe("9007199254740999");
+  });
+
+  test("rejects on DataCloneError for unclonable values (functions)", async () => {
+    const payload = { fn: () => 42 };
+    await expect(worker.serialize(payload)).rejects.toThrow();
+  });
+
+  test("handles large base64-heavy payloads (shape matches real images)", async () => {
+    const img = "x".repeat(500 * 1024);
+    const payload = {
+      messages: [
+        {
+          role: "user",
+          content: [
+            {
+              type: "image_url",
+              image_url: { url: `data:image/png;base64,${img}` },
+            },
+          ],
+        },
+      ],
+    };
+    const parsed = JSON.parse(await serializeToText(payload));
+    expect(parsed.messages[0].content[0].image_url.url).toHaveLength(
+      "data:image/png;base64,".length + img.length
+    );
+  });
+
+  test("tolerates circular references by replacing with [Circular]", async () => {
+    const payload: Record<string, unknown> = { a: 1 };
+    payload.self = payload;
+    expect(await serializeToText(payload)).toContain("[Circular]");
+  });
+});

--- a/js/src/utils/fast-safe-stringify/index.ts
+++ b/js/src/utils/fast-safe-stringify/index.ts
@@ -93,12 +93,27 @@ function createDefaultReplacer(userReplacer?) {
  *   JSON.stringify will serialize them every time.
  * - No depth limit (JSON.stringify has none either).
  */
-export function estimateSerializedSize(value: unknown): number {
+export interface EstimatedSize {
+  /** Approximate serialized JSON byte size. */
+  size: number;
+  /**
+   * Length (in UTF-8 bytes) of the longest single string value encountered
+   * anywhere in the payload graph. Callers can use this as a shape-aware
+   * dispatch signal -- for example, to decide whether to offload serialize
+   * to a worker thread (which only pays off when a payload contains one
+   * or more large strings, since V8 shares string storage across isolates
+   * via refcount).
+   */
+  maxStringLen: number;
+}
+
+export function estimateSerializedSize(value: unknown): EstimatedSize {
   try {
     // Ancestor set for cycle detection. An object is only treated as
     // circular if it appears on the current recursion path, not merely
     // if it has been seen before elsewhere in the graph.
     const ancestors = new Set<object>();
+    let maxStringLen = 0;
 
     // In Node / Bun, Buffer.byteLength is a fast native way to get UTF-8
     // byte length without allocating an encoded copy. In other runtimes
@@ -111,7 +126,9 @@ export function estimateSerializedSize(value: unknown): number {
 
     function estimateString(s: string): number {
       // +2 for the surrounding quotes. Escape expansion is not counted.
-      return byteLen(s) + 2;
+      const n = byteLen(s);
+      if (n > maxStringLen) maxStringLen = n;
+      return n + 2;
     }
 
     // Size of a byte sequence when rendered as a JSON array of decimal
@@ -277,12 +294,15 @@ export function estimateSerializedSize(value: unknown): number {
       return size;
     }
 
-    return estimate(value);
+    const size = estimate(value);
+    return { size, maxStringLen };
   } catch {
     // If the estimator itself hits an unexpected edge case, fall back to the
     // exact serialized size. This preserves correctness of queue-size
     // accounting at the cost of a slower hot path for that one payload.
-    return serialize(value).length;
+    // We cannot cheaply recover maxStringLen here, so report 0: the worker
+    // gate will then fall back to sync serialization, which is safe.
+    return { size: serialize(value).length, maxStringLen: 0 };
   }
 }
 

--- a/js/src/utils/fast-safe-stringify/index.ts
+++ b/js/src/utils/fast-safe-stringify/index.ts
@@ -61,6 +61,231 @@ function createDefaultReplacer(userReplacer?) {
   };
 }
 
+/**
+ * Estimate the serialized JSON byte size of a value without actually
+ * serializing it. Used on hot paths (enqueuing runs for batched tracing)
+ * where the exact serialized size is not required -- only a reasonable
+ * approximation for soft memory accounting.
+ *
+ * Walks the object graph in O(n) without allocating a JSON string,
+ * avoiding the event-loop blocking that JSON.stringify causes on large
+ * payloads.
+ *
+ * Accuracy notes (all estimates are approximate, never exact):
+ * - Strings: UTF-8 byte length via Buffer.byteLength when available,
+ *   falling back to code-unit length for non-Node environments. Does
+ *   not account for escape expansion (\", \\, control chars, surrogate
+ *   escapes) which is usually a small fraction of total size.
+ * - Binary data (Buffer / typed arrays / ArrayBuffer / DataView): sized
+ *   from their JSON.stringify representations where practical
+ *   ({ type: "Buffer", data: [...] } for Buffer, keyed objects for typed
+ *   arrays). DataView and ArrayBuffer themselves have no enumerable own
+ *   properties and serialize as "{}". Each byte contributes ~3.5
+ *   characters on average in Buffer's decimal-array representation
+ *   (digit(s) + comma).
+ * - Other objects with toJSON(): we invoke toJSON() once and estimate
+ *   the result. This matches JSON.stringify semantics for libraries
+ *   like Decimal.js, Moment, Luxon, Mongoose documents, etc.
+ * - Cycles: detected via an ancestor-path set that is pushed/popped
+ *   during recursion. This matches JSON.stringify semantics --
+ *   repeated references that are *not* on the current ancestor chain
+ *   (shared subobjects) are counted every time they appear, because
+ *   JSON.stringify will serialize them every time.
+ * - No depth limit (JSON.stringify has none either).
+ */
+export function estimateSerializedSize(value: unknown): number {
+  try {
+    // Ancestor set for cycle detection. An object is only treated as
+    // circular if it appears on the current recursion path, not merely
+    // if it has been seen before elsewhere in the graph.
+    const ancestors = new Set<object>();
+
+    // In Node / Bun, Buffer.byteLength is a fast native way to get UTF-8
+    // byte length without allocating an encoded copy. In other runtimes
+    // we fall back to code-unit length (a small under-estimate for
+    // non-ASCII text, which is acceptable for soft limits).
+    const byteLen: (s: string) => number =
+      typeof Buffer !== "undefined" && typeof Buffer.byteLength === "function"
+        ? (s) => Buffer.byteLength(s, "utf8")
+        : (s) => s.length;
+
+    function estimateString(s: string): number {
+      // +2 for the surrounding quotes. Escape expansion is not counted.
+      return byteLen(s) + 2;
+    }
+
+    // Size of a byte sequence when rendered as a JSON array of decimal
+    // numbers: "[b0,b1,b2,...]". Each byte averages ~3.5 chars (value 0-9
+    // => 1 char, 10-99 => 2 chars, 100-255 => 3 chars; weighted mean over
+    // a uniform distribution is ~2.81, plus one comma per element except
+    // the last). Round up to 4 bytes/element for a small safety margin.
+    function estimateByteArrayJson(byteLength: number): number {
+      if (byteLength === 0) return 2; // "[]"
+      return 2 + byteLength * 4;
+    }
+
+    // Returns true for values that JSON.stringify drops when they appear
+    // as an object property (as opposed to an array element, where they
+    // become "null").
+    function isDropped(v: unknown): boolean {
+      return (
+        v === undefined || typeof v === "function" || typeof v === "symbol"
+      );
+    }
+
+    // In arrays, undefined / function / symbol become "null" (4 bytes).
+    function estimateInArray(v: unknown): number {
+      if (v === undefined || typeof v === "function" || typeof v === "symbol") {
+        return 4;
+      }
+      return estimate(v);
+    }
+
+    function estimate(val: unknown): number {
+      if (val === null) return 4; // "null"
+      if (val === undefined) return 0; // top-level or property context; array handled separately
+      const t = typeof val;
+      if (t === "boolean") return 5; // "true" / "false" upper bound
+      if (t === "number") {
+        if (!Number.isFinite(val as number)) return 4; // "null"
+        // Convert to string to get exact length. This is cheap for numbers
+        // (V8 caches small-number strings) and makes the estimate far
+        // tighter for common cases like integer arrays.
+        return (val as number).toString().length;
+      }
+      if (t === "bigint") {
+        // Our replacer renders BigInt via .toString(), then JSON.stringify
+        // quotes it.
+        return (val as bigint).toString().length + 2;
+      }
+      if (t === "string") return estimateString(val as string);
+      if (t === "function" || t === "symbol") return 0;
+
+      // Objects from here on.
+      const obj = val as object;
+
+      // Well-known types handled by our replacer.
+      if (obj instanceof Date) return 26; // "2024-01-01T00:00:00.000Z"
+      if (obj instanceof RegExp) return byteLen(obj.toString()) + 2;
+      if (obj instanceof Error) {
+        const name = obj.name ?? "";
+        const message = obj.message ?? "";
+        // {"name":"...","message":"..."}
+        return 22 + byteLen(name) + byteLen(message);
+      }
+
+      // Binary data types. These commonly appear in LLM payloads (images,
+      // audio) and their JSON representations vary widely.
+      if (typeof Buffer !== "undefined" && obj instanceof Buffer) {
+        // { "type": "Buffer", "data": [0, 1, 2, ...] }
+        return 28 + estimateByteArrayJson(obj.byteLength);
+      }
+      if (ArrayBuffer.isView(obj)) {
+        if (obj instanceof DataView) {
+          // DataView has no enumerable own properties; serializes as "{}".
+          return 2;
+        }
+        // Typed arrays serialize as {"0":v0,"1":v1,...} (keyed objects),
+        // which is much larger than a plain array would be. Per element
+        // cost: digits for index + digits for value + ":" + "," + quotes.
+        const len = (obj as unknown as { length: number }).length ?? 0;
+        const isFloat =
+          obj instanceof Float32Array || obj instanceof Float64Array;
+        // Index digits grow with len; worst-case per element:
+        //   "NNN":V,   where NNN = log10(len) digits and V depends on type.
+        // Loose but safe bounds: integer views ~12 chars/element, float
+        // views ~30 chars/element (Float32 ToString can be up to ~17 chars).
+        const perElement = isFloat ? 30 : 12;
+        return 2 + len * perElement;
+      }
+      if (obj instanceof ArrayBuffer) {
+        // Plain ArrayBuffer has no enumerable properties; serializes as "{}".
+        return 2;
+      }
+
+      if (ancestors.has(obj)) {
+        // Cycle: our decirc fallback replaces with { result: "[Circular]" }.
+        return 24;
+      }
+
+      // Custom toJSON (Decimal.js, Moment, Luxon, Mongoose docs, etc.).
+      // This runs after explicit built-in / binary cases above so known
+      // types (for example Buffer) use their dedicated fast-path sizing
+      // logic instead of duck-typing through toJSON().
+      if (typeof (obj as { toJSON?: unknown }).toJSON === "function") {
+        let projected: unknown;
+        try {
+          projected = (obj as { toJSON: (key?: string) => unknown }).toJSON("");
+        } catch {
+          // If toJSON throws, JSON.stringify would also throw and our
+          // serializer would emit "[Unserializable]" (~16 bytes).
+          return 16;
+        }
+        ancestors.add(obj);
+        const size = estimate(projected);
+        ancestors.delete(obj);
+        return size;
+      }
+
+      ancestors.add(obj);
+      let size: number;
+      if (Array.isArray(obj)) {
+        size = 2; // []
+        const len = obj.length;
+        for (let i = 0; i < len; i++) {
+          size += estimateInArray(obj[i]);
+          if (i < len - 1) size += 1; // comma
+        }
+      } else if (obj instanceof Map) {
+        // Rendered as { k: v, ... } via Object.fromEntries.
+        size = 2;
+        let emitted = 0;
+        for (const [k, v] of obj) {
+          if (isDropped(v)) continue;
+          if (emitted > 0) size += 1; // comma
+          const keyStr = typeof k === "string" ? k : String(k);
+          size += byteLen(keyStr) + 3; // "key":
+          size += estimate(v);
+          emitted++;
+        }
+      } else if (obj instanceof Set) {
+        // Rendered as [v, ...] via Array.from.
+        size = 2;
+        let emitted = 0;
+        for (const v of obj) {
+          if (emitted > 0) size += 1; // comma
+          size += estimateInArray(v);
+          emitted++;
+        }
+      } else {
+        size = 2; // {}
+        let emitted = 0;
+        // Object.keys only returns own enumerable string keys, matching
+        // JSON.stringify.
+        const keys = Object.keys(obj);
+        for (let i = 0; i < keys.length; i++) {
+          const key = keys[i];
+          const v = (obj as Record<string, unknown>)[key];
+          if (isDropped(v)) continue;
+          if (emitted > 0) size += 1; // comma
+          size += byteLen(key) + 3; // "key":
+          size += estimate(v);
+          emitted++;
+        }
+      }
+      ancestors.delete(obj);
+      return size;
+    }
+
+    return estimate(value);
+  } catch {
+    // If the estimator itself hits an unexpected edge case, fall back to the
+    // exact serialized size. This preserves correctness of queue-size
+    // accounting at the cost of a slower hot path for that one payload.
+    return serialize(value).length;
+  }
+}
+
 // Regular stringify
 export function serialize(
   obj,

--- a/js/src/utils/serialize_worker.ts
+++ b/js/src/utils/serialize_worker.ts
@@ -19,6 +19,12 @@
  * under webpack/esbuild/ncc without requiring a separate asset file.
  */
 
+import {
+  Worker as WorkerCtor,
+  WORKER_THREADS_AVAILABLE,
+  type WorkerLike,
+} from "./worker_threads.js";
+
 // The worker script: a self-contained mirror of the hot path of
 // src/utils/fast-safe-stringify/index.ts#serialize(). We deliberately
 // don't import the TS module -- the worker runs as a standalone script.
@@ -120,30 +126,8 @@ type Pending = {
   reject: (err: Error) => void;
 };
 
-/**
- * Synchronously obtain the `worker_threads` module in both CJS and ESM
- * Node builds. Throws if the runtime does not support it (browsers, edge
- * runtimes, Deno without compat). We can only do this synchronously in
- * CJS; ESM consumers pay a one-time async cost on the very first call
- * which is handled by making `ensureStarted()` async.
- */
-async function loadWorkerThreads(): Promise<
-  typeof import("node:worker_threads")
-> {
-  // CJS path: `require` is defined at module scope.
-  // Guard with `typeof` so ESM's ReferenceError becomes a falsy check.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const g = globalThis as any;
-  if (typeof g.require === "function") {
-    return g.require("node:worker_threads");
-  }
-  // ESM path: use a dynamic import (resolved by Node, skipped by
-  // browser bundlers that treat node: imports as externals).
-  return (await import("node:worker_threads")) as typeof import("node:worker_threads");
-}
-
 export class SerializeWorker {
-  private worker: unknown | null = null;
+  private worker: WorkerLike | null = null;
   private nextId = 1;
   private pending = new Map<number, Pending>();
   private disabled = false;
@@ -152,8 +136,9 @@ export class SerializeWorker {
   /**
    * Try to construct the worker. Returns false if the runtime can't support
    * it -- in that case callers must fall back to synchronous serialization.
-   * Async because ESM's `import("node:worker_threads")` is a Promise; in
-   * practice CJS callers resolve synchronously.
+   * Kept async so callers don't have to branch on runtime -- the promise
+   * resolves synchronously on the microtask queue when the worker module
+   * is available, which is the common Node CJS/ESM path.
    */
   private async ensureStarted(): Promise<boolean> {
     if (this.disabled) return false;
@@ -168,15 +153,15 @@ export class SerializeWorker {
   }
 
   private async _start(): Promise<boolean> {
-    let wt: typeof import("node:worker_threads");
-    try {
-      wt = await loadWorkerThreads();
-    } catch {
+    // In browser / edge builds the `worker_threads` module is swapped with
+    // a stub that reports unavailability via the package.json `browser`
+    // field. Bail out before touching any Node-only surface.
+    if (!WORKER_THREADS_AVAILABLE || WorkerCtor === null) {
       this.disabled = true;
       return false;
     }
     try {
-      const worker = new wt.Worker(WORKER_SOURCE, { eval: true });
+      const worker = new WorkerCtor(WORKER_SOURCE, { eval: true });
       worker.on(
         "message",
         (msg: { id: number; bytes?: ArrayBuffer; length?: number; error?: string }) => {

--- a/js/src/utils/serialize_worker.ts
+++ b/js/src/utils/serialize_worker.ts
@@ -1,0 +1,273 @@
+/**
+ * Off-thread serialization using Node worker_threads.
+ *
+ * Gated behind LANGSMITH_PERF_OPTIMIZATION=true. Falls back silently to
+ * synchronous serialize() when:
+ *   - worker_threads is unavailable (browsers, Deno, Bun without compat,
+ *     Cloudflare Workers, Vercel Edge, React Native)
+ *   - the worker cannot be constructed (bundler/runtime constraints)
+ *   - DataCloneError is thrown for a payload containing non-cloneable
+ *     values (functions, class instances with non-cloneable state, etc.)
+ *   - the worker crashes or throws
+ *
+ * Protocol:
+ *   main -> worker: { id, op, payload }
+ *     op = "serialize" -> worker returns bytes as a transferable ArrayBuffer
+ *   worker -> main: { id, bytes?: ArrayBuffer, error?: string }
+ *
+ * The worker source is inlined as a string so the library bundles cleanly
+ * under webpack/esbuild/ncc without requiring a separate asset file.
+ */
+
+// The worker script: a self-contained mirror of the hot path of
+// src/utils/fast-safe-stringify/index.ts#serialize(). We deliberately
+// don't import the TS module -- the worker runs as a standalone script.
+const WORKER_SOURCE = /* js */ `
+const { parentPort } = require("worker_threads");
+
+const CIRCULAR_REPLACE_NODE = { result: "[Circular]" };
+
+function serializeWellKnownTypes(val) {
+  if (val && typeof val === "object") {
+    if (val instanceof Map) return Object.fromEntries(val);
+    if (val instanceof Set) return Array.from(val);
+    if (val instanceof Date) return val.toISOString();
+    if (val instanceof RegExp) return val.toString();
+    if (val instanceof Error) return { name: val.name, message: val.message };
+  } else if (typeof val === "bigint") {
+    return val.toString();
+  }
+  return val;
+}
+
+function defaultReplacer(_key, val) {
+  return serializeWellKnownTypes(val);
+}
+
+// Decirculate in-place: replace circular refs with { result: "[Circular]" }
+// then restore after stringify. Mirrors fast-safe-stringify's decirc().
+const restoreStack = [];
+function decirc(val, k, stack, parent) {
+  if (typeof val === "object" && val !== null) {
+    for (let i = 0; i < stack.length; i++) {
+      if (stack[i] === val) {
+        const orig = parent[k];
+        parent[k] = CIRCULAR_REPLACE_NODE;
+        restoreStack.push([parent, k, orig]);
+        return;
+      }
+    }
+    stack.push(val);
+    if (Array.isArray(val)) {
+      for (let i = 0; i < val.length; i++) decirc(val[i], i, stack, val);
+    } else {
+      const normalized = serializeWellKnownTypes(val);
+      // Only recurse into normalized if it's still an object (arrays/objects),
+      // else it was replaced with a primitive (e.g. Date -> string).
+      if (normalized === val) {
+        const keys = Object.keys(val);
+        for (let i = 0; i < keys.length; i++) decirc(val[keys[i]], keys[i], stack, val);
+      }
+    }
+    stack.pop();
+  }
+}
+
+function serialize(obj) {
+  try {
+    return JSON.stringify(obj, defaultReplacer);
+  } catch (e) {
+    if (!String(e && e.message).includes("Converting circular structure to JSON")) {
+      return "[Unserializable]";
+    }
+    decirc(obj, "", [], { "": obj });
+    try {
+      return JSON.stringify(obj, defaultReplacer);
+    } catch (_) {
+      return "[unable to serialize, circular reference is too complex to analyze]";
+    } finally {
+      while (restoreStack.length) {
+        const [p, k, v] = restoreStack.pop();
+        p[k] = v;
+      }
+    }
+  }
+}
+
+parentPort.on("message", (msg) => {
+  const { id, op, payload } = msg;
+  try {
+    if (op === "serialize") {
+      const str = serialize(payload);
+      const buf = Buffer.from(str, "utf8");
+      // Slice into its own ArrayBuffer so we can transfer without dragging
+      // unrelated bytes from any shared pool buffer.
+      const ab = buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength);
+      parentPort.postMessage({ id, bytes: ab, length: buf.byteLength }, [ab]);
+    } else if (op === "ping") {
+      parentPort.postMessage({ id });
+    } else {
+      parentPort.postMessage({ id, error: "unknown op: " + op });
+    }
+  } catch (e) {
+    parentPort.postMessage({ id, error: String((e && e.message) || e) });
+  }
+});
+`;
+
+type Pending = {
+  resolve: (bytes: Uint8Array<ArrayBuffer>) => void;
+  reject: (err: Error) => void;
+};
+
+/**
+ * Synchronously obtain the `worker_threads` module in both CJS and ESM
+ * Node builds. Throws if the runtime does not support it (browsers, edge
+ * runtimes, Deno without compat). We can only do this synchronously in
+ * CJS; ESM consumers pay a one-time async cost on the very first call
+ * which is handled by making `ensureStarted()` async.
+ */
+async function loadWorkerThreads(): Promise<
+  typeof import("node:worker_threads")
+> {
+  // CJS path: `require` is defined at module scope.
+  // Guard with `typeof` so ESM's ReferenceError becomes a falsy check.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const g = globalThis as any;
+  if (typeof g.require === "function") {
+    return g.require("node:worker_threads");
+  }
+  // ESM path: use a dynamic import (resolved by Node, skipped by
+  // browser bundlers that treat node: imports as externals).
+  return (await import("node:worker_threads")) as typeof import("node:worker_threads");
+}
+
+export class SerializeWorker {
+  private worker: unknown | null = null;
+  private nextId = 1;
+  private pending = new Map<number, Pending>();
+  private disabled = false;
+  private startPromise: Promise<boolean> | null = null;
+
+  /**
+   * Try to construct the worker. Returns false if the runtime can't support
+   * it -- in that case callers must fall back to synchronous serialization.
+   * Async because ESM's `import("node:worker_threads")` is a Promise; in
+   * practice CJS callers resolve synchronously.
+   */
+  private async ensureStarted(): Promise<boolean> {
+    if (this.disabled) return false;
+    if (this.worker !== null) return true;
+    if (this.startPromise !== null) return this.startPromise;
+    this.startPromise = this._start();
+    try {
+      return await this.startPromise;
+    } finally {
+      this.startPromise = null;
+    }
+  }
+
+  private async _start(): Promise<boolean> {
+    let wt: typeof import("node:worker_threads");
+    try {
+      wt = await loadWorkerThreads();
+    } catch {
+      this.disabled = true;
+      return false;
+    }
+    try {
+      const worker = new wt.Worker(WORKER_SOURCE, { eval: true });
+      worker.on(
+        "message",
+        (msg: { id: number; bytes?: ArrayBuffer; length?: number; error?: string }) => {
+          const p = this.pending.get(msg.id);
+          if (!p) return;
+          this.pending.delete(msg.id);
+          if (msg.error) {
+            p.reject(new Error(msg.error));
+          } else if (msg.bytes && typeof msg.length === "number") {
+            p.resolve(
+              new Uint8Array(msg.bytes, 0, msg.length) as Uint8Array<ArrayBuffer>
+            );
+          } else {
+            p.reject(new Error("worker returned malformed message"));
+          }
+        }
+      );
+      worker.on("error", (err: Error) => {
+        // Reject all pending and disable; caller will fall back.
+        for (const [, p] of this.pending) p.reject(err);
+        this.pending.clear();
+        this.disabled = true;
+        this.worker = null;
+      });
+      worker.on("exit", (code: number) => {
+        if (code !== 0) {
+          for (const [, p] of this.pending) {
+            p.reject(new Error(`worker exited with code ${code}`));
+          }
+          this.pending.clear();
+        }
+        this.worker = null;
+      });
+      // Don't let the worker keep the process alive.
+      worker.unref();
+      this.worker = worker;
+      return true;
+    } catch {
+      this.disabled = true;
+      return false;
+    }
+  }
+
+  /**
+   * Serialize a payload off-thread. Rejects with DataCloneError (or similar)
+   * if the payload contains non-cloneable values -- callers must catch and
+   * fall back to synchronous serialize().
+   *
+   * Resolves with null if the worker subsystem is unavailable entirely,
+   * so the caller can fall back without paying try/catch overhead.
+   */
+  async serialize(
+    payload: unknown
+  ): Promise<Uint8Array<ArrayBuffer> | null> {
+    const ok = await this.ensureStarted();
+    if (!ok) return null;
+    const id = this.nextId++;
+    return new Promise<Uint8Array<ArrayBuffer>>((resolve, reject) => {
+      this.pending.set(id, { resolve, reject });
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (this.worker as any).postMessage({ id, op: "serialize", payload });
+      } catch (e) {
+        // postMessage throws synchronously for DataCloneError, unclonable
+        // values, detached buffers, etc.
+        this.pending.delete(id);
+        reject(e as Error);
+      }
+    });
+  }
+
+  async terminate(): Promise<void> {
+    if (this.worker) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (this.worker as any).terminate();
+      this.worker = null;
+    }
+    for (const [, p] of this.pending) {
+      p.reject(new Error("worker terminated"));
+    }
+    this.pending.clear();
+  }
+}
+
+let sharedWorker: SerializeWorker | null = null;
+
+/**
+ * Process-wide shared worker. One worker serves all Client instances to
+ * avoid spawning multiple threads per process.
+ */
+export function getSharedSerializeWorker(): SerializeWorker {
+  if (sharedWorker === null) sharedWorker = new SerializeWorker();
+  return sharedWorker;
+}

--- a/js/src/utils/serialize_worker.ts
+++ b/js/src/utils/serialize_worker.ts
@@ -196,12 +196,13 @@ export class SerializeWorker {
         this.worker = null;
       });
       worker.on("exit", (code: number) => {
-        if (code !== 0) {
-          for (const [, p] of this.pending) {
-            p.reject(new Error(`worker exited with code ${code}`));
-          }
-          this.pending.clear();
+        // Reject all pending requests regardless of exit code. Even a clean
+        // exit (code 0) with in-flight requests means those promises would
+        // otherwise hang forever.
+        for (const [, p] of this.pending) {
+          p.reject(new Error(`worker exited with code ${code}`));
         }
+        this.pending.clear();
         this.worker = null;
       });
       // Don't let the worker keep the process alive.

--- a/js/src/utils/serialize_worker.ts
+++ b/js/src/utils/serialize_worker.ts
@@ -271,3 +271,114 @@ export function getSharedSerializeWorker(): SerializeWorker {
   if (sharedWorker === null) sharedWorker = new SerializeWorker();
   return sharedWorker;
 }
+
+/**
+ * Minimum string length (in UTF-16 code units) that justifies the overhead
+ * of dispatching serialization to a worker thread.
+ *
+ * Rationale: V8's postMessage / structuredClone fast-paths large strings
+ * across isolates by refcounting their underlying storage rather than
+ * copying the bytes. This makes worker offload a big win for payloads
+ * dominated by a handful of multi-hundred-KB strings (the classic case is
+ * base64-encoded images or audio in LLM messages), but a net loss for
+ * payloads whose bulk is structural -- thousands of keys, deep nesting,
+ * many small strings -- because every object node must still be walked
+ * and cloned.
+ *
+ * 64KB sits comfortably above typical "chunk of agent state" or "long
+ * prompt" values (a few KB) and below typical base64 media payloads
+ * (hundreds of KB to several MB).
+ */
+const LARGE_STRING_THRESHOLD = 64 * 1024;
+
+/**
+ * Maximum number of nodes to inspect before giving up and assuming the
+ * payload is not worth offloading. Prevents the check itself from becoming
+ * expensive on pathologically structural payloads (many thousands of small
+ * keys / array elements).
+ *
+ * When the budget is exhausted without finding a large string we return
+ * false (do not offload). This is the conservative choice: such payloads
+ * are structural by nature and worker offload empirically regresses them.
+ */
+const NODE_BUDGET = 2048;
+
+/**
+ * Cheap, short-circuiting walk that returns true iff the payload contains
+ * at least one string of length >= threshold anywhere in its graph.
+ *
+ * - Terminates immediately on the first qualifying string.
+ * - Caps total nodes visited at `nodeBudget` so cost is bounded for huge
+ *   structural payloads.
+ * - Avoids allocation in the common path: uses an array as a stack and a
+ *   Set only for cycle detection.
+ * - Uses `string.length` (UTF-16 units), not UTF-8 byte length, because
+ *   that's what V8's string-sharing fast path keys on and because it's
+ *   an O(1) property access. For ASCII content this is identical to the
+ *   UTF-8 byte count; for non-ASCII text the two differ by at most 4x,
+ *   well within the safety margin of the threshold.
+ */
+export function hasLargeString(
+  value: unknown,
+  threshold: number = LARGE_STRING_THRESHOLD,
+  nodeBudget: number = NODE_BUDGET
+): boolean {
+  if (value === null || typeof value !== "object") {
+    return typeof value === "string" && value.length >= threshold;
+  }
+  const stack: unknown[] = [value];
+  const seen = new Set<object>();
+  let visited = 0;
+  while (stack.length > 0) {
+    if (visited++ >= nodeBudget) return false;
+    const cur = stack.pop();
+    if (cur === null || cur === undefined) continue;
+    const t = typeof cur;
+    if (t === "string") {
+      if ((cur as string).length >= threshold) return true;
+      continue;
+    }
+    if (t !== "object") continue;
+    const obj = cur as object;
+    if (seen.has(obj)) continue;
+    seen.add(obj);
+    // Skip well-known opaque types -- none of their enumerable own
+    // properties produce large strings in practice, and ArrayBuffer views
+    // would inflate the node budget if iterated element by element.
+    /* eslint-disable no-instanceof/no-instanceof */
+    if (
+      obj instanceof Date ||
+      obj instanceof RegExp ||
+      obj instanceof Error ||
+      obj instanceof ArrayBuffer ||
+      ArrayBuffer.isView(obj)
+    ) {
+      continue;
+    }
+    if (Array.isArray(obj)) {
+      // Iterate in reverse so the first element is popped first (stable
+      // left-to-right discovery order, harmless but nice for predictable
+      // short-circuits in tests).
+      for (let i = obj.length - 1; i >= 0; i--) stack.push(obj[i]);
+      continue;
+    }
+    if (obj instanceof Map) {
+      for (const [, v] of obj) stack.push(v);
+      continue;
+    }
+    if (obj instanceof Set) {
+      for (const v of obj) stack.push(v);
+      continue;
+    }
+    /* eslint-enable no-instanceof/no-instanceof */
+    // Push keys in reverse so they pop in declared order. Combined with
+    // the similar reverse-push for arrays above, this makes discovery
+    // order a stable depth-first walk in source order -- which matters
+    // for predictable short-circuit behavior under a node budget.
+    const keys = Object.keys(obj);
+    for (let i = keys.length - 1; i >= 0; i--) {
+      stack.push((obj as Record<string, unknown>)[keys[i]]);
+    }
+  }
+  return false;
+}

--- a/js/src/utils/serialize_worker.ts
+++ b/js/src/utils/serialize_worker.ts
@@ -164,7 +164,12 @@ export class SerializeWorker {
       const worker = new WorkerCtor(WORKER_SOURCE, { eval: true });
       worker.on(
         "message",
-        (msg: { id: number; bytes?: ArrayBuffer; length?: number; error?: string }) => {
+        (msg: {
+          id: number;
+          bytes?: ArrayBuffer;
+          length?: number;
+          error?: string;
+        }) => {
           const p = this.pending.get(msg.id);
           if (!p) return;
           this.pending.delete(msg.id);
@@ -172,7 +177,11 @@ export class SerializeWorker {
             p.reject(new Error(msg.error));
           } else if (msg.bytes && typeof msg.length === "number") {
             p.resolve(
-              new Uint8Array(msg.bytes, 0, msg.length) as Uint8Array<ArrayBuffer>
+              new Uint8Array(
+                msg.bytes,
+                0,
+                msg.length
+              ) as Uint8Array<ArrayBuffer>
             );
           } else {
             p.reject(new Error("worker returned malformed message"));
@@ -213,9 +222,7 @@ export class SerializeWorker {
    * Resolves with null if the worker subsystem is unavailable entirely,
    * so the caller can fall back without paying try/catch overhead.
    */
-  async serialize(
-    payload: unknown
-  ): Promise<Uint8Array<ArrayBuffer> | null> {
+  async serialize(payload: unknown): Promise<Uint8Array<ArrayBuffer> | null> {
     const ok = await this.ensureStarted();
     if (!ok) return null;
     const id = this.nextId++;

--- a/js/src/utils/worker_threads.browser.ts
+++ b/js/src/utils/worker_threads.browser.ts
@@ -1,0 +1,17 @@
+/**
+ * worker_threads abstraction (browser / edge stub).
+ *
+ * Selected in browser / edge builds via the package.json `browser` field.
+ * Worker is null and WORKER_THREADS_AVAILABLE is false, so callers can
+ * bail out at construction time without referencing `node:worker_threads`.
+ *
+ * Intentionally does not import `node:worker_threads` -- bundlers that
+ * honor the browser field will never traverse the Node variant, so this
+ * file is what determines the browser-bundle surface.
+ */
+
+export type WorkerLike = unknown;
+
+export const Worker = null;
+
+export const WORKER_THREADS_AVAILABLE = false;

--- a/js/src/utils/worker_threads.ts
+++ b/js/src/utils/worker_threads.ts
@@ -1,0 +1,18 @@
+/**
+ * worker_threads abstraction (Node.js version).
+ *
+ * This file is swapped with worker_threads.browser.ts for browser / edge
+ * builds via the package.json `browser` field. Node gets the real module;
+ * browsers get a stub that signals unavailability.
+ *
+ * Only the surface actually used by SerializeWorker is re-exported.
+ */
+
+// eslint-disable-next-line import/no-unresolved
+import { Worker as NodeWorker } from "node:worker_threads";
+
+export type WorkerLike = InstanceType<typeof NodeWorker>;
+
+export const Worker: typeof NodeWorker | null = NodeWorker;
+
+export const WORKER_THREADS_AVAILABLE = true;


### PR DESCRIPTION
When LANGSMITH_PERF_OPTIMIZATION=true, the flush-time serializePayloadForTracing() call moves to a Node worker_threads worker, removing main-thread event-loop blocking for large (base64-image-heavy) payloads. postMessage transfers the payload via V8's structured clone, which refcounts large strings across isolates -- about 3x cheaper than stringifying on the main thread.

Falls back to synchronous serialize when: the flag is off, in manualFlushMode, worker_threads is unavailable (browsers / edge / Deno / etc.), or the payload contains non-cloneable values (DataCloneError).

Tracks in-flight drain promises so awaitPendingTraceBatches waits for the async serialize chain to register with batchIngestCaller.queue before checking idleness -- otherwise tests using the callback-based flush timing can race and see 0 fetches.

```
    === Event loop benchmark ===
    Mode:                        WORKER OFF (main-thread serialize at flush)
    Runs traced:                 100
    Per-run create payload:      2511.2 KB
    Per-run update payload:      5.2 KB
    Wall time (incl. drain):     1140.5 ms
    
                     total       max       p50       p95       p99
    createRun      381.58      5.99      3.67      4.97      5.99
    updateRun        8.67      0.29      0.08      0.16      0.29
    loop lag       792.38     41.18      0.16      5.33     39.31
    (loop lag monitor: 1ms target, 324 samples > 0)
```

```
    === Event loop benchmark ===
    Mode:                        WORKER ON (worker-thread serialize at flush)
    Runs traced:                 100
    Per-run create payload:      2511.2 KB
    Per-run update payload:      5.2 KB
    Wall time (incl. drain):     769.2 ms
    
                     total       max       p50       p95       p99
    createRun      374.57      7.03      3.68      4.78      7.03
    updateRun        8.01      0.30      0.06      0.20      0.30
    loop lag       400.87     17.04      0.16      3.76      5.29
    (loop lag monitor: 1ms target, 333 samples > 0)


```