### PR TITLE
fix(js): deliver sandbox output callbacks across stream reconnects

### DIFF
--- a/js/src/sandbox/command_handle.ts
+++ b/js/src/sandbox/command_handle.ts
@@ -54,6 +54,8 @@ export class CommandHandle {
   private _lastStdoutOffset: number;
   private _lastStderrOffset: number;
   private _started: boolean;
+  private _onStdout?: (data: string) => void;
+  private _onStderr?: (data: string) => void;
 
   /** @internal */
   constructor(
@@ -64,6 +66,8 @@ export class CommandHandle {
       commandId?: string;
       stdoutOffset?: number;
       stderrOffset?: number;
+      onStdout?: (data: string) => void;
+      onStderr?: (data: string) => void;
     },
   ) {
     this._stream = messageStream;
@@ -71,6 +75,10 @@ export class CommandHandle {
     this._sandbox = sandbox;
     this._lastStdoutOffset = options?.stdoutOffset ?? 0;
     this._lastStderrOffset = options?.stderrOffset ?? 0;
+    // Callbacks live on the handle (not the per-connection stream) so they
+    // keep firing for chunks delivered after an auto-reconnect.
+    this._onStdout = options?.onStdout;
+    this._onStderr = options?.onStderr;
 
     // New executions (no commandId): _ensureStarted reads "started".
     // Reconnections (commandId set): skip since reconnect streams
@@ -197,9 +205,11 @@ export class CommandHandle {
           if (chunk.stream === "stdout") {
             this._lastStdoutOffset =
               chunk.offset + new TextEncoder().encode(chunk.data).length;
+            this._onStdout?.(chunk.data);
           } else {
             this._lastStderrOffset =
               chunk.offset + new TextEncoder().encode(chunk.data).length;
+            this._onStderr?.(chunk.data);
           }
           yield chunk;
         }

--- a/js/src/sandbox/sandbox.ts
+++ b/js/src/sandbox/sandbox.ts
@@ -242,6 +242,7 @@ export class Sandbox {
       shell = "/bin/bash",
       onStdout,
       onStderr,
+      commandId,
       idleTimeout,
       killOnDisconnect,
       ttlSeconds,
@@ -259,8 +260,7 @@ export class Sandbox {
         env,
         cwd,
         shell,
-        onStdout,
-        onStderr,
+        commandId,
         idleTimeout,
         killOnDisconnect,
         ttlSeconds,
@@ -271,7 +271,12 @@ export class Sandbox {
       },
     );
 
-    const handle = new CommandHandle(stream, control, this);
+    // Callbacks are attached to the handle, not the connection, so they
+    // keep firing for output delivered after an auto-reconnect.
+    const handle = new CommandHandle(stream, control, this, {
+      onStdout,
+      onStderr,
+    });
     await handle._ensureStarted();
     return handle;
   }

--- a/js/src/sandbox/types.ts
+++ b/js/src/sandbox/types.ts
@@ -212,6 +212,12 @@ export interface RunOptions {
    */
   wait?: boolean;
   /**
+   * Client-assigned command ID. Executing with an existing command ID
+   * re-attaches to that command (get-or-create) instead of starting a
+   * new one. Only used by the WebSocket path.
+   */
+  commandId?: string;
+  /**
    * Callback invoked with each stdout chunk during streaming execution.
    * When provided, WebSocket streaming is used.
    */

--- a/js/src/tests/sandbox.test.ts
+++ b/js/src/tests/sandbox.test.ts
@@ -1205,6 +1205,69 @@ describe("CommandHandle", () => {
     });
   });
 
+  describe("output callbacks", () => {
+    it("should invoke onStdout/onStderr for every chunk", async () => {
+      const stream = createMockStream([
+        { type: "started", command_id: "cmd-123", pid: 42 },
+        { type: "stdout", data: "out1", offset: 0 },
+        { type: "stderr", data: "err1", offset: 0 },
+        { type: "stdout", data: "out2", offset: 4 },
+        { type: "exit", exit_code: 0 },
+      ]);
+
+      const stdoutData: string[] = [];
+      const stderrData: string[] = [];
+      const handle = new CommandHandle(stream, null, createMockSandbox(), {
+        onStdout: (d) => stdoutData.push(d),
+        onStderr: (d) => stderrData.push(d),
+      });
+
+      const result = await handle.result;
+
+      expect(result.exit_code).toBe(0);
+      expect(stdoutData).toEqual(["out1", "out2"]);
+      expect(stderrData).toEqual(["err1"]);
+    });
+
+    it("should keep invoking callbacks for chunks received after a reconnect", async () => {
+      // Mid-stream disconnect: the first connection delivers part of the
+      // output and dies without an exit message; the reconnected stream
+      // delivers the tail. Callbacks must see ALL chunks (this is the bug
+      // that silently truncated tails for sandbox.run({ onStdout })).
+      const stream = createMockStream([
+        { type: "started", command_id: "cmd-123", pid: 42 },
+        { type: "stdout", data: "before-disconnect ", offset: 0 },
+      ]);
+
+      const sandbox = createMockSandbox();
+      const reconnectHandle = {
+        _stream: createMockStream([
+          { type: "stdout", data: "after-reconnect", offset: 18 },
+          { type: "exit", exit_code: 0 },
+        ]),
+        _control: null,
+      };
+      (sandbox.reconnect as any).mockResolvedValue(reconnectHandle);
+
+      const stdoutData: string[] = [];
+      const handle = new CommandHandle(stream, null, sandbox, {
+        onStdout: (d) => stdoutData.push(d),
+      });
+
+      const backoffBase = CommandHandle.BACKOFF_BASE;
+      CommandHandle.BACKOFF_BASE = 0;
+      try {
+        const result = await handle.result;
+
+        expect(result.exit_code).toBe(0);
+        expect(stdoutData).toEqual(["before-disconnect ", "after-reconnect"]);
+        expect(result.stdout).toBe("before-disconnect after-reconnect");
+      } finally {
+        CommandHandle.BACKOFF_BASE = backoffBase;
+      }
+    });
+  });
+
   describe("kill", () => {
     it("should call sendKill on control", () => {
       const control = new WSStreamControl();


### PR DESCRIPTION
JS half of #3021 (split per language; Python: see companion PR).

## Problem

`sandbox.run(..., { onStdout })` silently drops all output produced after a mid-stream WebSocket reconnect. Callbacks are invoked inside the **per-connection** message pump (`runWsStream`), but `CommandHandle`'s auto-reconnect swaps in a fresh connection via `reconnectWsStream`, which has no callback support — so after the first transient disconnect (LB idle timeout, flaky WAN), callbacks go quiet while the command result still resolves with `exit_code 0`. Silent tail truncation.

Reported by a user migrating from E2B (follow-up to the server-side ring-buffer fix): their repro using the callback path lost 3,516 of 29,297 records on 2/3 runs over their network, with no error.

## Fix

Move callback invocation into `CommandHandle`'s reconnecting iterator — the one place that survives reconnects and sees every chunk exactly once — and stop passing callbacks to the per-connection stream function.

Also fixes `RunOptions.commandId` being silently dropped in the WS path before reaching the execute payload.

## Validation

- New unit tests: callbacks invoked for every chunk, and specifically for chunks delivered after a simulated mid-stream reconnect (fail before the fix, pass after). 100 sandbox tests pass.
- End-to-end against prod with a deterministic disconnect probe (30 MB JSONL stream via `run({ onStdout })`, hard `ws.terminate()` every 5 MB):
  - **Before:** 1 disconnect → 4,889 of 29,297 records delivered, `exit_code 0` (silent loss).
  - **After:** 6 forced disconnects → all 29,297 records delivered.
- The reporting user's repro (`mwcd/langsmith-sandbox-stream-repro@8589c98`) passes with this fix.