### PR TITLE
fix(js): add organization id to context URLs

### DIFF
--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -6912,7 +6912,12 @@ export class Client implements LangSmithTracingClientInterface {
     });
     const data = (await response.json()) as DirectoryCommitResponse;
     const commitHash = data.commit.commit_hash;
-    return `${this.getHostUrl()}/context/${name}/${commitHash.slice(0, 8)}`;
+    const settings = await this._getSettings();
+    const query = new URLSearchParams({ organizationId: settings.id });
+    return `${this.getHostUrl()}/context/${name}/${commitHash.slice(
+      0,
+      8,
+    )}?${query.toString()}`;
   }
 
   private async _deleteDirectory(identifier: string): Promise<void> {

--- a/js/src/tests/context.test.ts
+++ b/js/src/tests/context.test.ts
@@ -3,9 +3,18 @@ import { jest } from "@jest/globals";
 import { Client } from "../client.js";
 import { LangSmithConflictError } from "../utils/error.js";
 
+const WORKSPACE_ID = "00000000-0000-0000-0000-000000000000";
+const ORGANIZATION_QUERY = `?organizationId=${WORKSPACE_ID}`;
+
 function _mockClient() {
   const client = new Client({ apiKey: "test-api-key" });
   jest.spyOn(client as any, "_currentTenantIsOwner").mockResolvedValue(true);
+  jest.spyOn(client as any, "_getSettings").mockResolvedValue({
+    id: WORKSPACE_ID,
+    display_name: "Test Workspace",
+    created_at: "2026-05-27T00:00:00Z",
+    tenant_handle: "workspace-handle",
+  });
   jest
     .spyOn(client as any, "_ownerConflictError")
     .mockImplementation(async () => new Error("owner mismatch"));
@@ -146,7 +155,9 @@ describe("Context (agent/skill) on Client", () => {
       const url = await client.pushAgent("-/my-agent", {
         files: { "main.py": { type: "file", content: "x" } },
       });
-      expect(url).toContain("/context/my-agent/abc12345");
+      expect(url).toBe(
+        `https://smith.langchain.com/context/my-agent/abc12345${ORGANIZATION_QUERY}`,
+      );
 
       const calls = fetchSpy.mock.calls as [string, any][];
       expect(calls).toHaveLength(3);
@@ -277,7 +288,9 @@ describe("Context (agent/skill) on Client", () => {
         client.pushAgent("-/my-agent", {
           files: { "main.py": { type: "file", content: "x" } },
         }),
-      ).resolves.toContain("/context/my-agent/abc12345");
+      ).resolves.toBe(
+        `https://smith.langchain.com/context/my-agent/abc12345${ORGANIZATION_QUERY}`,
+      );
     });
 
     it("returns context URL without explicit owner", async () => {
@@ -296,12 +309,20 @@ describe("Context (agent/skill) on Client", () => {
       const url = await client.pushAgent("explicit-owner/my-agent", {
         files: { "main.py": { type: "file", content: "x" } },
       });
-      expect(url).toContain("/context/my-agent/abc12345");
+      expect(url).toBe(
+        `https://smith.langchain.com/context/my-agent/abc12345${ORGANIZATION_QUERY}`,
+      );
     });
 
-    it("returns context URL without fetching tenant_handle", async () => {
+    it("returns context URL with organizationId when tenant_handle is missing", async () => {
       const client = _mockClient();
       const settingsSpy = jest.spyOn(client as any, "_getSettings");
+      settingsSpy.mockResolvedValue({
+        id: WORKSPACE_ID,
+        display_name: "Test Workspace",
+        created_at: "2026-05-27T00:00:00Z",
+        tenant_handle: undefined,
+      });
       _setFetchSequence(client, [
         _response({ detail: "Not Found" }, 404),
         _response({ repo: { id: "r1" } }),
@@ -316,8 +337,10 @@ describe("Context (agent/skill) on Client", () => {
       const url = await client.pushAgent("-/my-agent", {
         files: { "main.py": { type: "file", content: "x" } },
       });
-      expect(url).toContain("/context/my-agent/abc12345");
-      expect(settingsSpy).not.toHaveBeenCalled();
+      expect(url).toBe(
+        `https://smith.langchain.com/context/my-agent/abc12345${ORGANIZATION_QUERY}`,
+      );
+      expect(settingsSpy).toHaveBeenCalled();
     });
 
     it("supports name-only identifier and returns context URL", async () => {
@@ -336,7 +359,9 @@ describe("Context (agent/skill) on Client", () => {
       const url = await client.pushAgent("email-assistant", {
         files: { "main.py": { type: "file", content: "x" } },
       });
-      expect(url).toContain("/context/email-assistant/abc12345");
+      expect(url).toBe(
+        `https://smith.langchain.com/context/email-assistant/abc12345${ORGANIZATION_QUERY}`,
+      );
 
       const calls = fetchSpy.mock.calls as [string, any][];
       expect(calls[0][0]).toContain("/repos/-/email-assistant");


### PR DESCRIPTION
## What

Append `organizationId` to JS SDK Context Hub URLs returned by `pushAgent` and `pushSkill`.

## Why

Context Hub commit links need the workspace ID in the URL so the LangSmith UI resolves the pushed context in the correct workspace.

## How

The returned `/context/<name>/<commit>` URL now uses the current workspace ID from `/settings`, matching the existing prompt URL behavior. The query string is encoded with `URLSearchParams` and the context unit tests now assert the full returned URL.

## Testing

- `pnpm exec oxfmt --write src/client.ts src/tests/context.test.ts`
- `pnpm test -- --runTestsByPath src/tests/context.test.ts`
- `pnpm run lint`
- `pnpm run check:types`
- `pnpm exec oxfmt --check src/client.ts src/tests/context.test.ts`