### PR TITLE
feat(sandbox): make snapshot optional and add TS options overload

### DIFF
--- a/js/src/sandbox/README.md
+++ b/js/src/sandbox/README.md
@@ -4,9 +4,8 @@ Sandboxed code execution for LangSmith. Run untrusted code safely in isolated co
 
 ## Quick Start
 
-Sandboxes are created from **snapshots**. A snapshot is a filesystem image you
-build once from a Docker image (or capture from a running sandbox) and then
-reuse to boot as many sandboxes as you need.
+By default, sandboxes are created with the server's standard runtime. You only
+need a snapshot when you want to boot from a reusable custom filesystem image.
 
 ```typescript
 import { SandboxClient } from "langsmith/sandbox";
@@ -14,15 +13,8 @@ import { SandboxClient } from "langsmith/sandbox";
 // Client uses LANGSMITH_ENDPOINT and LANGSMITH_API_KEY from environment
 const client = new SandboxClient();
 
-// Build a snapshot from a Docker image (do this once)
-const snapshot = await client.createSnapshot(
-  "python",
-  "python:3.12-slim",
-  1_073_741_824, // 1 GiB filesystem
-);
-
-// Create a sandbox from the snapshot and run code
-const sandbox = await client.createSandbox(snapshot.id);
+// Create a sandbox with the default runtime and run code
+const sandbox = await client.createSandbox();
 try {
   const result = await sandbox.run("python -c 'print(2 + 2)'");
   console.log(result.stdout); // "4\n"
@@ -36,9 +28,8 @@ const existingSb = await client.getSandbox("your-sandbox");
 const res = await existingSb.run("python -c 'print(2 + 2)'");
 ```
 
-If you already have a snapshot ID (for example, listed with
-`client.listSnapshots()`), you can skip the `createSnapshot` step and call
-`client.createSandbox(snapshotId)` directly.
+If you have a reusable snapshot ID, pass it to `client.createSandbox(snapshotId)`.
+Otherwise omit it; that is the expected default path.
 
 ## Configuration
 
@@ -386,9 +377,8 @@ console.log(captured.id, captured.source_sandbox_id);
 // Boot a new sandbox from the captured snapshot
 const resumed = await client.createSandbox(captured.id);
 
-// Or resolve by snapshot name instead of ID — the server looks up the
-// snapshot owned by your tenant. Exactly one of the positional `snapshotId`
-// or `options.snapshotName` must be provided.
+// Or resolve by snapshot name instead of ID. This is optional; omitting both
+// snapshotId and snapshotName uses the default runtime.
 const byName = await client.createSandbox(undefined, {
   snapshotName: "with-data",
 });
@@ -415,11 +405,10 @@ await client.deleteSnapshot(snapshot.id);
 ### Sizing and Resources
 
 `createSandbox` accepts optional per-sandbox resource limits. If omitted, the
-server-side defaults are used. `fsCapacityBytes` defaults to the snapshot's
-size.
+server-side defaults are used.
 
 ```typescript
-const sandbox = await client.createSandbox(snapshot.id, {
+const sandbox = await client.createSandbox(undefined, {
   vCpus: 2,
   memBytes: 2_147_483_648,        // 2 GiB
   fsCapacityBytes: 5_368_709_120, // 5 GiB
@@ -484,7 +473,7 @@ try {
 
 | Method | Description |
 |--------|-------------|
-| `createSandbox(snapshotId?, options?)` | Create a sandbox from a snapshot. Exactly one of the positional `snapshotId` or `options.snapshotName` must be provided. |
+| `createSandbox(snapshotId?, options?)` | Create a sandbox with the default runtime. Pass `snapshotId` or `options.snapshotName` only to boot from a reusable snapshot. |
 | `getSandbox(name)` | Get an existing sandbox by name |
 | `listSandboxes()` | List all sandboxes |
 | `updateSandbox(name, options)` | Rename or adjust retention (idle stop, delete-after-stop) on a sandbox |
@@ -547,7 +536,7 @@ try {
 
 | Property | Description |
 |----------|-------------|
-| `snapshotName?` | Snapshot name to boot from. Mutually exclusive with the positional `snapshotId` argument on `createSandbox`; exactly one must be set. |
+| `snapshotName?` | Optional snapshot name to boot from. Omit this and the positional `snapshotId` for the normal default-runtime sandbox. |
 | `name?` | Custom sandbox name |
 | `timeout?` | Wait timeout in seconds |
 | `waitForReady?` | Wait for the sandbox to be ready before returning (default: `true`) |

--- a/js/src/sandbox/README.md
+++ b/js/src/sandbox/README.md
@@ -378,7 +378,7 @@ const resumed = await client.createSandbox(captured.id);
 
 // Or resolve by snapshot name instead of ID. This is optional; omitting both
 // snapshotId and snapshotName uses the default runtime.
-const byName = await client.createSandbox(undefined, {
+const byName = await client.createSandbox({
   snapshotName: "with-data",
 });
 
@@ -407,7 +407,7 @@ await client.deleteSnapshot(snapshot.id);
 server-side defaults are used.
 
 ```typescript
-const sandbox = await client.createSandbox(undefined, {
+const sandbox = await client.createSandbox({
   vCpus: 2,
   memBytes: 2_147_483_648,        // 2 GiB
   fsCapacityBytes: 5_368_709_120, // 5 GiB
@@ -472,7 +472,7 @@ try {
 
 | Method | Description |
 |--------|-------------|
-| `createSandbox(snapshotId?, options?)` | Create a sandbox with the default runtime. Pass `snapshotId` or `options.snapshotName` only to boot from a reusable snapshot. |
+| `createSandbox(options?)` / `createSandbox(snapshotId?, options?)` | Create a sandbox. Pass `snapshotId` or `options.snapshotName` to boot from a reusable snapshot. |
 | `getSandbox(name)` | Get an existing sandbox by name |
 | `listSandboxes()` | List all sandboxes |
 | `updateSandbox(name, options)` | Rename or adjust retention (idle stop, delete-after-stop) on a sandbox |

--- a/js/src/sandbox/README.md
+++ b/js/src/sandbox/README.md
@@ -29,7 +29,6 @@ const res = await existingSb.run("python -c 'print(2 + 2)'");
 ```
 
 If you have a reusable snapshot ID, pass it to `client.createSandbox(snapshotId)`.
-Otherwise omit it; that is the expected default path.
 
 ## Configuration
 
@@ -536,7 +535,7 @@ try {
 
 | Property | Description |
 |----------|-------------|
-| `snapshotName?` | Optional snapshot name to boot from. Omit this and the positional `snapshotId` for the normal default-runtime sandbox. |
+| `snapshotName?` | Optional snapshot name to boot from. Mutually exclusive with the positional `snapshotId`. |
 | `name?` | Custom sandbox name |
 | `timeout?` | Wait timeout in seconds |
 | `waitForReady?` | Wait for the sandbox to be ready before returning (default: `true`) |

--- a/js/src/sandbox/client.ts
+++ b/js/src/sandbox/client.ts
@@ -197,7 +197,7 @@ export class SandboxClient {
    * ```typescript
    * const sandbox = await client.createSandbox();
    * // Or, resolve by snapshot name:
-   * const sandbox = await client.createSandbox(undefined, {
+   * const sandbox = await client.createSandbox({
    *   snapshotName: "python",
    * });
    * try {
@@ -208,10 +208,21 @@ export class SandboxClient {
    * }
    * ```
    */
+  async createSandbox(options?: CreateSandboxOptions): Promise<Sandbox>;
   async createSandbox(
     snapshotId?: string,
+    options?: CreateSandboxOptions,
+  ): Promise<Sandbox>;
+  async createSandbox(
+    snapshotIdOrOptions?: string | CreateSandboxOptions,
     options: CreateSandboxOptions = {},
   ): Promise<Sandbox> {
+    const snapshotId =
+      typeof snapshotIdOrOptions === "string" ? snapshotIdOrOptions : undefined;
+    const resolvedOptions =
+      typeof snapshotIdOrOptions === "object" && snapshotIdOrOptions !== null
+        ? snapshotIdOrOptions
+        : options;
     const {
       snapshotName,
       name,
@@ -223,7 +234,7 @@ export class SandboxClient {
       memBytes,
       fsCapacityBytes,
       proxyConfig,
-    } = options;
+    } = resolvedOptions;
 
     if (snapshotId && snapshotName) {
       throw new LangSmithValidationError(

--- a/js/src/sandbox/client.ts
+++ b/js/src/sandbox/client.ts
@@ -93,13 +93,8 @@ function getDefaultApiKey(): string | undefined {
  *   apiKey: "your-api-key",
  * });
  *
- * // Build a snapshot, then create a sandbox from it
- * const snapshot = await client.createSnapshot(
- *   "python",
- *   "python:3.12-slim",
- *   1_073_741_824 // 1 GiB
- * );
- * const sandbox = await client.createSandbox(snapshot.id);
+ * // Create a sandbox with the default runtime
+ * const sandbox = await client.createSandbox();
  * try {
  *   const result = await sandbox.run("python --version");
  *   console.log(result.stdout);
@@ -185,33 +180,26 @@ export class SandboxClient {
   // =========================================================================
 
   /**
-   * Create a new Sandbox from a snapshot.
+   * Create a new Sandbox.
    *
    * Remember to call `sandbox.delete()` when done to clean up resources.
    *
-   * Exactly one of `snapshotId` (positional) or `options.snapshotName` must
-   * be provided. When `snapshotName` is used, the server resolves it to a
-   * snapshot owned by the caller's tenant.
+   * Omitting `snapshotId` and `options.snapshotName` is the normal path; the
+   * server uses its default runtime. Pass one only to boot from a reusable
+   * snapshot.
    *
-   * @param snapshotId - ID of the snapshot to boot from. Create one with
-   *   `createSnapshot()` or `captureSnapshot()`, or pass an existing snapshot ID.
-   *   Pass `undefined` when booting by name via `options.snapshotName`.
-   * @param options - Creation options. Use `options.snapshotName` to boot
-   *   by snapshot name instead of ID.
+   * @param snapshotId - Optional snapshot ID to boot from.
+   * @param options - Creation options. Use `options.snapshotName` to boot from
+   *   a named snapshot instead of the default runtime.
    * @returns Created Sandbox.
    * @throws ResourceTimeoutError if timeout waiting for sandbox to be ready.
    * @throws SandboxCreationError if sandbox creation fails.
-   * @throws LangSmithValidationError if TTL values are invalid, or if neither
-   *   (or both) of `snapshotId` / `options.snapshotName` are provided.
+   * @throws LangSmithValidationError if TTL values are invalid, or if both
+   *   `snapshotId` and `options.snapshotName` are provided.
    *
    * @example
    * ```typescript
-   * const snapshot = await client.createSnapshot(
-   *   "python",
-   *   "python:3.12-slim",
-   *   1_073_741_824
-   * );
-   * const sandbox = await client.createSandbox(snapshot.id);
+   * const sandbox = await client.createSandbox();
    * // Or, resolve by snapshot name:
    * const sandbox = await client.createSandbox(undefined, {
    *   snapshotName: "python",
@@ -241,9 +229,9 @@ export class SandboxClient {
       proxyConfig,
     } = options;
 
-    if (!!snapshotId === !!snapshotName) {
+    if (snapshotId && snapshotName) {
       throw new LangSmithValidationError(
-        "Exactly one of snapshotId or options.snapshotName must be set",
+        "At most one of snapshotId or options.snapshotName may be set",
         "snapshotId",
       );
     }

--- a/js/src/sandbox/client.ts
+++ b/js/src/sandbox/client.ts
@@ -184,10 +184,6 @@ export class SandboxClient {
    *
    * Remember to call `sandbox.delete()` when done to clean up resources.
    *
-   * Omitting `snapshotId` and `options.snapshotName` is the normal path; the
-   * server uses its default runtime. Pass one only to boot from a reusable
-   * snapshot.
-   *
    * @param snapshotId - Optional snapshot ID to boot from.
    * @param options - Creation options. Use `options.snapshotName` to boot from
    *   a named snapshot instead of the default runtime.

--- a/js/src/sandbox/types.ts
+++ b/js/src/sandbox/types.ts
@@ -267,8 +267,8 @@ export interface SandboxProxyConfig {
  */
 export interface CreateSandboxOptions {
   /**
-   * Optional snapshot name to boot from. Omit this and the positional
-   * `snapshotId` for the normal default-runtime sandbox.
+   * Optional snapshot name to boot from. Mutually exclusive with the positional
+   * `snapshotId`.
    * Resolved server-side to a snapshot owned by the caller's tenant.
    */
   snapshotName?: string;

--- a/js/src/sandbox/types.ts
+++ b/js/src/sandbox/types.ts
@@ -267,8 +267,8 @@ export interface SandboxProxyConfig {
  */
 export interface CreateSandboxOptions {
   /**
-   * Snapshot name to boot from. Mutually exclusive with the positional
-   * `snapshotId` argument on `createSandbox`; exactly one must be provided.
+   * Optional snapshot name to boot from. Omit this and the positional
+   * `snapshotId` for the normal default-runtime sandbox.
    * Resolved server-side to a snapshot owned by the caller's tenant.
    */
   snapshotName?: string;

--- a/js/src/tests/sandbox.test.ts
+++ b/js/src/tests/sandbox.test.ts
@@ -1167,7 +1167,7 @@ describe("SandboxClient - createSandbox (snapshotId)", () => {
     } as Response);
 
     const client = createClientWithMock(mockFetch);
-    const sandbox = await client.createSandbox(undefined, {
+    const sandbox = await client.createSandbox({
       snapshotName: "my-snap",
     });
 
@@ -1190,7 +1190,7 @@ describe("SandboxClient - createSandbox (snapshotId)", () => {
     } as Response);
     const client = createClientWithMock(mockFetch);
 
-    await client.createSandbox(undefined, { name: "test-sb" });
+    await client.createSandbox({ name: "test-sb" });
 
     const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
     const body = JSON.parse(init.body as string);

--- a/js/src/tests/sandbox.test.ts
+++ b/js/src/tests/sandbox.test.ts
@@ -1179,17 +1179,23 @@ describe("SandboxClient - createSandbox (snapshotId)", () => {
     expect(sandbox.snapshot_id).toBe("snap-1");
   });
 
-  it("should throw when neither snapshotId nor snapshotName is provided", async () => {
-    const mockFetch = jest.fn<typeof fetch>();
+  it("should omit snapshot_id when no snapshot is provided", async () => {
+    const mockFetch = jest.fn<typeof fetch>().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        name: "test-sb",
+        dataplane_url: "https://dp.example.com",
+        status: "ready",
+      }),
+    } as Response);
     const client = createClientWithMock(mockFetch);
 
-    await expect(client.createSandbox()).rejects.toThrow(
-      LangSmithValidationError,
-    );
-    await expect(client.createSandbox()).rejects.toThrow(
-      /Exactly one of snapshotId or options\.snapshotName must be set/,
-    );
-    expect(mockFetch).not.toHaveBeenCalled();
+    await client.createSandbox(undefined, { name: "test-sb" });
+
+    const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string);
+    expect(body.snapshot_id).toBeUndefined();
+    expect(body.snapshot_name).toBeUndefined();
   });
 
   it("should throw when both snapshotId and snapshotName are provided", async () => {
@@ -1199,6 +1205,11 @@ describe("SandboxClient - createSandbox (snapshotId)", () => {
     await expect(
       client.createSandbox("snap-1", { snapshotName: "my-snap" }),
     ).rejects.toThrow(LangSmithValidationError);
+    await expect(
+      client.createSandbox("snap-1", { snapshotName: "my-snap" }),
+    ).rejects.toThrow(
+      /At most one of snapshotId or options\.snapshotName may be set/,
+    );
     expect(mockFetch).not.toHaveBeenCalled();
   });
 });

--- a/python/langsmith/sandbox/README.md
+++ b/python/langsmith/sandbox/README.md
@@ -10,21 +10,14 @@ from langsmith.sandbox import SandboxClient
 # Client uses LANGSMITH_ENDPOINT and LANGSMITH_API_KEY from environment
 client = SandboxClient()
 
-# First, build a snapshot (defines the container image and root filesystem)
-snapshot = client.create_snapshot(
-    "python-snapshot",
-    docker_image="python:3.12-slim",
-    fs_capacity_bytes=4 * 1024**3,  # 4 GB
-)
-
-# Now create a sandbox from the snapshot and run code
-with client.sandbox(snapshot_id=snapshot.id) as sb:
+# Create a sandbox with the default runtime and run code
+with client.sandbox() as sb:
     result = sb.run("python -c 'print(2 + 2)'")
     print(result.stdout)  # "4\n"
     print(result.success)  # True
 
 # Or create a sandbox to keep
-sb = client.create_sandbox(snapshot_id=snapshot.id)
+sb = client.create_sandbox()
 result = sb.run("python -c 'print(2 + 2)'")
 client.delete_sandbox(sb.name)  # Don't forget to clean up when done
 
@@ -33,10 +26,8 @@ sb = client.get_sandbox(name="your-sandbox")
 result = sb.run("python -c 'print(2 + 2)'")
 ```
 
-The examples below assume `snapshot_id` is bound to a snapshot UUID obtained
-from `client.create_snapshot(...)` (or `client.list_snapshots()` /
-`client.get_snapshot(...)`). You only need to build a snapshot once; many
-sandboxes can be created from the same `snapshot_id`.
+Omitting `snapshot_id` and `snapshot_name` is the expected default path. Use a
+snapshot only when you want to boot from a reusable custom filesystem image.
 
 ## Installation
 
@@ -590,14 +581,13 @@ snapshot = client.create_snapshot(
     fs_capacity_bytes=4 * 1024**3,  # 4 GB
 )
 
-# Create a sandbox from the snapshot (by ID)
+# Optionally create a sandbox from the snapshot (by ID)
 with client.sandbox(snapshot_id=snapshot.id) as sb:
     result = sb.run("python --version")
     print(result.stdout)
 
-# Or resolve by snapshot name — the server looks up the snapshot owned by
-# your tenant and boots from it. Exactly one of snapshot_id or snapshot_name
-# must be provided.
+# Or resolve by snapshot name. This is optional; omitting both snapshot_id and
+# snapshot_name uses the default runtime.
 with client.sandbox(snapshot_name="my-python-env") as sb:
     result = sb.run("python --version")
     print(result.stdout)
@@ -900,8 +890,8 @@ except SandboxClientError as e:
 
 | Method | Description |
 |--------|-------------|
-| `sandbox(snapshot_id=None, *, snapshot_name=None, idle_ttl_seconds=None, delete_after_stop_seconds=None, ...)` | Create a sandbox (auto-deleted on context exit). Exactly one of `snapshot_id` / `snapshot_name` must be set. |
-| `create_sandbox(snapshot_id=None, *, snapshot_name=None, wait_for_ready=True, ...)` | Create a sandbox (requires explicit delete). Exactly one of `snapshot_id` / `snapshot_name` must be set. |
+| `sandbox(snapshot_id=None, *, snapshot_name=None, idle_ttl_seconds=None, delete_after_stop_seconds=None, ...)` | Create a sandbox with the default runtime (auto-deleted on context exit). Pass `snapshot_id` or `snapshot_name` only to boot from a reusable snapshot. |
+| `create_sandbox(snapshot_id=None, *, snapshot_name=None, wait_for_ready=True, ...)` | Create a sandbox with the default runtime (requires explicit delete). Pass `snapshot_id` or `snapshot_name` only to boot from a reusable snapshot. |
 | `get_sandbox(name)` | Get an existing sandbox by name |
 | `get_sandbox_status(name)` | Get lightweight provisioning status (`ResourceStatus`) |
 | `wait_for_sandbox(name, *, timeout=120, poll_interval=1.0)` | Poll until sandbox is ready or failed |

--- a/python/langsmith/sandbox/README.md
+++ b/python/langsmith/sandbox/README.md
@@ -26,8 +26,7 @@ sb = client.get_sandbox(name="your-sandbox")
 result = sb.run("python -c 'print(2 + 2)'")
 ```
 
-Omitting `snapshot_id` and `snapshot_name` is the expected default path. Use a
-snapshot only when you want to boot from a reusable custom filesystem image.
+Use a snapshot when you want to boot from a reusable custom filesystem image.
 
 ## Installation
 

--- a/python/langsmith/sandbox/_async_client.py
+++ b/python/langsmith/sandbox/_async_client.py
@@ -57,10 +57,8 @@ class AsyncSandboxClient:
     Example:
         # Uses LANGSMITH_ENDPOINT and LANGSMITH_API_KEY from environment
         async with AsyncSandboxClient() as client:
-            # Create a sandbox from a snapshot and run commands
-            async with await client.sandbox(
-                snapshot_id="<snapshot-uuid>"
-            ) as sandbox:
+            # Create a sandbox with the default runtime and run commands
+            async with await client.sandbox() as sandbox:
                 result = await sandbox.run("python --version")
                 print(result.stdout)
     """
@@ -180,11 +178,11 @@ class AsyncSandboxClient:
         For sandboxes with manual lifecycle management, use create_sandbox().
 
         Args:
-            snapshot_id: Snapshot ID to boot from. Mutually exclusive with
-                ``snapshot_name``; exactly one must be provided.
+            snapshot_id: Optional snapshot ID to boot from. Omit this and
+                ``snapshot_name`` for the normal default-runtime sandbox.
             snapshot_name: Snapshot name to boot from. Resolved server-side to a
                 snapshot owned by the caller's tenant. Mutually exclusive with
-                ``snapshot_id``; exactly one must be provided.
+                ``snapshot_id``.
             name: Optional sandbox name (auto-generated if not provided).
             timeout: Timeout in seconds when waiting for ready.
             idle_ttl_seconds: Idle timeout in seconds. The launcher
@@ -216,8 +214,8 @@ class AsyncSandboxClient:
             ResourceTimeoutError: If timeout waiting for sandbox to be ready.
             ResourceCreationError: If sandbox creation fails.
             SandboxClientError: For other errors.
-            ValueError: If TTL values are invalid, or if neither/both of
-                ``snapshot_id`` and ``snapshot_name`` are provided.
+            ValueError: If TTL values are invalid, or if both ``snapshot_id`` and
+                ``snapshot_name`` are provided.
         """
         sb = await self.create_sandbox(
             snapshot_id,
@@ -257,11 +255,11 @@ class AsyncSandboxClient:
         or use sandbox() for automatic cleanup with a context manager.
 
         Args:
-            snapshot_id: Snapshot ID to boot from. Mutually exclusive with
-                ``snapshot_name``; exactly one must be provided.
+            snapshot_id: Optional snapshot ID to boot from. Omit this and
+                ``snapshot_name`` for the normal default-runtime sandbox.
             snapshot_name: Snapshot name to boot from. Resolved server-side to a
                 snapshot owned by the caller's tenant. Mutually exclusive with
-                ``snapshot_id``; exactly one must be provided.
+                ``snapshot_id``.
             name: Optional sandbox name (auto-generated if not provided).
             timeout: Timeout in seconds when waiting for ready (only used when
                 wait_for_ready=True).
@@ -298,11 +296,11 @@ class AsyncSandboxClient:
             ResourceTimeoutError: If timeout waiting for sandbox to be ready.
             ResourceCreationError: If sandbox creation fails.
             SandboxClientError: For other errors.
-            ValueError: If TTL values are invalid, or if neither/both of
-                ``snapshot_id`` and ``snapshot_name`` are provided.
+            ValueError: If TTL values are invalid, or if both ``snapshot_id`` and
+                ``snapshot_name`` are provided.
         """
-        if bool(snapshot_id) == bool(snapshot_name):
-            raise ValueError("Exactly one of snapshot_id or snapshot_name must be set")
+        if snapshot_id and snapshot_name:
+            raise ValueError("At most one of snapshot_id or snapshot_name may be set")
 
         validate_ttl(idle_ttl_seconds, "idle_ttl_seconds")
         validate_ttl(delete_after_stop_seconds, "delete_after_stop_seconds")

--- a/python/langsmith/sandbox/_async_client.py
+++ b/python/langsmith/sandbox/_async_client.py
@@ -178,8 +178,8 @@ class AsyncSandboxClient:
         For sandboxes with manual lifecycle management, use create_sandbox().
 
         Args:
-            snapshot_id: Optional snapshot ID to boot from. Omit this and
-                ``snapshot_name`` for the normal default-runtime sandbox.
+            snapshot_id: Optional snapshot ID to boot from. Mutually exclusive
+                with ``snapshot_name``.
             snapshot_name: Snapshot name to boot from. Resolved server-side to a
                 snapshot owned by the caller's tenant. Mutually exclusive with
                 ``snapshot_id``.
@@ -255,8 +255,8 @@ class AsyncSandboxClient:
         or use sandbox() for automatic cleanup with a context manager.
 
         Args:
-            snapshot_id: Optional snapshot ID to boot from. Omit this and
-                ``snapshot_name`` for the normal default-runtime sandbox.
+            snapshot_id: Optional snapshot ID to boot from. Mutually exclusive
+                with ``snapshot_name``.
             snapshot_name: Snapshot name to boot from. Resolved server-side to a
                 snapshot owned by the caller's tenant. Mutually exclusive with
                 ``snapshot_id``.

--- a/python/langsmith/sandbox/_client.py
+++ b/python/langsmith/sandbox/_client.py
@@ -177,8 +177,8 @@ class SandboxClient:
         For sandboxes with manual lifecycle management, use create_sandbox().
 
         Args:
-            snapshot_id: Optional snapshot ID to boot from. Omit this and
-                ``snapshot_name`` for the normal default-runtime sandbox.
+            snapshot_id: Optional snapshot ID to boot from. Mutually exclusive
+                with ``snapshot_name``.
             snapshot_name: Snapshot name to boot from. Resolved server-side to a
                 snapshot owned by the caller's tenant. Mutually exclusive with
                 ``snapshot_id``.
@@ -254,8 +254,8 @@ class SandboxClient:
         or use sandbox() for automatic cleanup with a context manager.
 
         Args:
-            snapshot_id: Optional snapshot ID to boot from. Omit this and
-                ``snapshot_name`` for the normal default-runtime sandbox.
+            snapshot_id: Optional snapshot ID to boot from. Mutually exclusive
+                with ``snapshot_name``.
             snapshot_name: Snapshot name to boot from. Resolved server-side to a
                 snapshot owned by the caller's tenant. Mutually exclusive with
                 ``snapshot_id``.

--- a/python/langsmith/sandbox/_client.py
+++ b/python/langsmith/sandbox/_client.py
@@ -63,8 +63,8 @@ class SandboxClient:
             api_key="your-api-key",
         )
 
-        # Create a sandbox from a snapshot and run commands
-        with client.sandbox(snapshot_id="<snapshot-uuid>") as sandbox:
+        # Create a sandbox with the default runtime and run commands
+        with client.sandbox() as sandbox:
             result = sandbox.run("python --version")
             print(result.stdout)
     """
@@ -177,11 +177,11 @@ class SandboxClient:
         For sandboxes with manual lifecycle management, use create_sandbox().
 
         Args:
-            snapshot_id: Snapshot ID to boot from. Mutually exclusive with
-                ``snapshot_name``; exactly one must be provided.
+            snapshot_id: Optional snapshot ID to boot from. Omit this and
+                ``snapshot_name`` for the normal default-runtime sandbox.
             snapshot_name: Snapshot name to boot from. Resolved server-side to a
                 snapshot owned by the caller's tenant. Mutually exclusive with
-                ``snapshot_id``; exactly one must be provided.
+                ``snapshot_id``.
             name: Optional sandbox name (auto-generated if not provided).
             timeout: Timeout in seconds when waiting for ready.
             idle_ttl_seconds: Idle timeout in seconds. The launcher
@@ -213,8 +213,8 @@ class SandboxClient:
             ResourceTimeoutError: If timeout waiting for sandbox to be ready.
             ResourceCreationError: If sandbox creation fails.
             SandboxClientError: For other errors.
-            ValueError: If TTL values are invalid, or if neither/both of
-                ``snapshot_id`` and ``snapshot_name`` are provided.
+            ValueError: If TTL values are invalid, or if both ``snapshot_id`` and
+                ``snapshot_name`` are provided.
         """
         sb = self.create_sandbox(
             snapshot_id,
@@ -254,11 +254,11 @@ class SandboxClient:
         or use sandbox() for automatic cleanup with a context manager.
 
         Args:
-            snapshot_id: Snapshot ID to boot from. Mutually exclusive with
-                ``snapshot_name``; exactly one must be provided.
+            snapshot_id: Optional snapshot ID to boot from. Omit this and
+                ``snapshot_name`` for the normal default-runtime sandbox.
             snapshot_name: Snapshot name to boot from. Resolved server-side to a
                 snapshot owned by the caller's tenant. Mutually exclusive with
-                ``snapshot_id``; exactly one must be provided.
+                ``snapshot_id``.
             name: Optional sandbox name (auto-generated if not provided).
             timeout: Timeout in seconds when waiting for ready (only used when
                 wait_for_ready=True).
@@ -295,11 +295,11 @@ class SandboxClient:
             ResourceTimeoutError: If timeout waiting for sandbox to be ready.
             ResourceCreationError: If sandbox creation fails.
             SandboxClientError: For other errors.
-            ValueError: If TTL values are invalid, or if neither/both of
-                ``snapshot_id`` and ``snapshot_name`` are provided.
+            ValueError: If TTL values are invalid, or if both ``snapshot_id`` and
+                ``snapshot_name`` are provided.
         """
-        if bool(snapshot_id) == bool(snapshot_name):
-            raise ValueError("Exactly one of snapshot_id or snapshot_name must be set")
+        if snapshot_id and snapshot_name:
+            raise ValueError("At most one of snapshot_id or snapshot_name may be set")
 
         validate_ttl(idle_ttl_seconds, "idle_ttl_seconds")
         validate_ttl(delete_after_stop_seconds, "delete_after_stop_seconds")

--- a/python/tests/unit_tests/sandbox/test_async_client.py
+++ b/python/tests/unit_tests/sandbox/test_async_client.py
@@ -708,19 +708,39 @@ class TestAsyncSandboxOperations:
         assert "snapshot_id" not in body
         assert "template_name" not in body
 
-    async def test_create_sandbox_requires_exactly_one_identifier(
+    async def test_create_sandbox_omits_snapshot_id_when_absent(
+        self, client: AsyncSandboxClient, httpx_mock: HTTPXMock
+    ):
+        """Test creating a sandbox without a snapshot."""
+        import json
+
+        httpx_mock.add_response(
+            method="POST",
+            url="http://test-server:8080/boxes",
+            json={
+                "name": "my-vm",
+                "status": "ready",
+                "dataplane_url": "https://dp.example.com/my-vm",
+            },
+            status_code=201,
+        )
+
+        sandbox = await client.create_sandbox(name="my-vm")
+
+        assert sandbox.name == "my-vm"
+
+        body = json.loads(httpx_mock.get_request().content)
+        assert "snapshot_id" not in body
+        assert "snapshot_name" not in body
+
+    async def test_create_sandbox_rejects_both_snapshot_identifiers(
         self, client: AsyncSandboxClient
     ):
-        """Test that exactly one of snapshot_id / snapshot_name must be set."""
-        with pytest.raises(
-            ValueError,
-            match="Exactly one of snapshot_id or snapshot_name must be set",
-        ):
-            await client.create_sandbox()
+        """Test that snapshot_id / snapshot_name are mutually exclusive."""
 
         with pytest.raises(
             ValueError,
-            match="Exactly one of snapshot_id or snapshot_name must be set",
+            match="At most one of snapshot_id or snapshot_name may be set",
         ):
             await client.create_sandbox(snapshot_id="snap-1", snapshot_name="my-snap")
 

--- a/python/tests/unit_tests/sandbox/test_client.py
+++ b/python/tests/unit_tests/sandbox/test_client.py
@@ -1197,19 +1197,40 @@ class TestStartStopOperations:
         assert "snapshot_id" not in body
         assert "template_name" not in body
 
-    def test_create_sandbox_requires_exactly_one_identifier(
+    def test_create_sandbox_omits_snapshot_id_when_absent(
+        self, client: SandboxClient, httpx_mock: HTTPXMock
+    ):
+        """Test creating a sandbox without a snapshot."""
+        httpx_mock.add_response(
+            method="POST",
+            url="http://test-server:8080/boxes",
+            json={
+                "name": "my-vm",
+                "status": "ready",
+                "dataplane_url": "https://dp.example.com/my-vm",
+            },
+            status_code=201,
+        )
+
+        sandbox = client.create_sandbox(name="my-vm")
+
+        assert sandbox.name == "my-vm"
+
+        import json
+
+        request = httpx_mock.get_request()
+        body = json.loads(request.content)
+        assert "snapshot_id" not in body
+        assert "snapshot_name" not in body
+
+    def test_create_sandbox_rejects_both_snapshot_identifiers(
         self, client: SandboxClient
     ):
-        """Test that exactly one of snapshot_id / snapshot_name must be set."""
-        with pytest.raises(
-            ValueError,
-            match="Exactly one of snapshot_id or snapshot_name must be set",
-        ):
-            client.create_sandbox()
+        """Test that snapshot_id / snapshot_name are mutually exclusive."""
 
         with pytest.raises(
             ValueError,
-            match="Exactly one of snapshot_id or snapshot_name must be set",
+            match="At most one of snapshot_id or snapshot_name may be set",
         ):
             client.create_sandbox(snapshot_id="snap-1", snapshot_name="my-snap")
 


### PR DESCRIPTION
## Summary

Make Python and TypeScript sandbox creation allow no snapshot id or name. Keep snapshot id/name mutually exclusive when supplied.

Add a TypeScript `createSandbox(options?)` overload so callers can pass creation options directly without a positional `undefined`, while preserving the existing `createSandbox(snapshotId?, options?)` form.

## Test Plan

- [x] pnpm --dir js test:single src/tests/sandbox.test.ts --runInBand
- [x] uv run python -m pytest tests/unit_tests/sandbox/test_client.py tests/unit_tests/sandbox/test_async_client.py -k "omits_snapshot_id_when_absent or rejects_both_snapshot_identifiers"

