### PR TITLE
release(py): 0.8.6

### DIFF
--- a/python/.bumpversion.cfg
+++ b/python/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.8.5
+current_version = 0.8.6
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
 serialize = {major}.{minor}.{patch}
 search = {current_version}

--- a/python/langsmith/__init__.py
+++ b/python/langsmith/__init__.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
 
 # Avoid calling into importlib on every call to __version__
 
-__version__ = "0.8.5"
+__version__ = "0.8.6"
 version = __version__  # for backwards compatibility
 
 


### PR DESCRIPTION
## What

Bump the LangSmith Python SDK version to 0.8.6.

## Why

The Python Context Hub URL fix has merged and needs a package release so users can install it from PyPI.

## How

Updated the Python SDK version source and bumpversion config from 0.8.5 to 0.8.6.

## Testing

- Verified `python/langsmith/__init__.py` and `python/.bumpversion.cfg` both contain `0.8.6`
- Confirmed tag `v0.8.6` does not exist on origin