### PR TITLE
chore: js to 0.7.11

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langsmith",
-  "version": "0.7.10",
+  "version": "0.7.11",
   "description": "Client library to connect to the LangSmith Observability and Evaluation Platform.",
   "packageManager": "pnpm@10.33.0",
   "files": [

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -34,7 +34,7 @@ export {
 } from "./utils/prompt_cache/index.js";
 
 // Update using pnpm bump-version
-export const __version__ = "0.7.10";
+export const __version__ = "0.7.11";
 
 // Metadata key to hide a traced run from LangSmith's Messages View.
 export const LS_MESSAGE_VIEW_EXCLUDE = "ls_message_view_exclude" as const;


### PR DESCRIPTION
Release bump to publish the curated secret-detection anonymizer preset (`createSecretAnonymizer` / `DEFAULT_SECRET_RULES`) on the JS SDK:

JS -> 0.7.11

Python already shipped the preset in 0.9.0, so only JS needs a release here.

release #3059