### PR TITLE
perf(anonymizer): skip base64 blobs in createSecretAnonymizer

### DIFF
--- a/js/src/anonymizer/index.ts
+++ b/js/src/anonymizer/index.ts
@@ -308,6 +308,14 @@ export const DEFAULT_SECRET_RULES: StringNodeRule[] = [
  *   `createAnonymizer`'s default of 10 because traced payloads nest deeply,
  *   e.g. `messages[].content[].args`).
  *
+ * Strings that are wholly base64 (image/PDF/binary blobs) or `data:` URIs are
+ * skipped before the rules run — scanning a multi-MB blob with every rule is
+ * wasted CPU and risks matching random base64 substrings (corrupting it). The
+ * base64 check uses the STANDARD alphabet (A-Za-z0-9+/) only, NOT base64url, so
+ * `-`/`_`-bearing provider keys (sk-ant-, lsv2_, ghp_, glpat-) and dotted JWTs
+ * still scan. Consequence: a *standalone* pure-base64 value (e.g. a bare AWS
+ * key) isn't redacted, but the same key in context (`AWS_ACCESS_KEY_ID=…`) is.
+ *
  * @example
  * ```ts
  * import { Client } from "langsmith";
@@ -321,5 +329,24 @@ export function createSecretAnonymizer(options?: {
   maxDepth?: number;
 }) {
   const rules = [...DEFAULT_SECRET_RULES, ...(options?.extraRules ?? [])];
-  return createAnonymizer(rules, { maxDepth: options?.maxDepth ?? 24 });
+  const compiled: Array<[RegExp, string]> = rules.map(
+    ({ pattern, replace }) => [
+      typeof pattern === "string" ? new RegExp(pattern, "g") : pattern,
+      replace ?? "[redacted]",
+    ],
+  );
+
+  const redactString = (value: string): string => {
+    // Skip base64 blobs: a `data:` URI, or any wholly-base64 string.
+    if (/^\s*data:/i.test(value.slice(0, 16))) return value;
+    if (/^[A-Za-z0-9+/\r\n]+={0,2}$/.test(value)) return value;
+    let out = value;
+    for (const [regex, replace] of compiled) {
+      out = out.replace(regex, replace);
+      regex.lastIndex = 0;
+    }
+    return out;
+  };
+
+  return createAnonymizer(redactString, { maxDepth: options?.maxDepth ?? 24 });
 }

--- a/js/src/tests/anonymizer.test.ts
+++ b/js/src/tests/anonymizer.test.ts
@@ -385,6 +385,34 @@ describe("createSecretAnonymizer", () => {
     );
   });
 
+  describe("base64 skip", () => {
+    test("skips any wholly-base64 string (blob or bare pure-base64 key)", () => {
+      // Deliberate: a wholly-base64 value is treated as a blob and skipped, so
+      // a standalone pure-base64 secret (e.g. a bare AWS key) is NOT redacted.
+      expect(redact("AKIAIOSFODNN7EXAMPLE")).toBe("AKIAIOSFODNN7EXAMPLE");
+      const png =
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJ" + "A".repeat(40);
+      expect(redact(png)).toBe(png);
+    });
+
+    test("skips data: URI blobs", () => {
+      const blob = `data:image/png;base64,AKIAIOSFODNN7EXAMPLE${"A".repeat(60)}`;
+      expect(redact(blob)).toBe(blob);
+    });
+
+    test("still redacts a pure-base64 key when it appears in context", () => {
+      // The same AWS key in an assignment isn't wholly base64 → still scanned.
+      const out = redact("AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE") as string;
+      expect(out).toContain(SECRET_PLACEHOLDER);
+      expect(out).not.toContain("AKIAIOSFODNN7EXAMPLE");
+    });
+
+    test("still scans non-base64 strings (separators/dots/spaces present)", () => {
+      // sk-ant- (dash), JWT (dots) are not wholly base64 → still redacted.
+      expect(redact(`sk-ant-${"a".repeat(30)}`)).toContain(SECRET_PLACEHOLDER);
+    });
+  });
+
   test("DEFAULT_SECRET_RULES all set an explicit replacement token", () => {
     for (const rule of DEFAULT_SECRET_RULES) {
       expect(rule.replace).toContain(SECRET_PLACEHOLDER);
@@ -402,7 +430,7 @@ describe("createSecretAnonymizer", () => {
       { client, name: "fn", tracingEnabled: true },
     );
 
-    await fn({ apiKey: "AKIAIOSFODNN7EXAMPLE" });
+    await fn({ command: `export ANTHROPIC_API_KEY=sk-ant-${"a".repeat(30)}` });
 
     const tree = await getAssumedTreeFromCalls(callSpy.mock.calls, client);
     const data = tree.data["fn:0"] as {
@@ -410,7 +438,7 @@ describe("createSecretAnonymizer", () => {
       outputs: Record<string, unknown>;
     };
     expect(JSON.stringify(data.inputs)).toContain(SECRET_PLACEHOLDER);
-    expect(JSON.stringify(data.inputs)).not.toContain("AKIAIOSFODNN7EXAMPLE");
+    expect(JSON.stringify(data.inputs)).not.toContain("sk-ant-");
     expect(JSON.stringify(data.outputs)).toContain(SECRET_PLACEHOLDER);
   });
 });

--- a/python/langsmith/anonymizer.py
+++ b/python/langsmith/anonymizer.py
@@ -349,6 +349,15 @@ def create_secret_anonymizer(
     Pass the result to ``Client(anonymizer=...)`` to redact detected secrets
     from run inputs, outputs, and metadata client-side, before upload.
 
+    Strings that are wholly base64 (image/PDF/binary blobs) or ``data:`` URIs
+    are skipped before the rules run — scanning a multi-MB blob with every rule
+    is wasted CPU and risks matching random base64 substrings (corrupting it).
+    The base64 check uses the STANDARD alphabet (A-Za-z0-9+/) only, NOT
+    base64url, so ``-``/``_``-bearing provider keys (sk-ant-, lsv2_, ghp_,
+    glpat-) and dotted JWTs still scan. Consequence: a standalone pure-base64
+    value (e.g. a bare AWS key) isn't redacted, but the same key in context
+    (``AWS_ACCESS_KEY_ID=...``) is.
+
     Args:
         extra_rules: Additional rules appended after the defaults.
         max_depth: Max recursion depth (default 24; higher than
@@ -363,4 +372,27 @@ def create_secret_anonymizer(
     rules = list(DEFAULT_SECRET_RULES)
     if extra_rules:
         rules = rules + list(extra_rules)
-    return create_anonymizer(rules, max_depth=max_depth)
+    compiled = [
+        (
+            rule["pattern"]
+            if isinstance(rule["pattern"], re.Pattern)
+            else re.compile(rule["pattern"]),
+            rule["replace"] if isinstance(rule.get("replace"), str) else "[redacted]",
+        )
+        for rule in rules
+    ]
+    data_uri = re.compile(r"^\s*data:", re.IGNORECASE)
+    # Standard base64 alphabet only (not base64url) so `-`/`_` provider keys and
+    # dotted JWTs still scan; only wholly-base64 values are skipped.
+    base64_re = re.compile(r"[A-Za-z0-9+/\r\n]+={0,2}")
+
+    def redact_string(value: str, _path: list[Union[str, int]]) -> str:
+        # Skip base64 blobs: a data: URI, or any wholly-base64 string.
+        if data_uri.match(value[:16]) or base64_re.fullmatch(value):
+            return value
+        out = value
+        for pattern, replace in compiled:
+            out = pattern.sub(replace, out)
+        return out
+
+    return create_anonymizer(redact_string, max_depth=max_depth)

--- a/python/tests/unit_tests/test_anonymizer.py
+++ b/python/tests/unit_tests/test_anonymizer.py
@@ -383,15 +383,15 @@ def test_secret_anonymizer_in_traceable():
         api_key="123",
     )
 
-    aws_key = "AKIA" + "IOSFODNN7EXAMPLE"
     anthropic_key = "sk-ant-api03-" + "A" * 30
 
     @traceable(client=mock_client)
-    def my_func(api_key: str) -> dict:
+    def my_func(command: str) -> dict:
         return {"note": f"leaked {anthropic_key} here"}
 
     with tracing_context(enabled=True):
-        my_func(aws_key)
+        # In-context secret (assignment) so the string isn't wholly base64.
+        my_func("export ANTHROPIC_API_KEY=" + anthropic_key)
 
     posts = [
         json.loads(call[2]["data"])
@@ -400,6 +400,20 @@ def test_secret_anonymizer_in_traceable():
     ]
     assert len(posts) == 1
     blob = json.dumps(posts[0])
-    assert aws_key not in blob
-    assert anthropic_key not in blob
+    assert anthropic_key not in blob  # redacted in both input and output
     assert SECRET_PLACEHOLDER in blob
+
+
+def test_secret_anonymizer_skips_any_base64_string():
+    # Deliberate: a wholly-base64 value is treated as a blob and skipped, so a
+    # standalone pure-base64 secret (e.g. a bare AWS key) is NOT redacted.
+    redact = create_secret_anonymizer()
+    assert redact("AKIAIOSFODNN7EXAMPLE") == "AKIAIOSFODNN7EXAMPLE"
+    png = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJ" + "A" * 40
+    assert redact(png) == png
+    blob = "data:image/png;base64,AKIAIOSFODNN7EXAMPLE" + "A" * 60
+    assert redact(blob) == blob
+    # The same key in context isn't wholly base64 → still redacted.
+    out = redact("AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE")
+    assert SECRET_PLACEHOLDER in out
+    assert "AKIAIOSFODNN7EXAMPLE" not in out


### PR DESCRIPTION
## Summary

Skips base64 blobs in `createSecretAnonymizer` so the preset doesn't scan binary payloads. Before the rules run, a string is skipped if it's a `data:` URI or **wholly base64** (standard alphabet). Scanning a multi-MB base64 value (e.g. a screenshot in a tool result) with every rule is wasted CPU — ~50 ms (JS) / ~350 ms (Python) to find zero secrets — and risks matching random base64 substrings and corrupting the blob.

## Scope / deliberate tradeoff

- The base64 check uses the **standard alphabet (`A-Za-z0-9+/`) only — not base64url**, so `-`/`_`-bearing provider keys (`sk-ant-`, `lsv2_`, `ghp_`, `glpat-`) and dotted tokens (JWTs) are **not** wholly base64 and still get scanned.
- Consequence: a **standalone** pure-base64 value (e.g. a bare `AKIA…` AWS key) is no longer redacted, but the **same key in context** (`AWS_ACCESS_KEY_ID=AKIA…`) still is — that string isn't wholly base64.

## Changes

- `js/src/anonymizer/index.ts`, `python/langsmith/anonymizer.py` — `createSecretAnonymizer` / `create_secret_anonymizer` short-circuit `data:` URIs and wholly-base64 strings before applying rules.
- Tests for both: base64 blob / bare-key skipped, `data:` skipped, in-context key still redacted, non-base64 strings still scanned.

## Testing

- JS: `yarn jest src/tests/anonymizer.test.ts` — 59 pass.
- Python: `pytest tests/unit_tests/test_anonymizer.py` — 48 pass. (ruff + mypy clean.)

## Note

This rides on top of the already-released preset, so it needs a version bump to publish (JS `0.7.x`, Python `0.9.x`) — handled separately at release time.
