### PR TITLE
fix: use insights tab in sdk report links [closes LSO-2936]

### DIFF
--- a/python/langsmith/schemas.py
+++ b/python/langsmith/schemas.py
@@ -1429,7 +1429,7 @@ class InsightsReport(BaseModel):
     @property
     def link(self) -> str:
         """URL to view this Insights Report in LangSmith UI."""
-        return f"{self.host_url}/o/{str(self.tenant_id)}/projects/p/{str(self.project_id)}?tab=4&clusterJobId={str(self.id)}"
+        return f"{self.host_url}/o/{str(self.tenant_id)}/projects/p/{str(self.project_id)}?tab=3&clusterJobId={str(self.id)}"
 
     def _repr_html_(self) -> str:
         return f'<a href="{self.link}", target="_blank" rel="noopener">InsightsReport(\'{self.name}\')</a>'

--- a/python/tests/unit_tests/test_insights_report.py
+++ b/python/tests/unit_tests/test_insights_report.py
@@ -108,6 +108,25 @@ def test_get_insights_report_basic_metadata() -> None:
     assert cluster.num_runs == 2
 
 
+def test_insights_report_link_uses_insights_tab() -> None:
+    report = ls_schemas.InsightsReport(
+        id="11111111-1111-1111-1111-111111111111",
+        name="test-report",
+        status="success",
+        project_id="22222222-2222-2222-2222-222222222222",
+        host_url="https://smith.langchain.com",
+        tenant_id="33333333-3333-3333-3333-333333333333",
+    )
+
+    expected_link = (
+        "https://smith.langchain.com/o/"
+        "33333333-3333-3333-3333-333333333333/projects/p/"
+        "22222222-2222-2222-2222-222222222222?"
+        "tab=3&clusterJobId=11111111-1111-1111-1111-111111111111"
+    )
+    assert report.link == expected_link
+
+
 def test_get_insights_report_with_runs_and_cluster_load_traces() -> None:
     report_payload = _make_report_payload()
     runs_page_1 = _make_runs_page_payload(offset=0, has_next=True)


### PR DESCRIPTION
## Description
Update Python SDK Insights report links to open the Insights tab after Threads tab removal.

## Self-Hosted Release Note pls
Fix SDK-generated Insights report links to open the Insights tab.

## Test Plan
- [x] Run an Insights report from the SDK and confirm the printed result URL uses `tab=3`.

Made by [Open SWE](https://openswe.vercel.app/agents/f10741c5-bccf-a752-61c0-c784a6f20f9f)