### PR TITLE
chore(py): bump Python SDK to 0.8.13

### DIFF
--- a/python/langsmith/__init__.py
+++ b/python/langsmith/__init__.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
 
 # Avoid calling into importlib on every call to __version__
 
-__version__ = "0.8.12"
+__version__ = "0.8.13"
 version = __version__  # for backwards compatibility
 
 # Metadata key to hide a traced run from LangSmith's Messages View.


### PR DESCRIPTION
## Summary

- Bump the Python SDK version to 0.8.13 so the sandbox startup error typing fix from #3004 gets a fresh PyPI release.
- No runtime code changes in this PR.

## Self-Hosted Release Note

none

## Test Plan

- [x] `cd python && make format`
- [x] `cd python && UV_PYTHON=3.12 make lint`
- [ ] `cd python && UV_PYTHON=3.12 make tests` (local run: 1265 passed, 3 skipped, 4 failed in sandbox custom-header tests because this dev environment injects a default LangSmith API key; CI should validate in a clean environment)
