### PR TITLE
feat(python): expose pairwise comparison URL on ComparativeExperimentResults [LSE-2270]

### DIFF
--- a/python/langsmith/evaluation/_runner.py
+++ b/python/langsmith/evaluation/_runner.py
@@ -1010,13 +1010,14 @@ def evaluate_comparative(
 class ComparativeExperimentResults:
     """Represents the results of an evaluate_comparative() call.
 
-    This class provides an iterator interface to iterate over the experiment results
-    as they become available. It also provides methods to access the experiment name,
-    the number of results, and to wait for the results to be processed.
+    This class provides an iterator interface to iterate over the comparison results,
+    indexed access by example ID, and properties to access the pairwise comparison
+    URL and the underlying comparative experiment.
 
-    Methods:
-        experiment_name() -> str: Returns the name of the experiment.
-        wait() -> None: Waits for the experiment data to be processed.
+    Attributes:
+        url (Optional[str]): URL of the pairwise comparison view in the LangSmith UI.
+        comparative_experiment (Optional[schemas.ComparativeExperiment]): The
+        comparative experiment, exposing its id, dataset, and metadata.
     """
 
     def __init__(

--- a/python/langsmith/evaluation/_runner.py
+++ b/python/langsmith/evaluation/_runner.py
@@ -892,13 +892,12 @@ def evaluate_comparative(
         metadata=metadata,
         id=comparative_experiment_id,
     )
-    _print_comparative_experiment_start(
-        cast(
-            tuple[schemas.TracerSessionResult, schemas.TracerSessionResult],
-            tuple(projects),
-        ),
-        comparative_experiment,
+    experiments_tuple = cast(
+        tuple[schemas.TracerSessionResult, schemas.TracerSessionResult],
+        tuple(projects),
     )
+    comparison_url = _build_comparative_url(experiments_tuple, comparative_experiment)
+    _print_comparative_experiment_start(comparison_url)
     runs = [
         _load_traces(experiment, client, load_nested=load_nested)
         for experiment in experiments
@@ -1000,7 +999,12 @@ def evaluate_comparative(
                 example_id, result = future.result()
                 results[example_id][f"feedback.{result.key}"] = result
 
-    return ComparativeExperimentResults(results, data)
+    return ComparativeExperimentResults(
+        results,
+        data,
+        comparative_experiment=comparative_experiment,
+        url=comparison_url,
+    )
 
 
 class ComparativeExperimentResults:
@@ -1019,9 +1023,23 @@ class ComparativeExperimentResults:
         self,
         results: dict,
         examples: Optional[dict[uuid.UUID, schemas.Example]] = None,
+        comparative_experiment: Optional[schemas.ComparativeExperiment] = None,
+        url: Optional[str] = None,
     ):
         self._results = results
         self._examples = examples
+        self._comparative_experiment = comparative_experiment
+        self._url = url
+
+    @property
+    def comparative_experiment(self) -> Optional[schemas.ComparativeExperiment]:
+        """The comparative experiment, exposing its id, dataset, and metadata."""
+        return self._comparative_experiment
+
+    @property
+    def url(self) -> Optional[str]:
+        """URL of the pairwise comparison view in the LangSmith UI."""
+        return self._url
 
     def __getitem__(self, key):
         """Return the result associated with the given key."""
@@ -1038,20 +1056,27 @@ class ComparativeExperimentResults:
 ## Private API
 
 
-def _print_comparative_experiment_start(
+def _build_comparative_url(
     experiments: tuple[schemas.TracerSession, schemas.TracerSession],
     comparative_experiment: schemas.ComparativeExperiment,
-) -> None:
+) -> Optional[str]:
     url = experiments[0].url or experiments[1].url
-    if url:
-        project_url = url.split("?")[0]
-        dataset_id = comparative_experiment.reference_dataset_id
-        base_url = project_url.split("/projects/p/")[0]
-        comparison_url = (
-            f"{base_url}/datasets/{dataset_id}/compare?"
-            f"selectedSessions={'%2C'.join([str(e.id) for e in experiments])}"
-            f"&comparativeExperiment={comparative_experiment.id}"
-        )
+    if not url:
+        return None
+    project_url = url.split("?")[0]
+    dataset_id = comparative_experiment.reference_dataset_id
+    base_url = project_url.split("/projects/p/")[0]
+    return (
+        f"{base_url}/datasets/{dataset_id}/compare?"
+        f"selectedSessions={'%2C'.join([str(e.id) for e in experiments])}"
+        f"&comparativeExperiment={comparative_experiment.id}"
+    )
+
+
+def _print_comparative_experiment_start(
+    comparison_url: Optional[str],
+) -> None:
+    if comparison_url:
         print(  # noqa: T201
             f"View the pairwise evaluation results at:\n{comparison_url}\n\n"
         )

--- a/python/tests/unit_tests/evaluation/test_runner.py
+++ b/python/tests/unit_tests/evaluation/test_runner.py
@@ -20,7 +20,11 @@ from langchain_core.runnables import chain as as_runnable
 
 from langsmith import Client, aevaluate, evaluate
 from langsmith import schemas as ls_schemas
-from langsmith.evaluation._runner import _get_target_args
+from langsmith.evaluation._runner import (
+    ComparativeExperimentResults,
+    _build_comparative_url,
+    _get_target_args,
+)
 from langsmith.evaluation.evaluator import (
     _normalize_comparison_evaluator_func,
     _normalize_evaluator_func,
@@ -1299,3 +1303,72 @@ async def test_invalid_aevaluate_args() -> None:
 
     with pytest.raises(ValueError, match="Received unsupported arguments"):
         await aevaluate((lambda x: x), data="data", load_nested=True)
+
+
+def _make_session(host_url, tenant_id, dataset_id, name):
+    return ls_schemas.TracerSessionResult(
+        _host_url=host_url,
+        id=uuid.uuid4(),
+        name=name,
+        tenant_id=tenant_id,
+        reference_dataset_id=dataset_id,
+        start_time=datetime.now(timezone.utc),
+    )
+
+
+def _make_comparative_experiment(tenant_id, dataset_id):
+    return ls_schemas.ComparativeExperiment(
+        id=uuid.uuid4(),
+        name="a vs. b",
+        tenant_id=tenant_id,
+        reference_dataset_id=dataset_id,
+        created_at=datetime.now(timezone.utc),
+        modified_at=datetime.now(timezone.utc),
+    )
+
+
+def test_build_comparative_url() -> None:
+    tenant_id = uuid.uuid4()
+    dataset_id = uuid.uuid4()
+    host = "https://smith.langchain.com"
+    exp_a = _make_session(host, tenant_id, dataset_id, "a")
+    exp_b = _make_session(host, tenant_id, dataset_id, "b")
+    comparative_experiment = _make_comparative_experiment(tenant_id, dataset_id)
+
+    url = _build_comparative_url((exp_a, exp_b), comparative_experiment)
+
+    assert url is not None
+    assert url.startswith(f"{host}/o/{tenant_id}/datasets/{dataset_id}/compare?")
+    assert f"selectedSessions={exp_a.id}%2C{exp_b.id}" in url
+    assert f"comparativeExperiment={comparative_experiment.id}" in url
+
+
+def test_build_comparative_url_no_host_returns_none() -> None:
+    tenant_id = uuid.uuid4()
+    dataset_id = uuid.uuid4()
+    # Sessions without a host URL cannot produce a comparison link.
+    exp_a = _make_session(None, tenant_id, dataset_id, "a")
+    exp_b = _make_session(None, tenant_id, dataset_id, "b")
+    comparative_experiment = _make_comparative_experiment(tenant_id, dataset_id)
+
+    assert _build_comparative_url((exp_a, exp_b), comparative_experiment) is None
+
+
+def test_comparative_experiment_results_exposes_url_and_experiment() -> None:
+    tenant_id = uuid.uuid4()
+    dataset_id = uuid.uuid4()
+    comparative_experiment = _make_comparative_experiment(tenant_id, dataset_id)
+
+    results = ComparativeExperimentResults(
+        results={},
+        examples={},
+        comparative_experiment=comparative_experiment,
+        url="https://smith.langchain.com/compare",
+    )
+    assert results.url == "https://smith.langchain.com/compare"
+    assert results.comparative_experiment is comparative_experiment
+
+    # Existing callers that omit the new args still work, defaulting to None.
+    legacy = ComparativeExperimentResults(results={}, examples={})
+    assert legacy.url is None
+    assert legacy.comparative_experiment is None


### PR DESCRIPTION
  ## Summary
  - Expose the pairwise comparison URL on `ComparativeExperimentResults` via new `.url` and
  `.comparative_experiment` properties, so non-interactive callers (CI, remote boxes) can
  capture it programmatically instead of scraping the stdout line.
  - Factor the URL construction out of `_print_comparative_experiment_start()` into a
  `_build_comparative_url(experiments, comparative_experiment)` helper; `evaluate_comparative()`
  builds the URL once and passes it to both the printer and the result object - no duplicated
  logic.
  - Purely additive: the printed `View the pairwise evaluation results at:` output is unchanged,
  and the two new `ComparativeExperimentResults` constructor args default to `None`, so
  existing callers are unaffected.

  ## Release Note
  `evaluate_comparative()` now returns the pairwise comparison URL and underlying comparative
  experiment on the result object (`results.url`, `results.comparative_experiment`).

  ## Test Plan
  - [x] `env -u LANGCHAIN_PROJECT -u LANGCHAIN_API_KEY -u LANGCHAIN_TRACING_V2 -u
  LANGSMITH_TRACING uv run python -m pytest --disable-socket --allow-unix-socket -n auto
  tests/unit_tests/evaluation/test_runner.py`: 81 passed (includes 3 new tests:
  `test_build_comparative_url`, `test_build_comparative_url_no_host_returns_none`,
  `test_comparative_experiment_results_exposes_url_and_experiment`)
  - [x] `uv run ruff check langsmith/evaluation/_runner.py
  tests/unit_tests/evaluation/test_runner.py`
  - [x] `uv run ruff format --check langsmith/evaluation/_runner.py
  tests/unit_tests/evaluation/test_runner.py`
  - [x] `uv run mypy langsmith/evaluation/_runner.py`
  - [x] Prod Python e2e: created dataset, ran `evaluate()` on two predictors, then
  `evaluate_comparative()`. Confirmed `results.url` resolves to the live compare view
  (comparative experiment `c9218d6a-2dde-44b6-99e0-09730b50f5a7`, dataset
  `d1bb2d43-4fac-41a0-b899-bb092de4b3ef`) and `results.comparative_experiment` exposes the
  matching IDs.

  ## Notes
  - Python SDK only. The JS SDK has an analogous `evaluateComparative`; JS parity could be a
  follow-up if desired.