### PR TITLE
docs(sandbox): document default idle TTL of 10 minutes

### DIFF
--- a/js/src/experimental/sandbox/README.md
+++ b/js/src/experimental/sandbox/README.md
@@ -554,7 +554,7 @@ try {
 | `timeout?` | Wait timeout in seconds |
 | `waitForReady?` | Wait for the sandbox to be ready before returning (default: `true`) |
 | `ttlSeconds?` | Maximum lifetime in seconds (multiple of 60; `0` disables) |
-| `idleTtlSeconds?` | Idle timeout in seconds (multiple of 60; `0` disables) |
+| `idleTtlSeconds?` | Idle timeout in seconds (multiple of 60; `0` disables). When omitted, the server applies a default of `600` seconds (10 minutes). |
 | `vCpus?` | Number of vCPUs |
 | `memBytes?` | Memory allocation in bytes |
 | `fsCapacityBytes?` | Root filesystem capacity in bytes |
@@ -586,7 +586,7 @@ try {
 |----------|-------------|
 | `newName?` | New display name |
 | `ttlSeconds?` | Maximum lifetime in seconds (multiple of 60; `0` disables) |
-| `idleTtlSeconds?` | Idle timeout in seconds (multiple of 60; `0` disables) |
+| `idleTtlSeconds?` | Idle timeout in seconds (multiple of 60; `0` disables). Omit to leave the existing value unchanged. |
 
 ### RunOptions
 

--- a/js/src/experimental/sandbox/sandbox.ts
+++ b/js/src/experimental/sandbox/sandbox.ts
@@ -56,7 +56,11 @@ export class Sandbox {
   readonly updated_at?: string;
   /** Maximum lifetime TTL in seconds (`0` means disabled). */
   readonly ttl_seconds?: number;
-  /** Idle timeout TTL in seconds (`0` means disabled). */
+  /**
+   * Idle timeout TTL in seconds (`0` means disabled).
+   * New sandboxes receive a server-side default of `600` seconds (10 minutes)
+   * when the caller did not set `idleTtlSeconds` explicitly.
+   */
   readonly idle_ttl_seconds?: number;
   /** Computed expiration timestamp when a TTL is active. */
   readonly expires_at?: string;

--- a/js/src/experimental/sandbox/types.ts
+++ b/js/src/experimental/sandbox/types.ts
@@ -282,7 +282,8 @@ export interface CreateSandboxOptions {
   ttlSeconds?: number;
   /**
    * Idle timeout in seconds. The sandbox is deleted after this much inactivity.
-   * Must be a multiple of 60, or `0`/`undefined` to disable or omit.
+   * Must be a multiple of 60. Pass `0` to explicitly disable the idle timeout.
+   * When omitted, the server applies a default of `600` seconds (10 minutes).
    */
   idleTtlSeconds?: number;
   /** Number of vCPUs. */
@@ -392,6 +393,7 @@ export interface UpdateSandboxOptions {
   ttlSeconds?: number;
   /**
    * Idle timeout in seconds. Must be a multiple of 60. Pass `0` to disable.
+   * Omit (or pass `undefined`) to leave the existing value unchanged.
    */
   idleTtlSeconds?: number;
 }

--- a/python/langsmith/sandbox/README.md
+++ b/python/langsmith/sandbox/README.md
@@ -700,7 +700,8 @@ Control how long a sandbox stays alive with two optional TTL parameters:
   deleted after this many seconds, regardless of activity.
 - **`idle_ttl_seconds`** — Idle timeout. The sandbox is automatically deleted after
   this many seconds of inactivity. Activity (command execution, file I/O) resets
-  the timer.
+  the timer. When omitted at creation, the server applies a default of `600`
+  seconds (10 minutes); pass `0` explicitly to disable the idle timeout.
 
 Both values must be multiples of 60 (minute-resolution). Pass `0` to explicitly
 disable a TTL. When both are set, whichever deadline comes first wins.
@@ -915,7 +916,7 @@ except SandboxClientError as e:
 | `dataplane_url` | URL for runtime operations (only functional when status is `"ready"`) |
 | `id` | Unique identifier (UUID) |
 | `ttl_seconds` | Maximum lifetime TTL in seconds (`0` means disabled, `None` means not set) |
-| `idle_ttl_seconds` | Idle timeout TTL in seconds (`0` means disabled, `None` means not set) |
+| `idle_ttl_seconds` | Idle timeout TTL in seconds (`0` means disabled, `None` means not set). New sandboxes get a server-side default of `600` (10 minutes) when not explicitly provided. |
 | `expires_at` | Computed expiration timestamp, or `None` if no TTL is active |
 
 | Method | Description |

--- a/python/langsmith/sandbox/_async_client.py
+++ b/python/langsmith/sandbox/_async_client.py
@@ -191,8 +191,10 @@ class AsyncSandboxClient:
                 will be automatically deleted after this duration. Must be a
                 multiple of 60. 0 or None disables this TTL.
             idle_ttl_seconds: Idle timeout in seconds. The sandbox will be
-                automatically deleted after this duration of inactivity. Must be
-                a multiple of 60. 0 or None disables this TTL.
+                automatically deleted after this duration of inactivity. Must
+                be a multiple of 60. ``0`` explicitly disables the idle
+                timeout. When omitted (``None``), the server applies a default
+                of ``600`` seconds (10 minutes).
             vcpus: Number of vCPUs.
             mem_bytes: Memory in bytes.
             fs_capacity_bytes: Root filesystem capacity in bytes.
@@ -268,8 +270,10 @@ class AsyncSandboxClient:
                 will be automatically deleted after this duration. Must be a
                 multiple of 60. 0 or None disables this TTL.
             idle_ttl_seconds: Idle timeout in seconds. The sandbox will be
-                automatically deleted after this duration of inactivity. Must be
-                a multiple of 60. 0 or None disables this TTL.
+                automatically deleted after this duration of inactivity. Must
+                be a multiple of 60. ``0`` explicitly disables the idle
+                timeout. When omitted (``None``), the server applies a default
+                of ``600`` seconds (10 minutes).
             vcpus: Number of vCPUs.
             mem_bytes: Memory in bytes.
             fs_capacity_bytes: Root filesystem capacity in bytes.
@@ -418,8 +422,9 @@ class AsyncSandboxClient:
             new_name: New display name.
             ttl_seconds: Maximum lifetime in seconds from creation. Must be a
                 multiple of 60. 0 disables this TTL.
-            idle_ttl_seconds: Idle timeout in seconds. Must be a multiple of 60.
-                0 disables this TTL.
+            idle_ttl_seconds: Idle timeout in seconds. Must be a multiple of
+                60. ``0`` disables this TTL. ``None`` leaves the existing
+                value unchanged.
 
         Returns:
             Updated AsyncSandbox.

--- a/python/langsmith/sandbox/_async_sandbox.py
+++ b/python/langsmith/sandbox/_async_sandbox.py
@@ -50,7 +50,10 @@ class AsyncSandbox:
         created_at: Timestamp when the sandbox was created.
         updated_at: Timestamp when the sandbox was last updated.
         ttl_seconds: Maximum lifetime TTL in seconds (0 means disabled).
-        idle_ttl_seconds: Idle timeout TTL in seconds (0 means disabled).
+        idle_ttl_seconds: Idle timeout TTL in seconds (``0`` means disabled).
+            Newly-created sandboxes receive a server-side default of ``600``
+            seconds (10 minutes) when the caller did not set ``idle_ttl_seconds``
+            explicitly.
         expires_at: Computed expiration timestamp, or None if no TTL is set.
         snapshot_id: Snapshot ID used to create this sandbox.
         vcpus: Number of vCPUs allocated.

--- a/python/langsmith/sandbox/_client.py
+++ b/python/langsmith/sandbox/_client.py
@@ -188,8 +188,10 @@ class SandboxClient:
                 will be automatically deleted after this duration. Must be a
                 multiple of 60. 0 or None disables this TTL.
             idle_ttl_seconds: Idle timeout in seconds. The sandbox will be
-                automatically deleted after this duration of inactivity. Must be
-                a multiple of 60. 0 or None disables this TTL.
+                automatically deleted after this duration of inactivity. Must
+                be a multiple of 60. ``0`` explicitly disables the idle
+                timeout. When omitted (``None``), the server applies a default
+                of ``600`` seconds (10 minutes).
             vcpus: Number of vCPUs.
             mem_bytes: Memory in bytes.
             fs_capacity_bytes: Root filesystem capacity in bytes.
@@ -265,8 +267,10 @@ class SandboxClient:
                 will be automatically deleted after this duration. Must be a
                 multiple of 60. 0 or None disables this TTL.
             idle_ttl_seconds: Idle timeout in seconds. The sandbox will be
-                automatically deleted after this duration of inactivity. Must be
-                a multiple of 60. 0 or None disables this TTL.
+                automatically deleted after this duration of inactivity. Must
+                be a multiple of 60. ``0`` explicitly disables the idle
+                timeout. When omitted (``None``), the server applies a default
+                of ``600`` seconds (10 minutes).
             vcpus: Number of vCPUs.
             mem_bytes: Memory in bytes.
             fs_capacity_bytes: Root filesystem capacity in bytes.
@@ -407,8 +411,9 @@ class SandboxClient:
             new_name: New display name.
             ttl_seconds: Maximum lifetime in seconds from creation. Must be a
                 multiple of 60. 0 disables this TTL.
-            idle_ttl_seconds: Idle timeout in seconds. Must be a multiple of 60.
-                0 disables this TTL.
+            idle_ttl_seconds: Idle timeout in seconds. Must be a multiple of
+                60. ``0`` disables this TTL. ``None`` leaves the existing
+                value unchanged.
 
         Returns:
             Updated Sandbox.

--- a/python/langsmith/sandbox/_sandbox.py
+++ b/python/langsmith/sandbox/_sandbox.py
@@ -49,7 +49,10 @@ class Sandbox:
         created_at: Timestamp when the sandbox was created.
         updated_at: Timestamp when the sandbox was last updated.
         ttl_seconds: Maximum lifetime TTL in seconds (0 means disabled).
-        idle_ttl_seconds: Idle timeout TTL in seconds (0 means disabled).
+        idle_ttl_seconds: Idle timeout TTL in seconds (``0`` means disabled).
+            Newly-created sandboxes receive a server-side default of ``600``
+            seconds (10 minutes) when the caller did not set ``idle_ttl_seconds``
+            explicitly.
         expires_at: Computed expiration timestamp, or None if no TTL is set.
         snapshot_id: Snapshot ID used to create this sandbox.
         vcpus: Number of vCPUs allocated.


### PR DESCRIPTION
## Summary

The sandbox API now applies a server-side default of **600 seconds (10 minutes)** to ``idle_ttl_seconds`` / ``idleTtlSeconds`` when a create-sandbox request omits the field. This PR updates the Python and JS sandbox SDK docs so users know what to expect.

Behavior being documented:

- Omit the field → server applies ``600`` seconds (10 minutes).
- Pass ``0`` explicitly → idle timeout is disabled.
- Pass a positive multiple of 60 → used as-is.

Update semantics are unchanged: for ``update_sandbox`` / ``updateSandbox``, omitting the field leaves the current value as-is; ``0`` disables.

## Changes

Python (``python/langsmith/sandbox/``)

- ``_client.py``, ``_async_client.py``: updated ``idle_ttl_seconds`` docstrings on ``sandbox()``, ``create_sandbox()``, and ``update_sandbox()``.
- ``_sandbox.py``, ``_async_sandbox.py``: updated the ``Sandbox`` / ``AsyncSandbox`` dataclass attribute doc to note the server-side default.
- ``README.md``: updated the *Sandbox Lifetime & TTL* section and the ``Sandbox`` property table.

JS (``js/src/experimental/sandbox/``)

- ``types.ts``: JSDoc for ``idleTtlSeconds`` on ``CreateSandboxOptions`` and ``UpdateSandboxOptions``.
- ``sandbox.ts``: JSDoc on the ``Sandbox.idle_ttl_seconds`` property.
- ``README.md``: updated the ``CreateSandboxOptions`` / ``UpdateSandboxOptions`` option tables.

No runtime code changes — documentation-only.

## Test plan

- [x] ``uv run ruff format langsmith/sandbox/`` (clean)
- [x] ``uv run ruff check langsmith/sandbox/`` (clean)
- [x] ``uv run python -c "from langsmith.sandbox import SandboxClient, Sandbox, AsyncSandboxClient, AsyncSandbox"`` (imports OK)
- [x] ``pnpm prettier --write`` on the edited ``.ts`` files (clean)
- [x] ``pnpm tsc --noEmit`` clean on the edited ``experimental/sandbox`` files
- [x] Pre-commit hooks all green (ruff format / ruff lint / mypy / prettier / eslint / tsc).

Made with [Cursor](https://cursor.com)