### PR TITLE
fix(sandbox): build Dockerfile snapshots off /tmp

### DIFF
--- a/python/.bumpversion.cfg
+++ b/python/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.8.7
+current_version = 0.8.8
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
 serialize = {major}.{minor}.{patch}
 search = {current_version}

--- a/python/langsmith/__init__.py
+++ b/python/langsmith/__init__.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
 
 # Avoid calling into importlib on every call to __version__
 
-__version__ = "0.8.7"
+__version__ = "0.8.8"
 version = __version__  # for backwards compatibility
 
 

--- a/python/langsmith/sandbox/_async_client.py
+++ b/python/langsmith/sandbox/_async_client.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+import posixpath
 import uuid
 from collections.abc import Callable, Mapping
 from typing import Any, Optional, Union
@@ -808,11 +809,17 @@ class AsyncSandboxClient:
         context_path, dockerfile_rel = _resolve_dockerfile_context(dockerfile, context)
 
         builder_name = f"snapshot-builder-{uuid.uuid4().hex[:12]}"
-        remote_context = "/tmp/langsmith-docker-context"
-        remote_tar = "/tmp/langsmith-docker-context.tar"
+        # Stage the build on the capacity-backed root filesystem, not /tmp.
+        # Inside the sandbox /tmp is a RAM-backed tmpfs that fs_capacity_bytes
+        # does not size, and BuildKit's native snapshotter writes a full copy
+        # of every layer under its root, so a /tmp build exhausts guest RAM and
+        # fails with "No space left on device".
+        build_root = f"/var/lib/langsmith-build/{uuid.uuid4().hex[:12]}"
+        remote_context = posixpath.join(build_root, "context")
+        remote_tar = posixpath.join(build_root, "context.tar")
         image_ref = f"langsmith-snapshot-build:{uuid.uuid4().hex}"
-        buildkit_root = f"/tmp/langsmith-buildkit-root-{uuid.uuid4().hex[:12]}"
-        buildkit_run = f"/tmp/langsmith-buildkit-run-{uuid.uuid4().hex[:12]}"
+        buildkit_root = posixpath.join(build_root, "buildkit-root")
+        buildkit_run = posixpath.join(build_root, "buildkit-run")
 
         async with await self.sandbox(
             name=builder_name,

--- a/python/langsmith/sandbox/_client.py
+++ b/python/langsmith/sandbox/_client.py
@@ -148,6 +148,7 @@ def _make_dockerfile_build_command(
         "  sleep 0.1\n"
         "done\n"
         f"{shlex.join(buildctl)} | docker load\n"
+        f"rm -rf {shlex.quote(buildkit_root)} || true\n"
     )
 
 
@@ -883,11 +884,17 @@ class SandboxClient:
         context_path, dockerfile_rel = _resolve_dockerfile_context(dockerfile, context)
 
         builder_name = f"snapshot-builder-{uuid.uuid4().hex[:12]}"
-        remote_context = "/tmp/langsmith-docker-context"
-        remote_tar = "/tmp/langsmith-docker-context.tar"
+        # Stage the build on the capacity-backed root filesystem, not /tmp.
+        # Inside the sandbox /tmp is a RAM-backed tmpfs that fs_capacity_bytes
+        # does not size, and BuildKit's native snapshotter writes a full copy
+        # of every layer under its root, so a /tmp build exhausts guest RAM and
+        # fails with "No space left on device".
+        build_root = f"/var/lib/langsmith-build/{uuid.uuid4().hex[:12]}"
+        remote_context = posixpath.join(build_root, "context")
+        remote_tar = posixpath.join(build_root, "context.tar")
         image_ref = f"langsmith-snapshot-build:{uuid.uuid4().hex}"
-        buildkit_root = f"/tmp/langsmith-buildkit-root-{uuid.uuid4().hex[:12]}"
-        buildkit_run = f"/tmp/langsmith-buildkit-run-{uuid.uuid4().hex[:12]}"
+        buildkit_root = posixpath.join(build_root, "buildkit-root")
+        buildkit_run = posixpath.join(build_root, "buildkit-run")
 
         with self.sandbox(
             name=builder_name,

--- a/python/tests/unit_tests/sandbox/test_async_client.py
+++ b/python/tests/unit_tests/sandbox/test_async_client.py
@@ -878,16 +878,17 @@ class TestAsyncSandboxOperations:
 
         assert snapshot.id == "snap-1"
         sandbox_mock.assert_awaited_once()
-        assert fake_sandbox.writes == [
-            (
-                "/tmp/langsmith-docker-context.tar",
-                b"tar",
-                {"timeout": 60, "headers": None},
-            )
-        ]
-        assert (
-            "tar -xf /tmp/langsmith-docker-context.tar" in fake_sandbox.commands[0][0]
-        )
+        # Build scratch must live on the capacity-backed root filesystem, not
+        # the RAM-backed /tmp tmpfs that fs_capacity_bytes does not size.
+        assert len(fake_sandbox.writes) == 1
+        tar_path, tar_content, tar_kwargs = fake_sandbox.writes[0]
+        assert tar_path.startswith("/var/lib/langsmith-build/")
+        assert tar_path.endswith("/context.tar")
+        assert tar_content == b"tar"
+        assert tar_kwargs == {"timeout": 60, "headers": None}
+        assert "/tmp" not in fake_sandbox.commands[0][0]
+        assert "/tmp" not in fake_sandbox.commands[1][0]
+        assert f"tar -xf {tar_path}" in fake_sandbox.commands[0][0]
         assert "--frontend dockerfile.v0" in fake_sandbox.commands[1][0]
         assert "docker info >/dev/null 2>&1" in fake_sandbox.commands[1][0]
         assert "| docker load" in fake_sandbox.commands[1][0]

--- a/python/tests/unit_tests/sandbox/test_client.py
+++ b/python/tests/unit_tests/sandbox/test_client.py
@@ -1043,16 +1043,17 @@ class TestSnapshotOperations:
 
         assert snapshot.id == "snap-1"
         sandbox_mock.assert_called_once()
-        assert fake_sandbox.writes == [
-            (
-                "/tmp/langsmith-docker-context.tar",
-                b"tar",
-                {"timeout": 60, "headers": None},
-            )
-        ]
-        assert (
-            "tar -xf /tmp/langsmith-docker-context.tar" in fake_sandbox.commands[0][0]
-        )
+        # Build scratch must live on the capacity-backed root filesystem, not
+        # the RAM-backed /tmp tmpfs that fs_capacity_bytes does not size.
+        assert len(fake_sandbox.writes) == 1
+        tar_path, tar_content, tar_kwargs = fake_sandbox.writes[0]
+        assert tar_path.startswith("/var/lib/langsmith-build/")
+        assert tar_path.endswith("/context.tar")
+        assert tar_content == b"tar"
+        assert tar_kwargs == {"timeout": 60, "headers": None}
+        assert "/tmp" not in fake_sandbox.commands[0][0]
+        assert "/tmp" not in fake_sandbox.commands[1][0]
+        assert f"tar -xf {tar_path}" in fake_sandbox.commands[0][0]
         assert "--frontend dockerfile.v0" in fake_sandbox.commands[1][0]
         assert "docker info >/dev/null 2>&1" in fake_sandbox.commands[1][0]
         assert "| docker load" in fake_sandbox.commands[1][0]


### PR DESCRIPTION
## Summary

`SandboxClient.create_snapshot(..., dockerfile=...)` consistently failed with `No space left on device` for non-trivial Dockerfiles, and bumping `fs_capacity_bytes` had no effect.

**Cause:** the build staged the context, BuildKit `--root`, and run dir under `/tmp` inside the builder sandbox. Inside the sandbox `/tmp` is a RAM-backed `tmpfs` (`vminit_linux.go` mounts `{"tmpfs", "/tmp", "tmpfs", 0}` with no size opt → ~50% of guest RAM). `fs_capacity_bytes` sizes the **root ext4** (`/`), not `/tmp`, so bumping it grew a filesystem the build never touched. BuildKit's native snapshotter writes a full uncompressed copy of every layer under its root, so the build is bounded by guest RAM and OOMs the tmpfs.

**Fix:** stage the build under `/var/lib/langsmith-build/<id>` on the capacity-backed root ext4, so build space scales with `fs_capacity_bytes` as expected. Also `rm -rf` the BuildKit root after `docker load` to cap peak disk usage (now relevant since scratch persists on the ext4 rather than vanishing with the tmpfs; the captured snapshot is built server-side from the loaded image, so this only reclaims space). Applied to both the sync and async clients via the shared build-command helper.

This is Python-only. The JS `createSnapshot` builds from a registry image server-side and has no client-side BuildKit/Dockerfile path, so it is unaffected.

Includes a patch version bump to 0.8.8.

## Test Plan

- [x] `pytest tests/unit_tests/sandbox/test_client.py tests/unit_tests/sandbox/test_async_client.py` (127 passed); assertions updated to verify scratch lives under `/var/lib/langsmith-build/` and `/tmp` no longer appears in the build commands.
- [ ] End-to-end Dockerfile build against a live sandbox builder (the original failing path) — requires the sandbox control/data plane + firecracker builder, which can't run in unit CI.

## Release Note

Fix `No space left on device` failures when building sandbox snapshots from a Dockerfile with `create_snapshot(dockerfile=...)`; build space now scales with `fs_capacity_bytes`.