### PR TITLE
fix(python): [LSDK-202] return context hub URLs for pushed contexts

### DIFF
--- a/python/langsmith/_internal/_hub.py
+++ b/python/langsmith/_internal/_hub.py
@@ -12,14 +12,9 @@ PLATFORM_HUB = "/v1/platform/hub/repos"
 HUB = "/repos"
 
 
-def build_commit_url(
-    host: str, name: str, commit_hash: str, *, tenant_id: Optional[str]
-) -> str:
+def build_commit_url(host: str, name: str, commit_hash: str) -> str:
     """Build the URL for a hub directory commit."""
-    url = f"{host}/context/{name}/{commit_hash[:8]}"
-    if tenant_id:
-        url += f"?organizationId={tenant_id}"
-    return url
+    return f"{host}/context/{name}/{commit_hash[:8]}"
 
 
 def validate_parent_commit(parent_commit: Optional[str]) -> None:

--- a/python/langsmith/_internal/_hub.py
+++ b/python/langsmith/_internal/_hub.py
@@ -12,16 +12,14 @@ PLATFORM_HUB = "/v1/platform/hub/repos"
 HUB = "/repos"
 
 
-def build_commit_url(host: str, owner: str, name: str, commit_hash: str) -> str:
+def build_commit_url(
+    host: str, name: str, commit_hash: str, *, tenant_id: Optional[str]
+) -> str:
     """Build the URL for a hub directory commit."""
-    return f"{host}/hub/{owner}/{name}:{commit_hash[:8]}"
-
-
-def resolve_owner_for_url(owner: str, tenant_handle: Optional[str]) -> str:
-    """Resolve internal owner sentinel to a user-visible owner in URLs."""
-    if owner == "-" and tenant_handle:
-        return tenant_handle
-    return owner
+    url = f"{host}/context/{name}/{commit_hash[:8]}"
+    if tenant_id:
+        url += f"?organizationId={tenant_id}"
+    return url
 
 
 def validate_parent_commit(parent_commit: Optional[str]) -> None:

--- a/python/langsmith/async_client.py
+++ b/python/langsmith/async_client.py
@@ -2455,7 +2455,6 @@ class AsyncClient:
             "repo_handle": name,
             "repo_type": repo_type,
             "is_public": is_public,
-            "source": "internal",
         }
         if description is not None:
             body["description"] = description

--- a/python/langsmith/async_client.py
+++ b/python/langsmith/async_client.py
@@ -29,7 +29,6 @@ from langsmith._internal._hub import (
     PLATFORM_HUB,
     REPO_HANDLE_PATTERN,
     build_commit_url,
-    resolve_owner_for_url,
     validate_parent_commit,
 )
 from langsmith.prompt_cache import AsyncPromptCache, async_prompt_cache_singleton
@@ -2392,11 +2391,13 @@ class AsyncClient:
             json=body,
         )
         commit_hash = response.json()["commit"]["commit_hash"]
-        tenant_handle = (
-            (await self._get_settings()).tenant_handle if owner == "-" else None
+        settings = await self._get_settings()
+        return build_commit_url(
+            self._host_url,
+            name,
+            commit_hash,
+            tenant_id=settings.id,
         )
-        owner_for_url = resolve_owner_for_url(owner, tenant_handle)
-        return build_commit_url(self._host_url, owner_for_url, name, commit_hash)
 
     async def _delete_hub_directory(self, identifier: str) -> None:
         """Delete a hub directory repo."""
@@ -2460,6 +2461,7 @@ class AsyncClient:
             "repo_handle": name,
             "repo_type": repo_type,
             "is_public": is_public,
+            "source": "internal",
         }
         if description is not None:
             body["description"] = description

--- a/python/langsmith/async_client.py
+++ b/python/langsmith/async_client.py
@@ -2391,13 +2391,7 @@ class AsyncClient:
             json=body,
         )
         commit_hash = response.json()["commit"]["commit_hash"]
-        settings = await self._get_settings()
-        return build_commit_url(
-            self._host_url,
-            name,
-            commit_hash,
-            tenant_id=settings.id,
-        )
+        return build_commit_url(self._host_url, name, commit_hash)
 
     async def _delete_hub_directory(self, identifier: str) -> None:
         """Delete a hub directory repo."""

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -9789,7 +9789,6 @@ class Client:
             "repo_handle": name,
             "repo_type": repo_type,
             "is_public": is_public,
-            "source": "internal",
         }
         if description is not None:
             body["description"] = description

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -89,7 +89,6 @@ from langsmith._internal._hub import (
     PLATFORM_HUB,
     REPO_HANDLE_PATTERN,
     build_commit_url,
-    resolve_owner_for_url,
     validate_parent_commit,
 )
 from langsmith._internal._multipart import (
@@ -9726,9 +9725,12 @@ class Client:
             json=body,
         )
         commit_hash = response.json()["commit"]["commit_hash"]
-        tenant_handle = self._get_settings().tenant_handle if owner == "-" else None
-        owner_for_url = resolve_owner_for_url(owner, tenant_handle)
-        return build_commit_url(self._host_url, owner_for_url, name, commit_hash)
+        return build_commit_url(
+            self._host_url,
+            name,
+            commit_hash,
+            tenant_id=self._get_settings().id,
+        )
 
     def _delete_hub_directory(self, identifier: str) -> None:
         """Delete a hub directory repo."""
@@ -9792,6 +9794,7 @@ class Client:
             "repo_handle": name,
             "repo_type": repo_type,
             "is_public": is_public,
+            "source": "internal",
         }
         if description is not None:
             body["description"] = description

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -9725,12 +9725,7 @@ class Client:
             json=body,
         )
         commit_hash = response.json()["commit"]["commit_hash"]
-        return build_commit_url(
-            self._host_url,
-            name,
-            commit_hash,
-            tenant_id=self._get_settings().id,
-        )
+        return build_commit_url(self._host_url, name, commit_hash)
 
     def _delete_hub_directory(self, identifier: str) -> None:
         """Delete a hub directory repo."""

--- a/python/tests/integration_tests/test_hub_client.py
+++ b/python/tests/integration_tests/test_hub_client.py
@@ -42,7 +42,7 @@ def test_push_and_pull_agent_roundtrip(
             files={"AGENTS.md": ls_schemas.FileEntry(content="# Test Agent\n")},
             description="integration test agent",
         )
-        assert "/hub/" in url
+        assert "/context/" in url
 
         agent = ctx.pull_agent(agent_identifier)
         assert isinstance(agent, ls_schemas.AgentContext)
@@ -68,7 +68,7 @@ def test_push_and_pull_agent_tools_json_roundtrip(
             files={"tools.json": ls_schemas.FileEntry(content=TOOLS_JSON)},
             description="integration test agent tools",
         )
-        assert "/hub/" in url
+        assert "/context/" in url
 
         agent = ctx.pull_agent(agent_identifier)
         assert isinstance(agent, ls_schemas.AgentContext)
@@ -94,7 +94,7 @@ def test_push_and_pull_skill_roundtrip(
             files={"SKILL.md": ls_schemas.FileEntry(content="# Test Skill\n")},
             description="integration test skill",
         )
-        assert "/hub/" in url
+        assert "/context/" in url
 
         skill = ctx.pull_skill(skill_identifier)
         assert isinstance(skill, ls_schemas.SkillContext)

--- a/python/tests/integration_tests/test_hub_client_async.py
+++ b/python/tests/integration_tests/test_hub_client_async.py
@@ -34,7 +34,7 @@ async def test_push_and_pull_agent_roundtrip(
             files={"AGENTS.md": ls_schemas.FileEntry(content="# Test Agent\n")},
             description="integration test agent",
         )
-        assert "/hub/" in url
+        assert "/context/" in url
 
         agent = await ctx.pull_agent(agent_identifier)
         assert isinstance(agent, ls_schemas.AgentContext)
@@ -60,7 +60,7 @@ async def test_push_and_pull_skill_roundtrip(
             files={"SKILL.md": ls_schemas.FileEntry(content="# Test Skill\n")},
             description="integration test skill",
         )
-        assert "/hub/" in url
+        assert "/context/" in url
 
         skill = await ctx.pull_skill(skill_identifier)
         assert isinstance(skill, ls_schemas.SkillContext)

--- a/python/tests/unit_tests/test_hub_methods.py
+++ b/python/tests/unit_tests/test_hub_methods.py
@@ -221,7 +221,6 @@ def test_push_agent_creates_new_repo_and_commits() -> None:
     assert create_call.args == ("POST", "/repos/")
     assert create_call.kwargs["json"]["repo_type"] == "agent"
     assert create_call.kwargs["json"]["repo_handle"] == "my-agent"
-    assert create_call.kwargs["json"]["source"] == "internal"
 
     commit_call = client.request_with_retries.call_args_list[2]
     assert commit_call.args == (
@@ -509,8 +508,6 @@ async def test_async_push_agent_creates_and_commits() -> None:
         == "https://smith.langchain.com/context/my-agent/abc12345"
     )
     assert client._arequest_with_retries.await_count == 3
-    create_call = client._arequest_with_retries.call_args_list[1]
-    assert create_call.kwargs["json"]["source"] == "internal"
 
 
 async def test_async_push_agent_context_url_without_tenant_handle() -> None:

--- a/python/tests/unit_tests/test_hub_methods.py
+++ b/python/tests/unit_tests/test_hub_methods.py
@@ -211,10 +211,7 @@ def test_push_agent_creates_new_repo_and_commits() -> None:
     url = ctx.push_agent(
         "-/my-agent", files={"main.py": ls_schemas.FileEntry(content="x")}
     )
-    assert (
-        url
-        == "https://smith.langchain.com/context/my-agent/abc12345"
-    )
+    assert url == "https://smith.langchain.com/context/my-agent/abc12345"
     assert client.request_with_retries.call_count == 3
 
     create_call = client.request_with_retries.call_args_list[1]
@@ -249,10 +246,7 @@ def test_push_agent_explicit_owner_returns_context_url() -> None:
     url = client.push_agent(
         "explicit-owner/my-agent", files={"main.py": ls_schemas.FileEntry(content="x")}
     )
-    assert (
-        url
-        == "https://smith.langchain.com/context/my-agent/abc12345"
-    )
+    assert url == "https://smith.langchain.com/context/my-agent/abc12345"
 
 
 def test_push_agent_name_only_identifier_returns_context_url() -> None:
@@ -272,10 +266,7 @@ def test_push_agent_name_only_identifier_returns_context_url() -> None:
     url = client.push_agent(
         "email-assistant", files={"main.py": ls_schemas.FileEntry(content="x")}
     )
-    assert (
-        url
-        == "https://smith.langchain.com/context/email-assistant/abc12345"
-    )
+    assert url == "https://smith.langchain.com/context/email-assistant/abc12345"
     commit_call = client.request_with_retries.call_args_list[2]
     assert commit_call.args == (
         "POST",
@@ -301,10 +292,7 @@ def test_push_agent_returns_context_url_when_tenant_handle_missing() -> None:
     url = client.push_agent(
         "-/my-agent", files={"main.py": ls_schemas.FileEntry(content="x")}
     )
-    assert (
-        url
-        == "https://smith.langchain.com/context/my-agent/abc12345"
-    )
+    assert url == "https://smith.langchain.com/context/my-agent/abc12345"
 
 
 def test_push_agent_updates_metadata_when_repo_exists() -> None:
@@ -503,10 +491,7 @@ async def test_async_push_agent_creates_and_commits() -> None:
     url = await ctx.push_agent(
         "-/my-agent", files={"main.py": ls_schemas.FileEntry(content="x")}
     )
-    assert (
-        url
-        == "https://smith.langchain.com/context/my-agent/abc12345"
-    )
+    assert url == "https://smith.langchain.com/context/my-agent/abc12345"
     assert client._arequest_with_retries.await_count == 3
 
 
@@ -528,10 +513,7 @@ async def test_async_push_agent_context_url_without_tenant_handle() -> None:
     url = await client.push_agent(
         "-/my-agent", files={"main.py": ls_schemas.FileEntry(content="x")}
     )
-    assert (
-        url
-        == "https://smith.langchain.com/context/my-agent/abc12345"
-    )
+    assert url == "https://smith.langchain.com/context/my-agent/abc12345"
 
 
 async def test_async_push_agent_accepts_tools_json_as_normal_file_entry() -> None:
@@ -577,10 +559,7 @@ async def test_async_create_repo_swallows_conflict() -> None:
     url = await ctx.push_agent(
         "-/my-agent", files={"main.py": ls_schemas.FileEntry(content="x")}
     )
-    assert (
-        url
-        == "https://smith.langchain.com/context/my-agent/abc12345"
-    )
+    assert url == "https://smith.langchain.com/context/my-agent/abc12345"
     assert client._arequest_with_retries.await_count == 3
 
 

--- a/python/tests/unit_tests/test_hub_methods.py
+++ b/python/tests/unit_tests/test_hub_methods.py
@@ -46,7 +46,7 @@ def _mock_sync_client() -> MagicMock:
     client._host_url = "https://smith.langchain.com"
     client._current_tenant_is_owner.return_value = True
     client._get_settings.return_value = SimpleNamespace(
-        tenant_handle="workspace-handle"
+        id="tenant-id", tenant_handle="workspace-handle"
     )
     client._owner_conflict_error.return_value = ls_utils.LangSmithUserError(
         "owner mismatch"
@@ -62,7 +62,7 @@ def _mock_async_client() -> MagicMock:
     client._host_url = "https://smith.langchain.com"
     client._current_tenant_is_owner = AsyncMock(return_value=True)
     client._get_settings = AsyncMock(
-        return_value=SimpleNamespace(tenant_handle="workspace-handle")
+        return_value=SimpleNamespace(id="tenant-id", tenant_handle="workspace-handle")
     )
     client._owner_conflict_error = AsyncMock(
         return_value=ls_utils.LangSmithUserError("owner mismatch")
@@ -211,13 +211,17 @@ def test_push_agent_creates_new_repo_and_commits() -> None:
     url = ctx.push_agent(
         "-/my-agent", files={"main.py": ls_schemas.FileEntry(content="x")}
     )
-    assert url == "https://smith.langchain.com/hub/workspace-handle/my-agent:abc12345"
+    assert (
+        url
+        == "https://smith.langchain.com/context/my-agent/abc12345?organizationId=tenant-id"
+    )
     assert client.request_with_retries.call_count == 3
 
     create_call = client.request_with_retries.call_args_list[1]
     assert create_call.args == ("POST", "/repos/")
     assert create_call.kwargs["json"]["repo_type"] == "agent"
     assert create_call.kwargs["json"]["repo_handle"] == "my-agent"
+    assert create_call.kwargs["json"]["source"] == "internal"
 
     commit_call = client.request_with_retries.call_args_list[2]
     assert commit_call.args == (
@@ -229,7 +233,7 @@ def test_push_agent_creates_new_repo_and_commits() -> None:
     }
 
 
-def test_push_agent_preserves_explicit_owner_in_url() -> None:
+def test_push_agent_explicit_owner_returns_context_url() -> None:
     client = _mock_sync_client()
     client.request_with_retries.side_effect = [
         ls_utils.LangSmithNotFoundError("not found"),
@@ -246,10 +250,13 @@ def test_push_agent_preserves_explicit_owner_in_url() -> None:
     url = client.push_agent(
         "explicit-owner/my-agent", files={"main.py": ls_schemas.FileEntry(content="x")}
     )
-    assert url == "https://smith.langchain.com/hub/explicit-owner/my-agent:abc12345"
+    assert (
+        url
+        == "https://smith.langchain.com/context/my-agent/abc12345?organizationId=tenant-id"
+    )
 
 
-def test_push_agent_name_only_identifier_uses_workspace_handle_in_url() -> None:
+def test_push_agent_name_only_identifier_returns_context_url() -> None:
     client = _mock_sync_client()
     client.request_with_retries.side_effect = [
         ls_utils.LangSmithNotFoundError("not found"),
@@ -268,7 +275,7 @@ def test_push_agent_name_only_identifier_uses_workspace_handle_in_url() -> None:
     )
     assert (
         url
-        == "https://smith.langchain.com/hub/workspace-handle/email-assistant:abc12345"
+        == "https://smith.langchain.com/context/email-assistant/abc12345?organizationId=tenant-id"
     )
     commit_call = client.request_with_retries.call_args_list[2]
     assert commit_call.args == (
@@ -277,9 +284,11 @@ def test_push_agent_name_only_identifier_uses_workspace_handle_in_url() -> None:
     )
 
 
-def test_push_agent_falls_back_to_dash_owner_when_tenant_handle_missing() -> None:
+def test_push_agent_uses_tenant_id_when_tenant_handle_missing() -> None:
     client = _mock_sync_client()
-    client._get_settings.return_value = SimpleNamespace(tenant_handle=None)
+    client._get_settings.return_value = SimpleNamespace(
+        id="tenant-id", tenant_handle=None
+    )
     client.request_with_retries.side_effect = [
         ls_utils.LangSmithNotFoundError("not found"),
         _response({}),
@@ -295,7 +304,10 @@ def test_push_agent_falls_back_to_dash_owner_when_tenant_handle_missing() -> Non
     url = client.push_agent(
         "-/my-agent", files={"main.py": ls_schemas.FileEntry(content="x")}
     )
-    assert url == "https://smith.langchain.com/hub/-/my-agent:abc12345"
+    assert (
+        url
+        == "https://smith.langchain.com/context/my-agent/abc12345?organizationId=tenant-id"
+    )
 
 
 def test_push_agent_updates_metadata_when_repo_exists() -> None:
@@ -494,13 +506,20 @@ async def test_async_push_agent_creates_and_commits() -> None:
     url = await ctx.push_agent(
         "-/my-agent", files={"main.py": ls_schemas.FileEntry(content="x")}
     )
-    assert url == "https://smith.langchain.com/hub/workspace-handle/my-agent:abc12345"
+    assert (
+        url
+        == "https://smith.langchain.com/context/my-agent/abc12345?organizationId=tenant-id"
+    )
     assert client._arequest_with_retries.await_count == 3
+    create_call = client._arequest_with_retries.call_args_list[1]
+    assert create_call.kwargs["json"]["source"] == "internal"
 
 
-async def test_async_push_agent_falls_back_to_dash_without_tenant_handle() -> None:
+async def test_async_push_agent_uses_tenant_id_when_tenant_handle_missing() -> None:
     client = _mock_async_client()
-    client._get_settings = AsyncMock(return_value=SimpleNamespace(tenant_handle=None))
+    client._get_settings = AsyncMock(
+        return_value=SimpleNamespace(id="tenant-id", tenant_handle=None)
+    )
     client._arequest_with_retries.side_effect = [
         ls_utils.LangSmithNotFoundError("not found"),
         _response({}),
@@ -516,7 +535,10 @@ async def test_async_push_agent_falls_back_to_dash_without_tenant_handle() -> No
     url = await client.push_agent(
         "-/my-agent", files={"main.py": ls_schemas.FileEntry(content="x")}
     )
-    assert url == "https://smith.langchain.com/hub/-/my-agent:abc12345"
+    assert (
+        url
+        == "https://smith.langchain.com/context/my-agent/abc12345?organizationId=tenant-id"
+    )
 
 
 async def test_async_push_agent_accepts_tools_json_as_normal_file_entry() -> None:
@@ -562,7 +584,10 @@ async def test_async_create_repo_swallows_conflict() -> None:
     url = await ctx.push_agent(
         "-/my-agent", files={"main.py": ls_schemas.FileEntry(content="x")}
     )
-    assert url == "https://smith.langchain.com/hub/workspace-handle/my-agent:abc12345"
+    assert (
+        url
+        == "https://smith.langchain.com/context/my-agent/abc12345?organizationId=tenant-id"
+    )
     assert client._arequest_with_retries.await_count == 3
 
 

--- a/python/tests/unit_tests/test_hub_methods.py
+++ b/python/tests/unit_tests/test_hub_methods.py
@@ -46,7 +46,7 @@ def _mock_sync_client() -> MagicMock:
     client._host_url = "https://smith.langchain.com"
     client._current_tenant_is_owner.return_value = True
     client._get_settings.return_value = SimpleNamespace(
-        id="tenant-id", tenant_handle="workspace-handle"
+        tenant_handle="workspace-handle"
     )
     client._owner_conflict_error.return_value = ls_utils.LangSmithUserError(
         "owner mismatch"
@@ -62,7 +62,7 @@ def _mock_async_client() -> MagicMock:
     client._host_url = "https://smith.langchain.com"
     client._current_tenant_is_owner = AsyncMock(return_value=True)
     client._get_settings = AsyncMock(
-        return_value=SimpleNamespace(id="tenant-id", tenant_handle="workspace-handle")
+        return_value=SimpleNamespace(tenant_handle="workspace-handle")
     )
     client._owner_conflict_error = AsyncMock(
         return_value=ls_utils.LangSmithUserError("owner mismatch")
@@ -213,7 +213,7 @@ def test_push_agent_creates_new_repo_and_commits() -> None:
     )
     assert (
         url
-        == "https://smith.langchain.com/context/my-agent/abc12345?organizationId=tenant-id"
+        == "https://smith.langchain.com/context/my-agent/abc12345"
     )
     assert client.request_with_retries.call_count == 3
 
@@ -252,7 +252,7 @@ def test_push_agent_explicit_owner_returns_context_url() -> None:
     )
     assert (
         url
-        == "https://smith.langchain.com/context/my-agent/abc12345?organizationId=tenant-id"
+        == "https://smith.langchain.com/context/my-agent/abc12345"
     )
 
 
@@ -275,7 +275,7 @@ def test_push_agent_name_only_identifier_returns_context_url() -> None:
     )
     assert (
         url
-        == "https://smith.langchain.com/context/email-assistant/abc12345?organizationId=tenant-id"
+        == "https://smith.langchain.com/context/email-assistant/abc12345"
     )
     commit_call = client.request_with_retries.call_args_list[2]
     assert commit_call.args == (
@@ -284,11 +284,9 @@ def test_push_agent_name_only_identifier_returns_context_url() -> None:
     )
 
 
-def test_push_agent_uses_tenant_id_when_tenant_handle_missing() -> None:
+def test_push_agent_returns_context_url_when_tenant_handle_missing() -> None:
     client = _mock_sync_client()
-    client._get_settings.return_value = SimpleNamespace(
-        id="tenant-id", tenant_handle=None
-    )
+    client._get_settings.return_value = SimpleNamespace(tenant_handle=None)
     client.request_with_retries.side_effect = [
         ls_utils.LangSmithNotFoundError("not found"),
         _response({}),
@@ -306,7 +304,7 @@ def test_push_agent_uses_tenant_id_when_tenant_handle_missing() -> None:
     )
     assert (
         url
-        == "https://smith.langchain.com/context/my-agent/abc12345?organizationId=tenant-id"
+        == "https://smith.langchain.com/context/my-agent/abc12345"
     )
 
 
@@ -508,18 +506,16 @@ async def test_async_push_agent_creates_and_commits() -> None:
     )
     assert (
         url
-        == "https://smith.langchain.com/context/my-agent/abc12345?organizationId=tenant-id"
+        == "https://smith.langchain.com/context/my-agent/abc12345"
     )
     assert client._arequest_with_retries.await_count == 3
     create_call = client._arequest_with_retries.call_args_list[1]
     assert create_call.kwargs["json"]["source"] == "internal"
 
 
-async def test_async_push_agent_uses_tenant_id_when_tenant_handle_missing() -> None:
+async def test_async_push_agent_context_url_without_tenant_handle() -> None:
     client = _mock_async_client()
-    client._get_settings = AsyncMock(
-        return_value=SimpleNamespace(id="tenant-id", tenant_handle=None)
-    )
+    client._get_settings = AsyncMock(return_value=SimpleNamespace(tenant_handle=None))
     client._arequest_with_retries.side_effect = [
         ls_utils.LangSmithNotFoundError("not found"),
         _response({}),
@@ -537,7 +533,7 @@ async def test_async_push_agent_uses_tenant_id_when_tenant_handle_missing() -> N
     )
     assert (
         url
-        == "https://smith.langchain.com/context/my-agent/abc12345?organizationId=tenant-id"
+        == "https://smith.langchain.com/context/my-agent/abc12345"
     )
 
 
@@ -586,7 +582,7 @@ async def test_async_create_repo_swallows_conflict() -> None:
     )
     assert (
         url
-        == "https://smith.langchain.com/context/my-agent/abc12345?organizationId=tenant-id"
+        == "https://smith.langchain.com/context/my-agent/abc12345"
     )
     assert client._arequest_with_retries.await_count == 3
 


### PR DESCRIPTION
## What

Updates the Python `push_agent` / `push_skill` flow to return Context Hub commit URLs for agent and skill repos.

## Why

Python SDK users could push a Context Hub skill successfully but receive a Prompt Hub-style `/hub/-/<repo>:<commit>` URL. Those links do not open the Context Hub UI.

The SDK should not force repo source metadata. Context Hub server filtering now excludes only external repos, so repos with unset source still show up without the SDK hardcoding `source: "internal"`.

## How

The Python URL builder now emits `/context/<repo>/<commit>` and no longer includes an owner segment. Repo creation continues to send the existing required repo fields, leaving source classification to the API/backend.

JS/TS is intentionally left out of this PR and will be handled separately.

## Testing

- `cd python && uv run pytest tests/unit_tests/test_hub_methods.py`
- `cd python && uv run ruff check langsmith/_internal/_hub.py langsmith/client.py langsmith/async_client.py tests/unit_tests/test_hub_methods.py tests/integration_tests/test_hub_client.py tests/integration_tests/test_hub_client_async.py`
