### PR TITLE
chore: exclude langsmith_api from ruff linter

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -159,6 +159,7 @@ exclude = [".test", ".venv*"]
 packages = ["langsmith"]
 
 [tool.ruff]
+exclude = ["langsmith_api"]
 lint.select = [
   "E",    # pycodestyle
   "F",    # pyflakes


### PR DESCRIPTION
## Summary

- Adds `langsmith_api` to ruff's `exclude` list in `python/pyproject.toml`
- `python/langsmith_api` is auto-generated code (synced via [#2911](https://github.com/langchain-ai/langsmith-sdk/pull/2911)) and should not be subject to the project's lint rules

## Test plan
- [x] Python Lint CI check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)