### PR TITLE
fix(python): add organization id to context URLs

### DIFF
--- a/python/langsmith/_internal/_hub.py
+++ b/python/langsmith/_internal/_hub.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import re
 from typing import Optional
+from urllib.parse import urlencode
 
 from langsmith import utils as ls_utils
 
@@ -12,9 +13,12 @@ PLATFORM_HUB = "/v1/platform/hub/repos"
 HUB = "/repos"
 
 
-def build_commit_url(host: str, name: str, commit_hash: str) -> str:
+def build_commit_url(
+    host: str, name: str, commit_hash: str, organization_id: str
+) -> str:
     """Build the URL for a hub directory commit."""
-    return f"{host}/context/{name}/{commit_hash[:8]}"
+    query = urlencode({"organizationId": organization_id})
+    return f"{host}/context/{name}/{commit_hash[:8]}?{query}"
 
 
 def validate_parent_commit(parent_commit: Optional[str]) -> None:

--- a/python/langsmith/async_client.py
+++ b/python/langsmith/async_client.py
@@ -2391,7 +2391,8 @@ class AsyncClient:
             json=body,
         )
         commit_hash = response.json()["commit"]["commit_hash"]
-        return build_commit_url(self._host_url, name, commit_hash)
+        settings = await self._get_settings()
+        return build_commit_url(self._host_url, name, commit_hash, settings.id)
 
     async def _delete_hub_directory(self, identifier: str) -> None:
         """Delete a hub directory repo."""

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -9725,7 +9725,8 @@ class Client:
             json=body,
         )
         commit_hash = response.json()["commit"]["commit_hash"]
-        return build_commit_url(self._host_url, name, commit_hash)
+        settings = self._get_settings()
+        return build_commit_url(self._host_url, name, commit_hash, settings.id)
 
     def _delete_hub_directory(self, identifier: str) -> None:
         """Delete a hub directory repo."""

--- a/python/tests/unit_tests/test_hub_methods.py
+++ b/python/tests/unit_tests/test_hub_methods.py
@@ -18,6 +18,8 @@ TOOLS_JSON = json.dumps(
         "interrupt_config": {},
     }
 )
+WORKSPACE_ID = "ebbaf2eb-769b-4505-aca2-d11de10372a4"
+ORGANIZATION_QUERY = f"?organizationId={WORKSPACE_ID}"
 
 
 _HUB_METHODS = [
@@ -46,7 +48,7 @@ def _mock_sync_client() -> MagicMock:
     client._host_url = "https://smith.langchain.com"
     client._current_tenant_is_owner.return_value = True
     client._get_settings.return_value = SimpleNamespace(
-        tenant_handle="workspace-handle"
+        id=WORKSPACE_ID, tenant_handle="workspace-handle"
     )
     client._owner_conflict_error.return_value = ls_utils.LangSmithUserError(
         "owner mismatch"
@@ -62,7 +64,7 @@ def _mock_async_client() -> MagicMock:
     client._host_url = "https://smith.langchain.com"
     client._current_tenant_is_owner = AsyncMock(return_value=True)
     client._get_settings = AsyncMock(
-        return_value=SimpleNamespace(tenant_handle="workspace-handle")
+        return_value=SimpleNamespace(id=WORKSPACE_ID, tenant_handle="workspace-handle")
     )
     client._owner_conflict_error = AsyncMock(
         return_value=ls_utils.LangSmithUserError("owner mismatch")
@@ -211,7 +213,10 @@ def test_push_agent_creates_new_repo_and_commits() -> None:
     url = ctx.push_agent(
         "-/my-agent", files={"main.py": ls_schemas.FileEntry(content="x")}
     )
-    assert url == "https://smith.langchain.com/context/my-agent/abc12345"
+    assert (
+        url == f"https://smith.langchain.com/context/my-agent/abc12345"
+        f"{ORGANIZATION_QUERY}"
+    )
     assert client.request_with_retries.call_count == 3
 
     create_call = client.request_with_retries.call_args_list[1]
@@ -246,7 +251,10 @@ def test_push_agent_explicit_owner_returns_context_url() -> None:
     url = client.push_agent(
         "explicit-owner/my-agent", files={"main.py": ls_schemas.FileEntry(content="x")}
     )
-    assert url == "https://smith.langchain.com/context/my-agent/abc12345"
+    assert (
+        url == f"https://smith.langchain.com/context/my-agent/abc12345"
+        f"{ORGANIZATION_QUERY}"
+    )
 
 
 def test_push_agent_name_only_identifier_returns_context_url() -> None:
@@ -266,7 +274,10 @@ def test_push_agent_name_only_identifier_returns_context_url() -> None:
     url = client.push_agent(
         "email-assistant", files={"main.py": ls_schemas.FileEntry(content="x")}
     )
-    assert url == "https://smith.langchain.com/context/email-assistant/abc12345"
+    assert (
+        url == f"https://smith.langchain.com/context/email-assistant/abc12345"
+        f"{ORGANIZATION_QUERY}"
+    )
     commit_call = client.request_with_retries.call_args_list[2]
     assert commit_call.args == (
         "POST",
@@ -276,7 +287,9 @@ def test_push_agent_name_only_identifier_returns_context_url() -> None:
 
 def test_push_agent_returns_context_url_when_tenant_handle_missing() -> None:
     client = _mock_sync_client()
-    client._get_settings.return_value = SimpleNamespace(tenant_handle=None)
+    client._get_settings.return_value = SimpleNamespace(
+        id=WORKSPACE_ID, tenant_handle=None
+    )
     client.request_with_retries.side_effect = [
         ls_utils.LangSmithNotFoundError("not found"),
         _response({}),
@@ -292,7 +305,10 @@ def test_push_agent_returns_context_url_when_tenant_handle_missing() -> None:
     url = client.push_agent(
         "-/my-agent", files={"main.py": ls_schemas.FileEntry(content="x")}
     )
-    assert url == "https://smith.langchain.com/context/my-agent/abc12345"
+    assert (
+        url == f"https://smith.langchain.com/context/my-agent/abc12345"
+        f"{ORGANIZATION_QUERY}"
+    )
 
 
 def test_push_agent_updates_metadata_when_repo_exists() -> None:
@@ -491,13 +507,18 @@ async def test_async_push_agent_creates_and_commits() -> None:
     url = await ctx.push_agent(
         "-/my-agent", files={"main.py": ls_schemas.FileEntry(content="x")}
     )
-    assert url == "https://smith.langchain.com/context/my-agent/abc12345"
+    assert (
+        url == f"https://smith.langchain.com/context/my-agent/abc12345"
+        f"{ORGANIZATION_QUERY}"
+    )
     assert client._arequest_with_retries.await_count == 3
 
 
 async def test_async_push_agent_context_url_without_tenant_handle() -> None:
     client = _mock_async_client()
-    client._get_settings = AsyncMock(return_value=SimpleNamespace(tenant_handle=None))
+    client._get_settings = AsyncMock(
+        return_value=SimpleNamespace(id=WORKSPACE_ID, tenant_handle=None)
+    )
     client._arequest_with_retries.side_effect = [
         ls_utils.LangSmithNotFoundError("not found"),
         _response({}),
@@ -513,7 +534,10 @@ async def test_async_push_agent_context_url_without_tenant_handle() -> None:
     url = await client.push_agent(
         "-/my-agent", files={"main.py": ls_schemas.FileEntry(content="x")}
     )
-    assert url == "https://smith.langchain.com/context/my-agent/abc12345"
+    assert (
+        url == f"https://smith.langchain.com/context/my-agent/abc12345"
+        f"{ORGANIZATION_QUERY}"
+    )
 
 
 async def test_async_push_agent_accepts_tools_json_as_normal_file_entry() -> None:
@@ -559,7 +583,10 @@ async def test_async_create_repo_swallows_conflict() -> None:
     url = await ctx.push_agent(
         "-/my-agent", files={"main.py": ls_schemas.FileEntry(content="x")}
     )
-    assert url == "https://smith.langchain.com/context/my-agent/abc12345"
+    assert (
+        url == f"https://smith.langchain.com/context/my-agent/abc12345"
+        f"{ORGANIZATION_QUERY}"
+    )
     assert client._arequest_with_retries.await_count == 3
 
 


### PR DESCRIPTION
## What

Append `organizationId` to Python SDK Context Hub URLs returned by `push_agent` and `push_skill`.

## Why

Context Hub commit links need the workspace ID in the URL so the LangSmith UI resolves the pushed context in the correct workspace.

## How

The returned `/context/<name>/<commit>` URL now uses the current workspace ID from `/settings`, matching the existing prompt URL behavior. The helper URL-encodes the query string and both sync and async clients use the same helper.

## Testing

- `uv run pytest tests/unit_tests/test_hub_methods.py`
- `uv run ruff check langsmith/_internal/_hub.py langsmith/client.py langsmith/async_client.py tests/unit_tests/test_hub_methods.py`
- `make format`
- `UV_PYTHON=3.12 TEST=tests/unit_tests/test_hub_methods.py make tests`
- `UV_PYTHON=3.12 make lint` currently fails on an existing unrelated mypy error in `langsmith/_internal/_orjson.py:76`; ruff passes before mypy runs.