### PR TITLE
feat(python): cross-process OAuth refresh filesystem lock

### DIFF
--- a/python/langsmith/_internal/_oauth_refresh_lock.py
+++ b/python/langsmith/_internal/_oauth_refresh_lock.py
@@ -1,0 +1,160 @@
+"""Cross-process filesystem lock for OAuth token refresh.
+
+Mirrors langsmith-go: ``fcntl.flock`` on POSIX, an atomic-``mkdir`` directory
+lock with a stale-break heuristic and owner-checked unlock elsewhere. The lock
+serializes refresh across processes sharing one profile config file.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import datetime
+import errno
+import os
+import secrets
+import shutil
+import time
+from collections.abc import Iterator
+from typing import Optional
+
+try:
+    import fcntl  # type: ignore
+except ImportError:  # pragma: no cover - Windows
+    fcntl = None  # type: ignore
+
+_LOCK_POLL_INTERVAL = 0.01
+_LOCK_STALE_AFTER = 10.0
+_LOCK_METADATA_FILE = "created_at"
+
+
+def _now_iso() -> str:
+    return (
+        datetime.datetime.now(datetime.timezone.utc).isoformat().replace("+00:00", "Z")
+    )
+
+
+def _force_remove(path: str) -> None:
+    try:
+        shutil.rmtree(path)
+    except OSError:
+        pass
+
+
+def _write_lock_metadata(lock_dir: str, owner: str) -> None:
+    meta = os.path.join(lock_dir, _LOCK_METADATA_FILE)
+    with open(meta, "w", encoding="utf-8") as f:
+        f.write(_now_iso() + "\n" + owner + "\n")
+    os.chmod(meta, 0o600)
+
+
+def _lock_metadata_lines(lock_dir: str) -> Optional[list[str]]:
+    try:
+        with open(os.path.join(lock_dir, _LOCK_METADATA_FILE), encoding="utf-8") as f:
+            return f.read().split("\n")
+    except OSError:
+        return None
+
+
+def _lock_created_at(lock_dir: str) -> Optional[float]:
+    lines = _lock_metadata_lines(lock_dir)
+    if lines and lines[0].strip():
+        try:
+            parsed = datetime.datetime.fromisoformat(
+                lines[0].strip().replace("Z", "+00:00")
+            )
+            return parsed.timestamp()
+        except ValueError:
+            pass
+    try:
+        return os.stat(lock_dir).st_mtime
+    except OSError:
+        return None
+
+
+def _lock_owner(lock_dir: str) -> Optional[str]:
+    lines = _lock_metadata_lines(lock_dir)
+    if lines and len(lines) >= 2 and lines[1].strip():
+        return lines[1].strip()
+    return None
+
+
+def _remove_stale_lock(lock_dir: str) -> bool:
+    created_at = _lock_created_at(lock_dir)
+    if created_at is None or time.time() - created_at <= _LOCK_STALE_AFTER:
+        return False
+    _force_remove(lock_dir)
+    return True
+
+
+def _release_dir_lock(lock_dir: str, owner: str) -> None:
+    if _lock_owner(lock_dir) != owner:
+        return
+    _force_remove(lock_dir)
+
+
+@contextlib.contextmanager
+def _dir_lock(lock_dir: str, deadline: float) -> Iterator[None]:
+    owner = secrets.token_hex(16)
+    while True:
+        try:
+            os.mkdir(lock_dir, 0o700)
+        except FileExistsError:
+            if not _remove_stale_lock(lock_dir):
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise TimeoutError("timed out acquiring OAuth refresh lock")
+                time.sleep(min(_LOCK_POLL_INTERVAL, remaining))
+            continue
+        try:
+            _write_lock_metadata(lock_dir, owner)
+        except OSError:
+            _force_remove(lock_dir)
+            raise
+        break
+    try:
+        yield
+    finally:
+        _release_dir_lock(lock_dir, owner)
+
+
+@contextlib.contextmanager
+def _flock_lock(lock_path: str, deadline: float) -> Iterator[None]:
+    fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
+    try:
+        while True:
+            try:
+                fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                break
+            except OSError as exc:
+                if exc.errno not in (errno.EWOULDBLOCK, errno.EAGAIN):
+                    raise
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise TimeoutError("timed out acquiring OAuth refresh lock")
+            time.sleep(min(_LOCK_POLL_INTERVAL, remaining))
+        try:
+            yield
+        finally:
+            try:
+                fcntl.flock(fd, fcntl.LOCK_UN)
+            except OSError:
+                pass
+    finally:
+        os.close(fd)
+
+
+def oauth_refresh_lock(config_path, *, deadline: float):
+    """Acquire an exclusive cross-process lock for refreshing OAuth tokens.
+
+    ``config_path`` is the profile config file path; the lock lives beside it.
+    ``deadline`` is a ``time.monotonic()`` value; acquisition raises
+    ``TimeoutError`` if it cannot be obtained before then. The caller treats any
+    ``OSError`` (incl. ``TimeoutError``) as "skip refresh, use current token".
+    """
+    lock_path = f"{os.fspath(config_path)}.oauth.lock"
+    parent = os.path.dirname(lock_path)
+    if parent:
+        os.makedirs(parent, mode=0o700, exist_ok=True)
+    if fcntl is not None:
+        return _flock_lock(lock_path, deadline)
+    return _dir_lock(f"{lock_path}.lock", deadline)

--- a/python/langsmith/_internal/_profiles.py
+++ b/python/langsmith/_internal/_profiles.py
@@ -6,11 +6,14 @@ import datetime
 import json
 import os
 import threading
+import time
 from collections.abc import Mapping
 from pathlib import Path
 from typing import Any, NamedTuple, Optional, TypedDict, cast
 
 import requests
+
+from langsmith._internal._oauth_refresh_lock import oauth_refresh_lock
 
 _OAUTH_CLIENT_ID = "langsmith-cli"
 _TOKEN_REFRESH_LEEWAY = datetime.timedelta(minutes=1)
@@ -160,7 +163,7 @@ def should_refresh_profile_token(profile: ProfileConfig) -> bool:
 
 
 def _refresh_profile_oauth_token(
-    api_url: Optional[str], refresh_token: str
+    api_url: Optional[str], refresh_token: str, timeout: float = _TOKEN_REFRESH_TIMEOUT
 ) -> Optional[dict[str, Any]]:
     refresh_url = _normalize_profile_api_url(
         api_url or "https://api.smith.langchain.com"
@@ -174,7 +177,7 @@ def _refresh_profile_oauth_token(
                 "refresh_token": refresh_token,
             },
             headers={"Content-Type": "application/x-www-form-urlencoded"},
-            timeout=_TOKEN_REFRESH_TIMEOUT,
+            timeout=timeout,
         )
     except requests.RequestException:
         return None
@@ -288,24 +291,65 @@ class ProfileAuth:
             with self._lock:
                 profile = self._profile()
                 if profile is not None and should_refresh_profile_token(profile):
-                    self._refresh(profile)
+                    profile = self._refresh(profile)
         return self._headers_from_profile(profile)
 
-    def _refresh(self, profile: ProfileConfig) -> None:
-        refresh_token = trim_auth_value(
-            (profile.get("oauth") or {}).get("refresh_token")
+    def _reload_profile(self) -> Optional[ProfileConfig]:
+        if self._state is None:
+            return None
+        try:
+            raw = json.loads(self._state.path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return None
+        if not isinstance(raw, dict):
+            return None
+        profiles = raw.get("profiles")
+        if not isinstance(profiles, dict):
+            return None
+        profile = profiles.get(self._state.profile_name)
+        if not isinstance(profile, dict):
+            return None
+        self._state = ProfileState(
+            self._state.path,
+            cast(ProfileConfigFile, raw),
+            self._state.profile_name,
         )
-        if refresh_token is None or self._state is None:
-            return
-        api_url = profile.get("api_url")
-        token = _refresh_profile_oauth_token(api_url, refresh_token)
-        if token is None:
-            return
-        _apply_profile_token_response(profile, token)
-        profiles = self._state.config.get("profiles") or {}
-        profiles[self._state.profile_name] = profile
-        self._state.config["profiles"] = profiles
-        _save_profile_config(self._state.path, self._state.config)
+        return cast(ProfileConfig, profile)
+
+    def _refresh(self, profile: ProfileConfig) -> ProfileConfig:
+        if self._state is None:
+            return profile
+        if trim_auth_value((profile.get("oauth") or {}).get("refresh_token")) is None:
+            return profile
+        deadline = time.monotonic() + _TOKEN_REFRESH_TIMEOUT
+        try:
+            with oauth_refresh_lock(self._state.path, deadline=deadline):
+                fresh = self._reload_profile()
+                if fresh is not None:
+                    profile = fresh
+                    if not should_refresh_profile_token(profile):
+                        return profile
+                refresh_token = trim_auth_value(
+                    (profile.get("oauth") or {}).get("refresh_token")
+                )
+                if refresh_token is None:
+                    return profile
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    return profile
+                token = _refresh_profile_oauth_token(
+                    profile.get("api_url"), refresh_token, timeout=remaining
+                )
+                if token is None:
+                    return profile
+                _apply_profile_token_response(profile, token)
+                profiles = self._state.config.get("profiles") or {}
+                profiles[self._state.profile_name] = profile
+                self._state.config["profiles"] = profiles
+                _save_profile_config(self._state.path, self._state.config)
+                return profile
+        except OSError:
+            return profile
 
     def _headers_from_profile(self, profile: Optional[ProfileConfig]) -> dict[str, str]:
         if profile is None:

--- a/python/tests/unit_tests/test_oauth_refresh_lock.py
+++ b/python/tests/unit_tests/test_oauth_refresh_lock.py
@@ -1,0 +1,97 @@
+"""Tests for the cross-process OAuth refresh lock."""
+
+from __future__ import annotations
+
+import datetime
+import os
+import time
+
+import pytest
+
+from langsmith._internal import _oauth_refresh_lock as lock_mod
+
+
+def _write_meta(lock_dir: str, created_at: str, owner: str) -> None:
+    os.makedirs(lock_dir, exist_ok=True)
+    with open(
+        os.path.join(lock_dir, lock_mod._LOCK_METADATA_FILE), "w", encoding="utf-8"
+    ) as f:
+        f.write(created_at + "\n" + owner + "\n")
+
+
+def test_remove_stale_lock_breaks_expired_timestamp(tmp_path):
+    lock_dir = str(tmp_path / "config.json.oauth.lock.lock")
+    stale = time.time() - lock_mod._LOCK_STALE_AFTER - 1
+    iso = (
+        datetime.datetime.fromtimestamp(stale, datetime.timezone.utc)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+    _write_meta(lock_dir, iso, "someone-else")
+
+    assert lock_mod._remove_stale_lock(lock_dir) is True
+    assert not os.path.exists(lock_dir)
+
+
+def test_remove_stale_lock_keeps_fresh_lock(tmp_path):
+    lock_dir = str(tmp_path / "config.json.oauth.lock.lock")
+    iso = (
+        datetime.datetime.now(datetime.timezone.utc).isoformat().replace("+00:00", "Z")
+    )
+    _write_meta(lock_dir, iso, "someone-else")
+
+    assert lock_mod._remove_stale_lock(lock_dir) is False
+    assert os.path.exists(lock_dir)
+
+
+def test_remove_stale_lock_breaks_expired_via_mtime(tmp_path):
+    lock_dir = str(tmp_path / "config.json.oauth.lock.lock")
+    os.mkdir(lock_dir)  # no metadata file
+    stale = time.time() - lock_mod._LOCK_STALE_AFTER - 1
+    os.utime(lock_dir, (stale, stale))
+
+    assert lock_mod._remove_stale_lock(lock_dir) is True
+    assert not os.path.exists(lock_dir)
+
+
+def test_release_dir_lock_keeps_other_owner(tmp_path):
+    lock_dir = str(tmp_path / "config.json.oauth.lock.lock")
+    iso = datetime.datetime.now(datetime.timezone.utc).isoformat()
+    _write_meta(lock_dir, iso, "new-owner")
+
+    lock_mod._release_dir_lock(lock_dir, "our-owner")  # owner mismatch
+    assert os.path.exists(lock_dir)
+
+    lock_mod._release_dir_lock(lock_dir, "new-owner")  # owner match
+    assert not os.path.exists(lock_dir)
+
+
+def test_dir_lock_acquires_and_releases(tmp_path):
+    lock_dir = str(tmp_path / "config.json.oauth.lock.lock")
+    with lock_mod._dir_lock(lock_dir, time.monotonic() + 5):
+        assert os.path.isdir(lock_dir)
+    assert not os.path.exists(lock_dir)
+
+
+def test_dir_lock_times_out_when_held(tmp_path):
+    lock_dir = str(tmp_path / "config.json.oauth.lock.lock")
+    with lock_mod._dir_lock(lock_dir, time.monotonic() + 5):
+        with pytest.raises(TimeoutError):
+            with lock_mod._dir_lock(lock_dir, time.monotonic() + 0.05):
+                pass
+
+
+def test_oauth_refresh_lock_acquires(tmp_path):
+    config_path = tmp_path / "sub" / "config.json"
+    with lock_mod.oauth_refresh_lock(config_path, deadline=time.monotonic() + 5):
+        pass  # acquired and released without error
+
+
+def test_oauth_refresh_lock_serializes_same_path(tmp_path):
+    config_path = tmp_path / "config.json"
+    with lock_mod.oauth_refresh_lock(config_path, deadline=time.monotonic() + 5):
+        with pytest.raises((TimeoutError, OSError)):
+            with lock_mod.oauth_refresh_lock(
+                config_path, deadline=time.monotonic() + 0.05
+            ):
+                pass

--- a/python/tests/unit_tests/test_oauth_refresh_lock.py
+++ b/python/tests/unit_tests/test_oauth_refresh_lock.py
@@ -3,12 +3,15 @@
 from __future__ import annotations
 
 import datetime
+import json
 import os
 import time
+from pathlib import Path
 
 import pytest
 
 from langsmith._internal import _oauth_refresh_lock as lock_mod
+from langsmith._internal import _profiles
 
 
 def _write_meta(lock_dir: str, created_at: str, owner: str) -> None:
@@ -95,3 +98,61 @@ def test_oauth_refresh_lock_serializes_same_path(tmp_path):
                 config_path, deadline=time.monotonic() + 0.05
             ):
                 pass
+
+
+def _write_config(path: Path, *, access_token: str, expires_at: str) -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "current_profile": "default",
+                "profiles": {
+                    "default": {
+                        "api_url": "https://api.smith.langchain.com",
+                        "oauth": {
+                            "access_token": access_token,
+                            "refresh_token": "refresh-abc",
+                            "expires_at": expires_at,
+                        },
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_refresh_skips_network_when_disk_already_fresh(tmp_path, monkeypatch):
+    config_path = tmp_path / "config.json"
+    past = "2000-01-01T00:00:00Z"  # already expired -> should_refresh == True
+    _write_config(config_path, access_token="stale", expires_at=past)
+    monkeypatch.setenv("LANGSMITH_CONFIG_FILE", str(config_path))
+
+    calls = {"n": 0}
+
+    def fake_refresh(api_url, refresh_token, timeout=None):
+        calls["n"] += 1
+        return {
+            "access_token": "network-token",
+            "refresh_token": "refresh-xyz",
+            "expires_in": 3600,
+        }
+
+    monkeypatch.setattr(_profiles, "_refresh_profile_oauth_token", fake_refresh)
+
+    # Two independent loads simulate two processes: each gets its own
+    # in-memory state, so B does NOT see A's refresh except via disk.
+    auth_a = _profiles.ProfileAuth(
+        _profiles.load_profile_client_config(), api_key_header="x-api-key"
+    )
+    auth_b = _profiles.ProfileAuth(
+        _profiles.load_profile_client_config(), api_key_header="x-api-key"
+    )
+
+    headers_a = auth_a.get_auth_headers()
+    headers_b = auth_b.get_auth_headers()
+
+    assert calls["n"] == 1
+    assert headers_a == {"Authorization": "Bearer network-token"}
+    assert headers_b == {"Authorization": "Bearer network-token"}
+    on_disk = json.loads(config_path.read_text())
+    assert on_disk["profiles"]["default"]["oauth"]["access_token"] == "network-token"


### PR DESCRIPTION
## Summary
- Serializes OAuth token refresh across processes that share `~/.langsmith/config.json` (gunicorn/PM2 workers, parallel test runners, the `langsmith` CLI alongside an SDK). Without this, every process can detect the stale token at once, all POST `/oauth/token` with the same refresh token, and all write the file — racing on refresh-token rotation and clobbering the stored credentials. Mirrors the implementation in `langsmith-go`.
- New `langsmith/_internal/_oauth_refresh_lock.py`: `fcntl.flock` on POSIX (interoperates with the Go CLI), atomic-`mkdir` directory lock with a 10s stale-break and owner-checked unlock on Windows. Lock lives at `<config>.oauth.lock`.
- `ProfileAuth._refresh` now acquires the lock, **re-reads the profile from disk**, and skips the network refresh if another process already refreshed; `_auth_headers` consumes the returned profile so the fresh token reaches the response. Lock-wait and the token request share one 10s deadline. Lock-acquire failure degrades to using the current token (best-effort, matching prior behavior). The async client is unaffected (it offloads this same sync path via `asyncio.to_thread`).

## Test Plan
- New `tests/unit_tests/test_oauth_refresh_lock.py` (9 tests): dir-lock stale-break by timestamp and by mtime fallback, owner-checked unlock, dir-lock acquire/contend, `flock` serialization, and a two-process integration test asserting `/oauth/token` is hit exactly once (the waiter adopts the refreshed token via the disk re-read).
- `cd python && python -m pytest tests/unit_tests/test_oauth_refresh_lock.py -v`
- `ruff` + `mypy langsmith` clean; no regressions in `test_client.py`/`test_async_client.py`.

## Follow-up
- Equivalent JS SDK change in a separate PR (dir-lock everywhere since Node lacks a stable `flock`; browser-safe via the existing `fs.ts`/`fs.browser.ts` swap).

## Note for reviewers / CI
Pre-existing, unrelated to this PR: the locked `aiohttp 3.14.0` removed `aiohttp.streams.AsyncStreamReaderMixin`, which `vcrpy` still references, so the autouse `vcr_fixture` errors across the whole unit suite locally. New tests were run with `aiohttp<3.14`. Worth a separate fix (pin `aiohttp<3.14` or bump `vcrpy`). Also `pyproject.toml` has an invalid `exclude-newer = "P1D"`.