### PR TITLE
test(python): fix fake_server fixture teardown in context propagation test

### DIFF
--- a/python/tests/integration_tests/test_context_propagation.py
+++ b/python/tests/integration_tests/test_context_propagation.py
@@ -21,14 +21,25 @@ async def fake_server():
     config = Config(app=fake_app, loop="asyncio", port=8000, log_level="info")
     server = Server(config=config)
 
-    asyncio.create_task(server.serve())
-    await asyncio.sleep(0.1)
+    task = asyncio.create_task(server.serve())
+    # Wait until startup actually completes (which is what populates
+    # ``server.servers``) instead of guessing with a fixed sleep. If the serve
+    # task exits early — e.g. the port is unavailable — surface that error
+    # rather than hanging.
+    while not server.started:
+        if task.done():
+            task.result()
+            raise RuntimeError("uvicorn server exited before startup completed")
+        await asyncio.sleep(0.01)
 
-    yield
     try:
-        await server.shutdown()
-    except RuntimeError:
-        pass
+        yield
+    finally:
+        # Shut down gracefully: signal serve() to exit and let it run its own
+        # shutdown. Calling server.shutdown() directly races startup and
+        # raises AttributeError on server.servers before it is set.
+        server.should_exit = True
+        await task
 
 
 @traceable


### PR DESCRIPTION
The module-scoped fake_server fixture started uvicorn via asyncio.create_task(server.serve()), waited a fixed asyncio.sleep(0.1), then called `await server.shutdown()` at teardown. uvicorn's Server.shutdown() immediately iterates `self.servers`, which is only set once serve() reaches startup(). Under CI load 0.1s isn't enough, so self.servers is unset and teardown raises:

    AttributeError: 'Server' object has no attribute 'servers'

Wait for `server.started` (polling, with a guard that surfaces an early serve-task exit instead of hanging) so startup has definitely completed, and shut down gracefully via `should_exit = True` + awaiting the serve task instead of calling the low-level shutdown() directly.