### PR TITLE
chore: update dependabot.yml to comply with posture checks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/js"
     schedule:
-      interval: "weekly"
-      day: "monday"
+      interval: "monthly"
     labels:
       - "dependencies"
       - "javascript"
@@ -16,16 +15,22 @@ updates:
       - dependency-name: "p-queue"
     groups:
       js-minor-and-patch:
+        patterns:
+          - "*"
         update-types:
           - "minor"
           - "patch"
+      js-major:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
 
   # Python dependencies (python/)
   - package-ecosystem: "uv"
     directory: "/python"
     schedule:
-      interval: "weekly"
-      day: "monday"
+      interval: "monthly"
     labels:
       - "dependencies"
       - "python"
@@ -34,23 +39,36 @@ updates:
       prefix-development: "chore(deps-dev)"
     groups:
       py-minor-and-patch:
+        patterns:
+          - "*"
         update-types:
           - "minor"
           - "patch"
+      py-major:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
 
   # GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "monday"
+      interval: "monthly"
     labels:
       - "dependencies"
       - "github-actions"
     commit-message:
       prefix: "chore(deps)"
     groups:
-      actions:
+      actions-minor-and-patch:
+        patterns:
+          - "*"
         update-types:
           - "minor"
           - "patch"
+      actions-major:
+        patterns:
+          - "*"
+        update-types:
+          - "major"


### PR DESCRIPTION
Brings `.github/dependabot.yml` in line with org posture checks.

- Switches all three `updates` entries (npm `/js`, uv `/python`, github-actions `/`) from a weekly to a **monthly** cadence to cut PR noise.
- Adds a `*-major` group alongside the existing `*-minor-and-patch` group for each ecosystem, and an explicit `patterns: ["*"]` on every group. Previously major (breaking) updates matched no group and arrived as one PR per dependency; now they are grouped separately from safe minor/patch bumps.

Existing labels, commit-message prefixes, and the `p-queue` ignore are preserved. The single `/js` entry continues to target the pnpm workspace root.