### PR TITLE
fix(python): add OAuth user header and refresh locking

### DIFF
--- a/python/langsmith/_internal/_profiles.py
+++ b/python/langsmith/_internal/_profiles.py
@@ -2,10 +2,14 @@
 
 from __future__ import annotations
 
+import base64
+import binascii
 import datetime
+import errno
 import json
 import os
 import threading
+import time
 from collections.abc import Mapping
 from pathlib import Path
 from typing import Any, NamedTuple, Optional, TypedDict, cast
@@ -15,6 +19,13 @@ import requests
 _OAUTH_CLIENT_ID = "langsmith-cli"
 _TOKEN_REFRESH_LEEWAY = datetime.timedelta(minutes=1)
 _TOKEN_REFRESH_TIMEOUT = 10
+_X_USER_ID_HEADER = "x-user-id"
+_OAUTH_USER_ID_CLAIM = "sub"
+_REFRESH_LOCK_POLL_SECONDS = 0.05
+_REFRESH_LOCK_STALE_SECONDS = _TOKEN_REFRESH_TIMEOUT + 30
+_REFRESH_LOCK_TIMEOUT_SECONDS = _REFRESH_LOCK_STALE_SECONDS + _TOKEN_REFRESH_TIMEOUT
+_REFRESH_LOCKS_LOCK = threading.Lock()
+_REFRESH_LOCKS: dict[tuple[Path, str], threading.Lock] = {}
 
 
 class ProfileOAuth(TypedDict, total=False):
@@ -102,6 +113,84 @@ def _profile_from_state(state: ProfileState) -> Optional[ProfileConfig]:
     if not isinstance(profile, dict):
         return None
     return cast(ProfileConfig, profile)
+
+
+def _reload_profile_state(state: ProfileState) -> ProfileState:
+    try:
+        raw = json.loads(state.path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return state
+    if not isinstance(raw, dict):
+        return state
+    profiles = raw.get("profiles")
+    if not isinstance(profiles, dict):
+        return state
+    if not isinstance(profiles.get(state.profile_name), dict):
+        return state
+    return ProfileState(state.path, cast(ProfileConfigFile, raw), state.profile_name)
+
+
+def _refresh_lock_for_state(state: ProfileState) -> threading.Lock:
+    key = (state.path, state.profile_name)
+    with _REFRESH_LOCKS_LOCK:
+        lock = _REFRESH_LOCKS.get(key)
+        if lock is None:
+            lock = threading.Lock()
+            _REFRESH_LOCKS[key] = lock
+        return lock
+
+
+def _refresh_lock_path(state: ProfileState) -> Path:
+    return state.path.with_name(f"{state.path.name}.oauth-refresh.lock")
+
+
+def _is_refresh_lock_stale(lock_path: Path) -> bool:
+    try:
+        modified_at = lock_path.stat().st_mtime
+    except OSError:
+        return False
+    return time.time() - modified_at > _REFRESH_LOCK_STALE_SECONDS
+
+
+def _acquire_filesystem_refresh_lock(state: ProfileState) -> Optional[Path]:
+    lock_path = _refresh_lock_path(state)
+    deadline = time.monotonic() + _REFRESH_LOCK_TIMEOUT_SECONDS
+    while True:
+        try:
+            fd = os.open(lock_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+        except FileExistsError:
+            if _is_refresh_lock_stale(lock_path):
+                try:
+                    lock_path.unlink()
+                except OSError:
+                    pass
+                continue
+            if time.monotonic() >= deadline:
+                return None
+            time.sleep(_REFRESH_LOCK_POLL_SECONDS)
+            continue
+        except OSError as exc:
+            if exc.errno == errno.ENOENT:
+                try:
+                    lock_path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+                except OSError:
+                    return None
+                continue
+            return None
+        try:
+            os.write(fd, str(os.getpid()).encode())
+        finally:
+            os.close(fd)
+        return lock_path
+
+
+def _release_filesystem_refresh_lock(lock_path: Optional[Path]) -> None:
+    if lock_path is None:
+        return
+    try:
+        lock_path.unlink()
+    except OSError:
+        pass
 
 
 def load_profile_client_config() -> ProfileClientConfig:
@@ -228,7 +317,6 @@ class ProfileAuth:
     ) -> None:
         self._state = config.profile_state
         self._api_key_header = api_key_header
-        self._lock = threading.Lock()
         self._managed_auth_headers: set[tuple[str, str]] = set()
         self._remember_auth_headers(self._auth_headers(refresh=False))
 
@@ -285,10 +373,18 @@ class ProfileAuth:
         if profile is None:
             return {}
         if refresh and should_refresh_profile_token(profile):
-            with self._lock:
-                profile = self._profile()
-                if profile is not None and should_refresh_profile_token(profile):
-                    self._refresh(profile)
+            if self._state is None:
+                return self._headers_from_profile(profile)
+            with _refresh_lock_for_state(self._state):
+                lock_path = _acquire_filesystem_refresh_lock(self._state)
+                try:
+                    self._state = _reload_profile_state(self._state)
+                    profile = self._profile()
+                    if profile is not None and should_refresh_profile_token(profile):
+                        self._refresh(profile)
+                    profile = self._profile()
+                finally:
+                    _release_filesystem_refresh_lock(lock_path)
         return self._headers_from_profile(profile)
 
     def _refresh(self, profile: ProfileConfig) -> None:
@@ -314,7 +410,11 @@ class ProfileAuth:
             (profile.get("oauth") or {}).get("access_token")
         )
         if oauth_access_token:
-            return {"Authorization": f"Bearer {oauth_access_token}"}
+            headers = {"Authorization": f"Bearer {oauth_access_token}"}
+            user_id = _oauth_user_id_from_access_token(oauth_access_token)
+            if user_id:
+                headers[_X_USER_ID_HEADER] = user_id
+            return headers
         api_key = trim_auth_value(profile.get("api_key"))
         if api_key:
             return {self._api_key_header: api_key}
@@ -322,7 +422,7 @@ class ProfileAuth:
 
     def _remember_auth_headers(self, headers: Mapping[str, str]) -> None:
         for name, value in headers.items():
-            if self._is_auth_header_name(name) and value:
+            if self._is_managed_header_name(name) and value:
                 self._managed_auth_headers.add((name.lower(), value))
 
     def _is_profile_auth_header(self, name: str, value: str) -> bool:
@@ -336,3 +436,27 @@ class ProfileAuth:
 
     def _is_auth_header_name(self, name: str) -> bool:
         return name.lower() in {"authorization", self._api_key_header.lower()}
+
+    def _is_managed_header_name(self, name: str) -> bool:
+        return self._is_auth_header_name(name) or name.lower() == _X_USER_ID_HEADER
+
+
+def _oauth_user_id_from_access_token(access_token: str) -> Optional[str]:
+    parts = access_token.split(".")
+    if len(parts) < 2:
+        return None
+    try:
+        payload = json.loads(_decode_base64_url(parts[1]))
+    except (binascii.Error, ValueError, UnicodeDecodeError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    value = payload.get(_OAUTH_USER_ID_CLAIM)
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
+
+
+def _decode_base64_url(value: str) -> bytes:
+    padding = "=" * (-len(value) % 4)
+    return base64.urlsafe_b64decode(value + padding)

--- a/python/tests/unit_tests/test_async_client.py
+++ b/python/tests/unit_tests/test_async_client.py
@@ -1,7 +1,10 @@
 """Test the AsyncClient."""
 
+import asyncio
+import base64
 import json
 import pathlib
+import time
 import uuid
 import warnings
 from datetime import datetime
@@ -28,6 +31,11 @@ def _clear_profile_env(monkeypatch: pytest.MonkeyPatch) -> None:
         "LANGSMITH_PROFILE",
     ):
         monkeypatch.delenv(key, raising=False)
+
+
+def _fake_oauth_token(payload: dict[str, object]) -> str:
+    encoded_payload = base64.urlsafe_b64encode(json.dumps(payload).encode()).decode()
+    return f"header.{encoded_payload.rstrip('=')}.signature"
 
 
 @mock.patch("langsmith.async_client.httpx.AsyncClient")
@@ -139,6 +147,7 @@ def test_async_client_profile_config_uses_oauth_access_token(
     mock_httpx_client = mock.Mock()
     mock_httpx_client.headers = httpx.Headers()
     mock_client_cls.return_value = mock_httpx_client
+    access_token = _fake_oauth_token({"sub": "user-123"})
     config_path = tmp_path / "config.json"
     config_path.write_text(
         json.dumps(
@@ -146,7 +155,7 @@ def test_async_client_profile_config_uses_oauth_access_token(
                 "profiles": {
                     "default": {
                         "api_url": "https://profile.example.com",
-                        "oauth": {"access_token": "profile-access-token"},
+                        "oauth": {"access_token": access_token},
                     }
                 }
             }
@@ -159,7 +168,8 @@ def test_async_client_profile_config_uses_oauth_access_token(
 
     assert mock_client_cls.call_args.kwargs["base_url"] == "https://profile.example.com"
     passed_headers = mock_client_cls.call_args.kwargs["headers"]
-    assert passed_headers["Authorization"] == "Bearer profile-access-token"
+    assert passed_headers["Authorization"] == f"Bearer {access_token}"
+    assert passed_headers["x-user-id"] == "user-123"
     assert "x-api-key" not in passed_headers
 
 
@@ -219,6 +229,79 @@ async def test_async_client_profile_refresh_replaces_snapshotted_auth_headers(
 
     request_headers = mock_httpx_client.request.call_args.kwargs["headers"]
     assert request_headers["Authorization"] == "Bearer new-access-token"
+
+
+@mock.patch("langsmith.async_client.httpx.AsyncClient")
+@pytest.mark.asyncio
+async def test_async_client_profile_refresh_singleflight_for_concurrent_requests(
+    mock_client_cls: mock.Mock,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: pathlib.Path,
+) -> None:
+    _clear_profile_env(monkeypatch)
+    mock_httpx_client = mock.AsyncMock()
+    mock_httpx_client.headers = httpx.Headers()
+    mock_client_cls.return_value = mock_httpx_client
+    old_access_token = _fake_oauth_token({"sub": "old-user"})
+    new_access_token = _fake_oauth_token({"sub": "new-user"})
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "profiles": {
+                    "default": {
+                        "api_url": "https://profile.example.com",
+                        "oauth": {
+                            "access_token": old_access_token,
+                            "refresh_token": "old-refresh-token",
+                            "expires_at": "2000-01-01T00:00:00Z",
+                        },
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("LANGSMITH_CONFIG_FILE", str(config_path))
+    refresh_calls = []
+
+    def mock_post(url: str, **kwargs: object) -> mock.Mock:
+        refresh_calls.append((url, kwargs))
+        time.sleep(0.05)
+        response = mock.Mock()
+        response.status_code = 200
+        response.json.return_value = {
+            "access_token": new_access_token,
+            "refresh_token": "new-refresh-token",
+            "expires_in": 300,
+        }
+        return response
+
+    monkeypatch.setattr(requests, "post", mock_post)
+    request_headers = []
+    response = mock.Mock()
+    response.status_code = 200
+    response.raise_for_status.return_value = None
+
+    async def mock_request(*args: object, **kwargs: object) -> mock.Mock:
+        request_headers.append(dict(mock_httpx_client.headers))
+        return response
+
+    mock_httpx_client.request.side_effect = mock_request
+    client = AsyncClient()
+    concurrency = 25
+
+    await asyncio.gather(
+        *(client._arequest_with_retries("GET", "/info") for _ in range(concurrency))
+    )
+
+    assert len(refresh_calls) == 1
+    assert len(request_headers) == concurrency
+    assert all(
+        headers["authorization"] == f"Bearer {new_access_token}"
+        and headers["x-user-id"] == "new-user"
+        for headers in request_headers
+    )
 
 
 @mock.patch("langsmith.async_client.httpx.AsyncClient")

--- a/python/tests/unit_tests/test_client.py
+++ b/python/tests/unit_tests/test_client.py
@@ -1,6 +1,7 @@
 """Test the LangSmith client."""
 
 import asyncio
+import base64
 import dataclasses
 import gc
 import inspect
@@ -182,6 +183,11 @@ def _clear_profile_env(monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv(key, raising=False)
 
 
+def _fake_oauth_token(payload: dict[str, object]) -> str:
+    encoded_payload = base64.urlsafe_b64encode(json.dumps(payload).encode()).decode()
+    return f"header.{encoded_payload.rstrip('=')}.signature"
+
+
 def test_profile_config_loads_api_key_and_workspace(
     monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path
 ) -> None:
@@ -238,6 +244,61 @@ def test_profile_config_uses_oauth_access_token_before_api_key(
     assert client.api_key is None
     assert client._headers["Authorization"] == "Bearer profile-access-token"
     assert "x-api-key" not in client._headers
+
+
+def test_profile_config_oauth_headers_include_user_id(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path
+) -> None:
+    _clear_profile_env(monkeypatch)
+    access_token = _fake_oauth_token({"sub": "user-123"})
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "profiles": {
+                    "default": {
+                        "api_key": "profile-key",
+                        "oauth": {"access_token": access_token},
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("LANGSMITH_CONFIG_FILE", str(config_path))
+
+    client = Client(auto_batch_tracing=False)
+
+    assert client.api_key is None
+    assert client._headers["Authorization"] == f"Bearer {access_token}"
+    assert client._headers["x-user-id"] == "user-123"
+    assert "x-api-key" not in client._headers
+
+
+def test_profile_config_oauth_headers_use_subject_claim_only(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path
+) -> None:
+    _clear_profile_env(monkeypatch)
+    access_token = _fake_oauth_token({"user_id": "generic-user"})
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "profiles": {
+                    "default": {
+                        "oauth": {"access_token": access_token},
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("LANGSMITH_CONFIG_FILE", str(config_path))
+
+    client = Client(auto_batch_tracing=False)
+
+    assert client._headers["Authorization"] == f"Bearer {access_token}"
+    assert "x-user-id" not in client._headers
 
 
 def test_profile_config_env_auth_suppresses_profile_auth(
@@ -383,6 +444,305 @@ def test_profile_config_refreshes_expired_oauth_token(
     assert "bearer_token" not in updated["profiles"]["default"]
 
 
+def test_profile_config_refresh_updates_x_user_id_header(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path
+) -> None:
+    _clear_profile_env(monkeypatch)
+    old_access_token = _fake_oauth_token({"sub": "old-user"})
+    new_access_token = _fake_oauth_token({"sub": "new-user"})
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "profiles": {
+                    "default": {
+                        "api_url": "https://profile.example.com",
+                        "oauth": {
+                            "access_token": old_access_token,
+                            "refresh_token": "old-refresh-token",
+                            "expires_at": "2000-01-01T00:00:00Z",
+                        },
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("LANGSMITH_CONFIG_FILE", str(config_path))
+
+    def mock_post(url: str, **kwargs: object) -> mock.Mock:
+        response = mock.Mock()
+        response.status_code = 200
+        response.json.return_value = {
+            "access_token": new_access_token,
+            "refresh_token": "new-refresh-token",
+            "expires_in": 300,
+        }
+        return response
+
+    monkeypatch.setattr(requests, "post", mock_post)
+    client = Client(auto_batch_tracing=False)
+    request_calls = []
+    response = mock.Mock()
+    response.raise_for_status.return_value = None
+
+    def mock_request(method: str, url: str, **kwargs: object) -> mock.Mock:
+        request_calls.append((method, url, kwargs))
+        return response
+
+    monkeypatch.setattr(client.session, "request", mock_request)
+
+    assert client._headers["x-user-id"] == "old-user"
+
+    client.request_with_retries("GET", "/info")
+
+    assert client._headers["x-user-id"] == "new-user"
+    assert request_calls[0][2]["headers"]["x-user-id"] == "new-user"
+
+
+def test_profile_config_refreshes_expired_oauth_token_once_for_concurrent_requests(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path
+) -> None:
+    _clear_profile_env(monkeypatch)
+    old_access_token = _fake_oauth_token({"sub": "old-user"})
+    new_access_token = _fake_oauth_token({"sub": "new-user"})
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "profiles": {
+                    "default": {
+                        "api_url": "https://profile.example.com",
+                        "oauth": {
+                            "access_token": old_access_token,
+                            "refresh_token": "old-refresh-token",
+                            "expires_at": "2000-01-01T00:00:00Z",
+                        },
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("LANGSMITH_CONFIG_FILE", str(config_path))
+    refresh_calls = []
+
+    def mock_post(url: str, **kwargs: object) -> mock.Mock:
+        refresh_calls.append((url, kwargs))
+        time.sleep(0.05)
+        response = mock.Mock()
+        response.status_code = 200
+        response.json.return_value = {
+            "access_token": new_access_token,
+            "refresh_token": "new-refresh-token",
+            "expires_in": 300,
+        }
+        return response
+
+    monkeypatch.setattr(requests, "post", mock_post)
+    client = Client(auto_batch_tracing=False)
+    request_headers = []
+    request_lock = threading.Lock()
+    response = mock.Mock()
+    response.status_code = 200
+    response.raise_for_status.return_value = None
+
+    def mock_request(method: str, url: str, **kwargs: object) -> mock.Mock:
+        with request_lock:
+            request_headers.append(dict(kwargs["headers"]))
+        return response
+
+    monkeypatch.setattr(client.session, "request", mock_request)
+    concurrency = 25
+    start = threading.Barrier(concurrency)
+    errors = []
+
+    def worker() -> None:
+        try:
+            start.wait()
+            client.request_with_retries("GET", "/info")
+        except BaseException as exc:
+            errors.append(exc)
+
+    threads = [threading.Thread(target=worker) for _ in range(concurrency)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert errors == []
+    assert len(refresh_calls) == 1
+    assert len(request_headers) == concurrency
+    assert all(
+        headers["Authorization"] == f"Bearer {new_access_token}"
+        and headers["x-user-id"] == "new-user"
+        for headers in request_headers
+    )
+
+
+def test_profile_config_refresh_singleflight_across_clients(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path
+) -> None:
+    _clear_profile_env(monkeypatch)
+    old_access_token = _fake_oauth_token({"sub": "old-user"})
+    new_access_token = _fake_oauth_token({"sub": "new-user"})
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "profiles": {
+                    "default": {
+                        "api_url": "https://profile.example.com",
+                        "oauth": {
+                            "access_token": old_access_token,
+                            "refresh_token": "old-refresh-token",
+                            "expires_at": "2000-01-01T00:00:00Z",
+                        },
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("LANGSMITH_CONFIG_FILE", str(config_path))
+    refresh_calls = []
+
+    def mock_post(url: str, **kwargs: object) -> mock.Mock:
+        refresh_calls.append((url, kwargs))
+        time.sleep(0.05)
+        response = mock.Mock()
+        response.status_code = 200
+        response.json.return_value = {
+            "access_token": new_access_token,
+            "refresh_token": "new-refresh-token",
+            "expires_in": 300,
+        }
+        return response
+
+    monkeypatch.setattr(requests, "post", mock_post)
+    concurrency = 25
+    clients = [Client(auto_batch_tracing=False) for _ in range(concurrency)]
+    request_headers = []
+    request_lock = threading.Lock()
+    response = mock.Mock()
+    response.status_code = 200
+    response.raise_for_status.return_value = None
+
+    def mock_request(method: str, url: str, **kwargs: object) -> mock.Mock:
+        with request_lock:
+            request_headers.append(dict(kwargs["headers"]))
+        return response
+
+    for client in clients:
+        monkeypatch.setattr(client.session, "request", mock_request)
+
+    start = threading.Barrier(concurrency)
+    errors = []
+
+    def worker(client: Client) -> None:
+        try:
+            start.wait()
+            client.request_with_retries("GET", "/info")
+        except BaseException as exc:
+            errors.append(exc)
+
+    threads = [threading.Thread(target=worker, args=(client,)) for client in clients]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert errors == []
+    assert len(refresh_calls) == 1
+    assert len(request_headers) == concurrency
+    assert all(
+        headers["Authorization"] == f"Bearer {new_access_token}"
+        and headers["x-user-id"] == "new-user"
+        for headers in request_headers
+    )
+
+
+def test_profile_config_refresh_waits_for_filesystem_lock(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path
+) -> None:
+    _clear_profile_env(monkeypatch)
+    old_access_token = _fake_oauth_token({"sub": "old-user"})
+    new_access_token = _fake_oauth_token({"sub": "new-user"})
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "profiles": {
+                    "default": {
+                        "api_url": "https://profile.example.com",
+                        "oauth": {
+                            "access_token": old_access_token,
+                            "refresh_token": "old-refresh-token",
+                            "expires_at": "2000-01-01T00:00:00Z",
+                        },
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("LANGSMITH_CONFIG_FILE", str(config_path))
+    lock_path = pathlib.Path(f"{config_path}.oauth-refresh.lock")
+    lock_path.write_text("locked", encoding="utf-8")
+    refresh_calls = []
+
+    def mock_post(url: str, **kwargs: object) -> mock.Mock:
+        refresh_calls.append((url, kwargs))
+        response = mock.Mock()
+        response.status_code = 200
+        response.json.return_value = {
+            "access_token": "unexpected-access-token",
+            "refresh_token": "unexpected-refresh-token",
+            "expires_in": 300,
+        }
+        return response
+
+    monkeypatch.setattr(requests, "post", mock_post)
+    client = Client(auto_batch_tracing=False)
+    request_headers = []
+    response = mock.Mock()
+    response.status_code = 200
+    response.raise_for_status.return_value = None
+
+    def mock_request(method: str, url: str, **kwargs: object) -> mock.Mock:
+        request_headers.append(dict(kwargs["headers"]))
+        return response
+
+    monkeypatch.setattr(client.session, "request", mock_request)
+    errors = []
+
+    def worker() -> None:
+        try:
+            client.request_with_retries("GET", "/info")
+        except BaseException as exc:
+            errors.append(exc)
+
+    thread = threading.Thread(target=worker)
+    thread.start()
+    time.sleep(0.1)
+
+    assert refresh_calls == []
+    assert request_headers == []
+
+    updated = json.loads(config_path.read_text(encoding="utf-8"))
+    updated["profiles"]["default"]["oauth"]["access_token"] = new_access_token
+    updated["profiles"]["default"]["oauth"]["expires_at"] = "2999-01-01T00:00:00Z"
+    config_path.write_text(json.dumps(updated), encoding="utf-8")
+    lock_path.unlink()
+    thread.join(timeout=2)
+
+    assert not thread.is_alive()
+    assert errors == []
+    assert refresh_calls == []
+    assert request_headers[0]["Authorization"] == f"Bearer {new_access_token}"
+    assert request_headers[0]["x-user-id"] == "new-user"
+
+
 def test_profile_config_refresh_replaces_snapshotted_auth_headers(
     monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path
 ) -> None:
@@ -445,6 +805,7 @@ def test_profile_config_refresh_preserves_explicit_auth_headers(
     monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path
 ) -> None:
     _clear_profile_env(monkeypatch)
+    old_access_token = _fake_oauth_token({"sub": "old-user"})
     config_path = tmp_path / "config.json"
     config_path.write_text(
         json.dumps(
@@ -453,7 +814,7 @@ def test_profile_config_refresh_preserves_explicit_auth_headers(
                     "default": {
                         "api_url": "https://profile.example.com",
                         "oauth": {
-                            "access_token": "old-access-token",
+                            "access_token": old_access_token,
                             "refresh_token": "old-refresh-token",
                             "expires_at": "2000-01-01T00:00:00Z",
                         },
@@ -490,10 +851,16 @@ def test_profile_config_refresh_preserves_explicit_auth_headers(
     client.request_with_retries(
         "GET",
         "/info",
-        request_kwargs={"headers": {"Authorization": "Bearer explicit-token"}},
+        request_kwargs={
+            "headers": {
+                **client._headers,
+                "Authorization": "Bearer explicit-token",
+            }
+        },
     )
 
     assert request_calls[0][2]["headers"]["Authorization"] == ("Bearer explicit-token")
+    assert "x-user-id" not in request_calls[0][2]["headers"]
 
 
 def test_profile_config_refresh_uses_profile_api_url(


### PR DESCRIPTION
Adds `x-user-id` to profile OAuth requests by deriving it from the access token `sub` claim, while continuing to omit it when explicit auth overrides profile auth.

Also coordinates OAuth refreshes with in-process singleflight and a config-adjacent filesystem lock so concurrent clients or CLI processes share the refreshed token.

## Release Note
none

## Test Plan
- [x] `LANGSMITH_CONFIG_FILE=/nonexistent/path/config.json uv run ruff check python/langsmith/_internal/_profiles.py python/tests/unit_tests/test_client.py python/tests/unit_tests/test_async_client.py`
- [x] `cd python && LANGSMITH_CONFIG_FILE=/nonexistent/path/config.json uv run pytest tests/unit_tests/test_client.py::test_profile_config_oauth_headers_include_user_id tests/unit_tests/test_client.py::test_profile_config_refresh_singleflight_across_clients tests/unit_tests/test_async_client.py::test_async_client_profile_refresh_singleflight_for_concurrent_requests`
