### PR TITLE
fix(python): allow-list fields accepted from baggage replica updates

### DIFF
--- a/python/langsmith/run_trees.py
+++ b/python/langsmith/run_trees.py
@@ -74,12 +74,61 @@ class WriteReplica(TypedDict, total=False):
 
 _HEADER_SAFE_REPLICA_FIELDS: frozenset[str] = frozenset({"project_name", "updates"})
 
+# Untrusted header-supplied replica `updates` is merged into the run, so restrict it
+# to a fail-closed allow-list. `reroot` (re-parenting control) is always kept;
+# `metadata`/`tags` are the default annotation fields, and everything else is dropped.
+_HEADER_REQUIRED_UPDATE_FIELDS: frozenset[str] = frozenset({"reroot"})
+_HEADER_SAFE_UPDATE_FIELDS_DEFAULT: frozenset[str] = frozenset(
+    {"reroot", "metadata", "tags"}
+)
+
+
+def _get_header_safe_update_fields() -> frozenset[str]:
+    """Allow-list of replica ``updates`` keys accepted from a ``baggage`` header.
+
+    Overridable via ``LANGSMITH_BAGGAGE_ALLOWED_UPDATE_FIELDS`` (comma-separated);
+    replaces the default ``{reroot, metadata, tags}`` but always keeps ``reroot``.
+    """
+    raw = utils.get_env_var("BAGGAGE_ALLOWED_UPDATE_FIELDS")
+    if raw is None:
+        return _HEADER_SAFE_UPDATE_FIELDS_DEFAULT
+    configured = {field.strip() for field in raw.split(",") if field.strip()}
+    return frozenset(_HEADER_REQUIRED_UPDATE_FIELDS | configured)
+
+
+def _sanitize_header_updates(updates: Any) -> Any:
+    """Filter untrusted header-supplied ``updates`` to the allow-list (fail closed).
+
+    Non-dict input passes through unchanged; dropped fields are logged, never raised.
+    """
+    if not isinstance(updates, dict):
+        return updates
+    allowed = _get_header_safe_update_fields()
+    sanitized = {key: value for key, value in updates.items() if key in allowed}
+    dropped = [key for key in updates if key not in allowed]
+    if dropped:
+        logger.warning(
+            "Ignored non-allow-listed field(s) %s in a distributed-tracing "
+            "`baggage` replica `updates` payload; they are dropped for security "
+            "reasons. If these come from a trusted upstream and are legitimate, "
+            "add them to the allow-list via the "
+            "LANGSMITH_BAGGAGE_ALLOWED_UPDATE_FIELDS environment variable "
+            "(comma-separated). Currently allowed: %s.",
+            sorted(dropped),
+            sorted(allowed),
+        )
+    return sanitized
+
 
 def _filter_replica_for_headers(replica: WriteReplica) -> WriteReplica:
-    return cast(
-        WriteReplica,
-        {k: v for k, v in replica.items() if k in _HEADER_SAFE_REPLICA_FIELDS},
-    )
+    filtered = {
+        key: value
+        for key, value in replica.items()
+        if key in _HEADER_SAFE_REPLICA_FIELDS
+    }
+    if "updates" in filtered:
+        filtered["updates"] = _sanitize_header_updates(filtered.get("updates"))
+    return cast(WriteReplica, filtered)
 
 
 LANGSMITH_PREFIX = "langsmith-"
@@ -1062,7 +1111,7 @@ class _Baggage:
                                 WriteReplica(
                                     api_url=None,
                                     project_name=str(replica_item[0]),
-                                    updates=replica_item[1],
+                                    updates=_sanitize_header_updates(replica_item[1]),
                                 )
                             )
                         elif isinstance(replica_item, dict):

--- a/python/tests/unit_tests/test_replica_endpoints.py
+++ b/python/tests/unit_tests/test_replica_endpoints.py
@@ -817,6 +817,18 @@ class TestRunTreeReplicas:
 class TestBaggageReplicaParsing:
     """Test baggage header parsing for replicas."""
 
+    @pytest.fixture(autouse=True)
+    def _allow_placeholder_update_fields(self, monkeypatch):
+        # These tests verify that replica `updates` is parsed/propagated, using
+        # placeholder keys. Allow those keys so the tests stay focused on parsing;
+        # the default allow-list and its enforcement are covered in test_run_trees.py.
+        monkeypatch.setenv(
+            "LANGSMITH_BAGGAGE_ALLOWED_UPDATE_FIELDS", "environment,tuple,env"
+        )
+        ls_utils.get_env_var.cache_clear()
+        yield
+        ls_utils.get_env_var.cache_clear()
+
     def test_baggage_parsing_tuple_format(self):
         """Test that baggage headers with tuple replica format are parsed correctly."""
         import json
@@ -1120,3 +1132,42 @@ class TestTracingContextReplicas:
         # This should not raise a type error
         with tracing_context(replicas=replicas):
             pass  # Just testing that the context manager works
+
+
+def test_baggage_parsing_uses_default_allowlist(monkeypatch):
+    """With no env override, header `updates` is filtered to the default allow-list.
+
+    The default allow-list is ``{reroot, metadata, tags}``; data/side-effecting
+    fields (`attachments`, `inputs`) and arbitrary keys (`environment`) are dropped.
+    """
+    import urllib.parse
+
+    from langsmith.run_trees import _Baggage
+
+    monkeypatch.delenv("LANGSMITH_BAGGAGE_ALLOWED_UPDATE_FIELDS", raising=False)
+    monkeypatch.delenv("LANGCHAIN_BAGGAGE_ALLOWED_UPDATE_FIELDS", raising=False)
+    ls_utils.get_env_var.cache_clear()
+    try:
+        replicas = [
+            {
+                "project_name": "replica-project",
+                "updates": {
+                    "reroot": True,
+                    "metadata": {"k": "v"},
+                    "tags": ["a"],
+                    "attachments": {"doc": ["text/plain", "notes.txt"]},
+                    "inputs": {"x": 1},
+                    "environment": "prod",
+                },
+            }
+        ]
+        baggage_value = f"langsmith-replicas={urllib.parse.quote(json.dumps(replicas))}"
+        baggage = _Baggage.from_header(baggage_value)
+
+        assert baggage.replicas[0]["updates"] == {
+            "reroot": True,
+            "metadata": {"k": "v"},
+            "tags": ["a"],
+        }
+    finally:
+        ls_utils.get_env_var.cache_clear()

--- a/python/tests/unit_tests/test_replica_endpoints.py
+++ b/python/tests/unit_tests/test_replica_endpoints.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import urllib.parse
 import uuid
 from unittest.mock import Mock, patch
 
@@ -15,6 +16,7 @@ from langsmith.run_trees import (
     RunTree,
     ServiceAuth,
     WriteReplica,
+    _Baggage,
     _ensure_write_replicas,
     _extract_replica_auth,
     _get_write_replicas_from_env,
@@ -1140,10 +1142,6 @@ def test_baggage_parsing_uses_default_allowlist(monkeypatch):
     The default allow-list is ``{reroot, metadata, tags}``; data/side-effecting
     fields (`attachments`, `inputs`) and arbitrary keys (`environment`) are dropped.
     """
-    import urllib.parse
-
-    from langsmith.run_trees import _Baggage
-
     monkeypatch.delenv("LANGSMITH_BAGGAGE_ALLOWED_UPDATE_FIELDS", raising=False)
     monkeypatch.delenv("LANGCHAIN_BAGGAGE_ALLOWED_UPDATE_FIELDS", raising=False)
     ls_utils.get_env_var.cache_clear()

--- a/python/tests/unit_tests/test_run_trees.py
+++ b/python/tests/unit_tests/test_run_trees.py
@@ -1,5 +1,6 @@
 import io
 import json
+import logging
 import time
 import urllib.parse
 from concurrent.futures import ThreadPoolExecutor
@@ -550,6 +551,108 @@ def test_from_headers_filters_replica_credentials():
     assert "api_url" not in replica
     assert replica.get("project_name") == "legit-project"
     assert replica.get("updates") == {"reroot": True}
+
+
+def test_from_headers_allowlists_update_fields():
+    """Only allow-listed fields survive in an untrusted baggage replica's `updates`."""
+    replicas_json = json.dumps(
+        [
+            {
+                "project_name": "legit-project",
+                "updates": {
+                    "reroot": True,
+                    "metadata": {"k": "v"},
+                    "tags": ["a"],
+                    "attachments": {"doc": ["text/plain", "notes.txt"]},
+                    "inputs": {"x": 1},
+                    "environment": "prod",
+                },
+            }
+        ]
+    )
+    baggage = f"langsmith-replicas={urllib.parse.quote(replicas_json)}"
+    headers = {
+        "langsmith-trace": "20240101T000000000000Z00000000-0000-0000-0000-000000000001",
+        "baggage": baggage,
+    }
+
+    parsed = RunTree.from_headers(headers)
+
+    assert parsed is not None
+    assert parsed.replicas is not None
+    assert parsed.replicas[0].get("updates") == {
+        "reroot": True,
+        "metadata": {"k": "v"},
+        "tags": ["a"],
+    }
+
+
+def test_from_headers_allowlists_update_fields_legacy_format():
+    """The legacy [project_name, updates] baggage form is also allow-listed."""
+    replicas_json = json.dumps(
+        [
+            [
+                "legit-project",
+                {
+                    "reroot": True,
+                    "metadata": {"k": "v"},
+                    "attachments": {"doc": ["text/plain", "notes.txt"]},
+                    "environment": "prod",
+                },
+            ]
+        ]
+    )
+    baggage = f"langsmith-replicas={urllib.parse.quote(replicas_json)}"
+    headers = {
+        "langsmith-trace": "20240101T000000000000Z00000000-0000-0000-0000-000000000001",
+        "baggage": baggage,
+    }
+
+    parsed = RunTree.from_headers(headers)
+
+    assert parsed is not None
+    assert parsed.replicas is not None
+    updates = parsed.replicas[0].get("updates")
+    assert "attachments" not in updates
+    assert updates == {"reroot": True, "metadata": {"k": "v"}}
+
+
+def test_sanitize_header_updates_env_override_keeps_reroot(monkeypatch):
+    """The allow-list can be overridden via env var; `reroot` is always kept."""
+    monkeypatch.setenv("LANGSMITH_BAGGAGE_ALLOWED_UPDATE_FIELDS", "environment")
+    run_trees.utils.get_env_var.cache_clear()
+    try:
+        result = run_trees._sanitize_header_updates(
+            {"reroot": True, "environment": "prod", "metadata": {"k": "v"}}
+        )
+        # `environment` now allowed, `reroot` always kept, default `metadata` dropped.
+        assert result == {"reroot": True, "environment": "prod"}
+    finally:
+        run_trees.utils.get_env_var.cache_clear()
+
+
+def test_sanitize_header_updates_warns_on_dropped_fields(caplog):
+    """Dropping a non-allow-listed field logs one actionable warning."""
+    run_trees.utils.get_env_var.cache_clear()
+    with caplog.at_level(logging.WARNING, logger="langsmith.run_trees"):
+        run_trees._sanitize_header_updates(
+            {"reroot": True, "attachments": {"doc": ["text/plain", "notes.txt"]}}
+        )
+    assert len(caplog.records) == 1
+    message = caplog.records[0].getMessage()
+    assert "attachments" in message
+    assert "LANGSMITH_BAGGAGE_ALLOWED_UPDATE_FIELDS" in message
+
+    caplog.clear()
+    with caplog.at_level(logging.WARNING, logger="langsmith.run_trees"):
+        run_trees._sanitize_header_updates({"reroot": True, "metadata": {"k": "v"}})
+    assert caplog.records == []
+
+
+def test_sanitize_header_updates_passes_through_non_dict():
+    """Non-dict `updates` is returned unchanged (defensive)."""
+    assert run_trees._sanitize_header_updates(None) is None
+    assert run_trees._sanitize_header_updates("nope") == "nope"
 
 
 # Tests for regression: RunTree should accept Pydantic BaseModel for inputs/outputs


### PR DESCRIPTION
## Summary

- Restrict header-supplied `baggage` replica `updates` to a fail-closed allow-list.
  Previously, any field in a distributed-tracing `baggage` header's `updates` dict
  was merged directly into the run without filtering.
- Default allow-list: `{reroot, metadata, tags}`. `reroot` is always required for
  distributed re-parenting; `metadata`/`tags` are benign annotation fields.
- Configurable via `LANGSMITH_BAGGAGE_ALLOWED_UPDATE_FIELDS` (comma-separated);
  replaces the default but `reroot` is always kept.
- Dropped fields emit an actionable warning naming the field and the env var — never
  raised, so unexpected fields don't break tracing.

## Potential breaking change

Customers relying on arbitrary fields in a `baggage` replica `updates` payload will have those fields silently dropped after this change.
They can restore prior behavior by setting `LANGSMITH_BAGGAGE_ALLOWED_UPDATE_FIELDS` to a comma-separated list of the fields they need. We accept this trade-off to improve security. 