### PR TITLE
refactor(python): move run-compression init into Client.__init__

### DIFF
--- a/python/langsmith/_internal/_background_thread.py
+++ b/python/langsmith/_internal/_background_thread.py
@@ -15,7 +15,6 @@ from typing import TYPE_CHECKING, Any, Optional, Union, cast
 
 from langsmith import schemas as ls_schemas
 from langsmith import utils as ls_utils
-from langsmith._internal._compressed_traces import ZSTD_AVAILABLE, CompressedTraces
 from langsmith._internal._constants import (
     _AUTO_SCALE_DOWN_NEMPTY_TRIGGER,
     _AUTO_SCALE_UP_NTHREADS_LIMIT,
@@ -586,39 +585,9 @@ def tracing_control_thread_func(client_ref: weakref.ref[Client]) -> None:
     )
 
     sub_threads: list[threading.Thread] = []
-    # 1 for this func, 1 for getrefcount, 1 for _get_data_type_cached
-    num_known_refs = 3
-
-    # Disable compression if explicitly set, using OpenTelemetry, or zstd unavailable
-    if not ZSTD_AVAILABLE:
-        logger.debug(
-            "zstandard package is not installed. "
-            "Falling back to uncompressed multipart ingestion."
-        )
-    disable_compression = (
-        ls_utils.is_env_var_truish("DISABLE_RUN_COMPRESSION")
-        or client._tracing_mode in ("otel", "hybrid")
-        or not ZSTD_AVAILABLE
-    )
-    if not disable_compression and use_multipart:
-        if not (client.info.instance_flags or {}).get(
-            "zstd_compression_enabled", False
-        ):
-            logger.warning(
-                "Run compression is not enabled. Please update to the latest "
-                "version of LangSmith. Falling back to regular multipart ingestion."
-            )
-        else:
-            client._futures = weakref.WeakSet()
-            client.compressed_traces = CompressedTraces()
-            client._data_available_event = threading.Event()
-            threading.Thread(
-                target=tracing_control_thread_func_compress_parallel,
-                args=(weakref.ref(client),),
-                daemon=client._use_daemon_threads,
-            ).start()
-
-            num_known_refs += 1
+    # 1 for this func, 1 for getrefcount, 1 for _get_data_type_cached,
+    # and 1 for the compression thread body when compression is enabled.
+    num_known_refs = 4 if client.compressed_traces is not None else 3
 
     def keep_thread_active() -> bool:
         # if `client.cleanup()` was called, stop thread

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -75,8 +75,11 @@ from langsmith._internal._background_thread import (
 from langsmith._internal._background_thread import (
     tracing_control_thread_func as _tracing_control_thread_func,
 )
+from langsmith._internal._background_thread import (
+    tracing_control_thread_func_compress_parallel as _tracing_control_thread_func_compress_parallel,
+)
 from langsmith._internal._beta_decorator import warn_beta
-from langsmith._internal._compressed_traces import CompressedTraces
+from langsmith._internal._compressed_traces import ZSTD_AVAILABLE, CompressedTraces
 from langsmith._internal._constants import (
     _AUTO_SCALE_UP_NTHREADS_LIMIT,
     _BLOCKSIZE_BYTES,
@@ -1150,6 +1153,22 @@ class Client:
                 maxsize=queue_maxsize
             )
 
+            use_multipart = True
+            if self._info is not None and self._info.batch_ingest_config is not None:
+                use_multipart = self._info.batch_ingest_config.get(
+                    "use_multipart_endpoint", True
+                )
+            disable_compression = (
+                ls_utils.is_env_var_truish("DISABLE_RUN_COMPRESSION")
+                or self._tracing_mode in ("otel", "hybrid")
+                or not ZSTD_AVAILABLE
+                or not use_multipart
+            )
+            if not disable_compression:
+                self.compressed_traces = CompressedTraces()
+                self._data_available_event = threading.Event()
+                self._futures = weakref.WeakSet()
+
             threading.Thread(
                 target=_tracing_control_thread_func,
                 # arg must be a weakref to self to avoid the Thread object
@@ -1157,6 +1176,13 @@ class Client:
                 args=(weakref.ref(self),),
                 daemon=self._use_daemon_threads,
             ).start()
+
+            if self.compressed_traces is not None:
+                threading.Thread(
+                    target=_tracing_control_thread_func_compress_parallel,
+                    args=(weakref.ref(self),),
+                    daemon=self._use_daemon_threads,
+                ).start()
         else:
             self.tracing_queue = None
 

--- a/python/tests/unit_tests/conftest.py
+++ b/python/tests/unit_tests/conftest.py
@@ -2,9 +2,26 @@
 
 from __future__ import annotations
 
+import io
 import json
 import re
 from typing import Any, Dict, List
+
+_ZSTD_MAGIC = b"\x28\xb5\x2f\xfd"
+
+
+def _normalize_request_data(data: Any) -> bytes:
+    """Return raw bytes for a request payload, decompressing zstd when present."""
+    if isinstance(data, io.IOBase):
+        data = data.read()
+    if isinstance(data, str):
+        data = data.encode("utf-8")
+    if isinstance(data, (bytes, bytearray)) and data.startswith(_ZSTD_MAGIC):
+        import zstandard as zstd
+
+        with zstd.ZstdDecompressor().stream_reader(io.BytesIO(bytes(data))) as reader:
+            data = reader.read()
+    return bytes(data) if isinstance(data, bytearray) else data
 
 
 def parse_multipart_data(data: bytes) -> Dict[str, Any]:
@@ -95,14 +112,13 @@ def parse_multipart_data(data: bytes) -> Dict[str, Any]:
     return result
 
 
-def parse_request_data(data: bytes, content_type: str = "") -> Dict[str, Any]:
+def parse_request_data(data: Any, content_type: str = "") -> Dict[str, Any]:
     """Parse request data, handling both JSON and multipart formats.
 
     This function automatically detects the format based on content type
     or data structure.
     """
-    if isinstance(data, str):
-        data = data.encode("utf-8")
+    data = _normalize_request_data(data)
 
     # Try JSON first
     if "multipart" not in content_type.lower():

--- a/python/tests/unit_tests/test_client.py
+++ b/python/tests/unit_tests/test_client.py
@@ -395,6 +395,8 @@ def test_create_run_unicode() -> None:
 def test_create_run_mutate(
     use_multipart_endpoint: bool, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    monkeypatch.setenv("LANGSMITH_DISABLE_RUN_COMPRESSION", "true")
+    ls_utils.get_env_var.cache_clear()
     inputs = {"messages": ["hi"], "mygen": (i for i in range(10))}
     session = mock.Mock()
     session.request = mock.Mock()
@@ -809,7 +811,7 @@ def test_client_gc(auto_batch_tracing: bool, supports_batch_endpoint: bool) -> N
 
     if auto_batch_tracing:
         assert client.tracing_queue
-        client.tracing_queue.join()
+        client.flush()
 
         request_calls = [
             call
@@ -1101,7 +1103,9 @@ def test_omit_traced_runtime_info() -> None:
 
 
 @pytest.mark.flaky(retries=3)
-def test_client_gc_after_autoscale() -> None:
+def test_client_gc_after_autoscale(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LANGSMITH_DISABLE_RUN_COMPRESSION", "true")
+    ls_utils.get_env_var.cache_clear()
     session = mock.MagicMock(spec=requests.Session)
     client = Client(
         api_url="http://localhost:1984",
@@ -1149,7 +1153,10 @@ def test_client_gc_after_autoscale() -> None:
 def test_create_run_includes_langchain_env_var_metadata(
     supports_batch_endpoint: bool,
     auto_batch_tracing: bool,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    monkeypatch.setenv("LANGSMITH_DISABLE_RUN_COMPRESSION", "true")
+    ls_utils.get_env_var.cache_clear()
     session = mock.Mock()
     session.request = mock.Mock()
     api_url = "http://localhost:1984"
@@ -1902,8 +1909,10 @@ def test_patch_sampling_mixed_traces():
         assert trace_ids[3] not in patch_trace_ids
 
 
-def test_original_sampling_and_batching():
+def test_original_sampling_and_batching(monkeypatch: pytest.MonkeyPatch):
     """Test that sampling and batching work correctly (continuation of original test)."""
+    monkeypatch.setenv("LANGSMITH_DISABLE_RUN_COMPRESSION", "true")
+    ls_utils.get_env_var.cache_clear()
     # Setup mock client
     mock_session = MagicMock()
     mock_response = MagicMock()
@@ -3589,108 +3598,6 @@ def test_create_feedback_with_zstd_compression(mock_session_cls: mock.Mock) -> N
     assert headers.get("Content-Encoding") == "zstd", (
         "Expected Content-Encoding header to be 'zstd'"
     )
-
-
-@patch("langsmith.client.requests.Session")
-def test_create_run_without_compression_support(mock_session_cls: mock.Mock) -> None:
-    """Test that runs use regular multipart when server doesn't support compression."""
-    mock_session = MagicMock()
-    mock_response = MagicMock()
-    mock_response.status_code = 200
-    mock_session.request.return_value = mock_response
-    mock_session_cls.return_value = mock_session
-
-    with patch.dict("os.environ", {}, clear=True):
-        info = ls_schemas.LangSmithInfo(
-            version="0.6.0",
-            instance_flags={},  # No compression flag
-            batch_ingest_config=ls_schemas.BatchIngestConfig(
-                use_multipart_endpoint=True,
-                size_limit=1,
-                size_limit_bytes=1024 * 1024 * 20,
-                scale_up_nthreads_limit=4,
-                scale_up_qsize_trigger=3,
-                scale_down_nempty_trigger=1,
-            ),
-        )
-        client = Client(
-            api_url="http://localhost:1984",
-            api_key="123",
-            auto_batch_tracing=True,
-            session=mock_session,
-            info=info,
-        )
-
-        run_id = uuid.uuid4()
-        inputs = {"key": "there"}
-        client.create_run(
-            name="test_run",
-            run_type="llm",
-            inputs=inputs,
-            id=run_id,
-            trace_id=run_id,
-            dotted_order=str(run_id),
-        )
-
-        outputs = {"key": "hi there"}
-
-        client.update_run(
-            run_id,
-            outputs=outputs,
-            end_time=datetime.now(timezone.utc),
-            trace_id=run_id,
-            dotted_order=str(run_id),
-        )
-
-        if client.tracing_queue:
-            client.tracing_queue.join()
-
-    time.sleep(0.1)
-
-    post_calls = [
-        call_obj
-        for call_obj in mock_session.request.mock_calls
-        if call_obj.args and call_obj.args[0] == "POST"
-    ]
-    assert len(post_calls) >= 1
-
-    payloads = [
-        (call[2]["headers"], call[2]["data"])
-        for call in mock_session.request.mock_calls
-        if call.args and call.args[1].endswith("runs/multipart")
-    ]
-    if not payloads:
-        assert False, "No payloads found"
-
-    parts: List[MultipartPart] = []
-    for payload in payloads:
-        headers, data = payload
-        assert headers["Content-Type"].startswith("multipart/form-data")
-        assert isinstance(data, bytes)
-        boundary = parse_options_header(headers["Content-Type"])[1]["boundary"]
-        parser = MultipartParser(io.BytesIO(data), boundary)
-        parts.extend(parser.parts())
-
-    assert [p.name for p in parts] == [
-        f"post.{run_id}",
-        f"post.{run_id}.inputs",
-        f"post.{run_id}.outputs",
-        f"post.{run_id}.extra",
-    ]
-    assert [p.headers.get("content-type") for p in parts] == [
-        "application/json",
-        "application/json",
-        "application/json",
-        "application/json",
-    ]
-
-    outputs_parsed = json.loads(parts[2].value)
-    assert outputs_parsed == outputs
-    inputs_parsed = json.loads(parts[1].value)
-    assert inputs_parsed == inputs
-    run_parsed = json.loads(parts[0].value)
-    assert run_parsed["trace_id"] == str(run_id)
-    assert run_parsed["dotted_order"] == str(run_id)
 
 
 @patch("langsmith.client.requests.Session")

--- a/python/tests/unit_tests/test_run_helpers.py
+++ b/python/tests/unit_tests/test_run_helpers.py
@@ -1746,7 +1746,9 @@ def test_traceable_stop_iteration():
 
 
 @pytest.mark.flaky(retries=3)
-def test_traceable_input_attachments():
+def test_traceable_input_attachments(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("LANGSMITH_DISABLE_RUN_COMPRESSION", "true")
+    ls_utils.get_env_var.cache_clear()
     with patch.object(ls_client.ls_env, "get_runtime_environment") as mock_get_env:
         mock_get_env.return_value = {
             "LANGSMITH_test_traceable_input_attachments": "aval"

--- a/python/tests/unit_tests/test_run_trees.py
+++ b/python/tests/unit_tests/test_run_trees.py
@@ -357,8 +357,12 @@ def test_remap_for_project():
     assert r1 == r2  # Deterministic
 
 
-def test_inputs_attachment_moved_to_attachments():
+def test_inputs_attachment_moved_to_attachments(monkeypatch: pytest.MonkeyPatch):
     """Ensure Attachment values in inputs are moved to attachments."""
+    from langsmith import utils as ls_utils
+
+    monkeypatch.setenv("LANGSMITH_DISABLE_RUN_COMPRESSION", "true")
+    ls_utils.get_env_var.cache_clear()
     mock_client = _get_mock_client(
         info=ls_schemas.LangSmithInfo(
             instance_flags={


### PR DESCRIPTION
## Summary

Compression setup previously ran inside `tracing_control_thread_func` after the first `client.info` fetch. This asynchronous gate meant runs created before the server-flag handshake completed lived in `tracing_queue`, while later runs went to `compressed_traces` — a race that required a defensive fix in #2796.

The server-side `zstd_compression_enabled` flag is now assumed to be set on every supported deployment (cloud and all self-hosted versions), so the asynchronous gate is no longer needed.

## Changes

- Compression state (`compressed_traces`, `_data_available_event`, `_futures`) is initialized in `Client.__init__` using only local signals: `ZSTD_AVAILABLE`, `DISABLE_RUN_COMPRESSION`, tracing mode, `auto_batch_tracing`, and user-provided `batch_ingest_config.use_multipart_endpoint`.
- Both the tracing and compression background threads spawn from `__init__`, so `compressed_traces` is either set or None for the lifetime of the client — no mid-flight transition.
- The server-flag check and the "Please update to the latest version of LangSmith" warning are removed from `_background_thread.py`. `num_known_refs` in the tracing thread is now computed from `client.compressed_traces is not None`.
- `tracing_queue` still exists and handles per-request auth/URL overrides, OTel mode, and the ZSTD-not-installed fallback. The race fix from #2796 stands as defense in depth.

## Test changes

- `parse_request_data` (tests/unit_tests/conftest.py) now detects zstd frames and streams-decompresses them, so existing payload assertions keep working without per-test changes.
- A few tests that assert the non-compressed multipart payload structure (attachments, raw `bytes` data) now opt out via `LANGSMITH_DISABLE_RUN_COMPRESSION=true` rather than relying on the (now-gone) server-flag behaviour.
- `test_create_run_without_compression_support` is deleted — the server-doesn't-support-compression scenario no longer exists.
- `test_client_gc` uses `client.flush()` instead of `client.tracing_queue.join()` so it drains both queues.