### PR TITLE
chore(py): bump Python SDK to 0.8.14

### DIFF
--- a/python/langsmith/__init__.py
+++ b/python/langsmith/__init__.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
 
 # Avoid calling into importlib on every call to __version__
 
-__version__ = "0.8.13"
+__version__ = "0.8.14"
 version = __version__  # for backwards compatibility
 
 # Metadata key to hide a traced run from LangSmith's Messages View.


### PR DESCRIPTION
## Summary

- Bump the Python SDK version to 0.8.14 to trigger a fresh PyPI release for the sandbox startup error typing fix from #3004.
- The previous 0.8.13 release bump in #3012 created the GitHub release/tag, but PyPI publishing failed during Sigstore/Rekor attestation with a transient 502, so `langsmith==0.8.13` is not available on PyPI.
- No runtime code changes in this PR.

## Self-Hosted Release Note

none

## Test Plan

- [x] `cd python && python3 -c "import langsmith; assert langsmith.__version__ == '0.8.14', langsmith.__version__; print(langsmith.__version__)"`
- [x] `git diff --check`
