### PR TITLE
release(py): 0.8.3

### DIFF
--- a/python/.bumpversion.cfg
+++ b/python/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.8.0
+current_version = 0.8.3
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
 serialize = {major}.{minor}.{patch}
 search = {current_version}

--- a/python/langsmith/__init__.py
+++ b/python/langsmith/__init__.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
 
 # Avoid calling into importlib on every call to __version__
 
-__version__ = "0.8.2"
+__version__ = "0.8.3"
 version = __version__  # for backwards compatibility
 
 


### PR DESCRIPTION
## Summary
Patch release bump for Python SDK from `0.8.2` to `0.8.3`.

## Changes
- `python/langsmith/__init__.py`: `__version__` -> `0.8.3`
- `python/.bumpversion.cfg`: `current_version` -> `0.8.3`

## Notes
- This PR is release-only and contains version bump files only.
- Local tag created by bump tool is intentionally not pushed.
