### PR TITLE
release(js): 0.5.24

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langsmith",
-  "version": "0.5.23",
+  "version": "0.5.24",
   "description": "Client library to connect to the LangSmith Observability and Evaluation Platform.",
   "packageManager": "pnpm@10.33.0",
   "files": [

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -32,4 +32,4 @@ export {
 } from "./utils/prompt_cache/index.js";
 
 // Update using pnpm bump-version
-export const __version__ = "0.5.23";
+export const __version__ = "0.5.24";


### PR DESCRIPTION
Bumps LangSmith JS from 0.5.23 → 0.5.24 to publish per-replica client arg support #2759 