### PR TITLE
sdk(js): replace ttlSeconds with idleTtlSeconds + deleteAfterStopSeconds

### DIFF
--- a/js/src/experimental/sandbox/README.md
+++ b/js/src/experimental/sandbox/README.md
@@ -489,7 +489,7 @@ try {
 | `createSandbox(snapshotId?, options?)` | Create a sandbox from a snapshot. Exactly one of the positional `snapshotId` or `options.snapshotName` must be provided. |
 | `getSandbox(name)` | Get an existing sandbox by name |
 | `listSandboxes()` | List all sandboxes |
-| `updateSandbox(name, options)` | Rename or adjust TTLs on a sandbox |
+| `updateSandbox(name, options)` | Rename or adjust retention (idle stop, delete-after-stop) on a sandbox |
 | `deleteSandbox(name)` | Delete a sandbox |
 | `startSandbox(name, options?)` | Start a stopped sandbox and wait until ready |
 | `stopSandbox(name)` | Stop a running sandbox (preserves files) |
@@ -553,8 +553,8 @@ try {
 | `name?` | Custom sandbox name |
 | `timeout?` | Wait timeout in seconds |
 | `waitForReady?` | Wait for the sandbox to be ready before returning (default: `true`) |
-| `ttlSeconds?` | Maximum lifetime in seconds (multiple of 60; `0` disables) |
-| `idleTtlSeconds?` | Idle timeout in seconds (multiple of 60; `0` disables). When omitted, the server applies a default of `600` seconds (10 minutes). |
+| `idleTtlSeconds?` | Idle timeout in seconds (multiple of 60; `0` disables idle stop). When omitted, the server applies a default of `600` seconds (10 minutes). |
+| `deleteAfterStopSeconds?` | Seconds after the sandbox enters `stopped` before deletion (multiple of 60; `0` disables stop-anchored deletion). When omitted, the server applies its configured default. |
 | `vCpus?` | Number of vCPUs |
 | `memBytes?` | Memory allocation in bytes |
 | `fsCapacityBytes?` | Root filesystem capacity in bytes |
@@ -585,8 +585,8 @@ try {
 | Property | Description |
 |----------|-------------|
 | `newName?` | New display name |
-| `ttlSeconds?` | Maximum lifetime in seconds (multiple of 60; `0` disables) |
-| `idleTtlSeconds?` | Idle timeout in seconds (multiple of 60; `0` disables). Omit to leave the existing value unchanged. |
+| `idleTtlSeconds?` | Idle timeout in seconds (multiple of 60; `0` disables idle stop). Omit to leave the existing value unchanged. |
+| `deleteAfterStopSeconds?` | Seconds after the sandbox enters `stopped` before deletion (multiple of 60; `0` disables). Omit to leave the existing value unchanged. |
 
 ### RunOptions
 

--- a/js/src/experimental/sandbox/client.ts
+++ b/js/src/experimental/sandbox/client.ts
@@ -235,8 +235,8 @@ export class SandboxClient {
       name,
       timeout = 30,
       waitForReady = true,
-      ttlSeconds,
       idleTtlSeconds,
+      deleteAfterStopSeconds,
       vCpus,
       memBytes,
       fsCapacityBytes,
@@ -250,8 +250,8 @@ export class SandboxClient {
       );
     }
 
-    validateTtl(ttlSeconds, "ttlSeconds");
     validateTtl(idleTtlSeconds, "idleTtlSeconds");
+    validateTtl(deleteAfterStopSeconds, "deleteAfterStopSeconds");
 
     const url = `${this._baseUrl}/boxes`;
 
@@ -270,11 +270,11 @@ export class SandboxClient {
     if (name) {
       payload.name = name;
     }
-    if (ttlSeconds !== undefined) {
-      payload.ttl_seconds = ttlSeconds;
-    }
     if (idleTtlSeconds !== undefined) {
       payload.idle_ttl_seconds = idleTtlSeconds;
+    }
+    if (deleteAfterStopSeconds !== undefined) {
+      payload.delete_after_stop_seconds = deleteAfterStopSeconds;
     }
     if (vCpus !== undefined) {
       payload.vcpus = vCpus;
@@ -370,14 +370,15 @@ export class SandboxClient {
    */
   async updateSandbox(name: string, newName: string): Promise<Sandbox>;
   /**
-   * Update a sandbox's name and/or TTL settings.
+   * Update a sandbox's name and/or retention settings (idle stop and
+   * delete-after-stop).
    *
    * @param name - Current sandbox name.
    * @param options - Fields to update. Omit a field to leave it unchanged.
    * @returns Updated Sandbox. If no fields are provided, returns the current sandbox.
    * @throws LangSmithResourceNotFoundError if sandbox not found.
    * @throws LangSmithResourceNameConflictError if newName is already in use.
-   * @throws LangSmithValidationError if TTL values are invalid.
+   * @throws LangSmithValidationError if retention values are invalid.
    */
   async updateSandbox(
     name: string,
@@ -392,14 +393,14 @@ export class SandboxClient {
         ? { newName: newNameOrOptions }
         : newNameOrOptions;
 
-    const { newName, ttlSeconds, idleTtlSeconds } = options;
-    validateTtl(ttlSeconds, "ttlSeconds");
+    const { newName, idleTtlSeconds, deleteAfterStopSeconds } = options;
     validateTtl(idleTtlSeconds, "idleTtlSeconds");
+    validateTtl(deleteAfterStopSeconds, "deleteAfterStopSeconds");
 
     if (
       newName === undefined &&
-      ttlSeconds === undefined &&
-      idleTtlSeconds === undefined
+      idleTtlSeconds === undefined &&
+      deleteAfterStopSeconds === undefined
     ) {
       return this.getSandbox(name);
     }
@@ -409,11 +410,11 @@ export class SandboxClient {
     if (newName !== undefined) {
       payload.name = newName;
     }
-    if (ttlSeconds !== undefined) {
-      payload.ttl_seconds = ttlSeconds;
-    }
     if (idleTtlSeconds !== undefined) {
       payload.idle_ttl_seconds = idleTtlSeconds;
+    }
+    if (deleteAfterStopSeconds !== undefined) {
+      payload.delete_after_stop_seconds = deleteAfterStopSeconds;
     }
 
     const response = await this._fetch(url, {

--- a/js/src/experimental/sandbox/sandbox.ts
+++ b/js/src/experimental/sandbox/sandbox.ts
@@ -54,16 +54,24 @@ export class Sandbox {
   readonly created_at?: string;
   /** Timestamp when the sandbox was last updated. */
   readonly updated_at?: string;
-  /** Maximum lifetime TTL in seconds (`0` means disabled). */
-  readonly ttl_seconds?: number;
   /**
    * Idle timeout TTL in seconds (`0` means disabled).
    * New sandboxes receive a server-side default of `600` seconds (10 minutes)
-   * when the caller did not set `idleTtlSeconds` explicitly.
+   * when the caller did not set `idleTtlSeconds` explicitly. The launcher
+   * stops the sandbox after this many idle seconds.
    */
   readonly idle_ttl_seconds?: number;
-  /** Computed expiration timestamp when a TTL is active. */
-  readonly expires_at?: string;
+  /**
+   * Seconds after the sandbox enters the `stopped` state before it (and
+   * its filesystem clone) are permanently deleted (`0` means disabled).
+   */
+  readonly delete_after_stop_seconds?: number;
+  /**
+   * Timestamp when the sandbox transitioned to `stopped`, or `undefined`
+   * while running. The deletion deadline is
+   * `stopped_at + delete_after_stop_seconds`.
+   */
+  readonly stopped_at?: string;
   /** Snapshot ID used to create this sandbox. */
   readonly snapshot_id?: string;
   /** Number of vCPUs allocated. */
@@ -84,9 +92,9 @@ export class Sandbox {
     this.id = data.id;
     this.created_at = data.created_at;
     this.updated_at = data.updated_at;
-    this.ttl_seconds = data.ttl_seconds;
     this.idle_ttl_seconds = data.idle_ttl_seconds;
-    this.expires_at = data.expires_at;
+    this.delete_after_stop_seconds = data.delete_after_stop_seconds;
+    this.stopped_at = data.stopped_at ?? undefined;
     this.snapshot_id = data.snapshot_id;
     this.vCpus = data.vcpus;
     this.mem_bytes = data.mem_bytes;

--- a/js/src/experimental/sandbox/types.ts
+++ b/js/src/experimental/sandbox/types.ts
@@ -57,12 +57,24 @@ export interface SandboxData {
   status_message?: string;
   created_at?: string;
   updated_at?: string;
-  /** Maximum lifetime TTL in seconds (`0` means disabled, omitted/`undefined` means not set). */
-  ttl_seconds?: number;
-  /** Idle timeout TTL in seconds (`0` means disabled, omitted/`undefined` means not set). */
+  /**
+   * Idle timeout in seconds. The launcher stops the sandbox after this
+   * many seconds of inactivity. `0` disables the idle stop;
+   * omitted/`undefined` means not set (the server applies a default).
+   */
   idle_ttl_seconds?: number;
-  /** Computed expiration timestamp when a TTL is active, else omitted/`undefined`. */
-  expires_at?: string;
+  /**
+   * Seconds after a sandbox enters the `stopped` state before it (and its
+   * filesystem clone) are permanently deleted. `0` disables stop-anchored
+   * deletion; omitted/`undefined` falls back to the server default.
+   */
+  delete_after_stop_seconds?: number;
+  /**
+   * Timestamp when the sandbox transitioned to the `stopped` state, or
+   * `undefined` while running. The deletion deadline is
+   * `stopped_at + delete_after_stop_seconds`.
+   */
+  stopped_at?: string;
   /** Snapshot ID used to create this sandbox. */
   snapshot_id?: string;
   /** Number of vCPUs allocated. */
@@ -276,16 +288,20 @@ export interface CreateSandboxOptions {
    */
   waitForReady?: boolean;
   /**
-   * Maximum lifetime in seconds from creation. The sandbox is deleted after
-   * this duration. Must be a multiple of 60, or `0`/`undefined` to disable or omit.
-   */
-  ttlSeconds?: number;
-  /**
-   * Idle timeout in seconds. The sandbox is deleted after this much inactivity.
-   * Must be a multiple of 60. Pass `0` to explicitly disable the idle timeout.
-   * When omitted, the server applies a default of `600` seconds (10 minutes).
+   * Idle timeout in seconds. The launcher stops the sandbox after this many
+   * seconds of inactivity. Must be a multiple of 60. Pass `0` to disable
+   * the idle stop. When omitted, the server applies a default of `600`
+   * seconds (10 minutes).
    */
   idleTtlSeconds?: number;
+  /**
+   * Seconds after the sandbox enters the `stopped` state before it (and
+   * its filesystem clone) are permanently deleted. Must be a multiple of
+   * 60. Pass `0` to disable stop-anchored deletion (manual cleanup
+   * required). When omitted, the server applies its configured default
+   * (typically 14 days).
+   */
+  deleteAfterStopSeconds?: number;
   /** Number of vCPUs. */
   vCpus?: number;
   /** Memory in bytes. */
@@ -381,21 +397,23 @@ export interface StartSandboxOptions {
 }
 
 /**
- * Options for updating a sandbox (name and/or TTL).
+ * Options for updating a sandbox (name and/or retention settings).
  */
 export interface UpdateSandboxOptions {
   /** New display name. */
   newName?: string;
   /**
-   * Maximum lifetime in seconds from creation. Must be a multiple of 60.
-   * Pass `0` to disable absolute TTL.
-   */
-  ttlSeconds?: number;
-  /**
-   * Idle timeout in seconds. Must be a multiple of 60. Pass `0` to disable.
-   * Omit (or pass `undefined`) to leave the existing value unchanged.
+   * Idle timeout in seconds. Must be a multiple of 60. Pass `0` to disable
+   * the idle stop. Omit (or pass `undefined`) to leave the existing value
+   * unchanged.
    */
   idleTtlSeconds?: number;
+  /**
+   * Seconds after entering `stopped` before deletion. Must be a multiple
+   * of 60. Pass `0` to disable stop-anchored deletion. Omit (or pass
+   * `undefined`) to leave the existing value unchanged.
+   */
+  deleteAfterStopSeconds?: number;
 }
 
 /**

--- a/js/src/tests/sandbox.test.ts
+++ b/js/src/tests/sandbox.test.ts
@@ -371,40 +371,43 @@ describe("SandboxClient - createSandbox", () => {
     expect(init.signal).toBeDefined();
   });
 
-  it("should include ttl_seconds and idle_ttl_seconds in the request body when set", async () => {
+  it("should include idle_ttl_seconds and delete_after_stop_seconds in the request body when set", async () => {
     const mockFetch = jest.fn<typeof fetch>().mockResolvedValue({
       ok: true,
       json: async () => ({
         name: "test-sb",
         dataplane_url: "https://dp.example.com",
         status: "ready",
-        ttl_seconds: 3600,
         idle_ttl_seconds: 600,
-        expires_at: "2026-03-24T15:00:00Z",
+        delete_after_stop_seconds: 86400,
+        stopped_at: null,
       }),
     } as Response);
 
     const client = createClientWithMock(mockFetch);
     const sandbox = await client.createSandbox("snap-123", {
-      ttlSeconds: 3600,
       idleTtlSeconds: 600,
+      deleteAfterStopSeconds: 86400,
     });
 
     const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
     const body = JSON.parse(init.body as string);
-    expect(body.ttl_seconds).toBe(3600);
     expect(body.idle_ttl_seconds).toBe(600);
-    expect(sandbox.ttl_seconds).toBe(3600);
+    expect(body.delete_after_stop_seconds).toBe(86400);
     expect(sandbox.idle_ttl_seconds).toBe(600);
-    expect(sandbox.expires_at).toBe("2026-03-24T15:00:00Z");
+    expect(sandbox.delete_after_stop_seconds).toBe(86400);
+    expect(sandbox.stopped_at).toBeUndefined();
   });
 
-  it("should reject invalid TTL values before calling the API", async () => {
+  it("should reject invalid retention values before calling the API", async () => {
     const mockFetch = jest.fn<typeof fetch>();
     const client = createClientWithMock(mockFetch);
 
     await expect(
-      client.createSandbox("snap-123", { ttlSeconds: 61 }),
+      client.createSandbox("snap-123", { idleTtlSeconds: 61 }),
+    ).rejects.toThrow(LangSmithValidationError);
+    await expect(
+      client.createSandbox("snap-123", { deleteAfterStopSeconds: 61 }),
     ).rejects.toThrow(LangSmithValidationError);
     expect(mockFetch).not.toHaveBeenCalled();
   });
@@ -451,20 +454,20 @@ describe("SandboxClient - createSandbox", () => {
 
 describe("validateTtl", () => {
   it("accepts undefined, 0, and positive multiples of 60", () => {
-    expect(() => validateTtl(undefined, "ttlSeconds")).not.toThrow();
-    expect(() => validateTtl(0, "ttlSeconds")).not.toThrow();
-    expect(() => validateTtl(60, "ttlSeconds")).not.toThrow();
-    expect(() => validateTtl(3600, "idleTtlSeconds")).not.toThrow();
+    expect(() => validateTtl(undefined, "idleTtlSeconds")).not.toThrow();
+    expect(() => validateTtl(0, "idleTtlSeconds")).not.toThrow();
+    expect(() => validateTtl(60, "idleTtlSeconds")).not.toThrow();
+    expect(() => validateTtl(3600, "deleteAfterStopSeconds")).not.toThrow();
   });
 
   it("rejects negative values and non-multiples of 60", () => {
-    expect(() => validateTtl(-1, "ttlSeconds")).toThrow(
+    expect(() => validateTtl(-1, "idleTtlSeconds")).toThrow(
       LangSmithValidationError,
     );
-    expect(() => validateTtl(30, "ttlSeconds")).toThrow(
+    expect(() => validateTtl(30, "idleTtlSeconds")).toThrow(
       LangSmithValidationError,
     );
-    expect(() => validateTtl(61, "idleTtlSeconds")).toThrow(
+    expect(() => validateTtl(61, "deleteAfterStopSeconds")).toThrow(
       LangSmithValidationError,
     );
   });
@@ -481,28 +484,28 @@ describe("SandboxClient - updateSandbox", () => {
     return client;
   };
 
-  it("should PATCH ttl fields when provided in options", async () => {
+  it("should PATCH retention fields when provided in options", async () => {
     const mockFetch = jest.fn<typeof fetch>().mockResolvedValue({
       ok: true,
       json: async () => ({
         name: "sb-1",
         status: "ready",
-        ttl_seconds: 0,
         idle_ttl_seconds: 1800,
+        delete_after_stop_seconds: 0,
       }),
     } as Response);
 
     const client = createClientWithMock(mockFetch);
     await client.updateSandbox("sb-1", {
-      ttlSeconds: 0,
       idleTtlSeconds: 1800,
+      deleteAfterStopSeconds: 0,
     });
 
     const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
     expect(init.method).toBe("PATCH");
     const body = JSON.parse(init.body as string);
-    expect(body.ttl_seconds).toBe(0);
     expect(body.idle_ttl_seconds).toBe(1800);
+    expect(body.delete_after_stop_seconds).toBe(0);
     expect(body.name).toBeUndefined();
   });
 


### PR DESCRIPTION
## Summary

Aligns the alpha TypeScript sandbox client with the new two-stage
retention model on the LangSmith sandbox API:

- `idleTtlSeconds` — stops the sandbox after a period of inactivity.
- `deleteAfterStopSeconds` (new) — deletes the stopped sandbox + its
  underlying clone N seconds after it transitioned to `stopped`.

Removes the legacy `ttl_seconds` / `expires_at` fields from:

- `SandboxClient.createSandbox` / `updateSandbox` options
- `SandboxData` / `Sandbox` attributes
- README + tests

Adds `stopped_at` to `Sandbox` so callers can read when the delete
countdown started. Coerces `null -> undefined` when reading from the
API response so the optional field stays consistent with its
TypeScript type.

The sandbox module is alpha (see `js/src/experimental/sandbox/README.md`),
so this is an intentional breaking change. The Python SDK gets the
matching change in a sibling PR; the docs are updated in another sibling
PR.

Made with [Cursor](https://cursor.com)