### PR TITLE
Bump Python SDK version to 0.8.2

### DIFF
--- a/python/langsmith/__init__.py
+++ b/python/langsmith/__init__.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
 
 # Avoid calling into importlib on every call to __version__
 
-__version__ = "0.8.1"
+__version__ = "0.8.2"
 version = __version__  # for backwards compatibility
 
 


### PR DESCRIPTION
## Summary
- Bump Python SDK version to 0.8.2.

## Test plan
- [x] `python3 -c "import langsmith; assert langsmith.__version__ == '0.8.2'; assert langsmith.version == '0.8.2'; print(langsmith.__version__)"`