### PR TITLE
chore: reconcile bumpversion config and mandate release process for agents

### DIFF
--- a/js/AGENTS.md
+++ b/js/AGENTS.md
@@ -17,6 +17,15 @@ To run a single test file, pass it to Jest, e.g.:
 NODE_OPTIONS=--experimental-vm-modules npx jest src/tests/context.test.ts
 ```
 
+## Releasing
+
+Releasing the SDK is governed **exclusively** by the "Cutting a release" section of
+[`../CONTRIBUTING.md`](../CONTRIBUTING.md). When asked to cut or publish a release,
+you **must** follow that process: use the documented `pnpm run bump-version` flow and
+open a version-bump PR against `main`. Do **not** hand-edit `package.json` or
+`src/index.ts`, bump the version by any other means, push tags, or invent an
+alternative release path.
+
 ## Conventions
 
 ### Constructing request URLs

--- a/python/.bumpversion.cfg
+++ b/python/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.8.12
+current_version = 0.8.17
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
 serialize = {major}.{minor}.{patch}
 search = {current_version}

--- a/python/AGENTS.md
+++ b/python/AGENTS.md
@@ -20,6 +20,15 @@ TEST=tests/unit_tests/test_client.py make tests
 
 Any pytest options may be included inside the `TEST` variable.
 
+## Releasing
+
+Releasing the SDK is governed **exclusively** by the "Cutting a release" section of
+[`../CONTRIBUTING.md`](../CONTRIBUTING.md). When asked to cut or publish a release,
+you **must** follow that process: use the documented `uv run bump2version` flow and
+open a version-bump PR against `main`. Do **not** hand-edit `langsmith/__init__.py`
+or `.bumpversion.cfg`, bump the version by any other means, push tags, or invent an
+alternative release path.
+
 ## Notes
 
 - The project uses `uv` for dependency management and the Makefile commands will automatically run inside the `uv` environment.


### PR DESCRIPTION
## What

- **`python/.bumpversion.cfg`**: set `current_version` to `0.8.17` to match `langsmith/__init__.py`. It had drifted (was `0.8.12`) because recent releases hand-edited the version instead of running `bump2version`, which made `bump2version` fail with `VersionNotFoundException`.
- **`python/AGENTS.md` / `js/AGENTS.md`**: add a `Releasing` section requiring agents to follow the `CONTRIBUTING.md` release process (`bump2version` / `bump-version` + a version-bump PR) rather than hand-editing version files or improvising.

## Why

Keeps the documented `bump2version` release flow working and prevents ad-hoc release steps.