### PR TITLE
release(js): 0.7.1

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langsmith",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Client library to connect to the LangSmith Observability and Evaluation Platform.",
   "packageManager": "pnpm@10.33.0",
   "files": [

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -32,4 +32,4 @@ export {
 } from "./utils/prompt_cache/index.js";
 
 // Update using pnpm bump-version
-export const __version__ = "0.7.0";
+export const __version__ = "0.7.1";


### PR DESCRIPTION
Bumps the JS SDK from 0.7.0 to 0.7.1. Test plan: node scripts/check-version.js.