### PR TITLE
fix(python): use current project issues endpoint

### DIFF
--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -10896,17 +10896,8 @@ class Client:
             params["status"] = status
         if priority is not None:
             params["priority"] = priority
-        path = _platform_path(self.api_url, "forge-issues")
-        full_url = _construct_url(self.api_url, path)
-        self._ensure_profile_auth()
-        response = self.session.request(
-            "GET",
-            full_url,
-            params=params,
-            headers=self._headers,
-            timeout=self._timeout,
-        )
-        ls_utils.raise_for_status_with_text(response)
+        path = _platform_path(self.api_url, "issues")
+        response = self.request_with_retries("GET", path, params=params)
         return response.json()
 
     def _ensure_insights_api_key(

--- a/python/tests/unit_tests/test_client.py
+++ b/python/tests/unit_tests/test_client.py
@@ -725,6 +725,39 @@ def test_cached_header_and_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
         assert kwargs["headers"]["x-api-key"] == "abc"
 
 
+@pytest.mark.parametrize(
+    ("api_url", "expected_url"),
+    [
+        ("http://localhost:1984", "http://localhost:1984/v1/platform/issues"),
+        (
+            "http://localhost:1984/api/v1",
+            "http://localhost:1984/api/v1/platform/issues",
+        ),
+    ],
+)
+def test_list_project_issues_uses_platform_issues_endpoint(
+    api_url: str, expected_url: str
+) -> None:
+    mock_session = MagicMock()
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = [{"id": "issue-1"}]
+    mock_session.request.return_value = mock_response
+
+    client = Client(api_url=api_url, api_key="test", session=mock_session)
+    issues = client.list_project_issues("my-project", status="open", priority="high")
+
+    assert issues == [{"id": "issue-1"}]
+    args, kwargs = mock_session.request.call_args
+    assert args[0] == "GET"
+    assert args[1] == expected_url
+    assert kwargs["params"] == {
+        "session_name": "my-project",
+        "status": "open",
+        "priority": "high",
+    }
+
+
 @mock.patch("langsmith.client.requests.Session")
 def test_upload_csv(mock_session_cls: mock.Mock) -> None:
     _clear_env_cache()


### PR DESCRIPTION
## Summary

- update `Client.list_project_issues()` to call the current platform issues endpoint instead of the removed `forge-issues` endpoint
- route the request through `request_with_retries()` so auth, retries, and `/api/v1`-suffixed base URLs use the standard client behavior
- add a regression test covering both normal and `/api/v1` API URLs

## Reported error

Calling `Client.list_project_issues(project_name="test", status="open")` against the current LangSmith backend returns:

```json
{
  "detail": "The requested path does not exist. If you are on a self-hosted installation, try upgrading to the latest backend version. You may also need to upgrade your LangSmith SDK.",
  "status": 404,
  "title": "Not Found",
  "type": "about:blank"
}
```

## What I tried

- reproduced the 404 through the Python SDK helper, which currently calls `/v1/platform/forge-issues`
- upgraded to the latest published Python package (`langsmith==0.8.18`), but the helper still calls the same stale endpoint
- checked upstream `main` and found the same `forge-issues` path in `Client.list_project_issues()`
- verified that calling `/v1/platform/issues` directly succeeds against the current backend and matches the documented issues endpoint

## Related

- #2654 originally added `Client.list_project_issues()` with the `/v1/platform/forge-issues` endpoint

## Validation

- `make format`
- `make lint`
- `TEST='tests/unit_tests/test_client.py::test_list_project_issues_uses_platform_issues_endpoint' make tests`
- `make tests` - 1375 passed, 3 skipped, 127 warnings
