### PR TITLE
feat(js,python): Adds hub model config and provider to schemas

### DIFF
--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -6258,6 +6258,8 @@ export class Client implements LangSmithTracingClientInterface {
       commit_hash: result.commit_hash,
       manifest: result.manifest,
       examples: result.examples,
+      hub_model_config: result.model_config,
+      hub_model_provider: result.model_provider,
     };
   }
 

--- a/js/src/schemas.ts
+++ b/js/src/schemas.ts
@@ -496,6 +496,10 @@ export interface PromptCommit {
   manifest: Record<string, any>;
   examples: Array<Record<any, any>>;
   description?: string;
+  /** The model configuration for the prompt. */
+  hub_model_config?: Record<string, any>;
+  /** The model provider (e.g. ChatOpenAI) */
+  hub_model_provider?: string;
 }
 
 export interface Prompt {

--- a/js/src/tests/perf.int.test.ts
+++ b/js/src/tests/perf.int.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-process-env, no-instanceof/no-instanceof */
 import { traceable } from "../traceable.js";
 import { Client } from "../client.js";
-import { v7 as uuidv7 } from "uuid";
+import { v7 as uuidv7 } from "../utils/uuid/src/index.js";
 
 import * as fs from "fs";
 import path from "path";

--- a/python/langsmith/schemas.py
+++ b/python/langsmith/schemas.py
@@ -55,7 +55,7 @@ class Attachment(NamedTuple):
 
 
 Attachments = dict[str, Union[tuple[str, bytes], Attachment, tuple[str, Path]]]
-"""Attachments associated with the run. 
+"""Attachments associated with the run.
 
 Each entry is a tuple of `(mime_type, bytes)`, or `(mime_type, file_path)`
 """
@@ -360,7 +360,7 @@ class RunBase(BaseModel):
         default_factory=dict
     )
     """Attachments associated with the run.
-    
+
     Each entry is a tuple of `(mime_type, bytes)`.
     """
 
@@ -986,6 +986,8 @@ class ComparativeExperiment(BaseModel):
 class PromptCommit(BaseModel):
     """Represents a Prompt with a manifest."""
 
+    model_config = ConfigDict(populate_by_name=True)
+
     owner: str
     """The handle of the owner of the prompt."""
     repo: str
@@ -998,6 +1000,10 @@ class PromptCommit(BaseModel):
     """The list of examples."""
     description: Optional[str] = None
     """Optional human-readable description for the commit."""
+    hub_model_config: Optional[dict] = Field(default=None, alias="model_config")
+    """The model configuration for the prompt."""
+    hub_model_provider: Optional[str] = Field(default=None, alias="model_provider")
+    """The model provider (e.g. ChatOpenAI)."""
 
 
 class ListedPromptCommit(BaseModel):


### PR DESCRIPTION
Applied a while back, adding to frontend schemas