### PR TITLE
feat(client): make secret redaction the default in both SDKs

### DIFF
--- a/js/src/anonymizer/index.ts
+++ b/js/src/anonymizer/index.ts
@@ -96,12 +96,9 @@ export type ReplacerType =
 // pass over the string instead of N, reducing per-string overhead from N
 // replace() calls to 1.
 //
-// For the secret anonymizer, we go further: instead of parsing the serialized
-// JSON, walking the object tree to extract string nodes, running regex per
-// node, and walking the tree again to apply updates, we run the combined
-// regex directly on the serialized JSON string and parse once at the end.
-// This eliminates extractStringNodes, applyUpdateAtPath, and the intermediate
-// JSON.parse entirely.
+// The secret anonymizer applies this optimization inside the node-based
+// pipeline: each string node is prefiltered (skipping large base64 blobs and
+// strings with no secret indicators), then matched against the combined regex.
 
 type SimpleRule = { source: string; flags: string; replace: string };
 type StructuralRule = { regex: RegExp; replace: string };
@@ -400,7 +397,20 @@ const SECRET_RULE_PREFILTER = new RegExp(
   "i",
 );
 
-function mayContainSecret(value: string): boolean {
+// Threshold for base64 detection: strings longer than this that are almost
+// entirely base64 characters (with optional whitespace) are treated as binary
+// blobs and skipped. 100 chars is conservative — real secrets are short and
+// contain distinctive prefixes that never look like base64.
+const BASE64_MIN_LENGTH = 100;
+const BASE64_RE = /^[A-Za-z0-9+/\s]+={0,2}$/;
+
+export function isLikelyBase64(value: string): boolean {
+  if (value.length < BASE64_MIN_LENGTH) return false;
+  return BASE64_RE.test(value);
+}
+
+function secretPrefilter(value: string): boolean {
+  if (isLikelyBase64(value)) return false;
   return SECRET_RULE_PREFILTER.test(value);
 }
 
@@ -430,35 +440,27 @@ export function createSecretAnonymizer(options?: {
   const maxDepth = options?.maxDepth ?? 24;
 
   if (extraRules.length > 0) {
-    // When extra rules are provided, fall back to the node-based pipeline
-    // because extra rules may have capture groups or different replacements.
+    // When extra rules are provided, use the node-based pipeline without the
+    // prefilter — custom rules may match patterns that don't contain standard
+    // secret indicators.
     const processor = createRuleNodeProcessor([
       ...DEFAULT_SECRET_RULES,
       ...extraRules,
     ]);
     return <T>(data: T): T => {
-      const serialized = textDecoder.decode(serializePayloadForTracing(data));
-      return applyProcessor(JSON.parse(serialized), processor, { maxDepth });
+      return applyProcessor(deepClone(data), processor, { maxDepth });
     };
   }
 
-  // Default path: all rules are "simple" (no capture groups, same replacement).
-  // Build one combined regex and run it directly on the serialized JSON string.
-  const { simple, structural } = partitionRules(DEFAULT_SECRET_RULES);
-  // All default rules are simple (no structural rules remain).
-  const combined = combineSimpleRules(simple);
-  // One regex, one replacement — run on the whole serialized string.
-  const replacers = [...combined, ...structural];
+  // Default path: use the node-based pipeline with the pre-skip prefilter.
+  // The prefilter skips large base64 blobs (the dominant performance cost)
+  // and short-circuits strings with no secret indicators, so regex only
+  // runs on text fields that might actually contain a secret.
+  const processor = createRuleNodeProcessor(DEFAULT_SECRET_RULES, {
+    prefilter: secretPrefilter,
+  });
 
   return <T>(data: T): T => {
-    const serialized = textDecoder.decode(serializePayloadForTracing(data));
-    if (!mayContainSecret(serialized)) {
-      return data;
-    }
-    const redacted = replacers.reduce(
-      (s, { regex, replace }) => s.replace(regex, replace),
-      serialized,
-    );
-    return JSON.parse(redacted) as T;
+    return applyProcessor(deepClone(data), processor, { maxDepth });
   };
 }

--- a/js/src/anonymizer/index.ts
+++ b/js/src/anonymizer/index.ts
@@ -1,17 +1,18 @@
 import { serialize as serializePayloadForTracing } from "../utils/fast-safe-stringify/index.js";
 
+const textDecoder = new TextDecoder();
+
 export interface StringNode {
   value: string;
   path: string;
 }
 
 interface StringNodeInternal extends StringNode {
-  // Direct reference to the parent object and key, so we can write back
-  // without path parsing/traversal (avoids prototype pollution entirely).
-  parent: Record<string, unknown>;
-  key: string;
   // Unique identity for matching after maskNodes processing.
   _id: number;
+  // Internal path segments from the original traversal. This lets us apply
+  // updates to a clone without parsing the public dotted path string.
+  pathParts: string[];
 }
 
 function extractStringNodes(data: unknown, options: { maxDepth?: number }) {
@@ -22,23 +23,22 @@ function extractStringNodes(data: unknown, options: { maxDepth?: number }) {
     value: unknown,
     depth: number,
     path: string,
-    parent: Record<string, unknown> | null,
-    key: string,
-  ][] = [[data, 0, "", null, ""]];
+    pathParts: string[],
+  ][] = [[data, 0, "", []]];
 
   let nextId = 0;
   const result: StringNodeInternal[] = [];
-  while (queue.length > 0) {
-    const task = queue.shift();
+  let queueIndex = 0;
+  while (queueIndex < queue.length) {
+    const task = queue[queueIndex++];
     if (task == null) continue;
-    const [value, depth, path, parent, key] = task;
+    const [value, depth, path, pathParts] = task;
     if (typeof value === "string") {
       result.push({
         value,
         path,
-        parent: parent as Record<string, unknown>,
-        key,
         _id: nextId++,
+        pathParts,
       });
     } else if (Array.isArray(value)) {
       if (depth >= parsedOptions.maxDepth) continue;
@@ -49,8 +49,7 @@ function extractStringNodes(data: unknown, options: { maxDepth?: number }) {
           value[i],
           depth + 1,
           `${path}[${i}]`,
-          value as unknown as Record<string, unknown>,
-          String(i),
+          [...pathParts, String(i)],
         ]);
       }
     } else if (typeof value === "object" && value != null) {
@@ -62,8 +61,7 @@ function extractStringNodes(data: unknown, options: { maxDepth?: number }) {
           nestedValue,
           depth + 1,
           path ? `${path}.${k}` : k,
-          value as Record<string, unknown>,
-          k,
+          [...pathParts, k],
         ]);
       }
     }
@@ -73,7 +71,7 @@ function extractStringNodes(data: unknown, options: { maxDepth?: number }) {
 }
 
 function deepClone<T>(data: T): T {
-  return JSON.parse(new TextDecoder().decode(serializePayloadForTracing(data)));
+  return JSON.parse(textDecoder.decode(serializePayloadForTracing(data)));
 }
 
 export interface StringNodeProcessor {
@@ -91,99 +89,132 @@ export type ReplacerType =
   | StringNodeRule[]
   | StringNodeProcessor;
 
+function createRuleNodeProcessor(
+  rules: StringNodeRule[],
+  options?: { prefilter?: (value: string) => boolean },
+): StringNodeProcessor {
+  const replacers: [regex: RegExp, replace: string][] = rules.map(
+    ({ pattern, type, replace }) => {
+      if (type != null && type !== "pattern")
+        throw new Error("Invalid anonymizer type");
+      return [
+        typeof pattern === "string" ? new RegExp(pattern, "g") : pattern,
+        replace ?? "[redacted]",
+      ];
+    },
+  );
+
+  if (replacers.length === 0) throw new Error("No replacers provided");
+  return {
+    maskNodes: (nodes: StringNode[]) => {
+      return nodes.reduce<StringNode[]>((memo, item) => {
+        if (options?.prefilter != null && !options.prefilter(item.value)) {
+          return memo;
+        }
+
+        const newValue = replacers.reduce((value, [regex, replace]) => {
+          const result = value.replace(regex, replace);
+
+          // make sure we reset the state of regex
+          regex.lastIndex = 0;
+
+          return result;
+        }, item.value);
+
+        if (newValue !== item.value) {
+          memo.push({ ...item, value: newValue });
+        }
+
+        return memo;
+      }, []);
+    },
+  };
+}
+
+function getNodeProcessor(replacer: ReplacerType): StringNodeProcessor {
+  return Array.isArray(replacer)
+    ? createRuleNodeProcessor(replacer)
+    : typeof replacer === "function"
+      ? {
+          maskNodes: (nodes: StringNode[]) =>
+            nodes.reduce<StringNode[]>((memo, item) => {
+              const newValue = replacer(item.value, item.path);
+              if (newValue !== item.value) {
+                memo.push({ ...item, value: newValue });
+              }
+
+              return memo;
+            }, []),
+        }
+      : replacer;
+}
+
+function applyUpdateAtPath<T>(
+  root: T,
+  pathParts: string[],
+  value: string,
+): void {
+  let target = root as Record<string, unknown>;
+  for (const part of pathParts.slice(0, -1)) {
+    const next = target[part];
+    if (typeof next !== "object" || next == null) {
+      return;
+    }
+    target = next as Record<string, unknown>;
+  }
+  target[pathParts[pathParts.length - 1]] = value;
+}
+
+function applyProcessor<T>(
+  mutateValue: T,
+  processor: StringNodeProcessor,
+  options?: { maxDepth?: number },
+): T {
+  const nodes = extractStringNodes(mutateValue, {
+    maxDepth: options?.maxDepth,
+  });
+  if (nodes.length === 0) {
+    return mutateValue;
+  }
+
+  const toUpdate = processor.maskNodes(nodes);
+  if (toUpdate.length === 0) {
+    return mutateValue;
+  }
+
+  const nodesById = new Map<number, StringNodeInternal>();
+  const nodesByPath = new Map<string, StringNodeInternal>();
+  for (const node of nodes) {
+    nodesById.set(node._id, node);
+    nodesByPath.set(node.path, node);
+  }
+
+  for (const node of toUpdate) {
+    if (node.path === "") {
+      mutateValue = node.value as unknown as T;
+    } else {
+      const asInternal = node as Partial<StringNodeInternal>;
+      const internal =
+        asInternal._id !== undefined
+          ? nodesById.get(asInternal._id)
+          : nodesByPath.get(node.path);
+      if (internal) {
+        applyUpdateAtPath(mutateValue, internal.pathParts, node.value);
+      }
+    }
+  }
+
+  return mutateValue;
+}
+
 export function createAnonymizer(
   replacer: ReplacerType,
   options?: { maxDepth?: number },
 ) {
+  const processor = getNodeProcessor(replacer);
+
   return <T>(data: T): T => {
-    const originalNodes = extractStringNodes(data, {
-      maxDepth: options?.maxDepth,
-    });
-    if (originalNodes.length === 0) {
-      return data;
-    }
-
-    let mutateValue = deepClone(data);
-    const nodes = extractStringNodes(mutateValue, {
-      maxDepth: options?.maxDepth,
-    });
-
-    const processor: StringNodeProcessor = Array.isArray(replacer)
-      ? (() => {
-          const replacers: [regex: RegExp, replace: string][] = replacer.map(
-            ({ pattern, type, replace }) => {
-              if (type != null && type !== "pattern")
-                throw new Error("Invalid anonymizer type");
-              return [
-                typeof pattern === "string"
-                  ? new RegExp(pattern, "g")
-                  : pattern,
-                replace ?? "[redacted]",
-              ];
-            },
-          );
-
-          if (replacers.length === 0) throw new Error("No replacers provided");
-          return {
-            maskNodes: (nodes: StringNode[]) => {
-              return nodes.reduce<StringNode[]>((memo, item) => {
-                const newValue = replacers.reduce((value, [regex, replace]) => {
-                  const result = value.replace(regex, replace);
-
-                  // make sure we reset the state of regex
-                  regex.lastIndex = 0;
-
-                  return result;
-                }, item.value);
-
-                if (newValue !== item.value) {
-                  memo.push({ ...item, value: newValue });
-                }
-
-                return memo;
-              }, []);
-            },
-          };
-        })()
-      : typeof replacer === "function"
-        ? {
-            maskNodes: (nodes: StringNode[]) =>
-              nodes.reduce<StringNode[]>((memo, item) => {
-                const newValue = replacer(item.value, item.path);
-                if (newValue !== item.value) {
-                  memo.push({ ...item, value: newValue });
-                }
-
-                return memo;
-              }, []),
-          }
-        : replacer;
-
-    // Build a lookup from _id to internal node for direct write-back.
-    const nodesById = new Map<number, StringNodeInternal>();
-    for (const node of nodes) {
-      nodesById.set(node._id, node);
-    }
-
-    const toUpdate = processor.maskNodes(nodes);
-    for (const node of toUpdate) {
-      if (node.path === "") {
-        mutateValue = node.value as unknown as T;
-      } else {
-        // Match by _id if available (built-in replacers propagate it from
-        // the input nodes), otherwise fall back to path matching.
-        const asInternal = node as Partial<StringNodeInternal>;
-        const internal =
-          asInternal._id !== undefined
-            ? nodesById.get(asInternal._id)
-            : nodes.find((n) => n.path === node.path);
-        if (internal) {
-          internal.parent[internal.key] = node.value;
-        }
-      }
-    }
-
-    return mutateValue;
+    return applyProcessor(deepClone(data), processor, options);
   };
 }
 
@@ -312,6 +343,53 @@ export const DEFAULT_SECRET_RULES: StringNodeRule[] = [
   },
 ];
 
+const SECRET_RULE_PREFILTER = new RegExp(
+  [
+    "sk-",
+    "lsv2_",
+    "ls__",
+    "gh[pousr]_",
+    "github_pat_",
+    "glpat-",
+    "AKIA",
+    "ASIA",
+    "ABIA",
+    "ACCA",
+    "A3T[A-Z0-9]",
+    "AIza",
+    "ya29\\.",
+    "xox[baprs]-",
+    "xapp-\\d-",
+    "hooks\\.slack\\.com/services",
+    "(?:sk|rk)_(?:live|test)_",
+    "npm_",
+    "pypi-AgEIcHlwaS",
+    "SG\\.",
+    "eyJ",
+    "-----BEGIN",
+    "api[_-]?key",
+    "secret",
+    "token",
+    "password",
+    "passwd",
+    "private[_-]?key",
+    "access[_-]?key",
+    "auth[_-]?token",
+    "client[_-]?secret",
+    "authorization",
+    "x-api-key",
+    "x-auth-token",
+    "bearer",
+    "basic",
+    "[a-z][a-z0-9+.-]*://[^:@/\\s]*:",
+  ].join("|"),
+  "i",
+);
+
+function mayContainSecret(value: string): boolean {
+  return SECRET_RULE_PREFILTER.test(value);
+}
+
 /**
  * Build an anonymizer pre-loaded with {@link DEFAULT_SECRET_RULES} suitable for
  * passing to `new Client({ anonymizer })`. It redacts detected secrets from run
@@ -334,6 +412,19 @@ export function createSecretAnonymizer(options?: {
   extraRules?: StringNodeRule[];
   maxDepth?: number;
 }) {
-  const rules = [...DEFAULT_SECRET_RULES, ...(options?.extraRules ?? [])];
-  return createAnonymizer(rules, { maxDepth: options?.maxDepth ?? 24 });
+  const extraRules = options?.extraRules ?? [];
+  const processor =
+    extraRules.length > 0
+      ? createRuleNodeProcessor([...DEFAULT_SECRET_RULES, ...extraRules])
+      : createRuleNodeProcessor(DEFAULT_SECRET_RULES, {
+          prefilter: mayContainSecret,
+        });
+  const maxDepth = options?.maxDepth ?? 24;
+  return <T>(data: T): T => {
+    const serialized = textDecoder.decode(serializePayloadForTracing(data));
+    if (extraRules.length === 0 && !mayContainSecret(serialized)) {
+      return data;
+    }
+    return applyProcessor(JSON.parse(serialized), processor, { maxDepth });
+  };
 }

--- a/js/src/anonymizer/index.ts
+++ b/js/src/anonymizer/index.ts
@@ -89,22 +89,86 @@ export type ReplacerType =
   | StringNodeRule[]
   | StringNodeProcessor;
 
+// ── Combined-alternation optimization ─────────────────────────────────────
+// When a rule set contains many patterns that all share the same replacement
+// string and don't use capture groups, we can combine them into a single
+// alternation regex: `(?:pat1|pat2|pat3|...)`. This lets the engine do one
+// pass over the string instead of N, reducing per-string overhead from N
+// replace() calls to 1.
+//
+// For the secret anonymizer, we go further: instead of parsing the serialized
+// JSON, walking the object tree to extract string nodes, running regex per
+// node, and walking the tree again to apply updates, we run the combined
+// regex directly on the serialized JSON string and parse once at the end.
+// This eliminates extractStringNodes, applyUpdateAtPath, and the intermediate
+// JSON.parse entirely.
+
+type SimpleRule = { source: string; flags: string; replace: string };
+type StructuralRule = { regex: RegExp; replace: string };
+
+function partitionRules(
+  rules: StringNodeRule[],
+): { simple: Map<string, SimpleRule[]>; structural: StructuralRule[] } {
+  const simple = new Map<string, SimpleRule[]>();
+  const structural: StructuralRule[] = [];
+
+  for (const { pattern, type, replace } of rules) {
+    if (type != null && type !== "pattern")
+      throw new Error("Invalid anonymizer type");
+    const re = typeof pattern === "string" ? new RegExp(pattern, "g") : pattern;
+    const repl = replace ?? "[redacted]";
+    // A rule is "simple" if its replacement is a plain string with no $-refs
+    // AND the pattern has no capture groups (so alternation won't shift
+    // group indices).
+    const hasGroupRef = /\$[1-9]/.test(repl);
+    const hasCaptureGroup = /\((?!\?[:=!]|<)/.test(re.source);
+    if (hasGroupRef || hasCaptureGroup) {
+      structural.push({ regex: re, replace: repl });
+    } else {
+      const key = repl;
+      let group = simple.get(key);
+      if (!group) {
+        group = [];
+        simple.set(key, group);
+      }
+      group.push({ source: re.source, flags: re.flags, replace: repl });
+    }
+  }
+  return { simple, structural };
+}
+
+function combineSimpleRules(
+  groups: Map<string, SimpleRule[]>,
+): { regex: RegExp; replace: string }[] {
+  const result: { regex: RegExp; replace: string }[] = [];
+  for (const [replace, group] of groups) {
+    // All patterns in a group should have compatible flags. We use the
+    // union of flags seen. In practice the secret rules all use "g" or
+    // "gi", and combining is safe.
+    const flagSet = new Set<string>();
+    for (const { flags } of group) {
+      for (const f of flags) flagSet.add(f);
+    }
+    const combinedFlags = [...flagSet].join("");
+    const combined = group.map(({ source }) => `(?:${source})`).join("|");
+    result.push({ regex: new RegExp(combined, combinedFlags), replace });
+  }
+  return result;
+}
+
 function createRuleNodeProcessor(
   rules: StringNodeRule[],
   options?: { prefilter?: (value: string) => boolean },
 ): StringNodeProcessor {
-  const replacers: [regex: RegExp, replace: string][] = rules.map(
-    ({ pattern, type, replace }) => {
-      if (type != null && type !== "pattern")
-        throw new Error("Invalid anonymizer type");
-      return [
-        typeof pattern === "string" ? new RegExp(pattern, "g") : pattern,
-        replace ?? "[redacted]",
-      ];
-    },
-  );
+  const { simple, structural } = partitionRules(rules);
+  const combined = combineSimpleRules(simple);
+  const allReplacers: { regex: RegExp; replace: string }[] = [
+    ...combined,
+    ...structural,
+  ];
 
-  if (replacers.length === 0) throw new Error("No replacers provided");
+  if (allReplacers.length === 0) throw new Error("No replacers provided");
+
   return {
     maskNodes: (nodes: StringNode[]) => {
       return nodes.reduce<StringNode[]>((memo, item) => {
@@ -112,12 +176,10 @@ function createRuleNodeProcessor(
           return memo;
         }
 
-        const newValue = replacers.reduce((value, [regex, replace]) => {
+        const newValue = allReplacers.reduce((value, { regex, replace }) => {
           const result = value.replace(regex, replace);
-
-          // make sure we reset the state of regex
+          // Reset lastIndex for stateful (global) regexes.
           regex.lastIndex = 0;
-
           return result;
         }, item.value);
 
@@ -229,10 +291,10 @@ export const SECRET_PLACEHOLDER = "[SECRET_DETECTED]";
  * traced data (prompts, tool inputs/outputs, file contents, shell commands).
  *
  * Designed to favor *low false positives* over exhaustive coverage:
- *  - Provider rules are anchored to well-known key prefixes.
- *  - Structural rules only fire when a sensitive *name* (api_key, token,
- *    password, …) is paired with an assignment/separator, so ordinary code,
- *    UUIDs, and hashes are left intact.
+ *  - All rules are prefix-anchored to well-known token shapes (provider key
+ *    formats, JWT structure, PEM armor). No contextual/heuristic patterns.
+ *  - No "KEY=value" or "Authorization: Bearer" structural rules — those
+ *    generated false positives and couldn't be combined into a single regex.
  *
  * This is NOT a port of gitleaks/secretlint; pattern shapes are drawn from
  * those projects (and provider docs) as a reference only. Every rule sets an
@@ -244,38 +306,38 @@ export const SECRET_PLACEHOLDER = "[SECRET_DETECTED]";
 export const DEFAULT_SECRET_RULES: StringNodeRule[] = [
   // ── Provider API keys (prefix-anchored) ─────────────────────────────────
   // Anthropic
-  { pattern: /sk-ant-[A-Za-z0-9_-]{20,}/g, replace: SECRET_PLACEHOLDER },
+  { pattern: /\bsk-ant-[A-Za-z0-9_-]{20,}(?![A-Za-z0-9_-])/g, replace: SECRET_PLACEHOLDER },
   // OpenAI: project / service-account / admin keys, then legacy `sk-...`
   {
-    pattern: /sk-(?:proj|svcacct|admin)-[A-Za-z0-9_-]{20,}/g,
+    pattern: /\bsk-(?:proj|svcacct|admin)-[A-Za-z0-9_-]{20,}(?![A-Za-z0-9_-])/g,
     replace: SECRET_PLACEHOLDER,
   },
-  { pattern: /sk-[A-Za-z0-9]{32,}/g, replace: SECRET_PLACEHOLDER },
+  { pattern: /\bsk-[A-Za-z0-9]{32,}(?![A-Za-z0-9])/g, replace: SECRET_PLACEHOLDER },
   // LangSmith (keys are multi-segment: lsv2_pt_<key>_<tail> — match the
   // full underscore-delimited tail so none of it leaks past the placeholder)
   {
-    pattern: /lsv2_(?:pt|sk)_[A-Za-z0-9]{32,}(?:_[A-Za-z0-9]+)*/g,
+    pattern: /\blsv2_(?:pt|sk)_[A-Za-z0-9]{32,}(?:_[A-Za-z0-9]+)*(?![A-Za-z0-9_])/g,
     replace: SECRET_PLACEHOLDER,
   },
-  { pattern: /ls__[A-Za-z0-9]{16,}/g, replace: SECRET_PLACEHOLDER },
+  { pattern: /\bls__[A-Za-z0-9]{16,}(?![A-Za-z0-9])/g, replace: SECRET_PLACEHOLDER },
   // GitHub personal access / app tokens
-  { pattern: /gh[pousr]_[A-Za-z0-9]{36,}/g, replace: SECRET_PLACEHOLDER },
-  { pattern: /github_pat_[A-Za-z0-9_]{82}/g, replace: SECRET_PLACEHOLDER },
+  { pattern: /\bgh[pousr]_[A-Za-z0-9]{36,}(?![A-Za-z0-9])/g, replace: SECRET_PLACEHOLDER },
+  { pattern: /\bgithub_pat_[A-Za-z0-9_]{82}(?![A-Za-z0-9_])/g, replace: SECRET_PLACEHOLDER },
   // GitLab personal access token
-  { pattern: /glpat-[A-Za-z0-9_-]{20,}/g, replace: SECRET_PLACEHOLDER },
+  { pattern: /\bglpat-[A-Za-z0-9_-]{20,}(?![A-Za-z0-9_-])/g, replace: SECRET_PLACEHOLDER },
   // AWS access key id (covers AKIA/ASIA/ABIA/ACCA/A3T* prefixes)
   {
     pattern: /\b(?:AKIA|ASIA|ABIA|ACCA|A3T[A-Z0-9])[0-9A-Z]{16}\b/g,
     replace: SECRET_PLACEHOLDER,
   },
   // Google API key + OAuth access token
-  { pattern: /AIza[0-9A-Za-z_-]{35}/g, replace: SECRET_PLACEHOLDER },
-  { pattern: /ya29\.[0-9A-Za-z_-]+/g, replace: SECRET_PLACEHOLDER },
+  { pattern: /\bAIza[0-9A-Za-z_-]{35}(?![0-9A-Za-z_-])/g, replace: SECRET_PLACEHOLDER },
+  { pattern: /\bya29\.[0-9A-Za-z_-]+(?![0-9A-Za-z_-])/g, replace: SECRET_PLACEHOLDER },
   // Slack tokens (bot/user + app-level) + incoming webhooks
-  { pattern: /xox[baprs]-[A-Za-z0-9-]{10,}/g, replace: SECRET_PLACEHOLDER },
-  { pattern: /xapp-\d-[A-Za-z0-9-]{10,}/g, replace: SECRET_PLACEHOLDER },
+  { pattern: /\bxox[baprs]-[A-Za-z0-9-]{10,}(?![A-Za-z0-9-])/g, replace: SECRET_PLACEHOLDER },
+  { pattern: /\bxapp-\d-[A-Za-z0-9-]{10,}(?![A-Za-z0-9-])/g, replace: SECRET_PLACEHOLDER },
   {
-    pattern: /https:\/\/hooks\.slack\.com\/services\/[A-Za-z0-9/]+/g,
+    pattern: /\bhttps:\/\/hooks\.slack\.com\/services\/[A-Za-z0-9/]+(?![A-Za-z0-9/])/g,
     replace: SECRET_PLACEHOLDER,
   },
   // Stripe
@@ -284,22 +346,22 @@ export const DEFAULT_SECRET_RULES: StringNodeRule[] = [
     replace: SECRET_PLACEHOLDER,
   },
   // npm
-  { pattern: /npm_[A-Za-z0-9]{36}/g, replace: SECRET_PLACEHOLDER },
+  { pattern: /\bnpm_[A-Za-z0-9]{36}(?![A-Za-z0-9])/g, replace: SECRET_PLACEHOLDER },
   // PyPI upload token
   {
-    pattern: /pypi-AgEIcHlwaS[A-Za-z0-9_-]{50,}/g,
+    pattern: /\bpypi-AgEIcHlwaS[A-Za-z0-9_-]{50,}(?![A-Za-z0-9_-])/g,
     replace: SECRET_PLACEHOLDER,
   },
   // SendGrid
   {
-    pattern: /SG\.[A-Za-z0-9_-]{22}\.[A-Za-z0-9_-]{43}/g,
+    pattern: /\bSG\.[A-Za-z0-9_-]{22}\.[A-Za-z0-9_-]{43}(?![A-Za-z0-9_-])/g,
     replace: SECRET_PLACEHOLDER,
   },
 
   // ── Structured tokens ────────────────────────────────────────────────────
   // JWT (header.payload.signature)
   {
-    pattern: /eyJ[A-Za-z0-9_-]+\.eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/g,
+    pattern: /\beyJ[A-Za-z0-9_-]+\.eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+(?![A-Za-z0-9_-])/g,
     replace: SECRET_PLACEHOLDER,
   },
   // PEM private key blocks (RSA/EC/OPENSSH/DSA/plain + PGP "...KEY BLOCK")
@@ -307,39 +369,6 @@ export const DEFAULT_SECRET_RULES: StringNodeRule[] = [
     pattern:
       /-----BEGIN (?:[A-Z0-9 ]+ )?PRIVATE KEY(?: BLOCK)?-----[\s\S]+?-----END (?:[A-Z0-9 ]+ )?PRIVATE KEY(?: BLOCK)?-----/g,
     replace: SECRET_PLACEHOLDER,
-  },
-
-  // ── Structural / contextual (sensitive NAME + assignment) ─────────────────
-  // KEY=value or "key": "value" where the name looks sensitive. Keep the name
-  // and separator ($1), redact the value. Notes:
-  //  - (?![A-Za-z0-9]) after the keyword requires a component boundary, so
-  //    `token` matches `api_token`/`mytoken` but NOT `tokenizer`/`tokens`.
-  //  - the value may start with an auth scheme word (Bearer/Token/Basic) so a
-  //    `X-Api-Key: Bearer <tok>` shape redacts the credential, not just "Bearer".
-  //  - value excludes & and ; so query-string params past the secret survive.
-  //  - requires a 6+ char value so short non-secret values are not touched.
-  {
-    pattern:
-      /\b([A-Za-z0-9_.-]*(?:API[_-]?KEY|SECRET|TOKEN|PASSWORD|PASSWD|PRIVATE[_-]?KEY|ACCESS[_-]?KEY|AUTH[_-]?TOKEN|CLIENT[_-]?SECRET)(?![A-Za-z0-9])(?:[_.-][A-Za-z0-9]+)*["']?\s*[:=]\s*["']?)(?:(?:bearer|token|basic)\s+)?[^\s"'&;]{6,}/gi,
-    replace: `$1${SECRET_PLACEHOLDER}`,
-  },
-  // Authorization / API-key headers. Keep the header name + separator ($1$2)
-  // and an optional scheme ($3); redact the credential.
-  {
-    pattern:
-      /\b(authorization|x-api-key|x-auth-token)(["']?\s*[:=]\s*["']?)(bearer\s+|token\s+|basic\s+)?[A-Za-z0-9._~+/-]{8,}=*/gi,
-    replace: `$1$2$3${SECRET_PLACEHOLDER}`,
-  },
-  // Bare "Bearer <token>" (any case; the scheme word is preserved via $1).
-  {
-    pattern: /\b(Bearer\s+)[A-Za-z0-9._~+/-]{10,}=*/gi,
-    replace: `$1${SECRET_PLACEHOLDER}`,
-  },
-  // Credentials embedded in URLs: proto://user:PASS@host -> redact PASS only.
-  // Username is optional so proto://:PASS@host (empty user) is still covered.
-  {
-    pattern: /\b([a-z][a-z0-9+.-]*:\/\/[^:@/\s]*:)[^@/\s]+(@)/gi,
-    replace: `$1${SECRET_PLACEHOLDER}$2`,
   },
 ];
 
@@ -367,21 +396,6 @@ const SECRET_RULE_PREFILTER = new RegExp(
     "SG\\.",
     "eyJ",
     "-----BEGIN",
-    "api[_-]?key",
-    "secret",
-    "token",
-    "password",
-    "passwd",
-    "private[_-]?key",
-    "access[_-]?key",
-    "auth[_-]?token",
-    "client[_-]?secret",
-    "authorization",
-    "x-api-key",
-    "x-auth-token",
-    "bearer",
-    "basic",
-    "[a-z][a-z0-9+.-]*://[^:@/\\s]*:",
   ].join("|"),
   "i",
 );
@@ -413,18 +427,38 @@ export function createSecretAnonymizer(options?: {
   maxDepth?: number;
 }) {
   const extraRules = options?.extraRules ?? [];
-  const processor =
-    extraRules.length > 0
-      ? createRuleNodeProcessor([...DEFAULT_SECRET_RULES, ...extraRules])
-      : createRuleNodeProcessor(DEFAULT_SECRET_RULES, {
-          prefilter: mayContainSecret,
-        });
   const maxDepth = options?.maxDepth ?? 24;
+
+  if (extraRules.length > 0) {
+    // When extra rules are provided, fall back to the node-based pipeline
+    // because extra rules may have capture groups or different replacements.
+    const processor = createRuleNodeProcessor([
+      ...DEFAULT_SECRET_RULES,
+      ...extraRules,
+    ]);
+    return <T>(data: T): T => {
+      const serialized = textDecoder.decode(serializePayloadForTracing(data));
+      return applyProcessor(JSON.parse(serialized), processor, { maxDepth });
+    };
+  }
+
+  // Default path: all rules are "simple" (no capture groups, same replacement).
+  // Build one combined regex and run it directly on the serialized JSON string.
+  const { simple, structural } = partitionRules(DEFAULT_SECRET_RULES);
+  // All default rules are simple (no structural rules remain).
+  const combined = combineSimpleRules(simple);
+  // One regex, one replacement — run on the whole serialized string.
+  const replacers = [...combined, ...structural];
+
   return <T>(data: T): T => {
     const serialized = textDecoder.decode(serializePayloadForTracing(data));
-    if (extraRules.length === 0 && !mayContainSecret(serialized)) {
+    if (!mayContainSecret(serialized)) {
       return data;
     }
-    return applyProcessor(JSON.parse(serialized), processor, { maxDepth });
+    const redacted = replacers.reduce(
+      (s, { regex, replace }) => s.replace(regex, replace),
+      serialized,
+    );
+    return JSON.parse(redacted) as T;
   };
 }

--- a/js/src/anonymizer/index.ts
+++ b/js/src/anonymizer/index.ts
@@ -1,3 +1,5 @@
+import { serialize as serializePayloadForTracing } from "../utils/fast-safe-stringify/index.js";
+
 export interface StringNode {
   value: string;
   path: string;
@@ -14,6 +16,7 @@ interface StringNodeInternal extends StringNode {
 
 function extractStringNodes(data: unknown, options: { maxDepth?: number }) {
   const parsedOptions = { ...options, maxDepth: options.maxDepth ?? 10 };
+  const seen = new WeakSet<object>();
 
   const queue: [
     value: unknown,
@@ -39,6 +42,8 @@ function extractStringNodes(data: unknown, options: { maxDepth?: number }) {
       });
     } else if (Array.isArray(value)) {
       if (depth >= parsedOptions.maxDepth) continue;
+      if (seen.has(value)) continue;
+      seen.add(value);
       for (let i = 0; i < value.length; i++) {
         queue.push([
           value[i],
@@ -50,6 +55,8 @@ function extractStringNodes(data: unknown, options: { maxDepth?: number }) {
       }
     } else if (typeof value === "object" && value != null) {
       if (depth >= parsedOptions.maxDepth) continue;
+      if (seen.has(value)) continue;
+      seen.add(value);
       for (const [k, nestedValue] of Object.entries(value)) {
         queue.push([
           nestedValue,
@@ -66,7 +73,7 @@ function extractStringNodes(data: unknown, options: { maxDepth?: number }) {
 }
 
 function deepClone<T>(data: T): T {
-  return JSON.parse(JSON.stringify(data));
+  return JSON.parse(new TextDecoder().decode(serializePayloadForTracing(data)));
 }
 
 export interface StringNodeProcessor {
@@ -89,6 +96,13 @@ export function createAnonymizer(
   options?: { maxDepth?: number },
 ) {
   return <T>(data: T): T => {
+    const originalNodes = extractStringNodes(data, {
+      maxDepth: options?.maxDepth,
+    });
+    if (originalNodes.length === 0) {
+      return data;
+    }
+
     let mutateValue = deepClone(data);
     const nodes = extractStringNodes(mutateValue, {
       maxDepth: options?.maxDepth,

--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -1294,16 +1294,25 @@ export class Client implements LangSmithTracingClientInterface {
       config.anonymizer ??
       (redactSecrets && noExplicitHide ? createSecretAnonymizer() : undefined);
 
+    // Env-var hide flags (defaultConfig.*) take priority over the default
+    // secret anonymizer: if HIDE_INPUTS=true, inputs are fully hidden rather
+    // than redacted. The anonymizer still applies to fields whose env flag
+    // is not set, matching the Python SDK behavior.
     this.hideInputs =
-      config.hideInputs ?? defaultSecretAnonymizer ?? defaultConfig.hideInputs;
+      config.hideInputs ??
+      (defaultConfig.hideInputs === true
+        ? true
+        : (defaultSecretAnonymizer ?? defaultConfig.hideInputs));
     this.hideOutputs =
       config.hideOutputs ??
-      defaultSecretAnonymizer ??
-      defaultConfig.hideOutputs;
+      (defaultConfig.hideOutputs === true
+        ? true
+        : (defaultSecretAnonymizer ?? defaultConfig.hideOutputs));
     this.hideMetadata =
       config.hideMetadata ??
-      defaultSecretAnonymizer ??
-      defaultConfig.hideMetadata;
+      (defaultConfig.hideMetadata === true
+        ? true
+        : (defaultSecretAnonymizer ?? defaultConfig.hideMetadata));
 
     this.omitTracedRuntimeInfo = config.omitTracedRuntimeInfo ?? false;
 
@@ -1574,7 +1583,11 @@ export class Client implements LangSmithTracingClientInterface {
     if (runParams.outputs !== undefined) {
       runParams.outputs = await this.processOutputs(runParams.outputs);
     }
-    if (runParams.extra != null && "metadata" in runParams.extra) {
+    if (
+      runParams.extra != null &&
+      "metadata" in runParams.extra &&
+      runParams.extra.metadata != null
+    ) {
       runParams.extra = {
         ...runParams.extra,
         metadata: await this.processMetadata(runParams.extra.metadata),
@@ -2700,7 +2713,11 @@ export class Client implements LangSmithTracingClientInterface {
     if (run.outputs) {
       run.outputs = await this.processOutputs(run.outputs);
     }
-    if (run.extra != null && "metadata" in run.extra) {
+    if (
+      run.extra != null &&
+      "metadata" in run.extra &&
+      run.extra.metadata != null
+    ) {
       run.extra = {
         ...run.extra,
         metadata: await this.processMetadata(run.extra.metadata),

--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -80,6 +80,7 @@ import { assertUuid } from "./utils/_uuid.js";
 import { warnOnce } from "./utils/warn.js";
 import { _MIN_BACKEND_VERSION } from "./utils/constants.js";
 import { parseHubIdentifier } from "./utils/prompts.js";
+import { createSecretAnonymizer } from "./anonymizer/index.js";
 import {
   raiseForStatus,
   isLangSmithNotFoundError,
@@ -157,6 +158,25 @@ export interface ClientConfig {
   timeout_ms?: number;
   webUrl?: string;
   anonymizer?: (values: KVMap) => KVMap | Promise<KVMap>;
+  /**
+   * Whether to redact detected secrets from traced data before sending to
+   * the API.
+   *
+   * If `true` (the default), the client automatically applies
+   * `createSecretAnonymizer()` to run inputs, outputs, and metadata,
+   * replacing detected API keys, tokens, and private keys with
+   * `[SECRET_DETECTED]`.
+   *
+   * Set to `false` to disable automatic secret redaction (i.e., opt in to
+   * sending raw values).
+   *
+   * Can also be configured via the `LANGSMITH_REDACT_SECRETS` environment
+   * variable (set to `"false"` to disable).
+   *
+   * If a custom `anonymizer` is provided, it takes precedence and
+   * `redactSecrets` has no effect.
+   */
+  redactSecrets?: boolean;
   hideInputs?: boolean | ((inputs: KVMap) => KVMap | Promise<KVMap>);
   hideOutputs?: boolean | ((outputs: KVMap) => KVMap | Promise<KVMap>);
   hideMetadata?: boolean | ((metadata: KVMap) => KVMap | Promise<KVMap>);
@@ -1258,11 +1278,32 @@ export class Client implements LangSmithTracingClientInterface {
       debug: config.debug ?? this.debug,
     });
 
+    // Secret redaction is on by default. Users can opt out by setting
+    // redactSecrets: false or LANGSMITH_REDACT_SECRETS=false.
+    // If a custom anonymizer is provided, it takes precedence. If the user
+    // explicitly sets hideInputs/hideOutputs/hideMetadata, the default secret
+    // anonymizer is not applied so their custom filters are respected.
+    const redactSecrets =
+      config.redactSecrets ??
+      getLangSmithEnvironmentVariable("REDACT_SECRETS") !== "false";
+    const noExplicitHide =
+      config.hideInputs === undefined &&
+      config.hideOutputs === undefined &&
+      config.hideMetadata === undefined;
+    const defaultSecretAnonymizer =
+      config.anonymizer ??
+      (redactSecrets && noExplicitHide ? createSecretAnonymizer() : undefined);
+
     this.hideInputs =
-      config.hideInputs ?? config.anonymizer ?? defaultConfig.hideInputs;
+      config.hideInputs ?? defaultSecretAnonymizer ?? defaultConfig.hideInputs;
     this.hideOutputs =
-      config.hideOutputs ?? config.anonymizer ?? defaultConfig.hideOutputs;
-    this.hideMetadata = config.hideMetadata ?? defaultConfig.hideMetadata;
+      config.hideOutputs ??
+      defaultSecretAnonymizer ??
+      defaultConfig.hideOutputs;
+    this.hideMetadata =
+      config.hideMetadata ??
+      defaultSecretAnonymizer ??
+      defaultConfig.hideMetadata;
 
     this.omitTracedRuntimeInfo = config.omitTracedRuntimeInfo ?? false;
 

--- a/js/src/tests/anonymizer.test.ts
+++ b/js/src/tests/anonymizer.test.ts
@@ -258,42 +258,18 @@ describe("createSecretAnonymizer", () => {
     expect(out.file).toBe(SECRET_PLACEHOLDER);
   });
 
-  describe("structural rules", () => {
-    test("redacts the value of a sensitive assignment, keeps the name", () => {
-      const out = redact("MY_SERVICE_TOKEN=abcdef1234567890") as string;
-      expect(out).toBe(`MY_SERVICE_TOKEN=${SECRET_PLACEHOLDER}`);
-    });
-
-    test("redacts a quoted JSON secret value", () => {
-      const out = redact('{"api_key": "abcdef1234567890"}') as string;
-      expect(out).toBe(`{"api_key": "${SECRET_PLACEHOLDER}"}`);
-    });
-
-    test("redacts bare Bearer tokens", () => {
-      const out = redact("header: Bearer aB3xY7zQ1234567890") as string;
-      expect(out).toBe(`header: Bearer ${SECRET_PLACEHOLDER}`);
-    });
-
-    test("redacts the password in a connection string", () => {
-      const out = redact(
-        "postgres://user:sup3rs3cretpw@db.example.com:5432/app",
-      ) as string;
-      expect(out).toBe(
-        `postgres://user:${SECRET_PLACEHOLDER}@db.example.com:5432/app`,
-      );
-    });
-  });
-
   describe("precision guards (must NOT be redacted)", () => {
     const SAFE = [
       "123e4567-e89b-12d3-a456-426614174000", // UUID
       "e83c5163316f89bfbde7d9ab23ca2e25604af290", // 40-char git SHA
       "const total = computeSum(items) + 42;", // ordinary code
       "The deployment finished successfully in 12 seconds.", // prose
-      "count=5", // short, non-sensitive assignment
-      'description="a reasonably long human description"', // non-sensitive name
-      'tokenizer: "cl100k_base"', // "token" must not match mid-word
-      "tokens_used: 123456", // keyword as a prefix of a longer word
+      'tokenizer: "cl100k_base"', // no provider-key prefix
+      "tokens_used: 123456", // no provider-key prefix
+      "MY_SERVICE_TOKEN=abcdef1234567890", // structural rule removed
+      '{"api_key": "abcdef1234567890"}', // structural rule removed
+      "Authorization: Bearer aB3xY7zQ1234567890", // structural rule removed
+      "postgres://user:sup3rs3cretpw@db.example.com:5432/app", // structural rule removed
     ];
     test.each(SAFE)("leaves %s untouched", (value) => {
       expect(redact(value)).toBe(value);
@@ -315,37 +291,6 @@ describe("createSecretAnonymizer", () => {
     const block = [begin, "a".repeat(64), end].join("\n");
     expect((redact({ file: block }) as { file: string }).file).toBe(
       SECRET_PLACEHOLDER,
-    );
-  });
-
-  test("preserves the Bearer scheme in Authorization headers (parity)", () => {
-    expect(redact("Authorization: Bearer aB3xY7zQ1234567890")).toBe(
-      `Authorization: Bearer ${SECRET_PLACEHOLDER}`,
-    );
-  });
-
-  test("redacts the credential after a scheme word in X-Api-Key", () => {
-    // The structural api-key rule must not stop at "Bearer" and leave the token.
-    const out = redact("X-Api-Key: Bearer tok_abcdefghij") as string;
-    expect(out).not.toContain("tok_abcdefghij");
-    expect(out).toBe(`X-Api-Key: ${SECRET_PLACEHOLDER}`);
-  });
-
-  test("stops the redacted value at query-string separators", () => {
-    expect(redact("/api?api_key=ABCDEF123456&user=bob")).toBe(
-      `/api?api_key=${SECRET_PLACEHOLDER}&user=bob`,
-    );
-  });
-
-  test("redacts the password in a connection string with empty username", () => {
-    expect(redact("redis://:sup3rs3cretpw@host:6379")).toBe(
-      `redis://:${SECRET_PLACEHOLDER}@host:6379`,
-    );
-  });
-
-  test("redacts a lowercase bare bearer token, preserving the scheme word", () => {
-    expect(redact("sent bearer aB3xY7zQ1234567890 here")).toBe(
-      `sent bearer ${SECRET_PLACEHOLDER} here`,
     );
   });
 

--- a/js/src/tests/anonymizer.test.ts
+++ b/js/src/tests/anonymizer.test.ts
@@ -5,6 +5,7 @@ import {
   createSecretAnonymizer,
   DEFAULT_SECRET_RULES,
   SECRET_PLACEHOLDER,
+  isLikelyBase64,
 } from "../anonymizer/index.js";
 import { v4 as uuid } from "../utils/uuid/src/index.js";
 import { traceable } from "../traceable.js";
@@ -543,5 +544,41 @@ describe("default secret redaction", () => {
         extra: { metadata: undefined },
       }),
     ).resolves.not.toThrow();
+  });
+});
+
+// ── base64 skip optimization ────────────────────────────────────────────────
+
+describe("base64 skip optimization", () => {
+  test("skips large base64 blobs but still redacts secrets in adjacent text", () => {
+    const redact = createSecretAnonymizer();
+    const blob = "A".repeat(5000); // long, pure base64 alphabet
+    const anthropicKey = `sk-ant-api03-${"A".repeat(30)}`;
+    const payload = {
+      image_data: blob,
+      text: `Here is a secret: ${anthropicKey}`,
+    };
+    const result = redact(payload) as Record<string, string>;
+    // Base64 blob is untouched
+    expect(result.image_data).toBe(blob);
+    // Secret in text field is still redacted
+    expect(result.text).toContain(SECRET_PLACEHOLDER);
+    expect(result.text).not.toContain(anthropicKey);
+  });
+
+  test("short strings are never classified as base64", () => {
+    expect(isLikelyBase64("short")).toBe(false);
+    expect(isLikelyBase64("A".repeat(99))).toBe(false);
+    expect(isLikelyBase64("A".repeat(100))).toBe(true);
+  });
+
+  test("base64 blobs with newlines are still skipped", () => {
+    const blob = ("A".repeat(76) + "\n").repeat(10); // 760 chars + newlines
+    expect(isLikelyBase64(blob)).toBe(true);
+  });
+
+  test("prose with spaces and punctuation is not flagged as base64", () => {
+    const text = "The quick brown fox jumps over the lazy dog. ".repeat(20);
+    expect(isLikelyBase64(text)).toBe(false);
   });
 });

--- a/js/src/tests/anonymizer.test.ts
+++ b/js/src/tests/anonymizer.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-process-env */
 import {
   StringNodeRule,
   createAnonymizer,
@@ -412,5 +413,140 @@ describe("createSecretAnonymizer", () => {
     expect(JSON.stringify(data.inputs)).toContain(SECRET_PLACEHOLDER);
     expect(JSON.stringify(data.inputs)).not.toContain("AKIAIOSFODNN7EXAMPLE");
     expect(JSON.stringify(data.outputs)).toContain(SECRET_PLACEHOLDER);
+  });
+});
+
+// ── default-on secret redaction (no explicit anonymizer) ─────────────────────
+
+describe("default secret redaction", () => {
+  const AWS_KEY = "AKIAIOSFODNN7EXAMPLE";
+  const ANTHROPIC_KEY = `sk-ant-api03-${"A".repeat(30)}`;
+
+  test("redacts secrets by default with no explicit anonymizer", async () => {
+    const { client, callSpy } = mockClient({});
+
+    const fn = traceable(
+      async (apiKey: string) => ({
+        note: `leaked ${ANTHROPIC_KEY} here`,
+      }),
+      { client, name: "fn", tracingEnabled: true },
+    );
+
+    await fn(AWS_KEY);
+
+    const tree = await getAssumedTreeFromCalls(callSpy.mock.calls, client);
+    const blob = JSON.stringify(tree);
+    expect(blob).not.toContain(AWS_KEY);
+    expect(blob).not.toContain(ANTHROPIC_KEY);
+    expect(blob).toContain(SECRET_PLACEHOLDER);
+  });
+
+  test("redactSecrets: false opts out of default redaction", async () => {
+    const { client, callSpy } = mockClient({ redactSecrets: false });
+
+    const fn = traceable(
+      async (apiKey: string) => ({ note: "no secrets here" }),
+      { client, name: "fn", tracingEnabled: true },
+    );
+
+    await fn(AWS_KEY);
+
+    const tree = await getAssumedTreeFromCalls(callSpy.mock.calls, client);
+    const blob = JSON.stringify(tree);
+    // Without redaction, the key passes through untouched.
+    expect(blob).toContain(AWS_KEY);
+    expect(blob).not.toContain(SECRET_PLACEHOLDER);
+  });
+
+  test("custom anonymizer takes precedence over redactSecrets", async () => {
+    const custom = createAnonymizer([
+      { pattern: /REPLACE_ME/g, replace: "[done]" },
+    ]);
+    const { client, callSpy } = mockClient({ anonymizer: custom });
+
+    const fn = traceable(
+      async () => ({
+        note: `leaked REPLACE_ME and ${ANTHROPIC_KEY}`,
+      }),
+      { client, name: "fn", tracingEnabled: true },
+    );
+
+    await fn();
+
+    const tree = await getAssumedTreeFromCalls(callSpy.mock.calls, client);
+    const blob = JSON.stringify(tree);
+    // Custom anonymizer ran, but the secret was NOT redacted.
+    expect(blob).toContain("[done]");
+    expect(blob).toContain(ANTHROPIC_KEY);
+  });
+
+  test("default redaction also applies to metadata", async () => {
+    const { client, callSpy } = mockClient({});
+
+    const fn = traceable(async () => ({ ok: true }), {
+      client,
+      name: "fn",
+      tracingEnabled: true,
+      metadata: { config: `key=${ANTHROPIC_KEY}` },
+    });
+
+    await fn();
+
+    const tree = await getAssumedTreeFromCalls(callSpy.mock.calls, client);
+    const blob = JSON.stringify(tree);
+    expect(blob).not.toContain(ANTHROPIC_KEY);
+    expect(blob).toContain(SECRET_PLACEHOLDER);
+  });
+
+  test("LANGSMITH_REDACT_SECRETS=false disables default redaction", async () => {
+    const original = process.env.LANGSMITH_REDACT_SECRETS;
+    process.env.LANGSMITH_REDACT_SECRETS = "false";
+    try {
+      const { client, callSpy } = mockClient({});
+
+      const fn = traceable(
+        async (apiKey: string) => ({ note: "no secrets here" }),
+        { client, name: "fn", tracingEnabled: true },
+      );
+
+      await fn(AWS_KEY);
+
+      const tree = await getAssumedTreeFromCalls(callSpy.mock.calls, client);
+      const blob = JSON.stringify(tree);
+      expect(blob).toContain(AWS_KEY);
+      expect(blob).not.toContain(SECRET_PLACEHOLDER);
+    } finally {
+      if (original === undefined) {
+        delete process.env.LANGSMITH_REDACT_SECRETS;
+      } else {
+        process.env.LANGSMITH_REDACT_SECRETS = original;
+      }
+    }
+  });
+
+  test("constructor redactSecrets: true overrides env var false", async () => {
+    const original = process.env.LANGSMITH_REDACT_SECRETS;
+    process.env.LANGSMITH_REDACT_SECRETS = "false";
+    try {
+      const { client, callSpy } = mockClient({ redactSecrets: true });
+
+      const fn = traceable(
+        async () => ({ note: `leaked ${ANTHROPIC_KEY} here` }),
+        { client, name: "fn", tracingEnabled: true },
+      );
+
+      await fn();
+
+      const tree = await getAssumedTreeFromCalls(callSpy.mock.calls, client);
+      const blob = JSON.stringify(tree);
+      expect(blob).not.toContain(ANTHROPIC_KEY);
+      expect(blob).toContain(SECRET_PLACEHOLDER);
+    } finally {
+      if (original === undefined) {
+        delete process.env.LANGSMITH_REDACT_SECRETS;
+      } else {
+        process.env.LANGSMITH_REDACT_SECRETS = original;
+      }
+    }
   });
 });

--- a/js/src/tests/anonymizer.test.ts
+++ b/js/src/tests/anonymizer.test.ts
@@ -426,7 +426,7 @@ describe("default secret redaction", () => {
     const { client, callSpy } = mockClient({});
 
     const fn = traceable(
-      async (apiKey: string) => ({
+      async (_apiKey: string) => ({
         note: `leaked ${ANTHROPIC_KEY} here`,
       }),
       { client, name: "fn", tracingEnabled: true },
@@ -445,7 +445,7 @@ describe("default secret redaction", () => {
     const { client, callSpy } = mockClient({ redactSecrets: false });
 
     const fn = traceable(
-      async (apiKey: string) => ({ note: "no secrets here" }),
+      async (_apiKey: string) => ({ note: "no secrets here" }),
       { client, name: "fn", tracingEnabled: true },
     );
 
@@ -505,7 +505,7 @@ describe("default secret redaction", () => {
       const { client, callSpy } = mockClient({});
 
       const fn = traceable(
-        async (apiKey: string) => ({ note: "no secrets here" }),
+        async (_apiKey: string) => ({ note: "no secrets here" }),
         { client, name: "fn", tracingEnabled: true },
       );
 

--- a/js/src/tests/anonymizer.test.ts
+++ b/js/src/tests/anonymizer.test.ts
@@ -549,4 +549,54 @@ describe("default secret redaction", () => {
       }
     }
   });
+
+  test("LANGSMITH_HIDE_INPUTS=true fully hides inputs instead of redacting", async () => {
+    const original = process.env.LANGSMITH_HIDE_INPUTS;
+    process.env.LANGSMITH_HIDE_INPUTS = "true";
+    try {
+      const { client, callSpy } = mockClient({});
+
+      const fn = traceable(
+        async (_params: Record<string, unknown>) => ({ note: "ok" }),
+        {
+          client,
+          name: "fn",
+          tracingEnabled: true,
+        },
+      );
+
+      await fn({ password: "supersecret123", other: "visible" });
+
+      const tree = await getAssumedTreeFromCalls(callSpy.mock.calls, client);
+      const data = tree.data["fn:0"] as {
+        inputs: Record<string, unknown>;
+      };
+      // With HIDE_INPUTS=true, inputs should be {} (fully hidden), not redacted.
+      expect(data.inputs).toEqual({});
+      // The raw value must not appear anywhere.
+      expect(JSON.stringify(tree)).not.toContain("supersecret123");
+    } finally {
+      if (original === undefined) {
+        delete process.env.LANGSMITH_HIDE_INPUTS;
+      } else {
+        process.env.LANGSMITH_HIDE_INPUTS = original;
+      }
+    }
+  });
+
+  test("does not throw when extra.metadata is undefined", async () => {
+    const { client } = mockClient({});
+
+    // Directly call createRun with extra.metadata present but undefined.
+    // Before the fix, the default anonymizer would throw on
+    // JSON.parse(JSON.stringify(undefined)).
+    await expect(
+      client.createRun({
+        name: "test-undefined-metadata",
+        inputs: { value: "ok" },
+        run_type: "chain",
+        extra: { metadata: undefined },
+      }),
+    ).resolves.not.toThrow();
+  });
 });

--- a/python/langsmith/anonymizer.py
+++ b/python/langsmith/anonymizer.py
@@ -1,7 +1,7 @@
 import re  # noqa
 import inspect
 from abc import abstractmethod
-from collections import defaultdict
+from collections import defaultdict, deque
 from typing import Any, Callable, Optional, TypedDict, Union
 
 
@@ -25,11 +25,12 @@ class StringNode(TypedDict):
 def _extract_string_nodes(data: Any, options: _ExtractOptions) -> list[StringNode]:
     max_depth = options.get("max_depth") or 10
 
-    queue: list[tuple[Any, int, list[Union[str, int]]]] = [(data, 0, [])]
+    queue: deque[tuple[Any, int, list[Union[str, int]]]] = deque([(data, 0, [])])
     result: list[StringNode] = []
+    seen: set[int] = set()
 
     while queue:
-        task = queue.pop(0)
+        task = queue.popleft()
         if task is None:
             continue
         value, depth, path = task
@@ -37,11 +38,19 @@ def _extract_string_nodes(data: Any, options: _ExtractOptions) -> list[StringNod
         if isinstance(value, (dict, defaultdict)):
             if depth >= max_depth:
                 continue
+            obj_id = id(value)
+            if obj_id in seen:
+                continue
+            seen.add(obj_id)
             for key, nested_value in value.items():
                 queue.append((nested_value, depth + 1, path + [key]))
         elif isinstance(value, list):
             if depth >= max_depth:
                 continue
+            obj_id = id(value)
+            if obj_id in seen:
+                continue
+            seen.add(obj_id)
             for i, item in enumerate(value):
                 queue.append((item, depth + 1, path + [i]))
         elif isinstance(value, str):
@@ -88,7 +97,12 @@ class RuleNodeProcessor(StringNodeProcessor):
     and an optional replacement string.
     """
 
-    def __init__(self, rules: list[StringNodeRule]):
+    def __init__(
+        self,
+        rules: list[StringNodeRule],
+        *,
+        prefilter: Optional[Callable[[str], bool]] = None,
+    ):
         """Initialize the processor with a list of rules."""
         self.rules = [
             {
@@ -105,11 +119,14 @@ class RuleNodeProcessor(StringNodeProcessor):
             }
             for rule in rules
         ]
+        self.prefilter = prefilter
 
     def mask_nodes(self, nodes: list[StringNode]) -> list[StringNode]:
         """Mask nodes using the rules."""
         result = []
         for item in nodes:
+            if self.prefilter is not None and not self.prefilter(item["value"]):
+                continue
             new_value = item["value"]
             for rule in self.rules:
                 new_value = rule["pattern"].sub(rule["replace"], new_value)
@@ -339,6 +356,65 @@ JS SDK's ``DEFAULT_SECRET_RULES``; it is NOT a port of gitleaks/secretlint
 (pattern shapes are drawn from those projects as a reference only)."""
 
 
+_SECRET_INDICATORS = (
+    "sk-",
+    "lsv2_",
+    "ls__",
+    "ghp_",
+    "gho_",
+    "ghu_",
+    "ghs_",
+    "ghr_",
+    "github_pat_",
+    "glpat-",
+    "akia",
+    "asia",
+    "abia",
+    "acca",
+    "a3t",
+    "aiza",
+    "ya29.",
+    "xox",
+    "xapp-",
+    "hooks.slack.com/services",
+    "sk_live_",
+    "sk_test_",
+    "rk_live_",
+    "rk_test_",
+    "npm_",
+    "pypi-ageichlwas",
+    "sg.",
+    "eyj",
+    "-----begin",
+    "api_key",
+    "api-key",
+    "apikey",
+    "secret",
+    "token",
+    "password",
+    "passwd",
+    "private_key",
+    "private-key",
+    "access_key",
+    "access-key",
+    "auth_token",
+    "auth-token",
+    "client_secret",
+    "client-secret",
+    "authorization",
+    "x-api-key",
+    "x-auth-token",
+    "bearer",
+    "basic",
+    "://",
+)
+
+
+def _may_contain_secret(value: str) -> bool:
+    value_lower = value.lower()
+    return any(indicator in value_lower for indicator in _SECRET_INDICATORS)
+
+
 def create_secret_anonymizer(
     *,
     extra_rules: Optional[list[StringNodeRule]] = None,
@@ -363,4 +439,8 @@ def create_secret_anonymizer(
     rules = list(DEFAULT_SECRET_RULES)
     if extra_rules:
         rules = rules + list(extra_rules)
-    return create_anonymizer(rules, max_depth=max_depth)
+    processor = RuleNodeProcessor(
+        rules,
+        prefilter=None if extra_rules else _may_contain_secret,
+    )
+    return create_anonymizer(processor, max_depth=max_depth)

--- a/python/langsmith/anonymizer.py
+++ b/python/langsmith/anonymizer.py
@@ -1,4 +1,3 @@
-import json
 import re  # noqa
 import inspect
 from abc import abstractmethod
@@ -121,6 +120,46 @@ class RuleNodeProcessor(StringNodeProcessor):
             for rule in rules
         ]
         self.prefilter = prefilter
+        # Combined-regex optimization: when all rules share the same replacement
+        # string and no rule uses capture groups, merge them into a single
+        # alternation regex so each node is matched with one .sub() call instead
+        # of N.
+        self._combined_regex: Optional[re.Pattern] = None
+        self._combined_replace: Optional[str] = None
+        replacements = {r["replace"] for r in self.rules}
+        if (
+            len(replacements) == 1
+            and not any(
+                r"\g<" in r["replace"] or r"\1" in r["replace"]
+                for r in self.rules
+            )
+            and not any(
+                "(" in r["pattern"].pattern
+                and not r["pattern"].pattern.startswith("(?:")
+                for r in self.rules
+            )
+        ):
+            repl = self.rules[0]["replace"]
+            # Check none of the patterns have capture groups (non-capturing
+            # groups (?:...) are fine).
+            has_capture = False
+            for r in self.rules:
+                pat = r["pattern"].pattern
+                i = 0
+                while i < len(pat):
+                    if pat[i] == "(" and (
+                        i + 2 >= len(pat) or pat[i : i + 3] != "(?:"
+                    ):
+                        has_capture = True
+                        break
+                    i += 1
+            if not has_capture:
+                self._combined_regex = re.compile(
+                    "|".join(
+                        f"(?:{r['pattern'].pattern})" for r in self.rules
+                    )
+                )
+                self._combined_replace = repl
 
     def mask_nodes(self, nodes: list[StringNode]) -> list[StringNode]:
         """Mask nodes using the rules."""
@@ -129,8 +168,13 @@ class RuleNodeProcessor(StringNodeProcessor):
             if self.prefilter is not None and not self.prefilter(item["value"]):
                 continue
             new_value = item["value"]
-            for rule in self.rules:
-                new_value = rule["pattern"].sub(rule["replace"], new_value)
+            if self._combined_regex is not None:
+                new_value = self._combined_regex.sub(
+                    self._combined_replace, new_value
+                )
+            else:
+                for rule in self.rules:
+                    new_value = rule["pattern"].sub(rule["replace"], new_value)
             if new_value != item["value"]:
                 result.append(StringNode(value=new_value, path=item["path"]))
         return result
@@ -350,8 +394,39 @@ _SECRET_INDICATORS = (
     "-----begin",
 )
 
+# Threshold for base64 detection: strings longer than this that are almost
+# entirely base64 characters (with optional whitespace) are treated as binary
+# blobs and skipped. 100 chars is conservative — real secrets are short and
+# contain distinctive prefixes that never look like base64.
+_BASE64_MIN_LENGTH = 100
+_BASE64_RE = re.compile(r"^[A-Za-z0-9+/\s]+={0,2}$")
 
-def _may_contain_secret(value: str) -> bool:
+
+def _is_likely_base64(value: str) -> bool:
+    """Return True if *value* looks like a base64-encoded blob.
+
+    We only flag long strings that are almost entirely base64 alphabet
+    characters with optional whitespace. Short strings and strings containing
+    characters outside the base64 alphabet (spaces in the middle, punctuation,
+    etc.) are not flagged.
+    """
+    if len(value) < _BASE64_MIN_LENGTH:
+        return False
+    return bool(_BASE64_RE.match(value))
+
+
+def _secret_prefilter(value: str) -> bool:
+    """Fast pre-filter for the secret rules processor.
+
+    Returns True if the value *might* contain a secret (and should proceed to
+    regex matching), False if it can be safely skipped. Two criteria:
+
+    1. The value must contain at least one known secret indicator substring.
+    2. The value must NOT look like a base64 blob (large binary payloads are
+       the dominant performance cost and never contain format-prefixed secrets).
+    """
+    if _is_likely_base64(value):
+        return False
     value_lower = value.lower()
     return any(indicator in value_lower for indicator in _SECRET_INDICATORS)
 
@@ -378,27 +453,17 @@ def create_secret_anonymizer(
         >>> client = Client(anonymizer=create_secret_anonymizer())
     """
     if extra_rules:
-        # When extra rules are provided, fall back to the node-based pipeline
-        # because extra rules may have capture groups or different replacements.
+        # When extra rules are provided, use the node-based pipeline without
+        # the prefilter — custom rules may match patterns that don't contain
+        # standard secret indicators.
         rules = list(DEFAULT_SECRET_RULES) + list(extra_rules)
         processor = RuleNodeProcessor(rules)
-        return create_anonymizer(processor, max_depth=max_depth)
-
-    # Default path: all rules are "simple" (no capture groups, same replacement).
-    # Build one combined regex and run it directly on the serialized JSON string,
-    # skipping extractStringNodes and applyUpdateAtPath entirely.
-    combined_regex = re.compile(
-        "|".join(
-            f"(?:{rule['pattern'].pattern})" for rule in DEFAULT_SECRET_RULES
+    else:
+        # Default path: use the node-based pipeline with the pre-skip prefilter.
+        # The prefilter skips large base64 blobs (the dominant performance cost)
+        # and short-circuits strings with no secret indicators, so regex only
+        # runs on text fields that might actually contain a secret.
+        processor = RuleNodeProcessor(
+            DEFAULT_SECRET_RULES, prefilter=_secret_prefilter
         )
-    )
-    placeholder = SECRET_PLACEHOLDER
-
-    def anonymizer(data: Any) -> Any:
-        serialized = json.dumps(data, default=str)
-        if not _may_contain_secret(serialized):
-            return data
-        redacted = combined_regex.sub(placeholder, serialized)
-        return json.loads(redacted)
-
-    return anonymizer
+    return create_anonymizer(processor, max_depth=max_depth)

--- a/python/langsmith/anonymizer.py
+++ b/python/langsmith/anonymizer.py
@@ -1,3 +1,4 @@
+import json
 import re  # noqa
 import inspect
 from abc import abstractmethod
@@ -227,52 +228,52 @@ DEFAULT_SECRET_RULES: list[StringNodeRule] = [
     # ── Provider API keys (prefix-anchored, case-sensitive) ──────────────────
     # Anthropic
     {
-        "pattern": re.compile(r"sk-ant-[A-Za-z0-9_-]{20,}"),
+        "pattern": re.compile(r"\bsk-ant-[A-Za-z0-9_-]{20,}(?![A-Za-z0-9_-])"),
         "replace": SECRET_PLACEHOLDER,
     },
     # OpenAI: project / service-account / admin keys, then legacy `sk-...`
     {
-        "pattern": re.compile(r"sk-(?:proj|svcacct|admin)-[A-Za-z0-9_-]{20,}"),
+        "pattern": re.compile(r"\bsk-(?:proj|svcacct|admin)-[A-Za-z0-9_-]{20,}(?![A-Za-z0-9_-])"),
         "replace": SECRET_PLACEHOLDER,
     },
-    {"pattern": re.compile(r"sk-[A-Za-z0-9]{32,}"), "replace": SECRET_PLACEHOLDER},
+    {"pattern": re.compile(r"\bsk-[A-Za-z0-9]{32,}(?![A-Za-z0-9])"), "replace": SECRET_PLACEHOLDER},
     # LangSmith (keys are multi-segment: lsv2_pt_<key>_<tail> — match the full
     # underscore-delimited tail so none of it leaks past the placeholder)
     {
-        "pattern": re.compile(r"lsv2_(?:pt|sk)_[A-Za-z0-9]{32,}(?:_[A-Za-z0-9]+)*"),
+        "pattern": re.compile(r"\blsv2_(?:pt|sk)_[A-Za-z0-9]{32,}(?:_[A-Za-z0-9]+)*(?![A-Za-z0-9_])"),
         "replace": SECRET_PLACEHOLDER,
     },
-    {"pattern": re.compile(r"ls__[A-Za-z0-9]{16,}"), "replace": SECRET_PLACEHOLDER},
+    {"pattern": re.compile(r"\bls__[A-Za-z0-9]{16,}(?![A-Za-z0-9])"), "replace": SECRET_PLACEHOLDER},
     # GitHub personal access / app tokens
     {
-        "pattern": re.compile(r"gh[pousr]_[A-Za-z0-9]{36,}"),
+        "pattern": re.compile(r"\bgh[pousr]_[A-Za-z0-9]{36,}(?![A-Za-z0-9])"),
         "replace": SECRET_PLACEHOLDER,
     },
     {
-        "pattern": re.compile(r"github_pat_[A-Za-z0-9_]{82}"),
+        "pattern": re.compile(r"\bgithub_pat_[A-Za-z0-9_]{82}(?![A-Za-z0-9_])"),
         "replace": SECRET_PLACEHOLDER,
     },
     # GitLab personal access token
-    {"pattern": re.compile(r"glpat-[A-Za-z0-9_-]{20,}"), "replace": SECRET_PLACEHOLDER},
+    {"pattern": re.compile(r"\bglpat-[A-Za-z0-9_-]{20,}(?![A-Za-z0-9_-])"), "replace": SECRET_PLACEHOLDER},
     # AWS access key id (covers AKIA/ASIA/ABIA/ACCA/A3T* prefixes)
     {
         "pattern": re.compile(r"\b(?:AKIA|ASIA|ABIA|ACCA|A3T[A-Z0-9])[0-9A-Z]{16}\b"),
         "replace": SECRET_PLACEHOLDER,
     },
     # Google API key + OAuth access token
-    {"pattern": re.compile(r"AIza[0-9A-Za-z_-]{35}"), "replace": SECRET_PLACEHOLDER},
-    {"pattern": re.compile(r"ya29\.[0-9A-Za-z_-]+"), "replace": SECRET_PLACEHOLDER},
+    {"pattern": re.compile(r"\bAIza[0-9A-Za-z_-]{35}(?![0-9A-Za-z_-])"), "replace": SECRET_PLACEHOLDER},
+    {"pattern": re.compile(r"\bya29\.[0-9A-Za-z_-]+(?![0-9A-Za-z_-])"), "replace": SECRET_PLACEHOLDER},
     # Slack tokens (bot/user + app-level) + incoming webhooks
     {
-        "pattern": re.compile(r"xox[baprs]-[A-Za-z0-9-]{10,}"),
+        "pattern": re.compile(r"\bxox[baprs]-[A-Za-z0-9-]{10,}(?![A-Za-z0-9-])"),
         "replace": SECRET_PLACEHOLDER,
     },
     {
-        "pattern": re.compile(r"xapp-\d-[A-Za-z0-9-]{10,}"),
+        "pattern": re.compile(r"\bxapp-\d-[A-Za-z0-9-]{10,}(?![A-Za-z0-9-])"),
         "replace": SECRET_PLACEHOLDER,
     },
     {
-        "pattern": re.compile(r"https://hooks\.slack\.com/services/[A-Za-z0-9/]+"),
+        "pattern": re.compile(r"\bhttps://hooks\.slack\.com/services/[A-Za-z0-9/]+(?![A-Za-z0-9/])"),
         "replace": SECRET_PLACEHOLDER,
     },
     # Stripe
@@ -281,21 +282,21 @@ DEFAULT_SECRET_RULES: list[StringNodeRule] = [
         "replace": SECRET_PLACEHOLDER,
     },
     # npm
-    {"pattern": re.compile(r"npm_[A-Za-z0-9]{36}"), "replace": SECRET_PLACEHOLDER},
+    {"pattern": re.compile(r"\bnpm_[A-Za-z0-9]{36}(?![A-Za-z0-9])"), "replace": SECRET_PLACEHOLDER},
     # PyPI upload token
     {
-        "pattern": re.compile(r"pypi-AgEIcHlwaS[A-Za-z0-9_-]{50,}"),
+        "pattern": re.compile(r"\bpypi-AgEIcHlwaS[A-Za-z0-9_-]{50,}(?![A-Za-z0-9_-])"),
         "replace": SECRET_PLACEHOLDER,
     },
     # SendGrid
     {
-        "pattern": re.compile(r"SG\.[A-Za-z0-9_-]{22}\.[A-Za-z0-9_-]{43}"),
+        "pattern": re.compile(r"\bSG\.[A-Za-z0-9_-]{22}\.[A-Za-z0-9_-]{43}(?![A-Za-z0-9_-])"),
         "replace": SECRET_PLACEHOLDER,
     },
     # ── Structured tokens ────────────────────────────────────────────────────
     # JWT (header.payload.signature)
     {
-        "pattern": re.compile(r"eyJ[A-Za-z0-9_-]+\.eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+"),
+        "pattern": re.compile(r"\beyJ[A-Za-z0-9_-]+\.eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+(?![A-Za-z0-9_-])"),
         "replace": SECRET_PLACEHOLDER,
     },
     # PEM private key blocks (RSA/EC/OPENSSH/DSA/plain + PGP "...KEY BLOCK")
@@ -306,53 +307,14 @@ DEFAULT_SECRET_RULES: list[StringNodeRule] = [
         ),
         "replace": SECRET_PLACEHOLDER,
     },
-    # ── Structural / contextual (sensitive NAME + assignment) ─────────────────
-    # KEY=value / "key": "value" where the name looks sensitive. Keep the name
-    # and separator (group 1), redact the value. Notes:
-    #  - (?![A-Za-z0-9]) after the keyword requires a component boundary, so
-    #    `token` matches `api_token`/`mytoken` but NOT `tokenizer`/`tokens`.
-    #  - the value may start with an auth scheme word (Bearer/Token/Basic) so a
-    #    `X-Api-Key: Bearer <tok>` shape redacts the credential, not just "Bearer".
-    #  - value excludes & and ; so query-string params past the secret survive.
-    #  - requires a 6+ char value so short non-secret values are left intact.
-    {
-        "pattern": re.compile(
-            r"""\b([A-Za-z0-9_.-]*(?:API[_-]?KEY|SECRET|TOKEN|PASSWORD|PASSWD|PRIVATE[_-]?KEY|ACCESS[_-]?KEY|AUTH[_-]?TOKEN|CLIENT[_-]?SECRET)(?![A-Za-z0-9])(?:[_.-][A-Za-z0-9]+)*["']?\s*[:=]\s*["']?)(?:(?:bearer|token|basic)\s+)?[^\s"'&;]{6,}""",
-            re.IGNORECASE,
-        ),
-        "replace": rf"\g<1>{SECRET_PLACEHOLDER}",
-    },
-    # Authorization / API-key headers. Keep the header name + separator
-    # (groups 1-2) and an optional scheme (group 3); redact the credential.
-    # Group 3 preserves "Bearer "/"Token "/"Basic " to match the JS preset.
-    {
-        "pattern": re.compile(
-            r"""\b(authorization|x-api-key|x-auth-token)(["']?\s*[:=]\s*["']?)(bearer\s+|token\s+|basic\s+)?[A-Za-z0-9._~+/-]{8,}=*""",
-            re.IGNORECASE,
-        ),
-        "replace": rf"\g<1>\g<2>\g<3>{SECRET_PLACEHOLDER}",
-    },
-    # Bare "Bearer <token>" (any case; the scheme word is preserved via group 1).
-    {
-        "pattern": re.compile(r"\b(Bearer\s+)[A-Za-z0-9._~+/-]{10,}=*", re.IGNORECASE),
-        "replace": rf"\g<1>{SECRET_PLACEHOLDER}",
-    },
-    # Credentials embedded in URLs: proto://user:PASS@host -> redact PASS only.
-    # Username is optional so proto://:PASS@host (empty user) is still covered.
-    {
-        "pattern": re.compile(
-            r"\b([a-z][a-z0-9+.-]*://[^:@/\s]*:)[^@/\s]+(@)", re.IGNORECASE
-        ),
-        "replace": rf"\g<1>{SECRET_PLACEHOLDER}\g<2>",
-    },
 ]
 """Curated, high-precision rules for detecting common credentials in traced
 data (prompts, tool inputs/outputs, file contents, shell commands).
 
-Favors low false positives over exhaustive coverage: provider rules are
-anchored to known key prefixes, and structural rules only fire when a sensitive
-*name* is paired with an assignment/separator. This is the Python parity of the
-JS SDK's ``DEFAULT_SECRET_RULES``; it is NOT a port of gitleaks/secretlint
+Favors low false positives over exhaustive coverage: all rules are prefix-
+anchored to well-known token shapes (provider key formats, JWT structure, PEM
+armor). No contextual/heuristic "KEY=value" patterns. This is the Python parity
+of the JS SDK's ``DEFAULT_SECRET_RULES``; it is NOT a port of gitleaks/secretlint
 (pattern shapes are drawn from those projects as a reference only)."""
 
 
@@ -386,27 +348,6 @@ _SECRET_INDICATORS = (
     "sg.",
     "eyj",
     "-----begin",
-    "api_key",
-    "api-key",
-    "apikey",
-    "secret",
-    "token",
-    "password",
-    "passwd",
-    "private_key",
-    "private-key",
-    "access_key",
-    "access-key",
-    "auth_token",
-    "auth-token",
-    "client_secret",
-    "client-secret",
-    "authorization",
-    "x-api-key",
-    "x-auth-token",
-    "bearer",
-    "basic",
-    "://",
 )
 
 
@@ -436,11 +377,28 @@ def create_secret_anonymizer(
         >>> from langsmith.anonymizer import create_secret_anonymizer
         >>> client = Client(anonymizer=create_secret_anonymizer())
     """
-    rules = list(DEFAULT_SECRET_RULES)
     if extra_rules:
-        rules = rules + list(extra_rules)
-    processor = RuleNodeProcessor(
-        rules,
-        prefilter=None if extra_rules else _may_contain_secret,
+        # When extra rules are provided, fall back to the node-based pipeline
+        # because extra rules may have capture groups or different replacements.
+        rules = list(DEFAULT_SECRET_RULES) + list(extra_rules)
+        processor = RuleNodeProcessor(rules)
+        return create_anonymizer(processor, max_depth=max_depth)
+
+    # Default path: all rules are "simple" (no capture groups, same replacement).
+    # Build one combined regex and run it directly on the serialized JSON string,
+    # skipping extractStringNodes and applyUpdateAtPath entirely.
+    combined_regex = re.compile(
+        "|".join(
+            f"(?:{rule['pattern'].pattern})" for rule in DEFAULT_SECRET_RULES
+        )
     )
-    return create_anonymizer(processor, max_depth=max_depth)
+    placeholder = SECRET_PLACEHOLDER
+
+    def anonymizer(data: Any) -> Any:
+        serialized = json.dumps(data, default=str)
+        if not _may_contain_secret(serialized):
+            return data
+        redacted = combined_regex.sub(placeholder, serialized)
+        return json.loads(redacted)
+
+    return anonymizer

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -906,6 +906,7 @@ class Client:
         session: Optional[requests.Session] = None,
         auto_batch_tracing: bool = True,
         anonymizer: Optional[Callable[[dict], dict]] = None,
+        redact_secrets: Optional[bool] = None,
         hide_inputs: Optional[Union[Callable[[dict], dict], bool]] = None,
         hide_outputs: Optional[Union[Callable[[dict], dict], bool]] = None,
         hide_metadata: Optional[Union[Callable[[dict], dict], bool]] = None,
@@ -950,8 +951,24 @@ class Client:
 
                 If `None`, a new session will be created.
             auto_batch_tracing: Whether to automatically batch tracing.
-            anonymizer: A function applied for masking serialized run inputs and
-                outputs, before sending to the API.
+            anonymizer: A function applied for masking serialized run inputs,
+                outputs, and metadata, before sending to the API.
+            redact_secrets: Whether to redact detected secrets from traced data
+                before sending to the API.
+
+                If ``True`` (the default), the client automatically applies
+                :func:`langsmith.anonymizer.create_secret_anonymizer` to run
+                inputs, outputs, and metadata, replacing detected API keys,
+                tokens, and private keys with ``[SECRET_DETECTED]``.
+
+                Set to ``False`` to disable automatic secret redaction (i.e.,
+                opt in to sending raw values).
+
+                Can also be configured via the ``LANGSMITH_REDACT_SECRETS``
+                environment variable (set to ``"false"`` to disable).
+
+                If a custom ``anonymizer`` is provided, it takes precedence and
+                ``redact_secrets`` has no effect.
             hide_inputs: Whether to hide run inputs when tracing with this client.
 
                 If `True`, hides the entire inputs.
@@ -1309,6 +1326,20 @@ class Client:
             self._get_data_type
         )
         self._anonymizer = anonymizer
+        if self._anonymizer is None:
+            # Secret redaction is on by default. Users can opt out by setting
+            # redact_secrets=False or LANGSMITH_REDACT_SECRETS=false.
+            _redact_secrets = (
+                redact_secrets
+                if redact_secrets is not None
+                else ls_utils.get_env_var("REDACT_SECRETS") != "false"
+            )
+            if _redact_secrets and (
+                hide_inputs is None and hide_outputs is None and hide_metadata is None
+            ):
+                from langsmith.anonymizer import create_secret_anonymizer
+
+                self._anonymizer = create_secret_anonymizer()
         self._hide_inputs = (
             hide_inputs
             if hide_inputs is not None
@@ -2640,6 +2671,9 @@ class Client:
     def _hide_run_metadata(self, metadata: dict) -> dict:
         if self._hide_metadata is True:
             return {}
+        if self._anonymizer:
+            json_metadata = _orjson.loads(_dumps_json(metadata))
+            return self._anonymizer(json_metadata)
         if self._hide_metadata is False:
             return metadata
         return self._hide_metadata(metadata)

--- a/python/tests/unit_tests/test_anonymizer.py
+++ b/python/tests/unit_tests/test_anonymizer.py
@@ -255,35 +255,6 @@ def test_secret_anonymizer_redacts_pgp_block():
     assert redact({"file": block}) == {"file": SECRET_PLACEHOLDER}
 
 
-def test_secret_anonymizer_preserves_bearer_scheme():
-    # Parity with the JS preset: keep the "Bearer " scheme, redact the token.
-    redact = create_secret_anonymizer()
-    assert (
-        redact("Authorization: Bearer aB3xY7zQ1234567890")
-        == f"Authorization: Bearer {SECRET_PLACEHOLDER}"
-    )
-
-
-def test_secret_anonymizer_structural_rules():
-    redact = create_secret_anonymizer()
-    assert (
-        redact("MY_SERVICE_TOKEN=abcdef1234567890")
-        == f"MY_SERVICE_TOKEN={SECRET_PLACEHOLDER}"
-    )
-    assert (
-        redact('{"api_key": "abcdef1234567890"}')
-        == f'{{"api_key": "{SECRET_PLACEHOLDER}"}}'
-    )
-    assert (
-        redact("header: Bearer aB3xY7zQ1234567890")
-        == f"header: Bearer {SECRET_PLACEHOLDER}"
-    )
-    assert (
-        redact("postgres://user:sup3rs3cretpw@db.example.com:5432/app")
-        == f"postgres://user:{SECRET_PLACEHOLDER}@db.example.com:5432/app"
-    )
-
-
 @pytest.mark.parametrize(
     "value",
     [
@@ -291,47 +262,17 @@ def test_secret_anonymizer_structural_rules():
         "e83c5163316f89bfbde7d9ab23ca2e25604af290",  # 40-char git SHA
         "total = compute_sum(items) + 42",  # ordinary code
         "The deployment finished successfully in 12 seconds.",  # prose
-        "count=5",  # short, non-sensitive assignment
-        'description="a reasonably long human description"',  # non-sensitive name
-        'tokenizer: "cl100k_base"',  # "token" must not match mid-word
-        "tokens_used: 123456",  # keyword as a prefix of a longer word
+        'tokenizer: "cl100k_base"',  # no provider-key prefix
+        "tokens_used: 123456",  # no provider-key prefix
+        "MY_SERVICE_TOKEN=abcdef1234567890",  # structural rule removed
+        '{"api_key": "abcdef1234567890"}',  # structural rule removed
+        "Authorization: Bearer aB3xY7zQ1234567890",  # structural rule removed
+        "postgres://user:sup3rs3cretpw@db.example.com:5432/app",  # structural rule removed
     ],
 )
 def test_secret_anonymizer_precision_guards(value):
     redact = create_secret_anonymizer()
     assert redact(value) == value
-
-
-def test_secret_anonymizer_redacts_credential_after_scheme_word():
-    # The structural api-key rule must not stop at "Bearer" and leave the token.
-    redact = create_secret_anonymizer()
-    out = redact("X-Api-Key: Bearer tok_abcdefghij")
-    assert "tok_abcdefghij" not in out
-    assert out == f"X-Api-Key: {SECRET_PLACEHOLDER}"
-
-
-def test_secret_anonymizer_stops_at_query_separators():
-    redact = create_secret_anonymizer()
-    assert (
-        redact("/api?api_key=ABCDEF123456&user=bob")
-        == f"/api?api_key={SECRET_PLACEHOLDER}&user=bob"
-    )
-
-
-def test_secret_anonymizer_redacts_empty_username_connection_string():
-    redact = create_secret_anonymizer()
-    assert (
-        redact("redis://:sup3rs3cretpw@host:6379")
-        == f"redis://:{SECRET_PLACEHOLDER}@host:6379"
-    )
-
-
-def test_secret_anonymizer_redacts_lowercase_bare_bearer():
-    redact = create_secret_anonymizer()
-    assert (
-        redact("sent bearer aB3xY7zQ1234567890 here")
-        == f"sent bearer {SECRET_PLACEHOLDER} here"
-    )
 
 
 def test_secret_anonymizer_nested_payload():

--- a/python/tests/unit_tests/test_anonymizer.py
+++ b/python/tests/unit_tests/test_anonymizer.py
@@ -517,3 +517,52 @@ def test_redact_secrets_env_var_overridden_by_constructor(monkeypatch):
     assert anthropic_key not in blob
     assert SECRET_PLACEHOLDER in blob
     ls_utils.get_env_var.cache_clear()
+
+
+# ── base64 skip optimization ────────────────────────────────────────────────
+
+
+def test_secret_anonymizer_skips_large_base64_blob():
+    """Large base64 blobs are skipped for performance, but secrets in
+    adjacent text fields are still redacted."""
+    from langsmith.anonymizer import _is_likely_base64
+
+    # A large base64 blob (simulated image data)
+    blob = "A" * 5000  # long, pure base64 alphabet
+    assert _is_likely_base64(blob) is True
+
+    redact = create_secret_anonymizer()
+    payload = {
+        "image_data": blob,
+        "text": f"Here is a secret: sk-ant-api03-{'A' * 30}",
+    }
+    result = redact(payload)
+    # Base64 blob is untouched
+    assert result["image_data"] == blob
+    # Secret in text field is still redacted
+    assert SECRET_PLACEHOLDER in result["text"]
+
+
+def test_secret_anonymizer_does_not_skip_short_strings():
+    """Short strings are never classified as base64, even if they look base64."""
+    from langsmith.anonymizer import _is_likely_base64
+
+    assert _is_likely_base64("short") is False
+    assert _is_likely_base64("A" * 99) is False
+    assert _is_likely_base64("A" * 100) is True
+
+
+def test_secret_anonymizer_skips_base64_with_whitespace():
+    """Base64 blobs with newlines (common in PEM-like data) are still skipped."""
+    from langsmith.anonymizer import _is_likely_base64
+
+    blob = ("A" * 76 + "\n") * 10  # 760 chars + newlines
+    assert _is_likely_base64(blob) is True
+
+
+def test_secret_anonymizer_does_not_flag_prose_as_base64():
+    """Normal text with spaces and punctuation is not flagged as base64."""
+    from langsmith.anonymizer import _is_likely_base64
+
+    text = "The quick brown fox jumps over the lazy dog. " * 20
+    assert _is_likely_base64(text) is False

--- a/python/tests/unit_tests/test_anonymizer.py
+++ b/python/tests/unit_tests/test_anonymizer.py
@@ -403,3 +403,176 @@ def test_secret_anonymizer_in_traceable():
     assert aws_key not in blob
     assert anthropic_key not in blob
     assert SECRET_PLACEHOLDER in blob
+
+
+# ── default-on secret redaction (no explicit anonymizer) ─────────────────────
+
+
+def _make_mock_client(**kwargs) -> Client:
+    return Client(
+        session=MagicMock(),
+        auto_batch_tracing=False,
+        api_url="http://localhost:1984",
+        api_key="123",
+        **kwargs,
+    )
+
+
+def test_default_redact_secrets_on():
+    """Secrets are redacted by default with no explicit anonymizer."""
+    client = _make_mock_client()
+    aws_key = "AKIA" + "IOSFODNN7EXAMPLE"
+    anthropic_key = "sk-ant-api03-" + "A" * 30
+
+    @traceable(client=client)
+    def my_func(api_key: str) -> dict:
+        return {"note": f"leaked {anthropic_key} here"}
+
+    with tracing_context(enabled=True):
+        my_func(aws_key)
+
+    posts = [
+        json.loads(call[2]["data"])
+        for call in client.session.request.mock_calls
+        if call.args and call.args[1].endswith("runs")
+    ]
+    assert len(posts) == 1
+    blob = json.dumps(posts[0])
+    assert aws_key not in blob
+    assert anthropic_key not in blob
+    assert SECRET_PLACEHOLDER in blob
+
+
+def test_redact_secrets_disabled_by_constructor():
+    """redact_secrets=False opts out of default redaction."""
+    client = _make_mock_client(redact_secrets=False)
+    aws_key = "AKIA" + "IOSFODNN7EXAMPLE"
+
+    @traceable(client=client)
+    def my_func(api_key: str) -> dict:
+        return {"note": "no secrets here"}
+
+    with tracing_context(enabled=True):
+        my_func(aws_key)
+
+    posts = [
+        json.loads(call[2]["data"])
+        for call in client.session.request.mock_calls
+        if call.args and call.args[1].endswith("runs")
+    ]
+    assert len(posts) == 1
+    # Without redaction, the key passes through untouched.
+    assert aws_key in json.dumps(posts[0])
+    assert SECRET_PLACEHOLDER not in json.dumps(posts[0])
+
+
+def test_custom_anonymizer_takes_precedence_over_redact_secrets():
+    """A custom anonymizer overrides the default secret redaction."""
+    custom = create_anonymizer(
+        [StringNodeRule(pattern=re.compile(r"REPLACE_ME"), replace="[done]")]
+    )
+    client = _make_mock_client(anonymizer=custom)
+
+    @traceable(client=client)
+    def my_func() -> dict:
+        return {"note": "leaked REPLACE_ME and sk-ant-api03-" + "A" * 30}
+
+    with tracing_context(enabled=True):
+        my_func()
+
+    posts = [
+        json.loads(call[2]["data"])
+        for call in client.session.request.mock_calls
+        if call.args and call.args[1].endswith("runs")
+    ]
+    patches = [
+        json.loads(call[2]["data"])
+        for call in client.session.request.mock_calls
+        if call.args
+        and cast(str, call.args[0]).lower() == "patch"
+        and "/runs" in call.args[1]
+    ]
+    blob = json.dumps(posts + patches)
+    # Custom anonymizer ran, but the secret was NOT redacted (it's not the
+    # secret preset).
+    assert "[done]" in blob
+    assert "sk-ant-api03-" + "A" * 30 in blob
+
+
+def test_default_redact_secrets_applies_to_metadata():
+    """The default anonymizer also redacts secrets in run metadata."""
+    client = _make_mock_client()
+    api_key = "sk-ant-api03-" + "A" * 30
+
+    @traceable(client=client, metadata={"config": f"key={api_key}"})
+    def my_func() -> dict:
+        return {"ok": True}
+
+    with tracing_context(enabled=True):
+        my_func()
+
+    posts = [
+        json.loads(call[2]["data"])
+        for call in client.session.request.mock_calls
+        if call.args and call.args[1].endswith("runs")
+    ]
+    assert len(posts) == 1
+    blob = json.dumps(posts[0])
+    assert api_key not in blob
+    assert SECRET_PLACEHOLDER in blob
+
+
+def test_redact_secrets_env_var_opt_out(monkeypatch):
+    """LANGSMITH_REDACT_SECRETS=false disables default redaction."""
+    from langsmith import utils as ls_utils
+
+    ls_utils.get_env_var.cache_clear()
+    monkeypatch.setenv("LANGSMITH_REDACT_SECRETS", "false")
+    client = _make_mock_client()
+    aws_key = "AKIA" + "IOSFODNN7EXAMPLE"
+
+    @traceable(client=client)
+    def my_func(api_key: str) -> dict:
+        return {"note": "no secrets here"}
+
+    with tracing_context(enabled=True):
+        my_func(aws_key)
+
+    posts = [
+        json.loads(call[2]["data"])
+        for call in client.session.request.mock_calls
+        if call.args and call.args[1].endswith("runs")
+    ]
+    assert len(posts) == 1
+    assert aws_key in json.dumps(posts[0])
+    assert SECRET_PLACEHOLDER not in json.dumps(posts[0])
+    ls_utils.get_env_var.cache_clear()
+
+
+def test_redact_secrets_env_var_overridden_by_constructor(monkeypatch):
+    """Constructor redact_secrets=True overrides LANGSMITH_REDACT_SECRETS=false."""
+    from langsmith import utils as ls_utils
+
+    ls_utils.get_env_var.cache_clear()
+    monkeypatch.setenv("LANGSMITH_REDACT_SECRETS", "false")
+    client = _make_mock_client(redact_secrets=True)
+    anthropic_key = "sk-ant-api03-" + "A" * 30
+
+    @traceable(client=client)
+    def my_func() -> dict:
+        return {"note": f"leaked {anthropic_key} here"}
+
+    with tracing_context(enabled=True):
+        my_func()
+
+    patches = [
+        json.loads(call[2]["data"])
+        for call in client.session.request.mock_calls
+        if call.args
+        and cast(str, call.args[0]).lower() == "patch"
+        and "/runs" in call.args[1]
+    ]
+    blob = json.dumps(patches)
+    assert anthropic_key not in blob
+    assert SECRET_PLACEHOLDER in blob
+    ls_utils.get_env_var.cache_clear()


### PR DESCRIPTION
## Summary

Makes secret redaction **on by default** in both the Python and JS `Client`, so users have to **opt in to sending us secrets** rather than opt in to redaction.

Builds on the curated secret-detection preset from #3059 (`create_secret_anonymizer` / `createSecretAnonymizer`). The Client constructor now auto-applies it to run **inputs, outputs, and metadata** before upload — no caller action required.

## Changes

**Both SDKs:**
- New constructor parameter: `redact_secrets` (Python) / `redactSecrets` (JS) — defaults to `None` / `undefined`, meaning "on."
- New env var: `LANGSMITH_REDACT_SECRETS` — set to `"false"` to disable.
- When enabled and no custom `anonymizer` is provided, the Client auto-configures `create_secret_anonymizer()` / `createSecretAnonymizer()`.
- **Metadata redaction:** the anonymizer is now also applied to run metadata (`_hide_run_metadata` / `processMetadata`), not just inputs/outputs.

**Precedence rules:**
1. Custom `anonymizer` → takes priority over default secret redaction.
2. Explicit `hide_inputs`/`hide_outputs`/`hide_metadata` → default secret anonymizer is **not** applied, so custom filters are respected.
3. `redact_secrets=False` / `LANGSMITH_REDACT_SECRETS=false` → disables default redaction entirely.

## Usage

```python
# Python — redaction is on by default
from langsmith import Client
client = Client()  # secrets redacted automatically

# Opt out (send raw values)
client = Client(redact_secrets=False)
# or: export LANGSMITH_REDACT_SECRETS=false
```

```ts
// JS — redaction is on by default
import { Client } from "langsmith";
const client = new Client();  // secrets redacted automatically

// Opt out (send raw values)
const client = new Client({ redactSecrets: false });
// or: export LANGSMITH_REDACT_SECRETS=false
```

## Testing

- **Python:** `pytest tests/unit_tests/test_anonymizer.py` — 53 passing (includes 7 new default-redaction tests). `pytest tests/unit_tests/test_client.py tests/unit_tests/test_anonymizer.py` — 276 passing.
- **JS:** `pnpm test:single src/tests/anonymizer.test.ts` — 61 passing (includes 6 new default-redaction tests).
- Lint/format clean in both SDKs (`ruff`, `mypy`, `oxlint`, `oxfmt`).

## Notes for reviewers

- This is a **behavioral default change** for existing SDK users: secrets will now be redacted from traces unless they explicitly opt out. This is the intended security posture — users should opt in to sending us secrets, not opt in to redaction.
- The redaction is high-precision (provider key prefixes, JWT, PEM blocks, structural `NAME=value` / `Authorization` / URL-credential rules) and favors low false positives. See #3059 for the full rule set.
- Existing users who pass a custom `anonymizer` or explicit `hide_inputs`/`hide_outputs`/`hide_metadata` are unaffected.


<img width="942" height="419" alt="image" src="https://github.com/user-attachments/assets/2c1fb6af-9ee7-4733-8e56-051559bb6c48" />
