### PR TITLE
sdk(py): replace ttl_seconds with idle_ttl_seconds + delete_after_stop_seconds

### DIFF
--- a/python/langsmith/sandbox/README.md
+++ b/python/langsmith/sandbox/README.md
@@ -694,63 +694,78 @@ sandbox = client.start_sandbox("my-vm")
 
 ## Sandbox Lifetime & TTL
 
-Control how long a sandbox stays alive with two optional TTL parameters:
+Sandboxes follow a two-stage retention model anchored to **idle activity**
+and the **`stopped`** state — there is no wall-clock "max lifetime" TTL:
 
-- **`ttl_seconds`** — Maximum lifetime from creation. The sandbox is automatically
-  deleted after this many seconds, regardless of activity.
-- **`idle_ttl_seconds`** — Idle timeout. The sandbox is automatically deleted after
-  this many seconds of inactivity. Activity (command execution, file I/O) resets
-  the timer. When omitted at creation, the server applies a default of `600`
-  seconds (10 minutes); pass `0` explicitly to disable the idle timeout.
+- **`idle_ttl_seconds`** — Idle timeout. The launcher stops the sandbox
+  after this many seconds of inactivity (any command execution or file I/O
+  resets the timer). When omitted at creation, the server applies a default
+  of `600` seconds (10 minutes); pass `0` explicitly to disable the idle
+  stop and keep the sandbox running indefinitely.
+- **`delete_after_stop_seconds`** — Stop-anchored deletion. Once a sandbox
+  enters the `stopped` state (either via the idle timer above or an explicit
+  `stop_sandbox` call), this timer starts. After the deadline passes, the
+  sandbox row and its filesystem clone are permanently deleted by a
+  server-side sweep. Pass `0` to disable stop-anchored deletion (manual
+  cleanup required); when omitted, the server applies its configured default
+  (typically 14 days).
 
-Both values must be multiples of 60 (minute-resolution). Pass `0` to explicitly
-disable a TTL. When both are set, whichever deadline comes first wins.
+Both values must be multiples of 60 (minute-resolution). The lifecycle is:
+
+```
+running ──(idle for idle_ttl_seconds)──▶ stopped ──(delete_after_stop_seconds)──▶ deleted
+```
 
 ```python
-# Create a sandbox that expires after 1 hour
-with client.sandbox(
-    snapshot_id=snapshot_id,
-    ttl_seconds=3600,
-) as sb:
+# Default retention (server defaults: 10 min idle stop, 14 day delete)
+with client.sandbox(snapshot_id=snapshot_id) as sb:
     result = sb.run("echo hello")
 
-# Create a sandbox that expires after 10 min of inactivity
+# Aggressive: stop after 5 min idle, delete 1 hour after stop
 sb = client.create_sandbox(
     snapshot_id=snapshot_id,
-    idle_ttl_seconds=600,
+    idle_ttl_seconds=300,
+    delete_after_stop_seconds=3600,
 )
 
-# Combine both: 2-hour max lifetime, 15-min idle timeout
+# Long-running: never auto-stop, delete 7 days after manual stop
 sb = client.create_sandbox(
     snapshot_id=snapshot_id,
-    ttl_seconds=7200,
-    idle_ttl_seconds=900,
+    idle_ttl_seconds=0,
+    delete_after_stop_seconds=604800,
 )
 
-# Check expiration
-print(sb.ttl_seconds)       # 7200
-print(sb.idle_ttl_seconds)  # 900
-print(sb.expires_at)        # e.g. "2026-03-24T14:00:00Z"
+# Inspect retention settings
+print(sb.idle_ttl_seconds)            # e.g. 300
+print(sb.delete_after_stop_seconds)   # e.g. 3600
+print(sb.stopped_at)                  # None while running, ISO timestamp once stopped
 ```
 
-### Updating TTL on Existing Sandboxes
+### Updating retention on existing sandboxes
 
-You can update TTL values on an already-running sandbox:
+You can update either retention setting on a running or stopped sandbox.
+Updating `delete_after_stop_seconds` on an already-stopped sandbox shifts
+its deletion deadline (`stopped_at + delete_after_stop_seconds`):
 
 ```python
-# Extend the idle timeout to 30 minutes
+# Extend the idle stop to 30 minutes
 sb = client.update_sandbox("my-sandbox", idle_ttl_seconds=1800)
 
-# Disable the absolute TTL (sandbox runs indefinitely, idle TTL still applies)
-sb = client.update_sandbox("my-sandbox", ttl_seconds=0)
+# Push the deletion deadline out to 30 days after stop
+sb = client.update_sandbox("my-sandbox", delete_after_stop_seconds=2592000)
 
-# Update name and TTL together
+# Disable both — sandbox keeps running and never auto-deletes
 sb = client.update_sandbox(
     "my-sandbox",
-    new_name="my-sandbox-v2",
-    ttl_seconds=3600,
+    idle_ttl_seconds=0,
+    delete_after_stop_seconds=0,
 )
 ```
+
+> **Migration note (alpha):** the previous `ttl_seconds` (hard wall-clock
+> TTL) and `expires_at` fields were removed. The hard TTL never reliably
+> deleted stopped sandboxes; replace any usage with `idle_ttl_seconds` for
+> stopping and `delete_after_stop_seconds` for deletion.
 
 ## Reusing Existing Sandboxes
 
@@ -887,14 +902,14 @@ except SandboxClientError as e:
 
 | Method | Description |
 |--------|-------------|
-| `sandbox(snapshot_id=None, *, snapshot_name=None, ttl_seconds=None, idle_ttl_seconds=None, ...)` | Create a sandbox (auto-deleted on context exit). Exactly one of `snapshot_id` / `snapshot_name` must be set. |
+| `sandbox(snapshot_id=None, *, snapshot_name=None, idle_ttl_seconds=None, delete_after_stop_seconds=None, ...)` | Create a sandbox (auto-deleted on context exit). Exactly one of `snapshot_id` / `snapshot_name` must be set. |
 | `create_sandbox(snapshot_id=None, *, snapshot_name=None, wait_for_ready=True, ...)` | Create a sandbox (requires explicit delete). Exactly one of `snapshot_id` / `snapshot_name` must be set. |
 | `get_sandbox(name)` | Get an existing sandbox by name |
 | `get_sandbox_status(name)` | Get lightweight provisioning status (`ResourceStatus`) |
 | `wait_for_sandbox(name, *, timeout=120, poll_interval=1.0)` | Poll until sandbox is ready or failed |
 | `service(name, port, *, expires_in_seconds=600)` | Get a `ServiceURL` for an HTTP service on the given port |
 | `list_sandboxes()` | List all sandboxes |
-| `update_sandbox(name, *, new_name=None, ttl_seconds=None, idle_ttl_seconds=None)` | Update a sandbox's name or TTL settings |
+| `update_sandbox(name, *, new_name=None, idle_ttl_seconds=None, delete_after_stop_seconds=None)` | Update a sandbox's name or retention settings |
 | `delete_sandbox(name)` | Delete a sandbox |
 | `start_sandbox(name, *, timeout=120)` | Start a stopped sandbox, poll until ready |
 | `stop_sandbox(name)` | Stop a running sandbox (preserves sandbox files) |
@@ -915,9 +930,9 @@ except SandboxClientError as e:
 | `status_message` | Human-readable details when status is `"failed"`, `None` otherwise |
 | `dataplane_url` | URL for runtime operations (only functional when status is `"ready"`) |
 | `id` | Unique identifier (UUID) |
-| `ttl_seconds` | Maximum lifetime TTL in seconds (`0` means disabled, `None` means not set) |
-| `idle_ttl_seconds` | Idle timeout TTL in seconds (`0` means disabled, `None` means not set). New sandboxes get a server-side default of `600` (10 minutes) when not explicitly provided. |
-| `expires_at` | Computed expiration timestamp, or `None` if no TTL is active |
+| `idle_ttl_seconds` | Idle timeout in seconds before the launcher stops the sandbox (`0` means disabled, `None` means not set). New sandboxes get a server-side default of `600` (10 minutes) when not explicitly provided. |
+| `delete_after_stop_seconds` | Seconds after entering `stopped` before the sandbox and its filesystem clone are permanently deleted (`0` means disabled, `None` means server default). |
+| `stopped_at` | ISO 8601 timestamp when the sandbox transitioned to `stopped`, or `None` while running. |
 
 | Method | Description |
 |--------|-------------|

--- a/python/langsmith/sandbox/_async_client.py
+++ b/python/langsmith/sandbox/_async_client.py
@@ -156,8 +156,8 @@ class AsyncSandboxClient:
         snapshot_name: Optional[str] = None,
         name: Optional[str] = None,
         timeout: int = 30,
-        ttl_seconds: Optional[int] = None,
         idle_ttl_seconds: Optional[int] = None,
+        delete_after_stop_seconds: Optional[int] = None,
         vcpus: Optional[int] = None,
         mem_bytes: Optional[int] = None,
         fs_capacity_bytes: Optional[int] = None,
@@ -187,14 +187,16 @@ class AsyncSandboxClient:
                 ``snapshot_id``; exactly one must be provided.
             name: Optional sandbox name (auto-generated if not provided).
             timeout: Timeout in seconds when waiting for ready.
-            ttl_seconds: Maximum lifetime in seconds from creation. The sandbox
-                will be automatically deleted after this duration. Must be a
-                multiple of 60. 0 or None disables this TTL.
-            idle_ttl_seconds: Idle timeout in seconds. The sandbox will be
-                automatically deleted after this duration of inactivity. Must
-                be a multiple of 60. ``0`` explicitly disables the idle
-                timeout. When omitted (``None``), the server applies a default
-                of ``600`` seconds (10 minutes).
+            idle_ttl_seconds: Idle timeout in seconds. The launcher
+                automatically stops the sandbox after this duration of
+                inactivity. Must be a multiple of 60. ``0`` explicitly
+                disables the idle stop. When omitted (``None``), the server
+                applies a default of ``600`` seconds (10 minutes).
+            delete_after_stop_seconds: Seconds after the sandbox enters the
+                ``stopped`` state before it (and its filesystem clone) are
+                permanently deleted. Must be a multiple of 60. ``0`` disables
+                stop-anchored deletion (manual cleanup required). When
+                omitted (``None``), the server applies its configured default.
             vcpus: Number of vCPUs.
             mem_bytes: Memory in bytes.
             fs_capacity_bytes: Root filesystem capacity in bytes.
@@ -222,8 +224,8 @@ class AsyncSandboxClient:
             snapshot_name=snapshot_name,
             name=name,
             timeout=timeout,
-            ttl_seconds=ttl_seconds,
             idle_ttl_seconds=idle_ttl_seconds,
+            delete_after_stop_seconds=delete_after_stop_seconds,
             vcpus=vcpus,
             mem_bytes=mem_bytes,
             fs_capacity_bytes=fs_capacity_bytes,
@@ -241,8 +243,8 @@ class AsyncSandboxClient:
         name: Optional[str] = None,
         timeout: int = 30,
         wait_for_ready: bool = True,
-        ttl_seconds: Optional[int] = None,
         idle_ttl_seconds: Optional[int] = None,
+        delete_after_stop_seconds: Optional[int] = None,
         vcpus: Optional[int] = None,
         mem_bytes: Optional[int] = None,
         fs_capacity_bytes: Optional[int] = None,
@@ -266,14 +268,16 @@ class AsyncSandboxClient:
             wait_for_ready: If True (default), block until sandbox is ready.
                 If False, return immediately with status "provisioning". Use
                 get_sandbox_status() or wait_for_sandbox() to poll for readiness.
-            ttl_seconds: Maximum lifetime in seconds from creation. The sandbox
-                will be automatically deleted after this duration. Must be a
-                multiple of 60. 0 or None disables this TTL.
-            idle_ttl_seconds: Idle timeout in seconds. The sandbox will be
-                automatically deleted after this duration of inactivity. Must
-                be a multiple of 60. ``0`` explicitly disables the idle
-                timeout. When omitted (``None``), the server applies a default
-                of ``600`` seconds (10 minutes).
+            idle_ttl_seconds: Idle timeout in seconds. The launcher
+                automatically stops the sandbox after this duration of
+                inactivity. Must be a multiple of 60. ``0`` explicitly
+                disables the idle stop. When omitted (``None``), the server
+                applies a default of ``600`` seconds (10 minutes).
+            delete_after_stop_seconds: Seconds after the sandbox enters the
+                ``stopped`` state before it (and its filesystem clone) are
+                permanently deleted. Must be a multiple of 60. ``0`` disables
+                stop-anchored deletion (manual cleanup required). When
+                omitted (``None``), the server applies its configured default.
             vcpus: Number of vCPUs.
             mem_bytes: Memory in bytes.
             fs_capacity_bytes: Root filesystem capacity in bytes.
@@ -300,8 +304,8 @@ class AsyncSandboxClient:
         if bool(snapshot_id) == bool(snapshot_name):
             raise ValueError("Exactly one of snapshot_id or snapshot_name must be set")
 
-        validate_ttl(ttl_seconds, "ttl_seconds")
         validate_ttl(idle_ttl_seconds, "idle_ttl_seconds")
+        validate_ttl(delete_after_stop_seconds, "delete_after_stop_seconds")
 
         url = f"{self._base_url}/boxes"
 
@@ -316,10 +320,10 @@ class AsyncSandboxClient:
             payload["timeout"] = timeout
         if name:
             payload["name"] = name
-        if ttl_seconds is not None:
-            payload["ttl_seconds"] = ttl_seconds
         if idle_ttl_seconds is not None:
             payload["idle_ttl_seconds"] = idle_ttl_seconds
+        if delete_after_stop_seconds is not None:
+            payload["delete_after_stop_seconds"] = delete_after_stop_seconds
         if vcpus is not None:
             payload["vcpus"] = vcpus
         if mem_bytes is not None:
@@ -411,8 +415,8 @@ class AsyncSandboxClient:
         name: str,
         *,
         new_name: Optional[str] = None,
-        ttl_seconds: Optional[int] = None,
         idle_ttl_seconds: Optional[int] = None,
+        delete_after_stop_seconds: Optional[int] = None,
         headers: RequestHeaders = None,
     ) -> AsyncSandbox:
         """Update a sandbox's properties.
@@ -420,11 +424,13 @@ class AsyncSandboxClient:
         Args:
             name: Current sandbox name.
             new_name: New display name.
-            ttl_seconds: Maximum lifetime in seconds from creation. Must be a
-                multiple of 60. 0 disables this TTL.
             idle_ttl_seconds: Idle timeout in seconds. Must be a multiple of
-                60. ``0`` disables this TTL. ``None`` leaves the existing
+                60. ``0`` disables idle-stop. ``None`` leaves the existing
                 value unchanged.
+            delete_after_stop_seconds: Seconds after entering ``stopped``
+                before deletion. Must be a multiple of 60. ``0`` disables
+                stop-anchored deletion. ``None`` leaves the existing value
+                unchanged.
 
         Returns:
             Updated AsyncSandbox.
@@ -435,17 +441,17 @@ class AsyncSandboxClient:
             SandboxClientError: For other errors.
             ValueError: If TTL values are invalid.
         """
-        validate_ttl(ttl_seconds, "ttl_seconds")
         validate_ttl(idle_ttl_seconds, "idle_ttl_seconds")
+        validate_ttl(delete_after_stop_seconds, "delete_after_stop_seconds")
 
         url = f"{self._base_url}/boxes/{name}"
         payload: dict[str, Any] = {}
         if new_name is not None:
             payload["name"] = new_name
-        if ttl_seconds is not None:
-            payload["ttl_seconds"] = ttl_seconds
         if idle_ttl_seconds is not None:
             payload["idle_ttl_seconds"] = idle_ttl_seconds
+        if delete_after_stop_seconds is not None:
+            payload["delete_after_stop_seconds"] = delete_after_stop_seconds
 
         try:
             response = await self._http.patch(

--- a/python/langsmith/sandbox/_async_sandbox.py
+++ b/python/langsmith/sandbox/_async_sandbox.py
@@ -49,12 +49,19 @@ class AsyncSandbox:
         status_message: Human-readable details when status is "failed", None otherwise.
         created_at: Timestamp when the sandbox was created.
         updated_at: Timestamp when the sandbox was last updated.
-        ttl_seconds: Maximum lifetime TTL in seconds (0 means disabled).
         idle_ttl_seconds: Idle timeout TTL in seconds (``0`` means disabled).
             Newly-created sandboxes receive a server-side default of ``600``
             seconds (10 minutes) when the caller did not set ``idle_ttl_seconds``
-            explicitly.
-        expires_at: Computed expiration timestamp, or None if no TTL is set.
+            explicitly. The launcher stops the sandbox after this many idle
+            seconds; deletion is anchored to ``stopped_at`` and controlled by
+            ``delete_after_stop_seconds`` (see below).
+        delete_after_stop_seconds: Seconds after a sandbox enters the
+            ``stopped`` state before it (and its filesystem clone) are
+            permanently deleted. ``0`` disables stop-anchored deletion;
+            ``None`` falls back to the server default.
+        stopped_at: Timestamp when the sandbox transitioned to ``stopped``,
+            or ``None`` while running. The deletion deadline is
+            ``stopped_at + delete_after_stop_seconds``.
         snapshot_id: Snapshot ID used to create this sandbox.
         vcpus: Number of vCPUs allocated.
         mem_bytes: Memory allocation in bytes.
@@ -76,9 +83,9 @@ class AsyncSandbox:
     status_message: Optional[str] = None
     created_at: Optional[str] = None
     updated_at: Optional[str] = None
-    ttl_seconds: Optional[int] = None
     idle_ttl_seconds: Optional[int] = None
-    expires_at: Optional[str] = None
+    delete_after_stop_seconds: Optional[int] = None
+    stopped_at: Optional[str] = None
     snapshot_id: Optional[str] = None
     vcpus: Optional[int] = None
     mem_bytes: Optional[int] = None
@@ -113,9 +120,9 @@ class AsyncSandbox:
             status_message=data.get("status_message"),
             created_at=data.get("created_at"),
             updated_at=data.get("updated_at"),
-            ttl_seconds=data.get("ttl_seconds"),
             idle_ttl_seconds=data.get("idle_ttl_seconds"),
-            expires_at=data.get("expires_at"),
+            delete_after_stop_seconds=data.get("delete_after_stop_seconds"),
+            stopped_at=data.get("stopped_at"),
             snapshot_id=data.get("snapshot_id"),
             vcpus=data.get("vcpus"),
             mem_bytes=data.get("mem_bytes"),

--- a/python/langsmith/sandbox/_client.py
+++ b/python/langsmith/sandbox/_client.py
@@ -153,8 +153,8 @@ class SandboxClient:
         snapshot_name: Optional[str] = None,
         name: Optional[str] = None,
         timeout: int = 30,
-        ttl_seconds: Optional[int] = None,
         idle_ttl_seconds: Optional[int] = None,
+        delete_after_stop_seconds: Optional[int] = None,
         vcpus: Optional[int] = None,
         mem_bytes: Optional[int] = None,
         fs_capacity_bytes: Optional[int] = None,
@@ -184,14 +184,16 @@ class SandboxClient:
                 ``snapshot_id``; exactly one must be provided.
             name: Optional sandbox name (auto-generated if not provided).
             timeout: Timeout in seconds when waiting for ready.
-            ttl_seconds: Maximum lifetime in seconds from creation. The sandbox
-                will be automatically deleted after this duration. Must be a
-                multiple of 60. 0 or None disables this TTL.
-            idle_ttl_seconds: Idle timeout in seconds. The sandbox will be
-                automatically deleted after this duration of inactivity. Must
-                be a multiple of 60. ``0`` explicitly disables the idle
-                timeout. When omitted (``None``), the server applies a default
-                of ``600`` seconds (10 minutes).
+            idle_ttl_seconds: Idle timeout in seconds. The launcher
+                automatically stops the sandbox after this duration of
+                inactivity. Must be a multiple of 60. ``0`` explicitly
+                disables the idle stop. When omitted (``None``), the server
+                applies a default of ``600`` seconds (10 minutes).
+            delete_after_stop_seconds: Seconds after the sandbox enters the
+                ``stopped`` state before it (and its filesystem clone) are
+                permanently deleted. Must be a multiple of 60. ``0`` disables
+                stop-anchored deletion (manual cleanup required). When
+                omitted (``None``), the server applies its configured default.
             vcpus: Number of vCPUs.
             mem_bytes: Memory in bytes.
             fs_capacity_bytes: Root filesystem capacity in bytes.
@@ -219,8 +221,8 @@ class SandboxClient:
             snapshot_name=snapshot_name,
             name=name,
             timeout=timeout,
-            ttl_seconds=ttl_seconds,
             idle_ttl_seconds=idle_ttl_seconds,
+            delete_after_stop_seconds=delete_after_stop_seconds,
             vcpus=vcpus,
             mem_bytes=mem_bytes,
             fs_capacity_bytes=fs_capacity_bytes,
@@ -238,8 +240,8 @@ class SandboxClient:
         name: Optional[str] = None,
         timeout: int = 30,
         wait_for_ready: bool = True,
-        ttl_seconds: Optional[int] = None,
         idle_ttl_seconds: Optional[int] = None,
+        delete_after_stop_seconds: Optional[int] = None,
         vcpus: Optional[int] = None,
         mem_bytes: Optional[int] = None,
         fs_capacity_bytes: Optional[int] = None,
@@ -263,14 +265,16 @@ class SandboxClient:
             wait_for_ready: If True (default), block until sandbox is ready.
                 If False, return immediately with status "provisioning". Use
                 get_sandbox_status() or wait_for_sandbox() to poll for readiness.
-            ttl_seconds: Maximum lifetime in seconds from creation. The sandbox
-                will be automatically deleted after this duration. Must be a
-                multiple of 60. 0 or None disables this TTL.
-            idle_ttl_seconds: Idle timeout in seconds. The sandbox will be
-                automatically deleted after this duration of inactivity. Must
-                be a multiple of 60. ``0`` explicitly disables the idle
-                timeout. When omitted (``None``), the server applies a default
-                of ``600`` seconds (10 minutes).
+            idle_ttl_seconds: Idle timeout in seconds. The launcher
+                automatically stops the sandbox after this duration of
+                inactivity. Must be a multiple of 60. ``0`` explicitly
+                disables the idle stop. When omitted (``None``), the server
+                applies a default of ``600`` seconds (10 minutes).
+            delete_after_stop_seconds: Seconds after the sandbox enters the
+                ``stopped`` state before it (and its filesystem clone) are
+                permanently deleted. Must be a multiple of 60. ``0`` disables
+                stop-anchored deletion (manual cleanup required). When
+                omitted (``None``), the server applies its configured default.
             vcpus: Number of vCPUs.
             mem_bytes: Memory in bytes.
             fs_capacity_bytes: Root filesystem capacity in bytes.
@@ -297,8 +301,8 @@ class SandboxClient:
         if bool(snapshot_id) == bool(snapshot_name):
             raise ValueError("Exactly one of snapshot_id or snapshot_name must be set")
 
-        validate_ttl(ttl_seconds, "ttl_seconds")
         validate_ttl(idle_ttl_seconds, "idle_ttl_seconds")
+        validate_ttl(delete_after_stop_seconds, "delete_after_stop_seconds")
 
         url = f"{self._base_url}/boxes"
 
@@ -313,10 +317,10 @@ class SandboxClient:
             payload["timeout"] = timeout
         if name:
             payload["name"] = name
-        if ttl_seconds is not None:
-            payload["ttl_seconds"] = ttl_seconds
         if idle_ttl_seconds is not None:
             payload["idle_ttl_seconds"] = idle_ttl_seconds
+        if delete_after_stop_seconds is not None:
+            payload["delete_after_stop_seconds"] = delete_after_stop_seconds
         if vcpus is not None:
             payload["vcpus"] = vcpus
         if mem_bytes is not None:
@@ -400,8 +404,8 @@ class SandboxClient:
         name: str,
         *,
         new_name: Optional[str] = None,
-        ttl_seconds: Optional[int] = None,
         idle_ttl_seconds: Optional[int] = None,
+        delete_after_stop_seconds: Optional[int] = None,
         headers: RequestHeaders = None,
     ) -> Sandbox:
         """Update a sandbox's properties.
@@ -409,11 +413,13 @@ class SandboxClient:
         Args:
             name: Current sandbox name.
             new_name: New display name.
-            ttl_seconds: Maximum lifetime in seconds from creation. Must be a
-                multiple of 60. 0 disables this TTL.
             idle_ttl_seconds: Idle timeout in seconds. Must be a multiple of
-                60. ``0`` disables this TTL. ``None`` leaves the existing
+                60. ``0`` disables idle-stop. ``None`` leaves the existing
                 value unchanged.
+            delete_after_stop_seconds: Seconds after entering ``stopped``
+                before deletion. Must be a multiple of 60. ``0`` disables
+                stop-anchored deletion. ``None`` leaves the existing value
+                unchanged.
 
         Returns:
             Updated Sandbox.
@@ -424,17 +430,17 @@ class SandboxClient:
             SandboxClientError: For other errors.
             ValueError: If TTL values are invalid.
         """
-        validate_ttl(ttl_seconds, "ttl_seconds")
         validate_ttl(idle_ttl_seconds, "idle_ttl_seconds")
+        validate_ttl(delete_after_stop_seconds, "delete_after_stop_seconds")
 
         url = f"{self._base_url}/boxes/{name}"
         payload: dict[str, Any] = {}
         if new_name is not None:
             payload["name"] = new_name
-        if ttl_seconds is not None:
-            payload["ttl_seconds"] = ttl_seconds
         if idle_ttl_seconds is not None:
             payload["idle_ttl_seconds"] = idle_ttl_seconds
+        if delete_after_stop_seconds is not None:
+            payload["delete_after_stop_seconds"] = delete_after_stop_seconds
 
         try:
             response = self._http.patch(

--- a/python/langsmith/sandbox/_sandbox.py
+++ b/python/langsmith/sandbox/_sandbox.py
@@ -48,12 +48,19 @@ class Sandbox:
         status_message: Human-readable details when status is "failed", None otherwise.
         created_at: Timestamp when the sandbox was created.
         updated_at: Timestamp when the sandbox was last updated.
-        ttl_seconds: Maximum lifetime TTL in seconds (0 means disabled).
         idle_ttl_seconds: Idle timeout TTL in seconds (``0`` means disabled).
             Newly-created sandboxes receive a server-side default of ``600``
             seconds (10 minutes) when the caller did not set ``idle_ttl_seconds``
-            explicitly.
-        expires_at: Computed expiration timestamp, or None if no TTL is set.
+            explicitly. The launcher stops the sandbox after this many idle
+            seconds; deletion is anchored to ``stopped_at`` and controlled by
+            ``delete_after_stop_seconds`` (see below).
+        delete_after_stop_seconds: Seconds after a sandbox enters the
+            ``stopped`` state before it (and its filesystem clone) are
+            permanently deleted. ``0`` disables stop-anchored deletion;
+            ``None`` falls back to the server default.
+        stopped_at: Timestamp when the sandbox transitioned to ``stopped``,
+            or ``None`` while running. The deletion deadline is
+            ``stopped_at + delete_after_stop_seconds``.
         snapshot_id: Snapshot ID used to create this sandbox.
         vcpus: Number of vCPUs allocated.
         mem_bytes: Memory allocation in bytes.
@@ -73,9 +80,9 @@ class Sandbox:
     status_message: Optional[str] = None
     created_at: Optional[str] = None
     updated_at: Optional[str] = None
-    ttl_seconds: Optional[int] = None
     idle_ttl_seconds: Optional[int] = None
-    expires_at: Optional[str] = None
+    delete_after_stop_seconds: Optional[int] = None
+    stopped_at: Optional[str] = None
     snapshot_id: Optional[str] = None
     vcpus: Optional[int] = None
     mem_bytes: Optional[int] = None
@@ -110,9 +117,9 @@ class Sandbox:
             status_message=data.get("status_message"),
             created_at=data.get("created_at"),
             updated_at=data.get("updated_at"),
-            ttl_seconds=data.get("ttl_seconds"),
             idle_ttl_seconds=data.get("idle_ttl_seconds"),
-            expires_at=data.get("expires_at"),
+            delete_after_stop_seconds=data.get("delete_after_stop_seconds"),
+            stopped_at=data.get("stopped_at"),
             snapshot_id=data.get("snapshot_id"),
             vcpus=data.get("vcpus"),
             mem_bytes=data.get("mem_bytes"),

--- a/python/tests/unit_tests/sandbox/test_async_client.py
+++ b/python/tests/unit_tests/sandbox/test_async_client.py
@@ -476,18 +476,18 @@ class TestAsyncSandboxOperations:
 
         assert exc_info.value.last_status == "provisioning"
 
-    async def test_create_sandbox_with_ttl(
+    async def test_create_sandbox_with_retention(
         self, client: AsyncSandboxClient, httpx_mock: HTTPXMock
     ):
-        """Test creating a sandbox with TTL values."""
+        """Creating a sandbox with idle and delete-after-stop retention."""
         httpx_mock.add_response(
             method="POST",
             url="http://test-server:8080/boxes",
             json={
                 "name": "test-sandbox",
-                "ttl_seconds": 3600,
                 "idle_ttl_seconds": 600,
-                "expires_at": "2026-03-24T12:00:00Z",
+                "delete_after_stop_seconds": 86400,
+                "stopped_at": None,
                 "dataplane_url": "https://sandbox-router.example.com/tenant/sb-123",
             },
             status_code=201,
@@ -495,25 +495,25 @@ class TestAsyncSandboxOperations:
 
         sandbox = await client.create_sandbox(
             snapshot_id="snap-1",
-            ttl_seconds=3600,
             idle_ttl_seconds=600,
+            delete_after_stop_seconds=86400,
         )
 
-        assert sandbox.ttl_seconds == 3600
         assert sandbox.idle_ttl_seconds == 600
-        assert sandbox.expires_at == "2026-03-24T12:00:00Z"
+        assert sandbox.delete_after_stop_seconds == 86400
+        assert sandbox.stopped_at is None
 
         import json
 
         request = httpx_mock.get_request()
         payload = json.loads(request.content)
-        assert payload["ttl_seconds"] == 3600
         assert payload["idle_ttl_seconds"] == 600
+        assert payload["delete_after_stop_seconds"] == 86400
 
-    async def test_create_sandbox_ttl_omitted_when_none(
+    async def test_create_sandbox_retention_omitted_when_none(
         self, client: AsyncSandboxClient, httpx_mock: HTTPXMock
     ):
-        """Test TTL fields are omitted from payload when None."""
+        """Retention fields are omitted from payload when None."""
         httpx_mock.add_response(
             method="POST",
             url="http://test-server:8080/boxes",
@@ -530,34 +530,42 @@ class TestAsyncSandboxOperations:
 
         request = httpx_mock.get_request()
         payload = json.loads(request.content)
-        assert "ttl_seconds" not in payload
         assert "idle_ttl_seconds" not in payload
+        assert "delete_after_stop_seconds" not in payload
 
-    async def test_create_sandbox_ttl_validation_negative(
+    async def test_create_sandbox_retention_validation_negative(
         self, client: AsyncSandboxClient
     ):
-        """Test that negative TTL values raise ValueError."""
+        """Negative retention values raise ValueError."""
         with pytest.raises(ValueError, match="must be >= 0"):
-            await client.create_sandbox(snapshot_id="snap-1", ttl_seconds=-1)
+            await client.create_sandbox(snapshot_id="snap-1", idle_ttl_seconds=-1)
+        with pytest.raises(ValueError, match="must be >= 0"):
+            await client.create_sandbox(
+                snapshot_id="snap-1", delete_after_stop_seconds=-1
+            )
 
-    async def test_create_sandbox_ttl_validation_not_multiple_of_60(
+    async def test_create_sandbox_retention_validation_not_multiple_of_60(
         self, client: AsyncSandboxClient
     ):
-        """Test that non-multiple-of-60 TTL values raise ValueError."""
+        """Non-multiple-of-60 retention values raise ValueError."""
         with pytest.raises(ValueError, match="must be a multiple of 60"):
-            await client.create_sandbox(snapshot_id="snap-1", ttl_seconds=90)
+            await client.create_sandbox(snapshot_id="snap-1", idle_ttl_seconds=90)
+        with pytest.raises(ValueError, match="must be a multiple of 60"):
+            await client.create_sandbox(
+                snapshot_id="snap-1", delete_after_stop_seconds=90
+            )
 
-    async def test_create_sandbox_ttl_zero_allowed(
+    async def test_create_sandbox_retention_zero_allowed(
         self, client: AsyncSandboxClient, httpx_mock: HTTPXMock
     ):
-        """Test that TTL value of 0 is allowed (disables TTL)."""
+        """Zero is accepted on both retention fields."""
         httpx_mock.add_response(
             method="POST",
             url="http://test-server:8080/boxes",
             json={
                 "name": "test-sandbox",
-                "ttl_seconds": 0,
                 "idle_ttl_seconds": 0,
+                "delete_after_stop_seconds": 0,
                 "dataplane_url": "https://sandbox-router.example.com/tenant/sb-123",
             },
             status_code=201,
@@ -565,62 +573,66 @@ class TestAsyncSandboxOperations:
 
         sandbox = await client.create_sandbox(
             snapshot_id="snap-1",
-            ttl_seconds=0,
             idle_ttl_seconds=0,
+            delete_after_stop_seconds=0,
         )
 
-        assert sandbox.ttl_seconds == 0
         assert sandbox.idle_ttl_seconds == 0
+        assert sandbox.delete_after_stop_seconds == 0
 
-    async def test_update_sandbox_with_ttl(
+    async def test_update_sandbox_with_retention(
         self, client: AsyncSandboxClient, httpx_mock: HTTPXMock
     ):
-        """Test updating a sandbox with TTL values."""
+        """Update both retention fields simultaneously."""
         httpx_mock.add_response(
             method="PATCH",
             url="http://test-server:8080/boxes/my-sandbox",
             json={
                 "name": "my-sandbox",
-                "ttl_seconds": 7200,
                 "idle_ttl_seconds": 1200,
-                "expires_at": "2026-03-24T14:00:00Z",
+                "delete_after_stop_seconds": 7200,
+                "stopped_at": None,
                 "dataplane_url": "https://sandbox-router.example.com/tenant/sb-123",
             },
         )
 
         sandbox = await client.update_sandbox(
             "my-sandbox",
-            ttl_seconds=7200,
             idle_ttl_seconds=1200,
+            delete_after_stop_seconds=7200,
         )
 
-        assert sandbox.ttl_seconds == 7200
         assert sandbox.idle_ttl_seconds == 1200
-        assert sandbox.expires_at == "2026-03-24T14:00:00Z"
+        assert sandbox.delete_after_stop_seconds == 7200
+        assert sandbox.stopped_at is None
 
         import json
 
         request = httpx_mock.get_request()
         payload = json.loads(request.content)
-        assert payload["ttl_seconds"] == 7200
         assert payload["idle_ttl_seconds"] == 1200
+        assert payload["delete_after_stop_seconds"] == 7200
         assert "name" not in payload
 
-    async def test_update_sandbox_ttl_validation(self, client: AsyncSandboxClient):
-        """Test that invalid TTL values raise ValueError on update."""
+    async def test_update_sandbox_retention_validation(
+        self, client: AsyncSandboxClient
+    ):
+        """Update path enforces the same retention bounds as create."""
         with pytest.raises(ValueError, match="must be >= 0"):
             await client.update_sandbox("my-sandbox", idle_ttl_seconds=-60)
+        with pytest.raises(ValueError, match="must be >= 0"):
+            await client.update_sandbox("my-sandbox", delete_after_stop_seconds=-60)
 
-    async def test_update_sandbox_name_and_ttl(
+    async def test_update_sandbox_name_and_retention(
         self, client: AsyncSandboxClient, httpx_mock: HTTPXMock
     ):
-        """Test updating sandbox name and TTL simultaneously."""
+        """Renaming and updating retention in one call."""
         httpx_mock.add_response(
             method="PATCH",
             url="http://test-server:8080/boxes/my-sandbox",
             json={
                 "name": "my-sandbox-renamed",
-                "ttl_seconds": 3600,
+                "delete_after_stop_seconds": 3600,
                 "dataplane_url": "https://sandbox-router.example.com/tenant/sb-123",
             },
         )
@@ -628,18 +640,18 @@ class TestAsyncSandboxOperations:
         sandbox = await client.update_sandbox(
             "my-sandbox",
             new_name="my-sandbox-renamed",
-            ttl_seconds=3600,
+            delete_after_stop_seconds=3600,
         )
 
         assert sandbox.name == "my-sandbox-renamed"
-        assert sandbox.ttl_seconds == 3600
+        assert sandbox.delete_after_stop_seconds == 3600
 
         import json
 
         request = httpx_mock.get_request()
         payload = json.loads(request.content)
         assert payload["name"] == "my-sandbox-renamed"
-        assert payload["ttl_seconds"] == 3600
+        assert payload["delete_after_stop_seconds"] == 3600
 
     async def test_list_sandboxes_includes_status(
         self, client: AsyncSandboxClient, httpx_mock: HTTPXMock

--- a/python/tests/unit_tests/sandbox/test_async_sandbox.py
+++ b/python/tests/unit_tests/sandbox/test_async_sandbox.py
@@ -50,53 +50,73 @@ class TestAsyncSandboxProperties:
         assert sandbox.dataplane_url == "https://sandbox-router.example.com/sb-123"
 
 
-class TestAsyncSandboxTTLFields:
-    """Tests for TTL fields on AsyncSandbox."""
+class TestAsyncSandboxRetentionFields:
+    """Tests for the two-stage retention fields on AsyncSandbox."""
 
-    def test_from_dict_with_ttl(self, client):
-        """Test from_dict parses TTL fields."""
+    def test_from_dict_with_retention(self, client):
+        """from_dict parses idle_ttl_seconds, delete_after_stop_seconds,
+        and stopped_at."""
+        sb = AsyncSandbox.from_dict(
+            data={
+                "name": "test-sandbox",
+                "idle_ttl_seconds": 600,
+                "delete_after_stop_seconds": 86400,
+                "stopped_at": "2026-03-24T12:00:00Z",
+            },
+            client=client,
+            auto_delete=False,
+        )
+        assert sb.idle_ttl_seconds == 600
+        assert sb.delete_after_stop_seconds == 86400
+        assert sb.stopped_at == "2026-03-24T12:00:00Z"
+
+    def test_from_dict_without_retention(self, client):
+        """Retention fields default to None when absent."""
+        sb = AsyncSandbox.from_dict(
+            data={
+                "name": "test-sandbox",
+            },
+            client=client,
+            auto_delete=False,
+        )
+        assert sb.idle_ttl_seconds is None
+        assert sb.delete_after_stop_seconds is None
+        assert sb.stopped_at is None
+
+    def test_from_dict_with_zero_retention(self, client):
+        """Zero values are preserved (each disables that retention stage)."""
+        sb = AsyncSandbox.from_dict(
+            data={
+                "name": "test-sandbox",
+                "idle_ttl_seconds": 0,
+                "delete_after_stop_seconds": 0,
+                "stopped_at": None,
+            },
+            client=client,
+            auto_delete=False,
+        )
+        assert sb.idle_ttl_seconds == 0
+        assert sb.delete_after_stop_seconds == 0
+        assert sb.stopped_at is None
+
+    def test_from_dict_silently_ignores_legacy_fields(self, client):
+        """Older smith-go responses may include the now-removed
+        ttl_seconds/expires_at fields; the SDK should silently drop them."""
         sb = AsyncSandbox.from_dict(
             data={
                 "name": "test-sandbox",
                 "ttl_seconds": 3600,
-                "idle_ttl_seconds": 600,
                 "expires_at": "2026-03-24T12:00:00Z",
+                "idle_ttl_seconds": 600,
             },
             client=client,
             auto_delete=False,
         )
-        assert sb.ttl_seconds == 3600
         assert sb.idle_ttl_seconds == 600
-        assert sb.expires_at == "2026-03-24T12:00:00Z"
-
-    def test_from_dict_without_ttl(self, client):
-        """Test from_dict defaults TTL fields to None when absent."""
-        sb = AsyncSandbox.from_dict(
-            data={
-                "name": "test-sandbox",
-            },
-            client=client,
-            auto_delete=False,
-        )
-        assert sb.ttl_seconds is None
-        assert sb.idle_ttl_seconds is None
-        assert sb.expires_at is None
-
-    def test_from_dict_with_zero_ttl(self, client):
-        """Test from_dict handles zero TTL values (TTL disabled)."""
-        sb = AsyncSandbox.from_dict(
-            data={
-                "name": "test-sandbox",
-                "ttl_seconds": 0,
-                "idle_ttl_seconds": 0,
-                "expires_at": None,
-            },
-            client=client,
-            auto_delete=False,
-        )
-        assert sb.ttl_seconds == 0
-        assert sb.idle_ttl_seconds == 0
-        assert sb.expires_at is None
+        assert sb.delete_after_stop_seconds is None
+        assert sb.stopped_at is None
+        assert not hasattr(sb, "ttl_seconds")
+        assert not hasattr(sb, "expires_at")
 
 
 class TestAsyncSandboxStatusFields:

--- a/python/tests/unit_tests/sandbox/test_client.py
+++ b/python/tests/unit_tests/sandbox/test_client.py
@@ -504,18 +504,18 @@ class TestSandboxOperations:
 
         assert exc_info.value.last_status == "provisioning"
 
-    def test_create_sandbox_with_ttl(
+    def test_create_sandbox_with_retention(
         self, client: SandboxClient, httpx_mock: HTTPXMock
     ):
-        """Test creating a sandbox with TTL values."""
+        """Test creating a sandbox with idle and delete-after-stop retention."""
         httpx_mock.add_response(
             method="POST",
             url="http://test-server:8080/boxes",
             json={
                 "name": "test-sandbox",
-                "ttl_seconds": 3600,
                 "idle_ttl_seconds": 600,
-                "expires_at": "2026-03-24T12:00:00Z",
+                "delete_after_stop_seconds": 86400,
+                "stopped_at": None,
                 "dataplane_url": "https://sandbox-router.example.com/sb-123",
             },
             status_code=201,
@@ -523,25 +523,25 @@ class TestSandboxOperations:
 
         sandbox = client.create_sandbox(
             snapshot_id="snap-1",
-            ttl_seconds=3600,
             idle_ttl_seconds=600,
+            delete_after_stop_seconds=86400,
         )
 
-        assert sandbox.ttl_seconds == 3600
         assert sandbox.idle_ttl_seconds == 600
-        assert sandbox.expires_at == "2026-03-24T12:00:00Z"
+        assert sandbox.delete_after_stop_seconds == 86400
+        assert sandbox.stopped_at is None
 
         import json
 
         request = httpx_mock.get_request()
         payload = json.loads(request.content)
-        assert payload["ttl_seconds"] == 3600
         assert payload["idle_ttl_seconds"] == 600
+        assert payload["delete_after_stop_seconds"] == 86400
 
-    def test_create_sandbox_ttl_omitted_when_none(
+    def test_create_sandbox_retention_omitted_when_none(
         self, client: SandboxClient, httpx_mock: HTTPXMock
     ):
-        """Test TTL fields are omitted from payload when None."""
+        """Retention fields are omitted from the payload when not specified."""
         httpx_mock.add_response(
             method="POST",
             url="http://test-server:8080/boxes",
@@ -558,32 +558,36 @@ class TestSandboxOperations:
 
         request = httpx_mock.get_request()
         payload = json.loads(request.content)
-        assert "ttl_seconds" not in payload
         assert "idle_ttl_seconds" not in payload
+        assert "delete_after_stop_seconds" not in payload
 
-    def test_create_sandbox_ttl_validation_negative(self, client: SandboxClient):
-        """Test that negative TTL values raise ValueError."""
+    def test_create_sandbox_retention_validation_negative(self, client: SandboxClient):
+        """Negative retention values raise ValueError."""
         with pytest.raises(ValueError, match="must be >= 0"):
-            client.create_sandbox(snapshot_id="snap-1", ttl_seconds=-1)
+            client.create_sandbox(snapshot_id="snap-1", idle_ttl_seconds=-1)
+        with pytest.raises(ValueError, match="must be >= 0"):
+            client.create_sandbox(snapshot_id="snap-1", delete_after_stop_seconds=-1)
 
-    def test_create_sandbox_ttl_validation_not_multiple_of_60(
+    def test_create_sandbox_retention_validation_not_multiple_of_60(
         self, client: SandboxClient
     ):
-        """Test that non-multiple-of-60 TTL values raise ValueError."""
+        """Non-multiple-of-60 retention values raise ValueError."""
         with pytest.raises(ValueError, match="must be a multiple of 60"):
-            client.create_sandbox(snapshot_id="snap-1", ttl_seconds=90)
+            client.create_sandbox(snapshot_id="snap-1", idle_ttl_seconds=90)
+        with pytest.raises(ValueError, match="must be a multiple of 60"):
+            client.create_sandbox(snapshot_id="snap-1", delete_after_stop_seconds=90)
 
-    def test_create_sandbox_ttl_zero_allowed(
+    def test_create_sandbox_retention_zero_allowed(
         self, client: SandboxClient, httpx_mock: HTTPXMock
     ):
-        """Test that TTL value of 0 is allowed (disables TTL)."""
+        """Zero is accepted on both retention fields and disables that stage."""
         httpx_mock.add_response(
             method="POST",
             url="http://test-server:8080/boxes",
             json={
                 "name": "test-sandbox",
-                "ttl_seconds": 0,
                 "idle_ttl_seconds": 0,
+                "delete_after_stop_seconds": 0,
                 "dataplane_url": "https://sandbox-router.example.com/sb-123",
             },
             status_code=201,
@@ -591,62 +595,64 @@ class TestSandboxOperations:
 
         sandbox = client.create_sandbox(
             snapshot_id="snap-1",
-            ttl_seconds=0,
             idle_ttl_seconds=0,
+            delete_after_stop_seconds=0,
         )
 
-        assert sandbox.ttl_seconds == 0
         assert sandbox.idle_ttl_seconds == 0
+        assert sandbox.delete_after_stop_seconds == 0
 
-    def test_update_sandbox_with_ttl(
+    def test_update_sandbox_with_retention(
         self, client: SandboxClient, httpx_mock: HTTPXMock
     ):
-        """Test updating a sandbox with TTL values."""
+        """Update both retention fields simultaneously."""
         httpx_mock.add_response(
             method="PATCH",
             url="http://test-server:8080/boxes/my-sandbox",
             json={
                 "name": "my-sandbox",
-                "ttl_seconds": 7200,
                 "idle_ttl_seconds": 1200,
-                "expires_at": "2026-03-24T14:00:00Z",
+                "delete_after_stop_seconds": 7200,
+                "stopped_at": None,
                 "dataplane_url": "https://sandbox-router.example.com/sb-123",
             },
         )
 
         sandbox = client.update_sandbox(
             "my-sandbox",
-            ttl_seconds=7200,
             idle_ttl_seconds=1200,
+            delete_after_stop_seconds=7200,
         )
 
-        assert sandbox.ttl_seconds == 7200
         assert sandbox.idle_ttl_seconds == 1200
-        assert sandbox.expires_at == "2026-03-24T14:00:00Z"
+        assert sandbox.delete_after_stop_seconds == 7200
+        assert sandbox.stopped_at is None
 
         import json
 
         request = httpx_mock.get_request()
         payload = json.loads(request.content)
-        assert payload["ttl_seconds"] == 7200
         assert payload["idle_ttl_seconds"] == 1200
+        assert payload["delete_after_stop_seconds"] == 7200
         assert "name" not in payload
 
-    def test_update_sandbox_ttl_validation(self, client: SandboxClient):
-        """Test that invalid TTL values raise ValueError on update."""
+    def test_update_sandbox_retention_validation(self, client: SandboxClient):
+        """Update path enforces the same retention bounds as create."""
         with pytest.raises(ValueError, match="must be >= 0"):
             client.update_sandbox("my-sandbox", idle_ttl_seconds=-60)
+        with pytest.raises(ValueError, match="must be >= 0"):
+            client.update_sandbox("my-sandbox", delete_after_stop_seconds=-60)
 
-    def test_update_sandbox_name_and_ttl(
+    def test_update_sandbox_name_and_retention(
         self, client: SandboxClient, httpx_mock: HTTPXMock
     ):
-        """Test updating sandbox name and TTL simultaneously."""
+        """Renaming and updating retention in one call."""
         httpx_mock.add_response(
             method="PATCH",
             url="http://test-server:8080/boxes/my-sandbox",
             json={
                 "name": "my-sandbox-renamed",
-                "ttl_seconds": 3600,
+                "delete_after_stop_seconds": 3600,
                 "dataplane_url": "https://sandbox-router.example.com/sb-123",
             },
         )
@@ -654,18 +660,18 @@ class TestSandboxOperations:
         sandbox = client.update_sandbox(
             "my-sandbox",
             new_name="my-sandbox-renamed",
-            ttl_seconds=3600,
+            delete_after_stop_seconds=3600,
         )
 
         assert sandbox.name == "my-sandbox-renamed"
-        assert sandbox.ttl_seconds == 3600
+        assert sandbox.delete_after_stop_seconds == 3600
 
         import json
 
         request = httpx_mock.get_request()
         payload = json.loads(request.content)
         assert payload["name"] == "my-sandbox-renamed"
-        assert payload["ttl_seconds"] == 3600
+        assert payload["delete_after_stop_seconds"] == 3600
 
     def test_list_sandboxes_includes_status(
         self, client: SandboxClient, httpx_mock: HTTPXMock

--- a/python/tests/unit_tests/sandbox/test_sandbox.py
+++ b/python/tests/unit_tests/sandbox/test_sandbox.py
@@ -47,53 +47,74 @@ class TestSandboxProperties:
         assert sandbox.dataplane_url == "https://sandbox-router.example.com/sb-123"
 
 
-class TestSandboxTTLFields:
-    """Tests for TTL fields on Sandbox."""
+class TestSandboxRetentionFields:
+    """Tests for the two-stage retention fields on Sandbox."""
 
-    def test_from_dict_with_ttl(self, client):
-        """Test from_dict parses TTL fields."""
+    def test_from_dict_with_retention(self, client):
+        """from_dict parses idle_ttl_seconds, delete_after_stop_seconds,
+        and stopped_at."""
+        sb = Sandbox.from_dict(
+            data={
+                "name": "test-sandbox",
+                "idle_ttl_seconds": 600,
+                "delete_after_stop_seconds": 86400,
+                "stopped_at": "2026-03-24T12:00:00Z",
+            },
+            client=client,
+            auto_delete=False,
+        )
+        assert sb.idle_ttl_seconds == 600
+        assert sb.delete_after_stop_seconds == 86400
+        assert sb.stopped_at == "2026-03-24T12:00:00Z"
+
+    def test_from_dict_without_retention(self, client):
+        """Retention fields default to None when absent."""
+        sb = Sandbox.from_dict(
+            data={
+                "name": "test-sandbox",
+            },
+            client=client,
+            auto_delete=False,
+        )
+        assert sb.idle_ttl_seconds is None
+        assert sb.delete_after_stop_seconds is None
+        assert sb.stopped_at is None
+
+    def test_from_dict_with_zero_retention(self, client):
+        """Zero values are preserved (each disables that retention stage)."""
+        sb = Sandbox.from_dict(
+            data={
+                "name": "test-sandbox",
+                "idle_ttl_seconds": 0,
+                "delete_after_stop_seconds": 0,
+                "stopped_at": None,
+            },
+            client=client,
+            auto_delete=False,
+        )
+        assert sb.idle_ttl_seconds == 0
+        assert sb.delete_after_stop_seconds == 0
+        assert sb.stopped_at is None
+
+    def test_from_dict_silently_ignores_legacy_fields(self, client):
+        """Older smith-go responses may include the now-removed
+        ttl_seconds/expires_at fields; the SDK should silently drop them
+        rather than fail."""
         sb = Sandbox.from_dict(
             data={
                 "name": "test-sandbox",
                 "ttl_seconds": 3600,
-                "idle_ttl_seconds": 600,
                 "expires_at": "2026-03-24T12:00:00Z",
+                "idle_ttl_seconds": 600,
             },
             client=client,
             auto_delete=False,
         )
-        assert sb.ttl_seconds == 3600
         assert sb.idle_ttl_seconds == 600
-        assert sb.expires_at == "2026-03-24T12:00:00Z"
-
-    def test_from_dict_without_ttl(self, client):
-        """Test from_dict defaults TTL fields to None when absent."""
-        sb = Sandbox.from_dict(
-            data={
-                "name": "test-sandbox",
-            },
-            client=client,
-            auto_delete=False,
-        )
-        assert sb.ttl_seconds is None
-        assert sb.idle_ttl_seconds is None
-        assert sb.expires_at is None
-
-    def test_from_dict_with_zero_ttl(self, client):
-        """Test from_dict handles zero TTL values (TTL disabled)."""
-        sb = Sandbox.from_dict(
-            data={
-                "name": "test-sandbox",
-                "ttl_seconds": 0,
-                "idle_ttl_seconds": 0,
-                "expires_at": None,
-            },
-            client=client,
-            auto_delete=False,
-        )
-        assert sb.ttl_seconds == 0
-        assert sb.idle_ttl_seconds == 0
-        assert sb.expires_at is None
+        assert sb.delete_after_stop_seconds is None
+        assert sb.stopped_at is None
+        assert not hasattr(sb, "ttl_seconds")
+        assert not hasattr(sb, "expires_at")
 
 
 class TestSandboxStatusFields:


### PR DESCRIPTION
## Summary

Aligns the alpha Python sandbox client with the new two-stage retention
model on the LangSmith sandbox API:

- `idle_ttl_seconds` — stops the sandbox after a period of inactivity.
- `delete_after_stop_seconds` (new) — deletes the stopped sandbox + its
  underlying clone N seconds after it transitioned to `stopped`.

Removes the legacy `ttl_seconds` and `expires_at` fields from:

- `SandboxClient.create_sandbox` / `update_sandbox` / `sandbox()` and
  the async equivalents
- `Sandbox` / `AsyncSandbox` data shape (`from_dict`, attributes, repr)
- README + tests

The sandbox module is alpha (see `langsmith.sandbox` README), so this
is an intentional breaking change. The server has dropped `ttl_seconds`
from its accepted/returned payload, so keeping the field in the SDK
would mis-represent what is actually being configured. Passing the old
`ttl_seconds=` kwarg now raises `TypeError`, which fails loudly instead
of silently mis-configuring.

Adds `stopped_at` to `Sandbox` / `AsyncSandbox` so callers can read
when the delete countdown started.

## Related

- TypeScript sandbox client gets the same change in a sibling PR.
- Docs are updated in a sibling PR.

Made with [Cursor](https://cursor.com)