### PR TITLE
fix(sandbox): deliver output callbacks across stream reconnects

### DIFF
--- a/js/src/sandbox/command_handle.ts
+++ b/js/src/sandbox/command_handle.ts
@@ -54,6 +54,8 @@ export class CommandHandle {
   private _lastStdoutOffset: number;
   private _lastStderrOffset: number;
   private _started: boolean;
+  private _onStdout?: (data: string) => void;
+  private _onStderr?: (data: string) => void;
 
   /** @internal */
   constructor(
@@ -64,6 +66,8 @@ export class CommandHandle {
       commandId?: string;
       stdoutOffset?: number;
       stderrOffset?: number;
+      onStdout?: (data: string) => void;
+      onStderr?: (data: string) => void;
     },
   ) {
     this._stream = messageStream;
@@ -71,6 +75,10 @@ export class CommandHandle {
     this._sandbox = sandbox;
     this._lastStdoutOffset = options?.stdoutOffset ?? 0;
     this._lastStderrOffset = options?.stderrOffset ?? 0;
+    // Callbacks live on the handle (not the per-connection stream) so they
+    // keep firing for chunks delivered after an auto-reconnect.
+    this._onStdout = options?.onStdout;
+    this._onStderr = options?.onStderr;
 
     // New executions (no commandId): _ensureStarted reads "started".
     // Reconnections (commandId set): skip since reconnect streams
@@ -197,9 +205,11 @@ export class CommandHandle {
           if (chunk.stream === "stdout") {
             this._lastStdoutOffset =
               chunk.offset + new TextEncoder().encode(chunk.data).length;
+            this._onStdout?.(chunk.data);
           } else {
             this._lastStderrOffset =
               chunk.offset + new TextEncoder().encode(chunk.data).length;
+            this._onStderr?.(chunk.data);
           }
           yield chunk;
         }

--- a/js/src/sandbox/sandbox.ts
+++ b/js/src/sandbox/sandbox.ts
@@ -242,6 +242,7 @@ export class Sandbox {
       shell = "/bin/bash",
       onStdout,
       onStderr,
+      commandId,
       idleTimeout,
       killOnDisconnect,
       ttlSeconds,
@@ -259,8 +260,7 @@ export class Sandbox {
         env,
         cwd,
         shell,
-        onStdout,
-        onStderr,
+        commandId,
         idleTimeout,
         killOnDisconnect,
         ttlSeconds,
@@ -271,7 +271,12 @@ export class Sandbox {
       },
     );
 
-    const handle = new CommandHandle(stream, control, this);
+    // Callbacks are attached to the handle, not the connection, so they
+    // keep firing for output delivered after an auto-reconnect.
+    const handle = new CommandHandle(stream, control, this, {
+      onStdout,
+      onStderr,
+    });
     await handle._ensureStarted();
     return handle;
   }

--- a/js/src/tests/sandbox.test.ts
+++ b/js/src/tests/sandbox.test.ts
@@ -1205,6 +1205,69 @@ describe("CommandHandle", () => {
     });
   });
 
+  describe("output callbacks", () => {
+    it("should invoke onStdout/onStderr for every chunk", async () => {
+      const stream = createMockStream([
+        { type: "started", command_id: "cmd-123", pid: 42 },
+        { type: "stdout", data: "out1", offset: 0 },
+        { type: "stderr", data: "err1", offset: 0 },
+        { type: "stdout", data: "out2", offset: 4 },
+        { type: "exit", exit_code: 0 },
+      ]);
+
+      const stdoutData: string[] = [];
+      const stderrData: string[] = [];
+      const handle = new CommandHandle(stream, null, createMockSandbox(), {
+        onStdout: (d) => stdoutData.push(d),
+        onStderr: (d) => stderrData.push(d),
+      });
+
+      const result = await handle.result;
+
+      expect(result.exit_code).toBe(0);
+      expect(stdoutData).toEqual(["out1", "out2"]);
+      expect(stderrData).toEqual(["err1"]);
+    });
+
+    it("should keep invoking callbacks for chunks received after a reconnect", async () => {
+      // Mid-stream disconnect: the first connection delivers part of the
+      // output and dies without an exit message; the reconnected stream
+      // delivers the tail. Callbacks must see ALL chunks (this is the bug
+      // that silently truncated tails for sandbox.run({ onStdout })).
+      const stream = createMockStream([
+        { type: "started", command_id: "cmd-123", pid: 42 },
+        { type: "stdout", data: "before-disconnect ", offset: 0 },
+      ]);
+
+      const sandbox = createMockSandbox();
+      const reconnectHandle = {
+        _stream: createMockStream([
+          { type: "stdout", data: "after-reconnect", offset: 18 },
+          { type: "exit", exit_code: 0 },
+        ]),
+        _control: null,
+      };
+      (sandbox.reconnect as any).mockResolvedValue(reconnectHandle);
+
+      const stdoutData: string[] = [];
+      const handle = new CommandHandle(stream, null, sandbox, {
+        onStdout: (d) => stdoutData.push(d),
+      });
+
+      const backoffBase = CommandHandle.BACKOFF_BASE;
+      CommandHandle.BACKOFF_BASE = 0;
+      try {
+        const result = await handle.result;
+
+        expect(result.exit_code).toBe(0);
+        expect(stdoutData).toEqual(["before-disconnect ", "after-reconnect"]);
+        expect(result.stdout).toBe("before-disconnect after-reconnect");
+      } finally {
+        CommandHandle.BACKOFF_BASE = backoffBase;
+      }
+    });
+  });
+
   describe("kill", () => {
     it("should call sendKill on control", () => {
       const control = new WSStreamControl();

--- a/python/langsmith/sandbox/_async_sandbox.py
+++ b/python/langsmith/sandbox/_async_sandbox.py
@@ -355,8 +355,6 @@ class AsyncSandbox:
             "env": env,
             "cwd": cwd,
             "shell": shell,
-            "on_stdout": on_stdout,
-            "on_stderr": on_stderr,
             "idle_timeout": idle_timeout,
             "kill_on_disconnect": kill_on_disconnect,
             "ttl_seconds": ttl_seconds,
@@ -373,7 +371,15 @@ class AsyncSandbox:
             **ws_kwargs,
         )
 
-        handle = AsyncCommandHandle(msg_stream, control, self)
+        # Callbacks are attached to the handle, not the connection, so they
+        # keep firing for output delivered after an auto-reconnect.
+        handle = AsyncCommandHandle(
+            msg_stream,
+            control,
+            self,
+            on_stdout=on_stdout,
+            on_stderr=on_stderr,
+        )
         await handle._ensure_started()
 
         if not wait:

--- a/python/langsmith/sandbox/_models.py
+++ b/python/langsmith/sandbox/_models.py
@@ -494,10 +494,16 @@ class CommandHandle:
         command_id: str = "",
         stdout_offset: int = 0,
         stderr_offset: int = 0,
+        on_stdout: Optional[Callable[[str], Any]] = None,
+        on_stderr: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._stream = message_stream
         self._control = control
         self._sandbox = sandbox
+        # Callbacks live on the handle (not the per-connection stream) so
+        # they keep firing for chunks delivered after an auto-reconnect.
+        self._on_stdout = on_stdout
+        self._on_stderr = on_stderr
         self._command_id: Optional[str] = None
         self._pid: Optional[int] = None
         self._result: Optional[ExecutionResult] = None
@@ -611,10 +617,14 @@ class CommandHandle:
                         self._last_stdout_offset = chunk.offset + len(
                             chunk.data.encode("utf-8")
                         )
+                        if self._on_stdout is not None:
+                            self._on_stdout(chunk.data)
                     else:
                         self._last_stderr_offset = chunk.offset + len(
                             chunk.data.encode("utf-8")
                         )
+                        if self._on_stderr is not None:
+                            self._on_stderr(chunk.data)
                     yield chunk
                 return  # Stream ended normally (exit message received)
 
@@ -746,10 +756,16 @@ class AsyncCommandHandle:
         command_id: str = "",
         stdout_offset: int = 0,
         stderr_offset: int = 0,
+        on_stdout: Optional[Callable[[str], Any]] = None,
+        on_stderr: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._stream = message_stream
         self._control = control
         self._sandbox = sandbox
+        # Callbacks live on the handle (not the per-connection stream) so
+        # they keep firing for chunks delivered after an auto-reconnect.
+        self._on_stdout = on_stdout
+        self._on_stderr = on_stderr
         self._command_id: Optional[str] = None
         self._pid: Optional[int] = None
         self._result: Optional[ExecutionResult] = None
@@ -852,10 +868,14 @@ class AsyncCommandHandle:
                         self._last_stdout_offset = chunk.offset + len(
                             chunk.data.encode("utf-8")
                         )
+                        if self._on_stdout is not None:
+                            self._on_stdout(chunk.data)
                     else:
                         self._last_stderr_offset = chunk.offset + len(
                             chunk.data.encode("utf-8")
                         )
+                        if self._on_stderr is not None:
+                            self._on_stderr(chunk.data)
                     yield chunk
                 return  # Stream ended normally
 

--- a/python/langsmith/sandbox/_sandbox.py
+++ b/python/langsmith/sandbox/_sandbox.py
@@ -354,8 +354,6 @@ class Sandbox:
             "env": env,
             "cwd": cwd,
             "shell": shell,
-            "on_stdout": on_stdout,
-            "on_stderr": on_stderr,
             "idle_timeout": idle_timeout,
             "kill_on_disconnect": kill_on_disconnect,
             "ttl_seconds": ttl_seconds,
@@ -372,7 +370,15 @@ class Sandbox:
             **ws_kwargs,
         )
 
-        handle = CommandHandle(msg_stream, control, self)
+        # Callbacks are attached to the handle, not the connection, so they
+        # keep firing for output delivered after an auto-reconnect.
+        handle = CommandHandle(
+            msg_stream,
+            control,
+            self,
+            on_stdout=on_stdout,
+            on_stderr=on_stderr,
+        )
 
         if not wait:
             return handle

--- a/python/tests/unit_tests/sandbox/test_async_ws_execute.py
+++ b/python/tests/unit_tests/sandbox/test_async_ws_execute.py
@@ -735,8 +735,6 @@ class TestAsyncSandboxRunWs:
             cwd=None,
             shell="/bin/bash",
             headers={"X-Test-Header": "sandbox-ws"},
-            on_stdout=None,
-            on_stderr=None,
             idle_timeout=300,
             kill_on_disconnect=False,
             ttl_seconds=600,

--- a/python/tests/unit_tests/sandbox/test_command_handle.py
+++ b/python/tests/unit_tests/sandbox/test_command_handle.py
@@ -1,0 +1,153 @@
+"""CommandHandle / AsyncCommandHandle callback delivery across reconnects.
+
+Output callbacks must be attached to the handle (which survives
+auto-reconnects), not to a single WebSocket connection — otherwise every
+chunk delivered after a mid-stream reconnect is silently dropped from the
+on_stdout/on_stderr path while the result still reports exit_code 0.
+"""
+
+from unittest import mock
+
+import pytest
+
+from langsmith.sandbox._models import AsyncCommandHandle, CommandHandle
+
+
+def _messages(*msgs):
+    return iter(list(msgs))
+
+
+async def _async_messages(*msgs):
+    for msg in msgs:
+        yield msg
+
+
+def _mock_sandbox():
+    return mock.MagicMock()
+
+
+def _mock_async_sandbox():
+    sandbox = mock.MagicMock()
+    sandbox.reconnect = mock.AsyncMock()
+    return sandbox
+
+
+class TestCommandHandleCallbacks:
+    def test_callbacks_invoked_for_every_chunk(self):
+        stream = _messages(
+            {"type": "started", "command_id": "cmd-1", "pid": 42},
+            {"type": "stdout", "data": "out1", "offset": 0},
+            {"type": "stderr", "data": "err1", "offset": 0},
+            {"type": "stdout", "data": "out2", "offset": 4},
+            {"type": "exit", "exit_code": 0},
+        )
+        stdout_data: list[str] = []
+        stderr_data: list[str] = []
+
+        handle = CommandHandle(
+            stream,
+            None,
+            _mock_sandbox(),
+            on_stdout=stdout_data.append,
+            on_stderr=stderr_data.append,
+        )
+        result = handle.result
+
+        assert result.exit_code == 0
+        assert stdout_data == ["out1", "out2"]
+        assert stderr_data == ["err1"]
+
+    def test_callbacks_survive_reconnect(self):
+        # First connection dies without an exit message; the reconnected
+        # stream delivers the tail. Callbacks must see ALL chunks.
+        stream = _messages(
+            {"type": "started", "command_id": "cmd-1", "pid": 42},
+            {"type": "stdout", "data": "before-disconnect ", "offset": 0},
+        )
+        sandbox = _mock_sandbox()
+        reconnect_handle = mock.MagicMock()
+        reconnect_handle._stream = _messages(
+            {"type": "stdout", "data": "after-reconnect", "offset": 18},
+            {"type": "exit", "exit_code": 0},
+        )
+        reconnect_handle._control = None
+        sandbox.reconnect.return_value = reconnect_handle
+
+        stdout_data: list[str] = []
+        handle = CommandHandle(
+            stream,
+            None,
+            sandbox,
+            on_stdout=stdout_data.append,
+        )
+
+        original_backoff = CommandHandle._BACKOFF_BASE
+        CommandHandle._BACKOFF_BASE = 0
+        try:
+            result = handle.result
+        finally:
+            CommandHandle._BACKOFF_BASE = original_backoff
+
+        assert result.exit_code == 0
+        assert stdout_data == ["before-disconnect ", "after-reconnect"]
+        assert result.stdout == "before-disconnect after-reconnect"
+
+
+class TestAsyncCommandHandleCallbacks:
+    @pytest.mark.asyncio
+    async def test_callbacks_invoked_for_every_chunk(self):
+        stream = _async_messages(
+            {"type": "started", "command_id": "cmd-1", "pid": 42},
+            {"type": "stdout", "data": "out1", "offset": 0},
+            {"type": "stderr", "data": "err1", "offset": 0},
+            {"type": "stdout", "data": "out2", "offset": 4},
+            {"type": "exit", "exit_code": 0},
+        )
+        stdout_data: list[str] = []
+        stderr_data: list[str] = []
+
+        handle = AsyncCommandHandle(
+            stream,
+            None,
+            _mock_async_sandbox(),
+            on_stdout=stdout_data.append,
+            on_stderr=stderr_data.append,
+        )
+        result = await handle.result
+
+        assert result.exit_code == 0
+        assert stdout_data == ["out1", "out2"]
+        assert stderr_data == ["err1"]
+
+    @pytest.mark.asyncio
+    async def test_callbacks_survive_reconnect(self):
+        stream = _async_messages(
+            {"type": "started", "command_id": "cmd-1", "pid": 42},
+            {"type": "stdout", "data": "before-disconnect ", "offset": 0},
+        )
+        sandbox = _mock_async_sandbox()
+        reconnect_handle = mock.MagicMock()
+        reconnect_handle._stream = _async_messages(
+            {"type": "stdout", "data": "after-reconnect", "offset": 18},
+            {"type": "exit", "exit_code": 0},
+        )
+        reconnect_handle._control = None
+        sandbox.reconnect.return_value = reconnect_handle
+
+        stdout_data: list[str] = []
+        handle = AsyncCommandHandle(
+            stream,
+            None,
+            sandbox,
+            on_stdout=stdout_data.append,
+        )
+        original_backoff = AsyncCommandHandle._BACKOFF_BASE
+        AsyncCommandHandle._BACKOFF_BASE = 0
+        try:
+            result = await handle.result
+        finally:
+            AsyncCommandHandle._BACKOFF_BASE = original_backoff
+
+        assert result.exit_code == 0
+        assert stdout_data == ["before-disconnect ", "after-reconnect"]
+        assert result.stdout == "before-disconnect after-reconnect"

--- a/python/tests/unit_tests/sandbox/test_ws_execute.py
+++ b/python/tests/unit_tests/sandbox/test_ws_execute.py
@@ -694,8 +694,6 @@ class TestSandboxRunWs:
             cwd=None,
             shell="/bin/bash",
             headers={"X-Test-Header": "sandbox-ws"},
-            on_stdout=None,
-            on_stderr=None,
             idle_timeout=300,
             kill_on_disconnect=False,
             ttl_seconds=600,


### PR DESCRIPTION
## Problem

`sandbox.run(..., { onStdout })` (Python: `on_stdout`) silently drops all output produced after a mid-stream WebSocket reconnect. The callbacks are invoked inside the **per-connection** message pump (`runWsStream` / `run_ws_stream`), but `CommandHandle`'s auto-reconnect swaps in a fresh connection via `reconnectWsStream`, which has no callback support — so after the first transient disconnect (LB idle timeout, flaky WAN), callbacks go quiet while the command result still resolves with `exit_code 0`. Silent tail truncation.

Reported by a user migrating from E2B (follow-up to the server-side ring-buffer fix in langchainplus#27168): their repro using the callback path lost 3,516 of 29,297 records on 2/3 runs over their network, with no error.

## Fix

Move callback invocation into `CommandHandle` / `AsyncCommandHandle`'s reconnecting iterator — the one place that survives reconnects and sees every chunk exactly once — and stop passing callbacks to the per-connection stream functions. Applied to the JS handle and both sync/async Python handles (the JS handle is a port of the Python one; all three had the bug).

Also fixes `RunOptions.commandId` being silently dropped in the JS WS path before reaching the execute payload.

## Validation

- New unit tests in both SDKs: callbacks invoked for every chunk, and specifically for chunks delivered after a simulated mid-stream reconnect (fail before the fix, pass after). JS: 100 sandbox tests pass; Python: 444 sandbox tests pass.
- End-to-end against prod with a deterministic disconnect probe (30 MB JSONL stream via `run({ onStdout })`, hard `ws.terminate()` every 5 MB):
  - **Before:** 1 disconnect → 4,889 of 29,297 records delivered, `exit_code 0` (silent loss).
  - **After:** 6 forced disconnects → all 29,297 records delivered, `exit_code 0`.
- The reporting user's updated repro (`mwcd/langsmith-sandbox-stream-repro@8589c98`) passes with this fix.