### PR TITLE
chore: protect JS openapi client in workflow

### DIFF
--- a/.github/workflows/protect-openapi-client.yml
+++ b/.github/workflows/protect-openapi-client.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - "python/langsmith/_openapi_client/**"
+      - "js/src/_openapi_client/**"
 
 permissions: {}
 
@@ -30,11 +31,11 @@ jobs:
           fi
 
           echo ""
-          echo "❌ Unauthorized changes detected in python/langsmith/_openapi_client/"
+          echo "❌ Unauthorized changes detected in python/langsmith/_openapi_client/ or js/src/_openapi_client/"
           echo ""
-          echo "This directory is auto-generated and must only be updated via the"
-          echo "sync_python_sdk workflow in langchain-ai/langchainplus:"
-          echo "https://github.com/langchain-ai/langchainplus/actions/workflows/sync_python_sdk.yml"
+          echo "These directories are auto-generated and must only be updated via the"
+          echo "stlc_sync_python_and_js_sdks workflow in langchain-ai/langchainplus:"
+          echo "https://github.com/langchain-ai/langchainplus/actions/workflows/stlc_sync_python_and_js_sdks.yml"
           echo ""
-          echo "Please remove any modifications to python/langsmith/_openapi_client/ from this PR."
+          echo "Please remove any modifications to python/langsmith/_openapi_client/ or js/src/_openapi_client/ from this PR."
           exit 1


### PR DESCRIPTION
## Summary

- Extends the `protect-openapi-client` workflow to also trigger on changes to `js/src/_openapi_client/**`
- The authorization check is unchanged — only PRs from `sync/langsmith-api` branch by `langtions-bot[bot]` are allowed (the same sync workflow already writes both Python and JS clients together)
- Updated error message to reference both paths and the correct workflow URL (`stlc_sync_python_and_js_sdks`)

## Test plan

- [ ] Verify the workflow triggers on a PR touching `js/src/_openapi_client/`
- [ ] Verify it passes for the `langtions-bot[bot]` sync PR and blocks manual changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)