### PR TITLE
fix(python): enforce size_limit_bytes in multipart ingest path

### DIFF
--- a/python/langsmith/_internal/_multipart.py
+++ b/python/langsmith/_internal/_multipart.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from collections.abc import Iterable
 from io import BufferedReader
 from typing import Union
@@ -18,6 +19,20 @@ class MultipartPartsAndContext:
     def __init__(self, parts: list[MultipartPart], context: str) -> None:
         self.parts = parts
         self.context = context
+
+
+def _multipart_part_size(part: MultipartPartsAndContext) -> int:
+    """Estimate byte size of a MultipartPartsAndContext for batch splitting."""
+    total = 0
+    for _, (_, data, _, _) in part.parts:
+        if isinstance(data, bytes):
+            total += len(data)
+        elif isinstance(data, BufferedReader):
+            try:
+                total += os.fstat(data.fileno()).st_size
+            except Exception:
+                pass
+    return total
 
 
 def join_multipart_parts_and_context(

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -95,6 +95,7 @@ from langsmith._internal._hub import (
 from langsmith._internal._multipart import (
     MultipartPart,
     MultipartPartsAndContext,
+    _multipart_part_size,
     join_multipart_parts_and_context,
 )
 from langsmith._internal._operations import (
@@ -2974,43 +2975,61 @@ class Client:
         authorization: Optional[str] = None,
         cookie: Optional[str] = None,
     ) -> None:
-        parts: list[MultipartPartsAndContext] = []
-        opened_files_dict: dict[str, io.BufferedReader] = {}
+        size_limit_bytes = (
+            self._max_batch_size_bytes
+            or (self.info.batch_ingest_config or {}).get("size_limit_bytes")
+            or _SIZE_LIMIT_BYTES
+        )
+        all_opened_files: dict[str, io.BufferedReader] = {}
+        op_and_parts: list[
+            tuple[
+                Union[SerializedRunOperation, SerializedFeedbackOperation],
+                MultipartPartsAndContext,
+            ]
+        ] = []
         for op in ops:
             if isinstance(op, SerializedRunOperation):
                 (
                     part,
                     opened_files,
                 ) = serialized_run_operation_to_multipart_parts_and_context(op)
-                parts.append(part)
-                opened_files_dict.update(opened_files)
+                all_opened_files.update(opened_files)
             elif isinstance(op, SerializedFeedbackOperation):
-                parts.append(
-                    serialized_feedback_operation_to_multipart_parts_and_context(op)
-                )
+                part = serialized_feedback_operation_to_multipart_parts_and_context(op)
             else:
                 logger.error("Unknown operation type in tracing queue: %s", type(op))
-        acc_multipart = join_multipart_parts_and_context(parts)
-        if acc_multipart:
-            try:
-                self._send_multipart_req(
-                    acc_multipart,
-                    api_url=api_url,
-                    api_key=api_key,
-                    service_key=service_key,
-                    tenant_id=tenant_id,
-                    authorization=authorization,
-                    cookie=cookie,
-                )
-            except ls_utils.LangSmithNotFoundError:
-                # Fallback to batch ingest if multipart endpoint returns 404
-                # Disable multipart for future requests
-                self._multipart_disabled = True
-                # Filter out feedback operations as they're not supported in non-multipart mode
-                run_ops = [op for op in ops if isinstance(op, SerializedRunOperation)]
-                if run_ops:
-                    self._batch_ingest_run_ops(
-                        run_ops,
+                continue
+            op_and_parts.append((op, part))
+
+        try:
+            # Split into size-bounded batches, mirroring _batch_ingest_run_ops
+            batches: list[
+                tuple[
+                    list[Union[SerializedRunOperation, SerializedFeedbackOperation]],
+                    list[MultipartPartsAndContext],
+                ]
+            ] = []
+            cur_batch_ops: list[
+                Union[SerializedRunOperation, SerializedFeedbackOperation]
+            ] = []
+            cur_batch_parts: list[MultipartPartsAndContext] = []
+            cur_batch_size = 0
+            for op, part in op_and_parts:
+                part_size = _multipart_part_size(part)
+                if cur_batch_size > 0 and cur_batch_size + part_size > size_limit_bytes:
+                    batches.append((cur_batch_ops, cur_batch_parts))
+                    cur_batch_ops, cur_batch_parts, cur_batch_size = [], [], 0
+                cur_batch_ops.append(op)
+                cur_batch_parts.append(part)
+                cur_batch_size += part_size
+            if cur_batch_ops:
+                batches.append((cur_batch_ops, cur_batch_parts))
+
+            for batch_ops, batch_parts in batches:
+                acc_multipart = join_multipart_parts_and_context(batch_parts)
+                try:
+                    self._send_multipart_req(
+                        acc_multipart,
                         api_url=api_url,
                         api_key=api_key,
                         service_key=service_key,
@@ -3018,8 +3037,26 @@ class Client:
                         authorization=authorization,
                         cookie=cookie,
                     )
-            finally:
-                _close_files(list(opened_files_dict.values()))
+                except ls_utils.LangSmithNotFoundError:
+                    # Fallback to batch ingest if multipart endpoint returns 404
+                    # Disable multipart for future requests
+                    self._multipart_disabled = True
+                    # Feedback ops are not supported in non-multipart mode
+                    run_ops = [
+                        o for o in batch_ops if isinstance(o, SerializedRunOperation)
+                    ]
+                    if run_ops:
+                        self._batch_ingest_run_ops(
+                            run_ops,
+                            api_url=api_url,
+                            api_key=api_key,
+                            service_key=service_key,
+                            tenant_id=tenant_id,
+                            authorization=authorization,
+                            cookie=cookie,
+                        )
+        finally:
+            _close_files(list(all_opened_files.values()))
 
     def multipart_ingest(
         self,

--- a/python/tests/unit_tests/test_client.py
+++ b/python/tests/unit_tests/test_client.py
@@ -2014,8 +2014,9 @@ def test_batch_ingest_run_splits_large_batches(
 
     if use_multipart_endpoint:
         client.multipart_ingest(create=posts, update=patches)
-        # multipart endpoint should only send one request
-        expected_num_requests = 1
+        # multipart now enforces the same size_limit_bytes as batch_ingest_runs
+        max_in_batch = max(1, (20 * MB) // (payload_size + 20))
+        expected_num_requests = min(6, math.ceil((len(run_ids) * 2) / max_in_batch))
         # count the number of POST requests
         assert sum(
             [1 for call in mock_session.request.call_args_list if call[0][0] == "POST"]
@@ -4375,6 +4376,88 @@ def test_max_batch_size_bytes_override(mock_session_cls: mock.Mock) -> None:
                 break
 
     assert not found_zstd, "Expected no zstd compressed request"
+
+
+def test_multipart_ingest_ops_splits_by_size() -> None:
+    """_multipart_ingest_ops must split ops into multiple requests when payload exceeds size_limit_bytes."""
+    from langsmith._internal._operations import SerializedRunOperation
+
+    client = Client(
+        api_url="http://localhost:1984",
+        api_key="test",
+        auto_batch_tracing=False,
+    )
+    # Each op has ~500 bytes of outputs; limit of 600 means two ops cannot fit in one request.
+    client._max_batch_size_bytes = 600
+
+    def make_op(output_size: int) -> SerializedRunOperation:
+        run_id = uuid.uuid4()
+        none_bytes = json.dumps(
+            {
+                "id": str(run_id),
+                "name": "test",
+                "run_type": "chain",
+                "trace_id": str(run_id),
+                "dotted_order": str(run_id),
+            }
+        ).encode()
+        return SerializedRunOperation(
+            operation="post",
+            id=run_id,
+            trace_id=run_id,
+            _none=none_bytes,
+            outputs=b"x" * output_size,
+        )
+
+    op1 = make_op(500)
+    op2 = make_op(500)
+    op3 = make_op(500)
+
+    with mock.patch.object(Client, "_send_multipart_req") as mock_send:
+        client._multipart_ingest_ops([op1, op2, op3])
+
+    assert mock_send.call_count == 3, (
+        f"Expected 3 multipart requests (one per op due to size limit), got {mock_send.call_count}"
+    )
+
+
+def test_multipart_ingest_ops_no_split_when_within_limit() -> None:
+    """_multipart_ingest_ops sends a single request when total size is within limit."""
+    from langsmith._internal._operations import SerializedRunOperation
+
+    client = Client(
+        api_url="http://localhost:1984",
+        api_key="test",
+        auto_batch_tracing=False,
+    )
+    # Large enough limit that two small ops both fit in one request.
+    client._max_batch_size_bytes = 10_000
+
+    def make_op() -> SerializedRunOperation:
+        run_id = uuid.uuid4()
+        none_bytes = json.dumps(
+            {
+                "id": str(run_id),
+                "name": "test",
+                "run_type": "chain",
+                "trace_id": str(run_id),
+                "dotted_order": str(run_id),
+            }
+        ).encode()
+        return SerializedRunOperation(
+            operation="post",
+            id=run_id,
+            trace_id=run_id,
+            _none=none_bytes,
+            outputs=b"y" * 100,
+        )
+
+    with mock.patch.object(Client, "_send_multipart_req") as mock_send:
+        client._multipart_ingest_ops([make_op(), make_op()])
+
+    assert mock_send.call_count == 1, (
+        f"Expected 1 multipart request when ops fit within limit, got {mock_send.call_count}"
+    )
 
 
 def test__dataset_examples_path():


### PR DESCRIPTION
## Summary

- `_multipart_ingest_ops` now splits ops into multiple requests when the accumulated payload would exceed `size_limit_bytes`, mirroring the batch-splitting logic that already existed in `_batch_ingest_run_ops`
- Adds `_multipart_part_size` helper in `_multipart.py` to estimate the byte size of a `MultipartPartsAndContext` (uses `len(data)` for bytes parts, `os.fstat` for file attachments)
- Size limit respects the same hierarchy: `_max_batch_size_bytes` > server `batch_ingest_config.size_limit_bytes` > `_SIZE_LIMIT_BYTES` (20 MB default)
- A single op larger than the limit is still sent (the check requires `batch_size > 0` before splitting, preserving current behavior for oversized individual ops)

## Linear

https://linear.app/langchain/issue/LSDK-207/multipart-ingest-path-has-no-batch-size-enforcement-allowing

## Test Plan

- [x] `test_multipart_ingest_ops_splits_by_size` — calls `_multipart_ingest_ops` with 3 × 500-byte ops against a 600-byte limit; asserts 3 separate `_send_multipart_req` calls
- [x] `test_multipart_ingest_ops_no_split_when_within_limit` — 2 × 100-byte ops against 10 KB limit; asserts 1 `_send_multipart_req` call
- [x] `test_batch_ingest_run_splits_large_batches[True-*]` — updated expected request count to use the same formula as the `False` (non-multipart) parameterized variant, since both paths now enforce the same limit
- [x] Full unit test suite: 1208 passed, 10 pre-existing failures unrelated to this change (sandbox + test_utils env-var tests)

## Release Note

Fixed an issue where the multipart ingest path could send arbitrarily large requests when many runs with large payloads were batched together, causing OOM crashes in high-throughput environments.