### PR TITLE
Extract JS profile auth service

### DIFF
--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -91,6 +91,13 @@ import {
   _shouldStreamForGlobalFetchImplementation,
   _getFetchImplementation,
 } from "./singletons/fetch.js";
+import {
+  DEFAULT_API_URL,
+  type ProfileAuthHeader,
+  ProfileAuth,
+  hasValue,
+  loadProfileClientConfig,
+} from "./utils/profiles.js";
 
 import {
   serialize as serializePayloadForTracing,
@@ -475,31 +482,6 @@ interface FeedbackUpdate {
   comment?: string | null;
 }
 
-type LangSmithProfileOAuth = {
-  access_token?: string;
-  refresh_token?: string;
-  expires_at?: string;
-};
-
-type LangSmithProfile = {
-  api_key?: string;
-  api_url?: string;
-  workspace_id?: string;
-  oauth?: LangSmithProfileOAuth;
-};
-
-type LangSmithProfileConfigFile = {
-  current_profile?: string;
-  profiles?: Record<string, LangSmithProfile>;
-};
-
-type LangSmithProfileState = {
-  configPath: string;
-  config: LangSmithProfileConfigFile;
-  profileName: string;
-  profile: LangSmithProfile;
-};
-
 type DefaultClientConfig = {
   apiUrl: string;
   apiKey?: string;
@@ -509,7 +491,8 @@ type DefaultClientConfig = {
   hideMetadata?: boolean;
   workspaceId?: string;
   oauthAccessToken?: string;
-  profileState?: LangSmithProfileState;
+  oauthRefreshToken?: string;
+  profileAuth?: ProfileAuth;
 };
 
 interface CreateRunParams {
@@ -722,157 +705,6 @@ const SERVER_INFO_REQUEST_TIMEOUT_MS = 10000;
 /** Maximum number of operations to batch in a single request. */
 const DEFAULT_BATCH_SIZE_LIMIT = 100;
 
-const DEFAULT_API_URL = "https://api.smith.langchain.com";
-const OAUTH_CLIENT_ID = "langsmith-cli";
-const TOKEN_REFRESH_LEEWAY_MS = 60_000;
-const TOKEN_REFRESH_TIMEOUT_MS = 10_000;
-
-function isBrowserLikeRuntime(): boolean {
-  const env = getEnv();
-  return env === "browser" || env === "webworker";
-}
-
-function getProfileConfigPath(): string | undefined {
-  const explicitPath = getEnvironmentVariable("LANGSMITH_CONFIG_FILE");
-  if (explicitPath) {
-    return explicitPath;
-  }
-  const home =
-    getEnvironmentVariable("HOME") ?? getEnvironmentVariable("USERPROFILE");
-  if (!home) {
-    return undefined;
-  }
-  return fsUtils.path.join(home, ".langsmith", "config.json");
-}
-
-function resolveProfileName(
-  config: LangSmithProfileConfigFile,
-): string | undefined {
-  const envProfile = getEnvironmentVariable("LANGSMITH_PROFILE");
-  if (envProfile) {
-    return envProfile;
-  }
-  if (config.current_profile) {
-    return config.current_profile;
-  }
-  if (config.profiles?.default) {
-    return "default";
-  }
-  return undefined;
-}
-
-function loadProfileState(): LangSmithProfileState | undefined {
-  if (isBrowserLikeRuntime()) {
-    return undefined;
-  }
-  const configPath = getProfileConfigPath();
-  if (!configPath || !fsUtils.existsSync(configPath)) {
-    return undefined;
-  }
-  try {
-    const config = JSON.parse(
-      fsUtils.readFileSync(configPath),
-    ) as LangSmithProfileConfigFile;
-    const profileName = resolveProfileName(config);
-    const profile = profileName ? config.profiles?.[profileName] : undefined;
-    if (!profileName || !profile) {
-      return undefined;
-    }
-    return { configPath, config, profileName, profile };
-  } catch {
-    return undefined;
-  }
-}
-
-function hasValue(value?: string): boolean {
-  return value !== undefined && value.trim() !== "";
-}
-
-function shouldRefreshProfileToken(profile: LangSmithProfile): boolean {
-  const oauth = profile.oauth;
-  if (!oauth?.refresh_token) {
-    return false;
-  }
-  if (!oauth.access_token) {
-    return true;
-  }
-  if (!oauth.expires_at) {
-    return false;
-  }
-  const expiresAt = Date.parse(oauth.expires_at);
-  if (Number.isNaN(expiresAt)) {
-    return false;
-  }
-  return expiresAt <= Date.now() + TOKEN_REFRESH_LEEWAY_MS;
-}
-
-function normalizeConfigUrl(apiUrl: string): string {
-  let normalized = apiUrl;
-  while (normalized.endsWith("/")) {
-    normalized = normalized.slice(0, -1);
-  }
-  const apiV1Suffix = "/api/v1";
-  return normalized.endsWith(apiV1Suffix)
-    ? normalized.slice(0, -apiV1Suffix.length)
-    : normalized;
-}
-
-function applyTokenResponse(
-  profile: LangSmithProfile,
-  token: {
-    access_token?: string;
-    refresh_token?: string;
-    expires_in?: number;
-  },
-): void {
-  profile.oauth ??= {};
-  if (token.access_token) {
-    profile.oauth.access_token = token.access_token;
-  }
-  if (token.refresh_token) {
-    profile.oauth.refresh_token = token.refresh_token;
-  }
-  if (typeof token.expires_in === "number" && token.expires_in > 0) {
-    profile.oauth.expires_at = new Date(
-      Date.now() + token.expires_in * 1000,
-    ).toISOString();
-  }
-}
-
-function getAbortReason(signal: AbortSignal): unknown {
-  return (
-    (signal as AbortSignal & { reason?: unknown }).reason ??
-    new Error("The operation was aborted.")
-  );
-}
-
-async function waitForAbortSignal<T>(
-  promise: Promise<T>,
-  signal?: AbortSignal | null,
-): Promise<T> {
-  if (!signal) {
-    return promise;
-  }
-  if (signal.aborted) {
-    throw getAbortReason(signal);
-  }
-  let cleanup: (() => void) | undefined;
-  const abortPromise = new Promise<never>((_, reject) => {
-    const onAbort = () => {
-      reject(getAbortReason(signal));
-    };
-    signal.addEventListener("abort", onAbort, { once: true });
-    cleanup = () => {
-      signal.removeEventListener("abort", onAbort);
-    };
-  });
-  try {
-    return await Promise.race([promise, abortPromise]);
-  } finally {
-    cleanup?.();
-  }
-}
-
 export class AutoBatchQueue {
   items: {
     action: "create" | "update";
@@ -987,8 +819,6 @@ export class AutoBatchQueue {
 export class Client implements LangSmithTracingClientInterface {
   private apiKey?: string;
 
-  private oauthAccessToken?: string;
-
   private apiUrl: string;
 
   private webUrl?: string;
@@ -1068,126 +898,90 @@ export class Client implements LangSmithTracingClientInterface {
 
   private _promptCache?: PromptCache;
 
-  private profileState?: LangSmithProfileState;
-
-  private profileRefreshPromise?: Promise<void>;
+  private profileAuth?: ProfileAuth;
 
   private get _fetch(): typeof fetch {
     const fetchImplementation =
       this.fetchImplementation || _getFetchImplementation(this.debug);
-    return ((input: RequestInfo | URL, init?: RequestInit) => {
-      if (!this.needsProfileOAuthRefresh()) {
-        return fetchImplementation(input, this.applyCurrentAuthHeaders(init));
+    return (async (input: RequestInfo | URL, init?: RequestInit) => {
+      let authHeader: ProfileAuthHeader | undefined;
+      if (this.apiKey !== undefined) {
+        authHeader = { name: "x-api-key", value: `${this.apiKey}` };
+      } else if (!this.hasExplicitAuthHeader(init)) {
+        authHeader = await this.profileAuth?.getAuthHeader(
+          fetchImplementation,
+          init?.signal,
+        );
       }
-      return (async () => {
-        await this.ensureProfileOAuthToken(init?.signal);
-        return fetchImplementation(input, this.applyCurrentAuthHeaders(init));
-      })();
+      return fetchImplementation(
+        input,
+        this.applyCurrentAuthHeaders(init, authHeader),
+      );
     }) as typeof fetch;
   }
 
-  private needsProfileOAuthRefresh(): boolean {
-    if (
-      this.apiKey ||
-      !this.profileState ||
-      !shouldRefreshProfileToken(this.profileState.profile)
-    ) {
+  private hasExplicitAuthHeader(init?: RequestInit): boolean {
+    if (!init?.headers) {
       return false;
     }
-    return true;
+    const headers = new Headers(init.headers);
+    if (hasValue(headers.get("x-api-key"))) {
+      return true;
+    }
+    const authorization = headers.get("Authorization");
+    if (!hasValue(authorization)) {
+      return false;
+    }
+    return !this.profileAuth?.isProfileAuthorizationHeader(authorization ?? "");
   }
 
-  private async ensureProfileOAuthToken(
-    signal?: AbortSignal | null,
-  ): Promise<void> {
-    if (!this.needsProfileOAuthRefresh()) {
-      return;
-    }
-    if (!this.profileRefreshPromise) {
-      this.profileRefreshPromise = this.refreshProfileOAuthToken().finally(
-        () => {
-          this.profileRefreshPromise = undefined;
-        },
-      );
-    }
-    await waitForAbortSignal(this.profileRefreshPromise, signal);
-    if (!this.oauthAccessToken && this.profileState?.profile.api_key) {
-      this.apiKey = trimQuotes(this.profileState.profile.api_key);
-      this.profileState = undefined;
-    }
-  }
-
-  private async refreshProfileOAuthToken(): Promise<void> {
-    const refreshToken = this.profileState?.profile.oauth?.refresh_token;
-    if (!this.profileState || !refreshToken) {
-      return;
-    }
-    const refreshApiUrl =
-      trimQuotes(this.profileState.profile.api_url) ?? DEFAULT_API_URL;
-    try {
-      const fetchImplementation =
-        this.fetchImplementation || _getFetchImplementation(this.debug);
-      const body = new URLSearchParams({
-        grant_type: "refresh_token",
-        client_id: OAUTH_CLIENT_ID,
-        refresh_token: refreshToken,
-      });
-      const response = await fetchImplementation(
-        `${normalizeConfigUrl(refreshApiUrl)}/oauth/token`,
-        {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/x-www-form-urlencoded",
-          },
-          body: body.toString(),
-          signal: AbortSignal.timeout(TOKEN_REFRESH_TIMEOUT_MS),
-        },
-      );
-      if (!response.ok) {
-        return;
-      }
-      const token = (await response.json()) as {
-        access_token?: string;
-        refresh_token?: string;
-        expires_in?: number;
-      };
-      if (!token.access_token) {
-        return;
-      }
-      applyTokenResponse(this.profileState.profile, token);
-      this.oauthAccessToken = this.profileState.profile.oauth?.access_token;
-      this.profileState.config.profiles ??= {};
-      this.profileState.config.profiles[this.profileState.profileName] =
-        this.profileState.profile;
-      await fsUtils.writeFileAtomic(
-        this.profileState.configPath,
-        `${JSON.stringify(this.profileState.config, null, 2)}\n`,
-      );
-    } catch {
-      return;
-    }
-  }
-
-  private applyCurrentAuthHeaders(init?: RequestInit): RequestInit | undefined {
-    if (!this.apiKey && !this.oauthAccessToken) {
+  private applyCurrentAuthHeaders(
+    init?: RequestInit,
+    authHeader?: ProfileAuthHeader,
+  ): RequestInit | undefined {
+    if (!authHeader) {
       return init;
     }
     const applyAuth = (headers: Headers): Headers => {
-      if (this.apiKey) {
+      if (this.apiKey !== undefined && authHeader.name === "x-api-key") {
         headers.delete("Authorization");
         if (!headers.has("x-api-key")) {
-          headers.set("x-api-key", `${this.apiKey}`);
+          headers.set("x-api-key", authHeader.value);
         }
-      } else if (this.oauthAccessToken && !headers.has("x-api-key")) {
-        headers.set("Authorization", `Bearer ${this.oauthAccessToken}`);
+        return headers;
+      }
+      if (authHeader.name === "Authorization") {
+        if (hasValue(headers.get("x-api-key"))) {
+          return headers;
+        }
+        const authorization = headers.get("Authorization");
+        if (
+          hasValue(authorization) &&
+          !this.profileAuth?.isProfileAuthorizationHeader(authorization ?? "")
+        ) {
+          return headers;
+        }
+        headers.set("Authorization", authHeader.value);
+        return headers;
+      }
+      const authorization = headers.get("Authorization");
+      if (
+        hasValue(authorization) &&
+        !this.profileAuth?.isProfileAuthorizationHeader(authorization ?? "")
+      ) {
+        return headers;
+      }
+      if (hasValue(authorization)) {
+        headers.delete("Authorization");
+      }
+      if (!headers.has("x-api-key")) {
+        headers.set("x-api-key", authHeader.value);
       }
       return headers;
     };
     if (!init) {
       return {
-        headers: this.apiKey
-          ? { "x-api-key": `${this.apiKey}` }
-          : { Authorization: `Bearer ${this.oauthAccessToken}` },
+        headers: { [authHeader.name]: authHeader.value },
       };
     }
     if (init.headers instanceof Headers) {
@@ -1199,24 +993,45 @@ export class Client implements LangSmithTracingClientInterface {
     const headers = {
       ...((init.headers ?? {}) as Record<string, string>),
     };
-    if (this.apiKey) {
-      const hasApiKey = Object.keys(headers).some(
-        (key) => key.toLowerCase() === "x-api-key" && hasValue(headers[key]),
-      );
-      for (const key of Object.keys(headers)) {
-        if (key.toLowerCase() === "authorization") {
-          delete headers[key];
+    const getHeaderKey = (name: string) =>
+      Object.keys(headers).find((key) => key.toLowerCase() === name);
+    const getHeader = (name: string) => {
+      const key = getHeaderKey(name);
+      return key ? headers[key] : undefined;
+    };
+    const hasApiKey = hasValue(getHeader("x-api-key"));
+    const authorization = getHeader("authorization");
+    const hasExplicitAuthorization =
+      hasValue(authorization) &&
+      !this.profileAuth?.isProfileAuthorizationHeader(authorization ?? "");
+
+    if (this.apiKey !== undefined && authHeader.name === "x-api-key") {
+      const authorizationKey = getHeaderKey("authorization");
+      if (authorizationKey) {
+        delete headers[authorizationKey];
+      }
+      if (!hasApiKey) {
+        headers["x-api-key"] = authHeader.value;
+      }
+      return { ...init, headers };
+    }
+    if (authHeader.name === "Authorization") {
+      if (!hasApiKey && !hasExplicitAuthorization) {
+        const authorizationKey = getHeaderKey("authorization");
+        if (authorizationKey && authorizationKey !== "Authorization") {
+          delete headers[authorizationKey];
         }
+        headers.Authorization = authHeader.value;
+      }
+      return { ...init, headers };
+    }
+    if (!hasExplicitAuthorization) {
+      const authorizationKey = getHeaderKey("authorization");
+      if (authorizationKey) {
+        delete headers[authorizationKey];
       }
       if (!hasApiKey) {
-        headers["x-api-key"] = `${this.apiKey}`;
-      }
-    } else if (this.oauthAccessToken) {
-      const hasApiKey = Object.keys(headers).some(
-        (key) => key.toLowerCase() === "x-api-key" && hasValue(headers[key]),
-      );
-      if (!hasApiKey) {
-        headers.Authorization = `Bearer ${this.oauthAccessToken}`;
+        headers["x-api-key"] = authHeader.value;
       }
     }
     return { ...init, headers };
@@ -1304,13 +1119,10 @@ export class Client implements LangSmithTracingClientInterface {
       this.apiUrl = this.apiUrl.slice(0, -1);
     }
 
-    this.apiKey = trimQuotes(config.apiKey ?? defaultConfig.apiKey);
-    this.oauthAccessToken =
-      this.apiKey !== undefined
-        ? undefined
-        : trimQuotes(defaultConfig.oauthAccessToken);
-    this.profileState =
-      this.apiKey !== undefined ? undefined : defaultConfig.profileState;
+    const configuredApiKey = trimQuotes(config.apiKey ?? defaultConfig.apiKey);
+    this.apiKey = hasValue(configuredApiKey) ? configuredApiKey : undefined;
+    this.profileAuth =
+      this.apiKey !== undefined ? undefined : defaultConfig.profileAuth;
     this.webUrl = trimQuotes(config.webUrl ?? defaultConfig.webUrl);
     if (this.webUrl?.endsWith("/")) {
       this.webUrl = this.webUrl.slice(0, -1);
@@ -1415,21 +1227,13 @@ export class Client implements LangSmithTracingClientInterface {
   }
 
   public static getDefaultClientConfig(): DefaultClientConfig {
-    const profileState = loadProfileState();
-    const profile = profileState?.profile;
+    const profileConfig = loadProfileClientConfig();
     const envApiKey = getLangSmithEnvironmentVariable("API_KEY");
     const envApiUrl = getLangSmithEnvironmentVariable("ENDPOINT");
     const envWorkspaceId = getLangSmithEnvironmentVariable("WORKSPACE_ID");
     const envAuthSet = hasValue(envApiKey);
-    const profileOAuthAccessToken = profile?.oauth?.access_token;
-    const hasProfileOAuth = Boolean(
-      profile?.oauth?.access_token || profile?.oauth?.refresh_token,
-    );
-    const apiKey =
-      envApiKey ??
-      (!envAuthSet && hasProfileOAuth ? undefined : profile?.api_key);
-    const apiUrl = envApiUrl ?? profile?.api_url ?? DEFAULT_API_URL;
-    const workspaceId = envWorkspaceId ?? profile?.workspace_id;
+    const apiUrl = envApiUrl ?? profileConfig.apiUrl ?? DEFAULT_API_URL;
+    const workspaceId = envWorkspaceId ?? profileConfig.workspaceId;
     const hideInputs =
       getLangSmithEnvironmentVariable("HIDE_INPUTS") === "true";
     const hideOutputs =
@@ -1438,18 +1242,19 @@ export class Client implements LangSmithTracingClientInterface {
       getLangSmithEnvironmentVariable("HIDE_METADATA") === "true";
     return {
       apiUrl: apiUrl,
-      apiKey: apiKey,
+      apiKey: envApiKey,
       webUrl: undefined,
       hideInputs: hideInputs,
       hideOutputs: hideOutputs,
       hideMetadata: hideMetadata,
       workspaceId: workspaceId,
-      oauthAccessToken:
-        !envAuthSet && !apiKey ? profileOAuthAccessToken : undefined,
-      profileState:
-        !envAuthSet && !apiKey && hasProfileOAuth && profileState
-          ? profileState
-          : undefined,
+      oauthAccessToken: !envAuthSet
+        ? profileConfig.oauthAccessToken
+        : undefined,
+      oauthRefreshToken: !envAuthSet
+        ? profileConfig.oauthRefreshToken
+        : undefined,
+      profileAuth: !envAuthSet ? profileConfig.profileAuth : undefined,
     };
   }
 
@@ -1496,10 +1301,13 @@ export class Client implements LangSmithTracingClientInterface {
       ...this._customHeaders,
     };
     // Required headers that should not be overridden
-    if (this.apiKey) {
+    if (this.apiKey !== undefined) {
       headers["x-api-key"] = `${this.apiKey}`;
-    } else if (this.oauthAccessToken) {
-      headers["Authorization"] = `Bearer ${this.oauthAccessToken}`;
+    } else {
+      const profileAuthHeader = this.profileAuth?.currentAuthHeader();
+      if (profileAuthHeader) {
+        headers[profileAuthHeader.name] = profileAuthHeader.value;
+      }
     }
     if (this.workspaceId) {
       headers["x-tenant-id"] = this.workspaceId;

--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -905,9 +905,13 @@ export class Client implements LangSmithTracingClientInterface {
       this.fetchImplementation || _getFetchImplementation(this.debug);
     return (async (input: RequestInfo | URL, init?: RequestInit) => {
       let authHeader: ProfileAuthHeader | undefined;
+      const profileManagedAuthorization =
+        this.getProfileManagedAuthorizationHeader(init);
       if (this.apiKey !== undefined) {
         authHeader = { name: "x-api-key", value: `${this.apiKey}` };
-      } else if (!this.hasExplicitAuthHeader(init)) {
+      } else if (
+        !this.hasExplicitAuthHeader(init, profileManagedAuthorization)
+      ) {
         authHeader = await this.profileAuth?.getAuthHeader(
           fetchImplementation,
           init?.signal,
@@ -915,12 +919,44 @@ export class Client implements LangSmithTracingClientInterface {
       }
       return fetchImplementation(
         input,
-        this.applyCurrentAuthHeaders(init, authHeader),
+        this.applyCurrentAuthHeaders(
+          init,
+          authHeader,
+          profileManagedAuthorization,
+        ),
       );
     }) as typeof fetch;
   }
 
-  private hasExplicitAuthHeader(init?: RequestInit): boolean {
+  private getProfileManagedAuthorizationHeader(
+    init?: RequestInit,
+  ): string | undefined {
+    if (!init?.headers || !this.profileAuth) {
+      return undefined;
+    }
+    const authorization = new Headers(init.headers).get("Authorization");
+    if (!hasValue(authorization)) {
+      return undefined;
+    }
+    return this.profileAuth.isProfileAuthorizationHeader(authorization ?? "")
+      ? (authorization ?? undefined)
+      : undefined;
+  }
+
+  private isProfileManagedAuthorizationHeader(
+    value: string,
+    profileManagedAuthorization?: string,
+  ): boolean {
+    return (
+      value === profileManagedAuthorization ||
+      this.profileAuth?.isProfileAuthorizationHeader(value) === true
+    );
+  }
+
+  private hasExplicitAuthHeader(
+    init?: RequestInit,
+    profileManagedAuthorization?: string,
+  ): boolean {
     if (!init?.headers) {
       return false;
     }
@@ -932,12 +968,16 @@ export class Client implements LangSmithTracingClientInterface {
     if (!hasValue(authorization)) {
       return false;
     }
-    return !this.profileAuth?.isProfileAuthorizationHeader(authorization ?? "");
+    return !this.isProfileManagedAuthorizationHeader(
+      authorization ?? "",
+      profileManagedAuthorization,
+    );
   }
 
   private applyCurrentAuthHeaders(
     init?: RequestInit,
     authHeader?: ProfileAuthHeader,
+    profileManagedAuthorization?: string,
   ): RequestInit | undefined {
     if (!authHeader) {
       return init;
@@ -957,7 +997,10 @@ export class Client implements LangSmithTracingClientInterface {
         const authorization = headers.get("Authorization");
         if (
           hasValue(authorization) &&
-          !this.profileAuth?.isProfileAuthorizationHeader(authorization ?? "")
+          !this.isProfileManagedAuthorizationHeader(
+            authorization ?? "",
+            profileManagedAuthorization,
+          )
         ) {
           return headers;
         }
@@ -967,7 +1010,10 @@ export class Client implements LangSmithTracingClientInterface {
       const authorization = headers.get("Authorization");
       if (
         hasValue(authorization) &&
-        !this.profileAuth?.isProfileAuthorizationHeader(authorization ?? "")
+        !this.isProfileManagedAuthorizationHeader(
+          authorization ?? "",
+          profileManagedAuthorization,
+        )
       ) {
         return headers;
       }
@@ -1003,7 +1049,10 @@ export class Client implements LangSmithTracingClientInterface {
     const authorization = getHeader("authorization");
     const hasExplicitAuthorization =
       hasValue(authorization) &&
-      !this.profileAuth?.isProfileAuthorizationHeader(authorization ?? "");
+      !this.isProfileManagedAuthorizationHeader(
+        authorization ?? "",
+        profileManagedAuthorization,
+      );
 
     if (this.apiKey !== undefined && authHeader.name === "x-api-key") {
       const authorizationKey = getHeaderKey("authorization");

--- a/js/src/tests/client.test.ts
+++ b/js/src/tests/client.test.ts
@@ -119,7 +119,7 @@ describe("Client", () => {
       process.env = originalEnv;
     });
 
-    it("loads api URL, API key, and workspace from the active profile", () => {
+    it("loads api URL, API key header, and workspace from the active profile", () => {
       writeProfileConfig({
         current_profile: "prod",
         profiles: {
@@ -134,7 +134,7 @@ describe("Client", () => {
       const client = new Client();
 
       expect((client as any).apiUrl).toBe("https://profile.example.com");
-      expect((client as any).apiKey).toBe("profile-key");
+      expect((client as any).apiKey).toBeUndefined();
       expect((client as any).workspaceId).toBe("workspace-id");
       expect((client as any)._mergedHeaders["x-api-key"]).toBe("profile-key");
       expect((client as any)._mergedHeaders["x-tenant-id"]).toBe(
@@ -278,6 +278,40 @@ describe("Client", () => {
       );
       expect(updated.profiles.default.oauth).not.toHaveProperty("token_type");
       expect(updated.profiles.default).not.toHaveProperty("bearer_token");
+    });
+
+    it("preserves explicit Authorization headers during profile refresh", async () => {
+      writeProfileConfig({
+        profiles: {
+          default: {
+            api_url: "https://profile.example.com",
+            oauth: {
+              access_token: "old-access-token",
+              refresh_token: "old-refresh-token",
+              expires_at: new Date(Date.now() - 60_000).toISOString(),
+            },
+          },
+        },
+      });
+      const mockFetch = jest.fn(
+        async () => new Response("{}", { status: 200 }),
+      );
+      const client = new Client({ fetchImplementation: mockFetch as any });
+
+      await (client as any)._fetch("https://profile.example.com/info", {
+        headers: {
+          Authorization: "Bearer explicit-token",
+        },
+      });
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      const [[requestUrl, requestInit]] = mockFetch.mock.calls as unknown as [
+        [RequestInfo | URL, RequestInit | undefined],
+      ];
+      expect(String(requestUrl)).toBe("https://profile.example.com/info");
+      expect(requestInit?.headers).toMatchObject({
+        Authorization: "Bearer explicit-token",
+      });
     });
 
     it("refreshes profile OAuth tokens against profile api_url", async () => {

--- a/js/src/utils/profiles.ts
+++ b/js/src/utils/profiles.ts
@@ -221,7 +221,7 @@ export function loadProfileClientConfig(): ProfileClientConfig {
 export class ProfileAuth {
   private refreshPromise?: Promise<void>;
 
-  private managedAuthorizationValues = new Set<string>();
+  private managedAuthorizationValue?: string;
 
   constructor(private state: LangSmithProfileState) {
     this.rememberProfileAuthHeader(this.currentAuthHeader());
@@ -253,7 +253,7 @@ export class ProfileAuth {
   }
 
   isProfileAuthorizationHeader(value: string): boolean {
-    return this.managedAuthorizationValues.has(value);
+    return value === this.managedAuthorizationValue;
   }
 
   private async refreshOAuthToken(
@@ -308,9 +308,8 @@ export class ProfileAuth {
   private rememberProfileAuthHeader(
     header: ProfileAuthHeader | undefined,
   ): void {
-    if (header?.name === "Authorization") {
-      this.managedAuthorizationValues.add(header.value);
-    }
+    this.managedAuthorizationValue =
+      header?.name === "Authorization" ? header.value : undefined;
   }
 }
 

--- a/js/src/utils/profiles.ts
+++ b/js/src/utils/profiles.ts
@@ -1,0 +1,342 @@
+import { getEnv, getEnvironmentVariable } from "./env.js";
+import * as fsUtils from "./fs.js";
+
+export const DEFAULT_API_URL = "https://api.smith.langchain.com";
+
+const OAUTH_CLIENT_ID = "langsmith-cli";
+const TOKEN_REFRESH_LEEWAY_MS = 60_000;
+const TOKEN_REFRESH_TIMEOUT_MS = 10_000;
+
+type LangSmithProfileOAuth = {
+  access_token?: string;
+  refresh_token?: string;
+  expires_at?: string;
+};
+
+type LangSmithProfile = {
+  api_key?: string;
+  api_url?: string;
+  workspace_id?: string;
+  oauth?: LangSmithProfileOAuth;
+};
+
+type LangSmithProfileConfigFile = {
+  current_profile?: string;
+  profiles?: Record<string, LangSmithProfile>;
+};
+
+type LangSmithProfileState = {
+  configPath: string;
+  config: LangSmithProfileConfigFile;
+  profileName: string;
+  profile: LangSmithProfile;
+};
+
+export type ProfileAuthHeader = {
+  name: "Authorization" | "x-api-key";
+  value: string;
+};
+
+export type ProfileClientConfig = {
+  apiUrl?: string;
+  apiKey?: string;
+  workspaceId?: string;
+  oauthAccessToken?: string;
+  oauthRefreshToken?: string;
+  profileAuth?: ProfileAuth;
+};
+
+function isBrowserLikeRuntime(): boolean {
+  const env = getEnv();
+  return env === "browser" || env === "webworker";
+}
+
+function getProfileConfigPath(): string | undefined {
+  const explicitPath = getEnvironmentVariable("LANGSMITH_CONFIG_FILE");
+  if (explicitPath) {
+    return explicitPath;
+  }
+  const home =
+    getEnvironmentVariable("HOME") ?? getEnvironmentVariable("USERPROFILE");
+  if (!home) {
+    return undefined;
+  }
+  return fsUtils.path.join(home, ".langsmith", "config.json");
+}
+
+function resolveProfileName(
+  config: LangSmithProfileConfigFile,
+): string | undefined {
+  const envProfile = getEnvironmentVariable("LANGSMITH_PROFILE");
+  if (envProfile) {
+    return envProfile;
+  }
+  if (config.current_profile) {
+    return config.current_profile;
+  }
+  if (config.profiles?.default) {
+    return "default";
+  }
+  return undefined;
+}
+
+function loadProfileState(): LangSmithProfileState | undefined {
+  if (isBrowserLikeRuntime()) {
+    return undefined;
+  }
+  const configPath = getProfileConfigPath();
+  if (!configPath || !fsUtils.existsSync(configPath)) {
+    return undefined;
+  }
+  try {
+    const config = JSON.parse(
+      fsUtils.readFileSync(configPath),
+    ) as LangSmithProfileConfigFile;
+    const profileName = resolveProfileName(config);
+    const profile = profileName ? config.profiles?.[profileName] : undefined;
+    if (!profileName || !profile) {
+      return undefined;
+    }
+    return { configPath, config, profileName, profile };
+  } catch {
+    return undefined;
+  }
+}
+
+export function hasValue(value?: string | null): boolean {
+  return value !== undefined && value !== null && value.trim() !== "";
+}
+
+function trimConfigValue(value?: string): string | undefined {
+  return value?.trim().replace(/^["']|["']$/g, "");
+}
+
+function shouldRefreshProfileToken(profile: LangSmithProfile): boolean {
+  const oauth = profile.oauth;
+  if (!oauth?.refresh_token) {
+    return false;
+  }
+  if (!oauth.access_token) {
+    return true;
+  }
+  if (!oauth.expires_at) {
+    return false;
+  }
+  const expiresAt = Date.parse(oauth.expires_at);
+  if (Number.isNaN(expiresAt)) {
+    return false;
+  }
+  return expiresAt <= Date.now() + TOKEN_REFRESH_LEEWAY_MS;
+}
+
+function normalizeConfigUrl(apiUrl: string): string {
+  let normalized = apiUrl;
+  while (normalized.endsWith("/")) {
+    normalized = normalized.slice(0, -1);
+  }
+  const apiV1Suffix = "/api/v1";
+  return normalized.endsWith(apiV1Suffix)
+    ? normalized.slice(0, -apiV1Suffix.length)
+    : normalized;
+}
+
+function applyTokenResponse(
+  profile: LangSmithProfile,
+  token: {
+    access_token?: string;
+    refresh_token?: string;
+    expires_in?: number;
+  },
+): void {
+  profile.oauth ??= {};
+  if (token.access_token) {
+    profile.oauth.access_token = token.access_token;
+  }
+  if (token.refresh_token) {
+    profile.oauth.refresh_token = token.refresh_token;
+  }
+  if (typeof token.expires_in === "number" && token.expires_in > 0) {
+    profile.oauth.expires_at = new Date(
+      Date.now() + token.expires_in * 1000,
+    ).toISOString();
+  }
+}
+
+function getAbortReason(signal: AbortSignal): unknown {
+  return (
+    (signal as AbortSignal & { reason?: unknown }).reason ??
+    new Error("The operation was aborted.")
+  );
+}
+
+async function waitForAbortSignal<T>(
+  promise: Promise<T>,
+  signal?: AbortSignal | null,
+): Promise<T> {
+  if (!signal) {
+    return promise;
+  }
+  if (signal.aborted) {
+    throw getAbortReason(signal);
+  }
+  let cleanup: (() => void) | undefined;
+  const abortPromise = new Promise<never>((_, reject) => {
+    const onAbort = () => {
+      reject(getAbortReason(signal));
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+    cleanup = () => {
+      signal.removeEventListener("abort", onAbort);
+    };
+  });
+  try {
+    return await Promise.race([promise, abortPromise]);
+  } finally {
+    cleanup?.();
+  }
+}
+
+export function loadProfileClientConfig(): ProfileClientConfig {
+  const state = loadProfileState();
+  const profile = state?.profile;
+  if (!state || !profile) {
+    return {};
+  }
+  const apiKey = trimConfigValue(profile.api_key);
+  const oauthAccessToken = trimConfigValue(profile.oauth?.access_token);
+  const oauthRefreshToken = trimConfigValue(profile.oauth?.refresh_token);
+  return {
+    apiUrl: profile.api_url,
+    apiKey,
+    workspaceId: profile.workspace_id,
+    oauthAccessToken,
+    oauthRefreshToken,
+    profileAuth:
+      apiKey || oauthAccessToken || oauthRefreshToken
+        ? new ProfileAuth(state)
+        : undefined,
+  };
+}
+
+export class ProfileAuth {
+  private refreshPromise?: Promise<void>;
+
+  private managedAuthorizationValues = new Set<string>();
+
+  constructor(private state: LangSmithProfileState) {
+    this.rememberProfileAuthHeader(this.currentAuthHeader());
+  }
+
+  currentAuthHeader(): ProfileAuthHeader | undefined {
+    const header = currentAuthHeaderFromProfile(this.state.profile);
+    this.rememberProfileAuthHeader(header);
+    return header;
+  }
+
+  async getAuthHeader(
+    fetchImplementation: typeof fetch,
+    signal?: AbortSignal | null,
+  ): Promise<ProfileAuthHeader | undefined> {
+    if (shouldRefreshProfileToken(this.state.profile)) {
+      if (!this.refreshPromise) {
+        this.refreshPromise = this.refreshOAuthToken(
+          fetchImplementation,
+        ).finally(() => {
+          this.refreshPromise = undefined;
+        });
+      }
+      await waitForAbortSignal(this.refreshPromise, signal);
+    }
+    const header = authHeaderFromProfile(this.state.profile);
+    this.rememberProfileAuthHeader(header);
+    return header;
+  }
+
+  isProfileAuthorizationHeader(value: string): boolean {
+    return this.managedAuthorizationValues.has(value);
+  }
+
+  private async refreshOAuthToken(
+    fetchImplementation: typeof fetch,
+  ): Promise<void> {
+    const refreshToken = this.state.profile.oauth?.refresh_token;
+    if (!refreshToken) {
+      return;
+    }
+    const refreshApiUrl =
+      trimConfigValue(this.state.profile.api_url) ?? DEFAULT_API_URL;
+    try {
+      const body = new URLSearchParams({
+        grant_type: "refresh_token",
+        client_id: OAUTH_CLIENT_ID,
+        refresh_token: refreshToken,
+      });
+      const response = await fetchImplementation(
+        `${normalizeConfigUrl(refreshApiUrl)}/oauth/token`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/x-www-form-urlencoded",
+          },
+          body: body.toString(),
+          signal: AbortSignal.timeout(TOKEN_REFRESH_TIMEOUT_MS),
+        },
+      );
+      if (!response.ok) {
+        return;
+      }
+      const token = (await response.json()) as {
+        access_token?: string;
+        refresh_token?: string;
+        expires_in?: number;
+      };
+      if (!token.access_token) {
+        return;
+      }
+      applyTokenResponse(this.state.profile, token);
+      this.state.config.profiles ??= {};
+      this.state.config.profiles[this.state.profileName] = this.state.profile;
+      await fsUtils.writeFileAtomic(
+        this.state.configPath,
+        `${JSON.stringify(this.state.config, null, 2)}\n`,
+      );
+    } catch {
+      return;
+    }
+  }
+
+  private rememberProfileAuthHeader(
+    header: ProfileAuthHeader | undefined,
+  ): void {
+    if (header?.name === "Authorization") {
+      this.managedAuthorizationValues.add(header.value);
+    }
+  }
+}
+
+function currentAuthHeaderFromProfile(
+  profile: LangSmithProfile,
+): ProfileAuthHeader | undefined {
+  const oauthAccessToken = trimConfigValue(profile.oauth?.access_token);
+  if (oauthAccessToken) {
+    return { name: "Authorization", value: `Bearer ${oauthAccessToken}` };
+  }
+  if (trimConfigValue(profile.oauth?.refresh_token)) {
+    return undefined;
+  }
+  return authHeaderFromProfile(profile);
+}
+
+function authHeaderFromProfile(
+  profile: LangSmithProfile,
+): ProfileAuthHeader | undefined {
+  const oauthAccessToken = trimConfigValue(profile.oauth?.access_token);
+  if (oauthAccessToken) {
+    return { name: "Authorization", value: `Bearer ${oauthAccessToken}` };
+  }
+  const apiKey = trimConfigValue(profile.api_key);
+  if (apiKey) {
+    return { name: "x-api-key", value: apiKey };
+  }
+  return undefined;
+}


### PR DESCRIPTION
## Summary
- Extract JS profile loading, auth header selection, and OAuth refresh into a dedicated profile auth service.
- Keep loaded profile config explicit for api_key, oauth_access_token, and oauth_refresh_token; refresh expired OAuth tokens before requests and persist refreshed tokens.
- Preserve explicit per-request auth while replacing stale profile-managed bearer headers, and keep profile file loading disabled in browser-like runtimes.

## Testing
- pnpm exec oxfmt --write src/client.ts src/utils/profiles.ts src/tests/client.test.ts
- pnpm run format:check
- pnpm run lint (exits 0; reports existing warnings)
- pnpm exec oxlint src/client.ts src/utils/profiles.ts src/tests/client.test.ts (exits 0; reports existing client.ts warnings)
- pnpm run check:types
- env -u LANGSMITH_API_KEY -u LANGCHAIN_API_KEY -u LANGSMITH_ENDPOINT -u LANGCHAIN_ENDPOINT -u LANGSMITH_WORKSPACE_ID -u LANGCHAIN_WORKSPACE_ID -u LANGSMITH_PROFILE LANGSMITH_CONFIG_FILE=/nonexistent/path/config.json pnpm test:single -- src/tests/client.test.ts --runInBand
- pnpm run build:esm
- pnpm test (in js/internal/environment_tests/test-exports-esbuild)
- local profile smoke against /info: 200