### PR TITLE
test(python): deflake test_tracing_queue_limit_drops_when_full

### DIFF
--- a/python/tests/unit_tests/test_client.py
+++ b/python/tests/unit_tests/test_client.py
@@ -4470,10 +4470,17 @@ def test_compressed_traces_queue_limit_drops_new_items(
     )
 
 
+@mock.patch("langsmith.client._tracing_control_thread_func")
 def test_tracing_queue_limit_drops_when_full(
+    mock_tracing_thread: mock.Mock,
     caplog: pytest.LogCaptureFixture,
 ):
-    """Ensure the uncompressed tracing queue drops items when full."""
+    """Ensure the uncompressed tracing queue drops items when full.
+
+    The background drain thread is patched to a no-op so it can't pull items
+    off the queue while we fill it to capacity; otherwise ``qsize()`` races the
+    drainer and is non-deterministic under load.
+    """
     from langsmith._internal._background_thread import TracingQueueItem
     from langsmith._internal._operations import SerializedFeedbackOperation
     from langsmith.client import _reset_tracing_drop_log
@@ -4515,7 +4522,9 @@ def test_tracing_queue_limit_drops_when_full(
         "Dropped" in record.getMessage() and "tracing queue full" in record.getMessage()
         for record in caplog.records
     )
-    client.cleanup()
+    # The drain thread is disabled, so the enqueued items are never marked
+    # done; skip the flush/join (timeout=0) so cleanup doesn't block on them.
+    client.cleanup(timeout=0)
 
 
 def test_tracing_queue_default_maxsize():


### PR DESCRIPTION
The test builds Client(auto_batch_tracing=True), which starts a background drain thread alongside creating the tracing queue. It then fills the queue to capacity and asserts qsize() == maxsize, but the drain thread can pull items off concurrently, so under load the assertion sees fewer items than expected (observed `assert 1 == 3` in CI).

Patch the drain thread entry point (langsmith.client._tracing_control_thread_func) to a no-op so nothing consumes the queue while we fill it, making qsize() deterministic. The queue is still created with the env-derived maxsize, so the maxsize and drop-when-full assertions stay meaningful. Since the drainer is disabled the enqueued items are never marked done, so cleanup uses timeout=0 to skip the flush/join that would otherwise block.

Example failure:
https://github.com/langchain-ai/langsmith-sdk/actions/runs/26808399300/job/79031744668?pr=2959