### PR TITLE
feat(sandbox): size the dockerfile-build sandbox via vcpus/mem_bytes (python)

### DIFF
--- a/python/langsmith/__init__.py
+++ b/python/langsmith/__init__.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
 
 # Avoid calling into importlib on every call to __version__
 
-__version__ = "0.8.8"
+__version__ = "0.8.9"
 version = __version__  # for backwards compatibility
 
 

--- a/python/langsmith/sandbox/_async_client.py
+++ b/python/langsmith/sandbox/_async_client.py
@@ -802,10 +802,18 @@ class AsyncSandboxClient:
         build_args: Optional[Mapping[str, str]] = None,
         target: Optional[str] = None,
         on_build_log: Optional[Callable[[str], Any]] = None,
+        vcpus: Optional[int] = None,
+        mem_bytes: Optional[int] = None,
         timeout: int = 60,
         headers: RequestHeaders = None,
     ) -> Snapshot:
-        """Build a snapshot from a local Dockerfile context."""
+        """Build a snapshot from a local Dockerfile context.
+
+        ``vcpus`` and ``mem_bytes`` size the temporary builder sandbox. The
+        build runs BuildKit plus the native snapshotter's layer copies inside
+        it, which contend for a single core by default, so giving the builder
+        an extra vCPU can cut a cold build's wall time substantially.
+        """
         context_path, dockerfile_rel = _resolve_dockerfile_context(dockerfile, context)
 
         builder_name = f"snapshot-builder-{uuid.uuid4().hex[:12]}"
@@ -824,6 +832,8 @@ class AsyncSandboxClient:
         async with await self.sandbox(
             name=builder_name,
             timeout=timeout,
+            vcpus=vcpus,
+            mem_bytes=mem_bytes,
             fs_capacity_bytes=fs_capacity_bytes,
             headers=headers,
         ) as sandbox:

--- a/python/langsmith/sandbox/_client.py
+++ b/python/langsmith/sandbox/_client.py
@@ -877,10 +877,18 @@ class SandboxClient:
         build_args: Optional[Mapping[str, str]] = None,
         target: Optional[str] = None,
         on_build_log: Optional[Callable[[str], Any]] = None,
+        vcpus: Optional[int] = None,
+        mem_bytes: Optional[int] = None,
         timeout: int = 60,
         headers: RequestHeaders = None,
     ) -> Snapshot:
-        """Build a snapshot from a local Dockerfile context."""
+        """Build a snapshot from a local Dockerfile context.
+
+        ``vcpus`` and ``mem_bytes`` size the temporary builder sandbox. The
+        build runs BuildKit plus the native snapshotter's layer copies inside
+        it, which contend for a single core by default, so giving the builder
+        an extra vCPU can cut a cold build's wall time substantially.
+        """
         context_path, dockerfile_rel = _resolve_dockerfile_context(dockerfile, context)
 
         builder_name = f"snapshot-builder-{uuid.uuid4().hex[:12]}"
@@ -899,6 +907,8 @@ class SandboxClient:
         with self.sandbox(
             name=builder_name,
             timeout=timeout,
+            vcpus=vcpus,
+            mem_bytes=mem_bytes,
             fs_capacity_bytes=fs_capacity_bytes,
             headers=headers,
         ) as sandbox:

--- a/python/tests/unit_tests/sandbox/test_async_client.py
+++ b/python/tests/unit_tests/sandbox/test_async_client.py
@@ -899,6 +899,60 @@ class TestAsyncSandboxOperations:
         assert kwargs["docker_image"].startswith("langsmith-snapshot-build:")
         assert kwargs["fs_capacity_bytes"] == 4294967296
 
+    async def test_create_snapshot_from_dockerfile_forwards_builder_size(
+        self, client: AsyncSandboxClient, tmp_path
+    ):
+        """vcpus/mem_bytes are forwarded to the builder sandbox."""
+        (tmp_path / "Dockerfile").write_text("FROM scratch\n")
+
+        class FakeAsyncSandbox:
+            name = "builder"
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return None
+
+            async def write(self, path, content, **kwargs):
+                pass
+
+            async def run(self, command, **kwargs):
+                return ExecutionResult(stdout="", stderr="", exit_code=0)
+
+        with (
+            patch.object(
+                client, "sandbox", AsyncMock(return_value=FakeAsyncSandbox())
+            ) as sandbox_mock,
+            patch.object(
+                client,
+                "capture_snapshot",
+                AsyncMock(
+                    return_value=Snapshot(
+                        id="snap-1",
+                        name="snap",
+                        status="ready",
+                        fs_capacity_bytes=4294967296,
+                    )
+                ),
+            ),
+            patch(
+                "langsmith.sandbox._async_client._make_docker_context_tar",
+                return_value=b"tar",
+            ),
+        ):
+            await client.create_snapshot_from_dockerfile(
+                "snap",
+                "Dockerfile",
+                4294967296,
+                context=tmp_path,
+                vcpus=2,
+                mem_bytes=8589934592,
+            )
+
+        assert sandbox_mock.call_args.kwargs["vcpus"] == 2
+        assert sandbox_mock.call_args.kwargs["mem_bytes"] == 8589934592
+
 
 class TestAsyncConnectionErrors:
     """Tests for async connection error handling."""

--- a/python/tests/unit_tests/sandbox/test_client.py
+++ b/python/tests/unit_tests/sandbox/test_client.py
@@ -1064,6 +1064,58 @@ class TestSnapshotOperations:
         assert kwargs["docker_image"].startswith("langsmith-snapshot-build:")
         assert kwargs["fs_capacity_bytes"] == 4294967296
 
+    def test_create_snapshot_from_dockerfile_forwards_builder_size(
+        self, client: SandboxClient, tmp_path
+    ):
+        """vcpus/mem_bytes are forwarded to the builder sandbox."""
+        (tmp_path / "Dockerfile").write_text("FROM scratch\n")
+
+        class FakeSandbox:
+            name = "builder"
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return None
+
+            def write(self, path, content, **kwargs):
+                pass
+
+            def run(self, command, **kwargs):
+                return ExecutionResult(stdout="", stderr="", exit_code=0)
+
+        with (
+            patch.object(
+                client, "sandbox", return_value=FakeSandbox()
+            ) as sandbox_mock,
+            patch.object(
+                client,
+                "capture_snapshot",
+                return_value=Snapshot(
+                    id="snap-1",
+                    name="snap",
+                    status="ready",
+                    fs_capacity_bytes=4294967296,
+                ),
+            ),
+            patch(
+                "langsmith.sandbox._client._make_docker_context_tar",
+                return_value=b"tar",
+            ),
+        ):
+            client.create_snapshot_from_dockerfile(
+                "snap",
+                "Dockerfile",
+                4294967296,
+                context=tmp_path,
+                vcpus=2,
+                mem_bytes=8589934592,
+            )
+
+        assert sandbox_mock.call_args.kwargs["vcpus"] == 2
+        assert sandbox_mock.call_args.kwargs["mem_bytes"] == 8589934592
+
     def test_capture_snapshot_not_found(
         self, client: SandboxClient, httpx_mock: HTTPXMock
     ):

--- a/python/tests/unit_tests/sandbox/test_client.py
+++ b/python/tests/unit_tests/sandbox/test_client.py
@@ -1086,9 +1086,7 @@ class TestSnapshotOperations:
                 return ExecutionResult(stdout="", stderr="", exit_code=0)
 
         with (
-            patch.object(
-                client, "sandbox", return_value=FakeSandbox()
-            ) as sandbox_mock,
+            patch.object(client, "sandbox", return_value=FakeSandbox()) as sandbox_mock,
             patch.object(
                 client,
                 "capture_snapshot",


### PR DESCRIPTION
## What

`create_snapshot_from_dockerfile` builds the image inside a temporary builder sandbox created with the default **1 vCPU**, with no way to size it. This adds keyword-only `vcpus`/`mem_bytes` to the sync and async clients, forwarded to the internal `sandbox(...)` call. Defaults are unchanged (`None`), so existing callers are unaffected.

Bumps `langsmith` to **0.8.9**.

## Why

On a single vCPU, BuildKit, the native snapshotter's layer copies, and each `curl | sh` install step contend for one core, so downloads stall for minutes with the CPU otherwise idle. Measured on a multi-language toolchain image (Go + Node + Python + uv + pnpm):

| Step | 1 vCPU | 2 vCPU |
|------|-------:|-------:|
| `uv` install | 170s | 14s |
| `npm i -g pnpm` | 281s | 15s |
| langsmith CLI install | 277s | 13s |
| **total build** | **~13 min** | **~3 min** |

Memory is left at the default unless `mem_bytes` is passed — over-requesting RAM can make the builder unschedulable.

## Test plan

- [x] `pytest tests/unit_tests/sandbox/` — added sync + async tests asserting `vcpus`/`mem_bytes` reach the builder; existing orchestration tests pass.
- [x] ruff clean on changed files.
- [x] End-to-end: built a real snapshot at `vcpus=2` against dev and prod sandbox APIs (~3 min vs ~13 min on 1 vCPU).

Split from #2978; JS counterpart in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)