### PR TITLE
feat(js): add js crud operations for online evals

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langsmith",
-  "version": "0.7.5",
+  "version": "0.7.4",
   "description": "Client library to connect to the LangSmith Observability and Evaluation Platform.",
   "packageManager": "pnpm@10.33.0",
   "files": [

--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -52,6 +52,15 @@ import {
   AnnotationQueueWithDetails,
   AnnotationQueueRubricItem,
   FeedbackConfigSchema,
+  CreateCodeEvaluatorRequest,
+  CreateLLMEvaluatorRequest,
+  Evaluator,
+  EvaluatorRunRule,
+  EvaluatorSortBy,
+  EvaluatorType,
+  EvaluatorUpdate,
+  UpdateCodeEvaluatorRequest,
+  UpdateLLMEvaluatorRequest,
   AgentContext,
   SkillContext,
   Entry,
@@ -5378,6 +5387,362 @@ export class Client implements LangSmithTracingClientInterface {
   }
 
   /**
+   * Create an online evaluator on the LangSmith API.
+   * @param options - The options for creating the evaluator
+   * @param options.name - The evaluator name
+   * @param options.evaluatorType - The evaluator type
+   * @param options.feedbackKeys - The feedback keys this evaluator writes
+   * @param options.llmEvaluator - LLM-as-judge evaluator configuration
+   * @param options.codeEvaluator - Code evaluator configuration
+   * @param options.runRules - Rules that determine where this evaluator runs
+   * @returns The created Evaluator object
+   */
+  public async createEvaluator(options: {
+    name: string;
+    evaluatorType: EvaluatorType;
+    feedbackKeys?: string[];
+    llmEvaluator?: CreateLLMEvaluatorRequest;
+    codeEvaluator?: CreateCodeEvaluatorRequest;
+    runRules?: EvaluatorRunRule[];
+  }): Promise<Evaluator> {
+    const {
+      name,
+      evaluatorType,
+      feedbackKeys,
+      llmEvaluator,
+      codeEvaluator,
+      runRules,
+    } = options;
+    if (evaluatorType === "llm" && llmEvaluator === undefined) {
+      throw new Error("llmEvaluator is required for an LLM evaluator.");
+    }
+    if (evaluatorType === "code" && codeEvaluator === undefined) {
+      throw new Error("codeEvaluator is required for a code evaluator.");
+    }
+
+    const body: Record<string, unknown> = {
+      name,
+      type: evaluatorType,
+      feedback_keys: feedbackKeys ?? [],
+      llm_evaluator: llmEvaluator,
+      code_evaluator: codeEvaluator,
+      run_rules: runRules,
+    };
+    const serializedBody = JSON.stringify(
+      Object.fromEntries(
+        Object.entries(body).filter(([_, value]) => value !== undefined),
+      ),
+    );
+
+    const response = await this.caller.call(async () => {
+      const res = await this._fetch(
+        `${this.apiUrl}${this._getPlatformEndpointPath("evaluators")}`,
+        {
+          method: "POST",
+          headers: {
+            ...this._mergedHeaders,
+            "Content-Type": "application/json",
+          },
+          signal: AbortSignal.timeout(this.timeout_ms),
+          ...this.fetchOptions,
+          body: serializedBody,
+        },
+      );
+      await raiseForStatus(res, "create evaluator");
+      return res;
+    });
+    const { evaluator } = await response.json();
+    return evaluator;
+  }
+
+  /**
+   * Create an LLM-as-judge online evaluator.
+   */
+  public async createLLMEvaluator(options: {
+    name: string;
+    promptRepoHandle?: string;
+    feedbackKeys?: string[];
+    variableMapping?: Record<string, unknown>;
+    commitHashOrTag?: string;
+    runRules?: EvaluatorRunRule[];
+  }): Promise<Evaluator> {
+    const {
+      name,
+      promptRepoHandle,
+      feedbackKeys,
+      variableMapping,
+      commitHashOrTag,
+      runRules,
+    } = options;
+    return this.createEvaluator({
+      name,
+      evaluatorType: "llm",
+      feedbackKeys,
+      llmEvaluator: {
+        prompt_repo_handle: promptRepoHandle,
+        variable_mapping: variableMapping,
+        commit_hash_or_tag: commitHashOrTag,
+      },
+      runRules,
+    });
+  }
+
+  /**
+   * Create a code online evaluator.
+   */
+  public async createCodeEvaluator(options: {
+    name: string;
+    code: string;
+    feedbackKeys?: string[];
+    language?: string;
+    runRules?: EvaluatorRunRule[];
+  }): Promise<Evaluator> {
+    const { name, code, feedbackKeys, language = "python", runRules } = options;
+    return this.createEvaluator({
+      name,
+      evaluatorType: "code",
+      feedbackKeys,
+      codeEvaluator: {
+        code,
+        language,
+      },
+      runRules,
+    });
+  }
+
+  /**
+   * Read an online evaluator by ID.
+   * @param evaluatorId - The ID of the evaluator to read
+   * @returns The Evaluator object
+   */
+  public async readEvaluator(evaluatorId: string): Promise<Evaluator> {
+    const response = await this.caller.call(async () => {
+      const res = await this._fetch(
+        `${this.apiUrl}${this._getPlatformEndpointPath(
+          `evaluators/${assertUuid(evaluatorId, "evaluatorId")}`,
+        )}`,
+        {
+          method: "GET",
+          headers: this._mergedHeaders,
+          signal: AbortSignal.timeout(this.timeout_ms),
+          ...this.fetchOptions,
+        },
+      );
+      await raiseForStatus(res, "read evaluator");
+      return res;
+    });
+    return response.json();
+  }
+
+  /**
+   * List online evaluators on the LangSmith API.
+   * @param options - The options for listing evaluators
+   * @param options.evaluatorIds - Filter by evaluator IDs
+   * @param options.name - Filter by evaluator name
+   * @param options.evaluatorType - Filter by evaluator type
+   * @param options.sortBy - Field to sort by
+   * @param options.sortByDesc - Whether to sort descending
+   * @param options.limit - The maximum number of evaluators to return
+   * @returns An async iterator of Evaluator objects
+   */
+  public async *listEvaluators(
+    options: {
+      evaluatorIds?: string[];
+      name?: string;
+      evaluatorType?: EvaluatorType;
+      sortBy?: EvaluatorSortBy;
+      sortByDesc?: boolean;
+      limit?: number;
+    } = {},
+  ): AsyncIterableIterator<Evaluator> {
+    const { evaluatorIds, name, evaluatorType, sortBy, sortByDesc, limit } =
+      options;
+    const params = new URLSearchParams();
+    if (evaluatorIds) {
+      evaluatorIds.forEach((id, i) => {
+        assertUuid(id, `evaluatorIds[${i}]`);
+        params.append("evaluator_id", id);
+      });
+    }
+    if (name) params.append("name_contains", name);
+    if (evaluatorType) params.append("type", evaluatorType);
+    if (sortBy) params.append("sort_by", sortBy);
+    if (sortByDesc !== undefined)
+      params.append("sort_by_desc", String(sortByDesc));
+    params.append(
+      "limit",
+      (limit !== undefined ? Math.min(limit, 100) : 100).toString(),
+    );
+
+    let count = 0;
+    for await (const evaluators of this._getPaginated<
+      Evaluator,
+      { evaluators?: Evaluator[] }
+    >(
+      this._getPlatformEndpointPath("evaluators"),
+      params,
+      (data: { evaluators?: Evaluator[] }) => data.evaluators ?? [],
+    )) {
+      for (const evaluator of evaluators) {
+        yield evaluator;
+        count++;
+        if (limit !== undefined && count >= limit) return;
+      }
+    }
+  }
+
+  /**
+   * Update an online evaluator.
+   * @param evaluatorId - The ID of the evaluator to update
+   * @param options - The options for updating the evaluator
+   * @returns The updated Evaluator object
+   */
+  public async updateEvaluator(
+    evaluatorId: string,
+    options: {
+      name?: string;
+      feedbackKeys?: string[];
+      llmEvaluator?: UpdateLLMEvaluatorRequest;
+      codeEvaluator?: UpdateCodeEvaluatorRequest;
+      runRules?: EvaluatorRunRule[];
+    },
+  ): Promise<Evaluator> {
+    const { name, feedbackKeys, llmEvaluator, codeEvaluator, runRules } =
+      options;
+    const body: EvaluatorUpdate = {
+      name,
+      feedback_keys: feedbackKeys,
+      llm_evaluator: llmEvaluator,
+      code_evaluator: codeEvaluator,
+      run_rules: runRules,
+    };
+    const serializedBody = JSON.stringify(
+      Object.fromEntries(
+        Object.entries(body).filter(([_, value]) => value !== undefined),
+      ),
+    );
+
+    const response = await this.caller.call(async () => {
+      const res = await this._fetch(
+        `${this.apiUrl}${this._getPlatformEndpointPath(
+          `evaluators/${assertUuid(evaluatorId, "evaluatorId")}`,
+        )}`,
+        {
+          method: "PATCH",
+          headers: {
+            ...this._mergedHeaders,
+            "Content-Type": "application/json",
+          },
+          signal: AbortSignal.timeout(this.timeout_ms),
+          ...this.fetchOptions,
+          body: serializedBody,
+        },
+      );
+      await raiseForStatus(res, "update evaluator");
+      return res;
+    });
+    const { evaluator } = await response.json();
+    return evaluator;
+  }
+
+  /**
+   * Update an LLM-as-judge online evaluator.
+   */
+  public async updateLLMEvaluator(
+    evaluatorId: string,
+    options: {
+      name?: string;
+      feedbackKeys?: string[];
+      promptRepoHandle?: string;
+      variableMapping?: Record<string, unknown>;
+      commitHashOrTag?: string;
+      useCorrectionsDataset?: boolean;
+      numFewShotExamples?: number;
+      runRules?: EvaluatorRunRule[];
+    },
+  ): Promise<Evaluator> {
+    const {
+      name,
+      feedbackKeys,
+      promptRepoHandle,
+      variableMapping,
+      commitHashOrTag,
+      useCorrectionsDataset,
+      numFewShotExamples,
+      runRules,
+    } = options;
+    const llmEvaluator = Object.fromEntries(
+      Object.entries({
+        prompt_repo_handle: promptRepoHandle,
+        variable_mapping: variableMapping,
+        commit_hash_or_tag: commitHashOrTag,
+        use_corrections_dataset: useCorrectionsDataset,
+        num_few_shot_examples: numFewShotExamples,
+      }).filter(([_, value]) => value !== undefined),
+    ) as UpdateLLMEvaluatorRequest;
+
+    return this.updateEvaluator(evaluatorId, {
+      name,
+      feedbackKeys,
+      llmEvaluator:
+        Object.keys(llmEvaluator).length > 0 ? llmEvaluator : undefined,
+      runRules,
+    });
+  }
+
+  /**
+   * Update a code online evaluator.
+   */
+  public async updateCodeEvaluator(
+    evaluatorId: string,
+    options: {
+      name?: string;
+      feedbackKeys?: string[];
+      code?: string;
+      language?: string;
+      runRules?: EvaluatorRunRule[];
+    },
+  ): Promise<Evaluator> {
+    const { name, feedbackKeys, code, language, runRules } = options;
+    const codeEvaluator = Object.fromEntries(
+      Object.entries({
+        code,
+        language,
+      }).filter(([_, value]) => value !== undefined),
+    ) as UpdateCodeEvaluatorRequest;
+
+    return this.updateEvaluator(evaluatorId, {
+      name,
+      feedbackKeys,
+      codeEvaluator:
+        Object.keys(codeEvaluator).length > 0 ? codeEvaluator : undefined,
+      runRules,
+    });
+  }
+
+  /**
+   * Delete an online evaluator by ID.
+   * @param evaluatorId - The ID of the evaluator to delete
+   */
+  public async deleteEvaluator(evaluatorId: string): Promise<void> {
+    await this.caller.call(async () => {
+      const res = await this._fetch(
+        `${this.apiUrl}${this._getPlatformEndpointPath(
+          `evaluators/${assertUuid(evaluatorId, "evaluatorId")}`,
+        )}`,
+        {
+          method: "DELETE",
+          headers: { ...this._mergedHeaders, Accept: "application/json" },
+          signal: AbortSignal.timeout(this.timeout_ms),
+          ...this.fetchOptions,
+        },
+      );
+      await raiseForStatus(res, "delete evaluator", true);
+      return res;
+    });
+  }
+
+  /**
    * API for managing annotation queues
    */
 
@@ -5750,36 +6115,6 @@ export class Client implements LangSmithTracingClientInterface {
     return json.commits[0].commit_hash;
   }
 
-  protected async _createCommitTags(
-    promptOwnerAndName: string,
-    commitId: string,
-    tags: string | string[],
-  ): Promise<void> {
-    const tagList = typeof tags === "string" ? [tags] : tags;
-
-    await Promise.all(
-      tagList.map(async (tag) =>
-        this.caller.call(async () => {
-          const res = await this._fetch(
-            `${this.apiUrl}/repos/${promptOwnerAndName}/tags`,
-            {
-              method: "POST",
-              headers: {
-                ...this._mergedHeaders,
-                "Content-Type": "application/json",
-              },
-              signal: AbortSignal.timeout(this.timeout_ms),
-              ...this.fetchOptions,
-              body: JSON.stringify({ tag_name: tag, commit_id: commitId }),
-            },
-          );
-          await raiseForStatus(res, "create commit tag");
-          return res;
-        }),
-      ),
-    );
-  }
-
   protected async _likeOrUnlikePrompt(
     promptIdentifier: string,
     like: boolean,
@@ -6108,8 +6443,6 @@ export class Client implements LangSmithTracingClientInterface {
    * @param object - The prompt object/manifest to commit (e.g., ChatPromptTemplate, messages array, etc.)
    * @param options - Optional configuration for the commit
    * @param options.parentCommitHash - The parent commit hash. Defaults to "latest" (the most recent commit).
-   * @param options.tags - A tag or list of tags to apply to the commit.
-   * @param options.description - A description for the commit.
    * @returns A Promise that resolves to the URL of the newly created commit
    * @throws {Error} If the prompt does not exist
    * @example
@@ -6125,9 +6458,9 @@ export class Client implements LangSmithTracingClientInterface {
    * const commitUrl = await client.createCommit("my-prompt", template);
    * console.log(`Commit created: ${commitUrl}`);
    *
-   * // Create a commit with tags
+   * // Create a commit based on a specific parent commit
    * const commitUrl2 = await client.createCommit("my-prompt", template, {
-   *   tags: ["production", "v1"]
+   *   parentCommitHash: "abc123def456"
    * });
    * ```
    */
@@ -6136,7 +6469,6 @@ export class Client implements LangSmithTracingClientInterface {
     object: any,
     options?: {
       parentCommitHash?: string;
-      tags?: string | string[];
       description?: string;
     },
   ): Promise<string> {
@@ -6178,16 +6510,10 @@ export class Client implements LangSmithTracingClientInterface {
       return res;
     });
     const result = await response.json();
-    const commit = result.commit ?? result;
-    if (options?.tags) {
-      await this._createCommitTags(
-        `${owner}/${promptName}`,
-        commit.id,
-        options.tags,
-      );
-    }
     return this._getPromptUrl(
-      `${owner}/${promptName}${commit.commit_hash ? `:${commit.commit_hash}` : ""}`,
+      `${owner}/${promptName}${
+        result.commit_hash ? `:${result.commit_hash}` : ""
+      }`,
     );
   }
 
@@ -6677,18 +7003,12 @@ export class Client implements LangSmithTracingClientInterface {
       description?: string;
       readme?: string;
       tags?: string[];
-      commitTags?: string | string[];
       commitDescription?: string;
     },
   ): Promise<string> {
     // Create or update prompt metadata
     if (await this.promptExists(promptIdentifier)) {
-      if (
-        options &&
-        ["description", "readme", "tags", "isPublic"].some(
-          (key) => options[key as keyof typeof options] !== undefined,
-        )
-      ) {
+      if (options && Object.keys(options).some((key) => key !== "object")) {
         await this.updatePrompt(promptIdentifier, {
           description: options?.description,
           readme: options?.readme,
@@ -6712,7 +7032,6 @@ export class Client implements LangSmithTracingClientInterface {
     // Create a commit with the new manifest
     const url = await this.createCommit(promptIdentifier, options?.object, {
       parentCommitHash: options?.parentCommitHash,
-      tags: options?.commitTags,
       description: options?.commitDescription,
     });
     return url;

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -32,7 +32,7 @@ export {
 } from "./utils/prompt_cache/index.js";
 
 // Update using pnpm bump-version
-export const __version__ = "0.7.5";
+export const __version__ = "0.7.4";
 
 // Metadata key to hide a traced run from LangSmith's Messages View.
 export const LS_MESSAGE_VIEW_EXCLUDE = "ls_message_view_exclude" as const;

--- a/js/src/schemas.ts
+++ b/js/src/schemas.ts
@@ -678,6 +678,204 @@ export interface FeedbackConfigSchema {
   is_lower_score_better?: boolean | null;
 }
 
+export type EvaluatorType = "llm" | "code";
+
+export type EvaluatorSortBy = "created_at" | "updated_at";
+
+export interface EvaluatorRunRule {
+  /** The unique identifier of the run rule. */
+  id?: string;
+
+  /** The project/session ID this evaluator should run on. */
+  session_id?: string;
+
+  /** The project/session name this evaluator should run on. */
+  session_name?: string;
+
+  /** The dataset ID this evaluator should use. */
+  dataset_id?: string;
+
+  /** The dataset name this evaluator should use. */
+  dataset_name?: string;
+
+  /** How traces should be grouped before evaluation. */
+  group_by?: string;
+
+  /** Whether to use the corrections dataset for few-shot examples. */
+  use_corrections_dataset?: boolean;
+
+  /** Number of few-shot examples to include. */
+  num_few_shot_examples?: number;
+
+  /** The corrections dataset ID. */
+  corrections_dataset_id?: string;
+
+  /** The current USD spend for this rule. */
+  spend_usd?: number;
+
+  /** The current number of traces evaluated by this rule. */
+  trace_count?: number;
+
+  /** The spend limit configuration. */
+  spend_limit?: Record<string, unknown>;
+}
+
+export interface LLMEvaluator {
+  /** The parent online evaluator ID. */
+  evaluator_id: string;
+
+  /** The prompt ID used by the evaluator. */
+  prompt_id: string;
+
+  /** The prompt repo handle used by the evaluator. */
+  prompt_repo_handle: string;
+
+  /** Maps evaluator prompt variables to run fields. */
+  variable_mapping?: Record<string, unknown>;
+
+  /** The prompt commit hash or tag to use. */
+  commit_hash_or_tag?: string;
+
+  /** Optional annotation queue ID for corrections. */
+  annotation_queue_id?: string;
+
+  /** Optional corrections dataset ID. */
+  corrections_dataset_id?: string;
+
+  /** Whether to use the corrections dataset for few-shot examples. */
+  use_corrections_dataset?: boolean;
+
+  /** Number of few-shot examples to include. */
+  num_few_shot_examples?: number;
+}
+
+export interface CodeEvaluator {
+  /** The parent online evaluator ID. */
+  evaluator_id: string;
+
+  /** The evaluator source code. */
+  code: string;
+
+  /** The evaluator language. */
+  language: string;
+}
+
+export interface Evaluator {
+  /** The unique identifier of the online evaluator. */
+  id: string;
+
+  /** The ID of the tenant that owns this evaluator. */
+  tenant_id: string;
+
+  /** The evaluator name. */
+  name: string;
+
+  /** The evaluator type. */
+  type: EvaluatorType;
+
+  /** When this evaluator was created. */
+  created_at: string;
+
+  /** When this evaluator was last updated. */
+  updated_at: string;
+
+  /** The feedback keys this evaluator writes. */
+  feedback_keys: string[];
+
+  /** The user that created this evaluator. */
+  created_by?: string;
+
+  /** LLM-as-judge evaluator configuration. */
+  llm_evaluator?: LLMEvaluator;
+
+  /** Code evaluator configuration. */
+  code_evaluator?: CodeEvaluator;
+
+  /** Rules that determine where this evaluator runs. */
+  run_rules: EvaluatorRunRule[];
+}
+
+export interface CreateLLMEvaluatorRequest {
+  /** The prompt repo handle used by the evaluator. */
+  prompt_repo_handle?: string;
+
+  /** Maps evaluator prompt variables to run fields. */
+  variable_mapping?: Record<string, unknown>;
+
+  /** The prompt commit hash or tag to use. */
+  commit_hash_or_tag?: string;
+}
+
+export interface CreateCodeEvaluatorRequest {
+  /** The evaluator source code. */
+  code: string;
+
+  /** The evaluator language. */
+  language?: string;
+}
+
+export interface EvaluatorCreate {
+  /** The evaluator name. */
+  name: string;
+
+  /** The evaluator type. */
+  type: EvaluatorType;
+
+  /** The feedback keys this evaluator writes. */
+  feedback_keys?: string[];
+
+  /** LLM-as-judge evaluator configuration. */
+  llm_evaluator?: CreateLLMEvaluatorRequest;
+
+  /** Code evaluator configuration. */
+  code_evaluator?: CreateCodeEvaluatorRequest;
+
+  /** Rules that determine where this evaluator runs. */
+  run_rules?: EvaluatorRunRule[];
+}
+
+export interface UpdateLLMEvaluatorRequest {
+  /** The prompt repo handle used by the evaluator. */
+  prompt_repo_handle?: string;
+
+  /** Maps evaluator prompt variables to run fields. */
+  variable_mapping?: Record<string, unknown>;
+
+  /** The prompt commit hash or tag to use. */
+  commit_hash_or_tag?: string;
+
+  /** Whether to use the corrections dataset for few-shot examples. */
+  use_corrections_dataset?: boolean;
+
+  /** Number of few-shot examples to include. */
+  num_few_shot_examples?: number;
+}
+
+export interface UpdateCodeEvaluatorRequest {
+  /** The evaluator source code. */
+  code?: string;
+
+  /** The evaluator language. */
+  language?: string;
+}
+
+export interface EvaluatorUpdate {
+  /** The evaluator name. */
+  name?: string;
+
+  /** The feedback keys this evaluator writes. */
+  feedback_keys?: string[];
+
+  /** LLM-as-judge evaluator configuration. */
+  llm_evaluator?: UpdateLLMEvaluatorRequest;
+
+  /** Code evaluator configuration. */
+  code_evaluator?: UpdateCodeEvaluatorRequest;
+
+  /** Rules that determine where this evaluator runs. */
+  run_rules?: EvaluatorRunRule[];
+}
+
 export interface RunWithAnnotationQueueInfo extends Exclude<BaseRun, "id"> {
   /** An unique identifier for the run. */
   id: string;

--- a/js/src/tests/client.test.ts
+++ b/js/src/tests/client.test.ts
@@ -686,81 +686,6 @@ describe("Client", () => {
       const parsed = JSON.parse(capturedBody);
       expect(parsed.description).toBeUndefined();
     });
-
-    it("should create commit tags when provided", async () => {
-      const client = new Client({ apiKey: "test-api-key" });
-
-      jest.spyOn(client as any, "promptExists").mockResolvedValue(true);
-      jest
-        .spyOn(client as any, "_getLatestCommitHash")
-        .mockResolvedValue("parent123");
-      jest.spyOn(client as any, "_fetch").mockImplementation(async (url) => ({
-        ok: true,
-        status: 200,
-        json: async () =>
-          String(url).includes("/commits/")
-            ? { commit: { commit_hash: "new123", id: "commit-id" } }
-            : {},
-        text: async () => "",
-        headers: new Headers(),
-      }));
-      jest
-        .spyOn(client as any, "_getPromptUrl")
-        .mockReturnValue("https://smith.langchain.com/prompts/test");
-
-      const fetchSpy = jest.spyOn(client as any, "_fetch");
-
-      await client.createCommit(
-        "owner/my-prompt",
-        { id: "test" },
-        {
-          tags: ["production", "v1"],
-        },
-      );
-
-      const tagCalls = fetchSpy.mock.calls.filter(([url]) =>
-        String(url).endsWith("/repos/owner/my-prompt/tags"),
-      );
-      expect(tagCalls).toHaveLength(2);
-      expect(
-        tagCalls.map(([, init]) =>
-          JSON.parse((init as RequestInit).body as string),
-        ),
-      ).toEqual(
-        expect.arrayContaining([
-          { tag_name: "production", commit_id: "commit-id" },
-          { tag_name: "v1", commit_id: "commit-id" },
-        ]),
-      );
-    });
-  });
-
-  describe("pushPrompt", () => {
-    it("should forward commit tags without updating prompt metadata", async () => {
-      const client = new Client({ apiKey: "test-api-key" });
-
-      jest.spyOn(client, "promptExists").mockResolvedValue(true);
-      const updatePromptSpy = jest.spyOn(client, "updatePrompt");
-      const createCommitSpy = jest
-        .spyOn(client, "createCommit")
-        .mockResolvedValue("https://smith.langchain.com/prompts/test");
-
-      await client.pushPrompt("owner/my-prompt", {
-        object: { id: "test" },
-        commitTags: ["production"],
-      });
-
-      expect(updatePromptSpy).not.toHaveBeenCalled();
-      expect(createCommitSpy).toHaveBeenCalledWith(
-        "owner/my-prompt",
-        { id: "test" },
-        {
-          parentCommitHash: undefined,
-          tags: ["production"],
-          description: undefined,
-        },
-      );
-    });
   });
 
   describe("_filterForSampling patch logic", () => {
@@ -1570,6 +1495,206 @@ describe("Client", () => {
       expect(inspectFn.call(client)).toBe(
         '[LangSmithClient apiUrl="https://api.smith.langchain.com"]',
       );
+    });
+  });
+
+  describe("online evaluator CRUD", () => {
+    const evaluatorId = "550e8400-e29b-41d4-a716-446655440000";
+
+    const evaluatorResponse = (type: "llm" | "code" = "llm") => ({
+      id: evaluatorId,
+      tenant_id: "650e8400-e29b-41d4-a716-446655440000",
+      name: "quality judge",
+      type,
+      created_at: "2024-01-01T00:00:00Z",
+      updated_at: "2024-01-02T00:00:00Z",
+      feedback_keys: ["quality"],
+      created_by: "tester",
+      run_rules: [],
+      ...(type === "llm"
+        ? {
+            llm_evaluator: {
+              evaluator_id: evaluatorId,
+              prompt_id: "750e8400-e29b-41d4-a716-446655440000",
+              prompt_repo_handle: "owner/quality-judge",
+              variable_mapping: { input: "inputs.question" },
+              commit_hash_or_tag: "latest",
+            },
+          }
+        : {
+            code_evaluator: {
+              evaluator_id: evaluatorId,
+              code: "function score(run) { return true; }",
+              language: "js",
+            },
+          }),
+    });
+
+    const jsonResponse = (body: unknown) =>
+      new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+
+    it("creates an LLM evaluator with the expected payload", async () => {
+      const mockFetch = jest.fn(async () =>
+        jsonResponse({ evaluator: evaluatorResponse() }),
+      );
+      const client = new Client({
+        apiUrl: "https://api.smith.langchain.com",
+        apiKey: "test-api-key",
+        fetchImplementation: mockFetch as any,
+      });
+
+      const evaluator = await client.createLLMEvaluator({
+        name: "quality judge",
+        promptRepoHandle: "owner/quality-judge",
+        feedbackKeys: ["quality"],
+        variableMapping: { input: "inputs.question" },
+        commitHashOrTag: "latest",
+        runRules: [
+          {
+            session_name: "default",
+            trace_count: 10,
+            spend_limit: { limit: 1.0, period: "day" },
+          },
+        ],
+      });
+
+      expect(evaluator.id).toBe(evaluatorId);
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://api.smith.langchain.com/v1/platform/evaluators",
+        expect.objectContaining({ method: "POST" }),
+      );
+      const [, request] = mockFetch.mock.calls[0] as unknown as [
+        string,
+        RequestInit,
+      ];
+      expect(JSON.parse(request.body as string)).toEqual({
+        name: "quality judge",
+        type: "llm",
+        feedback_keys: ["quality"],
+        llm_evaluator: {
+          prompt_repo_handle: "owner/quality-judge",
+          variable_mapping: { input: "inputs.question" },
+          commit_hash_or_tag: "latest",
+        },
+        run_rules: [
+          {
+            session_name: "default",
+            trace_count: 10,
+            spend_limit: { limit: 1.0, period: "day" },
+          },
+        ],
+      });
+    });
+
+    it("requires matching evaluator config on generic create", async () => {
+      const client = new Client({ apiKey: "test-api-key" });
+
+      await expect(
+        client.createEvaluator({
+          name: "missing config",
+          evaluatorType: "llm",
+        }),
+      ).rejects.toThrow("llmEvaluator is required");
+
+      await expect(
+        client.createEvaluator({
+          name: "missing config",
+          evaluatorType: "code",
+        }),
+      ).rejects.toThrow("codeEvaluator is required");
+    });
+
+    it("updates a code evaluator with the expected payload", async () => {
+      const mockFetch = jest.fn(async () =>
+        jsonResponse({ evaluator: evaluatorResponse("code") }),
+      );
+      const client = new Client({
+        apiUrl: "https://api.smith.langchain.com",
+        apiKey: "test-api-key",
+        fetchImplementation: mockFetch as any,
+      });
+
+      const evaluator = await client.updateCodeEvaluator(evaluatorId, {
+        name: "updated judge",
+        feedbackKeys: ["correctness"],
+        code: "function score(run) { return false; }",
+      });
+
+      expect(evaluator.type).toBe("code");
+      expect(mockFetch).toHaveBeenCalledWith(
+        `https://api.smith.langchain.com/v1/platform/evaluators/${evaluatorId}`,
+        expect.objectContaining({ method: "PATCH" }),
+      );
+      const [, request] = mockFetch.mock.calls[0] as unknown as [
+        string,
+        RequestInit,
+      ];
+      expect(JSON.parse(request.body as string)).toEqual({
+        name: "updated judge",
+        feedback_keys: ["correctness"],
+        code_evaluator: { code: "function score(run) { return false; }" },
+      });
+    });
+
+    it("reads, lists, and deletes evaluators", async () => {
+      const responses = [
+        jsonResponse(evaluatorResponse()),
+        jsonResponse({ evaluators: [evaluatorResponse()] }),
+        new Response(null, { status: 204 }),
+      ];
+      const mockFetch = jest.fn(async () => responses.shift() as Response);
+      const client = new Client({
+        apiUrl: "https://api.smith.langchain.com",
+        apiKey: "test-api-key",
+        fetchImplementation: mockFetch as any,
+      });
+
+      const evaluator = await client.readEvaluator(evaluatorId);
+      expect(evaluator.id).toBe(evaluatorId);
+
+      const evaluators = [];
+      for await (const listedEvaluator of client.listEvaluators({
+        evaluatorIds: [evaluatorId],
+        evaluatorType: "llm",
+        sortBy: "created_at",
+        sortByDesc: true,
+        limit: 1,
+      })) {
+        evaluators.push(listedEvaluator);
+      }
+      expect(evaluators).toHaveLength(1);
+      expect(evaluators[0].id).toBe(evaluatorId);
+
+      await client.deleteEvaluator(evaluatorId);
+
+      const readCall = mockFetch.mock.calls[0] as unknown as [
+        string,
+        RequestInit,
+      ];
+      const listCall = mockFetch.mock.calls[1] as unknown as [
+        string,
+        RequestInit,
+      ];
+      const deleteCall = mockFetch.mock.calls[2] as unknown as [
+        string,
+        RequestInit,
+      ];
+
+      expect(readCall[0]).toBe(
+        `https://api.smith.langchain.com/v1/platform/evaluators/${evaluatorId}`,
+      );
+      expect(String(listCall[0])).toContain("/v1/platform/evaluators?");
+      expect(String(listCall[0])).toContain(`evaluator_id=${evaluatorId}`);
+      expect(String(listCall[0])).toContain("type=llm");
+      expect(String(listCall[0])).toContain("sort_by=created_at");
+      expect(String(listCall[0])).toContain("sort_by_desc=true");
+      expect(deleteCall[0]).toBe(
+        `https://api.smith.langchain.com/v1/platform/evaluators/${evaluatorId}`,
+      );
+      expect(deleteCall[1].method).toBe("DELETE");
     });
   });
 });


### PR DESCRIPTION
**Description**
Adds JavaScript SDK support for online evaluator CRUD operations, including evaluator schema types, Client methods for create/read/list/update/delete, and convenience helpers for LLM and code evaluators.

References [[LSE-2373]](https://linear.app/langchain/issue/LSE-2373/add-python-and-js-sdk-support-for-evaluator-crud-api)

**Test Plan**
I ran focused Jest coverage for the new evaluator CRUD methods, plus TypeScript, lint, format, and whitespace checks.