### PR TITLE
fix(lint): exclude _openapi_client from ruff

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -159,7 +159,7 @@ exclude = [".test", ".venv*"]
 packages = ["langsmith"]
 
 [tool.ruff]
-exclude = ["langsmith_api"]
+exclude = ["_openapi_client"]
 lint.select = [
   "E",    # pycodestyle
   "F",    # pyflakes


### PR DESCRIPTION
## Summary

- Updates ruff `exclude` in `python/pyproject.toml` from `langsmith_api` to `_openapi_client` to match the folder rename in [langchainplus#26726](https://github.com/langchain-ai/langchainplus/pull/26726)
- Fixes the failing Python Lint CI job on [#2911](https://github.com/langchain-ai/langsmith-sdk/pull/2911)

## Test plan
- [x] Python Lint CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)