### PR TITLE
fix(sandbox): use built-in gcp auth host matching

### DIFF
--- a/js/README.md
+++ b/js/README.md
@@ -76,7 +76,7 @@ Plaintext AWS credential values are not accepted directly; wrap them as
 
 When sandbox code needs to call Google APIs, use the sandbox GCP auth proxy.
 The proxy keeps the service account JSON outside the sandbox and injects OAuth
-bearer tokens for the Google API hosts you explicitly match.
+bearer tokens for Google API hosts matched automatically by the sandbox proxy.
 
 Store the service account JSON as a LangSmith workspace secret. Then create the
 sandbox with a GCP auth proxy config:
@@ -170,10 +170,9 @@ try {
 }
 ```
 
-GCS mounts require an enabled GCP auth proxy rule that covers
-`storage.googleapis.com` and `www.googleapis.com`. Read/write mounts require
-`devstorage.read_write` or `cloud-platform`; read-only mounts can also use
-`devstorage.read_only`.
+GCS mounts require an enabled GCP auth proxy rule with a compatible storage
+OAuth scope. Read/write mounts require `devstorage.read_write` or
+`cloud-platform`; read-only mounts can also use `devstorage.read_only`.
 
 ```ts
 import {

--- a/js/src/sandbox/README.md
+++ b/js/src/sandbox/README.md
@@ -125,8 +125,8 @@ short-lived write-only values with `opaqueSecret(...)`.
 
 Use the GCP auth proxy when sandbox code needs to call Google APIs. You
 configure service account JSON on the sandbox proxy, and the proxy injects OAuth
-bearer tokens for the Google API hosts you explicitly match. The real service
-account JSON stays outside the sandbox.
+bearer tokens for Google API hosts matched automatically by the sandbox proxy.
+The real service account JSON stays outside the sandbox.
 
 Store the service account JSON as a LangSmith workspace secret, then reference
 that secret name in the proxy config:
@@ -219,10 +219,9 @@ try {
 }
 ```
 
-GCS mounts require an enabled GCP auth proxy rule covering
-`storage.googleapis.com` and `www.googleapis.com`. Read/write mounts require
-`devstorage.read_write` or `cloud-platform`; read-only mounts can also use
-`devstorage.read_only`.
+GCS mounts require an enabled GCP auth proxy rule with a compatible storage
+OAuth scope. Read/write mounts require `devstorage.read_write` or
+`cloud-platform`; read-only mounts can also use `devstorage.read_only`.
 
 ```typescript
 import {

--- a/js/src/sandbox/proxy_config.ts
+++ b/js/src/sandbox/proxy_config.ts
@@ -150,21 +150,17 @@ export function awsAuth({
 }
 
 /** Build a sandbox proxy rule that injects GCP OAuth bearer auth. */
-export function gcpAuth(options: {
+export function gcpAuth({
+  serviceAccountJson,
+  scopes,
+  name = "gcp",
+  enabled = true,
+}: {
   serviceAccountJson: SandboxProxySecret;
   scopes: string[];
   name?: string;
   enabled?: boolean;
 }): SandboxGcpAuthRule {
-  const unsupportedOptions = Object.keys(options).filter(
-    (key) => !["serviceAccountJson", "scopes", "name", "enabled"].includes(key),
-  );
-  if (unsupportedOptions.length > 0) {
-    throw new Error(
-      `Unsupported GCP auth option(s): ${unsupportedOptions.join(", ")}`,
-    );
-  }
-  const { serviceAccountJson, scopes, name = "gcp", enabled = true } = options;
   return {
     name: requireNonEmptyString(name, "name"),
     type: "gcp",

--- a/js/src/sandbox/proxy_config.ts
+++ b/js/src/sandbox/proxy_config.ts
@@ -7,10 +7,6 @@ import type {
   SandboxProxySecret,
 } from "./types.js";
 
-const DEFAULT_GCP_AUTH_MATCH_HOSTS = [
-  "storage.googleapis.com",
-  "www.googleapis.com",
-];
 const PROVIDER_RULE_TYPES = new Set(["aws", "gcp"]);
 
 function requireNonEmptyString(value: string, field: string): string {
@@ -157,21 +153,25 @@ export function awsAuth({
 export function gcpAuth({
   serviceAccountJson,
   scopes,
-  matchHosts = DEFAULT_GCP_AUTH_MATCH_HOSTS,
   name = "gcp",
   enabled = true,
+  ...unsupported
 }: {
   serviceAccountJson: SandboxProxySecret;
   scopes: string[];
-  matchHosts?: string[];
+  matchHosts?: never;
   name?: string;
   enabled?: boolean;
 }): SandboxGcpAuthRule {
+  if ("matchHosts" in unsupported) {
+    throw new Error(
+      "matchHosts is not supported for GCP auth; Google API host matching is handled by the sandbox proxy",
+    );
+  }
   return {
     name: requireNonEmptyString(name, "name"),
     type: "gcp",
     enabled,
-    match_hosts: requireNonEmptyStringArray(matchHosts, "matchHosts"),
     gcp: {
       service_account_json: serviceAccountJson,
       scopes: requireNonEmptyStringArray(scopes, "scopes"),

--- a/js/src/sandbox/proxy_config.ts
+++ b/js/src/sandbox/proxy_config.ts
@@ -150,24 +150,21 @@ export function awsAuth({
 }
 
 /** Build a sandbox proxy rule that injects GCP OAuth bearer auth. */
-export function gcpAuth({
-  serviceAccountJson,
-  scopes,
-  name = "gcp",
-  enabled = true,
-  ...unsupported
-}: {
+export function gcpAuth(options: {
   serviceAccountJson: SandboxProxySecret;
   scopes: string[];
-  matchHosts?: never;
   name?: string;
   enabled?: boolean;
 }): SandboxGcpAuthRule {
-  if ("matchHosts" in unsupported) {
+  const unsupportedOptions = Object.keys(options).filter(
+    (key) => !["serviceAccountJson", "scopes", "name", "enabled"].includes(key),
+  );
+  if (unsupportedOptions.length > 0) {
     throw new Error(
-      "matchHosts is not supported for GCP auth; Google API host matching is handled by the sandbox proxy",
+      `Unsupported GCP auth option(s): ${unsupportedOptions.join(", ")}`,
     );
   }
+  const { serviceAccountJson, scopes, name = "gcp", enabled = true } = options;
   return {
     name: requireNonEmptyString(name, "name"),
     type: "gcp",

--- a/js/src/sandbox/types.ts
+++ b/js/src/sandbox/types.ts
@@ -293,12 +293,10 @@ export interface SandboxAwsAuthRule {
 export interface SandboxGcpAuthRule {
   /** Rule name. */
   name: string;
-  /** GCP auth rules match explicit Google API host patterns. */
+  /** GCP auth rules use the sandbox proxy's built-in Google API host matcher. */
   type: "gcp";
   /** Whether the rule is enabled. */
   enabled?: boolean;
-  /** Google API hosts covered by this rule, such as storage.googleapis.com. */
-  match_hosts: string[];
   /** GCP service-account credential and OAuth scopes. */
   gcp: {
     service_account_json: SandboxProxySecret;

--- a/js/src/tests/sandbox.test.ts
+++ b/js/src/tests/sandbox.test.ts
@@ -127,7 +127,7 @@ describe("sandbox proxy config helpers", () => {
     });
   });
 
-  it("gcpAuth builds a GCP auth rule with default GCS hosts", () => {
+  it("gcpAuth builds a GCP auth rule with built-in Google API host matching", () => {
     expect(
       gcpAuth({
         serviceAccountJson: workspaceSecret("GCP_SERVICE_ACCOUNT_JSON"),
@@ -137,7 +137,6 @@ describe("sandbox proxy config helpers", () => {
       name: "gcp",
       type: "gcp",
       enabled: true,
-      match_hosts: ["storage.googleapis.com", "www.googleapis.com"],
       gcp: {
         service_account_json: {
           type: "workspace_secret",
@@ -156,7 +155,6 @@ describe("sandbox proxy config helpers", () => {
     const gcpRule = gcpAuth({
       serviceAccountJson: workspaceSecret("GCP_SERVICE_ACCOUNT_JSON"),
       scopes: ["https://www.googleapis.com/auth/devstorage.read_write"],
-      matchHosts: ["storage.googleapis.com"],
     });
 
     expect(
@@ -392,29 +390,27 @@ describe("sandbox proxy config helpers", () => {
     expect(() => mountConfig({ auth, mounts })).toThrow(message);
   });
 
-  it.each([
-    { scopes: [], matchHosts: ["storage.googleapis.com"] },
-    {
-      scopes: ["https://www.googleapis.com/auth/devstorage.read_write"],
-      matchHosts: [],
-    },
-    { scopes: [""], matchHosts: ["storage.googleapis.com"] },
-    {
-      scopes: ["https://www.googleapis.com/auth/devstorage.read_write"],
-      matchHosts: [""],
-    },
-  ])(
-    "gcpAuth rejects empty scopes and match hosts",
-    ({ scopes, matchHosts }) => {
+  it.each([{ scopes: [] }, { scopes: [""] }])(
+    "gcpAuth rejects empty scopes",
+    ({ scopes }) => {
       expect(() =>
         gcpAuth({
           serviceAccountJson: workspaceSecret("GCP_SERVICE_ACCOUNT_JSON"),
           scopes,
-          matchHosts,
         }),
       ).toThrow();
     },
   );
+
+  it("gcpAuth rejects matchHosts overrides", () => {
+    expect(() =>
+      gcpAuth({
+        serviceAccountJson: workspaceSecret("GCP_SERVICE_ACCOUNT_JSON"),
+        scopes: ["https://www.googleapis.com/auth/devstorage.read_write"],
+        matchHosts: ["storage.googleapis.com"],
+      } as any),
+    ).toThrow(/matchHosts/);
+  });
 });
 
 describe("SandboxClient", () => {

--- a/js/src/tests/sandbox.test.ts
+++ b/js/src/tests/sandbox.test.ts
@@ -402,14 +402,14 @@ describe("sandbox proxy config helpers", () => {
     },
   );
 
-  it("gcpAuth rejects matchHosts overrides", () => {
+  it("gcpAuth rejects unsupported options", () => {
     expect(() =>
       gcpAuth({
         serviceAccountJson: workspaceSecret("GCP_SERVICE_ACCOUNT_JSON"),
         scopes: ["https://www.googleapis.com/auth/devstorage.read_write"],
         matchHosts: ["storage.googleapis.com"],
       } as any),
-    ).toThrow(/matchHosts/);
+    ).toThrow(/Unsupported GCP auth option\(s\): matchHosts/);
   });
 });
 

--- a/js/src/tests/sandbox.test.ts
+++ b/js/src/tests/sandbox.test.ts
@@ -401,16 +401,6 @@ describe("sandbox proxy config helpers", () => {
       ).toThrow();
     },
   );
-
-  it("gcpAuth rejects unsupported options", () => {
-    expect(() =>
-      gcpAuth({
-        serviceAccountJson: workspaceSecret("GCP_SERVICE_ACCOUNT_JSON"),
-        scopes: ["https://www.googleapis.com/auth/devstorage.read_write"],
-        matchHosts: ["storage.googleapis.com"],
-      } as any),
-    ).toThrow(/Unsupported GCP auth option\(s\): matchHosts/);
-  });
 });
 
 describe("SandboxClient", () => {

--- a/python/README.md
+++ b/python/README.md
@@ -94,7 +94,7 @@ them as `opaque_secret(...)` values.
 
 When sandbox code needs to call Google APIs, use the sandbox GCP auth proxy.
 The proxy keeps the service account JSON outside the sandbox and injects OAuth
-bearer tokens for the Google API hosts you explicitly match.
+bearer tokens for Google API hosts matched automatically by the sandbox proxy.
 
 Store the service account JSON as a LangSmith workspace secret. Then create the
 sandbox with a GCP auth proxy config:
@@ -180,10 +180,9 @@ with client.sandbox(
     print(result.stdout)
 ```
 
-GCS mounts require an enabled GCP auth proxy rule that covers
-`storage.googleapis.com` and `www.googleapis.com`. Read/write mounts require
-`devstorage.read_write` or `cloud-platform`; read-only mounts can also use
-`devstorage.read_only`.
+GCS mounts require an enabled GCP auth proxy rule with a compatible storage
+OAuth scope. Read/write mounts require `devstorage.read_write` or
+`cloud-platform`; read-only mounts can also use `devstorage.read_only`.
 
 ```python
 from langsmith.sandbox import (

--- a/python/langsmith/sandbox/README.md
+++ b/python/langsmith/sandbox/README.md
@@ -129,8 +129,8 @@ short-lived write-only values with `opaque_secret(...)`.
 
 Use the GCP auth proxy when sandbox code needs to call Google APIs. You
 configure service account JSON on the sandbox proxy, and the proxy injects OAuth
-bearer tokens for the Google API hosts you explicitly match. The real service
-account JSON stays outside the sandbox.
+bearer tokens for Google API hosts matched automatically by the sandbox proxy.
+The real service account JSON stays outside the sandbox.
 
 Store the service account JSON as a LangSmith workspace secret, then reference
 that secret name in the proxy config:
@@ -215,10 +215,9 @@ with client.sandbox(
     print(result.stdout)
 ```
 
-GCS mounts require an enabled GCP auth proxy rule covering
-`storage.googleapis.com` and `www.googleapis.com`. Read/write mounts require
-`devstorage.read_write` or `cloud-platform`; read-only mounts can also use
-`devstorage.read_only`.
+GCS mounts require an enabled GCP auth proxy rule with a compatible storage
+OAuth scope. Read/write mounts require `devstorage.read_write` or
+`cloud-platform`; read-only mounts can also use `devstorage.read_only`.
 
 ```python
 from langsmith.sandbox import (

--- a/python/langsmith/sandbox/_proxy_config.py
+++ b/python/langsmith/sandbox/_proxy_config.py
@@ -15,7 +15,6 @@ class SandboxProxySecret(TypedDict):
 
 SandboxProxyRule = dict[str, Any]
 SandboxProxyConfig = dict[str, Any]
-DEFAULT_GCP_AUTH_MATCH_HOSTS = ["storage.googleapis.com", "www.googleapis.com"]
 _PROVIDER_RULE_TYPES = {"aws", "gcp"}
 
 
@@ -172,14 +171,13 @@ def gcp_auth(
     *,
     service_account_json: SandboxProxySecret,
     scopes: Sequence[str],
-    match_hosts: Sequence[str] | None = None,
     name: str = "gcp",
     enabled: bool = True,
 ) -> SandboxProxyRule:
     """Build a sandbox proxy rule that injects GCP OAuth bearer auth.
 
     The sandbox proxy keeps the service account JSON outside the sandbox and
-    injects OAuth bearer tokens for the configured Google API hosts.
+    injects OAuth bearer tokens for built-in Google API host matching.
     ``service_account_json`` must be supplied as a ``workspace_secret`` or
     ``opaque`` value; plaintext service account JSON is intentionally not
     supported.
@@ -189,10 +187,6 @@ def gcp_auth(
         "name": rule_name,
         "type": "gcp",
         "enabled": enabled,
-        "match_hosts": _require_non_empty_string_list(
-            DEFAULT_GCP_AUTH_MATCH_HOSTS if match_hosts is None else match_hosts,
-            "match_hosts",
-        ),
         "gcp": {
             "service_account_json": service_account_json,
             "scopes": _require_non_empty_string_list(scopes, "scopes"),

--- a/python/tests/unit_tests/sandbox/test_proxy_config.py
+++ b/python/tests/unit_tests/sandbox/test_proxy_config.py
@@ -328,15 +328,6 @@ def test_gcp_auth_rejects_empty_scopes(scopes: list[str]) -> None:
         )
 
 
-def test_gcp_auth_rejects_match_hosts_override() -> None:
-    with pytest.raises(TypeError):
-        gcp_auth(
-            service_account_json=workspace_secret("GCP_SERVICE_ACCOUNT_JSON"),
-            scopes=["https://www.googleapis.com/auth/devstorage.read_write"],
-            match_hosts=["storage.googleapis.com"],  # type: ignore[call-arg]
-        )
-
-
 def test_create_sandbox_forwards_composed_proxy_config(
     httpx_mock: HTTPXMock,
 ) -> None:

--- a/python/tests/unit_tests/sandbox/test_proxy_config.py
+++ b/python/tests/unit_tests/sandbox/test_proxy_config.py
@@ -74,7 +74,7 @@ def test_aws_auth_builds_aws_rule() -> None:
     }
 
 
-def test_gcp_auth_builds_gcp_rule_with_default_gcs_hosts() -> None:
+def test_gcp_auth_builds_gcp_rule_with_builtin_google_api_host_matching() -> None:
     rule = gcp_auth(
         service_account_json=workspace_secret("GCP_SERVICE_ACCOUNT_JSON"),
         scopes=["https://www.googleapis.com/auth/devstorage.read_write"],
@@ -84,7 +84,6 @@ def test_gcp_auth_builds_gcp_rule_with_default_gcs_hosts() -> None:
         "name": "gcp",
         "type": "gcp",
         "enabled": True,
-        "match_hosts": ["storage.googleapis.com", "www.googleapis.com"],
         "gcp": {
             "service_account_json": {
                 "type": "workspace_secret",
@@ -103,7 +102,6 @@ def test_proxy_config_composes_multiple_provider_rules() -> None:
     gcp_rule = gcp_auth(
         service_account_json=workspace_secret("GCP_SERVICE_ACCOUNT_JSON"),
         scopes=["https://www.googleapis.com/auth/devstorage.read_write"],
-        match_hosts=["storage.googleapis.com"],
     )
 
     assert proxy_config(
@@ -321,23 +319,21 @@ def test_mount_config_validates_provider_auth(auth, mounts, message: str) -> Non
         mount_config(auth=auth, mounts=mounts)
 
 
-@pytest.mark.parametrize(
-    ("scopes", "match_hosts"),
-    [
-        ([], ["storage.googleapis.com"]),
-        (["https://www.googleapis.com/auth/devstorage.read_write"], []),
-        ([""], ["storage.googleapis.com"]),
-        (["https://www.googleapis.com/auth/devstorage.read_write"], [""]),
-    ],
-)
-def test_gcp_auth_rejects_empty_scopes_and_hosts(
-    scopes: list[str], match_hosts: list[str]
-) -> None:
+@pytest.mark.parametrize("scopes", [[], [""]])
+def test_gcp_auth_rejects_empty_scopes(scopes: list[str]) -> None:
     with pytest.raises(ValueError):
         gcp_auth(
             service_account_json=workspace_secret("GCP_SERVICE_ACCOUNT_JSON"),
             scopes=scopes,
-            match_hosts=match_hosts,
+        )
+
+
+def test_gcp_auth_rejects_match_hosts_override() -> None:
+    with pytest.raises(TypeError):
+        gcp_auth(
+            service_account_json=workspace_secret("GCP_SERVICE_ACCOUNT_JSON"),
+            scopes=["https://www.googleapis.com/auth/devstorage.read_write"],
+            match_hosts=["storage.googleapis.com"],  # type: ignore[call-arg]
         )
 
 


### PR DESCRIPTION
## Summary

- define Python and JS GCP sandbox auth helpers around service-account JSON plus OAuth scopes only
- keep Google API host matching owned by the API/proxy instead of the SDK helper surface
- update SDK sandbox readmes so GCP auth docs describe automatic Google API host matching and GCS mounts only require compatible storage scopes

## Testing

- `uv run --directory python pytest tests/unit_tests/sandbox/test_proxy_config.py`
- `uv run --directory python ruff check langsmith/sandbox/_proxy_config.py tests/unit_tests/sandbox/test_proxy_config.py`
- `uv run --directory python ruff format --check langsmith/sandbox/_proxy_config.py tests/unit_tests/sandbox/test_proxy_config.py`
- `pnpm test src/tests/sandbox.test.ts --runTestsByPath`
- `pnpm exec oxfmt --check src/sandbox/proxy_config.ts src/tests/sandbox.test.ts`
- `pnpm lint` passes with existing warnings
