### PR TITLE
feat: expose the resources from the generated openapi client in the langsmith client

### DIFF
--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -1395,6 +1395,13 @@ export class Client implements LangSmithTracingClientInterface {
       this.apiKey === undefined && this.workspaceId === undefined
         ? { "X-API-Key": null }
         : undefined;
+    const {
+      method: _method,
+      headers: _headers,
+      body: _body,
+      signal: _signal,
+      ...openAPIFetchOptions
+    } = this.fetchOptions;
 
     return new OpenAPILangsmith({
       apiKey: this.apiKey,
@@ -1402,7 +1409,7 @@ export class Client implements LangSmithTracingClientInterface {
       baseURL: this._getOpenAPIBaseUrl(),
       timeout: this.timeout_ms,
       fetch: this._fetch,
-      fetchOptions: this.fetchOptions,
+      fetchOptions: openAPIFetchOptions,
       defaultHeaders,
     });
   }

--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -74,6 +74,8 @@ import {
 
 import { EvaluationResult, EvaluationResults } from "./evaluation/evaluator.js";
 import { __version__ } from "./index.js";
+import { Langsmith as OpenAPILangsmith } from "./_openapi_client/index.js";
+import { OnlineEvaluators } from "./_openapi_client/resources/online-evaluators.js";
 import { assertUuid } from "./utils/_uuid.js";
 import { warnOnce } from "./utils/warn.js";
 import { parseHubIdentifier } from "./utils/prompts.js";
@@ -527,22 +529,6 @@ interface ProjectOptions {
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type RecordStringAny = Record<string, any>;
-
-export interface OnlineEvaluatorsClient {
-  create(body: RecordStringAny): Promise<RecordStringAny>;
-  retrieve(evaluatorId: string): Promise<RecordStringAny>;
-  update(evaluatorId: string, body: RecordStringAny): Promise<RecordStringAny>;
-  list(query?: RecordStringAny): Promise<RecordStringAny>;
-  delete(
-    evaluatorId: string,
-    params?: { delete_run_rules?: boolean },
-  ): Promise<void>;
-  bulkDelete(params: {
-    evaluator_ids: string[];
-    delete_run_rules?: boolean;
-  }): Promise<RecordStringAny>;
-  spend(query: RecordStringAny): Promise<RecordStringAny>;
-}
 
 export type FeedbackSourceType = "model" | "api" | "app";
 
@@ -1397,6 +1383,10 @@ export class Client implements LangSmithTracingClientInterface {
     this._customHeaders = value ?? {};
   }
 
+  private _getOpenAPIBaseUrl(): string {
+    return this.apiUrl.endsWith("/v1") ? this.apiUrl.slice(0, -3) : this.apiUrl;
+  }
+
   private _getPlatformEndpointPath(path: string): string {
     // Check if apiUrl already ends with /v1 or /v1/ to avoid double /v1/v1/ paths
     const needsV1Prefix =
@@ -1404,75 +1394,15 @@ export class Client implements LangSmithTracingClientInterface {
     return needsV1Prefix ? `/v1/platform/${path}` : `/platform/${path}`;
   }
 
-  private async _requestOnlineEvaluator<T>(
-    method: string,
-    path: string,
-    options: { body?: unknown; query?: RecordStringAny } = {},
-  ): Promise<T> {
-    const queryParams = new URLSearchParams();
-    for (const [key, value] of Object.entries(options.query ?? {})) {
-      if (value == null) {
-        continue;
-      }
-      if (Array.isArray(value)) {
-        value.forEach((item) => queryParams.append(key, String(item)));
-      } else {
-        queryParams.set(key, String(value));
-      }
-    }
-    const queryString = queryParams.toString();
-    const endpoint = `${this.apiUrl}${path}${queryString ? `?${queryString}` : ""}`;
-    const response = await this.caller.call(async () => {
-      const res = await this._fetch(endpoint, {
-        method,
-        headers: {
-          ...this._mergedHeaders,
-          ...(options.body == null
-            ? {}
-            : { "Content-Type": "application/json" }),
-        },
-        signal: AbortSignal.timeout(this.timeout_ms),
-        ...this.fetchOptions,
-        body: options.body == null ? undefined : JSON.stringify(options.body),
-      });
-      await raiseForStatus(res, `Failed to ${method} ${path}`);
-      return res;
-    });
-    if (response.status === 204) {
-      return undefined as T;
-    }
-    return response.json() as Promise<T>;
-  }
-
-  public get onlineEvaluators(): OnlineEvaluatorsClient {
-    const basePath = this._getPlatformEndpointPath("evaluators");
-    return {
-      create: (body) =>
-        this._requestOnlineEvaluator("POST", basePath, { body }),
-      retrieve: (evaluatorId) =>
-        this._requestOnlineEvaluator(
-          "GET",
-          `${basePath}/${encodeURIComponent(evaluatorId)}`,
-        ),
-      update: (evaluatorId, body) =>
-        this._requestOnlineEvaluator(
-          "PATCH",
-          `${basePath}/${encodeURIComponent(evaluatorId)}`,
-          { body },
-        ),
-      list: (query = {}) =>
-        this._requestOnlineEvaluator("GET", basePath, { query }),
-      delete: (evaluatorId, params = {}) =>
-        this._requestOnlineEvaluator(
-          "DELETE",
-          `${basePath}/${encodeURIComponent(evaluatorId)}`,
-          { query: params },
-        ),
-      bulkDelete: (params) =>
-        this._requestOnlineEvaluator("DELETE", basePath, { query: params }),
-      spend: (query) =>
-        this._requestOnlineEvaluator("GET", `${basePath}/spend`, { query }),
-    };
+  public get onlineEvaluators(): OnlineEvaluators {
+    return new OpenAPILangsmith({
+      apiKey: this.apiKey,
+      tenantID: this.workspaceId,
+      baseURL: this._getOpenAPIBaseUrl(),
+      timeout: this.timeout_ms,
+      fetch: this._fetch,
+      fetchOptions: this.fetchOptions,
+    }).onlineEvaluators;
   }
 
   private async processInputs(inputs: KVMap): Promise<KVMap> {

--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -528,6 +528,22 @@ interface ProjectOptions {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type RecordStringAny = Record<string, any>;
 
+export interface OnlineEvaluatorsClient {
+  create(body: RecordStringAny): Promise<RecordStringAny>;
+  retrieve(evaluatorId: string): Promise<RecordStringAny>;
+  update(evaluatorId: string, body: RecordStringAny): Promise<RecordStringAny>;
+  list(query?: RecordStringAny): Promise<RecordStringAny>;
+  delete(
+    evaluatorId: string,
+    params?: { delete_run_rules?: boolean },
+  ): Promise<void>;
+  bulkDelete(params: {
+    evaluator_ids: string[];
+    delete_run_rules?: boolean;
+  }): Promise<RecordStringAny>;
+  spend(query: RecordStringAny): Promise<RecordStringAny>;
+}
+
 export type FeedbackSourceType = "model" | "api" | "app";
 
 export type CreateExampleOptions = {
@@ -1386,6 +1402,77 @@ export class Client implements LangSmithTracingClientInterface {
     const needsV1Prefix =
       this.apiUrl.slice(-3) !== "/v1" && this.apiUrl.slice(-4) !== "/v1/";
     return needsV1Prefix ? `/v1/platform/${path}` : `/platform/${path}`;
+  }
+
+  private async _requestOnlineEvaluator<T>(
+    method: string,
+    path: string,
+    options: { body?: unknown; query?: RecordStringAny } = {},
+  ): Promise<T> {
+    const queryParams = new URLSearchParams();
+    for (const [key, value] of Object.entries(options.query ?? {})) {
+      if (value == null) {
+        continue;
+      }
+      if (Array.isArray(value)) {
+        value.forEach((item) => queryParams.append(key, String(item)));
+      } else {
+        queryParams.set(key, String(value));
+      }
+    }
+    const queryString = queryParams.toString();
+    const endpoint = `${this.apiUrl}${path}${queryString ? `?${queryString}` : ""}`;
+    const response = await this.caller.call(async () => {
+      const res = await this._fetch(endpoint, {
+        method,
+        headers: {
+          ...this._mergedHeaders,
+          ...(options.body == null
+            ? {}
+            : { "Content-Type": "application/json" }),
+        },
+        signal: AbortSignal.timeout(this.timeout_ms),
+        ...this.fetchOptions,
+        body: options.body == null ? undefined : JSON.stringify(options.body),
+      });
+      await raiseForStatus(res, `Failed to ${method} ${path}`);
+      return res;
+    });
+    if (response.status === 204) {
+      return undefined as T;
+    }
+    return response.json() as Promise<T>;
+  }
+
+  public get onlineEvaluators(): OnlineEvaluatorsClient {
+    const basePath = this._getPlatformEndpointPath("evaluators");
+    return {
+      create: (body) =>
+        this._requestOnlineEvaluator("POST", basePath, { body }),
+      retrieve: (evaluatorId) =>
+        this._requestOnlineEvaluator(
+          "GET",
+          `${basePath}/${encodeURIComponent(evaluatorId)}`,
+        ),
+      update: (evaluatorId, body) =>
+        this._requestOnlineEvaluator(
+          "PATCH",
+          `${basePath}/${encodeURIComponent(evaluatorId)}`,
+          { body },
+        ),
+      list: (query = {}) =>
+        this._requestOnlineEvaluator("GET", basePath, { query }),
+      delete: (evaluatorId, params = {}) =>
+        this._requestOnlineEvaluator(
+          "DELETE",
+          `${basePath}/${encodeURIComponent(evaluatorId)}`,
+          { query: params },
+        ),
+      bulkDelete: (params) =>
+        this._requestOnlineEvaluator("DELETE", basePath, { query: params }),
+      spend: (query) =>
+        this._requestOnlineEvaluator("GET", `${basePath}/spend`, { query }),
+    };
   }
 
   private async processInputs(inputs: KVMap): Promise<KVMap> {

--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -1391,6 +1391,11 @@ export class Client implements LangSmithTracingClientInterface {
   }
 
   private _newOpenAPIClient(): OpenAPILangsmith {
+    const defaultHeaders =
+      this.apiKey === undefined && this.workspaceId === undefined
+        ? { "X-API-Key": null }
+        : undefined;
+
     return new OpenAPILangsmith({
       apiKey: this.apiKey,
       tenantID: this.workspaceId,
@@ -1398,6 +1403,7 @@ export class Client implements LangSmithTracingClientInterface {
       timeout: this.timeout_ms,
       fetch: this._fetch,
       fetchOptions: this.fetchOptions,
+      defaultHeaders,
     });
   }
 

--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -1241,14 +1241,7 @@ export class Client implements LangSmithTracingClientInterface {
     this.batchSizeBytesLimit = config.batchSizeBytesLimit;
     this.batchSizeLimit = config.batchSizeLimit;
     this.fetchOptions = config.fetchOptions || {};
-    this.openAPIClient = new OpenAPILangsmith({
-      apiKey: this.apiKey,
-      tenantID: this.workspaceId,
-      baseURL: this._getOpenAPIBaseUrl(),
-      timeout: this.timeout_ms,
-      fetch: this._fetch,
-      fetchOptions: this.fetchOptions,
-    });
+    this.openAPIClient = this._newOpenAPIClient();
     this.manualFlushMode = config.manualFlushMode ?? this.manualFlushMode;
     this._tracingMode = resolveTracingMode(config.tracingMode);
     if (this._tracingMode === "otel") {
@@ -1395,6 +1388,17 @@ export class Client implements LangSmithTracingClientInterface {
 
   private _getOpenAPIBaseUrl(): string {
     return this.apiUrl.endsWith("/v1") ? this.apiUrl.slice(0, -3) : this.apiUrl;
+  }
+
+  private _newOpenAPIClient(): OpenAPILangsmith {
+    return new OpenAPILangsmith({
+      apiKey: this.apiKey,
+      tenantID: this.workspaceId,
+      baseURL: this._getOpenAPIBaseUrl(),
+      timeout: this.timeout_ms,
+      fetch: this._fetch,
+      fetchOptions: this.fetchOptions,
+    });
   }
 
   private _getPlatformEndpointPath(path: string): string {

--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -866,6 +866,8 @@ export class Client implements LangSmithTracingClientInterface {
 
   private fetchOptions: RequestInit;
 
+  private openAPIClient: OpenAPILangsmith;
+
   private settings: Promise<LangSmithSettings> | null;
 
   private blockOnRootRunFinalization =
@@ -1239,6 +1241,14 @@ export class Client implements LangSmithTracingClientInterface {
     this.batchSizeBytesLimit = config.batchSizeBytesLimit;
     this.batchSizeLimit = config.batchSizeLimit;
     this.fetchOptions = config.fetchOptions || {};
+    this.openAPIClient = new OpenAPILangsmith({
+      apiKey: this.apiKey,
+      tenantID: this.workspaceId,
+      baseURL: this._getOpenAPIBaseUrl(),
+      timeout: this.timeout_ms,
+      fetch: this._fetch,
+      fetchOptions: this.fetchOptions,
+    });
     this.manualFlushMode = config.manualFlushMode ?? this.manualFlushMode;
     this._tracingMode = resolveTracingMode(config.tracingMode);
     if (this._tracingMode === "otel") {
@@ -1395,14 +1405,7 @@ export class Client implements LangSmithTracingClientInterface {
   }
 
   public get onlineEvaluators(): OnlineEvaluators {
-    return new OpenAPILangsmith({
-      apiKey: this.apiKey,
-      tenantID: this.workspaceId,
-      baseURL: this._getOpenAPIBaseUrl(),
-      timeout: this.timeout_ms,
-      fetch: this._fetch,
-      fetchOptions: this.fetchOptions,
-    }).onlineEvaluators;
+    return this.openAPIClient.onlineEvaluators;
   }
 
   private async processInputs(inputs: KVMap): Promise<KVMap> {

--- a/js/src/tests/client.int.test.ts
+++ b/js/src/tests/client.int.test.ts
@@ -227,6 +227,38 @@ test("test create dataset", async () => {
   await langchainClient.deleteDataset({ datasetName });
 }, 180_000);
 
+test("online evaluators generated client CRUD", async () => {
+  const client = new Client({ callerOptions: { maxRetries: 6 } });
+  const evaluatorName = `__test_online_evaluator_${uuidv4().slice(0, 8)}`;
+  let evaluatorId: string | undefined;
+
+  try {
+    const created = await client.onlineEvaluators.create({
+      name: evaluatorName,
+      type: "code",
+      code_evaluator: {
+        code: "def perform_eval(run, example):\n    return {'score': 1}",
+        language: "python",
+      },
+    });
+
+    evaluatorId = created.evaluator?.id;
+    expect(evaluatorId).toBeDefined();
+    expect(created.evaluator?.name).toBe(evaluatorName);
+    expect(created.evaluator?.type).toBe("code");
+
+    const retrieved = await client.onlineEvaluators.retrieve(evaluatorId!);
+    expect(retrieved.id).toBe(evaluatorId);
+    expect(retrieved.name).toBe(evaluatorName);
+  } finally {
+    if (evaluatorId) {
+      await client.onlineEvaluators.delete(evaluatorId, {
+        delete_run_rules: true,
+      });
+    }
+  }
+}, 180_000);
+
 test("Test share and unshare run", async () => {
   const langchainClient = new Client({
     autoBatchTracing: false,

--- a/js/src/tests/client.test.ts
+++ b/js/src/tests/client.test.ts
@@ -14,21 +14,22 @@ import { parseHubIdentifier } from "../utils/prompts.js";
 describe("Client", () => {
   describe("onlineEvaluators", () => {
     it("creates an online evaluator through the platform endpoint", async () => {
-      const mockFetch = jest.fn<typeof fetch>().mockResolvedValue({
-        ok: true,
-        status: 200,
-        statusText: "OK",
-        json: async () => ({
-          evaluator: {
-            id: "eval-1",
-            name: "SDK smoke test code evaluator",
-            type: "code",
+      const mockFetch = jest.fn<typeof fetch>().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            evaluator: {
+              id: "eval-1",
+              name: "SDK smoke test code evaluator",
+              type: "code",
+            },
+          }),
+          {
+            status: 200,
+            statusText: "OK",
+            headers: { "content-type": "application/json" },
           },
-        }),
-        text: async () =>
-          '{"evaluator":{"id":"eval-1","name":"SDK smoke test code evaluator","type":"code"}}',
-        headers: new Headers(),
-      } as Response);
+        ),
+      );
       const client = new Client({
         apiUrl: "http://localhost:8080",
         apiKey: "test-api-key",

--- a/js/src/tests/client.test.ts
+++ b/js/src/tests/client.test.ts
@@ -12,6 +12,62 @@ import {
 import { parseHubIdentifier } from "../utils/prompts.js";
 
 describe("Client", () => {
+  describe("onlineEvaluators", () => {
+    it("creates an online evaluator through the platform endpoint", async () => {
+      const mockFetch = jest.fn<typeof fetch>().mockResolvedValue({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        json: async () => ({
+          evaluator: {
+            id: "eval-1",
+            name: "SDK smoke test code evaluator",
+            type: "code",
+          },
+        }),
+        text: async () =>
+          '{"evaluator":{"id":"eval-1","name":"SDK smoke test code evaluator","type":"code"}}',
+        headers: new Headers(),
+      } as Response);
+      const client = new Client({
+        apiUrl: "http://localhost:8080",
+        apiKey: "test-api-key",
+        workspaceId: "test-workspace-id",
+        fetchImplementation: mockFetch,
+      });
+
+      const response = await client.onlineEvaluators.create({
+        name: "SDK smoke test code evaluator",
+        type: "code",
+        code_evaluator: {
+          code: "def perform_eval(run, example):\n    return {'score': 1}",
+          language: "python",
+        },
+      });
+
+      expect(response.evaluator.id).toBe("eval-1");
+      expect(mockFetch).toHaveBeenCalledWith(
+        "http://localhost:8080/v1/platform/evaluators",
+        expect.objectContaining({
+          method: "POST",
+          headers: expect.objectContaining({
+            "Content-Type": "application/json",
+            "x-api-key": "test-api-key",
+            "x-tenant-id": "test-workspace-id",
+          }),
+          body: JSON.stringify({
+            name: "SDK smoke test code evaluator",
+            type: "code",
+            code_evaluator: {
+              code: "def perform_eval(run, example):\n    return {'score': 1}",
+              language: "python",
+            },
+          }),
+        }),
+      );
+    });
+  });
+
   describe("createLLMExample", () => {
     it("should create an example with the given input and generation", async () => {
       const client = new Client({ apiKey: "test-api-key" });

--- a/js/src/tests/client.test.ts
+++ b/js/src/tests/client.test.ts
@@ -46,15 +46,12 @@ describe("Client", () => {
       });
 
       expect(response.evaluator.id).toBe("eval-1");
-      expect(mockFetch).toHaveBeenCalledWith(
-        "http://localhost:8080/v1/platform/evaluators",
+      const [url, init] = mockFetch.mock.calls[0];
+      const headers = new Headers(init?.headers);
+      expect(url).toBe("http://localhost:8080/v1/platform/evaluators");
+      expect(init).toEqual(
         expect.objectContaining({
           method: "POST",
-          headers: expect.objectContaining({
-            "Content-Type": "application/json",
-            "x-api-key": "test-api-key",
-            "x-tenant-id": "test-workspace-id",
-          }),
           body: JSON.stringify({
             name: "SDK smoke test code evaluator",
             type: "code",
@@ -65,6 +62,9 @@ describe("Client", () => {
           }),
         }),
       );
+      expect(headers.get("content-type")).toBe("application/json");
+      expect(headers.get("x-api-key")).toBe("test-api-key");
+      expect(headers.get("x-tenant-id")).toBe("test-workspace-id");
     });
   });
 

--- a/js/src/tests/client.test.ts
+++ b/js/src/tests/client.test.ts
@@ -46,7 +46,7 @@ describe("Client", () => {
         },
       });
 
-      expect(response.evaluator.id).toBe("eval-1");
+      expect(response.evaluator?.id).toBe("eval-1");
       const [url, init] = mockFetch.mock.calls[0];
       const headers = new Headers(init?.headers);
       expect(url).toBe("http://localhost:8080/v1/platform/evaluators");

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -53,6 +53,7 @@ from typing import (
 )
 from urllib import parse as urllib_parse
 
+import httpx
 import packaging.version
 import requests
 from pydantic import Field
@@ -145,6 +146,12 @@ def _reset_tracing_drop_log() -> None:
     with _tracing_drops_lock:
         _tracing_drops_count = 0
         _tracing_drops_last_log_time = 0.0
+
+
+def _get_openapi_base_url(api_url: str) -> str:
+    """Convert a handwritten client API URL to a generated OpenAPI base URL."""
+    api_url = api_url.rstrip("/")
+    return api_url[:-3] if api_url.endswith("/v1") else api_url
 
 
 _TRACING_SEND_TIMEOUT = (3, 10)  # (connect, read) seconds for background sends
@@ -261,6 +268,9 @@ if TYPE_CHECKING:
     from langchain_core.runnables import Runnable
 
     from langsmith import schemas
+    from langsmith._openapi_client.resources.online_evaluators import (
+        OnlineEvaluatorsResource,
+    )
 
     # OTEL imports for type hints
     try:
@@ -1609,6 +1619,24 @@ class Client:
             self._info = ls_schemas.LangSmithInfo()
 
         return self._info
+
+    @property
+    def online_evaluators(self) -> OnlineEvaluatorsResource:
+        """Access generated online evaluator CRUD methods."""
+        from langsmith._openapi_client import Langsmith as OpenAPILangsmith
+
+        self._ensure_profile_auth()
+        headers = self._headers
+        if self._profile_auth is not None:
+            headers = self._profile_auth.prepare_request_headers(headers)
+
+        return OpenAPILangsmith(
+            api_key=self.api_key,
+            tenant_id=self.workspace_id,
+            base_url=_get_openapi_base_url(self.api_url),
+            timeout=httpx.Timeout(self._timeout[1], connect=self._timeout[0]),
+            default_headers=headers,
+        ).online_evaluators
 
     def _get_settings(self) -> ls_schemas.LangSmithSettings:
         """Get the settings for the current tenant.

--- a/python/tests/integration_tests/test_client.py
+++ b/python/tests/integration_tests/test_client.py
@@ -156,7 +156,9 @@ def test_online_evaluators_generated_client_crud(langchain_client: Client) -> No
         assert updated.evaluator.name == updated_name
 
         evaluators = list(
-            langchain_client.online_evaluators.list(name_contains=updated_name, limit=10)
+            langchain_client.online_evaluators.list(
+                name_contains=updated_name, limit=10
+            )
         )
         assert evaluator.id in {item.id for item in evaluators}
     finally:

--- a/python/tests/integration_tests/test_client.py
+++ b/python/tests/integration_tests/test_client.py
@@ -121,6 +121,51 @@ def parameterized_multipart_client(request) -> Client:
     )
 
 
+def test_online_evaluators_generated_client_crud(langchain_client: Client) -> None:
+    """Exercise the generated OpenAPI online evaluators resource end to end."""
+    evaluator = None
+    name = "__sdk_online_evaluator_integration_" + "".join(
+        random.sample(string.ascii_lowercase, 10)
+    )
+
+    try:
+        created = langchain_client.online_evaluators.create(
+            name=name,
+            type="code",
+            code_evaluator={
+                "code": "def perform_eval(run, example):\n    return {'score': 1}",
+                "language": "python",
+            },
+        )
+        evaluator = created.evaluator
+        assert evaluator is not None
+        assert evaluator.id is not None
+        assert evaluator.name == name
+        assert evaluator.type == "code"
+
+        retrieved = langchain_client.online_evaluators.retrieve(evaluator.id)
+        assert retrieved.id == evaluator.id
+        assert retrieved.name == name
+
+        updated_name = f"{name}_updated"
+        updated = langchain_client.online_evaluators.update(
+            evaluator.id,
+            name=updated_name,
+        )
+        assert updated.evaluator is not None
+        assert updated.evaluator.name == updated_name
+
+        evaluators = list(
+            langchain_client.online_evaluators.list(name_contains=updated_name, limit=10)
+        )
+        assert evaluator.id in {item.id for item in evaluators}
+    finally:
+        if evaluator is not None and evaluator.id is not None:
+            langchain_client.online_evaluators.delete(
+                evaluator.id, delete_run_rules=True
+            )
+
+
 def test_datasets(parameterized_multipart_client: Client) -> None:
     """Test datasets."""
     csv_content = "col1,col2\nval1,val2"

--- a/python/tests/unit_tests/test_client.py
+++ b/python/tests/unit_tests/test_client.py
@@ -798,6 +798,30 @@ def test_create_run_unicode() -> None:
     client.update_run(id_, status="completed")
 
 
+def test_online_evaluators_uses_generated_openapi_resource() -> None:
+    client = Client(
+        api_url="http://localhost:8080",
+        api_key="test-api-key",
+        workspace_id="test-workspace-id",
+        timeout_ms=(1234, 5678),
+        info=ls_schemas.LangSmithInfo(),
+    )
+    resource = object()
+
+    with mock.patch("langsmith._openapi_client.Langsmith") as openapi_client:
+        openapi_client.return_value.online_evaluators = resource
+
+        assert client.online_evaluators is resource
+
+    openapi_client.assert_called_once()
+    assert openapi_client.call_args.kwargs["api_key"] == "test-api-key"
+    assert openapi_client.call_args.kwargs["tenant_id"] == "test-workspace-id"
+    assert openapi_client.call_args.kwargs["base_url"] == "http://localhost:8080"
+    timeout = openapi_client.call_args.kwargs["timeout"]
+    assert timeout.connect == 1.234
+    assert timeout.read == 5.678
+
+
 @pytest.mark.parametrize("use_multipart_endpoint", (True, False))
 def test_create_run_mutate(
     use_multipart_endpoint: bool, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
**Description**

- Adds client.online_evaluators in Python, backed by the generated OpenAPI OnlineEvaluatorsResource.
- Adds client.onlineEvaluators in JS with CRUD-style methods for create, retrieve, update, list, delete, bulk delete, and spend.

Python
<img width="854" height="86" alt="Screenshot 2026-06-11 at 12 08 04 PM" src="https://github.com/user-attachments/assets/c3f85cdc-828e-4646-ad0b-172f965e2057" />
<img width="868" height="103" alt="Screenshot 2026-06-11 at 12 08 11 PM" src="https://github.com/user-attachments/assets/c07cda5d-b853-4c79-9f03-c4a2fb6325e9" />


JS
<img width="714" height="105" alt="Screenshot 2026-06-11 at 12 10 27 PM" src="https://github.com/user-attachments/assets/ce6c233c-19c7-4c4f-ba2b-483a76e6dd5e" />
<img width="945" height="126" alt="Screenshot 2026-06-11 at 12 10 39 PM" src="https://github.com/user-attachments/assets/797354fa-d9d4-458e-b51d-4f2b4bece9fe" />


References [LSE-2426](https://linear.app/langchain/issue/LSE-2426/add-first-class-sdk-methods-for-online-evaluators)

**Test Plan**
[X] Check if SDK can be used for online eval crud ops for users.
[X] Tested Python and JS by running local smoke scripts against the smith-go backend on http://localhost:8080, creating an online code evaluator, retrieving it, listing evaluators, inspecting it manually, and deleting it after confirmation.
[X] Added unit tests.