### PR TITLE
fix(python): declare missing runtime deps for _openapi_client

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,24 @@ jobs:
         run: make tests
         shell: bash
 
+  python-wheel-test:
+    name: "Python Wheel Test (strict deps)"
+    needs: changes
+    if: needs.changes.outputs.python == 'true'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: python
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - name: Install uv
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        with:
+          python-version: "3.11"
+          enable-cache: true
+      - name: Check declared runtime deps are sufficient
+        run: make test-wheel-imports
+
   # ============================================================================
   # JS CI
   # ============================================================================
@@ -645,6 +663,7 @@ jobs:
       # Python
       - python-lint
       - python-test
+      - python-wheel-test
       # JS
       - js-format
       - js-lint

--- a/python/Makefile
+++ b/python/Makefile
@@ -1,4 +1,4 @@
-.PHONY: tests lint format build publish doctest integration_tests integration_tests_fast evals benchmark benchmark-fast
+.PHONY: tests lint format build publish doctest integration_tests integration_tests_fast evals benchmark benchmark-fast test-wheel-imports
 
 
 OUTPUT ?= out/benchmark.json
@@ -67,6 +67,17 @@ build:
 
 publish:
 	uv publish --dry-run
+
+test-wheel-imports:
+	uv build --no-sources
+	uv run python3 -c "import tomllib; f=open('pyproject.toml','rb'); d=tomllib.load(f); f.close(); print('\n'.join(d['project']['dependencies']))" > /tmp/langsmith-declared-deps.txt
+	uv venv /tmp/langsmith-strict-test
+	uv pip install dist/langsmith-*.whl --no-deps --python /tmp/langsmith-strict-test
+	uv pip install -r /tmp/langsmith-declared-deps.txt --python /tmp/langsmith-strict-test
+	/tmp/langsmith-strict-test/bin/python -c "\
+from langsmith._openapi_client import Langsmith; \
+from langsmith.client import Client"
+	rm -rf /tmp/langsmith-strict-test /tmp/langsmith-declared-deps.txt
 
 api_docs_build:
 	uv run python docs/create_api_rst.py

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -34,6 +34,10 @@ dependencies = [
     "uuid-utils>=0.12.0,<1.0",
     "xxhash>=3.0.0",
     "websockets>=15.0",
+    "anyio>=3.5.0",
+    "distro>=1.7.0",
+    "sniffio>=1.1",
+    "typing_extensions>=4.0.0",
 ]
 
 [project.urls]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -34,6 +34,8 @@ dependencies = [
     "uuid-utils>=0.12.0,<1.0",
     "xxhash>=3.0.0",
     "websockets>=15.0",
+    # Imported at runtime by the generated _openapi_client; must be declared
+    # explicitly so distro builds that only install Requires-Dist don't fail.
     "anyio>=3.5.0",
     "distro>=1.7.0",
     "sniffio>=1.1",


### PR DESCRIPTION
## Description

`langsmith._openapi_client` imports `anyio`, `distro`, `sniffio`, and `typing_extensions` at runtime, but none of these packages were declared in `[project] dependencies` / wheel `Requires-Dist`. In distro build environments that only install declared dependencies (rather than following transitive deps), importing `langsmith._openapi_client` fails at import time.

`typing_extensions` is also used in several non-generated `langsmith` modules (`client.py`, `run_helpers.py`, `schemas.py`, `utils.py`, etc.) so its absence is even broader.

Changes:
- Add `anyio>=3.5.0` — used in `_base_client.py`, `_resource.py`, `_response.py`, `_files.py`, `_utils/_sync.py`, `_utils/_transform.py`
- Add `distro>=1.7.0` — used in `_base_client.py` for platform identification
- Add `sniffio>=1.1` — used in `_utils/_sync.py` for async library detection
- Add `typing_extensions>=4.0.0` — used throughout `_openapi_client` and core `langsmith` modules

Closes LSDK-242

## Self-Hosted Release Note
none

## Test Plan
- [x] Verify install in a strict distro build environment that only installs declared deps