### PR TITLE
release(py): 0.8.10

### DIFF
--- a/python/.bumpversion.cfg
+++ b/python/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.8.8
+current_version = 0.8.10
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
 serialize = {major}.{minor}.{patch}
 search = {current_version}

--- a/python/langsmith/__init__.py
+++ b/python/langsmith/__init__.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
 
 # Avoid calling into importlib on every call to __version__
 
-__version__ = "0.8.9"
+__version__ = "0.8.10"
 version = __version__  # for backwards compatibility
 
 # Metadata key to hide a traced run from LangSmith's Messages View.


### PR DESCRIPTION
## Summary

Bump the Python SDK version to **0.8.10** and cut a PyPI release.

## Test Plan

- [x] `python/langsmith/__init__.py` `__version__` bumped `0.8.9` → `0.8.10` (the Release workflow keys off this and publishes on merge to `main`).