### PR TITLE
fix(js): bump uuid to ^14.0.0 to resolve GHSA-w5hq-g745-h8pq

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -150,7 +150,7 @@
   "homepage": "https://github.com/langchain-ai/langsmith-sdk#readme",
   "dependencies": {
     "p-queue": "6.6.2",
-    "uuid": "10.0.0"
+    "uuid": "^14.0.0"
   },
   "devDependencies": {
     "@ai-sdk/anthropic": "^3.0.0",

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -19,8 +19,8 @@ importers:
         specifier: 6.6.2
         version: 6.6.2
       uuid:
-        specifier: 10.0.0
-        version: 10.0.0
+        specifier: ^14.0.0
+        version: 14.0.0
     devDependencies:
       '@ai-sdk/anthropic':
         specifier: ^3.0.0
@@ -4778,6 +4778,10 @@ packages:
 
   uuid@10.0.0:
     resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    hasBin: true
+
+  uuid@14.0.0:
+    resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
     hasBin: true
 
   uuid@9.0.1:
@@ -10463,6 +10467,8 @@ snapshots:
       punycode: 2.3.1
 
   uuid@10.0.0: {}
+
+  uuid@14.0.0: {}
 
   uuid@9.0.1: {}
 


### PR DESCRIPTION
## Summary
- Bump `uuid` direct dependency from `10.0.0` to `^14.0.0` to resolve [GHSA-w5hq-g745-h8pq](https://github.com/advisories/GHSA-w5hq-g745-h8pq) (missing buffer bounds check in v3/v5/v6 when `buf` is provided).

Fixes #2777