### PR TITLE
fix(python): retry sandbox connect timeouts

### DIFF
--- a/python/langsmith/sandbox/_transport.py
+++ b/python/langsmith/sandbox/_transport.py
@@ -35,7 +35,7 @@ class RetryTransport(httpx.BaseTransport):
     Retries on:
     - 502/503/504 with exponential backoff
     - 429 with Retry-After header support
-    - Connection errors with exponential backoff
+    - Connection errors/timeouts with exponential backoff
 
     After exhausting retries, the last response is returned (for status errors)
     or SandboxConnectionError is raised (for connection errors).
@@ -94,7 +94,7 @@ class RetryTransport(httpx.BaseTransport):
 
                 return response
 
-            except httpx.ConnectError as exc:
+            except (httpx.ConnectError, httpx.ConnectTimeout) as exc:
                 if not is_last_attempt:
                     sleep_time = _compute_backoff(attempt)
                     logger.debug(
@@ -180,7 +180,7 @@ class AsyncRetryTransport(httpx.AsyncBaseTransport):
 
                 return response
 
-            except httpx.ConnectError as exc:
+            except (httpx.ConnectError, httpx.ConnectTimeout) as exc:
                 if not is_last_attempt:
                     sleep_time = _compute_backoff(attempt)
                     logger.debug(

--- a/python/tests/unit_tests/sandbox/test_transport.py
+++ b/python/tests/unit_tests/sandbox/test_transport.py
@@ -106,6 +106,20 @@ class TestRetryTransport:
         assert mock_sleep.call_count == 1
 
     @patch("langsmith.sandbox._transport.time.sleep")
+    def test_retries_on_connect_timeout_then_succeeds(self, mock_sleep):
+        mock = MockTransport(
+            [
+                httpx.ConnectTimeout("timed out"),
+                httpx.Response(200),
+            ]
+        )
+        transport = RetryTransport(max_retries=3, transport=mock)
+        response = transport.handle_request(_make_request())
+        assert response.status_code == 200
+        assert mock.call_count == 2
+        assert mock_sleep.call_count == 1
+
+    @patch("langsmith.sandbox._transport.time.sleep")
     def test_exhausted_retries_on_server_error_returns_response(self, mock_sleep):
         mock = MockTransport([httpx.Response(502)] * 4)
         transport = RetryTransport(max_retries=3, transport=mock)
@@ -117,6 +131,14 @@ class TestRetryTransport:
     @patch("langsmith.sandbox._transport.time.sleep")
     def test_exhausted_retries_on_connect_error_raises(self, mock_sleep):
         mock = MockTransport([httpx.ConnectError(f"fail {i}") for i in range(4)])
+        transport = RetryTransport(max_retries=3, transport=mock)
+        with pytest.raises(SandboxConnectionError, match="4 attempts"):
+            transport.handle_request(_make_request())
+        assert mock.call_count == 4
+
+    @patch("langsmith.sandbox._transport.time.sleep")
+    def test_exhausted_retries_on_connect_timeout_raises(self, mock_sleep):
+        mock = MockTransport([httpx.ConnectTimeout(f"fail {i}") for i in range(4)])
         transport = RetryTransport(max_retries=3, transport=mock)
         with pytest.raises(SandboxConnectionError, match="4 attempts"):
             transport.handle_request(_make_request())
@@ -239,6 +261,20 @@ class TestAsyncRetryTransport:
 
     @pytest.mark.asyncio
     @pytest.mark.usefixtures("_patch_sleep")
+    async def test_retries_on_connect_timeout_then_succeeds(self):
+        mock = MockAsyncTransport(
+            [
+                httpx.ConnectTimeout("timed out"),
+                httpx.Response(200),
+            ]
+        )
+        transport = AsyncRetryTransport(max_retries=3, transport=mock)
+        response = await transport.handle_async_request(_make_request())
+        assert response.status_code == 200
+        assert mock.call_count == 2
+
+    @pytest.mark.asyncio
+    @pytest.mark.usefixtures("_patch_sleep")
     async def test_exhausted_retries_on_server_error_returns_response(self):
         mock = MockAsyncTransport([httpx.Response(502)] * 4)
         transport = AsyncRetryTransport(max_retries=3, transport=mock)
@@ -250,6 +286,17 @@ class TestAsyncRetryTransport:
     @pytest.mark.usefixtures("_patch_sleep")
     async def test_exhausted_retries_on_connect_error_raises(self):
         mock = MockAsyncTransport([httpx.ConnectError(f"fail {i}") for i in range(4)])
+        transport = AsyncRetryTransport(max_retries=3, transport=mock)
+        with pytest.raises(SandboxConnectionError, match="4 attempts"):
+            await transport.handle_async_request(_make_request())
+        assert mock.call_count == 4
+
+    @pytest.mark.asyncio
+    @pytest.mark.usefixtures("_patch_sleep")
+    async def test_exhausted_retries_on_connect_timeout_raises(self):
+        mock = MockAsyncTransport(
+            [httpx.ConnectTimeout(f"fail {i}") for i in range(4)]
+        )
         transport = AsyncRetryTransport(max_retries=3, transport=mock)
         with pytest.raises(SandboxConnectionError, match="4 attempts"):
             await transport.handle_async_request(_make_request())

--- a/python/tests/unit_tests/sandbox/test_transport.py
+++ b/python/tests/unit_tests/sandbox/test_transport.py
@@ -294,9 +294,7 @@ class TestAsyncRetryTransport:
     @pytest.mark.asyncio
     @pytest.mark.usefixtures("_patch_sleep")
     async def test_exhausted_retries_on_connect_timeout_raises(self):
-        mock = MockAsyncTransport(
-            [httpx.ConnectTimeout(f"fail {i}") for i in range(4)]
-        )
+        mock = MockAsyncTransport([httpx.ConnectTimeout(f"fail {i}") for i in range(4)])
         transport = AsyncRetryTransport(max_retries=3, transport=mock)
         with pytest.raises(SandboxConnectionError, match="4 attempts"):
             await transport.handle_async_request(_make_request())


### PR DESCRIPTION
## Summary

Retry sandbox HTTP connect timeouts in the Python sandbox transport so transient dataplane connect stalls use the same retry path as connection errors.

Also adds sync and async transport tests for connect-timeout retry success and exhaustion.

## Test Plan

- [x] `uv run python -m pytest tests/unit_tests/sandbox/test_transport.py`