### PR TITLE
chore: js to 0.7.8 and py to 0.8.16

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langsmith",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "description": "Client library to connect to the LangSmith Observability and Evaluation Platform.",
   "packageManager": "pnpm@10.33.0",
   "files": [

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -32,7 +32,7 @@ export {
 } from "./utils/prompt_cache/index.js";
 
 // Update using pnpm bump-version
-export const __version__ = "0.7.7";
+export const __version__ = "0.7.8";
 
 // Metadata key to hide a traced run from LangSmith's Messages View.
 export const LS_MESSAGE_VIEW_EXCLUDE = "ls_message_view_exclude" as const;

--- a/python/langsmith/__init__.py
+++ b/python/langsmith/__init__.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
 
 # Avoid calling into importlib on every call to __version__
 
-__version__ = "0.8.15"
+__version__ = "0.8.16"
 version = __version__  # for backwards compatibility
 
 # Metadata key to hide a traced run from LangSmith's Messages View.


### PR DESCRIPTION
Release bumps for evaluator loading state feedback key resolution: 

JS -> 0.7.8
PY -> 0.8.16
both release #3014 