### PR TITLE
fix(python): deliver sandbox output callbacks across stream reconnects

### DIFF
--- a/python/langsmith/sandbox/_async_sandbox.py
+++ b/python/langsmith/sandbox/_async_sandbox.py
@@ -371,8 +371,6 @@ class AsyncSandbox:
             **ws_kwargs,
         )
 
-        # Callbacks are attached to the handle, not the connection, so they
-        # keep firing for output delivered after an auto-reconnect.
         handle = AsyncCommandHandle(
             msg_stream,
             control,

--- a/python/langsmith/sandbox/_async_sandbox.py
+++ b/python/langsmith/sandbox/_async_sandbox.py
@@ -355,8 +355,6 @@ class AsyncSandbox:
             "env": env,
             "cwd": cwd,
             "shell": shell,
-            "on_stdout": on_stdout,
-            "on_stderr": on_stderr,
             "idle_timeout": idle_timeout,
             "kill_on_disconnect": kill_on_disconnect,
             "ttl_seconds": ttl_seconds,
@@ -373,7 +371,15 @@ class AsyncSandbox:
             **ws_kwargs,
         )
 
-        handle = AsyncCommandHandle(msg_stream, control, self)
+        # Callbacks are attached to the handle, not the connection, so they
+        # keep firing for output delivered after an auto-reconnect.
+        handle = AsyncCommandHandle(
+            msg_stream,
+            control,
+            self,
+            on_stdout=on_stdout,
+            on_stderr=on_stderr,
+        )
         await handle._ensure_started()
 
         if not wait:

--- a/python/langsmith/sandbox/_models.py
+++ b/python/langsmith/sandbox/_models.py
@@ -494,10 +494,16 @@ class CommandHandle:
         command_id: str = "",
         stdout_offset: int = 0,
         stderr_offset: int = 0,
+        on_stdout: Optional[Callable[[str], Any]] = None,
+        on_stderr: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._stream = message_stream
         self._control = control
         self._sandbox = sandbox
+        # Callbacks live on the handle (not the per-connection stream) so
+        # they keep firing for chunks delivered after an auto-reconnect.
+        self._on_stdout = on_stdout
+        self._on_stderr = on_stderr
         self._command_id: Optional[str] = None
         self._pid: Optional[int] = None
         self._result: Optional[ExecutionResult] = None
@@ -611,10 +617,14 @@ class CommandHandle:
                         self._last_stdout_offset = chunk.offset + len(
                             chunk.data.encode("utf-8")
                         )
+                        if self._on_stdout is not None:
+                            self._on_stdout(chunk.data)
                     else:
                         self._last_stderr_offset = chunk.offset + len(
                             chunk.data.encode("utf-8")
                         )
+                        if self._on_stderr is not None:
+                            self._on_stderr(chunk.data)
                     yield chunk
                 return  # Stream ended normally (exit message received)
 
@@ -746,10 +756,16 @@ class AsyncCommandHandle:
         command_id: str = "",
         stdout_offset: int = 0,
         stderr_offset: int = 0,
+        on_stdout: Optional[Callable[[str], Any]] = None,
+        on_stderr: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._stream = message_stream
         self._control = control
         self._sandbox = sandbox
+        # Callbacks live on the handle (not the per-connection stream) so
+        # they keep firing for chunks delivered after an auto-reconnect.
+        self._on_stdout = on_stdout
+        self._on_stderr = on_stderr
         self._command_id: Optional[str] = None
         self._pid: Optional[int] = None
         self._result: Optional[ExecutionResult] = None
@@ -852,10 +868,14 @@ class AsyncCommandHandle:
                         self._last_stdout_offset = chunk.offset + len(
                             chunk.data.encode("utf-8")
                         )
+                        if self._on_stdout is not None:
+                            self._on_stdout(chunk.data)
                     else:
                         self._last_stderr_offset = chunk.offset + len(
                             chunk.data.encode("utf-8")
                         )
+                        if self._on_stderr is not None:
+                            self._on_stderr(chunk.data)
                     yield chunk
                 return  # Stream ended normally
 

--- a/python/langsmith/sandbox/_models.py
+++ b/python/langsmith/sandbox/_models.py
@@ -500,8 +500,6 @@ class CommandHandle:
         self._stream = message_stream
         self._control = control
         self._sandbox = sandbox
-        # Callbacks live on the handle (not the per-connection stream) so
-        # they keep firing for chunks delivered after an auto-reconnect.
         self._on_stdout = on_stdout
         self._on_stderr = on_stderr
         self._command_id: Optional[str] = None
@@ -762,8 +760,6 @@ class AsyncCommandHandle:
         self._stream = message_stream
         self._control = control
         self._sandbox = sandbox
-        # Callbacks live on the handle (not the per-connection stream) so
-        # they keep firing for chunks delivered after an auto-reconnect.
         self._on_stdout = on_stdout
         self._on_stderr = on_stderr
         self._command_id: Optional[str] = None

--- a/python/langsmith/sandbox/_sandbox.py
+++ b/python/langsmith/sandbox/_sandbox.py
@@ -370,8 +370,6 @@ class Sandbox:
             **ws_kwargs,
         )
 
-        # Callbacks are attached to the handle, not the connection, so they
-        # keep firing for output delivered after an auto-reconnect.
         handle = CommandHandle(
             msg_stream,
             control,

--- a/python/langsmith/sandbox/_sandbox.py
+++ b/python/langsmith/sandbox/_sandbox.py
@@ -354,8 +354,6 @@ class Sandbox:
             "env": env,
             "cwd": cwd,
             "shell": shell,
-            "on_stdout": on_stdout,
-            "on_stderr": on_stderr,
             "idle_timeout": idle_timeout,
             "kill_on_disconnect": kill_on_disconnect,
             "ttl_seconds": ttl_seconds,
@@ -372,7 +370,15 @@ class Sandbox:
             **ws_kwargs,
         )
 
-        handle = CommandHandle(msg_stream, control, self)
+        # Callbacks are attached to the handle, not the connection, so they
+        # keep firing for output delivered after an auto-reconnect.
+        handle = CommandHandle(
+            msg_stream,
+            control,
+            self,
+            on_stdout=on_stdout,
+            on_stderr=on_stderr,
+        )
 
         if not wait:
             return handle

--- a/python/tests/unit_tests/sandbox/test_async_ws_execute.py
+++ b/python/tests/unit_tests/sandbox/test_async_ws_execute.py
@@ -735,8 +735,6 @@ class TestAsyncSandboxRunWs:
             cwd=None,
             shell="/bin/bash",
             headers={"X-Test-Header": "sandbox-ws"},
-            on_stdout=None,
-            on_stderr=None,
             idle_timeout=300,
             kill_on_disconnect=False,
             ttl_seconds=600,

--- a/python/tests/unit_tests/sandbox/test_command_handle.py
+++ b/python/tests/unit_tests/sandbox/test_command_handle.py
@@ -1,0 +1,153 @@
+"""CommandHandle / AsyncCommandHandle callback delivery across reconnects.
+
+Output callbacks must be attached to the handle (which survives
+auto-reconnects), not to a single WebSocket connection — otherwise every
+chunk delivered after a mid-stream reconnect is silently dropped from the
+on_stdout/on_stderr path while the result still reports exit_code 0.
+"""
+
+from unittest import mock
+
+import pytest
+
+from langsmith.sandbox._models import AsyncCommandHandle, CommandHandle
+
+
+def _messages(*msgs):
+    return iter(list(msgs))
+
+
+async def _async_messages(*msgs):
+    for msg in msgs:
+        yield msg
+
+
+def _mock_sandbox():
+    return mock.MagicMock()
+
+
+def _mock_async_sandbox():
+    sandbox = mock.MagicMock()
+    sandbox.reconnect = mock.AsyncMock()
+    return sandbox
+
+
+class TestCommandHandleCallbacks:
+    def test_callbacks_invoked_for_every_chunk(self):
+        stream = _messages(
+            {"type": "started", "command_id": "cmd-1", "pid": 42},
+            {"type": "stdout", "data": "out1", "offset": 0},
+            {"type": "stderr", "data": "err1", "offset": 0},
+            {"type": "stdout", "data": "out2", "offset": 4},
+            {"type": "exit", "exit_code": 0},
+        )
+        stdout_data: list[str] = []
+        stderr_data: list[str] = []
+
+        handle = CommandHandle(
+            stream,
+            None,
+            _mock_sandbox(),
+            on_stdout=stdout_data.append,
+            on_stderr=stderr_data.append,
+        )
+        result = handle.result
+
+        assert result.exit_code == 0
+        assert stdout_data == ["out1", "out2"]
+        assert stderr_data == ["err1"]
+
+    def test_callbacks_survive_reconnect(self):
+        # First connection dies without an exit message; the reconnected
+        # stream delivers the tail. Callbacks must see ALL chunks.
+        stream = _messages(
+            {"type": "started", "command_id": "cmd-1", "pid": 42},
+            {"type": "stdout", "data": "before-disconnect ", "offset": 0},
+        )
+        sandbox = _mock_sandbox()
+        reconnect_handle = mock.MagicMock()
+        reconnect_handle._stream = _messages(
+            {"type": "stdout", "data": "after-reconnect", "offset": 18},
+            {"type": "exit", "exit_code": 0},
+        )
+        reconnect_handle._control = None
+        sandbox.reconnect.return_value = reconnect_handle
+
+        stdout_data: list[str] = []
+        handle = CommandHandle(
+            stream,
+            None,
+            sandbox,
+            on_stdout=stdout_data.append,
+        )
+
+        original_backoff = CommandHandle._BACKOFF_BASE
+        CommandHandle._BACKOFF_BASE = 0
+        try:
+            result = handle.result
+        finally:
+            CommandHandle._BACKOFF_BASE = original_backoff
+
+        assert result.exit_code == 0
+        assert stdout_data == ["before-disconnect ", "after-reconnect"]
+        assert result.stdout == "before-disconnect after-reconnect"
+
+
+class TestAsyncCommandHandleCallbacks:
+    @pytest.mark.asyncio
+    async def test_callbacks_invoked_for_every_chunk(self):
+        stream = _async_messages(
+            {"type": "started", "command_id": "cmd-1", "pid": 42},
+            {"type": "stdout", "data": "out1", "offset": 0},
+            {"type": "stderr", "data": "err1", "offset": 0},
+            {"type": "stdout", "data": "out2", "offset": 4},
+            {"type": "exit", "exit_code": 0},
+        )
+        stdout_data: list[str] = []
+        stderr_data: list[str] = []
+
+        handle = AsyncCommandHandle(
+            stream,
+            None,
+            _mock_async_sandbox(),
+            on_stdout=stdout_data.append,
+            on_stderr=stderr_data.append,
+        )
+        result = await handle.result
+
+        assert result.exit_code == 0
+        assert stdout_data == ["out1", "out2"]
+        assert stderr_data == ["err1"]
+
+    @pytest.mark.asyncio
+    async def test_callbacks_survive_reconnect(self):
+        stream = _async_messages(
+            {"type": "started", "command_id": "cmd-1", "pid": 42},
+            {"type": "stdout", "data": "before-disconnect ", "offset": 0},
+        )
+        sandbox = _mock_async_sandbox()
+        reconnect_handle = mock.MagicMock()
+        reconnect_handle._stream = _async_messages(
+            {"type": "stdout", "data": "after-reconnect", "offset": 18},
+            {"type": "exit", "exit_code": 0},
+        )
+        reconnect_handle._control = None
+        sandbox.reconnect.return_value = reconnect_handle
+
+        stdout_data: list[str] = []
+        handle = AsyncCommandHandle(
+            stream,
+            None,
+            sandbox,
+            on_stdout=stdout_data.append,
+        )
+        original_backoff = AsyncCommandHandle._BACKOFF_BASE
+        AsyncCommandHandle._BACKOFF_BASE = 0
+        try:
+            result = await handle.result
+        finally:
+            AsyncCommandHandle._BACKOFF_BASE = original_backoff
+
+        assert result.exit_code == 0
+        assert stdout_data == ["before-disconnect ", "after-reconnect"]
+        assert result.stdout == "before-disconnect after-reconnect"

--- a/python/tests/unit_tests/sandbox/test_ws_execute.py
+++ b/python/tests/unit_tests/sandbox/test_ws_execute.py
@@ -694,8 +694,6 @@ class TestSandboxRunWs:
             cwd=None,
             shell="/bin/bash",
             headers={"X-Test-Header": "sandbox-ws"},
-            on_stdout=None,
-            on_stderr=None,
             idle_timeout=300,
             kill_on_disconnect=False,
             ttl_seconds=600,


### PR DESCRIPTION
Python half of #3021 (split per language; JS: #3022).

## Problem

`sandbox.run(..., on_stdout=...)` silently drops all output produced after a mid-stream WebSocket reconnect, in both the sync and async paths. Callbacks are invoked inside the **per-connection** message pump (`run_ws_stream` / `run_ws_stream_async`), but `CommandHandle`/`AsyncCommandHandle`'s auto-reconnect swaps in a fresh connection via the reconnect stream functions, which have no callback support — so after the first transient disconnect (LB idle timeout, flaky WAN), callbacks go quiet while the command result still resolves with `exit_code 0`. Silent tail truncation.

Same root cause as the JS bug (#3022) — the JS handle is a port of the Python one and both inherited it. Found while debugging a user's streaming data-loss report.

## Fix

Move callback invocation into the handles' reconnecting iterators — the one place that survives reconnects and sees every chunk exactly once — and stop passing callbacks to the per-connection stream functions. Applied to both `CommandHandle` (sync) and `AsyncCommandHandle`.

## Validation

- New unit tests (`test_command_handle.py`): callbacks invoked for every chunk, and specifically for chunks delivered after a simulated mid-stream reconnect, for both sync and async handles (fail before the fix, pass after). All 444 sandbox unit tests pass.
- The same failure mechanism was reproduced end-to-end against prod via the JS SDK (see #3022); the Python handles share the architecture and the same fix shape.