### PR TITLE
fix: use should_exit for uvicorn server teardown in context propagation test

### DIFF
--- a/python/tests/integration_tests/test_context_propagation.py
+++ b/python/tests/integration_tests/test_context_propagation.py
@@ -25,10 +25,8 @@ async def fake_server():
     await asyncio.sleep(0.1)
 
     yield
-    try:
-        await server.shutdown()
-    except RuntimeError:
-        pass
+    server.should_exit = True
+    await asyncio.sleep(0.1)
 
 
 @traceable


### PR DESCRIPTION
## Summary

- `test_tracing_fake_server` was failing during teardown with `AttributeError: 'Server' object has no attribute 'servers'`
- Root cause: calling `server.shutdown()` directly fails on some uvicorn versions because `self.servers` is only populated when the server is started via `serve()` — but in the fixture the server is started with `asyncio.create_task(server.serve())`, and `shutdown()` was being called before `serve()` fully initialized
- Fix: set `server.should_exit = True` to signal the running `serve()` task to stop gracefully, which is compatible across uvicorn versions and avoids accessing internal state

Fixes the failure seen in [#2911](https://github.com/langchain-ai/langsmith-sdk/pull/2911).

## Test plan
- [ ] Confirm `Python integration Test 4` passes in CI