### PR TITLE
release(js): 0.6.3

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langsmith",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Client library to connect to the LangSmith Observability and Evaluation Platform.",
   "packageManager": "pnpm@10.33.0",
   "files": [

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -32,4 +32,4 @@ export {
 } from "./utils/prompt_cache/index.js";
 
 // Update using pnpm bump-version
-export const __version__ = "0.6.2";
+export const __version__ = "0.6.3";


### PR DESCRIPTION
## Summary
Patch release bump for JS SDK from `0.6.2` to `0.6.3`.

## Changes
- `js/package.json`: `version` -> `0.6.3`
- `js/src/index.ts`: `__version__` -> `0.6.3`

## Notes
- This PR is release-only and contains version bump files only.
