### PR TITLE
fix(js): add OAuth user header and refresh locking

### DIFF
--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -93,6 +93,7 @@ import {
 } from "./singletons/fetch.js";
 import {
   DEFAULT_API_URL,
+  PROFILE_USER_ID_HEADER,
   type ProfileAuthHeader,
   ProfileAuth,
   hasValue,
@@ -980,11 +981,34 @@ export class Client implements LangSmithTracingClientInterface {
     profileManagedAuthorization?: string,
   ): RequestInit | undefined {
     if (!authHeader) {
-      return init;
+      return this.stripManagedProfileUserIdHeader(init);
     }
+    const profileUserIdHeaders = (): Record<string, string> => {
+      if (authHeader.name !== "Authorization" || !hasValue(authHeader.userId)) {
+        return {};
+      }
+      return { [PROFILE_USER_ID_HEADER]: authHeader.userId ?? "" };
+    };
     const applyAuth = (headers: Headers): Headers => {
+      const deleteManagedProfileUserId = () => {
+        const userId = headers.get(PROFILE_USER_ID_HEADER);
+        if (
+          hasValue(userId) &&
+          this.profileAuth?.isProfileUserIdHeader(userId ?? "") === true
+        ) {
+          headers.delete(PROFILE_USER_ID_HEADER);
+        }
+      };
+      const setProfileUserId = () => {
+        if (hasValue(authHeader.userId)) {
+          headers.set(PROFILE_USER_ID_HEADER, authHeader.userId ?? "");
+        } else {
+          deleteManagedProfileUserId();
+        }
+      };
       if (this.apiKey !== undefined && authHeader.name === "x-api-key") {
         headers.delete("Authorization");
+        deleteManagedProfileUserId();
         if (!headers.has("x-api-key")) {
           headers.set("x-api-key", authHeader.value);
         }
@@ -992,6 +1016,7 @@ export class Client implements LangSmithTracingClientInterface {
       }
       if (authHeader.name === "Authorization") {
         if (hasValue(headers.get("x-api-key"))) {
+          deleteManagedProfileUserId();
           return headers;
         }
         const authorization = headers.get("Authorization");
@@ -1002,9 +1027,11 @@ export class Client implements LangSmithTracingClientInterface {
             profileManagedAuthorization,
           )
         ) {
+          deleteManagedProfileUserId();
           return headers;
         }
         headers.set("Authorization", authHeader.value);
+        setProfileUserId();
         return headers;
       }
       const authorization = headers.get("Authorization");
@@ -1015,11 +1042,13 @@ export class Client implements LangSmithTracingClientInterface {
           profileManagedAuthorization,
         )
       ) {
+        deleteManagedProfileUserId();
         return headers;
       }
       if (hasValue(authorization)) {
         headers.delete("Authorization");
       }
+      deleteManagedProfileUserId();
       if (!headers.has("x-api-key")) {
         headers.set("x-api-key", authHeader.value);
       }
@@ -1027,7 +1056,10 @@ export class Client implements LangSmithTracingClientInterface {
     };
     if (!init) {
       return {
-        headers: { [authHeader.name]: authHeader.value },
+        headers: {
+          [authHeader.name]: authHeader.value,
+          ...profileUserIdHeaders(),
+        },
       };
     }
     if (init.headers instanceof Headers) {
@@ -1045,6 +1077,29 @@ export class Client implements LangSmithTracingClientInterface {
       const key = getHeaderKey(name);
       return key ? headers[key] : undefined;
     };
+    const deleteHeader = (name: string) => {
+      const key = getHeaderKey(name);
+      if (key) {
+        delete headers[key];
+      }
+    };
+    const deleteManagedProfileUserId = () => {
+      const userId = getHeader(PROFILE_USER_ID_HEADER);
+      if (
+        hasValue(userId) &&
+        this.profileAuth?.isProfileUserIdHeader(userId ?? "") === true
+      ) {
+        deleteHeader(PROFILE_USER_ID_HEADER);
+      }
+    };
+    const setProfileUserId = () => {
+      if (hasValue(authHeader.userId)) {
+        deleteHeader(PROFILE_USER_ID_HEADER);
+        headers[PROFILE_USER_ID_HEADER] = authHeader.userId ?? "";
+      } else {
+        deleteManagedProfileUserId();
+      }
+    };
     const hasApiKey = hasValue(getHeader("x-api-key"));
     const authorization = getHeader("authorization");
     const hasExplicitAuthorization =
@@ -1055,10 +1110,8 @@ export class Client implements LangSmithTracingClientInterface {
       );
 
     if (this.apiKey !== undefined && authHeader.name === "x-api-key") {
-      const authorizationKey = getHeaderKey("authorization");
-      if (authorizationKey) {
-        delete headers[authorizationKey];
-      }
+      deleteHeader("authorization");
+      deleteManagedProfileUserId();
       if (!hasApiKey) {
         headers["x-api-key"] = authHeader.value;
       }
@@ -1071,17 +1124,52 @@ export class Client implements LangSmithTracingClientInterface {
           delete headers[authorizationKey];
         }
         headers.Authorization = authHeader.value;
+        setProfileUserId();
+      } else {
+        deleteManagedProfileUserId();
       }
       return { ...init, headers };
     }
     if (!hasExplicitAuthorization) {
-      const authorizationKey = getHeaderKey("authorization");
-      if (authorizationKey) {
-        delete headers[authorizationKey];
-      }
+      deleteHeader("authorization");
+      deleteManagedProfileUserId();
       if (!hasApiKey) {
         headers["x-api-key"] = authHeader.value;
       }
+    }
+    return { ...init, headers };
+  }
+
+  private stripManagedProfileUserIdHeader(
+    init?: RequestInit,
+  ): RequestInit | undefined {
+    if (!init?.headers || !this.profileAuth) {
+      return init;
+    }
+    const stripFromHeaders = (headers: Headers): Headers => {
+      const userId = headers.get(PROFILE_USER_ID_HEADER);
+      if (
+        hasValue(userId) &&
+        this.profileAuth?.isProfileUserIdHeader(userId ?? "") === true
+      ) {
+        headers.delete(PROFILE_USER_ID_HEADER);
+      }
+      return headers;
+    };
+    if (init.headers instanceof Headers || Array.isArray(init.headers)) {
+      return { ...init, headers: stripFromHeaders(new Headers(init.headers)) };
+    }
+    const headers = {
+      ...((init.headers ?? {}) as Record<string, string>),
+    };
+    const userIdKey = Object.keys(headers).find(
+      (key) => key.toLowerCase() === PROFILE_USER_ID_HEADER,
+    );
+    if (
+      userIdKey &&
+      this.profileAuth.isProfileUserIdHeader(headers[userIdKey] ?? "")
+    ) {
+      delete headers[userIdKey];
     }
     return { ...init, headers };
   }
@@ -1356,6 +1444,12 @@ export class Client implements LangSmithTracingClientInterface {
       const profileAuthHeader = this.profileAuth?.currentAuthHeader();
       if (profileAuthHeader) {
         headers[profileAuthHeader.name] = profileAuthHeader.value;
+        if (
+          profileAuthHeader.name === "Authorization" &&
+          hasValue(profileAuthHeader.userId)
+        ) {
+          headers[PROFILE_USER_ID_HEADER] = profileAuthHeader.userId ?? "";
+        }
       }
     }
     if (this.workspaceId) {

--- a/js/src/tests/client.test.ts
+++ b/js/src/tests/client.test.ts
@@ -101,6 +101,10 @@ describe("Client", () => {
       process.env.LANGSMITH_CONFIG_FILE = configPath;
       return configPath;
     };
+    const fakeOAuthToken = (payload: Record<string, unknown>) =>
+      `header.${Buffer.from(JSON.stringify(payload)).toString(
+        "base64url",
+      )}.signature`;
 
     beforeEach(() => {
       process.env = { ...originalEnv };
@@ -143,12 +147,13 @@ describe("Client", () => {
     });
 
     it("uses profile OAuth access tokens before profile API keys", () => {
+      const accessToken = fakeOAuthToken({ sub: "user-123" });
       writeProfileConfig({
         profiles: {
           default: {
             api_key: "profile-key",
             oauth: {
-              access_token: "profile-access-token",
+              access_token: accessToken,
             },
           },
         },
@@ -158,9 +163,30 @@ describe("Client", () => {
 
       expect((client as any).apiKey).toBeUndefined();
       expect((client as any)._mergedHeaders.Authorization).toBe(
-        "Bearer profile-access-token",
+        `Bearer ${accessToken}`,
       );
+      expect((client as any)._mergedHeaders["x-user-id"]).toBe("user-123");
       expect((client as any)._mergedHeaders["x-api-key"]).toBeUndefined();
+    });
+
+    it("uses the OAuth subject claim for x-user-id", () => {
+      const accessToken = fakeOAuthToken({ user_id: "generic-user" });
+      writeProfileConfig({
+        profiles: {
+          default: {
+            oauth: {
+              access_token: accessToken,
+            },
+          },
+        },
+      });
+
+      const client = new Client();
+
+      expect((client as any)._mergedHeaders.Authorization).toBe(
+        `Bearer ${accessToken}`,
+      );
+      expect((client as any)._mergedHeaders["x-user-id"]).toBeUndefined();
     });
 
     it("suppresses profile auth when environment auth is set", () => {
@@ -225,12 +251,14 @@ describe("Client", () => {
     });
 
     it("refreshes expired profile OAuth tokens before requests", async () => {
+      const oldAccessToken = fakeOAuthToken({ sub: "old-user" });
+      const newAccessToken = fakeOAuthToken({ sub: "new-user" });
       const configPath = writeProfileConfig({
         profiles: {
           default: {
             api_url: "https://profile.example.com",
             oauth: {
-              access_token: "old-access-token",
+              access_token: oldAccessToken,
               refresh_token: "old-refresh-token",
               expires_at: new Date(Date.now() - 60_000).toISOString(),
             },
@@ -248,7 +276,7 @@ describe("Client", () => {
             );
             return new Response(
               JSON.stringify({
-                access_token: "new-access-token",
+                access_token: newAccessToken,
                 refresh_token: "new-refresh-token",
                 expires_in: 300,
               }),
@@ -267,12 +295,11 @@ describe("Client", () => {
       expect(mockFetch).toHaveBeenCalledTimes(2);
       const requestInit = mockFetch.mock.calls[1][1] as RequestInit;
       expect(requestInit.headers).toMatchObject({
-        Authorization: "Bearer new-access-token",
+        Authorization: `Bearer ${newAccessToken}`,
+        "x-user-id": "new-user",
       });
       const updated = JSON.parse(fs.readFileSync(configPath, "utf8"));
-      expect(updated.profiles.default.oauth.access_token).toBe(
-        "new-access-token",
-      );
+      expect(updated.profiles.default.oauth.access_token).toBe(newAccessToken);
       expect(updated.profiles.default.oauth.refresh_token).toBe(
         "new-refresh-token",
       );
@@ -280,13 +307,183 @@ describe("Client", () => {
       expect(updated.profiles.default).not.toHaveProperty("bearer_token");
     });
 
-    it("preserves explicit Authorization headers during profile refresh", async () => {
+    it("refreshes expired profile OAuth tokens once for concurrent requests", async () => {
+      const oldAccessToken = fakeOAuthToken({ sub: "old-user" });
+      const newAccessToken = fakeOAuthToken({ sub: "new-user" });
       writeProfileConfig({
         profiles: {
           default: {
             api_url: "https://profile.example.com",
             oauth: {
-              access_token: "old-access-token",
+              access_token: oldAccessToken,
+              refresh_token: "old-refresh-token",
+              expires_at: new Date(Date.now() - 60_000).toISOString(),
+            },
+          },
+        },
+      });
+      const mockFetch = jest.fn(async (input: RequestInfo | URL) => {
+        if (String(input) === "https://profile.example.com/oauth/token") {
+          await new Promise((resolve) => setTimeout(resolve, 25));
+          return new Response(
+            JSON.stringify({
+              access_token: newAccessToken,
+              refresh_token: "new-refresh-token",
+              expires_in: 300,
+            }),
+            { status: 200 },
+          );
+        }
+        return new Response("{}", { status: 200 });
+      });
+      const client = new Client({ fetchImplementation: mockFetch as any });
+      const concurrency = 25;
+
+      await Promise.all(
+        Array.from({ length: concurrency }, () =>
+          (client as any)._fetch("https://profile.example.com/info", {
+            headers: (client as any)._mergedHeaders,
+          }),
+        ),
+      );
+
+      const refreshCalls = mockFetch.mock.calls.filter(
+        ([input]) =>
+          String(input) === "https://profile.example.com/oauth/token",
+      );
+      const infoCalls = mockFetch.mock.calls.filter(
+        ([input]) => String(input) === "https://profile.example.com/info",
+      );
+      expect(refreshCalls).toHaveLength(1);
+      expect(infoCalls).toHaveLength(concurrency);
+      for (const [, requestInit] of infoCalls as unknown as [
+        RequestInfo | URL,
+        RequestInit | undefined,
+      ][]) {
+        const headers = new Headers(requestInit?.headers);
+        expect(headers.get("Authorization")).toBe(`Bearer ${newAccessToken}`);
+        expect(headers.get("x-user-id")).toBe("new-user");
+      }
+    });
+
+    it("refreshes expired profile OAuth tokens once across clients", async () => {
+      const oldAccessToken = fakeOAuthToken({ sub: "old-user" });
+      const newAccessToken = fakeOAuthToken({ sub: "new-user" });
+      writeProfileConfig({
+        profiles: {
+          default: {
+            api_url: "https://profile.example.com",
+            oauth: {
+              access_token: oldAccessToken,
+              refresh_token: "old-refresh-token",
+              expires_at: new Date(Date.now() - 60_000).toISOString(),
+            },
+          },
+        },
+      });
+      const mockFetch = jest.fn(async (input: RequestInfo | URL) => {
+        if (String(input) === "https://profile.example.com/oauth/token") {
+          await new Promise((resolve) => setTimeout(resolve, 25));
+          return new Response(
+            JSON.stringify({
+              access_token: newAccessToken,
+              refresh_token: "new-refresh-token",
+              expires_in: 300,
+            }),
+            { status: 200 },
+          );
+        }
+        return new Response("{}", { status: 200 });
+      });
+      const concurrency = 25;
+      const clients = Array.from(
+        { length: concurrency },
+        () => new Client({ fetchImplementation: mockFetch as any }),
+      );
+
+      await Promise.all(
+        clients.map((client) =>
+          (client as any)._fetch("https://profile.example.com/info", {
+            headers: (client as any)._mergedHeaders,
+          }),
+        ),
+      );
+
+      const refreshCalls = mockFetch.mock.calls.filter(
+        ([input]) =>
+          String(input) === "https://profile.example.com/oauth/token",
+      );
+      const infoCalls = mockFetch.mock.calls.filter(
+        ([input]) => String(input) === "https://profile.example.com/info",
+      );
+      expect(refreshCalls).toHaveLength(1);
+      expect(infoCalls).toHaveLength(concurrency);
+      for (const [, requestInit] of infoCalls as unknown as [
+        RequestInfo | URL,
+        RequestInit | undefined,
+      ][]) {
+        const headers = new Headers(requestInit?.headers);
+        expect(headers.get("Authorization")).toBe(`Bearer ${newAccessToken}`);
+        expect(headers.get("x-user-id")).toBe("new-user");
+      }
+    });
+
+    it("waits for an existing filesystem refresh lock", async () => {
+      const oldAccessToken = fakeOAuthToken({ sub: "old-user" });
+      const newAccessToken = fakeOAuthToken({ sub: "new-user" });
+      const configPath = writeProfileConfig({
+        profiles: {
+          default: {
+            api_url: "https://profile.example.com",
+            oauth: {
+              access_token: oldAccessToken,
+              refresh_token: "old-refresh-token",
+              expires_at: new Date(Date.now() - 60_000).toISOString(),
+            },
+          },
+        },
+      });
+      const lockPath = `${configPath}.oauth-refresh.lock`;
+      fs.writeFileSync(lockPath, "locked");
+      const mockFetch = jest.fn(
+        async () => new Response("{}", { status: 200 }),
+      );
+      const client = new Client({ fetchImplementation: mockFetch as any });
+      const request = (client as any)._fetch(
+        "https://profile.example.com/info",
+        {
+          headers: (client as any)._mergedHeaders,
+        },
+      );
+
+      await new Promise((resolve) => setTimeout(resolve, 25));
+      expect(mockFetch).toHaveBeenCalledTimes(0);
+
+      const updated = JSON.parse(fs.readFileSync(configPath, "utf8"));
+      updated.profiles.default.oauth.access_token = newAccessToken;
+      updated.profiles.default.oauth.expires_at = "2999-01-01T00:00:00.000Z";
+      fs.writeFileSync(configPath, `${JSON.stringify(updated, null, 2)}\n`);
+      fs.unlinkSync(lockPath);
+      await request;
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      const [[requestUrl, requestInit]] = mockFetch.mock.calls as unknown as [
+        [RequestInfo | URL, RequestInit | undefined],
+      ];
+      expect(String(requestUrl)).toBe("https://profile.example.com/info");
+      const headers = new Headers(requestInit?.headers);
+      expect(headers.get("Authorization")).toBe(`Bearer ${newAccessToken}`);
+      expect(headers.get("x-user-id")).toBe("new-user");
+    });
+
+    it("preserves explicit Authorization headers during profile refresh", async () => {
+      const oldAccessToken = fakeOAuthToken({ sub: "old-user" });
+      writeProfileConfig({
+        profiles: {
+          default: {
+            api_url: "https://profile.example.com",
+            oauth: {
+              access_token: oldAccessToken,
               refresh_token: "old-refresh-token",
               expires_at: new Date(Date.now() - 60_000).toISOString(),
             },
@@ -300,6 +497,7 @@ describe("Client", () => {
 
       await (client as any)._fetch("https://profile.example.com/info", {
         headers: {
+          ...(client as any)._mergedHeaders,
           Authorization: "Bearer explicit-token",
         },
       });
@@ -312,6 +510,7 @@ describe("Client", () => {
       expect(requestInit?.headers).toMatchObject({
         Authorization: "Bearer explicit-token",
       });
+      expect(new Headers(requestInit?.headers).get("x-user-id")).toBeNull();
     });
 
     it("refreshes profile OAuth tokens against profile api_url", async () => {

--- a/js/src/utils/fs.browser.ts
+++ b/js/src/utils/fs.browser.ts
@@ -45,10 +45,19 @@ export function mkdirSync(_dir: string): void {}
 
 export function writeFileSync(_filePath: string, _content: string): void {}
 
+export function writeFileExclusiveSync(
+  _filePath: string,
+  _content: string,
+): void {}
+
 export function renameSync(_oldPath: string, _newPath: string): void {}
 
 export function unlinkSync(_filePath: string): void {}
 
 export function readFileSync(_filePath: string): string {
   return "";
+}
+
+export function statSync(_filePath: string): { size: number; mtimeMs: number } {
+  return { size: 0, mtimeMs: 0 };
 }

--- a/js/src/utils/fs.ts
+++ b/js/src/utils/fs.ts
@@ -59,6 +59,17 @@ export function writeFileSync(filePath: string, content: string): void {
   nodeFs.writeFileSync(filePath, content);
 }
 
+export function writeFileExclusiveSync(
+  filePath: string,
+  content: string,
+): void {
+  nodeFs.writeFileSync(filePath, content, {
+    encoding: "utf8",
+    flag: "wx",
+    mode: 0o600,
+  });
+}
+
 export function renameSync(oldPath: string, newPath: string): void {
   nodeFs.renameSync(oldPath, newPath);
 }
@@ -69,4 +80,9 @@ export function unlinkSync(filePath: string): void {
 
 export function readFileSync(filePath: string): string {
   return nodeFs.readFileSync(filePath, "utf-8");
+}
+
+export function statSync(filePath: string): { size: number; mtimeMs: number } {
+  const stats = nodeFs.statSync(filePath);
+  return { size: stats.size, mtimeMs: stats.mtimeMs };
 }

--- a/js/src/utils/profiles.ts
+++ b/js/src/utils/profiles.ts
@@ -4,8 +4,15 @@ import * as fsUtils from "./fs.js";
 export const DEFAULT_API_URL = "https://api.smith.langchain.com";
 
 const OAUTH_CLIENT_ID = "langsmith-cli";
+export const PROFILE_USER_ID_HEADER = "x-user-id";
+const OAUTH_USER_ID_CLAIM = "sub";
 const TOKEN_REFRESH_LEEWAY_MS = 60_000;
 const TOKEN_REFRESH_TIMEOUT_MS = 10_000;
+const TOKEN_REFRESH_LOCK_POLL_MS = 50;
+const TOKEN_REFRESH_LOCK_STALE_MS = TOKEN_REFRESH_TIMEOUT_MS + 30_000;
+const TOKEN_REFRESH_LOCK_TIMEOUT_MS =
+  TOKEN_REFRESH_LOCK_STALE_MS + TOKEN_REFRESH_TIMEOUT_MS;
+const profileRefreshPromises = new Map<string, Promise<void>>();
 
 type LangSmithProfileOAuth = {
   access_token?: string;
@@ -35,6 +42,7 @@ type LangSmithProfileState = {
 export type ProfileAuthHeader = {
   name: "Authorization" | "x-api-key";
   value: string;
+  userId?: string;
 };
 
 export type ProfileClientConfig = {
@@ -100,6 +108,92 @@ function loadProfileState(): LangSmithProfileState | undefined {
     return { configPath, config, profileName, profile };
   } catch {
     return undefined;
+  }
+}
+
+function reloadProfileState(
+  state: LangSmithProfileState,
+): LangSmithProfileState {
+  try {
+    const config = JSON.parse(
+      fsUtils.readFileSync(state.configPath),
+    ) as LangSmithProfileConfigFile;
+    const profile = config.profiles?.[state.profileName];
+    if (!profile) {
+      return state;
+    }
+    state.config = config;
+    state.profile = profile;
+  } catch {
+    return state;
+  }
+  return state;
+}
+
+function getProfileRefreshKey(state: LangSmithProfileState): string {
+  return `${state.configPath}\0${state.profileName}`;
+}
+
+function getProfileRefreshLockPath(state: LangSmithProfileState): string {
+  return `${state.configPath}.oauth-refresh.lock`;
+}
+
+function isLockFileStale(lockPath: string): boolean {
+  try {
+    return (
+      Date.now() - fsUtils.statSync(lockPath).mtimeMs >
+      TOKEN_REFRESH_LOCK_STALE_MS
+    );
+  } catch {
+    return false;
+  }
+}
+
+function sleep(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+async function withFilesystemRefreshLock(
+  state: LangSmithProfileState,
+  refresh: () => Promise<void>,
+): Promise<void> {
+  const lockPath = getProfileRefreshLockPath(state);
+  const deadline = Date.now() + TOKEN_REFRESH_LOCK_TIMEOUT_MS;
+  let hasLock = false;
+  while (!hasLock) {
+    try {
+      fsUtils.writeFileExclusiveSync(lockPath, `${Date.now()}\n`);
+      hasLock = true;
+      break;
+    } catch (error) {
+      const code = (error as { code?: string }).code;
+      if (code !== "EEXIST") {
+        await refresh();
+        return;
+      }
+      if (isLockFileStale(lockPath)) {
+        try {
+          fsUtils.unlinkSync(lockPath);
+        } catch {
+          // Another process may have replaced the lock before us.
+        }
+        continue;
+      }
+      if (Date.now() >= deadline) {
+        await refresh();
+        return;
+      }
+      await sleep(TOKEN_REFRESH_LOCK_POLL_MS);
+    }
+  }
+  try {
+    await refresh();
+  } finally {
+    try {
+      fsUtils.unlinkSync(lockPath);
+    } catch {
+      // Another process may have already removed a stale lock.
+    }
   }
 }
 
@@ -219,9 +313,9 @@ export function loadProfileClientConfig(): ProfileClientConfig {
 }
 
 export class ProfileAuth {
-  private refreshPromise?: Promise<void>;
+  private managedAuthorizationValues = new Set<string>();
 
-  private managedAuthorizationValue?: string;
+  private managedUserIdValues = new Set<string>();
 
   constructor(private state: LangSmithProfileState) {
     this.rememberProfileAuthHeader(this.currentAuthHeader());
@@ -238,14 +332,26 @@ export class ProfileAuth {
     signal?: AbortSignal | null,
   ): Promise<ProfileAuthHeader | undefined> {
     if (shouldRefreshProfileToken(this.state.profile)) {
-      if (!this.refreshPromise) {
-        this.refreshPromise = this.refreshOAuthToken(
-          fetchImplementation,
-        ).finally(() => {
-          this.refreshPromise = undefined;
+      reloadProfileState(this.state);
+    }
+    if (shouldRefreshProfileToken(this.state.profile)) {
+      const refreshKey = getProfileRefreshKey(this.state);
+      let refreshPromise = profileRefreshPromises.get(refreshKey);
+      if (!refreshPromise) {
+        refreshPromise = withFilesystemRefreshLock(this.state, async () => {
+          reloadProfileState(this.state);
+          if (shouldRefreshProfileToken(this.state.profile)) {
+            await this.refreshOAuthToken(fetchImplementation);
+          }
+        }).finally(() => {
+          if (profileRefreshPromises.get(refreshKey) === refreshPromise) {
+            profileRefreshPromises.delete(refreshKey);
+          }
         });
+        profileRefreshPromises.set(refreshKey, refreshPromise);
       }
-      await waitForAbortSignal(this.refreshPromise, signal);
+      await waitForAbortSignal(refreshPromise, signal);
+      reloadProfileState(this.state);
     }
     const header = authHeaderFromProfile(this.state.profile);
     this.rememberProfileAuthHeader(header);
@@ -253,7 +359,11 @@ export class ProfileAuth {
   }
 
   isProfileAuthorizationHeader(value: string): boolean {
-    return value === this.managedAuthorizationValue;
+    return this.managedAuthorizationValues.has(value);
+  }
+
+  isProfileUserIdHeader(value: string): boolean {
+    return this.managedUserIdValues.has(value);
   }
 
   private async refreshOAuthToken(
@@ -308,9 +418,27 @@ export class ProfileAuth {
   private rememberProfileAuthHeader(
     header: ProfileAuthHeader | undefined,
   ): void {
-    this.managedAuthorizationValue =
-      header?.name === "Authorization" ? header.value : undefined;
+    if (header?.name === "Authorization") {
+      this.managedAuthorizationValues.add(header.value);
+      if (header.userId) {
+        this.managedUserIdValues.add(header.userId);
+      }
+    }
   }
+}
+
+function oauthAuthHeaderFromAccessToken(
+  accessToken: string,
+): ProfileAuthHeader {
+  const header: ProfileAuthHeader = {
+    name: "Authorization",
+    value: `Bearer ${accessToken}`,
+  };
+  const userId = oauthUserIdFromAccessToken(accessToken);
+  if (userId) {
+    header.userId = userId;
+  }
+  return header;
 }
 
 function currentAuthHeaderFromProfile(
@@ -318,7 +446,7 @@ function currentAuthHeaderFromProfile(
 ): ProfileAuthHeader | undefined {
   const oauthAccessToken = trimConfigValue(profile.oauth?.access_token);
   if (oauthAccessToken) {
-    return { name: "Authorization", value: `Bearer ${oauthAccessToken}` };
+    return oauthAuthHeaderFromAccessToken(oauthAccessToken);
   }
   if (trimConfigValue(profile.oauth?.refresh_token)) {
     return undefined;
@@ -331,11 +459,37 @@ function authHeaderFromProfile(
 ): ProfileAuthHeader | undefined {
   const oauthAccessToken = trimConfigValue(profile.oauth?.access_token);
   if (oauthAccessToken) {
-    return { name: "Authorization", value: `Bearer ${oauthAccessToken}` };
+    return oauthAuthHeaderFromAccessToken(oauthAccessToken);
   }
   const apiKey = trimConfigValue(profile.api_key);
   if (apiKey) {
     return { name: "x-api-key", value: apiKey };
   }
   return undefined;
+}
+
+function oauthUserIdFromAccessToken(accessToken: string): string | undefined {
+  const [, encodedPayload] = accessToken.split(".");
+  if (!encodedPayload) {
+    return undefined;
+  }
+  try {
+    const payload = JSON.parse(decodeBase64Url(encodedPayload)) as unknown;
+    if (payload === null || typeof payload !== "object") {
+      return undefined;
+    }
+    const value = (payload as Record<string, unknown>)[OAUTH_USER_ID_CLAIM];
+    return typeof value === "string" && value.trim() ? value.trim() : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function decodeBase64Url(value: string): string {
+  const base64 = value.replace(/-/g, "+").replace(/_/g, "/");
+  const padded = base64.padEnd(
+    base64.length + ((4 - (base64.length % 4)) % 4),
+    "=",
+  );
+  return Buffer.from(padded, "base64").toString("utf8");
 }


### PR DESCRIPTION
Adds `x-user-id` to profile OAuth requests by deriving it from the access token `sub` claim, while continuing to omit it when explicit auth overrides profile auth.

Also coordinates OAuth refreshes with in-process singleflight and a config-adjacent filesystem lock so concurrent clients or CLI processes share the refreshed token.

## Release Note
none

## Test Plan
- [x] `pnpm run check:types`
- [x] `LANGSMITH_WORKSPACE_ID= LANGCHAIN_WORKSPACE_ID= NODE_OPTIONS=--experimental-vm-modules pnpm exec jest --passWithNoTests --testPathIgnorePatterns="\\.int\\.test.[tj]s" --testTimeout 30000 src/tests/client.test.ts --runInBand --testNamePattern="profile config"`
