### PR TITLE
release(py): 0.8.4

### DIFF
--- a/python/.bumpversion.cfg
+++ b/python/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.8.3
+current_version = 0.8.4
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
 serialize = {major}.{minor}.{patch}
 search = {current_version}

--- a/python/langsmith/__init__.py
+++ b/python/langsmith/__init__.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
 
 # Avoid calling into importlib on every call to __version__
 
-__version__ = "0.8.3"
+__version__ = "0.8.4"
 version = __version__  # for backwards compatibility
 
 


### PR DESCRIPTION
## Summary

Bump the Python SDK version to 0.8.4 for release.

## Test Plan
- [x] Version-only release bump




