### PR TITLE
fix(js/sandbox): avoid cloning consumed error responses

### DIFF
--- a/js/src/experimental/sandbox/helpers.ts
+++ b/js/src/experimental/sandbox/helpers.ts
@@ -185,6 +185,7 @@ export async function handleSandboxCreationError(
   response: Response
 ): Promise<never> {
   const status = response.status;
+  const clonedResponse = response.clone();
   const data = await parseErrorResponse(response);
 
   if (status === 408) {
@@ -192,7 +193,6 @@ export async function handleSandboxCreationError(
     throw new LangSmithResourceTimeoutError(data.message, "sandbox");
   } else if (status === 422) {
     // Check if this is a Pydantic validation error (bad input) vs creation error
-    const clonedResponse = response.clone();
     const details = await parseValidationError(clonedResponse);
     if (details.length > 0 && details.some((d) => d.type === "value_error")) {
       // Pydantic validation error (bad input - exceeds server limits)
@@ -213,8 +213,8 @@ export async function handleSandboxCreationError(
       data.errorType || "Unschedulable"
     );
   }
-  // Fall through to generic handling
-  return handleClientHttpError(response);
+  // Fall through to generic handling — pass clone since body is already consumed
+  return handleClientHttpError(clonedResponse);
 }
 
 /**
@@ -230,6 +230,7 @@ export async function handleVolumeCreationError(
   response: Response
 ): Promise<never> {
   const status = response.status;
+  const clonedResponse = response.clone();
   const data = await parseErrorResponse(response);
 
   if (status === 429) {
@@ -243,8 +244,8 @@ export async function handleVolumeCreationError(
     // Timeout - volume didn't become ready in time
     throw new LangSmithResourceTimeoutError(data.message, "volume");
   }
-  // Fall through to generic handling
-  return handleClientHttpError(response);
+  // Fall through to generic handling — pass clone since body is already consumed
+  return handleClientHttpError(clonedResponse);
 }
 
 /**
@@ -259,6 +260,7 @@ export async function handleVolumeCreationError(
  */
 export async function handlePoolError(response: Response): Promise<never> {
   const status = response.status;
+  const clonedResponse = response.clone();
   const data = await parseErrorResponse(response);
   const errorType = data.errorType;
 
@@ -287,8 +289,8 @@ export async function handlePoolError(response: Response): Promise<never> {
     // Timeout waiting for pool to be ready
     throw new LangSmithResourceTimeoutError(data.message, "pool");
   }
-  // Fall through to generic handling
-  return handleClientHttpError(response);
+  // Fall through to generic handling — pass clone since body is already consumed
+  return handleClientHttpError(clonedResponse);
 }
 
 /**
@@ -297,6 +299,7 @@ export async function handlePoolError(response: Response): Promise<never> {
 export async function handleClientHttpError(
   response: Response
 ): Promise<never> {
+  const clonedResponse = response.clone();
   const data = await parseErrorResponse(response);
   const message = data.message;
   const errorType = data.errorType;
@@ -311,7 +314,6 @@ export async function handleClientHttpError(
 
   // Handle validation errors (invalid resource values, formats, etc.)
   if (status === 422) {
-    const clonedResponse = response.clone();
     const details = await parseValidationError(clonedResponse);
     const field = details[0]?.loc?.slice(-1)[0] as string | undefined;
     throw new LangSmithValidationError(message, field, details);

--- a/js/src/experimental/sandbox/helpers.ts
+++ b/js/src/experimental/sandbox/helpers.ts
@@ -299,11 +299,13 @@ export async function handlePoolError(response: Response): Promise<never> {
 export async function handleClientHttpError(
   response: Response
 ): Promise<never> {
-  const clonedResponse = response.clone();
+  const status = response.status;
+  // Only clone when we need to read the body twice (status 422 reads it again
+  // for structured validation details after parseErrorResponse consumes it).
+  const clonedResponse = status === 422 ? response.clone() : null;
   const data = await parseErrorResponse(response);
   const message = data.message;
   const errorType = data.errorType;
-  const status = response.status;
 
   if (status === 401 || status === 403) {
     throw new LangSmithSandboxAuthenticationError(message);
@@ -313,7 +315,7 @@ export async function handleClientHttpError(
   }
 
   // Handle validation errors (invalid resource values, formats, etc.)
-  if (status === 422) {
+  if (status === 422 && clonedResponse) {
     const details = await parseValidationError(clonedResponse);
     const field = details[0]?.loc?.slice(-1)[0] as string | undefined;
     throw new LangSmithValidationError(message, field, details);

--- a/js/src/tests/sandbox_error_handling.test.ts
+++ b/js/src/tests/sandbox_error_handling.test.ts
@@ -1,0 +1,102 @@
+import { createServer, Server } from "http";
+import { describe, it, expect, beforeAll, afterAll } from "@jest/globals";
+import { SandboxClient } from "../experimental/sandbox/client.js";
+import {
+  LangSmithValidationError,
+  LangSmithSandboxCreationError,
+} from "../experimental/sandbox/errors.js";
+
+let server: Server;
+let port: number;
+let nextResponse: { status: number; body: unknown };
+
+beforeAll((done) => {
+  server = createServer((_req, res) => {
+    res.writeHead(nextResponse.status, {
+      "Content-Type": "application/json",
+    });
+    res.end(JSON.stringify(nextResponse.body));
+  });
+  server.listen(0, () => {
+    port = (server.address() as any).port;
+    done();
+  });
+});
+
+afterAll((done) => {
+  server.close(done);
+});
+
+function makeClient(): SandboxClient {
+  return new SandboxClient({
+    apiEndpoint: `http://localhost:${port}/v2/sandboxes`,
+    apiKey: "test-key",
+    maxRetries: 0,
+  });
+}
+
+describe("handleClientHttpError body consumption", () => {
+  it("handles 422 with pydantic validation details without crashing", async () => {
+    nextResponse = {
+      status: 422,
+      body: {
+        detail: [
+          {
+            loc: ["body", "name"],
+            msg: "field required",
+            type: "value_error.missing",
+          },
+        ],
+      },
+    };
+
+    const client = makeClient();
+
+    // Bug: handleClientHttpError calls parseErrorResponse (consuming body),
+    // then response.clone() — crashes with "Body has already been consumed"
+    await expect(
+      client.captureSnapshot("test-sandbox", "my-snapshot")
+    ).rejects.toThrow(LangSmithValidationError);
+  });
+});
+
+describe("handleSandboxCreationError body consumption", () => {
+  it("handles 422 pydantic value_error during sandbox creation without crashing", async () => {
+    nextResponse = {
+      status: 422,
+      body: {
+        detail: [
+          {
+            loc: ["body", "vcpus"],
+            msg: "ensure this value is greater than 0",
+            type: "value_error",
+          },
+        ],
+      },
+    };
+
+    const client = makeClient();
+
+    await expect(
+      client.createSandbox(undefined, { snapshotId: "snap-123" })
+    ).rejects.toThrow(LangSmithValidationError);
+  });
+
+  it("handles 422 runtime creation error during sandbox creation", async () => {
+    nextResponse = {
+      status: 422,
+      body: {
+        detail: {
+          error: "ImagePullFailed",
+          message: "Failed to pull image foo:latest",
+        },
+      },
+    };
+
+    const client = makeClient();
+
+    await expect(
+      client.createSandbox(undefined, { snapshotId: "snap-123" })
+    ).rejects.toThrow(LangSmithSandboxCreationError);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes JS sandbox error handling so response bodies are only cloned before they are consumed, and only on paths that need a second read. This avoids throwing `Response.clone: Body has already been consumed` while preserving typed validation errors.

## Release Note

Fix JS sandbox error handling for non-OK responses whose body needs to be inspected.

## Test Plan

- [x] Added JS sandbox error handling tests.