### PR TITLE
fix(js): [LSDK-202] return context hub URLs for pushed contexts

### DIFF
--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -6912,15 +6912,7 @@ export class Client implements LangSmithTracingClientInterface {
     });
     const data = (await response.json()) as DirectoryCommitResponse;
     const commitHash = data.commit.commit_hash;
-    let ownerForUrl = owner;
-    if (owner === "-") {
-      const settings = await this._getSettings();
-      ownerForUrl = settings.tenant_handle || owner;
-    }
-    return `${this.getHostUrl()}/hub/${ownerForUrl}/${name}:${commitHash.slice(
-      0,
-      8,
-    )}`;
+    return `${this.getHostUrl()}/context/${name}/${commitHash.slice(0, 8)}`;
   }
 
   private async _deleteDirectory(identifier: string): Promise<void> {

--- a/js/src/tests/context.int.test.ts
+++ b/js/src/tests/context.int.test.ts
@@ -43,7 +43,7 @@ describe("Context integration (agent/skill)", () => {
         },
         description: "integration test agent (js)",
       });
-      expect(url).toContain("/hub/");
+      expect(url).toContain("/context/");
 
       const agent: AgentContext = await client.pullAgent(identifier);
       expect(agent.files["AGENTS.md"]).toBeDefined();
@@ -64,7 +64,7 @@ describe("Context integration (agent/skill)", () => {
         },
         description: "integration test skill (js)",
       });
-      expect(url).toContain("/hub/");
+      expect(url).toContain("/context/");
 
       const skill: SkillContext = await client.pullSkill(identifier);
       expect(skill.files["SKILL.md"]).toBeDefined();
@@ -83,7 +83,7 @@ describe("Context integration (agent/skill)", () => {
           "tools.json": { type: "file", content: TOOLS_JSON },
         },
       });
-      expect(url).toContain("/hub/");
+      expect(url).toContain("/context/");
 
       const agent: AgentContext = await client.pullAgent(identifier);
       expect(agent.files["tools.json"]).toBeDefined();

--- a/js/src/tests/context.test.ts
+++ b/js/src/tests/context.test.ts
@@ -7,9 +7,6 @@ function _mockClient() {
   const client = new Client({ apiKey: "test-api-key" });
   jest.spyOn(client as any, "_currentTenantIsOwner").mockResolvedValue(true);
   jest
-    .spyOn(client as any, "_getSettings")
-    .mockResolvedValue({ tenant_handle: "workspace-handle" });
-  jest
     .spyOn(client as any, "_ownerConflictError")
     .mockImplementation(async () => new Error("owner mismatch"));
   return client;
@@ -149,7 +146,7 @@ describe("Context (agent/skill) on Client", () => {
       const url = await client.pushAgent("-/my-agent", {
         files: { "main.py": { type: "file", content: "x" } },
       });
-      expect(url).toContain("/hub/workspace-handle/my-agent:abc12345");
+      expect(url).toContain("/context/my-agent/abc12345");
 
       const calls = fetchSpy.mock.calls as [string, any][];
       expect(calls).toHaveLength(3);
@@ -280,10 +277,10 @@ describe("Context (agent/skill) on Client", () => {
         client.pushAgent("-/my-agent", {
           files: { "main.py": { type: "file", content: "x" } },
         }),
-      ).resolves.toContain("/hub/workspace-handle/my-agent:abc12345");
+      ).resolves.toContain("/context/my-agent/abc12345");
     });
 
-    it("keeps explicit owner in returned URL", async () => {
+    it("returns context URL without explicit owner", async () => {
       const client = _mockClient();
       _setFetchSequence(client, [
         _response({ detail: "Not Found" }, 404),
@@ -299,14 +296,12 @@ describe("Context (agent/skill) on Client", () => {
       const url = await client.pushAgent("explicit-owner/my-agent", {
         files: { "main.py": { type: "file", content: "x" } },
       });
-      expect(url).toContain("/hub/explicit-owner/my-agent:abc12345");
+      expect(url).toContain("/context/my-agent/abc12345");
     });
 
-    it("falls back to dash owner when tenant_handle is missing", async () => {
+    it("returns context URL without fetching tenant_handle", async () => {
       const client = _mockClient();
-      jest.spyOn(client as any, "_getSettings").mockResolvedValue({
-        tenant_handle: "",
-      });
+      const settingsSpy = jest.spyOn(client as any, "_getSettings");
       _setFetchSequence(client, [
         _response({ detail: "Not Found" }, 404),
         _response({ repo: { id: "r1" } }),
@@ -321,10 +316,11 @@ describe("Context (agent/skill) on Client", () => {
       const url = await client.pushAgent("-/my-agent", {
         files: { "main.py": { type: "file", content: "x" } },
       });
-      expect(url).toContain("/hub/-/my-agent:abc12345");
+      expect(url).toContain("/context/my-agent/abc12345");
+      expect(settingsSpy).not.toHaveBeenCalled();
     });
 
-    it("supports name-only identifier and returns workspace-handle URL", async () => {
+    it("supports name-only identifier and returns context URL", async () => {
       const client = _mockClient();
       const fetchSpy = _setFetchSequence(client, [
         _response({ detail: "Not Found" }, 404),
@@ -340,7 +336,7 @@ describe("Context (agent/skill) on Client", () => {
       const url = await client.pushAgent("email-assistant", {
         files: { "main.py": { type: "file", content: "x" } },
       });
-      expect(url).toContain("/hub/workspace-handle/email-assistant:abc12345");
+      expect(url).toContain("/context/email-assistant/abc12345");
 
       const calls = fetchSpy.mock.calls as [string, any][];
       expect(calls[0][0]).toContain("/repos/-/email-assistant");


### PR DESCRIPTION
## What

Updates the TypeScript `pushAgent` / `pushSkill` flow to return Context Hub commit URLs for agent and skill repos.

## Why

The JS SDK could push Context Hub repos successfully but returned Prompt Hub-style `/hub/<owner>/<repo>:<commit>` URLs. Those links do not match the Context Hub route used by the UI.

## How

The JS commit URL now uses `/context/<repo>/<commit>` and no longer resolves tenant handles just to construct the returned URL. Unit and integration expectations were updated to assert the Context Hub URL route.

Repo creation still sends the existing required repo fields and does not force `source: "internal"`.

## Testing

- `cd js && pnpm test:single src/tests/context.test.ts`
- `cd js && pnpm run format:check`
- `cd js && pnpm exec oxlint src/client.ts src/tests/context.test.ts src/tests/context.int.test.ts`
- `cd js && pnpm run check:types`
- `cd js && pnpm test:single src/tests/context.int.test.ts` with `LANGSMITH_API_KEY` loaded from local env
