### PR TITLE
feat(js): cross-process OAuth refresh filesystem lock

### DIFF
--- a/js/src/tests/profile-lock.test.ts
+++ b/js/src/tests/profile-lock.test.ts
@@ -1,0 +1,59 @@
+import { jest } from "@jest/globals";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { acquireOAuthRefreshLock, _internal } from "../utils/profile-lock.js";
+
+function newConfigPath(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "ls-lock-"));
+  return path.join(dir, "config.json");
+}
+
+function writeMeta(lockDir: string, iso: string, owner: string): void {
+  fs.mkdirSync(lockDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(lockDir, _internal.LOCK_METADATA_FILE),
+    `${iso}\n${owner}\n`,
+  );
+}
+
+test("acquire creates the lock dir and release removes it", async () => {
+  const configPath = newConfigPath();
+  const lockDir = `${configPath}.oauth.lock.lock`;
+  const lock = await acquireOAuthRefreshLock(configPath, Date.now() + 5000);
+  expect(fs.existsSync(lockDir)).toBe(true);
+  await lock.release();
+  expect(fs.existsSync(lockDir)).toBe(false);
+});
+
+test("acquire times out when the lock is held", async () => {
+  const configPath = newConfigPath();
+  const held = await acquireOAuthRefreshLock(configPath, Date.now() + 5000);
+  await expect(
+    acquireOAuthRefreshLock(configPath, Date.now() + 50),
+  ).rejects.toThrow(/timed out/);
+  await held.release();
+});
+
+test("a stale lock (expired timestamp) is broken and reacquired", async () => {
+  const configPath = newConfigPath();
+  const lockDir = `${configPath}.oauth.lock.lock`;
+  const stale = new Date(
+    Date.now() - _internal.LOCK_STALE_AFTER_MS - 1000,
+  ).toISOString();
+  writeMeta(lockDir, stale, "someone-else");
+  const lock = await acquireOAuthRefreshLock(configPath, Date.now() + 5000);
+  expect(_internal.lockOwner(lockDir)).not.toBe("someone-else");
+  await lock.release();
+});
+
+test("release does not remove a lock owned by someone else", async () => {
+  const configPath = newConfigPath();
+  const lockDir = `${configPath}.oauth.lock.lock`;
+  const lock = await acquireOAuthRefreshLock(configPath, Date.now() + 5000);
+  // Simulate another owner reclaiming the dir.
+  writeMeta(lockDir, new Date().toISOString(), "new-owner");
+  await lock.release();
+  expect(fs.existsSync(lockDir)).toBe(true);
+  fs.rmSync(lockDir, { recursive: true, force: true });
+});

--- a/js/src/tests/profile-lock.test.ts
+++ b/js/src/tests/profile-lock.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-process-env */
 import { jest } from "@jest/globals";
 import * as fs from "node:fs";
 import * as os from "node:os";
@@ -14,7 +15,7 @@ function writeMeta(lockDir: string, iso: string, owner: string): void {
   fs.mkdirSync(lockDir, { recursive: true });
   fs.writeFileSync(
     path.join(lockDir, _internal.LOCK_METADATA_FILE),
-    `${iso}\n${owner}\n`
+    `${iso}\n${owner}\n`,
   );
 }
 
@@ -31,7 +32,7 @@ test("acquire times out when the lock is held", async () => {
   const configPath = newConfigPath();
   const held = await acquireOAuthRefreshLock(configPath, Date.now() + 5000);
   await expect(
-    acquireOAuthRefreshLock(configPath, Date.now() + 50)
+    acquireOAuthRefreshLock(configPath, Date.now() + 50),
   ).rejects.toThrow(/timed out/);
   await held.release();
 });
@@ -40,7 +41,7 @@ test("a stale lock (expired timestamp) is broken and reacquired", async () => {
   const configPath = newConfigPath();
   const lockDir = `${configPath}.oauth.lock.lock`;
   const stale = new Date(
-    Date.now() - _internal.LOCK_STALE_AFTER_MS - 1000
+    Date.now() - _internal.LOCK_STALE_AFTER_MS - 1000,
   ).toISOString();
   writeMeta(lockDir, stale, "someone-else");
   const lock = await acquireOAuthRefreshLock(configPath, Date.now() + 5000);
@@ -75,7 +76,7 @@ test("two ProfileAuth instances refresh the token endpoint only once", async () 
           },
         },
       },
-    })
+    }),
   );
   const prev = process.env.LANGSMITH_CONFIG_FILE;
   process.env.LANGSMITH_CONFIG_FILE = configPath;
@@ -93,13 +94,16 @@ test("two ProfileAuth instances refresh the token endpoint only once", async () 
       } as unknown as Response;
     });
 
-    const authA = loadProfileClientConfig().profileAuth!;
-    const authB = loadProfileClientConfig().profileAuth!;
+    const authA = loadProfileClientConfig().profileAuth;
+    const authB = loadProfileClientConfig().profileAuth;
+    if (!authA || !authB) {
+      throw new Error("expected profileAuth to be defined");
+    }
     const headerA = await authA.getAuthHeader(
-      fakeFetch as unknown as typeof fetch
+      fakeFetch as unknown as typeof fetch,
     );
     const headerB = await authB.getAuthHeader(
-      fakeFetch as unknown as typeof fetch
+      fakeFetch as unknown as typeof fetch,
     );
 
     expect(calls).toBe(1);

--- a/js/src/tests/profile-lock.test.ts
+++ b/js/src/tests/profile-lock.test.ts
@@ -3,6 +3,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { acquireOAuthRefreshLock, _internal } from "../utils/profile-lock.js";
+import { loadProfileClientConfig } from "../utils/profiles.js";
 
 function newConfigPath(): string {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "ls-lock-"));
@@ -13,7 +14,7 @@ function writeMeta(lockDir: string, iso: string, owner: string): void {
   fs.mkdirSync(lockDir, { recursive: true });
   fs.writeFileSync(
     path.join(lockDir, _internal.LOCK_METADATA_FILE),
-    `${iso}\n${owner}\n`,
+    `${iso}\n${owner}\n`
   );
 }
 
@@ -30,7 +31,7 @@ test("acquire times out when the lock is held", async () => {
   const configPath = newConfigPath();
   const held = await acquireOAuthRefreshLock(configPath, Date.now() + 5000);
   await expect(
-    acquireOAuthRefreshLock(configPath, Date.now() + 50),
+    acquireOAuthRefreshLock(configPath, Date.now() + 50)
   ).rejects.toThrow(/timed out/);
   await held.release();
 });
@@ -39,7 +40,7 @@ test("a stale lock (expired timestamp) is broken and reacquired", async () => {
   const configPath = newConfigPath();
   const lockDir = `${configPath}.oauth.lock.lock`;
   const stale = new Date(
-    Date.now() - _internal.LOCK_STALE_AFTER_MS - 1000,
+    Date.now() - _internal.LOCK_STALE_AFTER_MS - 1000
   ).toISOString();
   writeMeta(lockDir, stale, "someone-else");
   const lock = await acquireOAuthRefreshLock(configPath, Date.now() + 5000);
@@ -56,4 +57,67 @@ test("release does not remove a lock owned by someone else", async () => {
   await lock.release();
   expect(fs.existsSync(lockDir)).toBe(true);
   fs.rmSync(lockDir, { recursive: true, force: true });
+});
+
+test("two ProfileAuth instances refresh the token endpoint only once", async () => {
+  const configPath = newConfigPath();
+  fs.writeFileSync(
+    configPath,
+    JSON.stringify({
+      current_profile: "default",
+      profiles: {
+        default: {
+          api_url: "https://api.smith.langchain.com",
+          oauth: {
+            access_token: "stale",
+            refresh_token: "refresh-abc",
+            expires_at: "2000-01-01T00:00:00Z",
+          },
+        },
+      },
+    })
+  );
+  const prev = process.env.LANGSMITH_CONFIG_FILE;
+  process.env.LANGSMITH_CONFIG_FILE = configPath;
+  try {
+    let calls = 0;
+    const fakeFetch = jest.fn(async () => {
+      calls += 1;
+      return {
+        ok: true,
+        json: async () => ({
+          access_token: "network-token",
+          refresh_token: "refresh-xyz",
+          expires_in: 3600,
+        }),
+      } as unknown as Response;
+    });
+
+    const authA = loadProfileClientConfig().profileAuth!;
+    const authB = loadProfileClientConfig().profileAuth!;
+    const headerA = await authA.getAuthHeader(
+      fakeFetch as unknown as typeof fetch
+    );
+    const headerB = await authB.getAuthHeader(
+      fakeFetch as unknown as typeof fetch
+    );
+
+    expect(calls).toBe(1);
+    expect(headerA).toEqual({
+      name: "Authorization",
+      value: "Bearer network-token",
+    });
+    expect(headerB).toEqual({
+      name: "Authorization",
+      value: "Bearer network-token",
+    });
+    const onDisk = JSON.parse(fs.readFileSync(configPath, "utf-8"));
+    expect(onDisk.profiles.default.oauth.access_token).toBe("network-token");
+  } finally {
+    if (prev === undefined) {
+      delete process.env.LANGSMITH_CONFIG_FILE;
+    } else {
+      process.env.LANGSMITH_CONFIG_FILE = prev;
+    }
+  }
 });

--- a/js/src/utils/fs.browser.ts
+++ b/js/src/utils/fs.browser.ts
@@ -20,7 +20,7 @@ export async function mkdir(_dir: string): Promise<void> {}
 
 export async function writeFileAtomic(
   _filePath: string,
-  _content: string
+  _content: string,
 ): Promise<void> {}
 
 export async function readdir(_dir: string): Promise<string[]> {

--- a/js/src/utils/fs.browser.ts
+++ b/js/src/utils/fs.browser.ts
@@ -20,7 +20,7 @@ export async function mkdir(_dir: string): Promise<void> {}
 
 export async function writeFileAtomic(
   _filePath: string,
-  _content: string,
+  _content: string
 ): Promise<void> {}
 
 export async function readdir(_dir: string): Promise<string[]> {

--- a/js/src/utils/fs.browser.ts
+++ b/js/src/utils/fs.browser.ts
@@ -52,3 +52,15 @@ export function unlinkSync(_filePath: string): void {}
 export function readFileSync(_filePath: string): string {
   return "";
 }
+
+// ---------------------------------------------------------------------------
+// Lock primitives – no-op / safe defaults in browser
+// ---------------------------------------------------------------------------
+
+export async function mkdirExclusive(_dir: string): Promise<void> {}
+
+export function statMtimeMs(_filePath: string): number | undefined {
+  return undefined;
+}
+
+export async function rmRecursive(_filePath: string): Promise<void> {}

--- a/js/src/utils/fs.ts
+++ b/js/src/utils/fs.ts
@@ -21,7 +21,7 @@ export async function mkdir(dir: string): Promise<void> {
 
 export async function writeFileAtomic(
   filePath: string,
-  content: string
+  content: string,
 ): Promise<void> {
   const tempPath = `${filePath}.tmp`;
   await nodeFsPromises.writeFile(tempPath, content, {

--- a/js/src/utils/fs.ts
+++ b/js/src/utils/fs.ts
@@ -70,3 +70,25 @@ export function unlinkSync(filePath: string): void {
 export function readFileSync(filePath: string): string {
   return nodeFs.readFileSync(filePath, "utf-8");
 }
+
+// ---------------------------------------------------------------------------
+// Lock primitives (used by the OAuth refresh directory lock)
+// ---------------------------------------------------------------------------
+
+export async function mkdirExclusive(dir: string): Promise<void> {
+  // Non-recursive mkdir throws EEXIST if the directory already exists, which
+  // is the atomic test-and-set the cross-process lock relies on.
+  await nodeFsPromises.mkdir(dir, { mode: 0o700 });
+}
+
+export function statMtimeMs(filePath: string): number | undefined {
+  try {
+    return nodeFs.statSync(filePath).mtimeMs;
+  } catch {
+    return undefined;
+  }
+}
+
+export async function rmRecursive(filePath: string): Promise<void> {
+  await nodeFsPromises.rm(filePath, { recursive: true, force: true });
+}

--- a/js/src/utils/fs.ts
+++ b/js/src/utils/fs.ts
@@ -21,7 +21,7 @@ export async function mkdir(dir: string): Promise<void> {
 
 export async function writeFileAtomic(
   filePath: string,
-  content: string,
+  content: string
 ): Promise<void> {
   const tempPath = `${filePath}.tmp`;
   await nodeFsPromises.writeFile(tempPath, content, {

--- a/js/src/utils/profile-lock.ts
+++ b/js/src/utils/profile-lock.ts
@@ -72,7 +72,7 @@ async function removeStaleLock(lockDir: string): Promise<boolean> {
  */
 export async function acquireOAuthRefreshLock(
   configPath: string,
-  deadline: number
+  deadline: number,
 ): Promise<OAuthRefreshLock> {
   const lockDir = `${configPath}.oauth.lock.lock`;
   const parent = fsUtils.path.dirname(lockDir);
@@ -92,7 +92,7 @@ export async function acquireOAuthRefreshLock(
           throw new Error("timed out acquiring OAuth refresh lock");
         }
         await sleep(
-          Math.min(LOCK_POLL_INTERVAL_MS, Math.max(0, deadline - Date.now()))
+          Math.min(LOCK_POLL_INTERVAL_MS, Math.max(0, deadline - Date.now())),
         );
       }
       continue;
@@ -100,7 +100,7 @@ export async function acquireOAuthRefreshLock(
     try {
       await fsUtils.writeFileAtomic(
         fsUtils.path.join(lockDir, LOCK_METADATA_FILE),
-        `${new Date().toISOString()}\n${owner}\n`
+        `${new Date().toISOString()}\n${owner}\n`,
       );
     } catch (err) {
       await fsUtils.rmRecursive(lockDir);

--- a/js/src/utils/profile-lock.ts
+++ b/js/src/utils/profile-lock.ts
@@ -51,7 +51,10 @@ function lockOwner(lockDir: string): string | undefined {
 
 async function removeStaleLock(lockDir: string): Promise<boolean> {
   const createdAt = lockCreatedAtMs(lockDir);
-  if (createdAt === undefined || Date.now() - createdAt <= LOCK_STALE_AFTER_MS) {
+  if (
+    createdAt === undefined ||
+    Date.now() - createdAt <= LOCK_STALE_AFTER_MS
+  ) {
     return false;
   }
   await fsUtils.rmRecursive(lockDir);
@@ -69,7 +72,7 @@ async function removeStaleLock(lockDir: string): Promise<boolean> {
  */
 export async function acquireOAuthRefreshLock(
   configPath: string,
-  deadline: number,
+  deadline: number
 ): Promise<OAuthRefreshLock> {
   const lockDir = `${configPath}.oauth.lock.lock`;
   const parent = fsUtils.path.dirname(lockDir);
@@ -89,7 +92,7 @@ export async function acquireOAuthRefreshLock(
           throw new Error("timed out acquiring OAuth refresh lock");
         }
         await sleep(
-          Math.min(LOCK_POLL_INTERVAL_MS, Math.max(0, deadline - Date.now())),
+          Math.min(LOCK_POLL_INTERVAL_MS, Math.max(0, deadline - Date.now()))
         );
       }
       continue;
@@ -97,7 +100,7 @@ export async function acquireOAuthRefreshLock(
     try {
       await fsUtils.writeFileAtomic(
         fsUtils.path.join(lockDir, LOCK_METADATA_FILE),
-        `${new Date().toISOString()}\n${owner}\n`,
+        `${new Date().toISOString()}\n${owner}\n`
       );
     } catch (err) {
       await fsUtils.rmRecursive(lockDir);

--- a/js/src/utils/profile-lock.ts
+++ b/js/src/utils/profile-lock.ts
@@ -1,0 +1,122 @@
+import * as fsUtils from "./fs.js";
+
+const LOCK_POLL_INTERVAL_MS = 10;
+const LOCK_STALE_AFTER_MS = 10_000;
+const LOCK_METADATA_FILE = "created_at";
+
+export interface OAuthRefreshLock {
+  release(): Promise<void>;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function isEEXIST(err: unknown): boolean {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    (err as { code?: string }).code === "EEXIST"
+  );
+}
+
+function lockMetadataLines(lockDir: string): string[] | undefined {
+  try {
+    return fsUtils
+      .readFileSync(fsUtils.path.join(lockDir, LOCK_METADATA_FILE))
+      .split("\n");
+  } catch {
+    return undefined;
+  }
+}
+
+function lockCreatedAtMs(lockDir: string): number | undefined {
+  const lines = lockMetadataLines(lockDir);
+  if (lines && lines[0] && lines[0].trim()) {
+    const parsed = Date.parse(lines[0].trim());
+    if (!Number.isNaN(parsed)) {
+      return parsed;
+    }
+  }
+  return fsUtils.statMtimeMs(lockDir);
+}
+
+function lockOwner(lockDir: string): string | undefined {
+  const lines = lockMetadataLines(lockDir);
+  if (lines && lines.length >= 2 && lines[1].trim()) {
+    return lines[1].trim();
+  }
+  return undefined;
+}
+
+async function removeStaleLock(lockDir: string): Promise<boolean> {
+  const createdAt = lockCreatedAtMs(lockDir);
+  if (createdAt === undefined || Date.now() - createdAt <= LOCK_STALE_AFTER_MS) {
+    return false;
+  }
+  await fsUtils.rmRecursive(lockDir);
+  return true;
+}
+
+/**
+ * Acquire an exclusive cross-process lock for refreshing OAuth tokens.
+ *
+ * Uses an atomic-`mkdir` directory lock at `<configPath>.oauth.lock.lock` with a
+ * stale-break heuristic and owner-checked release, mirroring langsmith-go's
+ * non-POSIX path. `deadline` is a `Date.now()`-based timestamp; acquisition
+ * rejects once it passes. Callers treat any rejection as "skip refresh, use the
+ * current token".
+ */
+export async function acquireOAuthRefreshLock(
+  configPath: string,
+  deadline: number,
+): Promise<OAuthRefreshLock> {
+  const lockDir = `${configPath}.oauth.lock.lock`;
+  const parent = fsUtils.path.dirname(lockDir);
+  if (parent) {
+    await fsUtils.mkdir(parent);
+  }
+  const owner = globalThis.crypto.randomUUID();
+  for (;;) {
+    try {
+      await fsUtils.mkdirExclusive(lockDir);
+    } catch (err) {
+      if (!isEEXIST(err)) {
+        throw err;
+      }
+      if (!(await removeStaleLock(lockDir))) {
+        if (Date.now() >= deadline) {
+          throw new Error("timed out acquiring OAuth refresh lock");
+        }
+        await sleep(
+          Math.min(LOCK_POLL_INTERVAL_MS, Math.max(0, deadline - Date.now())),
+        );
+      }
+      continue;
+    }
+    try {
+      await fsUtils.writeFileAtomic(
+        fsUtils.path.join(lockDir, LOCK_METADATA_FILE),
+        `${new Date().toISOString()}\n${owner}\n`,
+      );
+    } catch (err) {
+      await fsUtils.rmRecursive(lockDir);
+      throw err;
+    }
+    break;
+  }
+  return {
+    async release() {
+      if (lockOwner(lockDir) === owner) {
+        await fsUtils.rmRecursive(lockDir);
+      }
+    },
+  };
+}
+
+// Exposed for tests only.
+export const _internal = {
+  LOCK_METADATA_FILE,
+  LOCK_STALE_AFTER_MS,
+  lockOwner,
+};

--- a/js/src/utils/profiles.ts
+++ b/js/src/utils/profiles.ts
@@ -66,7 +66,7 @@ function getProfileConfigPath(): string | undefined {
 }
 
 function resolveProfileName(
-  config: LangSmithProfileConfigFile
+  config: LangSmithProfileConfigFile,
 ): string | undefined {
   const envProfile = getEnvironmentVariable("LANGSMITH_PROFILE");
   if (envProfile) {
@@ -91,7 +91,7 @@ function loadProfileState(): LangSmithProfileState | undefined {
   }
   try {
     const config = JSON.parse(
-      fsUtils.readFileSync(configPath)
+      fsUtils.readFileSync(configPath),
     ) as LangSmithProfileConfigFile;
     const profileName = resolveProfileName(config);
     const profile = profileName ? config.profiles?.[profileName] : undefined;
@@ -147,7 +147,7 @@ function applyTokenResponse(
     access_token?: string;
     refresh_token?: string;
     expires_in?: number;
-  }
+  },
 ): void {
   profile.oauth ??= {};
   if (token.access_token) {
@@ -158,7 +158,7 @@ function applyTokenResponse(
   }
   if (typeof token.expires_in === "number" && token.expires_in > 0) {
     profile.oauth.expires_at = new Date(
-      Date.now() + token.expires_in * 1000
+      Date.now() + token.expires_in * 1000,
     ).toISOString();
   }
 }
@@ -172,7 +172,7 @@ function getAbortReason(signal: AbortSignal): unknown {
 
 async function waitForAbortSignal<T>(
   promise: Promise<T>,
-  signal?: AbortSignal | null
+  signal?: AbortSignal | null,
 ): Promise<T> {
   if (!signal) {
     return promise;
@@ -236,12 +236,12 @@ export class ProfileAuth {
 
   async getAuthHeader(
     fetchImplementation: typeof fetch,
-    signal?: AbortSignal | null
+    signal?: AbortSignal | null,
   ): Promise<ProfileAuthHeader | undefined> {
     if (shouldRefreshProfileToken(this.state.profile)) {
       if (!this.refreshPromise) {
         this.refreshPromise = this.refreshOAuthToken(
-          fetchImplementation
+          fetchImplementation,
         ).finally(() => {
           this.refreshPromise = undefined;
         });
@@ -260,7 +260,7 @@ export class ProfileAuth {
   private reloadProfile(): LangSmithProfile | undefined {
     try {
       const config = JSON.parse(
-        fsUtils.readFileSync(this.state.configPath)
+        fsUtils.readFileSync(this.state.configPath),
       ) as LangSmithProfileConfigFile;
       const profile = config.profiles?.[this.state.profileName];
       if (!profile) {
@@ -275,7 +275,7 @@ export class ProfileAuth {
   }
 
   private async refreshOAuthToken(
-    fetchImplementation: typeof fetch
+    fetchImplementation: typeof fetch,
   ): Promise<void> {
     const refreshToken = this.state.profile.oauth?.refresh_token;
     if (!refreshToken) {
@@ -305,7 +305,7 @@ export class ProfileAuth {
           },
           body: body.toString(),
           signal: AbortSignal.timeout(Math.max(0, deadline - Date.now())),
-        }
+        },
       );
       if (!response.ok) {
         return;
@@ -323,7 +323,7 @@ export class ProfileAuth {
       this.state.config.profiles[this.state.profileName] = this.state.profile;
       await fsUtils.writeFileAtomic(
         this.state.configPath,
-        `${JSON.stringify(this.state.config, null, 2)}\n`
+        `${JSON.stringify(this.state.config, null, 2)}\n`,
       );
     } catch {
       return;
@@ -333,7 +333,7 @@ export class ProfileAuth {
   }
 
   private rememberProfileAuthHeader(
-    header: ProfileAuthHeader | undefined
+    header: ProfileAuthHeader | undefined,
   ): void {
     this.managedAuthorizationValue =
       header?.name === "Authorization" ? header.value : undefined;
@@ -341,7 +341,7 @@ export class ProfileAuth {
 }
 
 function currentAuthHeaderFromProfile(
-  profile: LangSmithProfile
+  profile: LangSmithProfile,
 ): ProfileAuthHeader | undefined {
   const oauthAccessToken = trimConfigValue(profile.oauth?.access_token);
   if (oauthAccessToken) {
@@ -354,7 +354,7 @@ function currentAuthHeaderFromProfile(
 }
 
 function authHeaderFromProfile(
-  profile: LangSmithProfile
+  profile: LangSmithProfile,
 ): ProfileAuthHeader | undefined {
   const oauthAccessToken = trimConfigValue(profile.oauth?.access_token);
   if (oauthAccessToken) {

--- a/js/src/utils/profiles.ts
+++ b/js/src/utils/profiles.ts
@@ -1,5 +1,6 @@
 import { getEnv, getEnvironmentVariable } from "./env.js";
 import * as fsUtils from "./fs.js";
+import { acquireOAuthRefreshLock } from "./profile-lock.js";
 
 export const DEFAULT_API_URL = "https://api.smith.langchain.com";
 
@@ -65,7 +66,7 @@ function getProfileConfigPath(): string | undefined {
 }
 
 function resolveProfileName(
-  config: LangSmithProfileConfigFile,
+  config: LangSmithProfileConfigFile
 ): string | undefined {
   const envProfile = getEnvironmentVariable("LANGSMITH_PROFILE");
   if (envProfile) {
@@ -90,7 +91,7 @@ function loadProfileState(): LangSmithProfileState | undefined {
   }
   try {
     const config = JSON.parse(
-      fsUtils.readFileSync(configPath),
+      fsUtils.readFileSync(configPath)
     ) as LangSmithProfileConfigFile;
     const profileName = resolveProfileName(config);
     const profile = profileName ? config.profiles?.[profileName] : undefined;
@@ -146,7 +147,7 @@ function applyTokenResponse(
     access_token?: string;
     refresh_token?: string;
     expires_in?: number;
-  },
+  }
 ): void {
   profile.oauth ??= {};
   if (token.access_token) {
@@ -157,7 +158,7 @@ function applyTokenResponse(
   }
   if (typeof token.expires_in === "number" && token.expires_in > 0) {
     profile.oauth.expires_at = new Date(
-      Date.now() + token.expires_in * 1000,
+      Date.now() + token.expires_in * 1000
     ).toISOString();
   }
 }
@@ -171,7 +172,7 @@ function getAbortReason(signal: AbortSignal): unknown {
 
 async function waitForAbortSignal<T>(
   promise: Promise<T>,
-  signal?: AbortSignal | null,
+  signal?: AbortSignal | null
 ): Promise<T> {
   if (!signal) {
     return promise;
@@ -235,12 +236,12 @@ export class ProfileAuth {
 
   async getAuthHeader(
     fetchImplementation: typeof fetch,
-    signal?: AbortSignal | null,
+    signal?: AbortSignal | null
   ): Promise<ProfileAuthHeader | undefined> {
     if (shouldRefreshProfileToken(this.state.profile)) {
       if (!this.refreshPromise) {
         this.refreshPromise = this.refreshOAuthToken(
-          fetchImplementation,
+          fetchImplementation
         ).finally(() => {
           this.refreshPromise = undefined;
         });
@@ -256,8 +257,25 @@ export class ProfileAuth {
     return value === this.managedAuthorizationValue;
   }
 
+  private reloadProfile(): LangSmithProfile | undefined {
+    try {
+      const config = JSON.parse(
+        fsUtils.readFileSync(this.state.configPath)
+      ) as LangSmithProfileConfigFile;
+      const profile = config.profiles?.[this.state.profileName];
+      if (!profile) {
+        return undefined;
+      }
+      this.state.config = config;
+      this.state.profile = profile;
+      return profile;
+    } catch {
+      return undefined;
+    }
+  }
+
   private async refreshOAuthToken(
-    fetchImplementation: typeof fetch,
+    fetchImplementation: typeof fetch
   ): Promise<void> {
     const refreshToken = this.state.profile.oauth?.refresh_token;
     if (!refreshToken) {
@@ -265,11 +283,18 @@ export class ProfileAuth {
     }
     const refreshApiUrl =
       trimConfigValue(this.state.profile.api_url) ?? DEFAULT_API_URL;
+    const deadline = Date.now() + TOKEN_REFRESH_TIMEOUT_MS;
+    let lock: { release(): Promise<void> } | undefined;
     try {
+      lock = await acquireOAuthRefreshLock(this.state.configPath, deadline);
+      const fresh = this.reloadProfile();
+      if (fresh && !shouldRefreshProfileToken(this.state.profile)) {
+        return;
+      }
       const body = new URLSearchParams({
         grant_type: "refresh_token",
         client_id: OAUTH_CLIENT_ID,
-        refresh_token: refreshToken,
+        refresh_token: this.state.profile.oauth?.refresh_token ?? refreshToken,
       });
       const response = await fetchImplementation(
         `${normalizeConfigUrl(refreshApiUrl)}/oauth/token`,
@@ -279,8 +304,8 @@ export class ProfileAuth {
             "Content-Type": "application/x-www-form-urlencoded",
           },
           body: body.toString(),
-          signal: AbortSignal.timeout(TOKEN_REFRESH_TIMEOUT_MS),
-        },
+          signal: AbortSignal.timeout(Math.max(0, deadline - Date.now())),
+        }
       );
       if (!response.ok) {
         return;
@@ -298,15 +323,17 @@ export class ProfileAuth {
       this.state.config.profiles[this.state.profileName] = this.state.profile;
       await fsUtils.writeFileAtomic(
         this.state.configPath,
-        `${JSON.stringify(this.state.config, null, 2)}\n`,
+        `${JSON.stringify(this.state.config, null, 2)}\n`
       );
     } catch {
       return;
+    } finally {
+      await lock?.release();
     }
   }
 
   private rememberProfileAuthHeader(
-    header: ProfileAuthHeader | undefined,
+    header: ProfileAuthHeader | undefined
   ): void {
     this.managedAuthorizationValue =
       header?.name === "Authorization" ? header.value : undefined;
@@ -314,7 +341,7 @@ export class ProfileAuth {
 }
 
 function currentAuthHeaderFromProfile(
-  profile: LangSmithProfile,
+  profile: LangSmithProfile
 ): ProfileAuthHeader | undefined {
   const oauthAccessToken = trimConfigValue(profile.oauth?.access_token);
   if (oauthAccessToken) {
@@ -327,7 +354,7 @@ function currentAuthHeaderFromProfile(
 }
 
 function authHeaderFromProfile(
-  profile: LangSmithProfile,
+  profile: LangSmithProfile
 ): ProfileAuthHeader | undefined {
   const oauthAccessToken = trimConfigValue(profile.oauth?.access_token);
   if (oauthAccessToken) {


### PR DESCRIPTION
## Summary
- JS counterpart to #2988 (Python). Serializes OAuth token refresh across Node processes that share `~/.langsmith/config.json`, so multiple workers/runners don't all POST `/oauth/token` with the same refresh token and clobber the stored credentials. Mirrors `langsmith-go`.
- New `js/src/utils/profile-lock.ts`: an atomic-`mkdir` directory lock at `<config>.oauth.lock.lock` with a 10s stale-break and owner-checked release. It imports filesystem access **only** through `./fs.js`, so the package.json `browser` field swaps in `fs.browser.ts` and **no `node:*` reaches the browser bundle**.
- `ProfileAuth.refreshOAuthToken` acquires the lock, **re-reads the profile from disk**, and skips the network refresh if another process already refreshed; the in-place state update means the fresh token reaches `getAuthHeader`. Lock-wait and the token request share one deadline; acquisition failure degrades to using the current token. The lock never runs in browser (`loadProfileState` already returns `undefined` there).
- Adds three browser-safe fs primitives (`mkdirExclusive`, `statMtimeMs`, `rmRecursive`) to `fs.ts` with no-op stubs in `fs.browser.ts`.

## Platform note
Node has no stable `flock`, so JS uses the directory lock on all platforms. It interoperates with the Go CLI / Python SDK on **Windows** (same `<config>.oauth.lock.lock` path) but **not on POSIX**, where Go/Python use `flock` on `<config>.oauth.lock`. On POSIX, JS provides cross-process locking among JS processes only — the dominant multi-worker case. Avoiding a native `flock` dependency is deliberate.

## Test Plan
- New `src/tests/profile-lock.test.ts` (5 tests): acquire/release, contention timeout, stale-break, owner-checked release, and a two-process integration test asserting `/oauth/token` is hit exactly once.
- `cd js && NODE_OPTIONS=--experimental-vm-modules pnpm exec jest src/tests/profile-lock.test.ts`
- `tsc` clean for the touched files; `profile-lock.ts` imports nothing from `node:`.

## Spec
`docs/superpowers/specs/2026-06-04-oauth-refresh-profile-locking-design.md` (shared design for both SDKs).