### PR TITLE
fix: reconnect sandbox command streams on EOF

### DIFF
--- a/js/src/sandbox/command_handle.ts
+++ b/js/src/sandbox/command_handle.ts
@@ -174,7 +174,9 @@ export class CommandHandle {
         return;
       }
     }
-    this._exhausted = true;
+    throw new LangSmithSandboxConnectionError(
+      "Command stream ended without exit message",
+    );
   }
 
   /**

--- a/js/src/tests/sandbox.test.ts
+++ b/js/src/tests/sandbox.test.ts
@@ -1090,18 +1090,35 @@ describe("CommandHandle", () => {
       expect(result.exit_code).toBe(0);
     });
 
-    it("should throw if stream ends without exit message", async () => {
+    it("should reconnect if stream ends without exit message", async () => {
       const stream = createMockStream([
         { type: "started", command_id: "cmd-123", pid: 42 },
         { type: "stdout", data: "hello\n", offset: 0 },
       ]);
 
-      const handle = new CommandHandle(stream, null, createMockSandbox());
-      await handle._ensureStarted();
+      const sandbox = createMockSandbox();
+      const reconnectHandle = {
+        _stream: createMockStream([{ type: "exit", exit_code: 0 }]),
+        _control: null,
+      };
+      (sandbox.reconnect as any).mockResolvedValue(reconnectHandle);
 
-      await expect(handle.result).rejects.toThrow(
-        "Command stream ended without exit message",
-      );
+      const handle = new CommandHandle(stream, null, sandbox);
+      await handle._ensureStarted();
+      const backoffBase = CommandHandle.BACKOFF_BASE;
+      CommandHandle.BACKOFF_BASE = 0;
+      try {
+        const result = await handle.result;
+
+        expect(result.stdout).toBe("hello\n");
+        expect(result.exit_code).toBe(0);
+        expect(sandbox.reconnect).toHaveBeenCalledWith("cmd-123", {
+          stdoutOffset: 6,
+          stderrOffset: 0,
+        });
+      } finally {
+        CommandHandle.BACKOFF_BASE = backoffBase;
+      }
     });
   });
 

--- a/python/langsmith/sandbox/_models.py
+++ b/python/langsmith/sandbox/_models.py
@@ -590,7 +590,7 @@ class CommandHandle:
                 )
                 self._exhausted = True
                 return
-        self._exhausted = True
+        raise SandboxConnectionError("Command stream ended without exit message")
 
     def __iter__(self) -> Iterator[OutputChunk]:
         """Iterate over output chunks, auto-reconnecting on transient errors.
@@ -837,7 +837,7 @@ class AsyncCommandHandle:
                 )
                 self._exhausted = True
                 return
-        self._exhausted = True
+        raise SandboxConnectionError("Command stream ended without exit message")
 
     async def __aiter__(self) -> AsyncIterator[OutputChunk]:
         """Async iterate with auto-reconnect on transient errors."""

--- a/python/tests/unit_tests/sandbox/test_async_ws_execute.py
+++ b/python/tests/unit_tests/sandbox/test_async_ws_execute.py
@@ -159,7 +159,7 @@ class TestAsyncCommandHandle:
             await handle._ensure_started()
 
     @pytest.mark.asyncio
-    async def test_stream_ends_without_exit(self):
+    async def test_stream_end_without_exit_reconnects(self):
         stream = _make_async_stream(
             [
                 _started_msg(),
@@ -167,12 +167,26 @@ class TestAsyncCommandHandle:
             ]
         )
         sandbox = self._make_sandbox_mock()
+        reconnect_handle = MagicMock()
+        reconnect_handle._stream = _make_async_stream([_exit_msg(0)])
+        reconnect_handle._control = None
+        sandbox.reconnect.return_value = reconnect_handle
         handle = AsyncCommandHandle(stream, None, sandbox)
         await handle._ensure_started()
 
-        _ = [c async for c in handle]  # Exhaust
-        with pytest.raises(SandboxOperationError, match="without exit"):
-            await handle.result
+        with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            chunks = [c async for c in handle]
+
+        assert [chunk.data for chunk in chunks] == ["data"]
+        result = await handle.result
+        assert result.stdout == "data"
+        assert result.exit_code == 0
+        sandbox.reconnect.assert_called_once_with(
+            "cmd-123",
+            stdout_offset=len("data".encode("utf-8")),
+            stderr_offset=0,
+        )
+        mock_sleep.assert_called_once_with(0.5)
 
     @pytest.mark.asyncio
     async def test_kill(self):

--- a/python/tests/unit_tests/sandbox/test_ws_execute.py
+++ b/python/tests/unit_tests/sandbox/test_ws_execute.py
@@ -274,7 +274,7 @@ class TestCommandHandle:
         with pytest.raises(SandboxOperationError, match="before 'started'"):
             CommandHandle(stream, None, sandbox)
 
-    def test_stream_ends_without_exit(self):
+    def test_stream_end_without_exit_reconnects(self):
         stream = _make_stream(
             [
                 _started_msg(),
@@ -282,10 +282,22 @@ class TestCommandHandle:
             ]
         )
         sandbox = self._make_sandbox_mock()
+        reconnect_handle = MagicMock()
+        reconnect_handle._stream = _make_stream([_exit_msg(0)])
+        reconnect_handle._control = None
+        sandbox.reconnect.return_value = reconnect_handle
         handle = CommandHandle(stream, None, sandbox)
-        list(handle)  # Exhaust
-        with pytest.raises(SandboxOperationError, match="without exit"):
-            _ = handle.result
+        with patch("time.sleep") as mock_sleep:
+            chunks = list(handle)
+        assert [chunk.data for chunk in chunks] == ["data"]
+        assert handle.result.stdout == "data"
+        assert handle.result.exit_code == 0
+        sandbox.reconnect.assert_called_once_with(
+            "cmd-123",
+            stdout_offset=len("data".encode("utf-8")),
+            stderr_offset=0,
+        )
+        mock_sleep.assert_called_once_with(0.5)
 
     def test_kill(self):
         ctrl = _WSStreamControl()


### PR DESCRIPTION
## Summary

Treat sandbox command WebSocket EOF before an exit message as a reconnectable connection loss in the Python and JS SDKs, so infra redeploys or transient stream closes resume via existing command reconnect logic instead of surfacing an operation error.

Checked Go and Java SDKs for the same pattern; Go already reconnects on WebSocket receive failures and Java does not appear to have a matching sandbox command WebSocket handle.

## Test Plan

- [x] `uv run python -m pytest tests/unit_tests/sandbox/test_ws_execute.py tests/unit_tests/sandbox/test_async_ws_execute.py`
- [x] `NODE_OPTIONS=--experimental-vm-modules ./node_modules/.bin/jest src/tests/sandbox.test.ts --runInBand --testNamePattern='CommandHandle' --testTimeout=30000`