### PR TITLE
fix: value error was incorrectly raised when evaluations returned a list of EvaluationResult instances

### DIFF
--- a/python/langsmith/evaluation/evaluator.py
+++ b/python/langsmith/evaluation/evaluator.py
@@ -914,7 +914,7 @@ def _format_evaluator_result(
             f"EvaluationResult, or EvaluationResults. Got {result}"
         )
     elif isinstance(result, list):
-        if not all(isinstance(x, dict) for x in result):
+        if not all(isinstance(x, dict) or isinstance(x, EvaluationResult) for x in result):
             raise ValueError(
                 f"Expected a list of dicts or EvaluationResults. Received {result}."
             )


### PR DESCRIPTION
Even the error messages states that a list of EvaluationResult instances if a perfectly valid return value. The check just missed that EvaluationResult is a valid return type as it checked for dict only.