### PR TITLE
test(python): fix integration assertions for updated attachment error message

### DIFF
--- a/python/tests/integration_tests/test_client.py
+++ b/python/tests/integration_tests/test_client.py
@@ -1078,7 +1078,7 @@ def test_multipart_ingest_create_with_attachments_error(
     ]
 
     # make sure no warnings logged
-    with pytest.raises(ValueError, match="Must set dangerously_allow_filesystem"):
+    with pytest.raises(ValueError, match="dangerously_allow_filesystem"):
         langchain_client.multipart_ingest(create=runs_to_create, update=[])
 
 
@@ -1240,7 +1240,7 @@ def test_multipart_ingest_update_with_attachments_error(
                 },
             }
         ]
-        with pytest.raises(ValueError, match="Must set dangerously_allow_filesystem"):
+        with pytest.raises(ValueError, match="dangerously_allow_filesystem"):
             langchain_client.multipart_ingest(create=[], update=runs_to_update)
 
 


### PR DESCRIPTION
The `ValueError` raised for filesystem-path attachments when `dangerously_allow_filesystem` is not set was reworded. The two assertions in `test_multipart_ingest_create_with_attachments_error` still matched the old wording and were failing on `main`.