### PR TITLE
release(js): 0.7.3

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langsmith",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "Client library to connect to the LangSmith Observability and Evaluation Platform.",
   "packageManager": "pnpm@10.33.0",
   "files": [

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -32,4 +32,4 @@ export {
 } from "./utils/prompt_cache/index.js";
 
 // Update using pnpm bump-version
-export const __version__ = "0.7.2";
+export const __version__ = "0.7.3";


### PR DESCRIPTION
## What

Bump the LangSmith JS SDK package version to 0.7.3.

## Why

The Context Hub URL fix has merged for the JS SDK and needs a package release so users can install it from npm.

## How

Updated the package version and exported `__version__` using the existing JS version bump script.

## Testing

- `pnpm run check-version`
- `pnpm run check-npm-version`
- `npm view langsmith version`