### PR TITLE
release(js): 0.5.23

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langsmith",
-  "version": "0.5.22",
+  "version": "0.5.23",
   "description": "Client library to connect to the LangSmith Observability and Evaluation Platform.",
   "packageManager": "pnpm@10.33.0",
   "files": [

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -32,4 +32,4 @@ export {
 } from "./utils/prompt_cache/index.js";
 
 // Update using pnpm bump-version
-export const __version__ = "0.5.22";
+export const __version__ = "0.5.23";


### PR DESCRIPTION
Bumps langsmith JS from 0.5.22 → 0.5.23 to publish the hub methods merged in #2747.

Same two-file scope as #2774.