### PR TITLE
feat: updating create feedback to add opt out for trace retention

### DIFF
--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -475,6 +475,7 @@ interface FeedbackCreate {
   session_id?: string;
   start_time?: number | string;
   comparative_experiment_id?: string;
+  do_not_extend_trace_retention?: boolean;
 }
 
 interface FeedbackUpdate {
@@ -4907,6 +4908,7 @@ export class Client implements LangSmithTracingClientInterface {
       comparativeExperimentId,
       sessionId,
       startTime,
+      doNotExtendTraceRetention,
     }: {
       score?: ScoreType;
       value?: ValueType;
@@ -4924,6 +4926,8 @@ export class Client implements LangSmithTracingClientInterface {
       sessionId?: string;
       /** The start time of the run this feedback is for. Accepts ISO string or epoch ms. */
       startTime?: number | string;
+      /** If true, create feedback without extending the trace's retention tier. */
+      doNotExtendTraceRetention?: boolean;
     },
   ): Promise<Feedback> {
     if (!runId && !projectId) {
@@ -4962,6 +4966,7 @@ export class Client implements LangSmithTracingClientInterface {
       feedbackConfig,
       session_id: sessionId ?? projectId,
       start_time: startTime,
+      do_not_extend_trace_retention: doNotExtendTraceRetention,
     };
     const body = JSON.stringify(feedback);
     const url = `${this.apiUrl}/feedback`;

--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -475,7 +475,7 @@ interface FeedbackCreate {
   session_id?: string;
   start_time?: number | string;
   comparative_experiment_id?: string;
-  do_not_extend_trace_retention?: boolean;
+  extend_trace_retention?: boolean;
 }
 
 interface FeedbackUpdate {
@@ -4908,7 +4908,7 @@ export class Client implements LangSmithTracingClientInterface {
       comparativeExperimentId,
       sessionId,
       startTime,
-      doNotExtendTraceRetention,
+      extendTraceRetention,
     }: {
       score?: ScoreType;
       value?: ValueType;
@@ -4926,8 +4926,8 @@ export class Client implements LangSmithTracingClientInterface {
       sessionId?: string;
       /** The start time of the run this feedback is for. Accepts ISO string or epoch ms. */
       startTime?: number | string;
-      /** If true, create feedback without extending the trace's retention tier. */
-      doNotExtendTraceRetention?: boolean;
+      /** If false, create feedback without extending the trace's retention tier. */
+      extendTraceRetention?: boolean;
     },
   ): Promise<Feedback> {
     if (!runId && !projectId) {
@@ -4966,7 +4966,7 @@ export class Client implements LangSmithTracingClientInterface {
       feedbackConfig,
       session_id: sessionId ?? projectId,
       start_time: startTime,
-      do_not_extend_trace_retention: doNotExtendTraceRetention,
+      extend_trace_retention: extendTraceRetention,
     };
     const body = JSON.stringify(feedback);
     const url = `${this.apiUrl}/feedback`;

--- a/js/src/tests/client.test.ts
+++ b/js/src/tests/client.test.ts
@@ -27,10 +27,14 @@ describe("Client", () => {
         fetchImplementation: mockFetch,
       });
 
-      await client.createFeedback("550e8400-e29b-41d4-a716-446655440000", "Foo", {
-        score: 1,
-        doNotExtendTraceRetention: true,
-      });
+      await client.createFeedback(
+        "550e8400-e29b-41d4-a716-446655440000",
+        "Foo",
+        {
+          score: 1,
+          doNotExtendTraceRetention: true,
+        },
+      );
 
       const [, init] = mockFetch.mock.calls[0];
       expect(JSON.parse(init?.body as string)).toEqual(

--- a/js/src/tests/client.test.ts
+++ b/js/src/tests/client.test.ts
@@ -32,14 +32,14 @@ describe("Client", () => {
         "Foo",
         {
           score: 1,
-          doNotExtendTraceRetention: true,
+          extendTraceRetention: false,
         },
       );
 
       const [, init] = mockFetch.mock.calls[0];
       expect(JSON.parse(init?.body as string)).toEqual(
         expect.objectContaining({
-          do_not_extend_trace_retention: true,
+          extend_trace_retention: false,
         }),
       );
     });

--- a/js/src/tests/client.test.ts
+++ b/js/src/tests/client.test.ts
@@ -12,6 +12,35 @@ import {
 import { parseHubIdentifier } from "../utils/prompts.js";
 
 describe("Client", () => {
+  describe("createFeedback", () => {
+    it("can opt out of extending trace retention", async () => {
+      const mockFetch = jest.fn<typeof fetch>().mockResolvedValue(
+        new Response("{}", {
+          status: 200,
+          statusText: "OK",
+          headers: { "content-type": "application/json" },
+        }),
+      );
+      const client = new Client({
+        apiUrl: "http://localhost:1984",
+        apiKey: "test-api-key",
+        fetchImplementation: mockFetch,
+      });
+
+      await client.createFeedback("550e8400-e29b-41d4-a716-446655440000", "Foo", {
+        score: 1,
+        doNotExtendTraceRetention: true,
+      });
+
+      const [, init] = mockFetch.mock.calls[0];
+      expect(JSON.parse(init?.body as string)).toEqual(
+        expect.objectContaining({
+          do_not_extend_trace_retention: true,
+        }),
+      );
+    });
+  });
+
   describe("onlineEvaluators", () => {
     it("creates an online evaluator through the platform endpoint", async () => {
       const mockFetch = jest.fn<typeof fetch>().mockResolvedValue(

--- a/python/langsmith/_internal/_operations.py
+++ b/python/langsmith/_internal/_operations.py
@@ -170,10 +170,9 @@ def serialize_feedback_dict(
         feedback_create: dict = feedback.model_dump()  # type: ignore
     else:
         feedback_create = cast(dict, feedback)
-    if "do_not_extend_trace_retention" in feedback_create:
-        feedback_create["_skip_trace_upgrade"] = feedback_create.pop(
-            "do_not_extend_trace_retention"
-        )
+    extend_trace_retention = feedback_create.pop("extend_trace_retention", True)
+    if not extend_trace_retention:
+        feedback_create["_skip_trace_upgrade"] = True
     if "id" not in feedback_create:
         feedback_create["id"] = uuid.uuid4()
     elif isinstance(feedback_create["id"], str):

--- a/python/langsmith/_internal/_operations.py
+++ b/python/langsmith/_internal/_operations.py
@@ -170,6 +170,10 @@ def serialize_feedback_dict(
         feedback_create: dict = feedback.model_dump()  # type: ignore
     else:
         feedback_create = cast(dict, feedback)
+    if "do_not_extend_trace_retention" in feedback_create:
+        feedback_create["_skip_trace_upgrade"] = feedback_create.pop(
+            "do_not_extend_trace_retention"
+        )
     if "id" not in feedback_create:
         feedback_create["id"] = uuid.uuid4()
     elif isinstance(feedback_create["id"], str):

--- a/python/langsmith/_internal/_operations.py
+++ b/python/langsmith/_internal/_operations.py
@@ -173,6 +173,10 @@ def serialize_feedback_dict(
     extend_trace_retention = feedback_create.pop("extend_trace_retention", True)
     if not extend_trace_retention:
         feedback_create["_skip_trace_upgrade"] = True
+        # Multipart feedback parts validate against FeedbackCreateSchema, which
+        # does not read _skip_trace_upgrade. Keep extend_trace_retention for
+        # that path while _skip_trace_upgrade serves the redis queue path.
+        feedback_create["extend_trace_retention"] = False
     if "id" not in feedback_create:
         feedback_create["id"] = uuid.uuid4()
     elif isinstance(feedback_create["id"], str):

--- a/python/langsmith/async_client.py
+++ b/python/langsmith/async_client.py
@@ -877,6 +877,7 @@ class AsyncClient:
         session_id: Optional[ls_client.ID_TYPE] = None,
         start_time: Optional[datetime.datetime] = None,
         comment: Optional[str] = None,
+        do_not_extend_trace_retention: bool = False,
         **kwargs: Any,
     ) -> ls_schemas.Feedback:
         """Create feedback for a run.
@@ -907,6 +908,8 @@ class AsyncClient:
             session_id: The project ID of the run this feedback is for.
             start_time: The start time of the run this feedback is for.
             comment: A comment about this feedback.
+            do_not_extend_trace_retention: If true, create the feedback without
+                extending the trace's retention tier.
             **kwargs: Additional deprecated keyword arguments.
 
         Returns:
@@ -984,6 +987,7 @@ class AsyncClient:
             ),
             extra=extra,
             error=error,
+            do_not_extend_trace_retention=do_not_extend_trace_retention,
         )
         # Retry on NotFound: the run referenced by run_id/trace_id may have been
         # submitted moments ago and not yet ingested when this write lands.

--- a/python/langsmith/async_client.py
+++ b/python/langsmith/async_client.py
@@ -877,7 +877,7 @@ class AsyncClient:
         session_id: Optional[ls_client.ID_TYPE] = None,
         start_time: Optional[datetime.datetime] = None,
         comment: Optional[str] = None,
-        do_not_extend_trace_retention: bool = False,
+        extend_trace_retention: bool = True,
         **kwargs: Any,
     ) -> ls_schemas.Feedback:
         """Create feedback for a run.
@@ -908,7 +908,7 @@ class AsyncClient:
             session_id: The project ID of the run this feedback is for.
             start_time: The start time of the run this feedback is for.
             comment: A comment about this feedback.
-            do_not_extend_trace_retention: If true, create the feedback without
+            extend_trace_retention: If false, create the feedback without
                 extending the trace's retention tier.
             **kwargs: Additional deprecated keyword arguments.
 
@@ -987,7 +987,7 @@ class AsyncClient:
             ),
             extra=extra,
             error=error,
-            do_not_extend_trace_retention=do_not_extend_trace_retention,
+            extend_trace_retention=extend_trace_retention,
         )
         # Retry on NotFound: the run referenced by run_id/trace_id may have been
         # submitted moments ago and not yet ingested when this write lands.

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -7736,6 +7736,7 @@ class Client:
                     self.tracing_queue is not None or self.compressed_traces is not None
                 )
                 and feedback.trace_id is not None
+                and not do_not_extend_trace_retention
                 and self.otel_exporter is None
             ):
                 serialized_op = serialize_feedback_dict(feedback)

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -7530,7 +7530,7 @@ class Client:
         error: Optional[bool] = None,
         session_id: Optional[ID_TYPE] = None,
         start_time: Optional[datetime.datetime] = None,
-        do_not_extend_trace_retention: bool = False,
+        extend_trace_retention: bool = True,
         **kwargs: Any,
     ) -> ls_schemas.Feedback:
         """Create feedback for a run.
@@ -7594,8 +7594,8 @@ class Client:
             start_time (Optional[datetime]):
                 The start time of the run this feedback is for. Used to optimize
                 feedback ingestion by avoiding server-side lookups.
-            do_not_extend_trace_retention (bool, default=False):
-                If true, create the feedback without extending the trace's retention
+            extend_trace_retention (bool, default=True):
+                If false, create the feedback without extending the trace's retention
                 tier.
             **kwargs (Any):
                 Additional keyword arguments.
@@ -7721,7 +7721,7 @@ class Client:
                 feedback_group_id=_ensure_uuid(feedback_group_id, accept_null=True),
                 extra=extra,
                 error=error,
-                do_not_extend_trace_retention=do_not_extend_trace_retention,
+                extend_trace_retention=extend_trace_retention,
             )
 
             use_multipart = not self._multipart_disabled and (
@@ -7736,7 +7736,7 @@ class Client:
                     self.tracing_queue is not None or self.compressed_traces is not None
                 )
                 and feedback.trace_id is not None
-                and not do_not_extend_trace_retention
+                and extend_trace_retention
                 and self.otel_exporter is None
             ):
                 serialized_op = serialize_feedback_dict(feedback)

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -7530,6 +7530,7 @@ class Client:
         error: Optional[bool] = None,
         session_id: Optional[ID_TYPE] = None,
         start_time: Optional[datetime.datetime] = None,
+        do_not_extend_trace_retention: bool = False,
         **kwargs: Any,
     ) -> ls_schemas.Feedback:
         """Create feedback for a run.
@@ -7593,6 +7594,9 @@ class Client:
             start_time (Optional[datetime]):
                 The start time of the run this feedback is for. Used to optimize
                 feedback ingestion by avoiding server-side lookups.
+            do_not_extend_trace_retention (bool, default=False):
+                If true, create the feedback without extending the trace's retention
+                tier.
             **kwargs (Any):
                 Additional keyword arguments.
 
@@ -7717,6 +7721,7 @@ class Client:
                 feedback_group_id=_ensure_uuid(feedback_group_id, accept_null=True),
                 extra=extra,
                 error=error,
+                do_not_extend_trace_retention=do_not_extend_trace_retention,
             )
 
             use_multipart = not self._multipart_disabled and (

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -7736,7 +7736,6 @@ class Client:
                     self.tracing_queue is not None or self.compressed_traces is not None
                 )
                 and feedback.trace_id is not None
-                and extend_trace_retention
                 and self.otel_exporter is None
             ):
                 serialized_op = serialize_feedback_dict(feedback)

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -7730,6 +7730,7 @@ class Client:
 
             if (
                 use_multipart
+                and extend_trace_retention
                 and self.info.version  # TODO: Remove version check once versions have updated
                 and ls_utils.is_version_greater_or_equal(self.info.version, "0.8.10")
                 and (

--- a/python/langsmith/schemas.py
+++ b/python/langsmith/schemas.py
@@ -683,6 +683,8 @@ class FeedbackCreate(FeedbackBase):
     """The source of the feedback."""
     feedback_config: Optional[FeedbackConfig] = None
     """The config for the feedback"""
+    do_not_extend_trace_retention: bool = False
+    """When true, do not extend trace retention as a side effect of creating this feedback."""
     error: Optional[bool] = None
 
 

--- a/python/langsmith/schemas.py
+++ b/python/langsmith/schemas.py
@@ -683,8 +683,8 @@ class FeedbackCreate(FeedbackBase):
     """The source of the feedback."""
     feedback_config: Optional[FeedbackConfig] = None
     """The config for the feedback"""
-    do_not_extend_trace_retention: bool = False
-    """When true, do not extend trace retention as a side effect of creating this feedback."""
+    extend_trace_retention: bool = True
+    """When true, extend trace retention as a side effect of creating this feedback."""
     error: Optional[bool] = None
 
 

--- a/python/tests/unit_tests/test_client.py
+++ b/python/tests/unit_tests/test_client.py
@@ -1679,11 +1679,11 @@ def test_create_feedback_can_opt_out_of_extending_trace_retention() -> None:
     client.create_feedback(
         run_id,
         key="Foo",
-        do_not_extend_trace_retention=True,
+        extend_trace_retention=False,
     )
 
     payload = json.loads(session.request.call_args.kwargs["data"])
-    assert payload["do_not_extend_trace_retention"] is True
+    assert payload["extend_trace_retention"] is False
 
 
 def test_pydantic_serialize() -> None:

--- a/python/tests/unit_tests/test_client.py
+++ b/python/tests/unit_tests/test_client.py
@@ -1686,8 +1686,12 @@ def test_create_feedback_can_opt_out_of_extending_trace_retention() -> None:
     assert payload["extend_trace_retention"] is False
 
 
-def test_create_feedback_opt_out_uses_tracing_queue_when_available() -> None:
-    """Opt-out should not force POST /feedback when batching is available."""
+def test_create_feedback_opt_out_uses_direct_post_when_batching_available() -> None:
+    """Opt-out must POST /feedback so extend_trace_retention reaches the API.
+
+    The tracing-queue multipart path is not safe for opt-out on all backends
+    (e.g. Go multipart ingest ignores retention flags).
+    """
     session = mock.Mock()
     run_id = uuid.uuid4()
     trace_id = uuid.uuid4()
@@ -1717,12 +1721,10 @@ def test_create_feedback_opt_out_uses_tracing_queue_when_available() -> None:
         extend_trace_retention=False,
     )
 
-    session.request.assert_not_called()
-    assert client.tracing_queue.qsize() == 1
-    queue_item = client.tracing_queue.get_nowait()
-    feedback_payload = _orjson.loads(queue_item.item.feedback)
-    assert feedback_payload["_skip_trace_upgrade"] is True
-    assert "extend_trace_retention" not in feedback_payload
+    session.request.assert_called_once()
+    payload = json.loads(session.request.call_args.kwargs["data"])
+    assert payload["extend_trace_retention"] is False
+    assert client.tracing_queue.qsize() == 0
 
 
 def test_pydantic_serialize() -> None:

--- a/python/tests/unit_tests/test_client.py
+++ b/python/tests/unit_tests/test_client.py
@@ -1662,6 +1662,30 @@ def test_create_feedback_string_source_type(source_type: str) -> None:
     )
 
 
+def test_create_feedback_can_opt_out_of_extending_trace_retention() -> None:
+    session = mock.Mock()
+    client = Client(api_url="http://localhost:1984", api_key="123", session=session)
+    request_object = mock.Mock()
+    run_id = uuid.uuid4()
+    request_object.json.return_value = {
+        "id": uuid.uuid4(),
+        "key": "Foo",
+        "created_at": _CREATED_AT,
+        "modified_at": _CREATED_AT,
+        "run_id": run_id,
+    }
+    session.request.return_value = request_object
+
+    client.create_feedback(
+        run_id,
+        key="Foo",
+        do_not_extend_trace_retention=True,
+    )
+
+    payload = json.loads(session.request.call_args.kwargs["data"])
+    assert payload["do_not_extend_trace_retention"] is True
+
+
 def test_pydantic_serialize() -> None:
     """Test that pydantic objects can be serialized."""
     test_uuid = uuid.uuid4()

--- a/python/tests/unit_tests/test_client.py
+++ b/python/tests/unit_tests/test_client.py
@@ -1686,6 +1686,45 @@ def test_create_feedback_can_opt_out_of_extending_trace_retention() -> None:
     assert payload["extend_trace_retention"] is False
 
 
+def test_create_feedback_opt_out_uses_tracing_queue_when_available() -> None:
+    """Opt-out should not force POST /feedback when batching is available."""
+    session = mock.Mock()
+    run_id = uuid.uuid4()
+    trace_id = uuid.uuid4()
+    info = ls_schemas.LangSmithInfo(
+        version="0.8.11",
+        batch_ingest_config=ls_schemas.BatchIngestConfig(
+            use_multipart_endpoint=True,
+            size_limit=100,
+            scale_up_nthreads_limit=4,
+            scale_up_qsize_trigger=3,
+            scale_down_nempty_trigger=1,
+        ),
+    )
+    client = Client(
+        api_url="http://localhost:1984",
+        api_key="123",
+        session=session,
+        auto_batch_tracing=True,
+        info=info,
+    )
+    assert client.tracing_queue is not None
+
+    client.create_feedback(
+        run_id,
+        key="Foo",
+        trace_id=trace_id,
+        extend_trace_retention=False,
+    )
+
+    session.request.assert_not_called()
+    assert client.tracing_queue.qsize() == 1
+    queue_item = client.tracing_queue.get_nowait()
+    feedback_payload = _orjson.loads(queue_item.item.feedback)
+    assert feedback_payload["_skip_trace_upgrade"] is True
+    assert "extend_trace_retention" not in feedback_payload
+
+
 def test_pydantic_serialize() -> None:
     """Test that pydantic objects can be serialized."""
     test_uuid = uuid.uuid4()

--- a/python/tests/unit_tests/test_operations.py
+++ b/python/tests/unit_tests/test_operations.py
@@ -127,13 +127,13 @@ def test_serialize_feedback_dict_maps_retention_opt_out_for_queue() -> None:
             "run_id": trace_id,
             "key": "correctness",
             "score": 1,
-            "do_not_extend_trace_retention": True,
+            "extend_trace_retention": False,
         }
     )
     payload = _orjson.loads(serialized.feedback)
 
     assert payload["_skip_trace_upgrade"] is True
-    assert "do_not_extend_trace_retention" not in payload
+    assert "extend_trace_retention" not in payload
 
 
 def test_serialized_run_operation_missing_file(tmp_path, caplog) -> None:

--- a/python/tests/unit_tests/test_operations.py
+++ b/python/tests/unit_tests/test_operations.py
@@ -133,6 +133,26 @@ def test_serialize_feedback_dict_maps_retention_opt_out_for_queue() -> None:
     payload = _orjson.loads(serialized.feedback)
 
     assert payload["_skip_trace_upgrade"] is True
+    assert payload["extend_trace_retention"] is False
+
+
+def test_serialize_feedback_dict_omits_retention_fields_when_extending() -> None:
+    feedback_id = uuid.uuid4()
+    trace_id = uuid.uuid4()
+
+    serialized = serialize_feedback_dict(
+        {
+            "id": feedback_id,
+            "trace_id": trace_id,
+            "run_id": trace_id,
+            "key": "correctness",
+            "score": 1,
+            "extend_trace_retention": True,
+        }
+    )
+    payload = _orjson.loads(serialized.feedback)
+
+    assert "_skip_trace_upgrade" not in payload
     assert "extend_trace_retention" not in payload
 
 

--- a/python/tests/unit_tests/test_operations.py
+++ b/python/tests/unit_tests/test_operations.py
@@ -6,6 +6,7 @@ from langsmith._internal._operations import (
     SerializedFeedbackOperation,
     SerializedRunOperation,
     combine_serialized_queue_operations,
+    serialize_feedback_dict,
     serialized_run_operation_to_multipart_parts_and_context,
 )
 
@@ -113,6 +114,26 @@ def test_combine_serialized_queue_operations():
         serialized_run_operations[2],
         serialized_run_operations[4],
     ]
+
+
+def test_serialize_feedback_dict_maps_retention_opt_out_for_queue() -> None:
+    feedback_id = uuid.uuid4()
+    trace_id = uuid.uuid4()
+
+    serialized = serialize_feedback_dict(
+        {
+            "id": feedback_id,
+            "trace_id": trace_id,
+            "run_id": trace_id,
+            "key": "correctness",
+            "score": 1,
+            "do_not_extend_trace_retention": True,
+        }
+    )
+    payload = _orjson.loads(serialized.feedback)
+
+    assert payload["_skip_trace_upgrade"] is True
+    assert "do_not_extend_trace_retention" not in payload
 
 
 def test_serialized_run_operation_missing_file(tmp_path, caplog) -> None:


### PR DESCRIPTION
Description

Adds SDK support for the new do_not_extend_trace_retention feedback creation option, so callers can create feedback without extending the associated trace’s retention tier. Python sync/async clients now accept do_not_extend_trace_retention=True, and the JS client accepts doNotExtendTraceRetention: true while sending the backend’s snake_case field. This preserves existing behavior by default and only opts out when explicitly requested.

References [LSE-2442](https://linear.app/langchain/issue/LSE-2442/add-api-control-for-feedback-trace-retention-sdk)

Python Sync
<img width="1111" height="197" alt="Screenshot 2026-06-16 at 3 26 31 PM" src="https://github.com/user-attachments/assets/46eec01f-9315-468c-b991-7b5dbb7ba982" />

Python Async
<img width="1115" height="199" alt="Screenshot 2026-06-16 at 3 26 40 PM" src="https://github.com/user-attachments/assets/0eedef1a-0e16-4c05-8bab-9d79fc08ebe9" />

JS
<img width="1110" height="366" alt="Screenshot 2026-06-16 at 3 26 48 PM" src="https://github.com/user-attachments/assets/06ed0173-27ac-4eee-8458-0a6fcd86427a" />

Test Plan
Added/updated unit coverage to verify Python feedback creation sends the opt-out field.
Added/updated unit coverage to verify JS feedback creation sends the opt-out field.
Ran targeted linting for the touched Python and JS files.
Tested with scripts for each SDK.