### PR TITLE
fix(python): RunTree.create_child appends to self.child_runs LSE-2221

### DIFF
--- a/python/langsmith/run_trees.py
+++ b/python/langsmith/run_trees.py
@@ -590,7 +590,7 @@ class RunTree(ls_schemas.RunBase):
             attachments=attachments or {},  # type: ignore
             dangerously_allow_filesystem=self.dangerously_allow_filesystem,
         )
-
+        self.child_runs.append(run)
         return run
 
     def _get_dicts_safe(self):


### PR DESCRIPTION
## Summary
- `RunTree.create_child` now appends the new child to `self.child_runs`, mirroring `js/src/run_trees.ts` `createChild` (which already does `this.child_runs.push(child)`).
- Fixes #2852: `run.child_runs` is always `[]` inside evaluators, breaking the doc example at https://docs.langchain.com/langsmith/evaluate-on-intermediate-steps. 
- The in-memory `RunTree` returned by `evaluate()`'s `on_end` callback is the same object handed to evaluators. Until this patch, no code path populated `parent.child_runs` during live tracing — only `Client._load_child_runs` (server fetch) and `_load_traces` (post-hoc) did. The server side was always correct because each child carries `parent_run_id` in its POSTed payload; only the in-process tree was half-built.

