### PR TITLE
feat(python): support trace_id and retry-on-NotFound in async create_…

### DIFF
--- a/python/langsmith/async_client.py
+++ b/python/langsmith/async_client.py
@@ -275,10 +275,28 @@ class AsyncClient:
         self,
         method: str,
         endpoint: str,
+        retry_on: Optional[Sequence[type[BaseException]]] = None,
         **kwargs: Any,
     ) -> httpx.Response:
-        """Make an async HTTP request with retries."""
+        """Make an async HTTP request with retries.
+
+        Args:
+            method: The HTTP method.
+            endpoint: The request endpoint (appended to the API base URL).
+            retry_on: Additional exception types to retry on, beyond the
+                connection/timeout/server-error set that is always retried.
+            **kwargs: Forwarded to the underlying httpx request.
+        """
         max_retries = cast(int, self._retry_config.get("max_retries", 3))
+        # Transient connection/timeout/server errors are always retried; callers
+        # can opt into retrying additional types (e.g. LangSmithNotFoundError
+        # when writing against a run that may not be ingested yet).
+        retry_on_: tuple[type[BaseException], ...] = (
+            ls_utils.LangSmithConnectionError,
+            ls_utils.LangSmithRequestTimeout,
+            ls_utils.LangSmithAPIError,
+            *(retry_on or ()),
+        )
 
         # Python requests library used by the normal Client filters out params with None values
         # The httpx library does not. Filter them out here to keep behavior consistent
@@ -335,11 +353,7 @@ class AsyncClient:
                     raise ls_utils.LangSmithConnectionError(
                         f"Request error: {repr(e)}"
                     ) from e
-            except (
-                ls_utils.LangSmithConnectionError,
-                ls_utils.LangSmithRequestTimeout,
-                ls_utils.LangSmithAPIError,
-            ):
+            except retry_on_:
                 if attempt == max_retries - 1:
                     raise
                 sleep_time = 2**attempt + (random.random() * 0.5)
@@ -837,6 +851,7 @@ class AsyncClient:
         score: Optional[float] = None,
         value: Union[float, int, bool, str, dict, None] = None,
         comment: Optional[str] = None,
+        trace_id: Optional[ls_client.ID_TYPE] = None,
         **kwargs: Any,
     ) -> ls_schemas.Feedback:
         """Create feedback for a run.
@@ -849,6 +864,10 @@ class AsyncClient:
             score: The score to rate this run on the metric or aspect.
             value: The display value or non-numeric value for this feedback.
             comment: A comment about this feedback.
+            trace_id: The trace ID of the run to provide feedback for. For a
+                root run this equals `run_id`. Passing it lets the backend
+                route the write without a run->trace lookup, which is
+                recommended for latency-sensitive callers.
             **kwargs: Additional keyword arguments to include in the feedback data.
 
         Returns:
@@ -859,14 +878,20 @@ class AsyncClient:
         """  # noqa: E501
         data = {
             "run_id": ls_client._ensure_uuid(run_id, accept_null=True),
+            "trace_id": ls_client._ensure_uuid(trace_id, accept_null=True),
             "key": key,
             "score": score,
             "value": value,
             "comment": comment,
             **kwargs,
         }
+        # Retry on NotFound: the run referenced by run_id/trace_id may have been
+        # submitted moments ago and not yet ingested when this write lands.
         response = await self._arequest_with_retries(
-            "POST", "/feedback", content=ls_client._dumps_json(data)
+            "POST",
+            "/feedback",
+            content=ls_client._dumps_json(data),
+            retry_on=(ls_utils.LangSmithNotFoundError,),
         )
         return ls_schemas.Feedback(**response.json())
 

--- a/python/tests/unit_tests/test_async_client.py
+++ b/python/tests/unit_tests/test_async_client.py
@@ -253,6 +253,96 @@ async def test_arequest_with_retries_retries_on_502(
     client = AsyncClient(retry_config={"max_retries": 2})
     response = await client._arequest_with_retries("GET", "/repos/-/test")
     assert response == second_response
+
+
+@mock.patch("langsmith.async_client.httpx.AsyncClient")
+@pytest.mark.asyncio
+@patch("langsmith.async_client.ls_utils.raise_for_status_with_text")
+async def test_create_feedback_forwards_trace_id(
+    mock_raise_for_status: mock.Mock,
+    mock_client_cls: mock.Mock,
+) -> None:
+    mock_httpx_client = AsyncMock()
+    mock_client_cls.return_value = mock_httpx_client
+    mock_raise_for_status.return_value = None
+
+    run_id = uuid4()
+    trace_id = uuid4()
+    now = datetime(2024, 1, 1).isoformat()
+    response = MagicMock()
+    response.status_code = 200
+    response.json.return_value = {
+        "id": str(uuid4()),
+        "created_at": now,
+        "modified_at": now,
+        "run_id": str(run_id),
+        "trace_id": str(trace_id),
+        "key": "quality",
+    }
+    mock_httpx_client.request.return_value = response
+
+    client = AsyncClient(api_url="http://localhost:1984", api_key="test")
+    await client.create_feedback(run_id, key="quality", score=1, trace_id=trace_id)
+
+    call = mock_httpx_client.request.call_args
+    assert call.args[0] == "POST"
+    assert call.args[1] == "/feedback"
+    body = json.loads(call.kwargs["content"])
+    assert uuid.UUID(body["run_id"]) == run_id
+    assert uuid.UUID(body["trace_id"]) == trace_id
+    assert body["key"] == "quality"
+
+
+@mock.patch("langsmith.async_client.httpx.AsyncClient")
+@pytest.mark.asyncio
+@patch("langsmith.async_client.asyncio.sleep", new_callable=AsyncMock)
+@patch("langsmith.async_client.ls_utils.raise_for_status_with_text")
+async def test_create_feedback_retries_on_not_found(
+    mock_raise_for_status: mock.Mock,
+    _mock_sleep: AsyncMock,
+    mock_client_cls: mock.Mock,
+) -> None:
+    mock_httpx_client = AsyncMock()
+    mock_client_cls.return_value = mock_httpx_client
+
+    run_id = uuid4()
+    trace_id = uuid4()
+    now = datetime(2024, 1, 1).isoformat()
+
+    not_found = MagicMock()
+    not_found.status_code = 404
+    success = MagicMock()
+    success.status_code = 200
+    success.json.return_value = {
+        "id": str(uuid4()),
+        "created_at": now,
+        "modified_at": now,
+        "run_id": str(run_id),
+        "trace_id": str(trace_id),
+        "key": "quality",
+    }
+    mock_httpx_client.request.side_effect = [not_found, success]
+
+    def _raise_for_status(response: mock.Mock) -> None:
+        if response.status_code >= 400:
+            raise httpx.HTTPStatusError(
+                "status error",
+                request=httpx.Request("POST", "http://test"),
+                response=response,
+            )
+
+    mock_raise_for_status.side_effect = _raise_for_status
+
+    client = AsyncClient(
+        api_url="http://localhost:1984",
+        api_key="test",
+        retry_config={"max_retries": 2},
+    )
+    feedback = await client.create_feedback(run_id, key="quality", trace_id=trace_id)
+
+    # A 404 (run not yet ingested) is retried, unlike other 4xx.
+    assert mock_httpx_client.request.call_count == 2
+    assert str(feedback.run_id) == str(run_id)
     assert mock_httpx_client.request.call_count == 2
 
 


### PR DESCRIPTION
…feedback

Bring AsyncClient.create_feedback to parity with the sync client:

- Accept a `trace_id` argument and include it in the POST body. Passing it lets the backend route the write without a run->trace lookup, which is recommended for latency-sensitive callers.
- Retry on LangSmithNotFoundError. A run referenced by a just-submitted feedback write may not be ingested yet; the sync client already retries this case. Adds a `retry_on` parameter to _arequest_with_retries (mirroring the sync request_with_retries) so create_feedback can opt in.