### PR TITLE
chore: repoint support@langchain.dev mentions to the Support Portal

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,9 +1,9 @@
 blank_issues_enabled: true
 version: 2.1
 contact_links:
-  - name: Support Email
-    url: mailto:support@langchain.dev
-    about: Address to contact for enterprise support requests.
+  - name: Support Portal
+    url: https://support.langchain.com
+    about: Contact technical support for enterprise support requests.
   - name: Discord
     url: https://discord.gg/6adMQxSpJS
     about: General community discussions

--- a/js/src/sandbox/errors.ts
+++ b/js/src/sandbox/errors.ts
@@ -165,7 +165,8 @@ export class LangSmithValidationError extends LangSmithSandboxError {
 /**
  * Raised when organization quota limits are exceeded.
  *
- * Users should contact support@langchain.dev to increase quotas.
+ * Users should contact technical support via our Support Portal
+ * (https://support.langchain.com) to increase quotas.
  */
 export class LangSmithQuotaExceededError extends LangSmithSandboxError {
   quotaType?: string;

--- a/python/langsmith/sandbox/_exceptions.py
+++ b/python/langsmith/sandbox/_exceptions.py
@@ -182,7 +182,8 @@ class ValidationError(SandboxClientError):
 class QuotaExceededError(SandboxClientError):
     """Raised when organization quota limits are exceeded.
 
-    Users should contact support@langchain.dev to increase quotas.
+    Users should contact technical support via our Support Portal
+    (https://support.langchain.com) to increase quotas.
 
     Attributes:
         quota_type: Type of quota exceeded (e.g., "sandbox_count", "cpu").


### PR DESCRIPTION
## What
Repoints customer-facing mentions of `support@langchain.dev` to the Support Portal (https://support.langchain.com), part of the org-wide cleanup to route users through the portal instead of a raw mailto.

## Notes
- User-facing strings/links only, no logic changes.
- "Support Portal" is the visible link text in rendered surfaces (JSX/MDX/HTML); plain-text error strings use "contact technical support via our Support Portal (https://support.langchain.com)".

🤖 Generated with [Claude Code](https://claude.com/claude-code)