### PR TITLE
release(py): 0.7.36

### DIFF
--- a/python/.bumpversion.cfg
+++ b/python/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.7.35
+current_version = 0.7.36
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
 serialize = {major}.{minor}.{patch}
 search = {current_version}

--- a/python/langsmith/__init__.py
+++ b/python/langsmith/__init__.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
 
 # Avoid calling into importlib on every call to __version__
 
-__version__ = "0.7.35"
+__version__ = "0.7.36"
 version = __version__  # for backwards compatibility
 
 


### PR DESCRIPTION
Bumps langsmith Python from 0.7.35 → 0.7.36 to publish per-replica `client` arg support #2759.