### PR TITLE
feat(sandbox): allow sizing the dockerfile-build sandbox via vcpus/mem_bytes

### DIFF
--- a/js/src/sandbox/client.ts
+++ b/js/src/sandbox/client.ts
@@ -914,7 +914,8 @@ export class SandboxClient {
    * @param name - Snapshot name.
    * @param dockerfile - Local Dockerfile path, relative to context by default.
    * @param fsCapacityBytes - Filesystem capacity in bytes.
-   * @param options - Build context, args, target, build log callback, timeout.
+   * @param options - Build context, args, target, build log callback, builder
+   *   vCPUs/memory, timeout.
    * @returns Snapshot in "ready" status.
    */
   async createSnapshotFromDockerfile(
@@ -928,6 +929,8 @@ export class SandboxClient {
       buildArgs,
       target,
       onBuildLog,
+      vCpus,
+      memBytes,
       timeout = 60,
     } = options;
     const { contextPath, dockerfileRel } = await resolveDockerfileContext(
@@ -953,6 +956,8 @@ export class SandboxClient {
     const builder = await this.createSandbox({
       name: builderName,
       timeout,
+      vCpus,
+      memBytes,
       fsCapacityBytes,
     });
     try {

--- a/js/src/sandbox/types.ts
+++ b/js/src/sandbox/types.ts
@@ -359,6 +359,15 @@ export interface CreateDockerfileSnapshotOptions {
   target?: string;
   /** Callback for Docker build stdout/stderr chunks. */
   onBuildLog?: (data: string) => void;
+  /**
+   * Number of vCPUs for the temporary builder sandbox. The build runs
+   * BuildKit plus the native snapshotter's layer copies inside it, which
+   * contend for a single core by default, so an extra vCPU can cut a cold
+   * build's wall time substantially.
+   */
+  vCpus?: number;
+  /** Memory in bytes for the temporary builder sandbox. */
+  memBytes?: number;
   /** Timeout in seconds for builder sandbox operations. Default: 60. */
   timeout?: number;
 }

--- a/js/src/tests/sandbox.test.ts
+++ b/js/src/tests/sandbox.test.ts
@@ -1402,6 +1402,50 @@ describe("SandboxClient - snapshot operations", () => {
     }
   });
 
+  it("createSnapshotFromDockerfile should forward vCpus/memBytes to the builder", async () => {
+    const context = await mkdtemp(join(tmpdir(), "langsmith-docker-context-"));
+    const client = createClientWithMock(jest.fn<typeof fetch>());
+    const fakeSandbox = {
+      name: "builder",
+      write: jest
+        .fn<(path: string, content: string | Uint8Array) => Promise<void>>()
+        .mockResolvedValue(undefined),
+      run: jest
+        .fn<
+          (
+            command: string,
+          ) => Promise<{ stdout: string; stderr: string; exit_code: number }>
+        >()
+        .mockResolvedValue({ stdout: "", stderr: "", exit_code: 0 }),
+      delete: jest.fn<() => Promise<void>>().mockResolvedValue(undefined),
+    };
+    const createSandboxSpy = jest
+      .spyOn(client, "createSandbox")
+      .mockResolvedValue(fakeSandbox as any);
+    jest.spyOn(client, "captureSnapshot").mockResolvedValue({
+      id: "snap-1",
+      name: "snap",
+      status: "ready",
+      fs_capacity_bytes: 4294967296,
+    });
+
+    try {
+      await writeFile(join(context, "Dockerfile"), "FROM scratch\n");
+
+      await client.createSnapshotFromDockerfile("snap", "Dockerfile", 4294967296, {
+        context,
+        vCpus: 2,
+        memBytes: 8589934592,
+      });
+
+      expect(createSandboxSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ vCpus: 2, memBytes: 8589934592 }),
+      );
+    } finally {
+      await rm(context, { recursive: true, force: true });
+    }
+  });
+
   it("captureSnapshot should POST to /boxes/{name}/snapshot", async () => {
     const mockFetch = jest
       .fn<typeof fetch>()

--- a/python/langsmith/sandbox/_async_client.py
+++ b/python/langsmith/sandbox/_async_client.py
@@ -802,10 +802,18 @@ class AsyncSandboxClient:
         build_args: Optional[Mapping[str, str]] = None,
         target: Optional[str] = None,
         on_build_log: Optional[Callable[[str], Any]] = None,
+        vcpus: Optional[int] = None,
+        mem_bytes: Optional[int] = None,
         timeout: int = 60,
         headers: RequestHeaders = None,
     ) -> Snapshot:
-        """Build a snapshot from a local Dockerfile context."""
+        """Build a snapshot from a local Dockerfile context.
+
+        ``vcpus`` and ``mem_bytes`` size the temporary builder sandbox. The
+        build runs BuildKit plus the native snapshotter's layer copies inside
+        it, which contend for a single core by default, so giving the builder
+        an extra vCPU can cut a cold build's wall time substantially.
+        """
         context_path, dockerfile_rel = _resolve_dockerfile_context(dockerfile, context)
 
         builder_name = f"snapshot-builder-{uuid.uuid4().hex[:12]}"
@@ -824,6 +832,8 @@ class AsyncSandboxClient:
         async with await self.sandbox(
             name=builder_name,
             timeout=timeout,
+            vcpus=vcpus,
+            mem_bytes=mem_bytes,
             fs_capacity_bytes=fs_capacity_bytes,
             headers=headers,
         ) as sandbox:

--- a/python/langsmith/sandbox/_client.py
+++ b/python/langsmith/sandbox/_client.py
@@ -877,10 +877,18 @@ class SandboxClient:
         build_args: Optional[Mapping[str, str]] = None,
         target: Optional[str] = None,
         on_build_log: Optional[Callable[[str], Any]] = None,
+        vcpus: Optional[int] = None,
+        mem_bytes: Optional[int] = None,
         timeout: int = 60,
         headers: RequestHeaders = None,
     ) -> Snapshot:
-        """Build a snapshot from a local Dockerfile context."""
+        """Build a snapshot from a local Dockerfile context.
+
+        ``vcpus`` and ``mem_bytes`` size the temporary builder sandbox. The
+        build runs BuildKit plus the native snapshotter's layer copies inside
+        it, which contend for a single core by default, so giving the builder
+        an extra vCPU can cut a cold build's wall time substantially.
+        """
         context_path, dockerfile_rel = _resolve_dockerfile_context(dockerfile, context)
 
         builder_name = f"snapshot-builder-{uuid.uuid4().hex[:12]}"
@@ -899,6 +907,8 @@ class SandboxClient:
         with self.sandbox(
             name=builder_name,
             timeout=timeout,
+            vcpus=vcpus,
+            mem_bytes=mem_bytes,
             fs_capacity_bytes=fs_capacity_bytes,
             headers=headers,
         ) as sandbox:

--- a/python/tests/unit_tests/sandbox/test_async_client.py
+++ b/python/tests/unit_tests/sandbox/test_async_client.py
@@ -899,6 +899,60 @@ class TestAsyncSandboxOperations:
         assert kwargs["docker_image"].startswith("langsmith-snapshot-build:")
         assert kwargs["fs_capacity_bytes"] == 4294967296
 
+    async def test_create_snapshot_from_dockerfile_forwards_builder_size(
+        self, client: AsyncSandboxClient, tmp_path
+    ):
+        """vcpus/mem_bytes are forwarded to the builder sandbox."""
+        (tmp_path / "Dockerfile").write_text("FROM scratch\n")
+
+        class FakeAsyncSandbox:
+            name = "builder"
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return None
+
+            async def write(self, path, content, **kwargs):
+                pass
+
+            async def run(self, command, **kwargs):
+                return ExecutionResult(stdout="", stderr="", exit_code=0)
+
+        with (
+            patch.object(
+                client, "sandbox", AsyncMock(return_value=FakeAsyncSandbox())
+            ) as sandbox_mock,
+            patch.object(
+                client,
+                "capture_snapshot",
+                AsyncMock(
+                    return_value=Snapshot(
+                        id="snap-1",
+                        name="snap",
+                        status="ready",
+                        fs_capacity_bytes=4294967296,
+                    )
+                ),
+            ),
+            patch(
+                "langsmith.sandbox._async_client._make_docker_context_tar",
+                return_value=b"tar",
+            ),
+        ):
+            await client.create_snapshot_from_dockerfile(
+                "snap",
+                "Dockerfile",
+                4294967296,
+                context=tmp_path,
+                vcpus=2,
+                mem_bytes=8589934592,
+            )
+
+        assert sandbox_mock.call_args.kwargs["vcpus"] == 2
+        assert sandbox_mock.call_args.kwargs["mem_bytes"] == 8589934592
+
 
 class TestAsyncConnectionErrors:
     """Tests for async connection error handling."""

--- a/python/tests/unit_tests/sandbox/test_client.py
+++ b/python/tests/unit_tests/sandbox/test_client.py
@@ -1064,6 +1064,58 @@ class TestSnapshotOperations:
         assert kwargs["docker_image"].startswith("langsmith-snapshot-build:")
         assert kwargs["fs_capacity_bytes"] == 4294967296
 
+    def test_create_snapshot_from_dockerfile_forwards_builder_size(
+        self, client: SandboxClient, tmp_path
+    ):
+        """vcpus/mem_bytes are forwarded to the builder sandbox."""
+        (tmp_path / "Dockerfile").write_text("FROM scratch\n")
+
+        class FakeSandbox:
+            name = "builder"
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return None
+
+            def write(self, path, content, **kwargs):
+                pass
+
+            def run(self, command, **kwargs):
+                return ExecutionResult(stdout="", stderr="", exit_code=0)
+
+        with (
+            patch.object(
+                client, "sandbox", return_value=FakeSandbox()
+            ) as sandbox_mock,
+            patch.object(
+                client,
+                "capture_snapshot",
+                return_value=Snapshot(
+                    id="snap-1",
+                    name="snap",
+                    status="ready",
+                    fs_capacity_bytes=4294967296,
+                ),
+            ),
+            patch(
+                "langsmith.sandbox._client._make_docker_context_tar",
+                return_value=b"tar",
+            ),
+        ):
+            client.create_snapshot_from_dockerfile(
+                "snap",
+                "Dockerfile",
+                4294967296,
+                context=tmp_path,
+                vcpus=2,
+                mem_bytes=8589934592,
+            )
+
+        assert sandbox_mock.call_args.kwargs["vcpus"] == 2
+        assert sandbox_mock.call_args.kwargs["mem_bytes"] == 8589934592
+
     def test_capture_snapshot_not_found(
         self, client: SandboxClient, httpx_mock: HTTPXMock
     ):


### PR DESCRIPTION
## What

`create_snapshot_from_dockerfile` builds the image inside a temporary builder sandbox that runs BuildKit plus the native snapshotter's layer copies. The builder is created with the default **1 vCPU**, and there was no way to size it.

This adds `vcpus`/`mem_bytes` (Python) and `vCpus`/`memBytes` (JS) to `create_snapshot_from_dockerfile`, forwarded to the builder sandbox. Defaults are unchanged (`None`), so existing callers are unaffected.

## Why

On a single vCPU, BuildKit, the native snapshotter's layer copies, and each `curl | sh` install step contend for one core, so the downloads stall for minutes with the CPU otherwise idle. Measured on a multi-language toolchain image (Go + Node + Python + uv + pnpm):

| Step | 1 vCPU | 2 vCPU |
|------|-------:|-------:|
| `uv` install | 170s | 14s |
| `npm i -g pnpm` | 281s | 15s |
| langsmith CLI install | 277s | 13s |
| **total build** | **~13 min** | **~3 min** |

Memory is left at the default unless `mem_bytes` is passed — over-requesting RAM can make the builder unschedulable.

## Changes

- Python sync (`_client.py`) and async (`_async_client.py`): new keyword-only `vcpus`/`mem_bytes`, forwarded to the internal `sandbox(...)` call.
- JS (`client.ts` + `types.ts`): new `vCpus`/`memBytes` on `CreateDockerfileSnapshotOptions`, forwarded to `createSandbox(...)`.

## Test plan

- [x] `pytest tests/unit_tests/sandbox/` — added sync + async tests asserting `vcpus`/`mem_bytes` are forwarded to the builder; existing orchestration tests pass.
- [x] `jest src/tests/sandbox.test.ts` — added a test asserting `vCpus`/`memBytes` reach `createSandbox`; existing test passes.
- [x] ruff + oxlint clean on changed files; tsc clean for `src/sandbox`.
- [x] End-to-end: built a real snapshot at `vcpus=2` against dev and prod sandbox APIs (~3 min vs ~13 min on 1 vCPU).

🤖 Generated with [Claude Code](https://claude.com/claude-code)