### PR TITLE
feat(python): add python crud operations for online evals

### DIFF
--- a/python/conftest.py
+++ b/python/conftest.py
@@ -233,7 +233,7 @@ original_exit = vcr.patch.ConnectionRemover.__exit__
 
 def safe_exit(self, *args):
     """Create safer ConnectionRemover.__exit__."""
-    for pool, connections in self._connection_pool_to_connections.items():
+    for pool, connections in list(self._connection_pool_to_connections.items()):
         readd_connections = []
         # Get all connections from the pool first
         while pool.pool and not pool.pool.empty():

--- a/python/langsmith/async_client.py
+++ b/python/langsmith/async_client.py
@@ -366,6 +366,7 @@ class AsyncClient:
         self,
         path: str,
         params: Optional[dict[str, Any]] = None,
+        data_key: Optional[str] = None,
     ) -> AsyncIterator[dict[str, Any]]:
         """Get a paginated list of items."""
         params = params or {}
@@ -374,7 +375,8 @@ class AsyncClient:
         while True:
             params["offset"] = offset
             response = await self._arequest_with_retries("GET", path, params=params)
-            items = response.json()
+            response_body = response.json()
+            items = response_body.get(data_key, []) if data_key else response_body
             if not items:
                 break
             for item in items:
@@ -1417,6 +1419,271 @@ class AsyncClient:
             "DELETE",
             "/feedback-configs",
             params={"feedback_key": feedback_key},
+        )
+        ls_utils.raise_for_status_with_text(response)
+
+    # Online Evaluator API
+
+    async def create_evaluator(
+        self,
+        *,
+        name: str,
+        evaluator_type: ls_schemas.EvaluatorType,
+        feedback_keys: Optional[Sequence[str]] = None,
+        llm_evaluator: Optional[
+            Union[ls_schemas.CreateLLMEvaluatorRequest, dict[str, Any]]
+        ] = None,
+        code_evaluator: Optional[
+            Union[ls_schemas.CreateCodeEvaluatorRequest, dict[str, Any]]
+        ] = None,
+        run_rules: Optional[Sequence[Union[ls_schemas.EvaluatorRunRule, dict]]] = None,
+    ) -> ls_schemas.Evaluator:
+        """Create an online evaluator."""
+        if evaluator_type == "llm" and llm_evaluator is None:
+            raise ValueError("llm_evaluator is required for an LLM evaluator.")
+        if evaluator_type == "code" and code_evaluator is None:
+            raise ValueError("code_evaluator is required for a code evaluator.")
+
+        payload = ls_schemas.EvaluatorCreate(
+            name=name,
+            type=evaluator_type,
+            feedback_keys=list(feedback_keys or ()),
+            llm_evaluator=(
+                llm_evaluator
+                if isinstance(llm_evaluator, ls_schemas.CreateLLMEvaluatorRequest)
+                else (
+                    ls_schemas.CreateLLMEvaluatorRequest(**llm_evaluator)
+                    if llm_evaluator is not None
+                    else None
+                )
+            ),
+            code_evaluator=(
+                code_evaluator
+                if isinstance(code_evaluator, ls_schemas.CreateCodeEvaluatorRequest)
+                else (
+                    ls_schemas.CreateCodeEvaluatorRequest(**code_evaluator)
+                    if code_evaluator is not None
+                    else None
+                )
+            ),
+            run_rules=(
+                [
+                    rule
+                    if isinstance(rule, ls_schemas.EvaluatorRunRule)
+                    else ls_schemas.EvaluatorRunRule(**rule)
+                    for rule in run_rules
+                ]
+                if run_rules is not None
+                else None
+            ),
+        )
+        response = await self._arequest_with_retries(
+            "POST",
+            "/v1/platform/evaluators",
+            content=ls_client._dumps_json(payload.model_dump(exclude_none=True)),
+        )
+        ls_utils.raise_for_status_with_text(response)
+        return ls_schemas.Evaluator(**response.json()["evaluator"])
+
+    async def create_llm_evaluator(
+        self,
+        *,
+        name: str,
+        prompt_repo_handle: Optional[str] = None,
+        feedback_keys: Optional[Sequence[str]] = None,
+        variable_mapping: Optional[dict[str, Any]] = None,
+        commit_hash_or_tag: Optional[str] = None,
+        run_rules: Optional[Sequence[Union[ls_schemas.EvaluatorRunRule, dict]]] = None,
+    ) -> ls_schemas.Evaluator:
+        """Create an LLM-as-judge online evaluator."""
+        return await self.create_evaluator(
+            name=name,
+            evaluator_type="llm",
+            feedback_keys=feedback_keys,
+            llm_evaluator=ls_schemas.CreateLLMEvaluatorRequest(
+                prompt_repo_handle=prompt_repo_handle,
+                variable_mapping=variable_mapping,
+                commit_hash_or_tag=commit_hash_or_tag,
+            ),
+            run_rules=run_rules,
+        )
+
+    async def create_code_evaluator(
+        self,
+        *,
+        name: str,
+        code: str,
+        feedback_keys: Optional[Sequence[str]] = None,
+        language: str = "python",
+        run_rules: Optional[Sequence[Union[ls_schemas.EvaluatorRunRule, dict]]] = None,
+    ) -> ls_schemas.Evaluator:
+        """Create a code online evaluator."""
+        return await self.create_evaluator(
+            name=name,
+            evaluator_type="code",
+            feedback_keys=feedback_keys,
+            code_evaluator=ls_schemas.CreateCodeEvaluatorRequest(
+                code=code,
+                language=language,
+            ),
+            run_rules=run_rules,
+        )
+
+    async def read_evaluator(self, evaluator_id: ID_TYPE) -> ls_schemas.Evaluator:
+        """Read an online evaluator by ID."""
+        response = await self._arequest_with_retries(
+            "GET",
+            f"/v1/platform/evaluators/{ls_client._as_uuid(evaluator_id, 'evaluator_id')}",
+        )
+        ls_utils.raise_for_status_with_text(response)
+        return ls_schemas.Evaluator(**response.json())
+
+    async def list_evaluators(
+        self,
+        *,
+        evaluator_ids: Optional[Sequence[ID_TYPE]] = None,
+        name: Optional[str] = None,
+        evaluator_type: Optional[ls_schemas.EvaluatorType] = None,
+        sort_by: Optional[ls_schemas.EvaluatorSortBy] = None,
+        sort_by_desc: Optional[bool] = None,
+        limit: Optional[int] = None,
+    ) -> AsyncIterator[ls_schemas.Evaluator]:
+        """List online evaluators."""
+        params: dict[str, Any] = {
+            "evaluator_id": (
+                [
+                    ls_client._as_uuid(evaluator_id, f"evaluator_ids[{i}]")
+                    for i, evaluator_id in enumerate(evaluator_ids)
+                ]
+                if evaluator_ids is not None
+                else None
+            ),
+            "name_contains": name,
+            "type": evaluator_type,
+            "sort_by": sort_by,
+            "sort_by_desc": sort_by_desc,
+            "limit": min(limit, 100) if limit is not None else 100,
+        }
+        ix = 0
+        async for evaluator in self._aget_paginated_list(
+            "/v1/platform/evaluators", params=params, data_key="evaluators"
+        ):
+            yield ls_schemas.Evaluator(**evaluator)
+            ix += 1
+            if limit is not None and ix >= limit:
+                break
+
+    async def update_evaluator(
+        self,
+        evaluator_id: ID_TYPE,
+        *,
+        name: Optional[str] = None,
+        feedback_keys: Optional[Sequence[str]] = None,
+        llm_evaluator: Optional[
+            Union[ls_schemas.UpdateLLMEvaluatorRequest, dict[str, Any]]
+        ] = None,
+        code_evaluator: Optional[
+            Union[ls_schemas.UpdateCodeEvaluatorRequest, dict[str, Any]]
+        ] = None,
+        run_rules: Optional[Sequence[Union[ls_schemas.EvaluatorRunRule, dict]]] = None,
+    ) -> ls_schemas.Evaluator:
+        """Update an online evaluator."""
+        payload = ls_schemas.EvaluatorUpdate(
+            name=name,
+            feedback_keys=list(feedback_keys) if feedback_keys is not None else None,
+            llm_evaluator=(
+                llm_evaluator
+                if isinstance(llm_evaluator, ls_schemas.UpdateLLMEvaluatorRequest)
+                else (
+                    ls_schemas.UpdateLLMEvaluatorRequest(**llm_evaluator)
+                    if llm_evaluator is not None
+                    else None
+                )
+            ),
+            code_evaluator=(
+                code_evaluator
+                if isinstance(code_evaluator, ls_schemas.UpdateCodeEvaluatorRequest)
+                else (
+                    ls_schemas.UpdateCodeEvaluatorRequest(**code_evaluator)
+                    if code_evaluator is not None
+                    else None
+                )
+            ),
+            run_rules=(
+                [
+                    rule
+                    if isinstance(rule, ls_schemas.EvaluatorRunRule)
+                    else ls_schemas.EvaluatorRunRule(**rule)
+                    for rule in run_rules
+                ]
+                if run_rules is not None
+                else None
+            ),
+        )
+        response = await self._arequest_with_retries(
+            "PATCH",
+            f"/v1/platform/evaluators/{ls_client._as_uuid(evaluator_id, 'evaluator_id')}",
+            content=ls_client._dumps_json(payload.model_dump(exclude_none=True)),
+        )
+        ls_utils.raise_for_status_with_text(response)
+        return ls_schemas.Evaluator(**response.json()["evaluator"])
+
+    async def update_llm_evaluator(
+        self,
+        evaluator_id: ID_TYPE,
+        *,
+        name: Optional[str] = None,
+        feedback_keys: Optional[Sequence[str]] = None,
+        prompt_repo_handle: Optional[str] = None,
+        variable_mapping: Optional[dict[str, Any]] = None,
+        commit_hash_or_tag: Optional[str] = None,
+        use_corrections_dataset: Optional[bool] = None,
+        num_few_shot_examples: Optional[int] = None,
+        run_rules: Optional[Sequence[Union[ls_schemas.EvaluatorRunRule, dict]]] = None,
+    ) -> ls_schemas.Evaluator:
+        """Update an LLM-as-judge online evaluator."""
+        llm_payload = {
+            "prompt_repo_handle": prompt_repo_handle,
+            "variable_mapping": variable_mapping,
+            "commit_hash_or_tag": commit_hash_or_tag,
+            "use_corrections_dataset": use_corrections_dataset,
+            "num_few_shot_examples": num_few_shot_examples,
+        }
+        llm_payload = {k: v for k, v in llm_payload.items() if v is not None}
+        return await self.update_evaluator(
+            evaluator_id,
+            name=name,
+            feedback_keys=feedback_keys,
+            llm_evaluator=llm_payload or None,
+            run_rules=run_rules,
+        )
+
+    async def update_code_evaluator(
+        self,
+        evaluator_id: ID_TYPE,
+        *,
+        name: Optional[str] = None,
+        feedback_keys: Optional[Sequence[str]] = None,
+        code: Optional[str] = None,
+        language: Optional[str] = None,
+        run_rules: Optional[Sequence[Union[ls_schemas.EvaluatorRunRule, dict]]] = None,
+    ) -> ls_schemas.Evaluator:
+        """Update a code online evaluator."""
+        code_payload = {"code": code, "language": language}
+        code_payload = {k: v for k, v in code_payload.items() if v is not None}
+        return await self.update_evaluator(
+            evaluator_id,
+            name=name,
+            feedback_keys=feedback_keys,
+            code_evaluator=code_payload or None,
+            run_rules=run_rules,
+        )
+
+    async def delete_evaluator(self, evaluator_id: ID_TYPE) -> None:
+        """Delete an online evaluator by ID."""
+        response = await self._arequest_with_retries(
+            "DELETE",
+            f"/v1/platform/evaluators/{ls_client._as_uuid(evaluator_id, 'evaluator_id')}",
         )
         ls_utils.raise_for_status_with_text(response)
 

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -1881,13 +1881,18 @@ class Client:
         )
 
     def _get_paginated_list(
-        self, path: str, *, params: Optional[dict] = None
+        self,
+        path: str,
+        *,
+        params: Optional[dict] = None,
+        data_key: Optional[str] = None,
     ) -> Iterator[dict]:
         """Get a paginated list of items.
 
         Args:
             path: The path of the request URL.
             params: The query parameters.
+            data_key: The response key containing the list of items.
 
         Yields:
             The items in the paginated list.
@@ -1902,7 +1907,8 @@ class Client:
                 path,
                 params=params_,
             )
-            items = response.json()
+            response_body = response.json()
+            items = response_body.get(data_key, []) if data_key else response_body
             if not items:
                 break
             yield from items
@@ -8442,6 +8448,287 @@ class Client:
         )
         ls_utils.raise_for_status_with_text(response)
 
+    # Online Evaluator API
+
+    def create_evaluator(
+        self,
+        *,
+        name: str,
+        evaluator_type: ls_schemas.EvaluatorType,
+        feedback_keys: Optional[Sequence[str]] = None,
+        llm_evaluator: Optional[
+            Union[ls_schemas.CreateLLMEvaluatorRequest, dict[str, Any]]
+        ] = None,
+        code_evaluator: Optional[
+            Union[ls_schemas.CreateCodeEvaluatorRequest, dict[str, Any]]
+        ] = None,
+        run_rules: Optional[Sequence[Union[ls_schemas.EvaluatorRunRule, dict]]] = None,
+    ) -> ls_schemas.Evaluator:
+        """Create an online evaluator.
+
+        Args:
+            name (str): The evaluator name.
+            evaluator_type (Literal["llm", "code"]): The evaluator type.
+            feedback_keys (Optional[Sequence[str]]): The feedback keys it writes.
+            llm_evaluator: LLM-as-judge evaluator configuration.
+            code_evaluator: Code evaluator configuration.
+            run_rules: Rules that determine where the evaluator runs.
+
+        Returns:
+            Evaluator: The created online evaluator.
+        """
+        if evaluator_type == "llm" and llm_evaluator is None:
+            raise ValueError("llm_evaluator is required for an LLM evaluator.")
+        if evaluator_type == "code" and code_evaluator is None:
+            raise ValueError("code_evaluator is required for a code evaluator.")
+
+        payload = ls_schemas.EvaluatorCreate(
+            name=name,
+            type=evaluator_type,
+            feedback_keys=list(feedback_keys or ()),
+            llm_evaluator=(
+                llm_evaluator
+                if isinstance(llm_evaluator, ls_schemas.CreateLLMEvaluatorRequest)
+                else (
+                    ls_schemas.CreateLLMEvaluatorRequest(**llm_evaluator)
+                    if llm_evaluator is not None
+                    else None
+                )
+            ),
+            code_evaluator=(
+                code_evaluator
+                if isinstance(code_evaluator, ls_schemas.CreateCodeEvaluatorRequest)
+                else (
+                    ls_schemas.CreateCodeEvaluatorRequest(**code_evaluator)
+                    if code_evaluator is not None
+                    else None
+                )
+            ),
+            run_rules=(
+                [
+                    rule
+                    if isinstance(rule, ls_schemas.EvaluatorRunRule)
+                    else ls_schemas.EvaluatorRunRule(**rule)
+                    for rule in run_rules
+                ]
+                if run_rules is not None
+                else None
+            ),
+        )
+        response = self.request_with_retries(
+            "POST",
+            "/v1/platform/evaluators",
+            request_kwargs={
+                "data": _dumps_json(payload.model_dump(exclude_none=True)),
+            },
+        )
+        ls_utils.raise_for_status_with_text(response)
+        return ls_schemas.Evaluator(**response.json()["evaluator"])
+
+    def create_llm_evaluator(
+        self,
+        *,
+        name: str,
+        prompt_repo_handle: Optional[str] = None,
+        feedback_keys: Optional[Sequence[str]] = None,
+        variable_mapping: Optional[dict[str, Any]] = None,
+        commit_hash_or_tag: Optional[str] = None,
+        run_rules: Optional[Sequence[Union[ls_schemas.EvaluatorRunRule, dict]]] = None,
+    ) -> ls_schemas.Evaluator:
+        """Create an LLM-as-judge online evaluator."""
+        return self.create_evaluator(
+            name=name,
+            evaluator_type="llm",
+            feedback_keys=feedback_keys,
+            llm_evaluator=ls_schemas.CreateLLMEvaluatorRequest(
+                prompt_repo_handle=prompt_repo_handle,
+                variable_mapping=variable_mapping,
+                commit_hash_or_tag=commit_hash_or_tag,
+            ),
+            run_rules=run_rules,
+        )
+
+    def create_code_evaluator(
+        self,
+        *,
+        name: str,
+        code: str,
+        feedback_keys: Optional[Sequence[str]] = None,
+        language: str = "python",
+        run_rules: Optional[Sequence[Union[ls_schemas.EvaluatorRunRule, dict]]] = None,
+    ) -> ls_schemas.Evaluator:
+        """Create a code online evaluator."""
+        return self.create_evaluator(
+            name=name,
+            evaluator_type="code",
+            feedback_keys=feedback_keys,
+            code_evaluator=ls_schemas.CreateCodeEvaluatorRequest(
+                code=code,
+                language=language,
+            ),
+            run_rules=run_rules,
+        )
+
+    def read_evaluator(self, evaluator_id: ID_TYPE) -> ls_schemas.Evaluator:
+        """Read an online evaluator by ID."""
+        response = self.request_with_retries(
+            "GET",
+            f"/v1/platform/evaluators/{_as_uuid(evaluator_id, 'evaluator_id')}",
+        )
+        ls_utils.raise_for_status_with_text(response)
+        return ls_schemas.Evaluator(**response.json())
+
+    def list_evaluators(
+        self,
+        *,
+        evaluator_ids: Optional[Sequence[ID_TYPE]] = None,
+        name: Optional[str] = None,
+        evaluator_type: Optional[ls_schemas.EvaluatorType] = None,
+        sort_by: Optional[ls_schemas.EvaluatorSortBy] = None,
+        sort_by_desc: Optional[bool] = None,
+        limit: Optional[int] = None,
+    ) -> Iterator[ls_schemas.Evaluator]:
+        """List online evaluators."""
+        params: dict[str, Any] = {
+            "evaluator_id": (
+                [
+                    _as_uuid(evaluator_id, f"evaluator_ids[{i}]")
+                    for i, evaluator_id in enumerate(evaluator_ids)
+                ]
+                if evaluator_ids is not None
+                else None
+            ),
+            "name_contains": name,
+            "type": evaluator_type,
+            "sort_by": sort_by,
+            "sort_by_desc": sort_by_desc,
+            "limit": min(limit, 100) if limit is not None else 100,
+        }
+        for i, evaluator in enumerate(
+            self._get_paginated_list(
+                "/v1/platform/evaluators", params=params, data_key="evaluators"
+            )
+        ):
+            yield ls_schemas.Evaluator(**evaluator)
+            if limit is not None and i + 1 >= limit:
+                break
+
+    def update_evaluator(
+        self,
+        evaluator_id: ID_TYPE,
+        *,
+        name: Optional[str] = None,
+        feedback_keys: Optional[Sequence[str]] = None,
+        llm_evaluator: Optional[
+            Union[ls_schemas.UpdateLLMEvaluatorRequest, dict[str, Any]]
+        ] = None,
+        code_evaluator: Optional[
+            Union[ls_schemas.UpdateCodeEvaluatorRequest, dict[str, Any]]
+        ] = None,
+        run_rules: Optional[Sequence[Union[ls_schemas.EvaluatorRunRule, dict]]] = None,
+    ) -> ls_schemas.Evaluator:
+        """Update an online evaluator."""
+        payload = ls_schemas.EvaluatorUpdate(
+            name=name,
+            feedback_keys=list(feedback_keys) if feedback_keys is not None else None,
+            llm_evaluator=(
+                llm_evaluator
+                if isinstance(llm_evaluator, ls_schemas.UpdateLLMEvaluatorRequest)
+                else (
+                    ls_schemas.UpdateLLMEvaluatorRequest(**llm_evaluator)
+                    if llm_evaluator is not None
+                    else None
+                )
+            ),
+            code_evaluator=(
+                code_evaluator
+                if isinstance(code_evaluator, ls_schemas.UpdateCodeEvaluatorRequest)
+                else (
+                    ls_schemas.UpdateCodeEvaluatorRequest(**code_evaluator)
+                    if code_evaluator is not None
+                    else None
+                )
+            ),
+            run_rules=(
+                [
+                    rule
+                    if isinstance(rule, ls_schemas.EvaluatorRunRule)
+                    else ls_schemas.EvaluatorRunRule(**rule)
+                    for rule in run_rules
+                ]
+                if run_rules is not None
+                else None
+            ),
+        )
+        response = self.request_with_retries(
+            "PATCH",
+            f"/v1/platform/evaluators/{_as_uuid(evaluator_id, 'evaluator_id')}",
+            request_kwargs={
+                "data": _dumps_json(payload.model_dump(exclude_none=True)),
+            },
+        )
+        ls_utils.raise_for_status_with_text(response)
+        return ls_schemas.Evaluator(**response.json()["evaluator"])
+
+    def update_llm_evaluator(
+        self,
+        evaluator_id: ID_TYPE,
+        *,
+        name: Optional[str] = None,
+        feedback_keys: Optional[Sequence[str]] = None,
+        prompt_repo_handle: Optional[str] = None,
+        variable_mapping: Optional[dict[str, Any]] = None,
+        commit_hash_or_tag: Optional[str] = None,
+        use_corrections_dataset: Optional[bool] = None,
+        num_few_shot_examples: Optional[int] = None,
+        run_rules: Optional[Sequence[Union[ls_schemas.EvaluatorRunRule, dict]]] = None,
+    ) -> ls_schemas.Evaluator:
+        """Update an LLM-as-judge online evaluator."""
+        llm_payload = {
+            "prompt_repo_handle": prompt_repo_handle,
+            "variable_mapping": variable_mapping,
+            "commit_hash_or_tag": commit_hash_or_tag,
+            "use_corrections_dataset": use_corrections_dataset,
+            "num_few_shot_examples": num_few_shot_examples,
+        }
+        llm_payload = {k: v for k, v in llm_payload.items() if v is not None}
+        return self.update_evaluator(
+            evaluator_id,
+            name=name,
+            feedback_keys=feedback_keys,
+            llm_evaluator=llm_payload or None,
+            run_rules=run_rules,
+        )
+
+    def update_code_evaluator(
+        self,
+        evaluator_id: ID_TYPE,
+        *,
+        name: Optional[str] = None,
+        feedback_keys: Optional[Sequence[str]] = None,
+        code: Optional[str] = None,
+        language: Optional[str] = None,
+        run_rules: Optional[Sequence[Union[ls_schemas.EvaluatorRunRule, dict]]] = None,
+    ) -> ls_schemas.Evaluator:
+        """Update a code online evaluator."""
+        code_payload = {"code": code, "language": language}
+        code_payload = {k: v for k, v in code_payload.items() if v is not None}
+        return self.update_evaluator(
+            evaluator_id,
+            name=name,
+            feedback_keys=feedback_keys,
+            code_evaluator=code_payload or None,
+            run_rules=run_rules,
+        )
+
+    def delete_evaluator(self, evaluator_id: ID_TYPE) -> None:
+        """Delete an online evaluator by ID."""
+        response = self.request_with_retries(
+            "DELETE",
+            f"/v1/platform/evaluators/{_as_uuid(evaluator_id, 'evaluator_id')}",
+        )
+        ls_utils.raise_for_status_with_text(response)
+
     # Annotation Queue API
 
     def list_annotation_queues(
@@ -11077,7 +11364,9 @@ def _construct_url(api_url: str, pathname: str) -> str:
     if not path_parts:
         return api_url
 
-    if path_parts[0] == "api":
+    if path_parts[:2] == ["v1", "platform"] and api_parts[-1:] == ["api"]:
+        api_parts = api_parts[:-1]
+    elif path_parts[0] == "api":
         if api_parts[-1] == "api":
             api_parts = api_parts[:-1]
         elif api_parts[-2:] == ["api", "v1"]:

--- a/python/langsmith/schemas.py
+++ b/python/langsmith/schemas.py
@@ -1690,3 +1690,115 @@ class FeedbackConfigSchema(BaseModel):
     """When this feedback configuration was last modified."""
     is_lower_score_better: Optional[bool] = None
     """Whether a lower score is considered better for this feedback key."""
+
+
+EvaluatorType = Literal["llm", "code"]
+EvaluatorSortBy = Literal["created_at", "updated_at"]
+
+
+class EvaluatorRunRule(BaseModel):
+    """A run rule that uses an online evaluator."""
+
+    id: Optional[UUID] = None
+    session_id: Optional[UUID] = None
+    session_name: Optional[str] = None
+    dataset_id: Optional[UUID] = None
+    dataset_name: Optional[str] = None
+    group_by: Optional[str] = None
+    use_corrections_dataset: bool = False
+    num_few_shot_examples: Optional[int] = None
+    corrections_dataset_id: Optional[UUID] = None
+    spend_usd: Optional[float] = None
+    trace_count: Optional[int] = None
+    spend_limit: Optional[dict[str, Any]] = None
+
+
+class LLMEvaluator(BaseModel):
+    """Configuration for an LLM-as-judge online evaluator."""
+
+    evaluator_id: UUID
+    prompt_id: UUID
+    prompt_repo_handle: str
+    variable_mapping: Optional[dict[str, Any]] = None
+    commit_hash_or_tag: Optional[str] = None
+    annotation_queue_id: Optional[UUID] = None
+    corrections_dataset_id: Optional[UUID] = None
+    use_corrections_dataset: Optional[bool] = None
+    num_few_shot_examples: Optional[int] = None
+
+
+class CodeEvaluator(BaseModel):
+    """Configuration for a code online evaluator."""
+
+    evaluator_id: UUID
+    code: str
+    language: str = "python"
+
+
+class Evaluator(BaseModel):
+    """An online evaluator in a LangSmith workspace."""
+
+    id: UUID
+    tenant_id: UUID
+    name: str
+    type: EvaluatorType
+    created_at: datetime
+    updated_at: datetime
+    feedback_keys: list[str] = Field(default_factory=list)
+    created_by: Optional[str] = None
+    llm_evaluator: Optional[LLMEvaluator] = None
+    code_evaluator: Optional[CodeEvaluator] = None
+    run_rules: list[EvaluatorRunRule] = Field(default_factory=list)
+
+
+class CreateLLMEvaluatorRequest(BaseModel):
+    """Payload for creating an LLM-as-judge online evaluator."""
+
+    prompt_repo_handle: Optional[str] = None
+    variable_mapping: Optional[dict[str, Any]] = None
+    commit_hash_or_tag: Optional[str] = None
+
+
+class CreateCodeEvaluatorRequest(BaseModel):
+    """Payload for creating a code online evaluator."""
+
+    code: str
+    language: str = "python"
+
+
+class EvaluatorCreate(BaseModel):
+    """Payload for creating an online evaluator."""
+
+    name: str
+    type: EvaluatorType
+    feedback_keys: list[str] = Field(default_factory=list)
+    llm_evaluator: Optional[CreateLLMEvaluatorRequest] = None
+    code_evaluator: Optional[CreateCodeEvaluatorRequest] = None
+    run_rules: Optional[list[EvaluatorRunRule]] = None
+
+
+class UpdateLLMEvaluatorRequest(BaseModel):
+    """Payload for updating an LLM-as-judge online evaluator."""
+
+    prompt_repo_handle: Optional[str] = None
+    variable_mapping: Optional[dict[str, Any]] = None
+    commit_hash_or_tag: Optional[str] = None
+    use_corrections_dataset: Optional[bool] = None
+    num_few_shot_examples: Optional[int] = None
+
+
+class UpdateCodeEvaluatorRequest(BaseModel):
+    """Payload for updating a code online evaluator."""
+
+    code: Optional[str] = None
+    language: Optional[str] = None
+
+
+class EvaluatorUpdate(BaseModel):
+    """Payload for updating an online evaluator."""
+
+    name: Optional[str] = None
+    feedback_keys: Optional[list[str]] = None
+    llm_evaluator: Optional[UpdateLLMEvaluatorRequest] = None
+    code_evaluator: Optional[UpdateCodeEvaluatorRequest] = None
+    run_rules: Optional[list[EvaluatorRunRule]] = None

--- a/python/tests/integration_tests/test_runs.py
+++ b/python/tests/integration_tests/test_runs.py
@@ -339,6 +339,7 @@ def test_sync_generator_reduce_fn(langchain_client: Client):
     }
 
 
+@skip_if_rate_limited
 async def test_async_generator(langchain_client: Client):
     project_name = "__My Tracer Project - test_async_generator"
     run_meta = uuid.uuid4().hex

--- a/python/tests/unit_tests/test_async_client.py
+++ b/python/tests/unit_tests/test_async_client.py
@@ -563,3 +563,178 @@ def test_async_client_repr_hides_sensitive_info(mock_client_cls: mock.Mock) -> N
     assert "https://api.smith.langchain.com" in repr_str
     # Ensure it's properly formatted
     assert repr_str == "AsyncClient (API URL: https://api.smith.langchain.com)"
+
+
+def _online_evaluator_response(
+    evaluator_id: uuid.UUID,
+    *,
+    evaluator_type: str = "llm",
+) -> dict:
+    response = {
+        "id": str(evaluator_id),
+        "tenant_id": str(uuid.uuid4()),
+        "name": "quality judge",
+        "type": evaluator_type,
+        "created_at": "2024-01-01T00:00:00Z",
+        "updated_at": "2024-01-02T00:00:00Z",
+        "feedback_keys": ["quality"],
+        "created_by": "tester",
+        "run_rules": [],
+    }
+    if evaluator_type == "llm":
+        response["llm_evaluator"] = {
+            "evaluator_id": str(evaluator_id),
+            "prompt_id": str(uuid.uuid4()),
+            "prompt_repo_handle": "owner/quality-judge",
+            "variable_mapping": {"input": "inputs.question"},
+            "commit_hash_or_tag": "latest",
+        }
+    else:
+        response["code_evaluator"] = {
+            "evaluator_id": str(evaluator_id),
+            "code": "def score(run): return True",
+            "language": "python",
+        }
+    return response
+
+
+def _without_bound_client(args: tuple, client: AsyncClient) -> tuple:
+    return args[1:] if args and args[0] is client else args
+
+
+@pytest.mark.asyncio
+async def test_async_create_llm_evaluator_posts_payload() -> None:
+    evaluator_id = uuid.uuid4()
+    mock_response = MagicMock(status_code=200)
+    mock_response.json.return_value = {
+        "evaluator": _online_evaluator_response(evaluator_id)
+    }
+    client = AsyncClient(api_url="http://localhost:1984", api_key="test")
+
+    with patch.object(
+        AsyncClient, "_arequest_with_retries", new_callable=AsyncMock
+    ) as mock_request:
+        mock_request.return_value = mock_response
+        evaluator = await client.create_llm_evaluator(
+            name="quality judge",
+            prompt_repo_handle="owner/quality-judge",
+            feedback_keys=["quality"],
+            variable_mapping={"input": "inputs.question"},
+            commit_hash_or_tag="latest",
+            run_rules=[{"session_name": "default", "trace_count": 10}],
+        )
+
+    assert evaluator.id == evaluator_id
+    mock_request.assert_awaited_once()
+    request_args = _without_bound_client(mock_request.call_args.args, client)
+    assert request_args[:2] == ("POST", "/v1/platform/evaluators")
+    body = json.loads(mock_request.call_args.kwargs["content"])
+    assert body == {
+        "name": "quality judge",
+        "type": "llm",
+        "feedback_keys": ["quality"],
+        "llm_evaluator": {
+            "prompt_repo_handle": "owner/quality-judge",
+            "variable_mapping": {"input": "inputs.question"},
+            "commit_hash_or_tag": "latest",
+        },
+        "run_rules": [
+            {
+                "session_name": "default",
+                "use_corrections_dataset": False,
+                "trace_count": 10,
+            }
+        ],
+    }
+
+
+@pytest.mark.asyncio
+async def test_async_update_code_evaluator_patches_payload() -> None:
+    evaluator_id = uuid.uuid4()
+    mock_response = MagicMock(status_code=200)
+    mock_response.json.return_value = {
+        "evaluator": _online_evaluator_response(evaluator_id, evaluator_type="code")
+    }
+    client = AsyncClient(api_url="http://localhost:1984", api_key="test")
+
+    with patch.object(
+        AsyncClient, "_arequest_with_retries", new_callable=AsyncMock
+    ) as mock_request:
+        mock_request.return_value = mock_response
+        evaluator = await client.update_code_evaluator(
+            evaluator_id,
+            name="updated judge",
+            feedback_keys=["correctness"],
+            code="def score(run): return False",
+        )
+
+    assert evaluator.type == "code"
+    request_args = _without_bound_client(mock_request.call_args.args, client)
+    assert request_args[:2] == (
+        "PATCH",
+        f"/v1/platform/evaluators/{evaluator_id}",
+    )
+    body = json.loads(mock_request.call_args.kwargs["content"])
+    assert body == {
+        "name": "updated judge",
+        "feedback_keys": ["correctness"],
+        "code_evaluator": {"code": "def score(run): return False"},
+    }
+
+
+@pytest.mark.asyncio
+async def test_async_read_list_delete_evaluators() -> None:
+    evaluator_id = uuid.uuid4()
+    mock_response = MagicMock(status_code=200)
+    mock_response.json.return_value = _online_evaluator_response(evaluator_id)
+    client = AsyncClient(api_url="http://localhost:1984", api_key="test")
+
+    with patch.object(
+        AsyncClient, "_arequest_with_retries", new_callable=AsyncMock
+    ) as mock_request:
+        mock_request.return_value = mock_response
+        evaluator = await client.read_evaluator(evaluator_id)
+
+    assert evaluator.id == evaluator_id
+    request_args = _without_bound_client(mock_request.call_args.args, client)
+    assert request_args[:2] == ("GET", f"/v1/platform/evaluators/{evaluator_id}")
+
+    with patch.object(
+        AsyncClient, "_arequest_with_retries", new_callable=AsyncMock
+    ) as mock_request:
+        list_response = MagicMock(status_code=200)
+        list_response.json.return_value = {
+            "evaluators": [_online_evaluator_response(evaluator_id)]
+        }
+        mock_request.return_value = list_response
+        evaluators = [
+            evaluator
+            async for evaluator in client.list_evaluators(
+                evaluator_ids=[evaluator_id],
+                evaluator_type="llm",
+                sort_by="created_at",
+                sort_by_desc=True,
+                limit=1,
+            )
+        ]
+
+    assert [evaluator.id for evaluator in evaluators] == [evaluator_id]
+    request_args = _without_bound_client(mock_request.call_args.args, client)
+    assert request_args[:2] == ("GET", "/v1/platform/evaluators")
+    assert mock_request.call_args.kwargs["params"]["evaluator_id"] == [evaluator_id]
+    assert mock_request.call_args.kwargs["params"]["type"] == "llm"
+    assert mock_request.call_args.kwargs["params"]["sort_by"] == "created_at"
+    assert mock_request.call_args.kwargs["params"]["sort_by_desc"] is True
+    assert mock_request.call_args.kwargs["params"]["limit"] == 1
+
+    with patch.object(
+        AsyncClient, "_arequest_with_retries", new_callable=AsyncMock
+    ) as mock_request:
+        mock_request.return_value = mock_response
+        await client.delete_evaluator(evaluator_id)
+
+    request_args = _without_bound_client(mock_request.call_args.args, client)
+    assert request_args[:2] == (
+        "DELETE",
+        f"/v1/platform/evaluators/{evaluator_id}",
+    )

--- a/python/tests/unit_tests/test_client.py
+++ b/python/tests/unit_tests/test_client.py
@@ -5139,6 +5139,16 @@ class TestEndToEndWorkspaceFlow:
             "/api/v1/stuff",
             "https://self-hosted.smith.langchain.com/api/v1/stuff",
         ),
+        (
+            "http://localhost:1980/api",
+            "/v1/platform/evaluators",
+            "http://localhost:1980/v1/platform/evaluators",
+        ),
+        (
+            "https://self-hosted.smith.langchain.com/api",
+            "/v1/platform/evaluators",
+            "https://self-hosted.smith.langchain.com/v1/platform/evaluators",
+        ),
         # Self-hosted API URL with /api/v1: https://self-hosted.smith.langchain.com/api/v1
         (
             "https://self-hosted.smith.langchain.com/api/v1",
@@ -6344,3 +6354,203 @@ def test_client_close_idempotent_no_error() -> None:
     )
     client.close()
     client.close()
+
+
+def _online_evaluator_response(
+    evaluator_id: uuid.UUID,
+    *,
+    evaluator_type: Literal["llm", "code"] = "llm",
+) -> dict:
+    tenant_id = uuid.uuid4()
+    response = {
+        "id": str(evaluator_id),
+        "tenant_id": str(tenant_id),
+        "name": "quality judge",
+        "type": evaluator_type,
+        "created_at": "2024-01-01T00:00:00Z",
+        "updated_at": "2024-01-02T00:00:00Z",
+        "feedback_keys": ["quality"],
+        "created_by": "tester",
+        "run_rules": [],
+    }
+    if evaluator_type == "llm":
+        response["llm_evaluator"] = {
+            "evaluator_id": str(evaluator_id),
+            "prompt_id": str(uuid.uuid4()),
+            "prompt_repo_handle": "owner/quality-judge",
+            "variable_mapping": {"input": "inputs.question"},
+            "commit_hash_or_tag": "latest",
+        }
+    else:
+        response["code_evaluator"] = {
+            "evaluator_id": str(evaluator_id),
+            "code": "def score(run): return True",
+            "language": "python",
+        }
+    return response
+
+
+def _without_bound_client(args: tuple, client: Client) -> tuple:
+    return args[1:] if args and args[0] is client else args
+
+
+def test_create_llm_evaluator_posts_payload() -> None:
+    evaluator_id = uuid.uuid4()
+    mock_response = MagicMock(status_code=200)
+    mock_response.json.return_value = {
+        "evaluator": _online_evaluator_response(evaluator_id)
+    }
+    client = Client(
+        api_url="http://localhost:1984",
+        api_key="test",
+        auto_batch_tracing=False,
+    )
+
+    with patch.object(
+        Client, "request_with_retries", return_value=mock_response
+    ) as mock_request:
+        evaluator = client.create_llm_evaluator(
+            name="quality judge",
+            prompt_repo_handle="owner/quality-judge",
+            feedback_keys=["quality"],
+            variable_mapping={"input": "inputs.question"},
+            commit_hash_or_tag="latest",
+            run_rules=[
+                {
+                    "session_name": "default",
+                    "trace_count": 10,
+                    "spend_limit": {"limit": 1.0, "period": "day"},
+                }
+            ],
+        )
+
+    assert evaluator.id == evaluator_id
+    mock_request.assert_called_once()
+    request_args = _without_bound_client(mock_request.call_args.args, client)
+    assert request_args[:2] == ("POST", "/v1/platform/evaluators")
+    body = json.loads(mock_request.call_args.kwargs["request_kwargs"]["data"])
+    assert body == {
+        "name": "quality judge",
+        "type": "llm",
+        "feedback_keys": ["quality"],
+        "llm_evaluator": {
+            "prompt_repo_handle": "owner/quality-judge",
+            "variable_mapping": {"input": "inputs.question"},
+            "commit_hash_or_tag": "latest",
+        },
+        "run_rules": [
+            {
+                "session_name": "default",
+                "use_corrections_dataset": False,
+                "trace_count": 10,
+                "spend_limit": {"limit": 1.0, "period": "day"},
+            }
+        ],
+    }
+
+
+def test_create_evaluator_requires_matching_config() -> None:
+    client = Client(
+        api_url="http://localhost:1984",
+        api_key="test",
+        auto_batch_tracing=False,
+    )
+
+    with pytest.raises(ValueError, match="llm_evaluator is required"):
+        client.create_evaluator(name="missing config", evaluator_type="llm")
+
+    with pytest.raises(ValueError, match="code_evaluator is required"):
+        client.create_evaluator(name="missing config", evaluator_type="code")
+
+
+def test_update_code_evaluator_patches_payload() -> None:
+    evaluator_id = uuid.uuid4()
+    mock_response = MagicMock(status_code=200)
+    mock_response.json.return_value = {
+        "evaluator": _online_evaluator_response(evaluator_id, evaluator_type="code")
+    }
+    client = Client(
+        api_url="http://localhost:1984",
+        api_key="test",
+        auto_batch_tracing=False,
+    )
+
+    with patch.object(
+        Client, "request_with_retries", return_value=mock_response
+    ) as mock_request:
+        evaluator = client.update_code_evaluator(
+            evaluator_id,
+            name="updated judge",
+            feedback_keys=["correctness"],
+            code="def score(run): return False",
+        )
+
+    assert evaluator.type == "code"
+    request_args = _without_bound_client(mock_request.call_args.args, client)
+    assert request_args[:2] == (
+        "PATCH",
+        f"/v1/platform/evaluators/{evaluator_id}",
+    )
+    body = json.loads(mock_request.call_args.kwargs["request_kwargs"]["data"])
+    assert body == {
+        "name": "updated judge",
+        "feedback_keys": ["correctness"],
+        "code_evaluator": {"code": "def score(run): return False"},
+    }
+
+
+def test_read_list_delete_evaluators() -> None:
+    evaluator_id = uuid.uuid4()
+    client = Client(
+        api_url="http://localhost:1984",
+        api_key="test",
+        auto_batch_tracing=False,
+    )
+    mock_response = MagicMock(status_code=200)
+    mock_response.json.return_value = _online_evaluator_response(evaluator_id)
+
+    with patch.object(
+        Client, "request_with_retries", return_value=mock_response
+    ) as mock_request:
+        evaluator = client.read_evaluator(evaluator_id)
+
+    assert evaluator.id == evaluator_id
+    request_args = _without_bound_client(mock_request.call_args.args, client)
+    assert request_args[:2] == ("GET", f"/v1/platform/evaluators/{evaluator_id}")
+
+    list_response = MagicMock(status_code=200)
+    list_response.json.return_value = {
+        "evaluators": [_online_evaluator_response(evaluator_id)]
+    }
+    with patch.object(
+        Client, "request_with_retries", return_value=list_response
+    ) as mock_request:
+        evaluators = list(
+            client.list_evaluators(
+                evaluator_ids=[evaluator_id],
+                evaluator_type="llm",
+                sort_by="created_at",
+                sort_by_desc=True,
+                limit=1,
+            )
+        )
+
+    assert [evaluator.id for evaluator in evaluators] == [evaluator_id]
+    request_args = _without_bound_client(mock_request.call_args.args, client)
+    assert request_args[:2] == ("GET", "/v1/platform/evaluators")
+    assert mock_request.call_args.kwargs["params"]["evaluator_id"] == [evaluator_id]
+    assert mock_request.call_args.kwargs["params"]["type"] == "llm"
+    assert mock_request.call_args.kwargs["params"]["sort_by"] == "created_at"
+    assert mock_request.call_args.kwargs["params"]["sort_by_desc"] is True
+    assert mock_request.call_args.kwargs["params"]["limit"] == 1
+
+    with patch.object(
+        Client, "request_with_retries", return_value=mock_response
+    ) as mock_request:
+        client.delete_evaluator(evaluator_id)
+
+    request_args = _without_bound_client(mock_request.call_args.args, client)
+    assert request_args[:2] == (
+        "DELETE",
+        f"/v1/platform/evaluators/{evaluator_id}",
+    )


### PR DESCRIPTION
**Description**
Adds Python SDK support for online evaluator CRUD operations. This includes schema models for evaluator create/update payloads, sync Client methods, async AsyncClient methods, and unit coverage for request payloads, routes, and response parsing.

References [[LSE-2373]](https://linear.app/langchain/issue/LSE-2373/add-python-and-js-sdk-support-for-evaluator-crud-api)

<img width="763" height="131" alt="Screenshot 2026-06-04 at 5 36 14 PM" src="https://github.com/user-attachments/assets/c0ea4348-d514-4ace-aa45-9af04f07e0aa" />

<img width="1272" height="280" alt="Screenshot 2026-06-04 at 5 37 47 PM" src="https://github.com/user-attachments/assets/10f828ab-f38e-4a56-842c-d84956bb8ca8" />

**Test Plan**
[X] I ran the focused sync and async unit tests for the new evaluator CRUD methods to verify that create, update, read, list, and delete calls build the expected requests and parse evaluator responses correctly. I also ran Ruff on the touched Python files and checked the diff for whitespace issues.
[X] I used a smoke script to test online evaluator CRUD for both code evaluators and llm-as-a-judge evaluators against a local LangSmith instance.