### PR TITLE
feat(py): add sync/async conversion for Sandbox and SandboxClient [INF-0000]

### DIFF
--- a/python/langsmith/sandbox/_async_client.py
+++ b/python/langsmith/sandbox/_async_client.py
@@ -14,6 +14,7 @@ import httpx
 from langsmith import utils as ls_utils
 from langsmith.sandbox._async_sandbox import AsyncSandbox
 from langsmith.sandbox._client import (
+    SandboxClient,
     _make_docker_context_tar,
     _make_dockerfile_build_command,
     _resolve_dockerfile_context,
@@ -100,6 +101,8 @@ class AsyncSandboxClient:
         self._base_url = (api_endpoint or _get_default_api_endpoint()).rstrip("/")
         resolved_api_key = api_key or _get_default_api_key()
         self._api_key = resolved_api_key
+        self._timeout = timeout
+        self._max_retries = max_retries
         self._default_headers: dict[str, str] = dict(headers) if headers else {}
         client_headers: dict[str, str] = {}
         if resolved_api_key:
@@ -126,6 +129,24 @@ class AsyncSandboxClient:
         if not self._default_headers and headers is None:
             return None
         return merge_headers(self._default_headers, headers)
+
+    def to_sync(self) -> SandboxClient:
+        """Create a SandboxClient with the same configuration.
+
+        The returned client has its own HTTP connection pool; close it
+        independently (``client.close()`` or ``with``).
+
+        Returns:
+            SandboxClient with the same endpoint, credentials, timeout,
+            retry, and header configuration.
+        """
+        return SandboxClient(
+            api_endpoint=self._base_url,
+            timeout=self._timeout,
+            api_key=self._api_key,
+            max_retries=self._max_retries,
+            headers=self._default_headers or None,
+        )
 
     async def aclose(self) -> None:
         """Close the async HTTP client."""

--- a/python/langsmith/sandbox/_async_sandbox.py
+++ b/python/langsmith/sandbox/_async_sandbox.py
@@ -26,6 +26,8 @@ from langsmith.sandbox._tunnel import AsyncTunnel
 
 if TYPE_CHECKING:
     from langsmith.sandbox._async_client import AsyncSandboxClient
+    from langsmith.sandbox._client import SandboxClient
+    from langsmith.sandbox._sandbox import Sandbox
 
 
 RequestHeaders = Optional[Mapping[str, str]]
@@ -129,6 +131,42 @@ class AsyncSandbox:
             fs_capacity_bytes=data.get("fs_capacity_bytes"),
             _client=client,
             _auto_delete=auto_delete,
+        )
+
+    def to_sync(self, *, client: Optional[SandboxClient] = None) -> Sandbox:
+        """Create a Sandbox for the same underlying sandbox.
+
+        The returned instance has ``auto_delete`` disabled so the sandbox's
+        lifecycle stays tied to this instance; both refer to the same
+        server-side sandbox.
+
+        Args:
+            client: SandboxClient to use for operations. If not provided,
+                one is created with the same configuration as this sandbox's
+                client (see :meth:`AsyncSandboxClient.to_sync`).
+
+        Returns:
+            Sandbox referring to the same sandbox.
+        """
+        from langsmith.sandbox._sandbox import Sandbox
+
+        return Sandbox(
+            name=self.name,
+            dataplane_url=self.dataplane_url,
+            id=self.id,
+            status=self.status,
+            status_message=self.status_message,
+            created_at=self.created_at,
+            updated_at=self.updated_at,
+            idle_ttl_seconds=self.idle_ttl_seconds,
+            delete_after_stop_seconds=self.delete_after_stop_seconds,
+            stopped_at=self.stopped_at,
+            snapshot_id=self.snapshot_id,
+            vcpus=self.vcpus,
+            mem_bytes=self.mem_bytes,
+            fs_capacity_bytes=self.fs_capacity_bytes,
+            _client=client if client is not None else self._client.to_sync(),
+            _auto_delete=False,
         )
 
     async def __aenter__(self) -> AsyncSandbox:

--- a/python/langsmith/sandbox/_client.py
+++ b/python/langsmith/sandbox/_client.py
@@ -10,7 +10,7 @@ import tarfile
 import uuid
 from collections.abc import Callable, Mapping
 from pathlib import Path
-from typing import Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 import httpx
 
@@ -37,6 +37,9 @@ from langsmith.sandbox._models import (
 from langsmith.sandbox._proxy_config import SandboxProxyConfig
 from langsmith.sandbox._sandbox import Sandbox
 from langsmith.sandbox._transport import RetryTransport
+
+if TYPE_CHECKING:
+    from langsmith.sandbox._async_client import AsyncSandboxClient
 
 
 def _get_default_api_endpoint() -> str:
@@ -202,6 +205,8 @@ class SandboxClient:
         self._base_url = (api_endpoint or _get_default_api_endpoint()).rstrip("/")
         resolved_api_key = api_key or _get_default_api_key()
         self._api_key = resolved_api_key
+        self._timeout = timeout
+        self._max_retries = max_retries
         self._default_headers: dict[str, str] = dict(headers) if headers else {}
         client_headers: dict[str, str] = {}
         if resolved_api_key:
@@ -228,6 +233,26 @@ class SandboxClient:
         if not self._default_headers and headers is None:
             return None
         return merge_headers(self._default_headers, headers)
+
+    def to_async(self) -> AsyncSandboxClient:
+        """Create an AsyncSandboxClient with the same configuration.
+
+        The returned client has its own HTTP connection pool; close it
+        independently (``await client.aclose()`` or ``async with``).
+
+        Returns:
+            AsyncSandboxClient with the same endpoint, credentials, timeout,
+            retry, and header configuration.
+        """
+        from langsmith.sandbox._async_client import AsyncSandboxClient
+
+        return AsyncSandboxClient(
+            api_endpoint=self._base_url,
+            timeout=self._timeout,
+            api_key=self._api_key,
+            max_retries=self._max_retries,
+            headers=self._default_headers or None,
+        )
 
     def close(self) -> None:
         """Close the HTTP client."""

--- a/python/langsmith/sandbox/_sandbox.py
+++ b/python/langsmith/sandbox/_sandbox.py
@@ -24,6 +24,8 @@ from langsmith.sandbox._models import (
 from langsmith.sandbox._tunnel import Tunnel
 
 if TYPE_CHECKING:
+    from langsmith.sandbox._async_client import AsyncSandboxClient
+    from langsmith.sandbox._async_sandbox import AsyncSandbox
     from langsmith.sandbox._client import SandboxClient
 
 
@@ -126,6 +128,42 @@ class Sandbox:
             fs_capacity_bytes=data.get("fs_capacity_bytes"),
             _client=client,
             _auto_delete=auto_delete,
+        )
+
+    def to_async(self, *, client: Optional[AsyncSandboxClient] = None) -> AsyncSandbox:
+        """Create an AsyncSandbox for the same underlying sandbox.
+
+        The returned instance has ``auto_delete`` disabled so the sandbox's
+        lifecycle stays tied to this instance; both refer to the same
+        server-side sandbox.
+
+        Args:
+            client: AsyncSandboxClient to use for operations. If not provided,
+                one is created with the same configuration as this sandbox's
+                client (see :meth:`SandboxClient.to_async`).
+
+        Returns:
+            AsyncSandbox referring to the same sandbox.
+        """
+        from langsmith.sandbox._async_sandbox import AsyncSandbox
+
+        return AsyncSandbox(
+            name=self.name,
+            dataplane_url=self.dataplane_url,
+            id=self.id,
+            status=self.status,
+            status_message=self.status_message,
+            created_at=self.created_at,
+            updated_at=self.updated_at,
+            idle_ttl_seconds=self.idle_ttl_seconds,
+            delete_after_stop_seconds=self.delete_after_stop_seconds,
+            stopped_at=self.stopped_at,
+            snapshot_id=self.snapshot_id,
+            vcpus=self.vcpus,
+            mem_bytes=self.mem_bytes,
+            fs_capacity_bytes=self.fs_capacity_bytes,
+            _client=client if client is not None else self._client.to_async(),
+            _auto_delete=False,
         )
 
     def __enter__(self) -> Sandbox:

--- a/python/tests/unit_tests/sandbox/test_sync_async_conversion.py
+++ b/python/tests/unit_tests/sandbox/test_sync_async_conversion.py
@@ -1,0 +1,133 @@
+"""Tests for Sandbox <-> AsyncSandbox conversion."""
+
+import dataclasses
+
+import pytest
+
+from langsmith.sandbox import (
+    AsyncSandbox,
+    AsyncSandboxClient,
+    Sandbox,
+    SandboxClient,
+)
+
+SANDBOX_DATA = {
+    "name": "test-sandbox",
+    "dataplane_url": "https://sandbox-router.example.com/sb-123",
+    "id": "11111111-2222-3333-4444-555555555555",
+    "status": "ready",
+    "status_message": None,
+    "created_at": "2026-03-24T12:00:00Z",
+    "updated_at": "2026-03-24T12:05:00Z",
+    "idle_ttl_seconds": 600,
+    "delete_after_stop_seconds": 86400,
+    "stopped_at": None,
+    "snapshot_id": "66666666-7777-8888-9999-000000000000",
+    "vcpus": 2,
+    "mem_bytes": 1024**3,
+    "fs_capacity_bytes": 10 * 1024**3,
+}
+
+DATA_FIELDS = list(SANDBOX_DATA)
+
+
+@pytest.fixture
+def sync_client():
+    return SandboxClient(
+        api_endpoint="http://test-server:8080",
+        api_key="test-key",
+        timeout=42.0,
+        max_retries=7,
+        headers={"X-Service-Key": "svc"},
+    )
+
+
+@pytest.fixture
+def async_client():
+    return AsyncSandboxClient(
+        api_endpoint="http://test-server:8080",
+        api_key="test-key",
+        timeout=42.0,
+        max_retries=7,
+        headers={"X-Service-Key": "svc"},
+    )
+
+
+class TestClientConversion:
+    def test_to_async_copies_config(self, sync_client):
+        converted = sync_client.to_async()
+        assert isinstance(converted, AsyncSandboxClient)
+        assert converted._base_url == sync_client._base_url
+        assert converted._api_key == sync_client._api_key
+        assert converted._timeout == sync_client._timeout
+        assert converted._max_retries == sync_client._max_retries
+        assert converted._default_headers == sync_client._default_headers
+
+    def test_to_sync_copies_config(self, async_client):
+        converted = async_client.to_sync()
+        assert isinstance(converted, SandboxClient)
+        assert converted._base_url == async_client._base_url
+        assert converted._api_key == async_client._api_key
+        assert converted._timeout == async_client._timeout
+        assert converted._max_retries == async_client._max_retries
+        assert converted._default_headers == async_client._default_headers
+
+    def test_roundtrip(self, sync_client):
+        roundtripped = sync_client.to_async().to_sync()
+        assert roundtripped._base_url == sync_client._base_url
+        assert roundtripped._api_key == sync_client._api_key
+        assert roundtripped._default_headers == sync_client._default_headers
+
+    def test_to_async_without_optional_config(self):
+        client = SandboxClient(api_endpoint="http://test-server:8080")
+        converted = client.to_async()
+        assert converted._api_key == client._api_key
+        assert converted._default_headers == {}
+
+
+class TestSandboxConversion:
+    def test_to_async_copies_fields(self, sync_client):
+        sb = Sandbox.from_dict(SANDBOX_DATA, client=sync_client, auto_delete=True)
+        converted = sb.to_async()
+        assert isinstance(converted, AsyncSandbox)
+        for field in DATA_FIELDS:
+            assert getattr(converted, field) == getattr(sb, field), field
+        assert isinstance(converted._client, AsyncSandboxClient)
+        assert converted._client._base_url == sync_client._base_url
+
+    def test_to_sync_copies_fields(self, async_client):
+        sb = AsyncSandbox.from_dict(SANDBOX_DATA, client=async_client, auto_delete=True)
+        converted = sb.to_sync()
+        assert isinstance(converted, Sandbox)
+        for field in DATA_FIELDS:
+            assert getattr(converted, field) == getattr(sb, field), field
+        assert isinstance(converted._client, SandboxClient)
+        assert converted._client._base_url == async_client._base_url
+
+    def test_conversion_disables_auto_delete(self, sync_client, async_client):
+        sb = Sandbox.from_dict(SANDBOX_DATA, client=sync_client, auto_delete=True)
+        assert sb.to_async()._auto_delete is False
+        asb = AsyncSandbox.from_dict(
+            SANDBOX_DATA, client=async_client, auto_delete=True
+        )
+        assert asb.to_sync()._auto_delete is False
+
+    def test_explicit_client_is_used(self, sync_client, async_client):
+        sb = Sandbox.from_dict(SANDBOX_DATA, client=sync_client, auto_delete=False)
+        assert sb.to_async(client=async_client)._client is async_client
+        asb = AsyncSandbox.from_dict(
+            SANDBOX_DATA, client=async_client, auto_delete=False
+        )
+        assert asb.to_sync(client=sync_client)._client is sync_client
+
+    def test_data_fields_stay_in_sync(self):
+        """Conversion copies every non-internal dataclass field.
+
+        Guards against a new field being added to one class but missed in
+        the conversion methods.
+        """
+        sync_fields = {f.name for f in dataclasses.fields(Sandbox)}
+        async_fields = {f.name for f in dataclasses.fields(AsyncSandbox)}
+        assert sync_fields == async_fields
+        public_fields = {f for f in sync_fields if not f.startswith("_")}
+        assert public_fields == set(DATA_FIELDS)


### PR DESCRIPTION
Adds conversion methods between the sync and async sandbox APIs in the Python SDK:

- `Sandbox.to_async()` → `AsyncSandbox` and `AsyncSandbox.to_sync()` → `Sandbox`
- `SandboxClient.to_async()` → `AsyncSandboxClient` and `AsyncSandboxClient.to_sync()` → `SandboxClient`

Since httpx sync/async clients cannot be shared, conversion constructs a sibling client with identical configuration (endpoint, API key, timeout, max retries, default headers); callers can pass an existing client via `client=` to reuse one. The converted sandbox always has `auto_delete` disabled so the sandbox lifecycle stays tied to the original instance and a context-manager exit on both copies can't double-delete.

Tests include a field-parity guard that fails if a new data field is added to one of the `Sandbox`/`AsyncSandbox` dataclasses but missed in the conversion methods.

## Test Plan

- [x] `uv run pytest tests/unit_tests/sandbox/` (449 passed)
- [x] `make lint` (ruff + mypy clean)