### PR TITLE
ci: add minimum workflow permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       js: ${{ steps.filter.outputs.js }}
     steps:
       - uses: actions/checkout@v6
-      - uses: dorny/paths-filter@v4
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4
         id: filter
         with:
           filters: |
@@ -64,7 +64,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
         with:
           python-version: "3.12"
           enable-cache: true
@@ -93,7 +93,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
         with:
           python-version: ${{ matrix.python-version }}
           enable-cache: true
@@ -121,7 +121,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@ac6db6d3c1f721f886538a378a2d73e85697340a # v6
         with:
           version: 10
       - name: Use Node.js 24.x
@@ -146,7 +146,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@ac6db6d3c1f721f886538a378a2d73e85697340a # v6
         with:
           version: 10
       - name: Use Node.js 24.x
@@ -171,7 +171,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@ac6db6d3c1f721f886538a378a2d73e85697340a # v6
         with:
           version: 10
       - name: Use Node.js 24.x
@@ -205,7 +205,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@ac6db6d3c1f721f886538a378a2d73e85697340a # v6
         with:
           version: 10
       - name: Use Node.js ${{ matrix.node-version }}
@@ -236,7 +236,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@ac6db6d3c1f721f886538a378a2d73e85697340a # v6
         with:
           version: 10
       - name: Use Node.js ${{ env.NODE_VERSION }}
@@ -262,7 +262,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@ac6db6d3c1f721f886538a378a2d73e85697340a # v6
         with:
           version: 10
       - name: Use Node.js ${{ env.NODE_VERSION }}
@@ -288,7 +288,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@ac6db6d3c1f721f886538a378a2d73e85697340a # v6
         with:
           version: 10
       - name: Use Node.js ${{ env.NODE_VERSION }}
@@ -314,7 +314,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@ac6db6d3c1f721f886538a378a2d73e85697340a # v6
         with:
           version: 10
       - name: Use Node.js ${{ env.NODE_VERSION }}
@@ -340,7 +340,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@ac6db6d3c1f721f886538a378a2d73e85697340a # v6
         with:
           version: 10
       - name: Use Node.js ${{ env.NODE_VERSION }}
@@ -366,7 +366,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@ac6db6d3c1f721f886538a378a2d73e85697340a # v6
         with:
           version: 10
       - name: Use Node.js ${{ env.NODE_VERSION }}
@@ -392,7 +392,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@ac6db6d3c1f721f886538a378a2d73e85697340a # v6
         with:
           version: 10
       - name: Use Node.js ${{ env.NODE_VERSION }}
@@ -511,7 +511,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@ac6db6d3c1f721f886538a378a2d73e85697340a # v6
         with:
           version: 10
       - name: Use Node.js 24.x
@@ -548,7 +548,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@ac6db6d3c1f721f886538a378a2d73e85697340a # v6
         with:
           version: 10
       - name: Use Node.js 24.x
@@ -575,7 +575,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: latest
       - name: Install dependencies

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
       - name: Check links in Markdown files
-        uses: gaurav-nelson/github-action-markdown-link-check@v1
+        uses: gaurav-nelson/github-action-markdown-link-check@499c1e7f3637c131334fa8e937c45144f79d72d2 # v1
         with:
           # Do not check the `vendor/` directory.
           folder-path: .github,js,openapi,python

--- a/.github/workflows/py-baseline.yml
+++ b/.github/workflows/py-baseline.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v6
       - run: SHA=$(git rev-parse HEAD) && echo "SHA=$SHA" >> $GITHUB_ENV
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
         with:
           python-version: 3.11
           enable-cache: true

--- a/.github/workflows/py-bench.yml
+++ b/.github/workflows/py-bench.yml
@@ -18,12 +18,12 @@ jobs:
       - uses: actions/checkout@v6
       - id: files
         name: Get changed files
-        uses: Ana06/get-changed-files@v2.3.0
+        uses: Ana06/get-changed-files@25f79e676e7ea1868813e21465014798211fad8c # v2.3.0
         with:
           format: json
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
         with:
           python-version: 3.11
           enable-cache: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,9 @@ on:
         default: false
         description: "Release from a non-main branch (danger!)"
 
+permissions:
+  contents: read
+
 jobs:
   if_release:
     # Disallow publishing from branches that aren't `main`.
@@ -46,14 +49,14 @@ jobs:
           exit 1
       # Python Build
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
         with:
           python-version: "3.11"
           enable-cache: true
       - name: Build project for distribution
         run: cd python && uv build
       - name: Create Release
-        uses: ncipollo/release-action@v1
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1
         with:
           artifacts: |
             - "python/dist/*"
@@ -64,6 +67,6 @@ jobs:
           tag: v${{ steps.version-check.outputs.version }}
           commit: ${{ github.sha }}
       - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         with:
           packages-dir: "python/dist"

--- a/.github/workflows/release_js.yml
+++ b/.github/workflows/release_js.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v6
       # JS Build
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@ac6db6d3c1f721f886538a378a2d73e85697340a # v6
         with:
           version: 10
       - name: Use Node.js 24.x


### PR DESCRIPTION
Hardens GitHub Actions workflows against the org posture checks.

- Adds a top-level `permissions: contents: read` block to `release.yml`, which previously declared permissions only at the job level (so the workflow default was the broad repo/org token).
- SHA-pins every third-party action to a full commit SHA (with the original tag kept as a trailing comment) across `ci.yml`, `release.yml`, `release_js.yml`, `link-check.yml`, `py-bench.yml`, and `py-baseline.yml`. First-party `actions/*` and `github/*` references are left on tags. This prevents supply-chain attacks via tag hijacking.

Pinned actions: `dorny/paths-filter`, `astral-sh/setup-uv`, `pnpm/action-setup`, `oven-sh/setup-bun`, `ncipollo/release-action`, `pypa/gh-action-pypi-publish`, `gaurav-nelson/github-action-markdown-link-check`, `Ana06/get-changed-files`.

Note: this PR does not address the separate `pull_request` + secrets finding in `ci.yml` (integration tests using real API keys), which needs a design decision on the two-workflow split.