### PR TITLE
fix(python): retry sandbox pool timeouts

### DIFF
--- a/python/langsmith/sandbox/_transport.py
+++ b/python/langsmith/sandbox/_transport.py
@@ -94,7 +94,7 @@ class RetryTransport(httpx.BaseTransport):
 
                 return response
 
-            except (httpx.ConnectError, httpx.ConnectTimeout) as exc:
+            except (httpx.ConnectError, httpx.ConnectTimeout, httpx.PoolTimeout) as exc:
                 if not is_last_attempt:
                     sleep_time = _compute_backoff(attempt)
                     logger.debug(
@@ -180,7 +180,7 @@ class AsyncRetryTransport(httpx.AsyncBaseTransport):
 
                 return response
 
-            except (httpx.ConnectError, httpx.ConnectTimeout) as exc:
+            except (httpx.ConnectError, httpx.ConnectTimeout, httpx.PoolTimeout) as exc:
                 if not is_last_attempt:
                     sleep_time = _compute_backoff(attempt)
                     logger.debug(

--- a/python/tests/unit_tests/sandbox/test_transport.py
+++ b/python/tests/unit_tests/sandbox/test_transport.py
@@ -120,6 +120,28 @@ class TestRetryTransport:
         assert mock_sleep.call_count == 1
 
     @patch("langsmith.sandbox._transport.time.sleep")
+    def test_retries_on_pool_timeout_then_succeeds(self, mock_sleep):
+        mock = MockTransport(
+            [
+                httpx.PoolTimeout("pool timed out"),
+                httpx.Response(200),
+            ]
+        )
+        transport = RetryTransport(max_retries=3, transport=mock)
+        response = transport.handle_request(_make_request())
+        assert response.status_code == 200
+        assert mock.call_count == 2
+        assert mock_sleep.call_count == 1
+
+    @patch("langsmith.sandbox._transport.time.sleep")
+    def test_exhausted_retries_on_pool_timeout_raises(self, mock_sleep):
+        mock = MockTransport([httpx.PoolTimeout(f"fail {i}") for i in range(4)])
+        transport = RetryTransport(max_retries=3, transport=mock)
+        with pytest.raises(SandboxConnectionError, match="4 attempts"):
+            transport.handle_request(_make_request())
+        assert mock.call_count == 4
+
+    @patch("langsmith.sandbox._transport.time.sleep")
     def test_exhausted_retries_on_server_error_returns_response(self, mock_sleep):
         mock = MockTransport([httpx.Response(502)] * 4)
         transport = RetryTransport(max_retries=3, transport=mock)
@@ -272,6 +294,29 @@ class TestAsyncRetryTransport:
         response = await transport.handle_async_request(_make_request())
         assert response.status_code == 200
         assert mock.call_count == 2
+
+    @pytest.mark.asyncio
+    @pytest.mark.usefixtures("_patch_sleep")
+    async def test_retries_on_pool_timeout_then_succeeds(self):
+        mock = MockAsyncTransport(
+            [
+                httpx.PoolTimeout("pool timed out"),
+                httpx.Response(200),
+            ]
+        )
+        transport = AsyncRetryTransport(max_retries=3, transport=mock)
+        response = await transport.handle_async_request(_make_request())
+        assert response.status_code == 200
+        assert mock.call_count == 2
+
+    @pytest.mark.asyncio
+    @pytest.mark.usefixtures("_patch_sleep")
+    async def test_exhausted_retries_on_pool_timeout_raises(self):
+        mock = MockAsyncTransport([httpx.PoolTimeout(f"fail {i}") for i in range(4)])
+        transport = AsyncRetryTransport(max_retries=3, transport=mock)
+        with pytest.raises(SandboxConnectionError, match="4 attempts"):
+            await transport.handle_async_request(_make_request())
+        assert mock.call_count == 4
 
     @pytest.mark.asyncio
     @pytest.mark.usefixtures("_patch_sleep")


### PR DESCRIPTION
## What

Adds `httpx.PoolTimeout` to the retried-on-connection branch of the sandbox HTTP retry transport (`python/langsmith/sandbox/_transport.py`), in both the sync `RetryTransport` and async `AsyncRetryTransport`.

## Why

`httpx.PoolTimeout` (raised when a connection can't be acquired from the pool within the timeout) is a connection-*establishment* failure — the request is never transmitted — so retrying is always safe, exactly like `ConnectError` and `ConnectTimeout` (already retried, the latter added in #2940).

In the exception hierarchy `PoolTimeout -> TimeoutException -> TransportError`, it's a sibling of `ConnectError` (`-> NetworkError -> TransportError`), so it was not caught by the existing `except (httpx.ConnectError, httpx.ConnectTimeout)` clause. Under pool exhaustion the timeout propagated raw on the first attempt instead of being retried with exponential backoff, surfacing to callers (e.g. the deepagents LangSmith filesystem backend) as an unhandled `httpx.PoolTimeout`.

`ReadTimeout` and `WriteTimeout` are deliberately left non-retried: those mean the request *was* sent, so blanket-retrying them risks double-executing non-idempotent operations (command execution, writes).

## Test Plan

- [x] New unit tests for both sync and async transports: retry-then-succeed and exhausted-retries-raises on `PoolTimeout`
- [x] `tests/unit_tests/sandbox/test_transport.py` passes (46 tests)
- [x] `ruff format` / `ruff check` clean