### PR TITLE
feat(js): port `isTracingEnabled` utility from Python

### DIFF
--- a/js/src/env.ts
+++ b/js/src/env.ts
@@ -1,6 +1,6 @@
 import { getLangSmithEnvironmentVariable } from "./utils/env.js";
 
-export const isTracingEnabled = (tracingEnabled?: boolean): boolean => {
+export const isEnvTracingEnabled = (tracingEnabled?: boolean): boolean => {
   if (tracingEnabled !== undefined) {
     return tracingEnabled;
   }

--- a/js/src/experimental/otel/exporter.ts
+++ b/js/src/experimental/otel/exporter.ts
@@ -1,7 +1,7 @@
 import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-proto";
 import { ReadableSpan } from "@opentelemetry/sdk-trace-base";
 import * as constants from "./constants.js";
-import { isTracingEnabled } from "../../env.js";
+import { isEnvTracingEnabled } from "../../env.js";
 import {
   getEnvironmentVariable,
   getLangSmithEnvironmentVariable,
@@ -130,7 +130,7 @@ export class LangSmithOTLPTraceExporter extends OTLPTraceExporter {
     spans: ReadableSpan[],
     resultCallback: Parameters<OTLPTraceExporter["export"]>[1],
   ): void {
-    if (!isTracingEnabled()) {
+    if (!isEnvTracingEnabled()) {
       return resultCallback({ code: 0 });
     }
     const runExport = async () => {

--- a/js/src/experimental/vercel/telemetry.ts
+++ b/js/src/experimental/vercel/telemetry.ts
@@ -1,7 +1,7 @@
 import type { ModelMessage, StepResult, Telemetry, TypedToolCall } from "ai";
 import { isRunTree, RunTree, RunTreeConfig } from "../../run_trees.js";
 import { getCurrentRunTree, withRunTree } from "../../singletons/traceable.js";
-import { isTracingEnabled } from "../../env.js";
+import { isEnvTracingEnabled } from "../../env.js";
 import { convertMessageToTracedFormat } from "./utils.js";
 import { setUsageMetadataOnRunTree } from "./utils.js";
 import type { KVMap } from "../../schemas.js";
@@ -230,7 +230,7 @@ export function LangSmithTelemetry(
   const invocationsByCallId = new Map<string, InvocationState>();
 
   const onStart: Telemetry["onStart"] = async (event) => {
-    if (!isTracingEnabled(tracingEnabled)) return;
+    if (!isEnvTracingEnabled(tracingEnabled)) return;
     if (!("callId" in event) || typeof event.callId !== "string") return;
 
     // If called within an existing traceable context, nest under it

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -22,6 +22,8 @@ export { getDefaultProjectName } from "./utils/project.js";
 
 export { uuid7, uuid7FromTime } from "./uuid.js";
 
+export { isTracingEnabled } from "./utils/guard.js";
+
 export {
   Cache,
   PromptCache,

--- a/js/src/run_trees.ts
+++ b/js/src/run_trees.ts
@@ -1,5 +1,5 @@
 import { Client } from "./client.js";
-import { isTracingEnabled } from "./env.js";
+import { isEnvTracingEnabled } from "./env.js";
 import {
   Attachments,
   BaseRun,
@@ -965,7 +965,7 @@ export class RunTree implements BaseRun {
     let projectName: string | undefined;
     let client: Client | undefined;
 
-    let tracingEnabled = isTracingEnabled();
+    let tracingEnabled = isEnvTracingEnabled();
 
     if (callbackManager) {
       const parentRunId = callbackManager?.getParentRunId?.() ?? "";

--- a/js/src/tests/guard.vitesttest.ts
+++ b/js/src/tests/guard.vitesttest.ts
@@ -1,0 +1,92 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { traceable, withRunTree } from "../traceable.js";
+import type { RunTree } from "../run_trees.js";
+import { isTracingEnabled } from "../utils/guard.js";
+import { mockClient } from "./utils/vitest_mock_client.js";
+
+beforeEach(() => {
+  vi.stubEnv("LANGCHAIN_TRACING", undefined);
+  vi.stubEnv("LANGSMITH_TRACING", undefined);
+  vi.stubEnv("LANGSMITH_TRACING_V2", undefined);
+  vi.stubEnv("LANGCHAIN_TRACING_V2", undefined);
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("isTracingEnabled", () => {
+  it("returns false without an active run tree or tracing env var", () => {
+    expect(isTracingEnabled()).toBe(false);
+  });
+
+  it.each([
+    "LANGCHAIN_TRACING",
+    "LANGSMITH_TRACING",
+    "LANGCHAIN_TRACING_V2",
+    "LANGSMITH_TRACING_V2",
+  ])("reads %s=true without an active run tree", (envVar) => {
+    vi.stubEnv(envVar, "true");
+    expect(isTracingEnabled()).toBe(true);
+  });
+
+  it("traceable without any env vars", async () => {
+    const { client, callSpy } = mockClient();
+    const traced = traceable(() => isTracingEnabled(), { client });
+
+    await expect(traced()).resolves.toBe(false);
+    expect(callSpy).toHaveBeenCalledTimes(0);
+  });
+
+  it("traceable with tracingEnabled=true override", async () => {
+    vi.stubEnv("LANGSMITH_TRACING", "false");
+
+    const { client, callSpy } = mockClient();
+    const traced = traceable(() => isTracingEnabled(), {
+      client,
+      tracingEnabled: true,
+    });
+
+    await expect(traced()).resolves.toBe(true);
+    expect(callSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("traceable with env + tracingEnabled=false", async () => {
+    vi.stubEnv("LANGSMITH_TRACING", "true");
+
+    const { client, callSpy } = mockClient();
+    const traced = traceable(() => isTracingEnabled(), {
+      client,
+      tracingEnabled: false,
+    });
+
+    await expect(traced()).resolves.toBe(false);
+    expect(callSpy).toHaveBeenCalledTimes(0);
+  });
+
+  it.each([
+    ["LANGSMITH_TRACING", "true"],
+    ["LANGSMITH_TRACING", "false"],
+  ])("withRunTree from env var $1", async (_, value) => {
+    vi.stubEnv("LANGSMITH_TRACING", value);
+
+    await expect(
+      withRunTree({} as RunTree, () => isTracingEnabled()),
+    ).resolves.toBe(value === "true");
+  });
+
+  it("withRunTree explicit tracingEnabled", async () => {
+    await expect(
+      withRunTree({ tracingEnabled: false } as RunTree, () =>
+        isTracingEnabled(),
+      ),
+    ).resolves.toBe(false);
+
+    await expect(
+      withRunTree({ tracingEnabled: true } as RunTree, () =>
+        isTracingEnabled(),
+      ),
+    ).resolves.toBe(true);
+  });
+});

--- a/js/src/traceable.ts
+++ b/js/src/traceable.ts
@@ -13,7 +13,7 @@ import {
   KVMap,
   ExtractedUsageMetadata,
 } from "./schemas.js";
-import { isTracingEnabled } from "./env.js";
+import { isEnvTracingEnabled } from "./env.js";
 import {
   ROOT,
   AsyncLocalStorageProviderSingleton,
@@ -348,7 +348,7 @@ const getTracingRunTree = <Args extends unknown[]>(
     | ((...args: Args) => [Attachments | undefined, KVMap])
     | undefined,
 ): RunTree | ContextPlaceholder => {
-  if (!isTracingEnabled(runTree.tracingEnabled)) {
+  if (!isEnvTracingEnabled(runTree.tracingEnabled)) {
     return { tracingEnabled: runTree.tracingEnabled };
   }
 

--- a/js/src/utils/guard.ts
+++ b/js/src/utils/guard.ts
@@ -1,0 +1,11 @@
+import { isEnvTracingEnabled } from "../env.js";
+import { getCurrentRunTree } from "../singletons/traceable.js";
+
+/**
+ * Check if tracing is enabled for the current run tree or environment.
+ *
+ * @returns `true` if tracing is enabled, `false` otherwise.
+ */
+export function isTracingEnabled() {
+  return getCurrentRunTree(true)?.tracingEnabled ?? isEnvTracingEnabled();
+}

--- a/js/src/utils/jestlike/globals.ts
+++ b/js/src/utils/jestlike/globals.ts
@@ -2,7 +2,7 @@ import { AsyncLocalStorage } from "node:async_hooks";
 import { Dataset, TracerSession, Example } from "../../schemas.js";
 import { Client, CreateProjectParams } from "../../client.js";
 import { getEnvironmentVariable } from "../env.js";
-import { isTracingEnabled } from "../../env.js";
+import { isEnvTracingEnabled } from "../../env.js";
 import { RunTree } from "../../run_trees.js";
 import { SimpleEvaluationResult } from "./types.js";
 
@@ -34,7 +34,7 @@ export function trackingEnabled(context: TestWrapperAsyncLocalStorageData) {
   if (getEnvironmentVariable("LANGSMITH_TEST_TRACKING") === "false") {
     return false;
   }
-  return isTracingEnabled();
+  return isEnvTracingEnabled();
 }
 
 export const evaluatorLogFeedbackPromises = new Set();


### PR DESCRIPTION
Detect presence of run tree from async local storage (while respecting manual override > env var hierarchy)
