### PR TITLE
feat(js): allow disabling multipart streaming via env variable

### DIFF
--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -1142,7 +1142,8 @@ export class Client implements LangSmithTracingClientInterface {
     }
   }
 
-  private multipartStreamingDisabled = false;
+  private multipartStreamingDisabled =
+    getLangSmithEnvironmentVariable("DISABLE_MULTIPART_STREAMING") === "true";
 
   private _multipartDisabled = false;
 


### PR DESCRIPTION
Add LANGSMITH_MULTIPART_STREAMING env var to disable multipart streaming in unsupported fetch runtimes. 