### PR TITLE
fix: return context hub URLs for pushed contexts

### DIFF
--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -6912,15 +6912,11 @@ export class Client implements LangSmithTracingClientInterface {
     });
     const data = (await response.json()) as DirectoryCommitResponse;
     const commitHash = data.commit.commit_hash;
-    let ownerForUrl = owner;
-    if (owner === "-") {
-      const settings = await this._getSettings();
-      ownerForUrl = settings.tenant_handle || owner;
-    }
-    return `${this.getHostUrl()}/hub/${ownerForUrl}/${name}:${commitHash.slice(
+    const settings = await this._getSettings();
+    return `${this.getHostUrl()}/context/${name}/${commitHash.slice(
       0,
       8,
-    )}`;
+    )}?organizationId=${settings.id}`;
   }
 
   private async _deleteDirectory(identifier: string): Promise<void> {
@@ -6978,6 +6974,7 @@ export class Client implements LangSmithTracingClientInterface {
       repo_handle: name,
       repo_type: repoType,
       is_public: !!options.isPublic,
+      source: "internal",
     };
     if (options.description !== undefined)
       body.description = options.description;

--- a/js/src/tests/context.int.test.ts
+++ b/js/src/tests/context.int.test.ts
@@ -43,7 +43,7 @@ describe("Context integration (agent/skill)", () => {
         },
         description: "integration test agent (js)",
       });
-      expect(url).toContain("/hub/");
+      expect(url).toContain("/context/");
 
       const agent: AgentContext = await client.pullAgent(identifier);
       expect(agent.files["AGENTS.md"]).toBeDefined();
@@ -64,7 +64,7 @@ describe("Context integration (agent/skill)", () => {
         },
         description: "integration test skill (js)",
       });
-      expect(url).toContain("/hub/");
+      expect(url).toContain("/context/");
 
       const skill: SkillContext = await client.pullSkill(identifier);
       expect(skill.files["SKILL.md"]).toBeDefined();
@@ -83,7 +83,7 @@ describe("Context integration (agent/skill)", () => {
           "tools.json": { type: "file", content: TOOLS_JSON },
         },
       });
-      expect(url).toContain("/hub/");
+      expect(url).toContain("/context/");
 
       const agent: AgentContext = await client.pullAgent(identifier);
       expect(agent.files["tools.json"]).toBeDefined();

--- a/js/src/tests/context.test.ts
+++ b/js/src/tests/context.test.ts
@@ -8,7 +8,7 @@ function _mockClient() {
   jest.spyOn(client as any, "_currentTenantIsOwner").mockResolvedValue(true);
   jest
     .spyOn(client as any, "_getSettings")
-    .mockResolvedValue({ tenant_handle: "workspace-handle" });
+    .mockResolvedValue({ id: "tenant-id", tenant_handle: "workspace-handle" });
   jest
     .spyOn(client as any, "_ownerConflictError")
     .mockImplementation(async () => new Error("owner mismatch"));
@@ -149,7 +149,9 @@ describe("Context (agent/skill) on Client", () => {
       const url = await client.pushAgent("-/my-agent", {
         files: { "main.py": { type: "file", content: "x" } },
       });
-      expect(url).toContain("/hub/workspace-handle/my-agent:abc12345");
+      expect(url).toContain(
+        "/context/my-agent/abc12345?organizationId=tenant-id",
+      );
 
       const calls = fetchSpy.mock.calls as [string, any][];
       expect(calls).toHaveLength(3);
@@ -162,6 +164,7 @@ describe("Context (agent/skill) on Client", () => {
       const createBody = JSON.parse(calls[1][1].body);
       expect(createBody.repo_handle).toBe("my-agent");
       expect(createBody.repo_type).toBe("agent");
+      expect(createBody.source).toBe("internal");
       // 3. commit
       expect(calls[2][0]).toContain(
         "/v1/platform/hub/repos/-/my-agent/directories/commits",
@@ -280,10 +283,12 @@ describe("Context (agent/skill) on Client", () => {
         client.pushAgent("-/my-agent", {
           files: { "main.py": { type: "file", content: "x" } },
         }),
-      ).resolves.toContain("/hub/workspace-handle/my-agent:abc12345");
+      ).resolves.toContain(
+        "/context/my-agent/abc12345?organizationId=tenant-id",
+      );
     });
 
-    it("keeps explicit owner in returned URL", async () => {
+    it("returns the Context Hub URL for explicit owner identifiers", async () => {
       const client = _mockClient();
       _setFetchSequence(client, [
         _response({ detail: "Not Found" }, 404),
@@ -299,12 +304,15 @@ describe("Context (agent/skill) on Client", () => {
       const url = await client.pushAgent("explicit-owner/my-agent", {
         files: { "main.py": { type: "file", content: "x" } },
       });
-      expect(url).toContain("/hub/explicit-owner/my-agent:abc12345");
+      expect(url).toContain(
+        "/context/my-agent/abc12345?organizationId=tenant-id",
+      );
     });
 
-    it("falls back to dash owner when tenant_handle is missing", async () => {
+    it("uses the tenant ID in the returned URL when tenant_handle is missing", async () => {
       const client = _mockClient();
       jest.spyOn(client as any, "_getSettings").mockResolvedValue({
+        id: "tenant-id",
         tenant_handle: "",
       });
       _setFetchSequence(client, [
@@ -321,10 +329,12 @@ describe("Context (agent/skill) on Client", () => {
       const url = await client.pushAgent("-/my-agent", {
         files: { "main.py": { type: "file", content: "x" } },
       });
-      expect(url).toContain("/hub/-/my-agent:abc12345");
+      expect(url).toContain(
+        "/context/my-agent/abc12345?organizationId=tenant-id",
+      );
     });
 
-    it("supports name-only identifier and returns workspace-handle URL", async () => {
+    it("supports name-only identifier and returns a Context Hub URL", async () => {
       const client = _mockClient();
       const fetchSpy = _setFetchSequence(client, [
         _response({ detail: "Not Found" }, 404),
@@ -340,7 +350,9 @@ describe("Context (agent/skill) on Client", () => {
       const url = await client.pushAgent("email-assistant", {
         files: { "main.py": { type: "file", content: "x" } },
       });
-      expect(url).toContain("/hub/workspace-handle/email-assistant:abc12345");
+      expect(url).toContain(
+        "/context/email-assistant/abc12345?organizationId=tenant-id",
+      );
 
       const calls = fetchSpy.mock.calls as [string, any][];
       expect(calls[0][0]).toContain("/repos/-/email-assistant");

--- a/python/langsmith/_internal/_hub.py
+++ b/python/langsmith/_internal/_hub.py
@@ -12,16 +12,14 @@ PLATFORM_HUB = "/v1/platform/hub/repos"
 HUB = "/repos"
 
 
-def build_commit_url(host: str, owner: str, name: str, commit_hash: str) -> str:
+def build_commit_url(
+    host: str, name: str, commit_hash: str, *, tenant_id: Optional[str]
+) -> str:
     """Build the URL for a hub directory commit."""
-    return f"{host}/hub/{owner}/{name}:{commit_hash[:8]}"
-
-
-def resolve_owner_for_url(owner: str, tenant_handle: Optional[str]) -> str:
-    """Resolve internal owner sentinel to a user-visible owner in URLs."""
-    if owner == "-" and tenant_handle:
-        return tenant_handle
-    return owner
+    url = f"{host}/context/{name}/{commit_hash[:8]}"
+    if tenant_id:
+        url += f"?organizationId={tenant_id}"
+    return url
 
 
 def validate_parent_commit(parent_commit: Optional[str]) -> None:

--- a/python/langsmith/async_client.py
+++ b/python/langsmith/async_client.py
@@ -29,7 +29,6 @@ from langsmith._internal._hub import (
     PLATFORM_HUB,
     REPO_HANDLE_PATTERN,
     build_commit_url,
-    resolve_owner_for_url,
     validate_parent_commit,
 )
 from langsmith.prompt_cache import AsyncPromptCache, async_prompt_cache_singleton
@@ -2392,11 +2391,13 @@ class AsyncClient:
             json=body,
         )
         commit_hash = response.json()["commit"]["commit_hash"]
-        tenant_handle = (
-            (await self._get_settings()).tenant_handle if owner == "-" else None
+        settings = await self._get_settings()
+        return build_commit_url(
+            self._host_url,
+            name,
+            commit_hash,
+            tenant_id=settings.id,
         )
-        owner_for_url = resolve_owner_for_url(owner, tenant_handle)
-        return build_commit_url(self._host_url, owner_for_url, name, commit_hash)
 
     async def _delete_hub_directory(self, identifier: str) -> None:
         """Delete a hub directory repo."""
@@ -2460,6 +2461,7 @@ class AsyncClient:
             "repo_handle": name,
             "repo_type": repo_type,
             "is_public": is_public,
+            "source": "internal",
         }
         if description is not None:
             body["description"] = description

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -89,7 +89,6 @@ from langsmith._internal._hub import (
     PLATFORM_HUB,
     REPO_HANDLE_PATTERN,
     build_commit_url,
-    resolve_owner_for_url,
     validate_parent_commit,
 )
 from langsmith._internal._multipart import (
@@ -9726,9 +9725,12 @@ class Client:
             json=body,
         )
         commit_hash = response.json()["commit"]["commit_hash"]
-        tenant_handle = self._get_settings().tenant_handle if owner == "-" else None
-        owner_for_url = resolve_owner_for_url(owner, tenant_handle)
-        return build_commit_url(self._host_url, owner_for_url, name, commit_hash)
+        return build_commit_url(
+            self._host_url,
+            name,
+            commit_hash,
+            tenant_id=self._get_settings().id,
+        )
 
     def _delete_hub_directory(self, identifier: str) -> None:
         """Delete a hub directory repo."""
@@ -9792,6 +9794,7 @@ class Client:
             "repo_handle": name,
             "repo_type": repo_type,
             "is_public": is_public,
+            "source": "internal",
         }
         if description is not None:
             body["description"] = description

--- a/python/tests/integration_tests/test_hub_client.py
+++ b/python/tests/integration_tests/test_hub_client.py
@@ -42,7 +42,7 @@ def test_push_and_pull_agent_roundtrip(
             files={"AGENTS.md": ls_schemas.FileEntry(content="# Test Agent\n")},
             description="integration test agent",
         )
-        assert "/hub/" in url
+        assert "/context/" in url
 
         agent = ctx.pull_agent(agent_identifier)
         assert isinstance(agent, ls_schemas.AgentContext)
@@ -68,7 +68,7 @@ def test_push_and_pull_agent_tools_json_roundtrip(
             files={"tools.json": ls_schemas.FileEntry(content=TOOLS_JSON)},
             description="integration test agent tools",
         )
-        assert "/hub/" in url
+        assert "/context/" in url
 
         agent = ctx.pull_agent(agent_identifier)
         assert isinstance(agent, ls_schemas.AgentContext)
@@ -94,7 +94,7 @@ def test_push_and_pull_skill_roundtrip(
             files={"SKILL.md": ls_schemas.FileEntry(content="# Test Skill\n")},
             description="integration test skill",
         )
-        assert "/hub/" in url
+        assert "/context/" in url
 
         skill = ctx.pull_skill(skill_identifier)
         assert isinstance(skill, ls_schemas.SkillContext)

--- a/python/tests/integration_tests/test_hub_client_async.py
+++ b/python/tests/integration_tests/test_hub_client_async.py
@@ -34,7 +34,7 @@ async def test_push_and_pull_agent_roundtrip(
             files={"AGENTS.md": ls_schemas.FileEntry(content="# Test Agent\n")},
             description="integration test agent",
         )
-        assert "/hub/" in url
+        assert "/context/" in url
 
         agent = await ctx.pull_agent(agent_identifier)
         assert isinstance(agent, ls_schemas.AgentContext)
@@ -60,7 +60,7 @@ async def test_push_and_pull_skill_roundtrip(
             files={"SKILL.md": ls_schemas.FileEntry(content="# Test Skill\n")},
             description="integration test skill",
         )
-        assert "/hub/" in url
+        assert "/context/" in url
 
         skill = await ctx.pull_skill(skill_identifier)
         assert isinstance(skill, ls_schemas.SkillContext)

--- a/python/tests/unit_tests/test_hub_methods.py
+++ b/python/tests/unit_tests/test_hub_methods.py
@@ -46,7 +46,7 @@ def _mock_sync_client() -> MagicMock:
     client._host_url = "https://smith.langchain.com"
     client._current_tenant_is_owner.return_value = True
     client._get_settings.return_value = SimpleNamespace(
-        tenant_handle="workspace-handle"
+        id="tenant-id", tenant_handle="workspace-handle"
     )
     client._owner_conflict_error.return_value = ls_utils.LangSmithUserError(
         "owner mismatch"
@@ -62,7 +62,7 @@ def _mock_async_client() -> MagicMock:
     client._host_url = "https://smith.langchain.com"
     client._current_tenant_is_owner = AsyncMock(return_value=True)
     client._get_settings = AsyncMock(
-        return_value=SimpleNamespace(tenant_handle="workspace-handle")
+        return_value=SimpleNamespace(id="tenant-id", tenant_handle="workspace-handle")
     )
     client._owner_conflict_error = AsyncMock(
         return_value=ls_utils.LangSmithUserError("owner mismatch")
@@ -211,13 +211,17 @@ def test_push_agent_creates_new_repo_and_commits() -> None:
     url = ctx.push_agent(
         "-/my-agent", files={"main.py": ls_schemas.FileEntry(content="x")}
     )
-    assert url == "https://smith.langchain.com/hub/workspace-handle/my-agent:abc12345"
+    assert (
+        url
+        == "https://smith.langchain.com/context/my-agent/abc12345?organizationId=tenant-id"
+    )
     assert client.request_with_retries.call_count == 3
 
     create_call = client.request_with_retries.call_args_list[1]
     assert create_call.args == ("POST", "/repos/")
     assert create_call.kwargs["json"]["repo_type"] == "agent"
     assert create_call.kwargs["json"]["repo_handle"] == "my-agent"
+    assert create_call.kwargs["json"]["source"] == "internal"
 
     commit_call = client.request_with_retries.call_args_list[2]
     assert commit_call.args == (
@@ -229,7 +233,7 @@ def test_push_agent_creates_new_repo_and_commits() -> None:
     }
 
 
-def test_push_agent_preserves_explicit_owner_in_url() -> None:
+def test_push_agent_explicit_owner_returns_context_url() -> None:
     client = _mock_sync_client()
     client.request_with_retries.side_effect = [
         ls_utils.LangSmithNotFoundError("not found"),
@@ -246,10 +250,13 @@ def test_push_agent_preserves_explicit_owner_in_url() -> None:
     url = client.push_agent(
         "explicit-owner/my-agent", files={"main.py": ls_schemas.FileEntry(content="x")}
     )
-    assert url == "https://smith.langchain.com/hub/explicit-owner/my-agent:abc12345"
+    assert (
+        url
+        == "https://smith.langchain.com/context/my-agent/abc12345?organizationId=tenant-id"
+    )
 
 
-def test_push_agent_name_only_identifier_uses_workspace_handle_in_url() -> None:
+def test_push_agent_name_only_identifier_returns_context_url() -> None:
     client = _mock_sync_client()
     client.request_with_retries.side_effect = [
         ls_utils.LangSmithNotFoundError("not found"),
@@ -268,7 +275,7 @@ def test_push_agent_name_only_identifier_uses_workspace_handle_in_url() -> None:
     )
     assert (
         url
-        == "https://smith.langchain.com/hub/workspace-handle/email-assistant:abc12345"
+        == "https://smith.langchain.com/context/email-assistant/abc12345?organizationId=tenant-id"
     )
     commit_call = client.request_with_retries.call_args_list[2]
     assert commit_call.args == (
@@ -277,9 +284,11 @@ def test_push_agent_name_only_identifier_uses_workspace_handle_in_url() -> None:
     )
 
 
-def test_push_agent_falls_back_to_dash_owner_when_tenant_handle_missing() -> None:
+def test_push_agent_uses_tenant_id_when_tenant_handle_missing() -> None:
     client = _mock_sync_client()
-    client._get_settings.return_value = SimpleNamespace(tenant_handle=None)
+    client._get_settings.return_value = SimpleNamespace(
+        id="tenant-id", tenant_handle=None
+    )
     client.request_with_retries.side_effect = [
         ls_utils.LangSmithNotFoundError("not found"),
         _response({}),
@@ -295,7 +304,10 @@ def test_push_agent_falls_back_to_dash_owner_when_tenant_handle_missing() -> Non
     url = client.push_agent(
         "-/my-agent", files={"main.py": ls_schemas.FileEntry(content="x")}
     )
-    assert url == "https://smith.langchain.com/hub/-/my-agent:abc12345"
+    assert (
+        url
+        == "https://smith.langchain.com/context/my-agent/abc12345?organizationId=tenant-id"
+    )
 
 
 def test_push_agent_updates_metadata_when_repo_exists() -> None:
@@ -494,13 +506,20 @@ async def test_async_push_agent_creates_and_commits() -> None:
     url = await ctx.push_agent(
         "-/my-agent", files={"main.py": ls_schemas.FileEntry(content="x")}
     )
-    assert url == "https://smith.langchain.com/hub/workspace-handle/my-agent:abc12345"
+    assert (
+        url
+        == "https://smith.langchain.com/context/my-agent/abc12345?organizationId=tenant-id"
+    )
     assert client._arequest_with_retries.await_count == 3
+    create_call = client._arequest_with_retries.call_args_list[1]
+    assert create_call.kwargs["json"]["source"] == "internal"
 
 
-async def test_async_push_agent_falls_back_to_dash_without_tenant_handle() -> None:
+async def test_async_push_agent_uses_tenant_id_when_tenant_handle_missing() -> None:
     client = _mock_async_client()
-    client._get_settings = AsyncMock(return_value=SimpleNamespace(tenant_handle=None))
+    client._get_settings = AsyncMock(
+        return_value=SimpleNamespace(id="tenant-id", tenant_handle=None)
+    )
     client._arequest_with_retries.side_effect = [
         ls_utils.LangSmithNotFoundError("not found"),
         _response({}),
@@ -516,7 +535,10 @@ async def test_async_push_agent_falls_back_to_dash_without_tenant_handle() -> No
     url = await client.push_agent(
         "-/my-agent", files={"main.py": ls_schemas.FileEntry(content="x")}
     )
-    assert url == "https://smith.langchain.com/hub/-/my-agent:abc12345"
+    assert (
+        url
+        == "https://smith.langchain.com/context/my-agent/abc12345?organizationId=tenant-id"
+    )
 
 
 async def test_async_push_agent_accepts_tools_json_as_normal_file_entry() -> None:
@@ -562,7 +584,10 @@ async def test_async_create_repo_swallows_conflict() -> None:
     url = await ctx.push_agent(
         "-/my-agent", files={"main.py": ls_schemas.FileEntry(content="x")}
     )
-    assert url == "https://smith.langchain.com/hub/workspace-handle/my-agent:abc12345"
+    assert (
+        url
+        == "https://smith.langchain.com/context/my-agent/abc12345?organizationId=tenant-id"
+    )
     assert client._arequest_with_retries.await_count == 3
 
 


### PR DESCRIPTION
## What

`push_agent` and `push_skill` now return Context Hub URLs in both Python and JS: `/context/{repo}/{commit}?organizationId={tenant_id}`. New agent and skill repos created by the SDK are also marked with `source: "internal"`.

## Why

The SDK returned legacy `/hub/{owner}/{repo}:{commit}` URLs for Context Hub resources. For workspace-private resources, links with the `-` owner sentinel can route into the public Hub UI and fail to render. Repos created without the internal source marker are also filtered out of the Context Hub list.

## How

The SDK still uses the same platform directory endpoints for pull, push, and delete. Only the returned UI URL is changed, and repo creation now includes the source classification expected by LangSmith Context Hub.

## Testing

- `cd python && uv run pytest tests/unit_tests/test_hub_methods.py`
- `cd python && uv run ruff check langsmith/_internal/_hub.py langsmith/client.py langsmith/async_client.py tests/unit_tests/test_hub_methods.py tests/integration_tests/test_hub_client.py tests/integration_tests/test_hub_client_async.py`
- `cd js && pnpm test:single src/tests/context.test.ts`
- `cd js && pnpm exec oxfmt --check src/client.ts src/tests/context.test.ts src/tests/context.int.test.ts`
- `cd js && pnpm exec oxlint src/client.ts src/tests/context.test.ts src/tests/context.int.test.ts` (0 errors, existing warnings in `src/client.ts`)