### PR TITLE
sdk(py): drop sandbox alpha/experimental warnings

### DIFF
--- a/python/langsmith/sandbox/README.md
+++ b/python/langsmith/sandbox/README.md
@@ -2,8 +2,6 @@
 
 Sandboxed code execution for LangSmith. Run untrusted code safely in isolated containers.
 
-> ⚠️ **Warning**: This module is experimental. Features and APIs may change, and breaking changes are expected as we iterate.
-
 ## Quick Start
 
 ```python
@@ -762,7 +760,7 @@ sb = client.update_sandbox(
 )
 ```
 
-> **Migration note (alpha):** the previous `ttl_seconds` (hard wall-clock
+> **Migration note:** the previous `ttl_seconds` (hard wall-clock
 > TTL) and `expires_at` fields were removed. The hard TTL never reliably
 > deleted stopped sandboxes; replace any usage with `idle_ttl_seconds` for
 > stopping and `delete_after_stop_seconds` for deletion.

--- a/python/langsmith/sandbox/__init__.py
+++ b/python/langsmith/sandbox/__init__.py
@@ -112,13 +112,3 @@ __all__ = [
     "TunnelConnectionRefusedError",
     "TunnelUnsupportedVersionError",
 ]
-
-# Emit warning on import
-import warnings
-
-warnings.warn(
-    "langsmith.sandbox is in alpha. "
-    "This feature is experimental, and breaking changes are expected.",
-    FutureWarning,
-    stacklevel=2,
-)


### PR DESCRIPTION
## Summary

Drop the alpha/experimental signals on `langsmith.sandbox`:

- `python/langsmith/sandbox/__init__.py` — remove the `FutureWarning` emitted on import (and the `import warnings` it pulled in just for that warning).
- `python/langsmith/sandbox/README.md` — remove the top-of-file experimental warning banner and drop the `(alpha)` qualifier from the `ttl_seconds` migration note (the migration itself still applies).

No functional or API changes — only the warning text/emit is gone.

## Why

The sandbox surface has stabilized. Keeping the import-time `FutureWarning` was making `langsmith.sandbox` noisy for downstream callers, and the README banner no longer matches the state of the module.

## Verification

From `python/`:

- `make format` — clean
- `make lint` — clean (ruff + mypy)
- `make tests` — 1201 passed, 3 skipped
- `TEST=tests/unit_tests/sandbox make tests` — 408 passed

No test asserted on the removed `FutureWarning`.

## Notes

- A separate PR will follow for the JS SDK.
- Docs banners (`docs.langchain.com`) are tracked in a separate PR in the `docs` repo.
- Authored with AI agent assistance.

Made with [Cursor](https://cursor.com)