### PR TITLE
fix(python): derive create_child run id from start_time [LSDK-220]

### DIFF
--- a/python/langsmith/run_trees.py
+++ b/python/langsmith/run_trees.py
@@ -572,7 +572,8 @@ class RunTree(ls_schemas.RunBase):
         child_extra["metadata"] = {**parent_meta, **child_meta}
         # upfront resolution of start_time so run_id can be derived from it.
         child_start_time = start_time or datetime.now(timezone.utc)
-        # accept_null=True allows us to explicitly pass None to get a UUID based on start_time (instead of a random UUID)
+        # accept_null=True allows us to explicitly pass None
+        # UUID will be based on start_time (instead of a random UUID)
         run_id_ = _ensure_uuid(run_id, accept_null=True)
         if run_id_ is None:
             run_id_ = uuid7_from_datetime(child_start_time)

--- a/python/langsmith/run_trees.py
+++ b/python/langsmith/run_trees.py
@@ -570,16 +570,21 @@ class RunTree(ls_schemas.RunBase):
             child_meta = {}
         parent_meta = (self.extra or {}).get("metadata") or {}
         child_extra["metadata"] = {**parent_meta, **child_meta}
+        # upfront resolution of start_time so run_id can be derived from it.
+        child_start_time = start_time or datetime.now(timezone.utc)
+        run_id_ = _ensure_uuid(run_id, accept_null=True)
+        if run_id_ is None:
+            run_id_ = uuid7_from_datetime(child_start_time)
         run = RunTree(
             name=name,
-            id=_ensure_uuid(run_id),
+            id=run_id_,
             serialized=serialized_,
             inputs=inputs or {},
             outputs=outputs or {},
             error=error,
             run_type=run_type,
             reference_example_id=reference_example_id,
-            start_time=start_time or datetime.now(timezone.utc),
+            start_time=child_start_time,
             end_time=end_time,
             extra=child_extra,
             parent_run=self,

--- a/python/langsmith/run_trees.py
+++ b/python/langsmith/run_trees.py
@@ -572,6 +572,7 @@ class RunTree(ls_schemas.RunBase):
         child_extra["metadata"] = {**parent_meta, **child_meta}
         # upfront resolution of start_time so run_id can be derived from it.
         child_start_time = start_time or datetime.now(timezone.utc)
+        # accept_null=True allows us to explicitly pass None to get a UUID based on start_time (instead of a random UUID)
         run_id_ = _ensure_uuid(run_id, accept_null=True)
         if run_id_ is None:
             run_id_ = uuid7_from_datetime(child_start_time)


### PR DESCRIPTION
## Description
`RunTree.create_child` always minted the child id via `uuid7()` (current time), ignoring the `start_time` argument. Runs created with a backdated `start_time` (e.g. the claude-agent-sdk LLM run, timed to include model latency) ended up with a UUIDv7 whose embedded timestamp disagreed with `start_time`/`dotted_order`. Since by-id detail lookups key on the id's timestamp, those runs ingested fine but 404'd on open.

Fix: when no explicit `run_id` is given, derive the id from the resolved `start_time` via `uuid7_from_datetime`, matching `RunTree`'s own constructor logic. No-op for the common (non-backdated) path. 
JS already does this, so no parity change needed.

## Self-Hosted Release Note
Fix Claude Agent SDK LLM runs returning 404 when opened due to a run id / start_time mismatch.

## Test Plan
- [x] Existing `tests/unit_tests/test_run_trees.py` pass (21)
- [x] Existing `tests/unit_tests/wrappers/test_claude_agent_sdk_hooks.py` pass (18)
- [x] Verified backdated `create_child(start_time=T0)` yields an id whose UUIDv7 timestamp matches T0; explicit `run_id` still honored
