### PR TITLE
Add Python profile loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,12 +121,23 @@ celerybeat.pid
 
 # Environments
 .env
+.env.*
 .venv
 env/
 venv/
 ENV/
 env.bak/
 venv.bak/
+
+# Secrets and local credentials
+*.pem
+*.key
+*.crt
+credentials.json
+token.json
+
+# Node
+node_modules/
 
 # Spyder project settings
 .spyderproject

--- a/python/langsmith/_internal/_profiles.py
+++ b/python/langsmith/_internal/_profiles.py
@@ -1,0 +1,306 @@
+"""LangSmith profile configuration and auth helpers."""
+
+from __future__ import annotations
+
+import datetime
+import json
+import os
+import threading
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any, NamedTuple, Optional, TypedDict, cast
+
+import requests
+
+_OAUTH_CLIENT_ID = "langsmith-cli"
+_TOKEN_REFRESH_LEEWAY = datetime.timedelta(minutes=1)
+_TOKEN_REFRESH_TIMEOUT = 10
+
+
+class ProfileOAuth(TypedDict, total=False):
+    access_token: str
+    refresh_token: str
+    expires_at: str
+
+
+class ProfileConfig(TypedDict, total=False):
+    api_key: str
+    api_url: str
+    workspace_id: str
+    oauth: ProfileOAuth
+
+
+class ProfileConfigFile(TypedDict, total=False):
+    current_profile: str
+    profiles: dict[str, ProfileConfig]
+
+
+class ProfileState(NamedTuple):
+    path: Path
+    config: ProfileConfigFile
+    profile_name: str
+
+
+class ProfileClientConfig(NamedTuple):
+    api_url: Optional[str] = None
+    api_key: Optional[str] = None
+    workspace_id: Optional[str] = None
+    oauth_access_token: Optional[str] = None
+    oauth_refresh_token: Optional[str] = None
+    oauth_expires_at: Optional[str] = None
+    profile_state: Optional[ProfileState] = None
+
+    @property
+    def has_oauth(self) -> bool:
+        return bool(self.oauth_access_token or self.oauth_refresh_token)
+
+
+def trim_auth_value(value: Optional[str]) -> Optional[str]:
+    if not value:
+        return None
+    trimmed = value.strip().strip('"').strip("'")
+    return trimmed or None
+
+
+def _profile_config_path() -> Optional[Path]:
+    if config_file := os.environ.get("LANGSMITH_CONFIG_FILE"):
+        return Path(config_file)
+    try:
+        return Path.home() / ".langsmith" / "config.json"
+    except RuntimeError:
+        return None
+
+
+def _load_profile_state() -> Optional[ProfileState]:
+    path = _profile_config_path()
+    if path is None or not path.exists():
+        return None
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(raw, dict):
+        return None
+    profiles = raw.get("profiles")
+    if not isinstance(profiles, dict):
+        return None
+    profile_name = os.environ.get("LANGSMITH_PROFILE")
+    if not profile_name:
+        current_profile = raw.get("current_profile")
+        if isinstance(current_profile, str) and current_profile:
+            profile_name = current_profile
+        elif "default" in profiles:
+            profile_name = "default"
+    if not profile_name or not isinstance(profiles.get(profile_name), dict):
+        return None
+    return ProfileState(path, cast(ProfileConfigFile, raw), profile_name)
+
+
+def _profile_from_state(state: ProfileState) -> Optional[ProfileConfig]:
+    profiles = state.config.get("profiles") or {}
+    profile = profiles.get(state.profile_name)
+    if not isinstance(profile, dict):
+        return None
+    return cast(ProfileConfig, profile)
+
+
+def load_profile_client_config() -> ProfileClientConfig:
+    state = _load_profile_state()
+    if state is None:
+        return ProfileClientConfig()
+    profile = _profile_from_state(state)
+    if profile is None:
+        return ProfileClientConfig()
+    oauth = profile.get("oauth") or {}
+    return ProfileClientConfig(
+        api_url=profile.get("api_url"),
+        api_key=trim_auth_value(profile.get("api_key")),
+        workspace_id=profile.get("workspace_id"),
+        oauth_access_token=trim_auth_value(oauth.get("access_token")),
+        oauth_refresh_token=trim_auth_value(oauth.get("refresh_token")),
+        oauth_expires_at=oauth.get("expires_at"),
+        profile_state=state,
+    )
+
+
+def _normalize_profile_api_url(api_url: str) -> str:
+    while api_url.endswith("/"):
+        api_url = api_url[:-1]
+    suffix = "/api/v1"
+    if api_url.endswith(suffix):
+        return api_url[: -len(suffix)]
+    return api_url
+
+
+def _parse_profile_expires_at(expires_at: str) -> Optional[datetime.datetime]:
+    try:
+        parsed = datetime.datetime.fromisoformat(expires_at.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=datetime.timezone.utc)
+    return parsed
+
+
+def should_refresh_profile_token(profile: ProfileConfig) -> bool:
+    oauth = profile.get("oauth") or {}
+    if not oauth.get("refresh_token"):
+        return False
+    if not oauth.get("access_token"):
+        return True
+    expires_at = oauth.get("expires_at")
+    if not expires_at:
+        return False
+    parsed = _parse_profile_expires_at(expires_at)
+    if parsed is None:
+        return False
+    return (
+        parsed <= datetime.datetime.now(datetime.timezone.utc) + _TOKEN_REFRESH_LEEWAY
+    )
+
+
+def _refresh_profile_oauth_token(
+    api_url: Optional[str], refresh_token: str
+) -> Optional[dict[str, Any]]:
+    refresh_url = _normalize_profile_api_url(
+        api_url or "https://api.smith.langchain.com"
+    )
+    try:
+        response = requests.post(
+            f"{refresh_url}/oauth/token",
+            data={
+                "grant_type": "refresh_token",
+                "client_id": _OAUTH_CLIENT_ID,
+                "refresh_token": refresh_token,
+            },
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+            timeout=_TOKEN_REFRESH_TIMEOUT,
+        )
+    except requests.RequestException:
+        return None
+    if response.status_code < 200 or response.status_code >= 300:
+        return None
+    try:
+        token = response.json()
+    except ValueError:
+        return None
+    if not isinstance(token, dict) or not token.get("access_token"):
+        return None
+    return token
+
+
+def _apply_profile_token_response(
+    profile: ProfileConfig, token: Mapping[str, Any]
+) -> None:
+    oauth = profile.setdefault("oauth", {})
+    access_token = token.get("access_token")
+    if isinstance(access_token, str) and access_token:
+        oauth["access_token"] = access_token
+    refresh_token = token.get("refresh_token")
+    if isinstance(refresh_token, str) and refresh_token:
+        oauth["refresh_token"] = refresh_token
+    expires_in = token.get("expires_in")
+    if isinstance(expires_in, (int, float)) and expires_in > 0:
+        expires_at = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(
+            seconds=expires_in
+        )
+        oauth["expires_at"] = expires_at.isoformat().replace("+00:00", "Z")
+
+
+def _save_profile_config(path: Path, config: ProfileConfigFile) -> None:
+    try:
+        path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+        temp_path = path.with_name(f"{path.name}.tmp")
+        temp_path.write_text(json.dumps(config, indent=2) + "\n", encoding="utf-8")
+        os.chmod(temp_path, 0o600)
+        os.replace(temp_path, path)
+        os.chmod(path, 0o600)
+    except OSError:
+        return
+
+
+class ProfileAuth:
+    def __init__(
+        self,
+        config: ProfileClientConfig,
+        *,
+        api_url: str,
+        api_key_header: str,
+    ) -> None:
+        self._state = config.profile_state
+        self._api_url = api_url
+        self._api_key_header = api_key_header
+        self._lock = threading.Lock()
+
+    @property
+    def has_auth(self) -> bool:
+        profile = self._profile()
+        if profile is None:
+            return False
+        oauth = profile.get("oauth") or {}
+        return bool(
+            trim_auth_value(oauth.get("access_token"))
+            or trim_auth_value(oauth.get("refresh_token"))
+            or trim_auth_value(profile.get("api_key"))
+        )
+
+    @property
+    def oauth_access_token(self) -> Optional[str]:
+        profile = self._profile()
+        if profile is None:
+            return None
+        return trim_auth_value((profile.get("oauth") or {}).get("access_token"))
+
+    def needs_refresh(self) -> bool:
+        profile = self._profile()
+        return profile is not None and should_refresh_profile_token(profile)
+
+    def current_auth_headers(self) -> dict[str, str]:
+        return self._auth_headers(refresh=False)
+
+    def get_auth_headers(self) -> dict[str, str]:
+        return self._auth_headers(refresh=True)
+
+    def _profile(self) -> Optional[ProfileConfig]:
+        if self._state is None:
+            return None
+        return _profile_from_state(self._state)
+
+    def _auth_headers(self, *, refresh: bool) -> dict[str, str]:
+        profile = self._profile()
+        if profile is None:
+            return {}
+        if refresh and should_refresh_profile_token(profile):
+            with self._lock:
+                profile = self._profile()
+                if profile is not None and should_refresh_profile_token(profile):
+                    self._refresh(profile)
+        return self._headers_from_profile(profile)
+
+    def _refresh(self, profile: ProfileConfig) -> None:
+        refresh_token = trim_auth_value(
+            (profile.get("oauth") or {}).get("refresh_token")
+        )
+        if refresh_token is None or self._state is None:
+            return
+        token = _refresh_profile_oauth_token(self._api_url, refresh_token)
+        if token is None:
+            return
+        _apply_profile_token_response(profile, token)
+        profiles = self._state.config.get("profiles") or {}
+        profiles[self._state.profile_name] = profile
+        self._state.config["profiles"] = profiles
+        _save_profile_config(self._state.path, self._state.config)
+
+    def _headers_from_profile(self, profile: Optional[ProfileConfig]) -> dict[str, str]:
+        if profile is None:
+            return {}
+        oauth_access_token = trim_auth_value(
+            (profile.get("oauth") or {}).get("access_token")
+        )
+        if oauth_access_token:
+            return {"Authorization": f"Bearer {oauth_access_token}"}
+        api_key = trim_auth_value(profile.get("api_key"))
+        if api_key:
+            return {self._api_key_header: api_key}
+        return {}

--- a/python/langsmith/_internal/_profiles.py
+++ b/python/langsmith/_internal/_profiles.py
@@ -224,11 +224,9 @@ class ProfileAuth:
         self,
         config: ProfileClientConfig,
         *,
-        api_url: str,
         api_key_header: str,
     ) -> None:
         self._state = config.profile_state
-        self._api_url = api_url
         self._api_key_header = api_key_header
         self._lock = threading.Lock()
 
@@ -283,7 +281,8 @@ class ProfileAuth:
         )
         if refresh_token is None or self._state is None:
             return
-        token = _refresh_profile_oauth_token(self._api_url, refresh_token)
+        api_url = profile.get("api_url")
+        token = _refresh_profile_oauth_token(api_url, refresh_token)
         if token is None:
             return
         _apply_profile_token_response(profile, token)

--- a/python/langsmith/_internal/_profiles.py
+++ b/python/langsmith/_internal/_profiles.py
@@ -229,6 +229,8 @@ class ProfileAuth:
         self._state = config.profile_state
         self._api_key_header = api_key_header
         self._lock = threading.Lock()
+        self._managed_auth_headers: set[tuple[str, str]] = set()
+        self._remember_auth_headers(self._auth_headers(refresh=False))
 
     @property
     def has_auth(self) -> bool:
@@ -254,10 +256,24 @@ class ProfileAuth:
         return profile is not None and should_refresh_profile_token(profile)
 
     def current_auth_headers(self) -> dict[str, str]:
-        return self._auth_headers(refresh=False)
+        headers = self._auth_headers(refresh=False)
+        self._remember_auth_headers(headers)
+        return headers
 
     def get_auth_headers(self) -> dict[str, str]:
-        return self._auth_headers(refresh=True)
+        headers = self._auth_headers(refresh=True)
+        self._remember_auth_headers(headers)
+        return headers
+
+    def prepare_request_headers(self, headers: Mapping[str, str]) -> dict[str, str]:
+        """Replace stale profile-managed auth while preserving explicit auth."""
+        request_headers = dict(headers)
+        for key, value in list(request_headers.items()):
+            if self._is_profile_auth_header(key, value):
+                del request_headers[key]
+        if not self._has_auth_header(request_headers):
+            request_headers.update(self.current_auth_headers())
+        return request_headers
 
     def _profile(self) -> Optional[ProfileConfig]:
         if self._state is None:
@@ -303,3 +319,20 @@ class ProfileAuth:
         if api_key:
             return {self._api_key_header: api_key}
         return {}
+
+    def _remember_auth_headers(self, headers: Mapping[str, str]) -> None:
+        for name, value in headers.items():
+            if self._is_auth_header_name(name) and value:
+                self._managed_auth_headers.add((name.lower(), value))
+
+    def _is_profile_auth_header(self, name: str, value: str) -> bool:
+        return (name.lower(), value) in self._managed_auth_headers
+
+    def _has_auth_header(self, headers: Mapping[str, str]) -> bool:
+        return any(
+            self._is_auth_header_name(name) and bool(value)
+            for name, value in headers.items()
+        )
+
+    def _is_auth_header_name(self, name: str) -> bool:
+        return name.lower() in {"authorization", self._api_key_header.lower()}

--- a/python/langsmith/async_client.py
+++ b/python/langsmith/async_client.py
@@ -46,10 +46,12 @@ class AsyncClient:
         "_cache",
         "_custom_headers",
         "_api_key",
+        "_oauth_access_token",
     )
 
     _custom_headers: dict[str, str]
     _api_key: Optional[str]
+    _oauth_access_token: Optional[str]
 
     def _compute_headers(self) -> dict[str, str]:
         headers = {**self._custom_headers}
@@ -57,6 +59,8 @@ class AsyncClient:
         headers["Content-Type"] = "application/json"
         if self._api_key:
             headers[ls_client.X_API_KEY] = self._api_key
+        elif self._oauth_access_token:
+            headers["Authorization"] = f"Bearer {self._oauth_access_token}"
         return headers
 
     @property
@@ -124,11 +128,39 @@ class AsyncClient:
         """
         self._retry_config = retry_config or {"max_retries": 3}
         self._custom_headers = headers or {}
-        api_key = ls_utils.get_api_key(api_key)
-        api_url = ls_utils.get_api_url(api_url)
+        env_api_url = ls_client._get_langsmith_env_var_uncached("ENDPOINT")
+        env_api_key = ls_client._get_langsmith_env_var_uncached("API_KEY")
+        profile_config = ls_client._load_profile_client_config(
+            refresh_api_url=api_url if api_url is not None else env_api_url,
+            refresh_oauth=api_key is None,
+        )
+        api_url_ = (
+            api_url if api_url is not None else env_api_url or profile_config.api_url
+        )
+        explicit_or_env_api_key = api_key if api_key is not None else env_api_key
+        profile_auth_enabled = api_key is None and env_api_key is None
+        profile_oauth_access_token = (
+            profile_config.oauth_access_token if profile_auth_enabled else None
+        )
+        api_key_ = (
+            explicit_or_env_api_key
+            if explicit_or_env_api_key is not None
+            else None
+            if profile_oauth_access_token
+            else profile_config.api_key
+        )
+        self._oauth_access_token = (
+            profile_oauth_access_token.strip().strip('"').strip("'")
+            if profile_oauth_access_token
+            else None
+        )
+        api_key = ls_utils.get_api_key(api_key_)
+        api_url = ls_utils.get_api_url(api_url_)
         self._api_key = api_key
         _headers = self._compute_headers()
-        ls_client._validate_api_key_if_hosted(api_url, api_key)
+        ls_client._validate_api_key_if_hosted(
+            api_url, api_key or self._oauth_access_token
+        )
 
         if isinstance(timeout_ms, int):
             timeout_: Union[tuple, float] = (timeout_ms / 1000, None, None, None)

--- a/python/langsmith/async_client.py
+++ b/python/langsmith/async_client.py
@@ -288,6 +288,10 @@ class AsyncClient:
             kwargs["params"] = filtered_params
 
         await self._ensure_profile_auth()
+        if self._profile_auth is not None and "headers" in kwargs:
+            kwargs["headers"] = self._profile_auth.prepare_request_headers(
+                kwargs["headers"]
+            )
 
         for attempt in range(max_retries):
             try:

--- a/python/langsmith/async_client.py
+++ b/python/langsmith/async_client.py
@@ -23,6 +23,7 @@ import httpx
 from langsmith import client as ls_client
 from langsmith import schemas as ls_schemas
 from langsmith import utils as ls_utils
+from langsmith._internal import _profiles
 from langsmith._internal._hub import (
     HUB,
     PLATFORM_HUB,
@@ -47,11 +48,15 @@ class AsyncClient:
         "_custom_headers",
         "_api_key",
         "_oauth_access_token",
+        "_profile_auth",
+        "_profile_auth_headers",
     )
 
     _custom_headers: dict[str, str]
     _api_key: Optional[str]
     _oauth_access_token: Optional[str]
+    _profile_auth: Optional[_profiles.ProfileAuth]
+    _profile_auth_headers: dict[str, str]
 
     def _compute_headers(self) -> dict[str, str]:
         headers = {**self._custom_headers}
@@ -59,6 +64,8 @@ class AsyncClient:
         headers["Content-Type"] = "application/json"
         if self._api_key:
             headers[ls_client.X_API_KEY] = self._api_key
+        elif self._profile_auth_headers:
+            headers.update(self._profile_auth_headers)
         elif self._oauth_access_token:
             headers["Authorization"] = f"Bearer {self._oauth_access_token}"
         return headers
@@ -130,36 +137,46 @@ class AsyncClient:
         self._custom_headers = headers or {}
         env_api_url = ls_client._get_langsmith_env_var_uncached("ENDPOINT")
         env_api_key = ls_client._get_langsmith_env_var_uncached("API_KEY")
-        profile_config = ls_client._load_profile_client_config(
-            refresh_api_url=api_url if api_url is not None else env_api_url,
-            refresh_oauth=api_key is None,
-        )
+        profile_config = _profiles.load_profile_client_config()
         api_url_ = (
             api_url if api_url is not None else env_api_url or profile_config.api_url
         )
         explicit_or_env_api_key = api_key if api_key is not None else env_api_key
         profile_auth_enabled = api_key is None and env_api_key is None
-        profile_oauth_access_token = (
-            profile_config.oauth_access_token if profile_auth_enabled else None
-        )
+        use_profile_oauth = profile_auth_enabled and profile_config.has_oauth
         api_key_ = (
             explicit_or_env_api_key
             if explicit_or_env_api_key is not None
             else None
-            if profile_oauth_access_token
+            if use_profile_oauth
             else profile_config.api_key
         )
         self._oauth_access_token = (
-            profile_oauth_access_token.strip().strip('"').strip("'")
-            if profile_oauth_access_token
-            else None
+            profile_config.oauth_access_token if use_profile_oauth else None
         )
         api_key = ls_utils.get_api_key(api_key_)
         api_url = ls_utils.get_api_url(api_url_)
+        self._profile_auth = None
+        self._profile_auth_headers = {}
+        if use_profile_oauth:
+            self._profile_auth = _profiles.ProfileAuth(
+                profile_config,
+                api_url=api_url,
+                api_key_header=ls_client.X_API_KEY,
+            )
+            self._profile_auth_headers = self._profile_auth.current_auth_headers()
+            self._oauth_access_token = self._profile_auth.oauth_access_token
         self._api_key = api_key
         _headers = self._compute_headers()
         ls_client._validate_api_key_if_hosted(
-            api_url, api_key or self._oauth_access_token
+            api_url,
+            api_key
+            or self._oauth_access_token
+            or (
+                "profile-auth"
+                if self._profile_auth is not None and self._profile_auth.has_auth
+                else None
+            ),
         )
 
         if isinstance(timeout_ms, int):
@@ -244,6 +261,17 @@ class AsyncClient:
         """The web host url."""
         return ls_utils.get_host_url(self._web_url, self._api_url)
 
+    async def _ensure_profile_auth(self) -> None:
+        if self._api_key or self._profile_auth is None:
+            return
+        if self._profile_auth.needs_refresh():
+            auth_headers = await asyncio.to_thread(self._profile_auth.get_auth_headers)
+        else:
+            auth_headers = self._profile_auth.current_auth_headers()
+        self._profile_auth_headers = auth_headers
+        self._oauth_access_token = self._profile_auth.oauth_access_token
+        self._client.headers = httpx.Headers(self._compute_headers())
+
     async def _arequest_with_retries(
         self,
         method: str,
@@ -259,6 +287,8 @@ class AsyncClient:
             params = kwargs["params"]
             filtered_params = {k: v for k, v in params.items() if v is not None}
             kwargs["params"] = filtered_params
+
+        await self._ensure_profile_auth()
 
         for attempt in range(max_retries):
             try:

--- a/python/langsmith/async_client.py
+++ b/python/langsmith/async_client.py
@@ -161,7 +161,6 @@ class AsyncClient:
         if use_profile_oauth:
             self._profile_auth = _profiles.ProfileAuth(
                 profile_config,
-                api_url=api_url,
                 api_key_header=ls_client.X_API_KEY,
             )
             self._profile_auth_headers = self._profile_auth.current_auth_headers()

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -45,7 +45,6 @@ from typing import (
     Any,
     Callable,
     Literal,
-    NamedTuple,
     Optional,
     TypedDict,
     Union,
@@ -69,7 +68,7 @@ import langsmith
 from langsmith import env as ls_env
 from langsmith import schemas as ls_schemas
 from langsmith import utils as ls_utils
-from langsmith._internal import _orjson
+from langsmith._internal import _orjson, _profiles
 from langsmith._internal._background_thread import (
     TracingQueueItem,
 )
@@ -152,34 +151,6 @@ _TRACING_SEND_TIMEOUT = (3, 10)  # (connect, read) seconds for background sends
 
 _OPENAI_API_KEY = "OPENAI_API_KEY"
 _ANTHROPIC_API_KEY = "ANTHROPIC_API_KEY"
-_OAUTH_CLIENT_ID = "langsmith-cli"
-_TOKEN_REFRESH_LEEWAY = datetime.timedelta(minutes=1)
-_TOKEN_REFRESH_TIMEOUT = 10
-
-
-class _ProfileOAuth(TypedDict, total=False):
-    access_token: str
-    refresh_token: str
-    expires_at: str
-
-
-class _ProfileConfig(TypedDict, total=False):
-    api_key: str
-    api_url: str
-    workspace_id: str
-    oauth: _ProfileOAuth
-
-
-class _ProfileConfigFile(TypedDict, total=False):
-    current_profile: str
-    profiles: dict[str, _ProfileConfig]
-
-
-class _ProfileClientConfig(NamedTuple):
-    api_url: Optional[str] = None
-    api_key: Optional[str] = None
-    workspace_id: Optional[str] = None
-    oauth_access_token: Optional[str] = None
 
 
 def _resolve_tracing_mode(
@@ -621,170 +592,12 @@ def close_session(session: requests.Session) -> None:
     session.close()
 
 
-def _profile_config_path() -> Optional[Path]:
-    if config_file := os.environ.get("LANGSMITH_CONFIG_FILE"):
-        return Path(config_file)
-    try:
-        return Path.home() / ".langsmith" / "config.json"
-    except RuntimeError:
-        return None
-
-
-def _load_profile_state() -> Optional[tuple[Path, _ProfileConfigFile, str]]:
-    path = _profile_config_path()
-    if path is None or not path.exists():
-        return None
-    try:
-        raw = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
-        return None
-    if not isinstance(raw, dict):
-        return None
-    profiles = raw.get("profiles")
-    if not isinstance(profiles, dict):
-        return None
-    profile_name = os.environ.get("LANGSMITH_PROFILE")
-    if not profile_name:
-        current_profile = raw.get("current_profile")
-        if isinstance(current_profile, str) and current_profile:
-            profile_name = current_profile
-        elif "default" in profiles:
-            profile_name = "default"
-    if not profile_name or not isinstance(profiles.get(profile_name), dict):
-        return None
-    return path, cast(_ProfileConfigFile, raw), profile_name
-
-
 def _get_langsmith_env_var_uncached(name: str) -> Optional[str]:
     for namespace in ("LANGSMITH", "LANGCHAIN"):
         value = os.environ.get(f"{namespace}_{name}")
         if value is not None and value.strip() != "":
             return value
     return None
-
-
-def _normalize_profile_api_url(api_url: str) -> str:
-    return api_url.rstrip("/").removesuffix("/api/v1")
-
-
-def _parse_profile_expires_at(expires_at: str) -> Optional[datetime.datetime]:
-    try:
-        parsed = datetime.datetime.fromisoformat(expires_at.replace("Z", "+00:00"))
-    except ValueError:
-        return None
-    if parsed.tzinfo is None:
-        parsed = parsed.replace(tzinfo=datetime.timezone.utc)
-    return parsed
-
-
-def _should_refresh_profile_token(profile: _ProfileConfig) -> bool:
-    oauth = profile.get("oauth") or {}
-    if not oauth.get("refresh_token"):
-        return False
-    if not oauth.get("access_token"):
-        return True
-    expires_at = oauth.get("expires_at")
-    if not expires_at:
-        return False
-    parsed = _parse_profile_expires_at(expires_at)
-    if parsed is None:
-        return False
-    return (
-        parsed <= datetime.datetime.now(datetime.timezone.utc) + _TOKEN_REFRESH_LEEWAY
-    )
-
-
-def _refresh_profile_oauth_token(
-    api_url: Optional[str], refresh_token: str
-) -> Optional[dict[str, Any]]:
-    refresh_url = _normalize_profile_api_url(
-        api_url or "https://api.smith.langchain.com"
-    )
-    try:
-        response = requests.post(
-            f"{refresh_url}/oauth/token",
-            data={
-                "grant_type": "refresh_token",
-                "client_id": _OAUTH_CLIENT_ID,
-                "refresh_token": refresh_token,
-            },
-            headers={"Content-Type": "application/x-www-form-urlencoded"},
-            timeout=_TOKEN_REFRESH_TIMEOUT,
-        )
-    except requests.RequestException:
-        return None
-    if response.status_code < 200 or response.status_code >= 300:
-        return None
-    try:
-        token = response.json()
-    except ValueError:
-        return None
-    if not isinstance(token, dict) or not token.get("access_token"):
-        return None
-    return token
-
-
-def _apply_profile_token_response(
-    profile: _ProfileConfig, token: Mapping[str, Any]
-) -> None:
-    oauth = profile.setdefault("oauth", {})
-    access_token = token.get("access_token")
-    if isinstance(access_token, str) and access_token:
-        oauth["access_token"] = access_token
-    refresh_token = token.get("refresh_token")
-    if isinstance(refresh_token, str) and refresh_token:
-        oauth["refresh_token"] = refresh_token
-    expires_in = token.get("expires_in")
-    if isinstance(expires_in, int) and expires_in > 0:
-        expires_at = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(
-            seconds=expires_in
-        )
-        oauth["expires_at"] = expires_at.isoformat().replace("+00:00", "Z")
-
-
-def _save_profile_config(path: Path, config: _ProfileConfigFile) -> None:
-    try:
-        path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
-        temp_path = path.with_name(f"{path.name}.tmp")
-        temp_path.write_text(json.dumps(config, indent=2) + "\n", encoding="utf-8")
-        os.chmod(temp_path, 0o600)
-        os.replace(temp_path, path)
-        os.chmod(path, 0o600)
-    except OSError:
-        return
-
-
-def _load_profile_client_config(
-    *, refresh_api_url: Optional[str] = None, refresh_oauth: bool = True
-) -> _ProfileClientConfig:
-    state = _load_profile_state()
-    if state is None:
-        return _ProfileClientConfig()
-    path, config, profile_name = state
-    profiles = config.get("profiles") or {}
-    profile = profiles[profile_name]
-    env_auth_set = bool(_get_langsmith_env_var_uncached("API_KEY"))
-    refresh_url = (
-        refresh_api_url
-        or _get_langsmith_env_var_uncached("ENDPOINT")
-        or profile.get("api_url")
-    )
-    if refresh_oauth and not env_auth_set and _should_refresh_profile_token(profile):
-        refresh_token = (profile.get("oauth") or {}).get("refresh_token")
-        if refresh_token:
-            token = _refresh_profile_oauth_token(refresh_url, refresh_token)
-            if token is not None:
-                _apply_profile_token_response(profile, token)
-                profiles[profile_name] = profile
-                config["profiles"] = profiles
-                _save_profile_config(path, config)
-    oauth_access_token = (profile.get("oauth") or {}).get("access_token")
-    return _ProfileClientConfig(
-        api_url=profile.get("api_url"),
-        api_key=None if oauth_access_token else profile.get("api_key"),
-        workspace_id=profile.get("workspace_id"),
-        oauth_access_token=oauth_access_token,
-    )
 
 
 def _validate_api_key_if_hosted(
@@ -1006,6 +819,8 @@ class Client:
         "_failed_traces_dir",
         "_failed_traces_max_bytes",
         "_tracing_mode",
+        "_profile_auth",
+        "_profile_auth_headers",
     ]
 
     _api_key: Optional[str]
@@ -1014,6 +829,8 @@ class Client:
     _custom_headers: dict[str, str]
     _timeout: tuple[float, float]
     _manual_cleanup: bool
+    _profile_auth: Optional[_profiles.ProfileAuth]
+    _profile_auth_headers: dict[str, str]
 
     def __init__(
         self,
@@ -1243,23 +1060,18 @@ class Client:
         env_api_url = _get_langsmith_env_var_uncached("ENDPOINT")
         env_api_key = _get_langsmith_env_var_uncached("API_KEY")
         env_workspace_id = _get_langsmith_env_var_uncached("WORKSPACE_ID")
-        profile_config = _load_profile_client_config(
-            refresh_api_url=api_url if api_url is not None else env_api_url,
-            refresh_oauth=api_key is None,
-        )
+        profile_config = _profiles.load_profile_client_config()
         api_url_ = (
             api_url if api_url is not None else env_api_url or profile_config.api_url
         )
         explicit_or_env_api_key = api_key if api_key is not None else env_api_key
         profile_auth_enabled = api_key is None and env_api_key is None
-        profile_oauth_access_token = (
-            profile_config.oauth_access_token if profile_auth_enabled else None
-        )
+        use_profile_oauth = profile_auth_enabled and profile_config.has_oauth
         api_key_ = (
             explicit_or_env_api_key
             if explicit_or_env_api_key is not None
             else None
-            if profile_oauth_access_token
+            if use_profile_oauth
             else profile_config.api_key
         )
         workspace_id_ = (
@@ -1268,10 +1080,10 @@ class Client:
             else env_workspace_id or profile_config.workspace_id
         )
         self._oauth_access_token = (
-            profile_oauth_access_token.strip().strip('"').strip("'")
-            if profile_oauth_access_token
-            else None
+            profile_config.oauth_access_token if use_profile_oauth else None
         )
+        self._profile_auth: Optional[_profiles.ProfileAuth] = None
+        self._profile_auth_headers: dict[str, str] = {}
 
         self.tracing_sample_rate = _get_tracing_sampling_rate(tracing_sampling_rate)
         self._filtered_post_uuids: set[uuid.UUID] = set()
@@ -1286,13 +1098,29 @@ class Client:
         if self._write_api_urls:
             self.api_url = next(iter(self._write_api_urls))
             self._oauth_access_token = None
+            self._profile_auth = None
+            self._profile_auth_headers = {}
             self.api_key = self._write_api_urls[self.api_url]
         else:
             self.api_url = ls_utils.get_api_url(api_url_)
+            if use_profile_oauth:
+                self._profile_auth = _profiles.ProfileAuth(
+                    profile_config,
+                    api_url=self.api_url,
+                    api_key_header=X_API_KEY,
+                )
+                self._profile_auth_headers = self._profile_auth.current_auth_headers()
+                self._oauth_access_token = self._profile_auth.oauth_access_token
             self.api_key = ls_utils.get_api_key(api_key_)
             _validate_api_key_if_hosted(
                 self.api_url,
-                self.api_key or self._oauth_access_token,
+                self.api_key
+                or self._oauth_access_token
+                or (
+                    "profile-auth"
+                    if self._profile_auth is not None and self._profile_auth.has_auth
+                    else None
+                ),
                 tracing_mode=resolved_mode,
             )
             self._write_api_urls = {self.api_url: self.api_key}
@@ -1367,7 +1195,16 @@ class Client:
                 self.otel_exporter = None
                 self._tracing_mode = "langsmith"
                 _validate_api_key_if_hosted(
-                    self.api_url, self.api_key, tracing_mode="langsmith"
+                    self.api_url,
+                    self.api_key
+                    or self._oauth_access_token
+                    or (
+                        "profile-auth"
+                        if self._profile_auth is not None
+                        and self._profile_auth.has_auth
+                        else None
+                    ),
+                    tracing_mode="langsmith",
                 )
 
         # Initialize auto batching
@@ -1674,6 +1511,8 @@ class Client:
         headers.update(self._custom_headers)
         if self.api_key:
             headers[X_API_KEY] = self.api_key
+        elif self._profile_auth_headers:
+            headers.update(self._profile_auth_headers)
         elif self._oauth_access_token:
             headers["Authorization"] = f"Bearer {self._oauth_access_token}"
         if self._workspace_id:
@@ -1683,6 +1522,16 @@ class Client:
     def _set_header_affecting_attr(self, attr_name: str, value: Any) -> None:
         """Set attributes that affect headers and recalculate them."""
         object.__setattr__(self, attr_name, value)
+        object.__setattr__(self, "_headers", self._compute_headers())
+
+    def _ensure_profile_auth(self) -> None:
+        if self.api_key or self._profile_auth is None:
+            return
+        auth_headers = self._profile_auth.get_auth_headers()
+        object.__setattr__(self, "_profile_auth_headers", auth_headers)
+        object.__setattr__(
+            self, "_oauth_access_token", self._profile_auth.oauth_access_token
+        )
         object.__setattr__(self, "_headers", self._compute_headers())
 
     @property
@@ -1814,6 +1663,7 @@ class Client:
             LangSmithConnectionError: If a connection error occurs.
             LangSmithError: If the request fails.
         """
+        self._ensure_profile_auth()
         request_kwargs = request_kwargs or {}
         request_kwargs = {
             "timeout": self._timeout,
@@ -7249,6 +7099,7 @@ class Client:
             # Use platform path helper for consistent URL construction
             path = _platform_path(self.api_url, "datasets/examples/delete")
             full_url = _construct_url(self.api_url, path)
+            self._ensure_profile_auth()
             response = self.session.request(
                 "POST",
                 full_url,
@@ -10844,6 +10695,7 @@ class Client:
             params["priority"] = priority
         path = _platform_path(self.api_url, "forge-issues")
         full_url = _construct_url(self.api_url, path)
+        self._ensure_profile_auth()
         response = self.session.request(
             "GET",
             full_url,

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -1106,7 +1106,6 @@ class Client:
             if use_profile_oauth:
                 self._profile_auth = _profiles.ProfileAuth(
                     profile_config,
-                    api_url=self.api_url,
                     api_key_header=X_API_KEY,
                 )
                 self._profile_auth_headers = self._profile_auth.current_auth_headers()

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -45,6 +45,7 @@ from typing import (
     Any,
     Callable,
     Literal,
+    NamedTuple,
     Optional,
     TypedDict,
     Union,
@@ -151,6 +152,34 @@ _TRACING_SEND_TIMEOUT = (3, 10)  # (connect, read) seconds for background sends
 
 _OPENAI_API_KEY = "OPENAI_API_KEY"
 _ANTHROPIC_API_KEY = "ANTHROPIC_API_KEY"
+_OAUTH_CLIENT_ID = "langsmith-cli"
+_TOKEN_REFRESH_LEEWAY = datetime.timedelta(minutes=1)
+_TOKEN_REFRESH_TIMEOUT = 10
+
+
+class _ProfileOAuth(TypedDict, total=False):
+    access_token: str
+    refresh_token: str
+    expires_at: str
+
+
+class _ProfileConfig(TypedDict, total=False):
+    api_key: str
+    api_url: str
+    workspace_id: str
+    oauth: _ProfileOAuth
+
+
+class _ProfileConfigFile(TypedDict, total=False):
+    current_profile: str
+    profiles: dict[str, _ProfileConfig]
+
+
+class _ProfileClientConfig(NamedTuple):
+    api_url: Optional[str] = None
+    api_key: Optional[str] = None
+    workspace_id: Optional[str] = None
+    oauth_access_token: Optional[str] = None
 
 
 def _resolve_tracing_mode(
@@ -592,6 +621,172 @@ def close_session(session: requests.Session) -> None:
     session.close()
 
 
+def _profile_config_path() -> Optional[Path]:
+    if config_file := os.environ.get("LANGSMITH_CONFIG_FILE"):
+        return Path(config_file)
+    try:
+        return Path.home() / ".langsmith" / "config.json"
+    except RuntimeError:
+        return None
+
+
+def _load_profile_state() -> Optional[tuple[Path, _ProfileConfigFile, str]]:
+    path = _profile_config_path()
+    if path is None or not path.exists():
+        return None
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(raw, dict):
+        return None
+    profiles = raw.get("profiles")
+    if not isinstance(profiles, dict):
+        return None
+    profile_name = os.environ.get("LANGSMITH_PROFILE")
+    if not profile_name:
+        current_profile = raw.get("current_profile")
+        if isinstance(current_profile, str) and current_profile:
+            profile_name = current_profile
+        elif "default" in profiles:
+            profile_name = "default"
+    if not profile_name or not isinstance(profiles.get(profile_name), dict):
+        return None
+    return path, cast(_ProfileConfigFile, raw), profile_name
+
+
+def _get_langsmith_env_var_uncached(name: str) -> Optional[str]:
+    for namespace in ("LANGSMITH", "LANGCHAIN"):
+        value = os.environ.get(f"{namespace}_{name}")
+        if value is not None and value.strip() != "":
+            return value
+    return None
+
+
+def _normalize_profile_api_url(api_url: str) -> str:
+    return api_url.rstrip("/").removesuffix("/api/v1")
+
+
+def _parse_profile_expires_at(expires_at: str) -> Optional[datetime.datetime]:
+    try:
+        parsed = datetime.datetime.fromisoformat(expires_at.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=datetime.timezone.utc)
+    return parsed
+
+
+def _should_refresh_profile_token(profile: _ProfileConfig) -> bool:
+    oauth = profile.get("oauth") or {}
+    if not oauth.get("refresh_token"):
+        return False
+    if not oauth.get("access_token"):
+        return True
+    expires_at = oauth.get("expires_at")
+    if not expires_at:
+        return False
+    parsed = _parse_profile_expires_at(expires_at)
+    if parsed is None:
+        return False
+    return (
+        parsed <= datetime.datetime.now(datetime.timezone.utc) + _TOKEN_REFRESH_LEEWAY
+    )
+
+
+def _refresh_profile_oauth_token(
+    api_url: Optional[str], refresh_token: str
+) -> Optional[dict[str, Any]]:
+    refresh_url = _normalize_profile_api_url(
+        api_url or "https://api.smith.langchain.com"
+    )
+    try:
+        response = requests.post(
+            f"{refresh_url}/oauth/token",
+            data={
+                "grant_type": "refresh_token",
+                "client_id": _OAUTH_CLIENT_ID,
+                "refresh_token": refresh_token,
+            },
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+            timeout=_TOKEN_REFRESH_TIMEOUT,
+        )
+    except requests.RequestException:
+        return None
+    if response.status_code < 200 or response.status_code >= 300:
+        return None
+    try:
+        token = response.json()
+    except ValueError:
+        return None
+    if not isinstance(token, dict) or not token.get("access_token"):
+        return None
+    return token
+
+
+def _apply_profile_token_response(
+    profile: _ProfileConfig, token: Mapping[str, Any]
+) -> None:
+    oauth = profile.setdefault("oauth", {})
+    access_token = token.get("access_token")
+    if isinstance(access_token, str) and access_token:
+        oauth["access_token"] = access_token
+    refresh_token = token.get("refresh_token")
+    if isinstance(refresh_token, str) and refresh_token:
+        oauth["refresh_token"] = refresh_token
+    expires_in = token.get("expires_in")
+    if isinstance(expires_in, int) and expires_in > 0:
+        expires_at = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(
+            seconds=expires_in
+        )
+        oauth["expires_at"] = expires_at.isoformat().replace("+00:00", "Z")
+
+
+def _save_profile_config(path: Path, config: _ProfileConfigFile) -> None:
+    try:
+        path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+        temp_path = path.with_name(f"{path.name}.tmp")
+        temp_path.write_text(json.dumps(config, indent=2) + "\n", encoding="utf-8")
+        os.chmod(temp_path, 0o600)
+        os.replace(temp_path, path)
+        os.chmod(path, 0o600)
+    except OSError:
+        return
+
+
+def _load_profile_client_config(
+    *, refresh_api_url: Optional[str] = None, refresh_oauth: bool = True
+) -> _ProfileClientConfig:
+    state = _load_profile_state()
+    if state is None:
+        return _ProfileClientConfig()
+    path, config, profile_name = state
+    profiles = config.get("profiles") or {}
+    profile = profiles[profile_name]
+    env_auth_set = bool(_get_langsmith_env_var_uncached("API_KEY"))
+    refresh_url = (
+        refresh_api_url
+        or _get_langsmith_env_var_uncached("ENDPOINT")
+        or profile.get("api_url")
+    )
+    if refresh_oauth and not env_auth_set and _should_refresh_profile_token(profile):
+        refresh_token = (profile.get("oauth") or {}).get("refresh_token")
+        if refresh_token:
+            token = _refresh_profile_oauth_token(refresh_url, refresh_token)
+            if token is not None:
+                _apply_profile_token_response(profile, token)
+                profiles[profile_name] = profile
+                config["profiles"] = profiles
+                _save_profile_config(path, config)
+    oauth_access_token = (profile.get("oauth") or {}).get("access_token")
+    return _ProfileClientConfig(
+        api_url=profile.get("api_url"),
+        api_key=None if oauth_access_token else profile.get("api_key"),
+        workspace_id=profile.get("workspace_id"),
+        oauth_access_token=oauth_access_token,
+    )
+
+
 def _validate_api_key_if_hosted(
     api_url: str,
     api_key: Optional[str],
@@ -767,6 +962,7 @@ class Client:
         "__weakref__",
         "api_url",
         "_api_key",
+        "_oauth_access_token",
         "_workspace_id",
         "_headers",
         "_custom_headers",
@@ -813,6 +1009,7 @@ class Client:
     ]
 
     _api_key: Optional[str]
+    _oauth_access_token: Optional[str]
     _headers: dict[str, str]
     _custom_headers: dict[str, str]
     _timeout: tuple[float, float]
@@ -1043,6 +1240,38 @@ class Client:
 
         resolved_mode = _resolve_tracing_mode(tracing_mode, otel_enabled=otel_enabled)
         self._tracing_mode: TracingMode = resolved_mode
+        env_api_url = _get_langsmith_env_var_uncached("ENDPOINT")
+        env_api_key = _get_langsmith_env_var_uncached("API_KEY")
+        env_workspace_id = _get_langsmith_env_var_uncached("WORKSPACE_ID")
+        profile_config = _load_profile_client_config(
+            refresh_api_url=api_url if api_url is not None else env_api_url,
+            refresh_oauth=api_key is None,
+        )
+        api_url_ = (
+            api_url if api_url is not None else env_api_url or profile_config.api_url
+        )
+        explicit_or_env_api_key = api_key if api_key is not None else env_api_key
+        profile_auth_enabled = api_key is None and env_api_key is None
+        profile_oauth_access_token = (
+            profile_config.oauth_access_token if profile_auth_enabled else None
+        )
+        api_key_ = (
+            explicit_or_env_api_key
+            if explicit_or_env_api_key is not None
+            else None
+            if profile_oauth_access_token
+            else profile_config.api_key
+        )
+        workspace_id_ = (
+            workspace_id
+            if workspace_id is not None
+            else env_workspace_id or profile_config.workspace_id
+        )
+        self._oauth_access_token = (
+            profile_oauth_access_token.strip().strip('"').strip("'")
+            if profile_oauth_access_token
+            else None
+        )
 
         self.tracing_sample_rate = _get_tracing_sampling_rate(tracing_sampling_rate)
         self._filtered_post_uuids: set[uuid.UUID] = set()
@@ -1050,18 +1279,21 @@ class Client:
             api_urls
         )
         # Initialize workspace attribute first
-        self._workspace_id = ls_utils.get_workspace_id(workspace_id)
+        self._workspace_id = ls_utils.get_workspace_id(workspace_id_)
         # Store custom headers
         self._custom_headers = headers or {}
 
         if self._write_api_urls:
             self.api_url = next(iter(self._write_api_urls))
+            self._oauth_access_token = None
             self.api_key = self._write_api_urls[self.api_url]
         else:
-            self.api_url = ls_utils.get_api_url(api_url)
-            self.api_key = ls_utils.get_api_key(api_key)
+            self.api_url = ls_utils.get_api_url(api_url_)
+            self.api_key = ls_utils.get_api_key(api_key_)
             _validate_api_key_if_hosted(
-                self.api_url, self.api_key, tracing_mode=resolved_mode
+                self.api_url,
+                self.api_key or self._oauth_access_token,
+                tracing_mode=resolved_mode,
             )
             self._write_api_urls = {self.api_url: self.api_key}
         self.retry_config = retry_config or _default_retry_config()
@@ -1442,6 +1674,8 @@ class Client:
         headers.update(self._custom_headers)
         if self.api_key:
             headers[X_API_KEY] = self.api_key
+        elif self._oauth_access_token:
+            headers["Authorization"] = f"Bearer {self._oauth_access_token}"
         if self._workspace_id:
             headers["X-Tenant-Id"] = self._workspace_id
         return headers

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -1664,15 +1664,18 @@ class Client:
         """
         self._ensure_profile_auth()
         request_kwargs = request_kwargs or {}
+        headers = {
+            **self._headers,
+            **request_kwargs.get("headers", {}),
+            **kwargs.get("headers", {}),
+        }
+        if self._profile_auth is not None:
+            headers = self._profile_auth.prepare_request_headers(headers)
         request_kwargs = {
             "timeout": self._timeout,
             **request_kwargs,
             **kwargs,
-            "headers": {
-                **self._headers,
-                **request_kwargs.get("headers", {}),
-                **kwargs.get("headers", {}),
-            },
+            "headers": headers,
         }
         if (
             method != "GET"

--- a/python/tests/unit_tests/test_async_client.py
+++ b/python/tests/unit_tests/test_async_client.py
@@ -11,6 +11,7 @@ from uuid import uuid4
 
 import httpx
 import pytest
+import requests
 
 from langsmith import AsyncClient
 from langsmith import schemas as ls_schemas
@@ -160,6 +161,64 @@ def test_async_client_profile_config_uses_oauth_access_token(
     passed_headers = mock_client_cls.call_args.kwargs["headers"]
     assert passed_headers["Authorization"] == "Bearer profile-access-token"
     assert "x-api-key" not in passed_headers
+
+
+@mock.patch("langsmith.async_client.httpx.AsyncClient")
+@pytest.mark.asyncio
+async def test_async_client_profile_refresh_replaces_snapshotted_auth_headers(
+    mock_client_cls: mock.Mock,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: pathlib.Path,
+) -> None:
+    _clear_profile_env(monkeypatch)
+    mock_httpx_client = mock.AsyncMock()
+    mock_httpx_client.headers = httpx.Headers()
+    response = mock.Mock()
+    response.status_code = 200
+    mock_httpx_client.request.return_value = response
+    mock_client_cls.return_value = mock_httpx_client
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "profiles": {
+                    "default": {
+                        "api_url": "https://profile.example.com",
+                        "oauth": {
+                            "access_token": "old-access-token",
+                            "refresh_token": "old-refresh-token",
+                            "expires_at": "2000-01-01T00:00:00Z",
+                        },
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("LANGSMITH_CONFIG_FILE", str(config_path))
+
+    def mock_post(url: str, **kwargs: object) -> mock.Mock:
+        response = mock.Mock()
+        response.status_code = 200
+        response.json.return_value = {
+            "access_token": "new-access-token",
+            "refresh_token": "new-refresh-token",
+            "expires_in": 300,
+        }
+        return response
+
+    monkeypatch.setattr(requests, "post", mock_post)
+    client = AsyncClient()
+    snapshotted_headers = dict(mock_client_cls.call_args.kwargs["headers"])
+
+    await client._arequest_with_retries(
+        "GET",
+        "/info",
+        headers=snapshotted_headers,
+    )
+
+    request_headers = mock_httpx_client.request.call_args.kwargs["headers"]
+    assert request_headers["Authorization"] == "Bearer new-access-token"
 
 
 @mock.patch("langsmith.async_client.httpx.AsyncClient")

--- a/python/tests/unit_tests/test_async_client.py
+++ b/python/tests/unit_tests/test_async_client.py
@@ -1,5 +1,7 @@
 """Test the AsyncClient."""
 
+import json
+import pathlib
 import uuid
 import warnings
 from datetime import datetime
@@ -12,6 +14,19 @@ import pytest
 
 from langsmith import AsyncClient
 from langsmith import schemas as ls_schemas
+from langsmith import utils as ls_utils
+
+
+def _clear_profile_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    ls_utils.get_env_var.cache_clear()
+    for key in (
+        "LANGCHAIN_API_KEY",
+        "LANGSMITH_API_KEY",
+        "LANGCHAIN_ENDPOINT",
+        "LANGSMITH_ENDPOINT",
+        "LANGSMITH_PROFILE",
+    ):
+        monkeypatch.delenv(key, raising=False)
 
 
 @mock.patch("langsmith.async_client.httpx.AsyncClient")
@@ -111,6 +126,40 @@ def test_async_client_no_custom_headers(mock_client_cls: mock.Mock) -> None:
     passed_headers = mock_client_cls.call_args.kwargs["headers"]
     assert passed_headers["Content-Type"] == "application/json"
     assert passed_headers["x-api-key"] == "test-api-key"
+
+
+@mock.patch("langsmith.async_client.httpx.AsyncClient")
+def test_async_client_profile_config_uses_oauth_access_token(
+    mock_client_cls: mock.Mock,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: pathlib.Path,
+) -> None:
+    _clear_profile_env(monkeypatch)
+    mock_httpx_client = mock.Mock()
+    mock_httpx_client.headers = httpx.Headers()
+    mock_client_cls.return_value = mock_httpx_client
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "profiles": {
+                    "default": {
+                        "api_url": "https://profile.example.com",
+                        "oauth": {"access_token": "profile-access-token"},
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("LANGSMITH_CONFIG_FILE", str(config_path))
+
+    AsyncClient()
+
+    assert mock_client_cls.call_args.kwargs["base_url"] == "https://profile.example.com"
+    passed_headers = mock_client_cls.call_args.kwargs["headers"]
+    assert passed_headers["Authorization"] == "Bearer profile-access-token"
+    assert "x-api-key" not in passed_headers
 
 
 @mock.patch("langsmith.async_client.httpx.AsyncClient")

--- a/python/tests/unit_tests/test_client.py
+++ b/python/tests/unit_tests/test_client.py
@@ -364,6 +364,66 @@ def test_profile_config_refreshes_expired_oauth_token(
     assert "bearer_token" not in updated["profiles"]["default"]
 
 
+def test_profile_config_refresh_uses_profile_api_url(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path
+) -> None:
+    _clear_profile_env(monkeypatch)
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "profiles": {
+                    "default": {
+                        "api_url": "https://profile.example.com",
+                        "oauth": {
+                            "access_token": "old-access-token",
+                            "refresh_token": "old-refresh-token",
+                            "expires_at": "2000-01-01T00:00:00Z",
+                        },
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("LANGSMITH_CONFIG_FILE", str(config_path))
+    calls = []
+
+    def mock_post(url: str, **kwargs: object) -> mock.Mock:
+        calls.append((url, kwargs))
+        response = mock.Mock()
+        response.status_code = 200
+        response.json.return_value = {
+            "access_token": "new-access-token",
+            "refresh_token": "new-refresh-token",
+            "expires_in": 300,
+        }
+        return response
+
+    monkeypatch.setattr(requests, "post", mock_post)
+    client = Client(
+        api_url="https://override.example.com",
+        auto_batch_tracing=False,
+    )
+    request_calls = []
+    response = mock.Mock()
+    response.raise_for_status.return_value = None
+
+    def mock_request(method: str, url: str, **kwargs: object) -> mock.Mock:
+        request_calls.append((method, url, kwargs))
+        return response
+
+    monkeypatch.setattr(client.session, "request", mock_request)
+
+    client.request_with_retries("GET", "/info")
+
+    assert calls[0][0] == "https://profile.example.com/oauth/token"
+    assert request_calls[0][1] == "https://override.example.com/info"
+    assert request_calls[0][2]["headers"]["Authorization"] == (
+        "Bearer new-access-token"
+    )
+
+
 def test_validate_multiple_urls() -> None:
     """Test URL validation without environment variable manipulation."""
     _clear_env_cache()

--- a/python/tests/unit_tests/test_client.py
+++ b/python/tests/unit_tests/test_client.py
@@ -330,7 +330,25 @@ def test_profile_config_refreshes_expired_oauth_token(
 
     client = Client(auto_batch_tracing=False)
 
+    assert client._headers["Authorization"] == "Bearer old-access-token"
+    assert calls == []
+
+    request_calls = []
+    response = mock.Mock()
+    response.raise_for_status.return_value = None
+
+    def mock_request(method: str, url: str, **kwargs: object) -> mock.Mock:
+        request_calls.append((method, url, kwargs))
+        return response
+
+    monkeypatch.setattr(client.session, "request", mock_request)
+
+    client.request_with_retries("GET", "/info")
+
     assert client._headers["Authorization"] == "Bearer new-access-token"
+    assert request_calls[0][2]["headers"]["Authorization"] == (
+        "Bearer new-access-token"
+    )
     assert calls[0][0] == "https://profile.example.com/oauth/token"
     assert calls[0][1]["data"] == {
         "grant_type": "refresh_token",

--- a/python/tests/unit_tests/test_client.py
+++ b/python/tests/unit_tests/test_client.py
@@ -364,6 +364,119 @@ def test_profile_config_refreshes_expired_oauth_token(
     assert "bearer_token" not in updated["profiles"]["default"]
 
 
+def test_profile_config_refresh_replaces_snapshotted_auth_headers(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path
+) -> None:
+    _clear_profile_env(monkeypatch)
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "profiles": {
+                    "default": {
+                        "api_url": "https://profile.example.com",
+                        "oauth": {
+                            "access_token": "old-access-token",
+                            "refresh_token": "old-refresh-token",
+                            "expires_at": "2000-01-01T00:00:00Z",
+                        },
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("LANGSMITH_CONFIG_FILE", str(config_path))
+
+    def mock_post(url: str, **kwargs: object) -> mock.Mock:
+        response = mock.Mock()
+        response.status_code = 200
+        response.json.return_value = {
+            "access_token": "new-access-token",
+            "refresh_token": "new-refresh-token",
+            "expires_in": 300,
+        }
+        return response
+
+    monkeypatch.setattr(requests, "post", mock_post)
+    client = Client(auto_batch_tracing=False)
+    snapshotted_headers = dict(client._headers)
+    request_calls = []
+    response = mock.Mock()
+    response.raise_for_status.return_value = None
+
+    def mock_request(method: str, url: str, **kwargs: object) -> mock.Mock:
+        request_calls.append((method, url, kwargs))
+        return response
+
+    monkeypatch.setattr(client.session, "request", mock_request)
+
+    client.request_with_retries(
+        "GET",
+        "/info",
+        request_kwargs={"headers": snapshotted_headers},
+    )
+
+    assert request_calls[0][2]["headers"]["Authorization"] == (
+        "Bearer new-access-token"
+    )
+
+
+def test_profile_config_refresh_preserves_explicit_auth_headers(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path
+) -> None:
+    _clear_profile_env(monkeypatch)
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "profiles": {
+                    "default": {
+                        "api_url": "https://profile.example.com",
+                        "oauth": {
+                            "access_token": "old-access-token",
+                            "refresh_token": "old-refresh-token",
+                            "expires_at": "2000-01-01T00:00:00Z",
+                        },
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("LANGSMITH_CONFIG_FILE", str(config_path))
+
+    def mock_post(url: str, **kwargs: object) -> mock.Mock:
+        response = mock.Mock()
+        response.status_code = 200
+        response.json.return_value = {
+            "access_token": "new-access-token",
+            "refresh_token": "new-refresh-token",
+            "expires_in": 300,
+        }
+        return response
+
+    monkeypatch.setattr(requests, "post", mock_post)
+    client = Client(auto_batch_tracing=False)
+    request_calls = []
+    response = mock.Mock()
+    response.raise_for_status.return_value = None
+
+    def mock_request(method: str, url: str, **kwargs: object) -> mock.Mock:
+        request_calls.append((method, url, kwargs))
+        return response
+
+    monkeypatch.setattr(client.session, "request", mock_request)
+
+    client.request_with_retries(
+        "GET",
+        "/info",
+        request_kwargs={"headers": {"Authorization": "Bearer explicit-token"}},
+    )
+
+    assert request_calls[0][2]["headers"]["Authorization"] == ("Bearer explicit-token")
+
+
 def test_profile_config_refresh_uses_profile_api_url(
     monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path
 ) -> None:

--- a/python/tests/unit_tests/test_client.py
+++ b/python/tests/unit_tests/test_client.py
@@ -149,6 +149,203 @@ def test_validate_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
     assert client.api_key == "env_langsmith_api_key"
 
 
+def _clear_profile_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_env_cache()
+    for key in (
+        "LANGCHAIN_API_KEY",
+        "LANGSMITH_API_KEY",
+        "LANGCHAIN_ENDPOINT",
+        "LANGSMITH_ENDPOINT",
+        "LANGCHAIN_WORKSPACE_ID",
+        "LANGSMITH_WORKSPACE_ID",
+        "LANGSMITH_PROFILE",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
+def test_profile_config_loads_api_key_and_workspace(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path
+) -> None:
+    _clear_profile_env(monkeypatch)
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "current_profile": "prod",
+                "profiles": {
+                    "prod": {
+                        "api_key": "profile-key",
+                        "api_url": "https://profile.example.com",
+                        "workspace_id": "workspace-id",
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("LANGSMITH_CONFIG_FILE", str(config_path))
+
+    client = Client(auto_batch_tracing=False)
+
+    assert client.api_url == "https://profile.example.com"
+    assert client.api_key == "profile-key"
+    assert client.workspace_id == "workspace-id"
+    assert client._headers["x-api-key"] == "profile-key"
+    assert client._headers["X-Tenant-Id"] == "workspace-id"
+
+
+def test_profile_config_uses_oauth_access_token_before_api_key(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path
+) -> None:
+    _clear_profile_env(monkeypatch)
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "profiles": {
+                    "default": {
+                        "api_key": "profile-key",
+                        "oauth": {"access_token": "profile-access-token"},
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("LANGSMITH_CONFIG_FILE", str(config_path))
+
+    client = Client(auto_batch_tracing=False)
+
+    assert client.api_key is None
+    assert client._headers["Authorization"] == "Bearer profile-access-token"
+    assert "x-api-key" not in client._headers
+
+
+def test_profile_config_env_auth_suppresses_profile_auth(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path
+) -> None:
+    _clear_profile_env(monkeypatch)
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "profiles": {
+                    "default": {
+                        "api_key": "profile-key",
+                        "api_url": "https://profile.example.com",
+                        "workspace_id": "workspace-id",
+                        "oauth": {"access_token": "profile-access-token"},
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("LANGSMITH_CONFIG_FILE", str(config_path))
+    monkeypatch.setenv("LANGSMITH_API_KEY", "env-key")
+    _clear_env_cache()
+
+    client = Client(auto_batch_tracing=False)
+
+    assert client.api_url == "https://profile.example.com"
+    assert client.workspace_id == "workspace-id"
+    assert client.api_key == "env-key"
+    assert client._headers["x-api-key"] == "env-key"
+    assert "Authorization" not in client._headers
+
+
+def test_profile_config_constructor_auth_suppresses_profile_auth(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path
+) -> None:
+    _clear_profile_env(monkeypatch)
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "profiles": {
+                    "default": {
+                        "api_key": "profile-key",
+                        "api_url": "https://profile.example.com",
+                        "oauth": {
+                            "access_token": "old-access-token",
+                            "refresh_token": "old-refresh-token",
+                            "expires_at": "2000-01-01T00:00:00Z",
+                        },
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("LANGSMITH_CONFIG_FILE", str(config_path))
+    mock_post = mock.Mock()
+    monkeypatch.setattr(requests, "post", mock_post)
+
+    client = Client(api_key="constructor-key", auto_batch_tracing=False)
+
+    assert client.api_url == "https://profile.example.com"
+    assert client.api_key == "constructor-key"
+    assert client._headers["x-api-key"] == "constructor-key"
+    assert "Authorization" not in client._headers
+    mock_post.assert_not_called()
+
+
+def test_profile_config_refreshes_expired_oauth_token(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path
+) -> None:
+    _clear_profile_env(monkeypatch)
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "profiles": {
+                    "default": {
+                        "api_url": "https://profile.example.com",
+                        "oauth": {
+                            "access_token": "old-access-token",
+                            "refresh_token": "old-refresh-token",
+                            "expires_at": "2000-01-01T00:00:00Z",
+                        },
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("LANGSMITH_CONFIG_FILE", str(config_path))
+    calls = []
+
+    def mock_post(url: str, **kwargs: object) -> mock.Mock:
+        calls.append((url, kwargs))
+        response = mock.Mock()
+        response.status_code = 200
+        response.json.return_value = {
+            "access_token": "new-access-token",
+            "refresh_token": "new-refresh-token",
+            "expires_in": 300,
+        }
+        return response
+
+    monkeypatch.setattr(requests, "post", mock_post)
+
+    client = Client(auto_batch_tracing=False)
+
+    assert client._headers["Authorization"] == "Bearer new-access-token"
+    assert calls[0][0] == "https://profile.example.com/oauth/token"
+    assert calls[0][1]["data"] == {
+        "grant_type": "refresh_token",
+        "client_id": "langsmith-cli",
+        "refresh_token": "old-refresh-token",
+    }
+    updated = json.loads(config_path.read_text(encoding="utf-8"))
+    assert updated["profiles"]["default"]["oauth"]["access_token"] == "new-access-token"
+    assert (
+        updated["profiles"]["default"]["oauth"]["refresh_token"] == "new-refresh-token"
+    )
+    assert "token_type" not in updated["profiles"]["default"]["oauth"]
+    assert "bearer_token" not in updated["profiles"]["default"]
+
+
 def test_validate_multiple_urls() -> None:
     """Test URL validation without environment variable manipulation."""
     _clear_env_cache()


### PR DESCRIPTION
## Summary

Adds LangSmith profile loading to the Python sync and async clients.

- Loads the active profile from `LANGSMITH_CONFIG_FILE` or `~/.langsmith/config.json`
- Selects profiles with `LANGSMITH_PROFILE`, then `current_profile`, then `default`
- Applies profile `api_url`, `workspace_id`, OAuth access tokens, and API keys when explicit/env auth is not set
- Extracts profile parsing and auth refresh logic into `langsmith._internal._profiles`
- Refreshes expired OAuth profile tokens before requests and writes refreshed token fields back to the profile file
- Uses the selected profile's `api_url` for OAuth refresh, even when the client endpoint is overridden
- Reconciles stale profile-managed auth headers after refresh so snapshotted request headers do not send expired OAuth tokens

## Auth precedence

Explicit constructor auth and environment auth take precedence over profile auth. Profile OAuth is preferred over profile `api_key` when profile auth is used. Existing `LANGCHAIN_*` aliases continue to work for existing env vars, but new profile-specific config uses `LANGSMITH_CONFIG_FILE` and `LANGSMITH_PROFILE` only.

## Verification

- `uv run ruff check python/langsmith/client.py python/langsmith/async_client.py python/langsmith/_internal/_profiles.py python/tests/unit_tests/test_client.py python/tests/unit_tests/test_async_client.py`
- `uv run ruff format --check python/langsmith/client.py python/langsmith/async_client.py python/langsmith/_internal/_profiles.py python/tests/unit_tests/test_client.py python/tests/unit_tests/test_async_client.py`
- `PYTHONPATH=python uv run python /private/tmp/profile_auth_regression_check.py`

Not run: targeted pytest, because this local test environment is missing `vcr` (`ModuleNotFoundError: No module named 'vcr'`).
