### PR TITLE
chore: bump JS to 0.7.7 and Python to 0.8.15

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langsmith",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "Client library to connect to the LangSmith Observability and Evaluation Platform.",
   "packageManager": "pnpm@10.33.0",
   "files": [

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -32,7 +32,7 @@ export {
 } from "./utils/prompt_cache/index.js";
 
 // Update using pnpm bump-version
-export const __version__ = "0.7.6";
+export const __version__ = "0.7.7";
 
 // Metadata key to hide a traced run from LangSmith's Messages View.
 export const LS_MESSAGE_VIEW_EXCLUDE = "ls_message_view_exclude" as const;

--- a/js/src/sandbox/command_handle.ts
+++ b/js/src/sandbox/command_handle.ts
@@ -75,8 +75,6 @@ export class CommandHandle {
     this._sandbox = sandbox;
     this._lastStdoutOffset = options?.stdoutOffset ?? 0;
     this._lastStderrOffset = options?.stderrOffset ?? 0;
-    // Callbacks live on the handle (not the per-connection stream) so they
-    // keep firing for chunks delivered after an auto-reconnect.
     this._onStdout = options?.onStdout;
     this._onStderr = options?.onStderr;
 

--- a/js/src/sandbox/sandbox.ts
+++ b/js/src/sandbox/sandbox.ts
@@ -271,8 +271,6 @@ export class Sandbox {
       },
     );
 
-    // Callbacks are attached to the handle, not the connection, so they
-    // keep firing for output delivered after an auto-reconnect.
     const handle = new CommandHandle(stream, control, this, {
       onStdout,
       onStderr,

--- a/python/langsmith/__init__.py
+++ b/python/langsmith/__init__.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
 
 # Avoid calling into importlib on every call to __version__
 
-__version__ = "0.8.14"
+__version__ = "0.8.15"
 version = __version__  # for backwards compatibility
 
 # Metadata key to hide a traced run from LangSmith's Messages View.


### PR DESCRIPTION
Release bumps for the sandbox callback-reconnect fixes:

- **JS → 0.7.7** (`package.json` + `__version__`): releases #3022 (callbacks delivered across stream reconnects, `commandId` forwarding).
- **Python → 0.8.15** (`langsmith/__init__.py`, hatch-dynamic): releases #3023 (same fix, sync + async handles).

Also drops two redundant explanatory comments from the JS change (the Python ones were cleaned up in #3023 directly).