### PR TITLE
fix(lint): exclude _openapi_client from mypy

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -205,6 +205,10 @@ plugins = ["pydantic.mypy"]
 ignore_missing_imports = "True"
 disallow_untyped_defs = "True"
 
+[[tool.mypy.overrides]]
+module = "langsmith._openapi_client.*"
+ignore_errors = true
+
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 markers = ["slow: long-running tests"]


### PR DESCRIPTION
## Description

Adds a `[[tool.mypy.overrides]]` section to `pyproject.toml` to suppress mypy errors in `langsmith/_openapi_client.*`. The ruff `exclude` config was already in place but only applies to ruff — mypy has no equivalent, causing CI failures after the client was moved under the `langsmith/` package.