### PR TITLE
fix: resolve body[2] validation error caused by empty description in bug_report.yaml

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -24,7 +24,6 @@ body:
     id: runtime-language
     attributes:
       label: Language
-      description: ""
       options:
         - label: "Python"
         - label: "JavaScript/TypeScript"


### PR DESCRIPTION
## Problem
The `bug_report.yaml` issue template throws a validation error:
> body[2]: `description` must be of type String and cannot be empty

This is caused by `description: ""` (empty string) in the `runtime-language` checkboxes block.

## Fix
Removed the empty `description: ""` key from the `runtime-language` block.
GitHub's validation does not allow empty strings — the key must either have a value or be omitted entirely.

## Before & After
<img width="1329" height="676" alt="before-bug" src="https://github.com/user-attachments/assets/3570f5c6-9515-4cf8-bbea-38a5f0bc2b07" />

<img width="1505" height="699" alt="after-bug" src="https://github.com/user-attachments/assets/7919d350-e9b4-45a5-b088-f4e2e306e72e" />


## Reference
https://docs.github.com/communities/using-templates-to-encourage-useful-issues-and-pull-requests/common-validation-errors-when-creating-issue-forms