### PR TITLE
Add AWS auth proxy helpers to JS SDK

### DIFF
--- a/js/README.md
+++ b/js/README.md
@@ -25,6 +25,47 @@ A typical workflow looks like:
 
 We'll walk through these steps in more detail below.
 
+## Sandbox AWS auth proxy
+
+When you create a LangSmith sandbox that needs to call AWS services, use the
+sandbox AWS auth proxy helpers. The proxy keeps the real AWS credentials outside
+the sandbox and signs supported AWS HTTPS requests with SigV4, so code in the
+sandbox can use AWS SDKs normally without storing long-lived AWS keys in files,
+environment variables, shell history, or logs.
+
+First, store `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` as LangSmith
+workspace secrets. Then create the sandbox with an AWS auth proxy config:
+
+```ts
+import {
+  SandboxClient,
+  awsAuthProxyConfig,
+  workspaceSecret,
+} from "langsmith/sandbox";
+
+const client = new SandboxClient();
+
+const sandbox = await client.createSandbox({
+  name: "aws-sandbox",
+  proxyConfig: awsAuthProxyConfig({
+    accessKeyId: workspaceSecret("AWS_ACCESS_KEY_ID"),
+    secretAccessKey: workspaceSecret("AWS_SECRET_ACCESS_KEY"),
+  }),
+});
+
+try {
+  // Your sandbox code can use the AWS SDK, the AWS CLI, or other AWS tooling normally.
+  const result = await sandbox.run("node your-aws-script.js");
+  console.log(result.stdout);
+} finally {
+  await sandbox.delete();
+}
+```
+
+Use `opaqueSecret("...")` instead of `workspaceSecret(...)` when your application
+needs to pass short-lived write-only AWS credentials at sandbox creation time.
+Plaintext AWS credential values are not supported.
+
 ## 1. Connect to LangSmith
 
 Sign up for [LangSmith](https://smith.langchain.com/) using your GitHub, Discord accounts, or an email address and password. If you sign up with an email, make sure to verify your email address before logging in.

--- a/js/src/sandbox/README.md
+++ b/js/src/sandbox/README.md
@@ -49,6 +49,69 @@ const client = new SandboxClient({
 });
 ```
 
+## AWS Auth Proxy
+
+Use the AWS auth proxy when sandbox code needs to call AWS services such as S3,
+Bedrock, or another supported AWS HTTPS endpoint. You configure the AWS
+credentials on the sandbox proxy, and the proxy signs outbound AWS requests with
+SigV4. The real credentials stay outside the sandbox.
+
+This lets code inside the sandbox use normal AWS tooling without exposing
+long-lived AWS credentials in sandbox files, environment variables, shell
+history, or logs. Store the AWS credentials as LangSmith workspace secrets, then
+reference those secret names in the proxy config:
+
+```typescript
+import {
+  SandboxClient,
+  awsAuthProxyConfig,
+  workspaceSecret,
+} from "langsmith/sandbox";
+
+const client = new SandboxClient();
+
+const sandbox = await client.createSandbox({
+  name: "aws-sandbox",
+  proxyConfig: awsAuthProxyConfig({
+    accessKeyId: workspaceSecret("AWS_ACCESS_KEY_ID"),
+    secretAccessKey: workspaceSecret("AWS_SECRET_ACCESS_KEY"),
+  }),
+});
+
+try {
+  const result = await sandbox.run("node your-aws-script.js");
+  console.log(result.stdout);
+} finally {
+  await sandbox.delete();
+}
+```
+
+Inside `your-aws-script.js`, use AWS SDKs normally. For example, if
+`@aws-sdk/client-s3` is installed in the sandbox snapshot:
+
+```typescript
+import { S3Client, ListBucketsCommand } from "@aws-sdk/client-s3";
+
+const s3 = new S3Client({});
+const response = await s3.send(new ListBucketsCommand({}));
+console.log(response.Buckets?.map((bucket) => bucket.Name));
+```
+
+If your application mints short-lived AWS credentials, pass them as write-only
+opaque values instead:
+
+```typescript
+import { awsAuthProxyConfig, opaqueSecret } from "langsmith/sandbox";
+
+const proxyConfig = awsAuthProxyConfig({
+  accessKeyId: opaqueSecret(accessKeyId),
+  secretAccessKey: opaqueSecret(secretAccessKey),
+});
+```
+
+Do not put real AWS credentials in sandbox environment variables. Plaintext AWS
+credential values are not supported by the AWS auth proxy.
+
 ## Running Commands
 
 ```typescript

--- a/js/src/sandbox/index.ts
+++ b/js/src/sandbox/index.ts
@@ -32,6 +32,11 @@
 export { SandboxClient } from "./client.js";
 export { Sandbox } from "./sandbox.js";
 export { CommandHandle } from "./command_handle.js";
+export {
+  awsAuthProxyConfig,
+  opaqueSecret,
+  workspaceSecret,
+} from "./proxy_config.js";
 
 // Types
 export type {
@@ -46,7 +51,9 @@ export type {
   RunOptions,
   CreateSandboxOptions,
   SandboxAccessControl,
+  SandboxAwsAuthRule,
   SandboxProxyConfig,
+  SandboxProxySecret,
   CreateSnapshotOptions,
   CreateDockerfileSnapshotOptions,
   CaptureSnapshotOptions,

--- a/js/src/sandbox/proxy_config.ts
+++ b/js/src/sandbox/proxy_config.ts
@@ -1,0 +1,61 @@
+import type {
+  SandboxAwsAuthRule,
+  SandboxProxyConfig,
+  SandboxProxySecret,
+} from "./types.js";
+
+function requireNonEmptyString(value: string, field: string): string {
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new Error(`${field} must be a non-empty string`);
+  }
+  return value.trim();
+}
+
+/** Reference a LangSmith workspace secret in a sandbox proxy configuration. */
+export function workspaceSecret(name: string): SandboxProxySecret {
+  const normalized = requireNonEmptyString(name, "name");
+  const startsWithBrace = normalized.startsWith("{");
+  const endsWithBrace = normalized.endsWith("}");
+  if (startsWithBrace !== endsWithBrace) {
+    throw new Error("workspace secret must be a name or a {NAME} reference");
+  }
+  if (startsWithBrace && normalized.slice(1, -1).trim() === "") {
+    throw new Error("workspace secret reference must contain a name");
+  }
+  return {
+    type: "workspace_secret",
+    value: startsWithBrace ? normalized : `{${normalized}}`,
+  };
+}
+
+/** Provide a write-only secret value for a sandbox proxy configuration. */
+export function opaqueSecret(value: string): SandboxProxySecret {
+  return {
+    type: "opaque",
+    value: requireNonEmptyString(value, "value"),
+  };
+}
+
+/** Build a sandbox proxy config that signs AWS HTTPS requests with SigV4. */
+export function awsAuthProxyConfig({
+  accessKeyId,
+  secretAccessKey,
+  name = "aws",
+  enabled = true,
+}: {
+  accessKeyId: SandboxProxySecret;
+  secretAccessKey: SandboxProxySecret;
+  name?: string;
+  enabled?: boolean;
+}): SandboxProxyConfig {
+  const rule: SandboxAwsAuthRule = {
+    name: requireNonEmptyString(name, "name"),
+    type: "aws",
+    enabled,
+    aws: {
+      access_key_id: accessKeyId,
+      secret_access_key: secretAccessKey,
+    },
+  };
+  return { rules: [rule] };
+}

--- a/js/src/sandbox/types.ts
+++ b/js/src/sandbox/types.ts
@@ -260,6 +260,29 @@ export interface SandboxAccessControl {
   deny_list?: string[];
 }
 
+/** Secret value reference for sandbox proxy rules. */
+export interface SandboxProxySecret {
+  /** `workspace_secret` references a workspace secret; `opaque` is write-only. */
+  type: "workspace_secret" | "opaque";
+  /** Workspace secret reference or opaque secret value. */
+  value: string;
+}
+
+/** AWS auth rule for sandbox proxy SigV4 signing. */
+export interface SandboxAwsAuthRule {
+  /** Rule name. */
+  name: string;
+  /** AWS auth rules are matched by the sandbox proxy's AWS endpoint matcher. */
+  type: "aws";
+  /** Whether the rule is enabled. */
+  enabled?: boolean;
+  /** AWS credentials used by the proxy signer. */
+  aws: {
+    access_key_id: SandboxProxySecret;
+    secret_access_key: SandboxProxySecret;
+  };
+}
+
 /**
  * Full proxy configuration forwarded to the sandbox server as-is (snake_case
  * so it's wire-compatible with the backend). Mirrors the server's
@@ -324,7 +347,8 @@ export interface CreateSandboxOptions {
    * Per-sandbox proxy configuration. Use
    * `{ access_control: { allow_list: ["github.com", "*.example.com"] } }`
    * to restrict outbound HTTPS to a set of host patterns. Forwarded to the
-   * server as-is on the wire.
+   * server as-is on the wire. Use `awsAuthProxyConfig` to let the proxy sign
+   * supported AWS HTTPS requests on the sandbox's behalf.
    */
   proxyConfig?: SandboxProxyConfig;
 }

--- a/js/src/tests/sandbox.test.ts
+++ b/js/src/tests/sandbox.test.ts
@@ -8,6 +8,11 @@ import { SandboxClient } from "../sandbox/client.js";
 import { Sandbox } from "../sandbox/sandbox.js";
 import { CommandHandle } from "../sandbox/command_handle.js";
 import {
+  awsAuthProxyConfig,
+  opaqueSecret,
+  workspaceSecret,
+} from "../sandbox/index.js";
+import {
   buildWsUrl,
   buildAuthHeaders,
   WSStreamControl,
@@ -44,6 +49,60 @@ const createMockClient = (overrides: Record<string, any> = {}) =>
     deleteSandbox: jest.fn<() => Promise<void>>().mockResolvedValue(undefined),
     ...overrides,
   }) as unknown as SandboxClient;
+
+describe("sandbox proxy config helpers", () => {
+  it("workspaceSecret wraps names and preserves references", () => {
+    expect(workspaceSecret("AWS_KEY_ID_REF")).toEqual({
+      type: "workspace_secret",
+      value: "{AWS_KEY_ID_REF}",
+    });
+    expect(workspaceSecret("{AWS_KEY_VALUE_REF}")).toEqual({
+      type: "workspace_secret",
+      value: "{AWS_KEY_VALUE_REF}",
+    });
+  });
+
+  it.each(["", "   ", "{}", "{AWS_KEY_ID_REF"])(
+    "workspaceSecret rejects invalid name %p",
+    (name) => {
+      expect(() => workspaceSecret(name)).toThrow();
+    },
+  );
+
+  it("opaqueSecret builds a write-only secret value", () => {
+    expect(opaqueSecret("AKIAFAKE")).toEqual({
+      type: "opaque",
+      value: "AKIAFAKE",
+    });
+  });
+
+  it("awsAuthProxyConfig builds an AWS auth rule", () => {
+    expect(
+      awsAuthProxyConfig({
+        accessKeyId: workspaceSecret("AWS_KEY_ID_REF"),
+        secretAccessKey: workspaceSecret("AWS_KEY_VALUE_REF"),
+      }),
+    ).toEqual({
+      rules: [
+        {
+          name: "aws",
+          type: "aws",
+          enabled: true,
+          aws: {
+            access_key_id: {
+              type: "workspace_secret",
+              value: "{AWS_KEY_ID_REF}",
+            },
+            secret_access_key: {
+              type: "workspace_secret",
+              value: "{AWS_KEY_VALUE_REF}",
+            },
+          },
+        },
+      ],
+    });
+  });
+});
 
 describe("SandboxClient", () => {
   describe("constructor", () => {
@@ -451,6 +510,27 @@ describe("SandboxClient - createSandbox", () => {
         allow_list: ["github.com", "*.example.com"],
       },
     };
+    await client.createSandbox("snap-123", { proxyConfig });
+
+    const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string);
+    expect(body.proxy_config).toEqual(proxyConfig);
+  });
+
+  it("should forward AWS auth proxy config in the request body", async () => {
+    const mockFetch = jest.fn<typeof fetch>().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        name: "test-sb",
+        status: "ready",
+      }),
+    } as Response);
+
+    const client = createClientWithMock(mockFetch);
+    const proxyConfig = awsAuthProxyConfig({
+      accessKeyId: workspaceSecret("AWS_KEY_ID_REF"),
+      secretAccessKey: workspaceSecret("AWS_KEY_VALUE_REF"),
+    });
     await client.createSandbox("snap-123", { proxyConfig });
 
     const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];


### PR DESCRIPTION
## Summary

Adds JS SDK support for configuring the sandbox proxy AWS auth rule from user-facing helpers.

- Adds `workspaceSecret(...)`, `opaqueSecret(...)`, and `awsAuthProxyConfig(...)` under `langsmith/sandbox`.
- Wires `proxyConfig` through sandbox creation as the proxy `proxy_config` wire shape expected by the backend.
- Documents how users should use the helper in both the package README and the sandbox README, including workspace-secret and opaque-secret examples.
- Adds unit coverage for the helper wire shape and client request forwarding.

## User Impact

Users can create a sandbox that runs normal AWS SDK or AWS CLI code while the sandbox proxy keeps real AWS credentials outside the sandbox and SigV4-signs supported AWS HTTPS requests. This avoids putting long-lived AWS credentials into sandbox files, environment variables, shell history, or logs.

## Validation

- `pnpm lint` (passes with existing warnings)
- `pnpm exec tsc --noEmit`
- `pnpm test:single src/tests/sandbox.test.ts --runInBand`