### PR TITLE
fix(py): declare OpenAPI client runtime dependencies

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -24,11 +24,15 @@ keywords = [
     "platform",
 ]
 dependencies = [
+    "anyio>=3.5.0,<5",
+    "distro>=1.7.0,<2",
     "pydantic>=2,<3",
     "requests>=2.0.0",
     "orjson>=3.9.14; platform_python_implementation != 'PyPy'",
     "httpx>=0.23.0,<1",
     "requests-toolbelt>=1.0.0",
+    "sniffio>=1.3.0",
+    "typing-extensions>=4.11.0,<5",
     "zstandard>=0.23.0",
     "packaging>=23.2",
     "uuid-utils>=0.12.0,<1.0",

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -1427,12 +1427,16 @@ wheels = [
 name = "langsmith"
 source = { editable = "." }
 dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
     { name = "httpx" },
     { name = "orjson", marker = "platform_python_implementation != 'PyPy'" },
     { name = "packaging" },
     { name = "pydantic" },
     { name = "requests" },
     { name = "requests-toolbelt" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
     { name = "uuid-utils" },
     { name = "websockets" },
     { name = "xxhash" },
@@ -1535,7 +1539,9 @@ test = [
 
 [package.metadata]
 requires-dist = [
+    { name = "anyio", specifier = ">=3.5.0,<5" },
     { name = "claude-agent-sdk", marker = "python_full_version >= '3.10' and extra == 'claude-agent-sdk'", specifier = ">=0.1.0" },
+    { name = "distro", specifier = ">=1.7.0,<2" },
     { name = "google-adk", marker = "extra == 'google-adk'", specifier = ">=1.0.0" },
     { name = "httpx", specifier = ">=0.23.0,<1" },
     { name = "langsmith-pyo3", marker = "extra == 'langsmith-pyo3'", specifier = ">=0.1.0rc2" },
@@ -1553,8 +1559,10 @@ requires-dist = [
     { name = "requests", specifier = ">=2.0.0" },
     { name = "requests-toolbelt", specifier = ">=1.0.0" },
     { name = "rich", marker = "extra == 'pytest'", specifier = ">=13.9.4" },
+    { name = "sniffio", specifier = ">=1.3.0" },
     { name = "strands-agents", marker = "extra == 'strands-agents'", specifier = ">=0.1.0" },
     { name = "strands-agents-tools", marker = "extra == 'strands-agents'", specifier = ">=0.2.0" },
+    { name = "typing-extensions", specifier = ">=4.11.0,<5" },
     { name = "uuid-utils", specifier = ">=0.12.0,<1.0" },
     { name = "vcrpy", marker = "extra == 'pytest'", specifier = ">=7.0.0" },
     { name = "vcrpy", marker = "extra == 'vcr'", specifier = ">=7.0.0" },


### PR DESCRIPTION
## Summary
- add the generated Python OpenAPI client's direct runtime imports to project dependencies
- update uv.lock so wheel metadata includes anyio, distro, sniffio, and typing-extensions
- leave generated _openapi_client files untouched

## Testing
- make format
- uv run --python 3.12 ruff check . && uv run --python 3.12 mypy langsmith
- make tests
- make build
- uv run --python 3.12 --no-dev python -c "import langsmith._openapi_client"

Fixes #3057

AI assistance was used under my direction.