### PR TITLE
feat(python): expose LS_MESSAGE_VIEW_EXCLUDE constant [lso-2605]

### DIFF
--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -33,3 +33,6 @@ export {
 
 // Update using pnpm bump-version
 export const __version__ = "0.7.4";
+
+// Metadata key to hide a traced run from LangSmith's Messages View.
+export const LS_MESSAGE_VIEW_EXCLUDE = "ls_message_view_exclude" as const;

--- a/js/src/tests/traceable.test.ts
+++ b/js/src/tests/traceable.test.ts
@@ -12,7 +12,11 @@ import {
 } from "../traceable.js";
 import { getAssumedTreeFromCalls } from "./utils/tree.js";
 import { mockClient } from "./utils/mock_client.js";
-import { Client, overrideFetchImplementation } from "../index.js";
+import {
+  Client,
+  LS_MESSAGE_VIEW_EXCLUDE,
+  overrideFetchImplementation,
+} from "../index.js";
 import {
   AsyncLocalStorageProviderSingleton,
   getCurrentRunTree,
@@ -3360,4 +3364,53 @@ describe("tracingEnabled: false propagation to nested traceables", () => {
       false,
     );
   });
+});
+
+test("LS_MESSAGE_VIEW_EXCLUDE constant is exported with the correct value", () => {
+  expect(LS_MESSAGE_VIEW_EXCLUDE).toBe("ls_message_view_exclude");
+});
+
+test("LS_MESSAGE_VIEW_EXCLUDE metadata round-trips to run via traceable", async () => {
+  const { client, callSpy } = mockClient();
+  const classify = traceable(async (x: string): Promise<string> => x, {
+    client,
+    name: "classify",
+    metadata: { [LS_MESSAGE_VIEW_EXCLUDE]: true },
+    tracingEnabled: true,
+  });
+
+  await classify("hello");
+
+  expect(
+    await getAssumedTreeFromCalls(callSpy.mock.calls, client),
+  ).toMatchObject({
+    nodes: ["classify:0"],
+    edges: [],
+    data: {
+      "classify:0": {
+        extra: { metadata: { [LS_MESSAGE_VIEW_EXCLUDE]: true } },
+      },
+    },
+  });
+});
+
+test("LS_MESSAGE_VIEW_EXCLUDE metadata cascades from parent to child runs", async () => {
+  const { client, callSpy } = mockClient();
+  const child = traceable(async (): Promise<string> => "ok", { name: "child" });
+  const parent = traceable(async (): Promise<string> => child(), {
+    client,
+    name: "parent",
+    metadata: { [LS_MESSAGE_VIEW_EXCLUDE]: true },
+    tracingEnabled: true,
+  });
+
+  await parent();
+
+  const tree = await getAssumedTreeFromCalls(callSpy.mock.calls, client);
+  const runs = Object.values(tree.data);
+  expect(runs.length).toBeGreaterThanOrEqual(2);
+  for (const run of runs) {
+    const md = ((run.extra as any) ?? {}).metadata ?? {};
+    expect(md[LS_MESSAGE_VIEW_EXCLUDE]).toBe(true);
+  }
 });

--- a/python/langsmith/__init__.py
+++ b/python/langsmith/__init__.py
@@ -32,23 +32,8 @@ if TYPE_CHECKING:
 __version__ = "0.8.9"
 version = __version__  # for backwards compatibility
 
+# Metadata key to hide a traced run from LangSmith's Messages View.
 LS_MESSAGE_VIEW_EXCLUDE: Final = "ls_message_view_exclude"
-"""Metadata key that hides a traced run from LangSmith's Messages View.
-
-Set as a key on a `@traceable`'s `metadata` arg with a truthy value to
-prevent the run from appearing in Messages View. The run is still
-recorded in full — only the Messages View renderer hides it. Useful
-for tagging middleware-style runs (classifiers, guardrails, internal
-rewrites) so they don't appear in the chat-style rendering.
-
-Note: when set on a parent run, this metadata key cascades to all
-child runs via the tracing contextvar.
-
-Example:
-    @traceable(metadata={LS_MESSAGE_VIEW_EXCLUDE: True})
-    def classify_query(text: str) -> str:
-        ...
-"""
 
 
 def __getattr__(name: str) -> Any:

--- a/python/langsmith/__init__.py
+++ b/python/langsmith/__init__.py
@@ -1,6 +1,6 @@
 """LangSmith Client."""
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Final
 
 if TYPE_CHECKING:
     from langsmith._expect import expect
@@ -31,6 +31,24 @@ if TYPE_CHECKING:
 
 __version__ = "0.8.9"
 version = __version__  # for backwards compatibility
+
+LS_MESSAGE_VIEW_EXCLUDE: Final = "ls_message_view_exclude"
+"""Metadata key that hides a traced run from LangSmith's Messages View.
+
+Set as a key on a `@traceable`'s `metadata` arg with a truthy value to
+prevent the run from appearing in Messages View. The run is still
+recorded in full — only the Messages View renderer hides it. Useful
+for tagging middleware-style runs (classifiers, guardrails, internal
+rewrites) so they don't appear in the chat-style rendering.
+
+Note: when set on a parent run, this metadata key cascades to all
+child runs via the tracing contextvar.
+
+Example:
+    @traceable(metadata={LS_MESSAGE_VIEW_EXCLUDE: True})
+    def classify_query(text: str) -> str:
+        ...
+"""
 
 
 def __getattr__(name: str) -> Any:
@@ -200,4 +218,5 @@ __all__ = [
     "uuid7",
     "uuid7_from_datetime",
     "set_runtime_overrides",
+    "LS_MESSAGE_VIEW_EXCLUDE",
 ]

--- a/python/tests/unit_tests/test_run_helpers.py
+++ b/python/tests/unit_tests/test_run_helpers.py
@@ -2539,9 +2539,7 @@ def test_ls_message_view_exclude_metadata_round_trips_to_run() -> None:
 
     with tracing_context(enabled=True):
 
-        @traceable(
-            client=mock_client, metadata={LS_MESSAGE_VIEW_EXCLUDE: True}
-        )
+        @traceable(client=mock_client, metadata={LS_MESSAGE_VIEW_EXCLUDE: True})
         def classify(x: str) -> str:
             return x
 
@@ -2569,9 +2567,7 @@ def test_ls_message_view_exclude_metadata_cascades_to_child_runs() -> None:
         def child() -> str:
             return "ok"
 
-        @traceable(
-            client=mock_client, metadata={LS_MESSAGE_VIEW_EXCLUDE: True}
-        )
+        @traceable(client=mock_client, metadata={LS_MESSAGE_VIEW_EXCLUDE: True})
         def parent() -> str:
             return child()
 
@@ -2579,16 +2575,12 @@ def test_ls_message_view_exclude_metadata_cascades_to_child_runs() -> None:
 
     mock_calls = _get_calls(mock_client, minimum=2)
     payloads = [p for _, p in _get_data(mock_calls)]
-    assert len(payloads) >= 2, (
-        f"expected parent + child payloads, got {len(payloads)}"
-    )
+    assert len(payloads) >= 2, f"expected parent + child payloads, got {len(payloads)}"
 
     excluded = [
         p
         for p in payloads
-        if (p.get("extra") or {}).get("metadata", {}).get(
-            LS_MESSAGE_VIEW_EXCLUDE
-        )
+        if (p.get("extra") or {}).get("metadata", {}).get(LS_MESSAGE_VIEW_EXCLUDE)
         is True
     ]
     assert len(excluded) == len(payloads), (

--- a/python/tests/unit_tests/test_run_helpers.py
+++ b/python/tests/unit_tests/test_run_helpers.py
@@ -2518,3 +2518,80 @@ class TestTraceableExceptionsToHandle:
                 pytest.fail(
                     f"Expected error to be None for handled exception, got: {err}"
                 )
+
+
+def test_ls_message_view_exclude_constant_is_exposed() -> None:
+    """LS_MESSAGE_VIEW_EXCLUDE is importable from langsmith top-level,
+    has the canonical wire value, and is listed in __all__."""
+    from langsmith import LS_MESSAGE_VIEW_EXCLUDE
+
+    assert LS_MESSAGE_VIEW_EXCLUDE == "ls_message_view_exclude"
+    assert "LS_MESSAGE_VIEW_EXCLUDE" in langsmith.__all__
+
+
+def test_ls_message_view_exclude_metadata_round_trips_to_run() -> None:
+    """Using the constant as a metadata key in @traceable causes it to
+    land on the shipped run's extra.metadata at the canonical wire
+    key."""
+    from langsmith import LS_MESSAGE_VIEW_EXCLUDE
+
+    mock_client = _get_mock_client()
+
+    with tracing_context(enabled=True):
+
+        @traceable(
+            client=mock_client, metadata={LS_MESSAGE_VIEW_EXCLUDE: True}
+        )
+        def classify(x: str) -> str:
+            return x
+
+        classify("hello")
+
+    mock_calls = _get_calls(mock_client, minimum=1)
+    payloads = _get_data(mock_calls)
+    assert payloads, "expected at least one POST payload"
+    _, payload = payloads[0]
+    metadata = (payload.get("extra") or {}).get("metadata") or {}
+    assert metadata.get(LS_MESSAGE_VIEW_EXCLUDE) is True
+
+
+def test_ls_message_view_exclude_metadata_cascades_to_child_runs() -> None:
+    """Metadata set on a parent @traceable cascades to child @traceable
+    runs via the _METADATA contextvar. Regression test for the
+    cascade behavior LS_MESSAGE_VIEW_EXCLUDE depends on."""
+    from langsmith import LS_MESSAGE_VIEW_EXCLUDE
+
+    mock_client = _get_mock_client()
+
+    with tracing_context(enabled=True):
+
+        @traceable(client=mock_client)
+        def child() -> str:
+            return "ok"
+
+        @traceable(
+            client=mock_client, metadata={LS_MESSAGE_VIEW_EXCLUDE: True}
+        )
+        def parent() -> str:
+            return child()
+
+        parent()
+
+    mock_calls = _get_calls(mock_client, minimum=2)
+    payloads = [p for _, p in _get_data(mock_calls)]
+    assert len(payloads) >= 2, (
+        f"expected parent + child payloads, got {len(payloads)}"
+    )
+
+    excluded = [
+        p
+        for p in payloads
+        if (p.get("extra") or {}).get("metadata", {}).get(
+            LS_MESSAGE_VIEW_EXCLUDE
+        )
+        is True
+    ]
+    assert len(excluded) == len(payloads), (
+        f"expected all {len(payloads)} runs to carry "
+        f"{LS_MESSAGE_VIEW_EXCLUDE}=True, only {len(excluded)} did"
+    )


### PR DESCRIPTION

## Summary

Exposes `LS_MESSAGE_VIEW_EXCLUDE` as a public top-level constant in both the Python and JS SDKs so users can tag traced runs for LangSmith's Messages View filter without hardcoding the string.

```python
from langsmith import traceable, LS_MESSAGE_VIEW_EXCLUDE

@traceable(metadata={LS_MESSAGE_VIEW_EXCLUDE: True})
def classify_query(text: str) -> str: ...
```

```ts
import { traceable, LS_MESSAGE_VIEW_EXCLUDE } from "langsmith";

const classifyQuery = traceable(
  async (text: string) => ...,
  { metadata: { [LS_MESSAGE_VIEW_EXCLUDE]: true } },
);
```

Tagged runs — and their children, via the existing metadata cascade — are hidden from the Messages View chat render. Useful for middleware-style runs like classifiers, guardrails, and internal query rewrites. Runs are still recorded in full and remain visible in the regular trace tree.

Purely additive: no changes to `@traceable`, `RunTree`, schemas, or wire format. The backend filter already reads this key; users just stop hardcoding it.

## Test plan

- [x] **Python** (`python/tests/unit_tests/test_run_helpers.py`): constant identity, metadata round-trips to `extra.metadata`, parent→child cascade via `_METADATA` contextvar
- [x] **JS** (`js/src/tests/traceable.test.ts`): same three tests against `AsyncLocalStorage`
- [x] **End-to-end on dev**: ran a test script with the SDK to produce traces both with and without `LS_MESSAGE_VIEW_EXCLUDE`. Tagged runs are hidden from Messages View; untagged runs are visible. Confirms the core mechanism of this metadata key can be used to tag middleware-style runs  for visibility filtering.
**Added**

##Release Note
- `langsmith.LS_MESSAGE_VIEW_EXCLUDE` (Python) and `LS_MESSAGE_VIEW_EXCLUDE` (JS) — canonical metadata key to hide a traced run from LangSmith's Messages View. Apply via `@traceable(metadata={LS_MESSAGE_VIEW_EXCLUDE: True})`; propagates to child runs.

<img width="1380" height="859" alt="Screenshot 2026-06-04 at 11 47 04 AM" src="https://github.com/user-attachments/assets/25c2f2e1-d962-40ea-bd32-710988daed22" />





Refs: [LSO-2605](https://linear.app/langchain/issue/LSO-2605/)