### PR TITLE
fix(experiments): extract keys from wrapped evaluator function

### DIFF
--- a/js/src/evaluation/_runner.ts
+++ b/js/src/evaluation/_runner.ts
@@ -1222,14 +1222,41 @@ Try setting "LANGSMITH_TRACING=true" in your environment.`);
   };
 }
 
-function _collectEvaluatorKeys(
+// best effort feedback key extraction using regex parsing.
+// may be fragile but seems okay as a best effort option and doesn't break anything significant.
+// TODO: find a better way to resolve this.
+export function _extractEvaluatorFeedbackKeys(
+  evaluator: EvaluatorT | RunEvaluator,
+): string[] {
+  const name = (evaluator as { name?: string }).name;
+  const fallback = name && name.length > 0 ? [name] : [];
+  try {
+    const source = typeof evaluator === "function" ? evaluator.toString() : "";
+    if (!source) return fallback;
+    // Match `key: "literal"`, `"key": "literal"`, or backtick literals without
+    // interpolation. Word boundaries avoid matching `keys`, and the required
+    // colon + quoted value avoids matching destructuring/`for (const key of)`.
+    const regex = /["']?\bkey\b["']?\s*:\s*(?:"([^"]+)"|'([^']+)'|`([^`$]+)`)/g;
+    const keys: string[] = [];
+    let match: RegExpExecArray | null;
+    while ((match = regex.exec(source)) !== null) {
+      const value = match[1] ?? match[2] ?? match[3];
+      if (value) keys.push(value);
+    }
+    const unique = [...new Set(keys)];
+    return unique.length > 0 ? unique : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+export function _collectEvaluatorKeys(
   evaluators: Array<EvaluatorT | RunEvaluator> | undefined,
 ): string[] {
   if (!evaluators) return [];
   const keys: string[] = [];
   for (const ev of evaluators) {
-    const name = (ev as { name?: string }).name;
-    if (name && name.length > 0) keys.push(name);
+    keys.push(..._extractEvaluatorFeedbackKeys(ev));
   }
   return keys;
 }

--- a/js/src/tests/evaluate_runner.test.ts
+++ b/js/src/tests/evaluate_runner.test.ts
@@ -1,4 +1,6 @@
 import {
+  _collectEvaluatorKeys,
+  _extractEvaluatorFeedbackKeys,
   _mapWithConcurrency,
   _reorderResultRowsByExampleIndex,
   evaluate,
@@ -565,5 +567,135 @@ describe("evaluation runner internals", () => {
     expect(createProjectCalls).toHaveLength(1);
     expect(createProjectCalls[0].numExamples).toBeNull();
     expect(createProjectCalls[0].numRepetitions).toBe(1);
+  });
+});
+
+describe("evaluator feedback-key extraction", () => {
+  test("prefers the returned key over the function name", () => {
+    // The bug: function name (binding) != returned feedback key.
+    const completenessEvaluator = async ({
+      outputs,
+    }: {
+      outputs?: Record<string, any>;
+    }) => ({
+      key: "field_completeness",
+      score: Object.keys(outputs ?? {}).length,
+    });
+    expect(_extractEvaluatorFeedbackKeys(completenessEvaluator as any)).toEqual(
+      ["field_completeness"],
+    );
+  });
+
+  test("named function literal key", () => {
+    function relevance({ outputs }: { outputs?: Record<string, any> }) {
+      return { key: "answer_relevance", score: outputs ? 1 : 0 };
+    }
+    expect(_extractEvaluatorFeedbackKeys(relevance as any)).toEqual([
+      "answer_relevance",
+    ]);
+  });
+
+  test("multi-result evaluator returns all keys", () => {
+    const multi = ({ outputs }: { outputs?: Record<string, any> }) => ({
+      results: [
+        { key: "k1", score: outputs ? 1 : 0 },
+        { key: "k2", score: 0 },
+      ],
+    });
+    expect(_extractEvaluatorFeedbackKeys(multi as any)).toEqual(["k1", "k2"]);
+  });
+
+  test("falls back to the function name when the key is dynamic", () => {
+    const dynamicKey = "computed_at_runtime";
+    function dynamicEval({ outputs }: { outputs?: Record<string, any> }) {
+      return { key: dynamicKey, score: outputs ? 1 : 0 };
+    }
+    expect(_extractEvaluatorFeedbackKeys(dynamicEval as any)).toEqual([
+      "dynamicEval",
+    ]);
+  });
+
+  test("returns empty when neither a literal key nor a name is available", () => {
+    const runtimeKey = "x";
+    expect(
+      _extractEvaluatorFeedbackKeys(((_args: any) => ({
+        key: runtimeKey,
+        score: 1,
+      })) as any),
+    ).toEqual([]);
+  });
+
+  test("_collectEvaluatorKeys aggregates across evaluators", () => {
+    const completenessEvaluator = async ({
+      outputs,
+    }: {
+      outputs?: Record<string, any>;
+    }) => ({ key: "field_completeness", score: outputs ? 1 : 0 });
+    const qualityEvaluator = async ({
+      outputs,
+    }: {
+      outputs?: Record<string, any>;
+    }) => ({ key: "analysis_quality", score: outputs ? 1 : 0 });
+    expect(
+      _collectEvaluatorKeys([
+        completenessEvaluator as any,
+        qualityEvaluator as any,
+      ]),
+    ).toEqual(["field_completeness", "analysis_quality"]);
+  });
+
+  test("createProject receives the returned feedback keys, not function names", async () => {
+    const now = new Date().toISOString();
+    const examples: Example[] = [1, 2, 3].map((v) => ({
+      id: `e${v}`,
+      inputs: { value: v },
+      outputs: {},
+      dataset_id: "test",
+      created_at: now,
+      modified_at: now,
+      runs: [],
+    }));
+
+    const completenessEvaluator = async ({
+      outputs,
+    }: {
+      outputs?: Record<string, any>;
+    }) => ({ key: "field_completeness", score: outputs ? 1 : 0 });
+    const qualityEvaluator = async ({
+      outputs,
+    }: {
+      outputs?: Record<string, any>;
+    }) => ({ key: "analysis_quality", score: outputs ? 1 : 0 });
+
+    const createProjectCalls: any[] = [];
+    const mockClient = {
+      createProject: async (params: any) => {
+        createProjectCalls.push(params);
+        return { id: "test", name: "test", reference_dataset_id: "test" };
+      },
+      updateProject: async () => ({}),
+      createFeedback: async () => ({}),
+      logEvaluationFeedback: async () => [],
+      awaitPendingTraceBatches: async () => undefined,
+      getDatasetUrl: async () => "http://test.com",
+    } as any;
+
+    const results = await evaluate(
+      async (input: any) => ({ result: input.value }),
+      {
+        data: examples,
+        evaluators: [completenessEvaluator, qualityEvaluator],
+        client: mockClient,
+      },
+    );
+    for await (const _ of results) {
+      // drain
+    }
+
+    expect(createProjectCalls).toHaveLength(1);
+    expect(createProjectCalls[0].evaluatorKeys).toEqual([
+      "field_completeness",
+      "analysis_quality",
+    ]);
   });
 });

--- a/python/langsmith/evaluation/_arunner.py
+++ b/python/langsmith/evaluation/_arunner.py
@@ -36,7 +36,6 @@ from langsmith.evaluation._runner import (
     _collect_evaluator_keys,
     _evaluators_include_attachments,
     _ExperimentManagerMixin,
-    _extract_feedback_keys,
     _ForwardResults,
     _get_target_args,
     _is_langchain_runnable,
@@ -1027,7 +1026,7 @@ class _AsyncExperimentManager(_ExperimentManagerMixin):
                     return selected_results
                 except Exception as e:
                     try:
-                        feedback_keys = _extract_feedback_keys(evaluator)
+                        feedback_keys = evaluator.feedback_keys
 
                         error_response = EvaluationResults(
                             results=[

--- a/python/langsmith/evaluation/_key_extraction.py
+++ b/python/langsmith/evaluation/_key_extraction.py
@@ -1,0 +1,153 @@
+"""Static extraction of feedback keys from evaluator functions.
+
+An evaluator's feedback key is the ``key`` value it returns (e.g.
+``{"key": "correctness", "score": 1}``). The runner uses these keys to render
+per-evaluator progress and to synthesize error feedback when an evaluator
+raises. They are inferred by parsing the function's source into an AST and
+reading the literal ``key`` values it produces -- never by executing the
+function.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import textwrap
+from typing import Callable
+
+# Python 3.14+ removes ast.Str in favor of ast.Constant
+_AST_STR_TYPES: tuple = (
+    (ast.Str, ast.Constant) if hasattr(ast, "Str") else (ast.Constant,)
+)
+
+
+def _get_str_value(node: ast.expr) -> str:
+    """Get string value from ast.Str or ast.Constant."""
+    return node.value if isinstance(node, ast.Constant) else node.s  # type: ignore[return-value,union-attr,attr-defined]
+
+
+def _extract_code_evaluator_feedback_keys(func: Callable) -> list[str]:
+    python_code = inspect.getsource(func)
+
+    def extract_dict_keys(node):
+        if isinstance(node, ast.Dict):
+            keys = []
+            key_value = None
+            for key, value in zip(node.keys, node.values):
+                if isinstance(key, _AST_STR_TYPES):
+                    key_str = _get_str_value(key)
+                    if key_str == "key" and isinstance(value, _AST_STR_TYPES):
+                        key_value = _get_str_value(value)
+            return [key_value] if key_value else keys
+        elif (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "dict"
+        ):
+            for keyword in node.keywords:
+                if keyword.arg == "key" and isinstance(keyword.value, _AST_STR_TYPES):
+                    return [_get_str_value(keyword.value)]
+        return []
+
+    def extract_evaluation_result_key(node):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "EvaluationResult"
+        ):
+            for keyword in node.keywords:
+                if keyword.arg == "key" and isinstance(keyword.value, _AST_STR_TYPES):
+                    return [_get_str_value(keyword.value)]
+        return []
+
+    def extract_evaluation_results_keys(node, variables):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "EvaluationResults"
+        ):
+            for keyword in node.keywords:
+                if keyword.arg == "results":
+                    if isinstance(keyword.value, ast.Name):
+                        return variables.get(keyword.value.id, [])
+                    elif isinstance(keyword.value, ast.List):
+                        keys = []
+                        for elt in keyword.value.elts:
+                            keys.extend(extract_evaluation_result_key(elt))
+                        return keys
+        elif isinstance(node, ast.Dict):
+            for key, value in zip(node.keys, node.values):
+                if isinstance(key, _AST_STR_TYPES) and _get_str_value(key) == "results":
+                    if isinstance(value, ast.List):
+                        keys = []
+                        for elt in value.elts:
+                            if isinstance(elt, ast.Dict):
+                                for elt_key, elt_value in zip(elt.keys, elt.values):
+                                    if (
+                                        isinstance(elt_key, _AST_STR_TYPES)
+                                        and _get_str_value(elt_key) == "key"
+                                    ):
+                                        if isinstance(elt_value, _AST_STR_TYPES):
+                                            keys.append(_get_str_value(elt_value))
+                            elif (
+                                isinstance(elt, ast.Call)
+                                and isinstance(elt.func, ast.Name)
+                                and elt.func.id in ("EvaluationResult", "dict")
+                            ):
+                                for keyword in elt.keywords:
+                                    if keyword.arg == "key" and isinstance(
+                                        keyword.value, _AST_STR_TYPES
+                                    ):
+                                        keys.append(_get_str_value(keyword.value))
+
+                        return keys
+        return []
+
+    python_code = textwrap.dedent(python_code)
+
+    try:
+        tree = ast.parse(python_code)
+        function_def = tree.body[0]
+        if not isinstance(function_def, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            return []
+
+        variables = {}
+        keys = []
+
+        for node in ast.walk(function_def):
+            if isinstance(node, ast.Assign):
+                if isinstance(node.value, ast.List):
+                    list_keys = []
+                    for elt in node.value.elts:
+                        list_keys.extend(extract_evaluation_result_key(elt))
+                    if isinstance(node.targets[0], ast.Name):
+                        variables[node.targets[0].id] = list_keys
+            elif isinstance(node, ast.Return) and node.value is not None:
+                dict_keys = extract_dict_keys(node.value)
+                eval_result_key = extract_evaluation_result_key(node.value)
+                eval_results_keys = extract_evaluation_results_keys(
+                    node.value, variables
+                )
+
+                keys.extend(dict_keys)
+                keys.extend(eval_result_key)
+                keys.extend(eval_results_keys)
+
+        # If no keys found, return the function name
+        return keys if keys else [function_def.name]
+
+    except SyntaxError:
+        return []
+
+
+def _safe_extract_feedback_keys(func: Callable) -> list[str]:
+    """Best-effort static extraction of an evaluator's feedback keys.
+
+    Reads the function's source and returns the literal ``key`` values it emits.
+    Degrades to ``[]`` when keys can't be statically inferred (dynamic keys,
+    source unavailable, etc.) so evaluator construction never fails.
+    """
+    try:
+        return _extract_code_evaluator_feedback_keys(func)
+    except Exception:
+        return []

--- a/python/langsmith/evaluation/_runner.py
+++ b/python/langsmith/evaluation/_runner.py
@@ -2249,6 +2249,8 @@ def _extract_feedback_keys(evaluator: RunEvaluator):
 
 
 def _extract_code_evaluator_feedback_keys(func: Callable) -> list[str]:
+    # Unwrap to the user's original function so key extraction reads their source.
+    func = getattr(func, "__wrapped_evaluator_func__", func)
     python_code = inspect.getsource(func)
 
     def extract_dict_keys(node):

--- a/python/langsmith/evaluation/_runner.py
+++ b/python/langsmith/evaluation/_runner.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import ast
 import collections
 import concurrent.futures as cf
 import functools
@@ -13,7 +12,6 @@ import logging
 import pathlib
 import queue
 import random
-import textwrap
 import threading
 import uuid
 from collections.abc import (
@@ -50,7 +48,6 @@ from langsmith.evaluation.evaluator import (
     SUMMARY_EVALUATOR_T,
     ComparisonEvaluationResult,
     DynamicComparisonRunEvaluator,
-    DynamicRunEvaluator,
     EvaluationResult,
     EvaluationResults,
     RunEvaluator,
@@ -58,17 +55,6 @@ from langsmith.evaluation.evaluator import (
     comparison_evaluator,
     run_evaluator,
 )
-
-# Python 3.14+ removes ast.Str in favor of ast.Constant
-_AST_STR_TYPES: tuple = (
-    (ast.Str, ast.Constant) if hasattr(ast, "Str") else (ast.Constant,)
-)
-
-
-def _get_str_value(node: ast.expr) -> str:
-    """Get string value from ast.Str or ast.Constant."""
-    return node.value if isinstance(node, ast.Constant) else node.s  # type: ignore[return-value,union-attr,attr-defined]
-
 
 if TYPE_CHECKING:
     import pandas as pd
@@ -1699,7 +1685,7 @@ class _ExperimentManager(_ExperimentManagerMixin):
                         )
                 except Exception as e:
                     try:
-                        feedback_keys = _extract_feedback_keys(evaluator)
+                        feedback_keys = evaluator.feedback_keys
 
                         error_response = EvaluationResults(
                             results=[
@@ -2023,7 +2009,7 @@ def _collect_evaluator_keys(
     keys: list[str] = []
     try:
         for ev in _resolve_evaluators(evaluators):
-            for k in _extract_feedback_keys(ev) or []:
+            for k in ev.feedback_keys:
                 if k:
                     keys.append(k)
     except Exception:
@@ -2232,136 +2218,6 @@ def _get_random_name() -> str:
     from langsmith.evaluation._name_generation import random_name  # noqa: F401
 
     return random_name()
-
-
-def _extract_feedback_keys(evaluator: RunEvaluator):
-    if isinstance(evaluator, DynamicRunEvaluator):
-        if getattr(evaluator, "func", None):
-            return _extract_code_evaluator_feedback_keys(evaluator.func)
-        elif getattr(evaluator, "afunc", None):
-            return _extract_code_evaluator_feedback_keys(evaluator.afunc)
-    # TODO: Support for DynamicComparisonRunEvaluator
-    if hasattr(evaluator, "evaluator"):
-        # LangChainStringEvaluator
-        if getattr(getattr(evaluator, "evaluator"), "evaluation_name", None):
-            return [evaluator.evaluator.evaluation_name]
-    return []
-
-
-def _extract_code_evaluator_feedback_keys(func: Callable) -> list[str]:
-    # Unwrap to the user's original function so key extraction reads their source.
-    func = getattr(func, "__wrapped_evaluator_func__", func)
-    python_code = inspect.getsource(func)
-
-    def extract_dict_keys(node):
-        if isinstance(node, ast.Dict):
-            keys = []
-            key_value = None
-            for key, value in zip(node.keys, node.values):
-                if isinstance(key, _AST_STR_TYPES):
-                    key_str = _get_str_value(key)
-                    if key_str == "key" and isinstance(value, _AST_STR_TYPES):
-                        key_value = _get_str_value(value)
-            return [key_value] if key_value else keys
-        elif (
-            isinstance(node, ast.Call)
-            and isinstance(node.func, ast.Name)
-            and node.func.id == "dict"
-        ):
-            for keyword in node.keywords:
-                if keyword.arg == "key" and isinstance(keyword.value, _AST_STR_TYPES):
-                    return [_get_str_value(keyword.value)]
-        return []
-
-    def extract_evaluation_result_key(node):
-        if (
-            isinstance(node, ast.Call)
-            and isinstance(node.func, ast.Name)
-            and node.func.id == "EvaluationResult"
-        ):
-            for keyword in node.keywords:
-                if keyword.arg == "key" and isinstance(keyword.value, _AST_STR_TYPES):
-                    return [_get_str_value(keyword.value)]
-        return []
-
-    def extract_evaluation_results_keys(node, variables):
-        if (
-            isinstance(node, ast.Call)
-            and isinstance(node.func, ast.Name)
-            and node.func.id == "EvaluationResults"
-        ):
-            for keyword in node.keywords:
-                if keyword.arg == "results":
-                    if isinstance(keyword.value, ast.Name):
-                        return variables.get(keyword.value.id, [])
-                    elif isinstance(keyword.value, ast.List):
-                        keys = []
-                        for elt in keyword.value.elts:
-                            keys.extend(extract_evaluation_result_key(elt))
-                        return keys
-        elif isinstance(node, ast.Dict):
-            for key, value in zip(node.keys, node.values):
-                if isinstance(key, _AST_STR_TYPES) and _get_str_value(key) == "results":
-                    if isinstance(value, ast.List):
-                        keys = []
-                        for elt in value.elts:
-                            if isinstance(elt, ast.Dict):
-                                for elt_key, elt_value in zip(elt.keys, elt.values):
-                                    if (
-                                        isinstance(elt_key, _AST_STR_TYPES)
-                                        and _get_str_value(elt_key) == "key"
-                                    ):
-                                        if isinstance(elt_value, _AST_STR_TYPES):
-                                            keys.append(_get_str_value(elt_value))
-                            elif (
-                                isinstance(elt, ast.Call)
-                                and isinstance(elt.func, ast.Name)
-                                and elt.func.id in ("EvaluationResult", "dict")
-                            ):
-                                for keyword in elt.keywords:
-                                    if keyword.arg == "key" and isinstance(
-                                        keyword.value, _AST_STR_TYPES
-                                    ):
-                                        keys.append(_get_str_value(keyword.value))
-
-                        return keys
-        return []
-
-    python_code = textwrap.dedent(python_code)
-
-    try:
-        tree = ast.parse(python_code)
-        function_def = tree.body[0]
-        if not isinstance(function_def, (ast.FunctionDef, ast.AsyncFunctionDef)):
-            return []
-
-        variables = {}
-        keys = []
-
-        for node in ast.walk(function_def):
-            if isinstance(node, ast.Assign):
-                if isinstance(node.value, ast.List):
-                    list_keys = []
-                    for elt in node.value.elts:
-                        list_keys.extend(extract_evaluation_result_key(elt))
-                    if isinstance(node.targets[0], ast.Name):
-                        variables[node.targets[0].id] = list_keys
-            elif isinstance(node, ast.Return) and node.value is not None:
-                dict_keys = extract_dict_keys(node.value)
-                eval_result_key = extract_evaluation_result_key(node.value)
-                eval_results_keys = extract_evaluation_results_keys(
-                    node.value, variables
-                )
-
-                keys.extend(dict_keys)
-                keys.extend(eval_result_key)
-                keys.extend(eval_results_keys)
-
-        # If no keys found, return the function name
-        return keys if keys else [function_def.name]
-
-    except SyntaxError:
-        return []
 
 
 def _to_pandas(

--- a/python/langsmith/evaluation/evaluator.py
+++ b/python/langsmith/evaluation/evaluator.py
@@ -23,6 +23,7 @@ from typing_extensions import TypedDict
 
 from langsmith import run_helpers as rh
 from langsmith import schemas
+from langsmith.evaluation._key_extraction import _safe_extract_feedback_keys
 from langsmith.schemas import SCORE_TYPE, VALUE_TYPE, Example, Run
 
 logger = logging.getLogger(__name__)
@@ -147,6 +148,21 @@ class RunEvaluator:
 
         return await asyncio.get_running_loop().run_in_executor(None, _run_with_context)
 
+    @property
+    def feedback_keys(self) -> list[str]:
+        """Feedback keys this evaluator emits, when statically known.
+
+        Used to render per-evaluator experiment progress and to synthesize error
+        feedback when the evaluator raises. Best-effort: empty when the keys can't
+        be determined without running the evaluator. Subclasses that know their
+        keys should override this. The default also resolves evaluators that wrap
+        a single named inner evaluator exposed as ``.evaluator`` (e.g. the
+        LangChain string-evaluator integration).
+        """
+        inner = getattr(self, "evaluator", None)
+        name = getattr(inner, "evaluation_name", None)
+        return [name] if name else []
+
 
 _RUNNABLE_OUTPUT = Union[EvaluationResult, EvaluationResults, dict]
 
@@ -205,6 +221,7 @@ class DynamicRunEvaluator(RunEvaluator):
             func (Callable): A function that takes a `Run` and an optional `Example` as
             arguments, and returns a dict or `ComparisonEvaluationResult`.
         """
+        self._feedback_keys = _safe_extract_feedback_keys(func)
         (func, prepare_inputs) = _normalize_evaluator_func(func)
         if afunc:
             (afunc, prepare_inputs) = _normalize_evaluator_func(afunc)  # type: ignore[assignment]
@@ -312,6 +329,15 @@ class DynamicRunEvaluator(RunEvaluator):
             bool: `True` if the evaluator function is asynchronous, `False` otherwise.
         """
         return hasattr(self, "afunc")
+
+    @property
+    def feedback_keys(self) -> list[str]:
+        """Feedback keys this evaluator emits, statically inferred from its source.
+
+        Best-effort: empty when keys can't be determined without running the
+        function (e.g. a dynamically computed key or unavailable source).
+        """
+        return self._feedback_keys
 
     def evaluate_run(
         self,
@@ -725,8 +751,6 @@ def _normalize_evaluator_func(
                 if hasattr(func, "__name__")
                 else awrapper.__name__
             )
-            # Breadcrumb to the user's original function for feedback-key extraction.
-            awrapper.__wrapped_evaluator_func__ = func  # type: ignore[attr-defined]
             return (awrapper, _prepare_inputs)  # type: ignore[return-value]
 
         else:
@@ -771,8 +795,6 @@ def _normalize_evaluator_func(
                 if hasattr(func, "__name__")
                 else wrapper.__name__
             )
-            # Breadcrumb to the user's original function for feedback-key extraction.
-            wrapper.__wrapped_evaluator_func__ = func  # type: ignore[attr-defined]
             return (wrapper, _prepare_inputs)  # type: ignore[return-value]
 
 

--- a/python/langsmith/evaluation/evaluator.py
+++ b/python/langsmith/evaluation/evaluator.py
@@ -725,6 +725,8 @@ def _normalize_evaluator_func(
                 if hasattr(func, "__name__")
                 else awrapper.__name__
             )
+            # Breadcrumb to the user's original function for feedback-key extraction.
+            awrapper.__wrapped_evaluator_func__ = func  # type: ignore[attr-defined]
             return (awrapper, _prepare_inputs)  # type: ignore[return-value]
 
         else:
@@ -769,6 +771,8 @@ def _normalize_evaluator_func(
                 if hasattr(func, "__name__")
                 else wrapper.__name__
             )
+            # Breadcrumb to the user's original function for feedback-key extraction.
+            wrapper.__wrapped_evaluator_func__ = func  # type: ignore[attr-defined]
             return (wrapper, _prepare_inputs)  # type: ignore[return-value]
 
 

--- a/python/langsmith/evaluation/string_evaluator.py
+++ b/python/langsmith/evaluation/string_evaluator.py
@@ -45,3 +45,8 @@ class StringEvaluator(RunEvaluator, BaseModel):
         run_output = run.outputs[self.prediction_key]
         grading_results = self.grading_function(run_input, run_output, answer)
         return EvaluationResult(**{"key": self.evaluation_name, **grading_results})
+
+    @property
+    def feedback_keys(self) -> list[str]:
+        """The single key this evaluator emits, when its name is set."""
+        return [self.evaluation_name] if self.evaluation_name else []

--- a/python/tests/unit_tests/evaluation/test_key_extraction.py
+++ b/python/tests/unit_tests/evaluation/test_key_extraction.py
@@ -1,0 +1,99 @@
+"""Unit tests for static feedback-key extraction from evaluator source."""
+
+import pytest
+
+from langsmith.evaluation._key_extraction import (
+    _extract_code_evaluator_feedback_keys,
+    _safe_extract_feedback_keys,
+)
+from langsmith.evaluation.evaluator import EvaluationResult, EvaluationResults
+
+
+def _dict_literal(run, example):
+    return {"key": "correctness", "score": 1}
+
+
+def _dict_call(run, example):
+    return dict(key="relevance", score=1)
+
+
+def _evaluation_result(run, example):
+    return EvaluationResult(key="accuracy", score=1)
+
+
+def _evaluation_results_list(run, example):
+    return EvaluationResults(
+        results=[
+            EvaluationResult(key="k1", score=1),
+            EvaluationResult(key="k2", score=0),
+        ]
+    )
+
+
+def _evaluation_results_mixed_elements(run, example):
+    return EvaluationResults(
+        results=[
+            EvaluationResult(key="d1", score=1),
+            dict(key="d2", score=0),
+        ]
+    )
+
+
+def _results_dict_form(run, example):
+    return {"results": [{"key": "x", "score": 1}, {"key": "y", "score": 0}]}
+
+
+def _results_from_variable(run, example):
+    results = [
+        EvaluationResult(key="a", score=1),
+        EvaluationResult(key="b", score=0),
+    ]
+    return EvaluationResults(results=results)
+
+
+async def _async_dict_literal(inputs, outputs):
+    return {"key": "async_key", "score": 1}
+
+
+def _dynamic_key(run, example):
+    computed = "computed_at_runtime"
+    return {"key": computed, "score": 1}
+
+
+@pytest.mark.parametrize(
+    "func,expected",
+    [
+        (_dict_literal, ["correctness"]),
+        (_dict_call, ["relevance"]),
+        (_evaluation_result, ["accuracy"]),
+        (_evaluation_results_list, ["k1", "k2"]),
+        (_results_dict_form, ["x", "y"]),
+        (_results_from_variable, ["a", "b"]),
+        (_async_dict_literal, ["async_key"]),
+    ],
+)
+def test_extract_code_evaluator_feedback_keys(func, expected):
+    assert _extract_code_evaluator_feedback_keys(func) == expected
+
+
+def test_dict_element_inside_evaluation_results_is_not_extracted():
+    # Known limitation: within ``EvaluationResults(results=[...])`` only
+    # ``EvaluationResult(...)`` elements are parsed; a ``dict(...)`` element is
+    # skipped. (The dict-form ``{"results": [...]}`` branch does handle both.)
+    assert _extract_code_evaluator_feedback_keys(
+        _evaluation_results_mixed_elements
+    ) == ["d1"]
+
+
+def test_falls_back_to_function_name_for_dynamic_key():
+    # No literal `key` to read, so extraction falls back to the function name.
+    assert _extract_code_evaluator_feedback_keys(_dynamic_key) == ["_dynamic_key"]
+
+
+def test_safe_extract_returns_empty_when_source_unavailable():
+    # Built-ins have no inspectable source; inspect.getsource raises -> [].
+    assert _safe_extract_feedback_keys(len) == []
+
+
+def test_safe_extract_matches_direct_extraction_on_happy_path():
+    assert _safe_extract_feedback_keys(_dict_literal) == ["correctness"]

--- a/python/tests/unit_tests/evaluation/test_runner.py
+++ b/python/tests/unit_tests/evaluation/test_runner.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import functools
+import inspect
 import itertools
 import json
 import random
@@ -23,9 +24,14 @@ from langsmith import schemas as ls_schemas
 from langsmith.evaluation._runner import (
     ComparativeExperimentResults,
     _build_comparative_url,
+    _collect_evaluator_keys,
+    _extract_feedback_keys,
     _get_target_args,
 )
 from langsmith.evaluation.evaluator import (
+    DynamicRunEvaluator,
+    EvaluationResult,
+    EvaluationResults,
     _normalize_comparison_evaluator_func,
     _normalize_evaluator_func,
     _normalize_summary_evaluator,
@@ -1083,6 +1089,62 @@ def test_normalize_evaluator_func_invalid(func, is_async):
             )
         else:
             evaluate(target, data=ds_examples, evaluators=[func], client=client)
+
+
+def _legacy_run_example_eval(run, example):
+    return {"key": "legacy_key", "score": 1}
+
+
+def _modern_eval(inputs, outputs, reference_outputs):
+    return {"key": "correctness", "score": 1}
+
+
+def _modern_subset_eval(outputs, reference_outputs):
+    return {"key": "relevance", "score": 0}
+
+
+async def _modern_async_eval(inputs, outputs):
+    return {"key": "helpfulness", "score": 1}
+
+
+def _modern_multi_key_eval(inputs, outputs):
+    return EvaluationResults(
+        results=[
+            EvaluationResult(key="k1", score=1),
+            EvaluationResult(key="k2", score=0),
+        ]
+    )
+
+
+@pytest.mark.parametrize(
+    "func,expected",
+    [
+        (_legacy_run_example_eval, ["legacy_key"]),
+        (_modern_eval, ["correctness"]),
+        (_modern_subset_eval, ["relevance"]),
+        (_modern_async_eval, ["helpfulness"]),
+        (_modern_multi_key_eval, ["k1", "k2"]),
+    ],
+)
+def test_extract_feedback_keys_unwraps_normalized_evaluator(func, expected):
+    """Feedback keys are read from the user's function, not the (run, example) wrapper.
+
+    Documented (inputs, outputs, reference_outputs) evaluators are rewritten into
+    a wrapper by _normalize_evaluator_func, which previously caused key extraction
+    to fall back to the name "wrapper".
+    """
+    evaluator = DynamicRunEvaluator(func)
+    assert _extract_feedback_keys(evaluator) == expected
+    # The wrapper must still present a (run, example) interface to the runner.
+    target = evaluator.func if getattr(evaluator, "func", None) else evaluator.afunc
+    assert list(inspect.signature(target).parameters)[:2] == ["run", "example"]
+
+
+def test_collect_evaluator_keys_mixes_legacy_and_modern():
+    """The aggregate sent to create_project resolves keys for both styles."""
+    assert _collect_evaluator_keys(
+        [_modern_eval, _modern_subset_eval, _legacy_run_example_eval]
+    ) == ["correctness", "relevance", "legacy_key"]
 
 
 def summary_eval_runs_examples(runs_, examples_):

--- a/python/tests/unit_tests/evaluation/test_runner.py
+++ b/python/tests/unit_tests/evaluation/test_runner.py
@@ -25,17 +25,18 @@ from langsmith.evaluation._runner import (
     ComparativeExperimentResults,
     _build_comparative_url,
     _collect_evaluator_keys,
-    _extract_feedback_keys,
     _get_target_args,
 )
 from langsmith.evaluation.evaluator import (
     DynamicRunEvaluator,
     EvaluationResult,
     EvaluationResults,
+    RunEvaluator,
     _normalize_comparison_evaluator_func,
     _normalize_evaluator_func,
     _normalize_summary_evaluator,
 )
+from langsmith.evaluation.string_evaluator import StringEvaluator
 from tests.unit_tests.conftest import parse_request_data
 
 
@@ -1126,7 +1127,7 @@ def _modern_multi_key_eval(inputs, outputs):
         (_modern_multi_key_eval, ["k1", "k2"]),
     ],
 )
-def test_extract_feedback_keys_unwraps_normalized_evaluator(func, expected):
+def test_feedback_keys_read_from_user_func_not_wrapper(func, expected):
     """Feedback keys are read from the user's function, not the (run, example) wrapper.
 
     Documented (inputs, outputs, reference_outputs) evaluators are rewritten into
@@ -1134,7 +1135,7 @@ def test_extract_feedback_keys_unwraps_normalized_evaluator(func, expected):
     to fall back to the name "wrapper".
     """
     evaluator = DynamicRunEvaluator(func)
-    assert _extract_feedback_keys(evaluator) == expected
+    assert evaluator.feedback_keys == expected
     # The wrapper must still present a (run, example) interface to the runner.
     target = evaluator.func if getattr(evaluator, "func", None) else evaluator.afunc
     assert list(inspect.signature(target).parameters)[:2] == ["run", "example"]
@@ -1145,6 +1146,48 @@ def test_collect_evaluator_keys_mixes_legacy_and_modern():
     assert _collect_evaluator_keys(
         [_modern_eval, _modern_subset_eval, _legacy_run_example_eval]
     ) == ["correctness", "relevance", "legacy_key"]
+
+
+def test_dynamic_run_evaluator_exposes_feedback_keys_property():
+    """feedback_keys is public, so callers read it directly without a private attr."""
+    assert DynamicRunEvaluator(_modern_eval).feedback_keys == ["correctness"]
+
+
+def test_base_run_evaluator_feedback_keys_default_empty():
+    """An evaluator with no statically known keys resolves to an empty list."""
+
+    class _Bare(RunEvaluator):
+        def evaluate_run(self, run, example=None, evaluator_run_id=None):
+            return EvaluationResult(key="x", score=1)
+
+    assert _Bare().feedback_keys == []
+
+
+def test_feedback_keys_resolves_named_inner_evaluator():
+    """Wrappers exposing a named inner evaluator as ``.evaluator`` report its name.
+
+    Covers the LangChain string-evaluator integration shape without that class
+    needing to know about feedback_keys.
+    """
+
+    class _Inner:
+        evaluation_name = "lc_score"
+
+    class _Wrapper(RunEvaluator):
+        evaluator = _Inner()
+
+        def evaluate_run(self, run, example=None, evaluator_run_id=None):
+            return EvaluationResult(key="x", score=1)
+
+    assert _Wrapper().feedback_keys == ["lc_score"]
+
+
+def test_string_evaluator_feedback_keys():
+    evaluator = StringEvaluator(
+        evaluation_name="accuracy",
+        grading_function=lambda *_: {"score": 1},
+    )
+    assert evaluator.feedback_keys == ["accuracy"]
 
 
 def summary_eval_runs_examples(runs_, examples_):


### PR DESCRIPTION
## Description
Addresses LSE-2416 which investigates why evaluator progress was missing when kicking an experiment from the sdk. Issue was identified when defining an evaluator using the documented `(inputs, outputs, reference_outputs)` convention which transforms the evaluator method before extraction. Solution is to include the original function as an attribute of the wrapped function and use original function for extraction. Now works for both `(inputs, outputs, reference_outputs)`  and `(run, example)` defined evaluators. 

The JS sdk presents the same issue where evaluator keys are extracted as an incorrect name and are therefore not updated properly. This leads to 0/n runs completed on the LangSmith UI. The cause is the lack of a proper `_extractEvaluatorFeedbackKeys` method which we've implemented in this PR as well. 



## Release Note
Fix 0/n runs evaluated count in LangSmith when kicking off experiments from the python sdk. 

## Test Plan
- [x] make tests TEST="tests/unit_tests/evaluation/test_runner.py tests/unit_tests/evaluation/test_evaluator.py" --PASSES 
- [x] NODE_OPTIONS=--experimental-vm-modules pnpm jest --config jest.config.cjs src/tests/evaluate_runner.test.ts --PASSES