### PR TITLE
feat: adding python async for online evals

### DIFF
--- a/python/langsmith/async_client.py
+++ b/python/langsmith/async_client.py
@@ -11,6 +11,7 @@ import warnings
 from collections.abc import AsyncGenerator, AsyncIterator, Mapping, Sequence
 from functools import partial
 from typing import (
+    TYPE_CHECKING,
     Any,
     Literal,
     Optional,
@@ -35,6 +36,11 @@ from langsmith.prompt_cache import AsyncPromptCache, async_prompt_cache_singleto
 
 ID_TYPE = Union[uuid.UUID, str]
 
+if TYPE_CHECKING:
+    from langsmith._openapi_client.resources.online_evaluators import (
+        AsyncOnlineEvaluatorsResource,
+    )
+
 
 class AsyncClient:
     """Async Client for interacting with the LangSmith API."""
@@ -48,6 +54,7 @@ class AsyncClient:
         "_custom_headers",
         "_api_key",
         "_oauth_access_token",
+        "_workspace_id",
         "_profile_auth",
         "_profile_auth_headers",
     )
@@ -55,6 +62,7 @@ class AsyncClient:
     _custom_headers: dict[str, str]
     _api_key: Optional[str]
     _oauth_access_token: Optional[str]
+    _workspace_id: Optional[str]
     _profile_auth: Optional[_profiles.ProfileAuth]
     _profile_auth_headers: dict[str, str]
 
@@ -68,6 +76,8 @@ class AsyncClient:
             headers.update(self._profile_auth_headers)
         elif self._oauth_access_token:
             headers["Authorization"] = f"Bearer {self._oauth_access_token}"
+        if self._workspace_id:
+            headers["X-Tenant-Id"] = self._workspace_id
         return headers
 
     @property
@@ -95,6 +105,29 @@ class AsyncClient:
         self._api_key = value
         self._client.headers = httpx.Headers(self._compute_headers())
 
+    @property
+    def workspace_id(self) -> Optional[str]:
+        """Return the workspace ID used for API requests."""
+        return self._workspace_id
+
+    @workspace_id.setter
+    def workspace_id(self, value: Optional[str]) -> None:
+        self._workspace_id = ls_utils.get_workspace_id(value)
+        self._client.headers = httpx.Headers(self._compute_headers())
+
+    @property
+    def online_evaluators(self) -> AsyncOnlineEvaluatorsResource:
+        """Access generated async online evaluator CRUD methods."""
+        from langsmith._openapi_client import AsyncLangsmith as AsyncOpenAPILangsmith
+
+        return AsyncOpenAPILangsmith(
+            api_key=self.api_key,
+            tenant_id=self.workspace_id,
+            base_url=ls_client._get_openapi_base_url(self._api_url),
+            timeout=self._client.timeout,
+            default_headers=self._headers,
+        ).online_evaluators
+
     def __init__(
         self,
         api_url: Optional[str] = None,
@@ -107,6 +140,7 @@ class AsyncClient:
         retry_config: Optional[Mapping[str, Any]] = None,
         web_url: Optional[str] = None,
         headers: Optional[dict[str, str]] = None,
+        workspace_id: Optional[str] = None,
         disable_prompt_cache: bool = False,
         cache: Optional[Union[bool, AsyncPromptCache]] = None,
     ):
@@ -123,6 +157,7 @@ class AsyncClient:
                 These headers will be merged with the default headers
                 (Content-Type, x-api-key, etc.). Custom headers will not override
                 the default required headers.
+            workspace_id: The workspace ID. Required for org-scoped API keys.
             disable_prompt_cache: Disable prompt caching for this client.
             cache: **[Deprecated]** Control prompt caching behavior.
 
@@ -137,6 +172,7 @@ class AsyncClient:
         self._custom_headers = headers or {}
         env_api_url = ls_client._get_langsmith_env_var_uncached("ENDPOINT")
         env_api_key = ls_client._get_langsmith_env_var_uncached("API_KEY")
+        env_workspace_id = ls_client._get_langsmith_env_var_uncached("WORKSPACE_ID")
         profile_config = _profiles.load_profile_client_config()
         api_url_ = (
             api_url if api_url is not None else env_api_url or profile_config.api_url
@@ -154,8 +190,14 @@ class AsyncClient:
         self._oauth_access_token = (
             profile_config.oauth_access_token if use_profile_oauth else None
         )
+        workspace_id_ = (
+            workspace_id
+            if workspace_id is not None
+            else env_workspace_id or profile_config.workspace_id
+        )
         api_key = ls_utils.get_api_key(api_key_)
         api_url = ls_utils.get_api_url(api_url_)
+        self._workspace_id = ls_utils.get_workspace_id(workspace_id_)
         self._profile_auth = None
         self._profile_auth_headers = {}
         if use_profile_oauth:

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -151,6 +151,8 @@ def _reset_tracing_drop_log() -> None:
 def _get_openapi_base_url(api_url: str) -> str:
     """Convert a handwritten client API URL to a generated OpenAPI base URL."""
     api_url = api_url.rstrip("/")
+    if api_url.endswith("/api/v1"):
+        return api_url[: -len("/api/v1")]
     return api_url[:-3] if api_url.endswith("/v1") else api_url
 
 

--- a/python/tests/unit_tests/test_client.py
+++ b/python/tests/unit_tests/test_client.py
@@ -47,6 +47,7 @@ from langsmith.client import (
     _dataset_examples_path,
     _default_retry_config,
     _dumps_json,
+    _get_openapi_base_url,
     _is_langchain_hosted,
     _parse_token_or_url,
     _resolve_tracing_mode,
@@ -847,6 +848,18 @@ def test_async_online_evaluators_uses_generated_openapi_resource() -> None:
         openapi_client.call_args.kwargs["default_headers"]["x-tenant-id"]
         == "test-workspace-id"
     )
+
+
+@pytest.mark.parametrize(
+    ("api_url", "expected"),
+    [
+        ("http://localhost:8080", "http://localhost:8080"),
+        ("http://localhost:8080/v1", "http://localhost:8080"),
+        ("http://localhost:8080/api/v1", "http://localhost:8080"),
+    ],
+)
+def test_get_openapi_base_url(api_url: str, expected: str) -> None:
+    assert _get_openapi_base_url(api_url) == expected
 
 
 @pytest.mark.parametrize("use_multipart_endpoint", (True, False))

--- a/python/tests/unit_tests/test_client.py
+++ b/python/tests/unit_tests/test_client.py
@@ -822,6 +822,33 @@ def test_online_evaluators_uses_generated_openapi_resource() -> None:
     assert timeout.read == 5.678
 
 
+def test_async_online_evaluators_uses_generated_openapi_resource() -> None:
+    client = AsyncClient(
+        api_url="http://localhost:8080",
+        api_key="test-api-key",
+        workspace_id="test-workspace-id",
+        timeout_ms=(1234, 5678),
+    )
+    resource = object()
+
+    with mock.patch("langsmith._openapi_client.AsyncLangsmith") as openapi_client:
+        openapi_client.return_value.online_evaluators = resource
+
+        assert client.online_evaluators is resource
+
+    openapi_client.assert_called_once()
+    assert openapi_client.call_args.kwargs["api_key"] == "test-api-key"
+    assert openapi_client.call_args.kwargs["tenant_id"] == "test-workspace-id"
+    assert openapi_client.call_args.kwargs["base_url"] == "http://localhost:8080"
+    timeout = openapi_client.call_args.kwargs["timeout"]
+    assert timeout.connect == 1.234
+    assert timeout.read == 5.678
+    assert (
+        openapi_client.call_args.kwargs["default_headers"]["x-tenant-id"]
+        == "test-workspace-id"
+    )
+
+
 @pytest.mark.parametrize("use_multipart_endpoint", (True, False))
 def test_create_run_mutate(
     use_multipart_endpoint: bool, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
**Description**
We want to also add compatibility for the Python Async SDK just like we have to the Sync SDK for crud operations with online evals.

<img width="1261" height="289" alt="Screenshot 2026-06-16 at 4 43 08 PM" src="https://github.com/user-attachments/assets/b5ebfcdd-d62d-4842-b4b9-9304d37a933c" />
<img width="502" height="154" alt="Screenshot 2026-06-16 at 4 43 33 PM" src="https://github.com/user-attachments/assets/17bc4fac-ca96-4e19-bea8-413d0f541f8e" />

References [LSO-2932](https://linear.app/langchain/issue/LSO-2932/adding-online-evals-crud-to-python-async-sdk)

**Test Plan**
[X] Update unit test
[X] Check via script as if you were a user