### PR TITLE
Bump JS SDK version to 0.6.1

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langsmith",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Client library to connect to the LangSmith Observability and Evaluation Platform.",
   "packageManager": "pnpm@10.33.0",
   "files": [

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -32,4 +32,4 @@ export {
 } from "./utils/prompt_cache/index.js";
 
 // Update using pnpm bump-version
-export const __version__ = "0.6.0";
+export const __version__ = "0.6.1";


### PR DESCRIPTION
## Summary
- Bump JS SDK package version to 0.6.1.
- Keep exported __version__ in sync.

## Testing
- pnpm run check-version