### PR TITLE
feat(sandbox): size the dockerfile-build sandbox via vCpus/memBytes (js)

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langsmith",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "Client library to connect to the LangSmith Observability and Evaluation Platform.",
   "packageManager": "pnpm@10.33.0",
   "files": [

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -32,4 +32,4 @@ export {
 } from "./utils/prompt_cache/index.js";
 
 // Update using pnpm bump-version
-export const __version__ = "0.7.3";
+export const __version__ = "0.7.4";

--- a/js/src/sandbox/client.ts
+++ b/js/src/sandbox/client.ts
@@ -914,7 +914,8 @@ export class SandboxClient {
    * @param name - Snapshot name.
    * @param dockerfile - Local Dockerfile path, relative to context by default.
    * @param fsCapacityBytes - Filesystem capacity in bytes.
-   * @param options - Build context, args, target, build log callback, timeout.
+   * @param options - Build context, args, target, build log callback, builder
+   *   vCPUs/memory, timeout.
    * @returns Snapshot in "ready" status.
    */
   async createSnapshotFromDockerfile(
@@ -928,6 +929,8 @@ export class SandboxClient {
       buildArgs,
       target,
       onBuildLog,
+      vCpus,
+      memBytes,
       timeout = 60,
     } = options;
     const { contextPath, dockerfileRel } = await resolveDockerfileContext(
@@ -953,6 +956,8 @@ export class SandboxClient {
     const builder = await this.createSandbox({
       name: builderName,
       timeout,
+      vCpus,
+      memBytes,
       fsCapacityBytes,
     });
     try {

--- a/js/src/sandbox/types.ts
+++ b/js/src/sandbox/types.ts
@@ -359,6 +359,15 @@ export interface CreateDockerfileSnapshotOptions {
   target?: string;
   /** Callback for Docker build stdout/stderr chunks. */
   onBuildLog?: (data: string) => void;
+  /**
+   * Number of vCPUs for the temporary builder sandbox. The build runs
+   * BuildKit plus the native snapshotter's layer copies inside it, which
+   * contend for a single core by default, so an extra vCPU can cut a cold
+   * build's wall time substantially.
+   */
+  vCpus?: number;
+  /** Memory in bytes for the temporary builder sandbox. */
+  memBytes?: number;
   /** Timeout in seconds for builder sandbox operations. Default: 60. */
   timeout?: number;
 }

--- a/js/src/tests/sandbox.test.ts
+++ b/js/src/tests/sandbox.test.ts
@@ -1402,6 +1402,50 @@ describe("SandboxClient - snapshot operations", () => {
     }
   });
 
+  it("createSnapshotFromDockerfile should forward vCpus/memBytes to the builder", async () => {
+    const context = await mkdtemp(join(tmpdir(), "langsmith-docker-context-"));
+    const client = createClientWithMock(jest.fn<typeof fetch>());
+    const fakeSandbox = {
+      name: "builder",
+      write: jest
+        .fn<(path: string, content: string | Uint8Array) => Promise<void>>()
+        .mockResolvedValue(undefined),
+      run: jest
+        .fn<
+          (
+            command: string,
+          ) => Promise<{ stdout: string; stderr: string; exit_code: number }>
+        >()
+        .mockResolvedValue({ stdout: "", stderr: "", exit_code: 0 }),
+      delete: jest.fn<() => Promise<void>>().mockResolvedValue(undefined),
+    };
+    const createSandboxSpy = jest
+      .spyOn(client, "createSandbox")
+      .mockResolvedValue(fakeSandbox as any);
+    jest.spyOn(client, "captureSnapshot").mockResolvedValue({
+      id: "snap-1",
+      name: "snap",
+      status: "ready",
+      fs_capacity_bytes: 4294967296,
+    });
+
+    try {
+      await writeFile(join(context, "Dockerfile"), "FROM scratch\n");
+
+      await client.createSnapshotFromDockerfile("snap", "Dockerfile", 4294967296, {
+        context,
+        vCpus: 2,
+        memBytes: 8589934592,
+      });
+
+      expect(createSandboxSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ vCpus: 2, memBytes: 8589934592 }),
+      );
+    } finally {
+      await rm(context, { recursive: true, force: true });
+    }
+  });
+
   it("captureSnapshot should POST to /boxes/{name}/snapshot", async () => {
     const mockFetch = jest
       .fn<typeof fetch>()

--- a/js/src/tests/sandbox.test.ts
+++ b/js/src/tests/sandbox.test.ts
@@ -1432,11 +1432,16 @@ describe("SandboxClient - snapshot operations", () => {
     try {
       await writeFile(join(context, "Dockerfile"), "FROM scratch\n");
 
-      await client.createSnapshotFromDockerfile("snap", "Dockerfile", 4294967296, {
-        context,
-        vCpus: 2,
-        memBytes: 8589934592,
-      });
+      await client.createSnapshotFromDockerfile(
+        "snap",
+        "Dockerfile",
+        4294967296,
+        {
+          context,
+          vCpus: 2,
+          memBytes: 8589934592,
+        },
+      );
 
       expect(createSandboxSpy).toHaveBeenCalledWith(
         expect.objectContaining({ vCpus: 2, memBytes: 8589934592 }),


### PR DESCRIPTION
## What

`createSnapshotFromDockerfile` builds the image inside a temporary builder sandbox created with the default **1 vCPU**, with no way to size it. This adds `vCpus`/`memBytes` to `CreateDockerfileSnapshotOptions`, forwarded to `createSandbox(...)`. Defaults are unchanged, so existing callers are unaffected.

Bumps the js client to **0.7.4**.

## Why

On a single vCPU, BuildKit, the native snapshotter's layer copies, and each `curl | sh` install step contend for one core, so downloads stall for minutes with the CPU otherwise idle. On a multi-language toolchain image, a second vCPU cut a cold build from ~13min to ~3min (per-step: `uv` 170s→14s, `npm i -g pnpm` 281s→15s, langsmith CLI 277s→13s). Memory is left at the default unless `memBytes` is passed — over-requesting RAM can make the builder unschedulable.

## Test plan

- [x] `jest src/tests/sandbox.test.ts` — added a test asserting `vCpus`/`memBytes` reach `createSandbox`; existing orchestration test passes.
- [x] oxlint clean; tsc clean for `src/sandbox`.

Split from #2978; Python counterpart in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)