### PR TITLE
Add AWS auth proxy helpers to Python SDK

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -48,6 +48,42 @@ A typical workflow looks like:
 
 We'll walk through these steps in more detail below.
 
+## Sandbox AWS auth proxy
+
+When you create a LangSmith sandbox that needs to call AWS services, use the
+sandbox AWS auth proxy helpers. The proxy keeps the real AWS credentials outside
+the sandbox and signs supported AWS HTTPS requests with SigV4, so code in the
+sandbox can use AWS SDKs normally without storing long-lived AWS keys in files,
+environment variables, shell history, or logs.
+
+First, store `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` as LangSmith
+workspace secrets. Then create the sandbox with an AWS auth proxy config:
+
+```python
+from langsmith.sandbox import (
+    SandboxClient,
+    aws_auth_proxy_config,
+    workspace_secret,
+)
+
+client = SandboxClient()
+
+with client.sandbox(
+    name="aws-sandbox",
+    proxy_config=aws_auth_proxy_config(
+        access_key_id=workspace_secret("AWS_ACCESS_KEY_ID"),
+        secret_access_key=workspace_secret("AWS_SECRET_ACCESS_KEY"),
+    ),
+) as sandbox:
+    # Your sandbox code can use boto3, the AWS CLI, or other AWS tooling normally.
+    result = sandbox.run("python your_aws_script.py")
+    print(result.stdout)
+```
+
+Use `opaque_secret("...")` instead of `workspace_secret(...)` when your
+application needs to pass short-lived write-only AWS credentials at sandbox
+creation time. Plaintext AWS credential values are not supported.
+
 ## 1. Connect to LangSmith
 
 Sign up for [LangSmith](https://smith.langchain.com/) using your GitHub, Discord accounts, or an email address and password. If you sign up with an email, make sure to verify your email address before logging in.

--- a/python/langsmith/sandbox/README.md
+++ b/python/langsmith/sandbox/README.md
@@ -59,6 +59,63 @@ client = SandboxClient(
 )
 ```
 
+## AWS Auth Proxy
+
+Use the AWS auth proxy when sandbox code needs to call AWS services such as S3,
+Bedrock, or another supported AWS HTTPS endpoint. You configure the AWS
+credentials on the sandbox proxy, and the proxy signs outbound AWS requests with
+SigV4. The real credentials stay outside the sandbox.
+
+This lets code inside the sandbox use normal AWS tooling without exposing
+long-lived AWS credentials in sandbox files, environment variables, shell
+history, or logs. Store the AWS credentials as LangSmith workspace secrets, then
+reference those secret names in the proxy config:
+
+```python
+from langsmith.sandbox import (
+    SandboxClient,
+    aws_auth_proxy_config,
+    workspace_secret,
+)
+
+client = SandboxClient()
+
+with client.sandbox(
+    name="aws-sandbox",
+    proxy_config=aws_auth_proxy_config(
+        access_key_id=workspace_secret("AWS_ACCESS_KEY_ID"),
+        secret_access_key=workspace_secret("AWS_SECRET_ACCESS_KEY"),
+    ),
+) as sb:
+    result = sb.run("python your_aws_script.py")
+    print(result.stdout)
+```
+
+Inside `your_aws_script.py`, use AWS SDKs normally. For example, if `boto3` is
+installed in the sandbox snapshot:
+
+```python
+import boto3
+
+s3 = boto3.client("s3")
+print([bucket["Name"] for bucket in s3.list_buckets()["Buckets"]])
+```
+
+If your application mints short-lived AWS credentials, pass them as write-only
+opaque values instead:
+
+```python
+from langsmith.sandbox import aws_auth_proxy_config, opaque_secret
+
+proxy_config = aws_auth_proxy_config(
+    access_key_id=opaque_secret(access_key_id),
+    secret_access_key=opaque_secret(secret_access_key),
+)
+```
+
+Do not put real AWS credentials in sandbox environment variables. Plaintext AWS
+credential values are not supported by the AWS auth proxy.
+
 ## Running Commands
 
 ```python

--- a/python/langsmith/sandbox/__init__.py
+++ b/python/langsmith/sandbox/__init__.py
@@ -64,6 +64,13 @@ from langsmith.sandbox._models import (
     ServiceURL,
     Snapshot,
 )
+from langsmith.sandbox._proxy_config import (
+    SandboxProxyConfig,
+    SandboxProxySecret,
+    aws_auth_proxy_config,
+    opaque_secret,
+    workspace_secret,
+)
 from langsmith.sandbox._sandbox import Sandbox
 from langsmith.sandbox._tunnel import AsyncTunnel, Tunnel
 
@@ -83,6 +90,11 @@ __all__ = [
     "CommandHandle",
     "AsyncCommandHandle",
     "OutputChunk",
+    "SandboxProxyConfig",
+    "SandboxProxySecret",
+    "aws_auth_proxy_config",
+    "opaque_secret",
+    "workspace_secret",
     # Base and connection errors
     "SandboxClientError",
     "SandboxAPIError",

--- a/python/langsmith/sandbox/_async_client.py
+++ b/python/langsmith/sandbox/_async_client.py
@@ -37,6 +37,7 @@ from langsmith.sandbox._models import (
     ResourceStatus,
     Snapshot,
 )
+from langsmith.sandbox._proxy_config import SandboxProxyConfig
 from langsmith.sandbox._transport import AsyncRetryTransport
 
 
@@ -185,7 +186,7 @@ class AsyncSandboxClient:
         vcpus: Optional[int] = None,
         mem_bytes: Optional[int] = None,
         fs_capacity_bytes: Optional[int] = None,
-        proxy_config: Optional[dict[str, Any]] = None,
+        proxy_config: Optional[SandboxProxyConfig] = None,
         headers: RequestHeaders = None,
     ) -> AsyncSandbox:
         """Create a sandbox and return an AsyncSandbox instance.
@@ -231,7 +232,8 @@ class AsyncSandboxClient:
                 {"deny_list": [...]}}``. Use ``access_control.allow_list`` to
                 restrict outbound HTTPS to a set of host patterns (exact
                 domains, globs like ``*.example.com``, IPs, CIDRs, or
-                ``~regex``).
+                ``~regex``). Use ``aws_auth_proxy_config`` to let the proxy
+                sign supported AWS HTTPS requests on the sandbox's behalf.
 
         Returns:
             AsyncSandbox instance.
@@ -272,7 +274,7 @@ class AsyncSandboxClient:
         vcpus: Optional[int] = None,
         mem_bytes: Optional[int] = None,
         fs_capacity_bytes: Optional[int] = None,
-        proxy_config: Optional[dict[str, Any]] = None,
+        proxy_config: Optional[SandboxProxyConfig] = None,
         headers: RequestHeaders = None,
     ) -> AsyncSandbox:
         """Create a new Sandbox.
@@ -312,7 +314,8 @@ class AsyncSandboxClient:
                 {"deny_list": [...]}}``. Use ``access_control.allow_list`` to
                 restrict outbound HTTPS to a set of host patterns (exact
                 domains, globs like ``*.example.com``, IPs, CIDRs, or
-                ``~regex``).
+                ``~regex``). Use ``aws_auth_proxy_config`` to let the proxy
+                sign supported AWS HTTPS requests on the sandbox's behalf.
 
         Returns:
             Created AsyncSandbox. When wait_for_ready=False, the sandbox will have

--- a/python/langsmith/sandbox/_client.py
+++ b/python/langsmith/sandbox/_client.py
@@ -34,6 +34,7 @@ from langsmith.sandbox._models import (
     ServiceURL,
     Snapshot,
 )
+from langsmith.sandbox._proxy_config import SandboxProxyConfig
 from langsmith.sandbox._sandbox import Sandbox
 from langsmith.sandbox._transport import RetryTransport
 
@@ -277,7 +278,7 @@ class SandboxClient:
         vcpus: Optional[int] = None,
         mem_bytes: Optional[int] = None,
         fs_capacity_bytes: Optional[int] = None,
-        proxy_config: Optional[dict[str, Any]] = None,
+        proxy_config: Optional[SandboxProxyConfig] = None,
         headers: RequestHeaders = None,
     ) -> Sandbox:
         """Create a sandbox and return a Sandbox instance.
@@ -323,7 +324,8 @@ class SandboxClient:
                 {"deny_list": [...]}}``. Use ``access_control.allow_list`` to
                 restrict outbound HTTPS to a set of host patterns (exact
                 domains, globs like ``*.example.com``, IPs, CIDRs, or
-                ``~regex``).
+                ``~regex``). Use ``aws_auth_proxy_config`` to let the proxy
+                sign supported AWS HTTPS requests on the sandbox's behalf.
 
         Returns:
             Sandbox instance.
@@ -364,7 +366,7 @@ class SandboxClient:
         vcpus: Optional[int] = None,
         mem_bytes: Optional[int] = None,
         fs_capacity_bytes: Optional[int] = None,
-        proxy_config: Optional[dict[str, Any]] = None,
+        proxy_config: Optional[SandboxProxyConfig] = None,
         headers: RequestHeaders = None,
     ) -> Sandbox:
         """Create a new Sandbox.
@@ -404,7 +406,8 @@ class SandboxClient:
                 {"deny_list": [...]}}``. Use ``access_control.allow_list`` to
                 restrict outbound HTTPS to a set of host patterns (exact
                 domains, globs like ``*.example.com``, IPs, CIDRs, or
-                ``~regex``).
+                ``~regex``). Use ``aws_auth_proxy_config`` to let the proxy
+                sign supported AWS HTTPS requests on the sandbox's behalf.
 
         Returns:
             Created Sandbox. When wait_for_ready=False, the sandbox will have

--- a/python/langsmith/sandbox/_proxy_config.py
+++ b/python/langsmith/sandbox/_proxy_config.py
@@ -1,0 +1,81 @@
+"""Helpers for building sandbox proxy configurations."""
+
+from __future__ import annotations
+
+from typing import Any, Literal, TypedDict
+
+
+class SandboxProxySecret(TypedDict):
+    """A secret value that can be used by sandbox proxy rules."""
+
+    type: Literal["workspace_secret", "opaque"]
+    value: str
+
+
+SandboxProxyConfig = dict[str, Any]
+
+
+def _require_non_empty_string(value: str, field: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{field} must be a non-empty string")
+    return value.strip()
+
+
+def workspace_secret(name: str) -> SandboxProxySecret:
+    """Create a LangSmith workspace secret reference for a proxy configuration.
+
+    Args:
+        name: Workspace secret name, with or without surrounding braces.
+
+    Returns:
+        A proxy secret reference such as
+        ``{"type": "workspace_secret", "value": "{AWS_ACCESS_KEY_ID}"}``.
+    """
+    normalized = _require_non_empty_string(name, "name")
+    starts = normalized.startswith("{")
+    ends = normalized.endswith("}")
+    if starts != ends:
+        raise ValueError("workspace secret must be a name or a {NAME} reference")
+    if starts and not normalized[1:-1].strip():
+        raise ValueError("workspace secret reference must contain a name")
+    value = normalized if starts else f"{{{normalized}}}"
+    return {"type": "workspace_secret", "value": value}
+
+
+def opaque_secret(value: str) -> SandboxProxySecret:
+    """Provide a write-only secret value for a proxy configuration.
+
+    The value is sent when creating or updating the sandbox proxy config, but
+    LangSmith stores it as an opaque secret and does not return it from the API.
+    """
+    return {"type": "opaque", "value": _require_non_empty_string(value, "value")}
+
+
+def aws_auth_proxy_config(
+    *,
+    access_key_id: SandboxProxySecret,
+    secret_access_key: SandboxProxySecret,
+    name: str = "aws",
+    enabled: bool = True,
+) -> SandboxProxyConfig:
+    """Build a sandbox proxy config that signs AWS HTTPS requests.
+
+    The sandbox proxy keeps the real AWS credentials outside the sandbox and
+    signs supported AWS requests with SigV4 on the sandbox's behalf. AWS
+    credentials must be supplied as ``workspace_secret`` or ``opaque`` values;
+    plaintext AWS credentials are intentionally not supported.
+    """
+    rule_name = _require_non_empty_string(name, "name")
+    return {
+        "rules": [
+            {
+                "name": rule_name,
+                "type": "aws",
+                "enabled": enabled,
+                "aws": {
+                    "access_key_id": access_key_id,
+                    "secret_access_key": secret_access_key,
+                },
+            }
+        ]
+    }

--- a/python/tests/unit_tests/sandbox/test_proxy_config.py
+++ b/python/tests/unit_tests/sandbox/test_proxy_config.py
@@ -1,0 +1,86 @@
+"""Tests for sandbox proxy configuration helpers."""
+
+import json
+
+import pytest
+from pytest_httpx import HTTPXMock
+
+from langsmith.sandbox import (
+    SandboxClient,
+    aws_auth_proxy_config,
+    opaque_secret,
+    workspace_secret,
+)
+
+
+def test_workspace_secret_wraps_names() -> None:
+    assert workspace_secret("AWS_ACCESS_KEY_ID") == {
+        "type": "workspace_secret",
+        "value": "{AWS_ACCESS_KEY_ID}",
+    }
+    assert workspace_secret("{AWS_SECRET_ACCESS_KEY}") == {
+        "type": "workspace_secret",
+        "value": "{AWS_SECRET_ACCESS_KEY}",
+    }
+
+
+@pytest.mark.parametrize("name", ["", "   ", "{}", "{AWS_ACCESS_KEY_ID"])
+def test_workspace_secret_rejects_invalid_names(name: str) -> None:
+    with pytest.raises(ValueError):
+        workspace_secret(name)
+
+
+def test_opaque_secret_builds_write_only_value() -> None:
+    assert opaque_secret("AKIAFAKE") == {
+        "type": "opaque",
+        "value": "AKIAFAKE",
+    }
+
+
+def test_aws_auth_proxy_config_builds_aws_rule() -> None:
+    config = aws_auth_proxy_config(
+        access_key_id=workspace_secret("AWS_ACCESS_KEY_ID"),
+        secret_access_key=workspace_secret("AWS_SECRET_ACCESS_KEY"),
+    )
+
+    assert config == {
+        "rules": [
+            {
+                "name": "aws",
+                "type": "aws",
+                "enabled": True,
+                "aws": {
+                    "access_key_id": {
+                        "type": "workspace_secret",
+                        "value": "{AWS_ACCESS_KEY_ID}",
+                    },
+                    "secret_access_key": {
+                        "type": "workspace_secret",
+                        "value": "{AWS_SECRET_ACCESS_KEY}",
+                    },
+                },
+            }
+        ]
+    }
+
+
+def test_create_sandbox_forwards_aws_auth_proxy_config(
+    httpx_mock: HTTPXMock,
+) -> None:
+    client = SandboxClient(api_endpoint="http://test-server:8080", max_retries=0)
+    httpx_mock.add_response(
+        method="POST",
+        url="http://test-server:8080/boxes",
+        json={"name": "test-sandbox"},
+        status_code=201,
+    )
+    proxy_config = aws_auth_proxy_config(
+        access_key_id=workspace_secret("AWS_ACCESS_KEY_ID"),
+        secret_access_key=workspace_secret("AWS_SECRET_ACCESS_KEY"),
+    )
+
+    client.create_sandbox(snapshot_id="snap-1", proxy_config=proxy_config)
+
+    body = json.loads(httpx_mock.get_request().content)
+    assert body["proxy_config"] == proxy_config
+    client.close()


### PR DESCRIPTION
## Summary

Adds Python SDK support for configuring the sandbox proxy AWS auth rule from user-facing helpers.

- Adds `workspace_secret(...)`, `opaque_secret(...)`, and `aws_auth_proxy_config(...)` under `langsmith.sandbox`.
- Wires `proxy_config` through the sandbox create APIs so users can pass the generated AWS auth proxy config when creating a sandbox.
- Documents how users should use the helper in both the package README and the sandbox README, including workspace-secret and opaque-secret examples.
- Adds unit coverage for the helper wire shape and client request forwarding.

## User Impact

Users can create a sandbox that runs normal AWS SDK or AWS CLI code while the sandbox proxy keeps real AWS credentials outside the sandbox and SigV4-signs supported AWS HTTPS requests. This avoids putting long-lived AWS credentials into sandbox files, environment variables, shell history, or logs.

## Validation

- `UV_CACHE_DIR=/private/tmp/codex-uv-cache MISE_CACHE_DIR=/private/tmp/codex-mise-cache XDG_CACHE_HOME=/private/tmp/codex-xdg-cache make format`
- `UV_CACHE_DIR=/private/tmp/codex-uv-cache MISE_CACHE_DIR=/private/tmp/codex-mise-cache XDG_CACHE_HOME=/private/tmp/codex-xdg-cache make lint`
- `env -u LANGSMITH_ENDPOINT UV_CACHE_DIR=/private/tmp/codex-uv-cache MISE_CACHE_DIR=/private/tmp/codex-mise-cache XDG_CACHE_HOME=/private/tmp/codex-xdg-cache make tests`