### PR TITLE
fix: parse urllib3 version with packaging.Version

### DIFF
--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -53,7 +53,7 @@ from typing import (
 )
 from urllib import parse as urllib_parse
 
-import packaging
+import packaging.version
 import requests
 from pydantic import Field
 from requests import adapters as requests_adapters

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -585,8 +585,8 @@ def _default_retry_config() -> Retry:
     # the `allowed_methods` keyword is not available in urllib3 < 1.26
 
     # check to see if urllib3 version is 1.26 or greater
-    urllib3_version = importlib.metadata.version("urllib3")
-    use_allowed_methods = tuple(map(int, urllib3_version.split("."))) >= (1, 26)
+    urllib3_version = packaging.version.parse(importlib.metadata.version("urllib3"))
+    use_allowed_methods = urllib3_version >= packaging.version.parse("1.26")
 
     if use_allowed_methods:
         # Retry on all methods

--- a/python/tests/unit_tests/test_client.py
+++ b/python/tests/unit_tests/test_client.py
@@ -45,6 +45,7 @@ from langsmith.client import (
     _construct_url,
     _convert_stored_attachments_to_attachments_dict,
     _dataset_examples_path,
+    _default_retry_config,
     _dumps_json,
     _is_langchain_hosted,
     _parse_token_or_url,
@@ -68,6 +69,24 @@ def test__is_langchain_hosted() -> None:
     assert _is_langchain_hosted("https://api.smith.langchain.com")
     assert _is_langchain_hosted("https://beta.api.smith.langchain.com")
     assert _is_langchain_hosted("https://dev.api.smith.langchain.com")
+
+
+@pytest.mark.parametrize(
+    "urllib3_version",
+    ["1.26.0", "2.5.0", "2.5.0+cgr.2", "2.6.3+abc.def.4", "1.25.99"],
+)
+def test__default_retry_config_handles_pep440_local_versions(
+    monkeypatch: pytest.MonkeyPatch, urllib3_version: str
+) -> None:
+    import importlib.metadata
+
+    monkeypatch.setattr(importlib.metadata, "version", lambda name: urllib3_version)
+    _default_retry_config.cache_clear()
+    try:
+        retry = _default_retry_config()
+    finally:
+        _default_retry_config.cache_clear()
+    assert retry is not None
 
 
 def _clear_env_cache():


### PR DESCRIPTION
## Problem

`_default_retry_config()` in `python/langsmith/client.py` parses `urllib3.__version__` with `tuple(map(int, version.split(".")))`. This raises `ValueError` on any PEP 440 version that includes a local-version identifier (`<public>+<label>`).

[PEP 440 §"Local version identifiers"](https://peps.python.org/pep-0440/#local-version-identifiers) explicitly carves out this `+<label>` syntax for downstream integrators publishing patched rebuilds. Anyone pulling `urllib3` from a downstream index (Chainguard Libraries publishes `2.5.0+cgr.2`, distro repackagers, internal mirrors with backported fixes) hits `ValueError: invalid literal for int() with base 10: '0+cgr'` on `Client()` construction.

## Fix

Switch to `packaging.version.parse`. It is already a hard dep (declared in `pyproject.toml`) and already the established pattern in this same file for the langchain-core version check (see `client.py:313`).

## Reproducer

```python
>>> from packaging.version import parse
>>> parse("2.5.0+cgr.2") >= parse("1.26")
True
>>> tuple(map(int, "2.5.0+cgr.2".split(".")))
ValueError: invalid literal for int() with base 10: '0+cgr'
```

## Test plan
- [x] `make format`
- [x] `make lint`
- [x] `make tests` (1195 passed, 3 skipped)
- [x] Added regression test parametrized over clean and local-version urllib3 strings (`test__default_retry_config_handles_pep440_local_versions`)