### PR TITLE
feat: support JS prompt commit tags

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langsmith",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "Client library to connect to the LangSmith Observability and Evaluation Platform.",
   "packageManager": "pnpm@10.33.0",
   "files": [

--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -5750,6 +5750,36 @@ export class Client implements LangSmithTracingClientInterface {
     return json.commits[0].commit_hash;
   }
 
+  protected async _createCommitTags(
+    promptOwnerAndName: string,
+    commitId: string,
+    tags: string | string[],
+  ): Promise<void> {
+    const tagList = typeof tags === "string" ? [tags] : tags;
+
+    await Promise.all(
+      tagList.map(async (tag) =>
+        this.caller.call(async () => {
+          const res = await this._fetch(
+            `${this.apiUrl}/repos/${promptOwnerAndName}/tags`,
+            {
+              method: "POST",
+              headers: {
+                ...this._mergedHeaders,
+                "Content-Type": "application/json",
+              },
+              signal: AbortSignal.timeout(this.timeout_ms),
+              ...this.fetchOptions,
+              body: JSON.stringify({ tag_name: tag, commit_id: commitId }),
+            },
+          );
+          await raiseForStatus(res, "create commit tag");
+          return res;
+        }),
+      ),
+    );
+  }
+
   protected async _likeOrUnlikePrompt(
     promptIdentifier: string,
     like: boolean,
@@ -6078,6 +6108,8 @@ export class Client implements LangSmithTracingClientInterface {
    * @param object - The prompt object/manifest to commit (e.g., ChatPromptTemplate, messages array, etc.)
    * @param options - Optional configuration for the commit
    * @param options.parentCommitHash - The parent commit hash. Defaults to "latest" (the most recent commit).
+   * @param options.tags - A tag or list of tags to apply to the commit.
+   * @param options.description - A description for the commit.
    * @returns A Promise that resolves to the URL of the newly created commit
    * @throws {Error} If the prompt does not exist
    * @example
@@ -6093,9 +6125,9 @@ export class Client implements LangSmithTracingClientInterface {
    * const commitUrl = await client.createCommit("my-prompt", template);
    * console.log(`Commit created: ${commitUrl}`);
    *
-   * // Create a commit based on a specific parent commit
+   * // Create a commit with tags
    * const commitUrl2 = await client.createCommit("my-prompt", template, {
-   *   parentCommitHash: "abc123def456"
+   *   tags: ["production", "v1"]
    * });
    * ```
    */
@@ -6104,6 +6136,7 @@ export class Client implements LangSmithTracingClientInterface {
     object: any,
     options?: {
       parentCommitHash?: string;
+      tags?: string | string[];
       description?: string;
     },
   ): Promise<string> {
@@ -6145,10 +6178,16 @@ export class Client implements LangSmithTracingClientInterface {
       return res;
     });
     const result = await response.json();
+    const commit = result.commit ?? result;
+    if (options?.tags) {
+      await this._createCommitTags(
+        `${owner}/${promptName}`,
+        commit.id,
+        options.tags,
+      );
+    }
     return this._getPromptUrl(
-      `${owner}/${promptName}${
-        result.commit_hash ? `:${result.commit_hash}` : ""
-      }`,
+      `${owner}/${promptName}${commit.commit_hash ? `:${commit.commit_hash}` : ""}`,
     );
   }
 
@@ -6638,12 +6677,18 @@ export class Client implements LangSmithTracingClientInterface {
       description?: string;
       readme?: string;
       tags?: string[];
+      commitTags?: string | string[];
       commitDescription?: string;
     },
   ): Promise<string> {
     // Create or update prompt metadata
     if (await this.promptExists(promptIdentifier)) {
-      if (options && Object.keys(options).some((key) => key !== "object")) {
+      if (
+        options &&
+        ["description", "readme", "tags", "isPublic"].some(
+          (key) => options[key as keyof typeof options] !== undefined,
+        )
+      ) {
         await this.updatePrompt(promptIdentifier, {
           description: options?.description,
           readme: options?.readme,
@@ -6667,6 +6712,7 @@ export class Client implements LangSmithTracingClientInterface {
     // Create a commit with the new manifest
     const url = await this.createCommit(promptIdentifier, options?.object, {
       parentCommitHash: options?.parentCommitHash,
+      tags: options?.commitTags,
       description: options?.commitDescription,
     });
     return url;

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -32,7 +32,7 @@ export {
 } from "./utils/prompt_cache/index.js";
 
 // Update using pnpm bump-version
-export const __version__ = "0.7.4";
+export const __version__ = "0.7.5";
 
 // Metadata key to hide a traced run from LangSmith's Messages View.
 export const LS_MESSAGE_VIEW_EXCLUDE = "ls_message_view_exclude" as const;

--- a/js/src/tests/client.test.ts
+++ b/js/src/tests/client.test.ts
@@ -686,6 +686,81 @@ describe("Client", () => {
       const parsed = JSON.parse(capturedBody);
       expect(parsed.description).toBeUndefined();
     });
+
+    it("should create commit tags when provided", async () => {
+      const client = new Client({ apiKey: "test-api-key" });
+
+      jest.spyOn(client as any, "promptExists").mockResolvedValue(true);
+      jest
+        .spyOn(client as any, "_getLatestCommitHash")
+        .mockResolvedValue("parent123");
+      jest.spyOn(client as any, "_fetch").mockImplementation(async (url) => ({
+        ok: true,
+        status: 200,
+        json: async () =>
+          String(url).includes("/commits/")
+            ? { commit: { commit_hash: "new123", id: "commit-id" } }
+            : {},
+        text: async () => "",
+        headers: new Headers(),
+      }));
+      jest
+        .spyOn(client as any, "_getPromptUrl")
+        .mockReturnValue("https://smith.langchain.com/prompts/test");
+
+      const fetchSpy = jest.spyOn(client as any, "_fetch");
+
+      await client.createCommit(
+        "owner/my-prompt",
+        { id: "test" },
+        {
+          tags: ["production", "v1"],
+        },
+      );
+
+      const tagCalls = fetchSpy.mock.calls.filter(([url]) =>
+        String(url).endsWith("/repos/owner/my-prompt/tags"),
+      );
+      expect(tagCalls).toHaveLength(2);
+      expect(
+        tagCalls.map(([, init]) =>
+          JSON.parse((init as RequestInit).body as string),
+        ),
+      ).toEqual(
+        expect.arrayContaining([
+          { tag_name: "production", commit_id: "commit-id" },
+          { tag_name: "v1", commit_id: "commit-id" },
+        ]),
+      );
+    });
+  });
+
+  describe("pushPrompt", () => {
+    it("should forward commit tags without updating prompt metadata", async () => {
+      const client = new Client({ apiKey: "test-api-key" });
+
+      jest.spyOn(client, "promptExists").mockResolvedValue(true);
+      const updatePromptSpy = jest.spyOn(client, "updatePrompt");
+      const createCommitSpy = jest
+        .spyOn(client, "createCommit")
+        .mockResolvedValue("https://smith.langchain.com/prompts/test");
+
+      await client.pushPrompt("owner/my-prompt", {
+        object: { id: "test" },
+        commitTags: ["production"],
+      });
+
+      expect(updatePromptSpy).not.toHaveBeenCalled();
+      expect(createCommitSpy).toHaveBeenCalledWith(
+        "owner/my-prompt",
+        { id: "test" },
+        {
+          parentCommitHash: undefined,
+          tags: ["production"],
+          description: undefined,
+        },
+      );
+    });
   });
 
   describe("_filterForSampling patch logic", () => {


### PR DESCRIPTION
## Description
Adds JS SDK support for applying tags to prompt commits, mirroring the Python SDK flow for `createCommit` and `pushPrompt`.

## Release Note
JS SDK prompt commits can now be tagged via `createCommit` and `pushPrompt`.

## Test Plan
- [x] Create a prompt commit with multiple commit tags against LangSmith and verify the tags resolve in Prompts.

Made by [Open SWE](https://openswe.vercel.app)