### PR TITLE
fix: wrap flat prompt pushes so overview shows correct evaluator details

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langsmith",
-  "version": "0.7.10",
+  "version": "0.7.11",
   "description": "Client library to connect to the LangSmith Observability and Evaluation Platform.",
   "packageManager": "pnpm@10.33.0",
   "files": [

--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -111,6 +111,7 @@ import {
   hasLargeString,
   SerializeWorker,
 } from "./utils/serialize_worker.js";
+import { wrapManifestForHubPush } from "./utils/hub_manifest.js";
 
 function assertPullPublicPromptAllowed(
   promptIdentifier: string,
@@ -6243,7 +6244,9 @@ export class Client implements LangSmithTracingClientInterface {
         : options?.parentCommitHash;
 
     const payload = {
-      manifest: JSON.parse(JSON.stringify(object)),
+      manifest: wrapManifestForHubPush(
+        JSON.parse(JSON.stringify(object)) as Record<string, unknown>,
+      ),
       parent_commit: resolvedParentCommitHash,
       ...(options?.description !== undefined && {
         description: options.description,

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -34,7 +34,7 @@ export {
 } from "./utils/prompt_cache/index.js";
 
 // Update using pnpm bump-version
-export const __version__ = "0.7.10";
+export const __version__ = "0.7.11";
 
 // Metadata key to hide a traced run from LangSmith's Messages View.
 export const LS_MESSAGE_VIEW_EXCLUDE = "ls_message_view_exclude" as const;

--- a/js/src/tests/client.test.ts
+++ b/js/src/tests/client.test.ts
@@ -751,53 +751,6 @@ describe("Client", () => {
       expect(parsed.description).toBe("initial prompt version");
     });
 
-    it("should wrap flat StructuredPrompt manifests for Hub commits", async () => {
-      const client = new Client({ apiKey: "test-api-key" });
-      const flatStructuredPrompt = {
-        lc: 1,
-        type: "constructor",
-        id: ["langchain_core", "prompts", "structured", "StructuredPrompt"],
-        kwargs: {
-          input_variables: ["input"],
-          messages: [],
-          schema_: {
-            type: "object",
-            properties: { score: { type: "boolean" } },
-          },
-        },
-      };
-
-      jest.spyOn(client as any, "promptExists").mockResolvedValue(true);
-      jest
-        .spyOn(client as any, "_getLatestCommitHash")
-        .mockResolvedValue("parent123");
-      jest.spyOn(client as any, "_fetch").mockResolvedValue({
-        ok: true,
-        status: 200,
-        json: async () => ({ commit: { commit_hash: "new123", id: "1" } }),
-        text: async () => "",
-        headers: new Headers(),
-      });
-      jest
-        .spyOn(client as any, "_getPromptUrl")
-        .mockReturnValue("https://smith.langchain.com/prompts/test");
-
-      const fetchSpy = jest.spyOn(client as any, "_fetch");
-
-      await client.createCommit("owner/my-prompt", flatStructuredPrompt);
-
-      const fetchCall = fetchSpy.mock.calls[0];
-      const capturedBody = (fetchCall[1] as Record<string, unknown>)
-        ?.body as string;
-      const parsed = JSON.parse(capturedBody);
-      expect(parsed.manifest.id).toEqual([
-        "langsmith",
-        "playground",
-        "PromptPlayground",
-      ]);
-      expect(parsed.manifest.kwargs.first).toEqual(flatStructuredPrompt);
-    });
-
     it("should omit description from request body when not provided", async () => {
       const client = new Client({ apiKey: "test-api-key" });
 

--- a/js/src/tests/client.test.ts
+++ b/js/src/tests/client.test.ts
@@ -734,7 +734,6 @@ describe("Client", () => {
         .spyOn(client as any, "_getPromptUrl")
         .mockReturnValue("https://smith.langchain.com/prompts/test");
 
-      // Capture the fetch call body
       const fetchSpy = jest.spyOn(client as any, "_fetch");
 
       await client.createCommit(
@@ -750,6 +749,53 @@ describe("Client", () => {
         ?.body as string;
       const parsed = JSON.parse(capturedBody);
       expect(parsed.description).toBe("initial prompt version");
+    });
+
+    it("should wrap flat StructuredPrompt manifests for Hub commits", async () => {
+      const client = new Client({ apiKey: "test-api-key" });
+      const flatStructuredPrompt = {
+        lc: 1,
+        type: "constructor",
+        id: ["langchain_core", "prompts", "structured", "StructuredPrompt"],
+        kwargs: {
+          input_variables: ["input"],
+          messages: [],
+          schema_: {
+            type: "object",
+            properties: { score: { type: "boolean" } },
+          },
+        },
+      };
+
+      jest.spyOn(client as any, "promptExists").mockResolvedValue(true);
+      jest
+        .spyOn(client as any, "_getLatestCommitHash")
+        .mockResolvedValue("parent123");
+      jest.spyOn(client as any, "_fetch").mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ commit: { commit_hash: "new123", id: "1" } }),
+        text: async () => "",
+        headers: new Headers(),
+      });
+      jest
+        .spyOn(client as any, "_getPromptUrl")
+        .mockReturnValue("https://smith.langchain.com/prompts/test");
+
+      const fetchSpy = jest.spyOn(client as any, "_fetch");
+
+      await client.createCommit("owner/my-prompt", flatStructuredPrompt);
+
+      const fetchCall = fetchSpy.mock.calls[0];
+      const capturedBody = (fetchCall[1] as Record<string, unknown>)
+        ?.body as string;
+      const parsed = JSON.parse(capturedBody);
+      expect(parsed.manifest.id).toEqual([
+        "langsmith",
+        "playground",
+        "PromptPlayground",
+      ]);
+      expect(parsed.manifest.kwargs.first).toEqual(flatStructuredPrompt);
     });
 
     it("should omit description from request body when not provided", async () => {

--- a/js/src/tests/hub_manifest.test.ts
+++ b/js/src/tests/hub_manifest.test.ts
@@ -1,54 +1,48 @@
 import { describe, expect, it } from "@jest/globals";
 
-import {
-  defaultHubModelManifest,
-  wrapManifestForHubPush,
-} from "../utils/hub_manifest.js";
+import { wrapManifestForHubPush } from "../utils/hub_manifest.js";
+
+const FLAT_STRUCTURED_PROMPT = {
+  lc: 1,
+  type: "constructor",
+  id: ["langchain_core", "prompts", "structured", "StructuredPrompt"],
+  kwargs: {
+    input_variables: ["input"],
+    messages: [],
+    schema_: {
+      type: "object",
+      properties: { score: { type: "boolean" } },
+    },
+  },
+};
 
 describe("wrapManifestForHubPush", () => {
   it("wraps flat StructuredPrompt manifests", () => {
-    const flat = {
-      lc: 1,
-      type: "constructor",
-      id: ["langchain_core", "prompts", "structured", "StructuredPrompt"],
-      kwargs: {
-        input_variables: ["input"],
-        messages: [],
-        schema_: {
-          type: "object",
-          properties: { score: { type: "boolean" } },
-        },
-      },
-    };
-
-    const wrapped = wrapManifestForHubPush(flat);
+    const wrapped = wrapManifestForHubPush(FLAT_STRUCTURED_PROMPT);
 
     expect(wrapped.id).toEqual(["langsmith", "playground", "PromptPlayground"]);
-    expect((wrapped as { kwargs: { first: unknown } }).kwargs.first).toBe(flat);
-    expect(defaultHubModelManifest().id).toEqual([
-      "langchain",
-      "schema",
-      "runnable",
-      "RunnableBinding",
-    ]);
+    expect((wrapped as { kwargs: { first: unknown } }).kwargs.first).toBe(
+      FLAT_STRUCTURED_PROMPT,
+    );
+    expect((wrapped as { kwargs: { last: { id: string[] } } }).kwargs.last.id).toEqual(
+      ["langchain", "schema", "runnable", "RunnableBinding"],
+    );
   });
 
-  it("leaves PromptPlayground manifests unchanged", () => {
-    const manifest = {
-      lc: 1,
-      type: "constructor",
+  it.each([
+    {
       id: ["langsmith", "playground", "PromptPlayground"],
-      kwargs: { first: { id: ["prompt"] }, last: { id: ["model"] } },
-    };
-
-    expect(wrapManifestForHubPush(manifest)).toBe(manifest);
-  });
-
-  it("leaves RunnableSequence manifests unchanged", () => {
+      label: "PromptPlayground",
+    },
+    {
+      id: ["langchain", "schema", "runnable", "RunnableSequence"],
+      label: "RunnableSequence",
+    },
+  ])("leaves $label manifests unchanged", ({ id }) => {
     const manifest = {
       lc: 1,
       type: "constructor",
-      id: ["langchain", "schema", "runnable", "RunnableSequence"],
+      id,
       kwargs: { first: { id: ["prompt"] }, last: { id: ["model"] } },
     };
 

--- a/js/src/tests/hub_manifest.test.ts
+++ b/js/src/tests/hub_manifest.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "@jest/globals";
+
+import {
+  defaultHubModelManifest,
+  wrapManifestForHubPush,
+} from "../utils/hub_manifest.js";
+
+describe("wrapManifestForHubPush", () => {
+  it("wraps flat StructuredPrompt manifests", () => {
+    const flat = {
+      lc: 1,
+      type: "constructor",
+      id: ["langchain_core", "prompts", "structured", "StructuredPrompt"],
+      kwargs: {
+        input_variables: ["input"],
+        messages: [],
+        schema_: {
+          type: "object",
+          properties: { score: { type: "boolean" } },
+        },
+      },
+    };
+
+    const wrapped = wrapManifestForHubPush(flat);
+
+    expect(wrapped.id).toEqual(["langsmith", "playground", "PromptPlayground"]);
+    expect((wrapped as { kwargs: { first: unknown } }).kwargs.first).toBe(flat);
+    expect(defaultHubModelManifest().id).toEqual([
+      "langchain",
+      "schema",
+      "runnable",
+      "RunnableBinding",
+    ]);
+  });
+
+  it("leaves PromptPlayground manifests unchanged", () => {
+    const manifest = {
+      lc: 1,
+      type: "constructor",
+      id: ["langsmith", "playground", "PromptPlayground"],
+      kwargs: { first: { id: ["prompt"] }, last: { id: ["model"] } },
+    };
+
+    expect(wrapManifestForHubPush(manifest)).toBe(manifest);
+  });
+
+  it("leaves RunnableSequence manifests unchanged", () => {
+    const manifest = {
+      lc: 1,
+      type: "constructor",
+      id: ["langchain", "schema", "runnable", "RunnableSequence"],
+      kwargs: { first: { id: ["prompt"] }, last: { id: ["model"] } },
+    };
+
+    expect(wrapManifestForHubPush(manifest)).toBe(manifest);
+  });
+});

--- a/js/src/utils/hub_manifest.ts
+++ b/js/src/utils/hub_manifest.ts
@@ -3,6 +3,10 @@ const FLAT_HUB_PROMPT_TAGS = new Set([
   "ChatPromptTemplate",
   "PromptTemplate",
 ]);
+const WRAPPED_HUB_PROMPT_TAGS = new Set([
+  "PromptPlayground",
+  "RunnableSequence",
+]);
 
 function hubManifestTag(manifest: Record<string, unknown>): string | undefined {
   const id = manifest.id;
@@ -13,8 +17,7 @@ function hubManifestTag(manifest: Record<string, unknown>): string | undefined {
   return typeof tag === "string" ? tag : undefined;
 }
 
-/** Default OpenAI chat model manifest used when wrapping flat Hub prompt commits. */
-export function defaultHubModelManifest(): Record<string, unknown> {
+function defaultHubModelManifest(): Record<string, unknown> {
   return {
     id: ["langchain", "schema", "runnable", "RunnableBinding"],
     lc: 1,
@@ -37,17 +40,12 @@ export function defaultHubModelManifest(): Record<string, unknown> {
   };
 }
 
-/**
- * Wrap flat prompt manifests in PromptPlayground format for Hub commits.
- *
- * Matches Playground saves and SDK pushes that pipe a prompt to a model
- * (`kwargs.first` + `kwargs.last`).
- */
+/** Wrap flat prompt manifests in PromptPlayground format for Hub commits. */
 export function wrapManifestForHubPush<T extends Record<string, unknown>>(
   manifest: T,
 ): T | Record<string, unknown> {
   const tag = hubManifestTag(manifest);
-  if (tag === "PromptPlayground" || tag === "RunnableSequence") {
+  if (tag && WRAPPED_HUB_PROMPT_TAGS.has(tag)) {
     return manifest;
   }
   if (manifest.lc !== 1 || manifest.type !== "constructor") {

--- a/js/src/utils/hub_manifest.ts
+++ b/js/src/utils/hub_manifest.ts
@@ -1,0 +1,68 @@
+const FLAT_HUB_PROMPT_TAGS = new Set([
+  "StructuredPrompt",
+  "ChatPromptTemplate",
+  "PromptTemplate",
+]);
+
+function hubManifestTag(manifest: Record<string, unknown>): string | undefined {
+  const id = manifest.id;
+  if (!Array.isArray(id) || id.length === 0) {
+    return undefined;
+  }
+  const tag = id[id.length - 1];
+  return typeof tag === "string" ? tag : undefined;
+}
+
+/** Default OpenAI chat model manifest used when wrapping flat Hub prompt commits. */
+export function defaultHubModelManifest(): Record<string, unknown> {
+  return {
+    id: ["langchain", "schema", "runnable", "RunnableBinding"],
+    lc: 1,
+    type: "constructor",
+    kwargs: {
+      bound: {
+        id: ["langchain", "chat_models", "openai", "ChatOpenAI"],
+        lc: 1,
+        type: "constructor",
+        kwargs: {
+          openai_api_key: {
+            id: ["OPENAI_API_KEY"],
+            lc: 1,
+            type: "secret",
+          },
+        },
+      },
+      kwargs: {},
+    },
+  };
+}
+
+/**
+ * Wrap flat prompt manifests in PromptPlayground format for Hub commits.
+ *
+ * Matches Playground saves and SDK pushes that pipe a prompt to a model
+ * (`kwargs.first` + `kwargs.last`).
+ */
+export function wrapManifestForHubPush<T extends Record<string, unknown>>(
+  manifest: T,
+): T | Record<string, unknown> {
+  const tag = hubManifestTag(manifest);
+  if (tag === "PromptPlayground" || tag === "RunnableSequence") {
+    return manifest;
+  }
+  if (manifest.lc !== 1 || manifest.type !== "constructor") {
+    return manifest;
+  }
+  if (!tag || !FLAT_HUB_PROMPT_TAGS.has(tag)) {
+    return manifest;
+  }
+  return {
+    lc: 1,
+    type: "constructor",
+    id: ["langsmith", "playground", "PromptPlayground"],
+    kwargs: {
+      first: manifest,
+      last: defaultHubModelManifest(),
+    },
+  };
+}

--- a/python/langsmith/_internal/_hub.py
+++ b/python/langsmith/_internal/_hub.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import re
-from typing import Optional
+from typing import Any, Optional
 from urllib.parse import urlencode
 
 from langsmith import utils as ls_utils
@@ -11,6 +11,11 @@ from langsmith import utils as ls_utils
 REPO_HANDLE_PATTERN = re.compile(r"^[a-z][a-z0-9-_]*$")
 PLATFORM_HUB = "/v1/platform/hub/repos"
 HUB = "/repos"
+
+_FLAT_HUB_PROMPT_TAGS = frozenset(
+    {"StructuredPrompt", "ChatPromptTemplate", "PromptTemplate"}
+)
+_WRAPPED_HUB_PROMPT_TAGS = frozenset({"PromptPlayground", "RunnableSequence"})
 
 
 def platform_hub_path(api_url: str) -> str:
@@ -32,3 +37,54 @@ def validate_parent_commit(parent_commit: Optional[str]) -> None:
     """Raise ``LangSmithUserError`` if ``parent_commit`` is set but malformed."""
     if parent_commit is not None and not (8 <= len(parent_commit) <= 64):
         raise ls_utils.LangSmithUserError("parent_commit must be 8-64 characters.")
+
+
+def _hub_manifest_tag(manifest: dict[str, Any]) -> Optional[str]:
+    id_ = manifest.get("id")
+    if not isinstance(id_, list) or not id_:
+        return None
+    tag = id_[-1]
+    return tag if isinstance(tag, str) else None
+
+
+def _default_hub_model_manifest() -> dict[str, Any]:
+    return {
+        "id": ["langchain", "schema", "runnable", "RunnableBinding"],
+        "lc": 1,
+        "type": "constructor",
+        "kwargs": {
+            "bound": {
+                "id": ["langchain", "chat_models", "openai", "ChatOpenAI"],
+                "lc": 1,
+                "type": "constructor",
+                "kwargs": {
+                    "openai_api_key": {
+                        "id": ["OPENAI_API_KEY"],
+                        "lc": 1,
+                        "type": "secret",
+                    }
+                },
+            },
+            "kwargs": {},
+        },
+    }
+
+
+def wrap_manifest_for_hub_push(manifest: dict[str, Any]) -> dict[str, Any]:
+    """Wrap flat prompt manifests in PromptPlayground format for Hub commits."""
+    tag = _hub_manifest_tag(manifest)
+    if tag in _WRAPPED_HUB_PROMPT_TAGS:
+        return manifest
+    if manifest.get("lc") != 1 or manifest.get("type") != "constructor":
+        return manifest
+    if tag not in _FLAT_HUB_PROMPT_TAGS:
+        return manifest
+    return {
+        "lc": 1,
+        "type": "constructor",
+        "id": ["langsmith", "playground", "PromptPlayground"],
+        "kwargs": {
+            "first": manifest,
+            "last": _default_hub_model_manifest(),
+        },
+    }

--- a/python/langsmith/async_client.py
+++ b/python/langsmith/async_client.py
@@ -23,6 +23,7 @@ from typing import (
 import httpx
 
 from langsmith import client as ls_client
+from langsmith._internal._hub import wrap_manifest_for_hub_push
 from langsmith import schemas as ls_schemas
 from langsmith import utils as ls_utils
 from langsmith._internal import _profiles
@@ -1939,7 +1940,7 @@ class AsyncClient:
             json_object = dumps(prepped)
             manifest_dict = json.loads(json_object)
 
-        manifest_dict = ls_client.wrap_manifest_for_hub_push(manifest_dict)
+        manifest_dict = wrap_manifest_for_hub_push(manifest_dict)
 
         owner, prompt_name, _ = ls_utils.parse_prompt_identifier(prompt_identifier)
         prompt_owner_and_name = f"{owner}/{prompt_name}"

--- a/python/langsmith/async_client.py
+++ b/python/langsmith/async_client.py
@@ -1939,6 +1939,8 @@ class AsyncClient:
             json_object = dumps(prepped)
             manifest_dict = json.loads(json_object)
 
+        manifest_dict = ls_client.wrap_manifest_for_hub_push(manifest_dict)
+
         owner, prompt_name, _ = ls_utils.parse_prompt_identifier(prompt_identifier)
         prompt_owner_and_name = f"{owner}/{prompt_name}"
 

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -92,6 +92,7 @@ from langsmith._internal._hub import (
     build_commit_url,
     platform_hub_path,
     validate_parent_commit,
+    wrap_manifest_for_hub_push,
 )
 from langsmith._internal._multipart import (
     MultipartPart,
@@ -11169,68 +11170,6 @@ def dump_model(model, *, exclude_none: bool = False) -> dict[str, Any]:
         return model.dict(exclude_none=exclude_none)
     else:
         raise TypeError("Unsupported model type")
-
-
-_FLAT_HUB_PROMPT_TAGS = frozenset(
-    {"StructuredPrompt", "ChatPromptTemplate", "PromptTemplate"}
-)
-
-
-def _hub_manifest_tag(manifest: dict[str, Any]) -> Optional[str]:
-    id_ = manifest.get("id")
-    if not isinstance(id_, list) or not id_:
-        return None
-    tag = id_[-1]
-    return tag if isinstance(tag, str) else None
-
-
-def _default_hub_model_manifest() -> dict[str, Any]:
-    return {
-        "id": ["langchain", "schema", "runnable", "RunnableBinding"],
-        "lc": 1,
-        "type": "constructor",
-        "kwargs": {
-            "bound": {
-                "id": ["langchain", "chat_models", "openai", "ChatOpenAI"],
-                "lc": 1,
-                "type": "constructor",
-                "kwargs": {
-                    "openai_api_key": {
-                        "id": ["OPENAI_API_KEY"],
-                        "lc": 1,
-                        "type": "secret",
-                    }
-                },
-            },
-            "kwargs": {},
-        },
-    }
-
-
-def wrap_manifest_for_hub_push(manifest: dict[str, Any]) -> dict[str, Any]:
-    """Wrap flat prompt manifests in PromptPlayground format for Hub commits.
-
-    Playground saves and SDK pushes that pipe a prompt to a model store the prompt
-    under ``kwargs.first`` and the model under ``kwargs.last``. Bare
-    ``push_prompt(StructuredPrompt)`` commits omit that wrapper; wrapping on push
-    matches the Playground commit shape Hub consumers expect.
-    """
-    tag = _hub_manifest_tag(manifest)
-    if tag in ("PromptPlayground", "RunnableSequence"):
-        return manifest
-    if manifest.get("lc") != 1 or manifest.get("type") != "constructor":
-        return manifest
-    if tag not in _FLAT_HUB_PROMPT_TAGS:
-        return manifest
-    return {
-        "lc": 1,
-        "type": "constructor",
-        "id": ["langsmith", "playground", "PromptPlayground"],
-        "kwargs": {
-            "first": manifest,
-            "last": _default_hub_model_manifest(),
-        },
-    }
 
 
 def prep_obj_for_push(obj: Any) -> Any:

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -9163,6 +9163,8 @@ class Client:
             json_object = dumps(prepped)
             manifest_dict = json.loads(json_object)
 
+        manifest_dict = wrap_manifest_for_hub_push(manifest_dict)
+
         owner, prompt_name, _ = ls_utils.parse_prompt_identifier(prompt_identifier)
         prompt_owner_and_name = f"{owner}/{prompt_name}"
 
@@ -11167,6 +11169,68 @@ def dump_model(model, *, exclude_none: bool = False) -> dict[str, Any]:
         return model.dict(exclude_none=exclude_none)
     else:
         raise TypeError("Unsupported model type")
+
+
+_FLAT_HUB_PROMPT_TAGS = frozenset(
+    {"StructuredPrompt", "ChatPromptTemplate", "PromptTemplate"}
+)
+
+
+def _hub_manifest_tag(manifest: dict[str, Any]) -> Optional[str]:
+    id_ = manifest.get("id")
+    if not isinstance(id_, list) or not id_:
+        return None
+    tag = id_[-1]
+    return tag if isinstance(tag, str) else None
+
+
+def _default_hub_model_manifest() -> dict[str, Any]:
+    return {
+        "id": ["langchain", "schema", "runnable", "RunnableBinding"],
+        "lc": 1,
+        "type": "constructor",
+        "kwargs": {
+            "bound": {
+                "id": ["langchain", "chat_models", "openai", "ChatOpenAI"],
+                "lc": 1,
+                "type": "constructor",
+                "kwargs": {
+                    "openai_api_key": {
+                        "id": ["OPENAI_API_KEY"],
+                        "lc": 1,
+                        "type": "secret",
+                    }
+                },
+            },
+            "kwargs": {},
+        },
+    }
+
+
+def wrap_manifest_for_hub_push(manifest: dict[str, Any]) -> dict[str, Any]:
+    """Wrap flat prompt manifests in PromptPlayground format for Hub commits.
+
+    Playground saves and SDK pushes that pipe a prompt to a model store the prompt
+    under ``kwargs.first`` and the model under ``kwargs.last``. Bare
+    ``push_prompt(StructuredPrompt)`` commits omit that wrapper; wrapping on push
+    matches the Playground commit shape Hub consumers expect.
+    """
+    tag = _hub_manifest_tag(manifest)
+    if tag in ("PromptPlayground", "RunnableSequence"):
+        return manifest
+    if manifest.get("lc") != 1 or manifest.get("type") != "constructor":
+        return manifest
+    if tag not in _FLAT_HUB_PROMPT_TAGS:
+        return manifest
+    return {
+        "lc": 1,
+        "type": "constructor",
+        "id": ["langsmith", "playground", "PromptPlayground"],
+        "kwargs": {
+            "first": manifest,
+            "last": _default_hub_model_manifest(),
+        },
+    }
 
 
 def prep_obj_for_push(obj: Any) -> Any:

--- a/python/tests/unit_tests/test_client.py
+++ b/python/tests/unit_tests/test_client.py
@@ -54,12 +54,111 @@ from langsmith.client import (
     _parse_token_or_url,
     _reject_filesystem_attachments,
     _resolve_tracing_mode,
+    wrap_manifest_for_hub_push,
 )
 from langsmith.run_trees import RunTree
 from langsmith.utils import LangSmithRateLimitError, LangSmithUserError
 from tests.unit_tests.conftest import parse_request_data
 
 _CREATED_AT = datetime(2015, 1, 1, 0, 0, 0)
+
+
+def test_wrap_manifest_for_hub_push_wraps_flat_structured_prompt() -> None:
+    flat = {
+        "lc": 1,
+        "type": "constructor",
+        "id": ["langchain_core", "prompts", "structured", "StructuredPrompt"],
+        "kwargs": {
+            "input_variables": ["input"],
+            "messages": [],
+            "schema_": {
+                "type": "object",
+                "properties": {"score": {"type": "boolean"}},
+            },
+        },
+    }
+
+    wrapped = wrap_manifest_for_hub_push(flat)
+
+    assert wrapped["id"] == ["langsmith", "playground", "PromptPlayground"]
+    assert wrapped["kwargs"]["first"] == flat
+    assert wrapped["kwargs"]["last"]["id"][-1] == "RunnableBinding"
+
+
+def test_wrap_manifest_for_hub_push_leaves_playground_manifest_unchanged() -> None:
+    manifest = {
+        "lc": 1,
+        "type": "constructor",
+        "id": ["langsmith", "playground", "PromptPlayground"],
+        "kwargs": {"first": {"id": ["prompt"]}, "last": {"id": ["model"]}},
+    }
+
+    assert wrap_manifest_for_hub_push(manifest) is manifest
+
+
+def test_wrap_manifest_for_hub_push_leaves_runnable_sequence_unchanged() -> None:
+    manifest = {
+        "lc": 1,
+        "type": "constructor",
+        "id": ["langchain", "schema", "runnable", "RunnableSequence"],
+        "kwargs": {"first": {"id": ["prompt"]}, "last": {"id": ["model"]}},
+    }
+
+    assert wrap_manifest_for_hub_push(manifest) is manifest
+
+
+def test_create_commit_wraps_flat_structured_prompt_manifest() -> None:
+    flat = {
+        "lc": 1,
+        "type": "constructor",
+        "id": ["langchain_core", "prompts", "structured", "StructuredPrompt"],
+        "kwargs": {
+            "input_variables": ["input"],
+            "messages": [],
+            "schema_": {
+                "type": "object",
+                "properties": {"score": {"type": "boolean"}},
+            },
+        },
+    }
+    posted: dict = {}
+    mock_session = mock.Mock()
+
+    def mock_request(method, url, **kwargs):
+        if method == "POST" and "/commits/" in url:
+            posted.update(kwargs.get("json", {}))
+            return mock.Mock(
+                json=lambda: {"commit": {"commit_hash": "new_hash", "id": "new_id"}}
+            )
+        return mock.Mock(json=lambda: {})
+
+    mock_session.request.side_effect = mock_request
+    client = Client(
+        api_url="http://localhost:1984",
+        api_key="fake_api_key",
+        session=mock_session,
+        auto_batch_tracing=False,
+    )
+
+    with (
+        mock.patch("langsmith.client.Client._prompt_exists", return_value=True),
+        mock.patch(
+            "langsmith.client.Client._get_latest_commit_hash",
+            return_value="parent_hash",
+        ),
+        mock.patch(
+            "langsmith.client.Client._get_settings",
+            return_value=ls_schemas.LangSmithSettings(
+                id="test-tenant-id",
+                display_name="Test Tenant",
+                created_at=_CREATED_AT,
+            ),
+        ),
+    ):
+        client.create_commit("owner/my-prompt", flat)
+
+    assert posted["manifest"]["id"] == ["langsmith", "playground", "PromptPlayground"]
+    assert posted["manifest"]["kwargs"]["first"] == flat
 
 
 def test_is_localhost() -> None:

--- a/python/tests/unit_tests/test_client.py
+++ b/python/tests/unit_tests/test_client.py
@@ -54,111 +54,12 @@ from langsmith.client import (
     _parse_token_or_url,
     _reject_filesystem_attachments,
     _resolve_tracing_mode,
-    wrap_manifest_for_hub_push,
 )
 from langsmith.run_trees import RunTree
 from langsmith.utils import LangSmithRateLimitError, LangSmithUserError
 from tests.unit_tests.conftest import parse_request_data
 
 _CREATED_AT = datetime(2015, 1, 1, 0, 0, 0)
-
-
-def test_wrap_manifest_for_hub_push_wraps_flat_structured_prompt() -> None:
-    flat = {
-        "lc": 1,
-        "type": "constructor",
-        "id": ["langchain_core", "prompts", "structured", "StructuredPrompt"],
-        "kwargs": {
-            "input_variables": ["input"],
-            "messages": [],
-            "schema_": {
-                "type": "object",
-                "properties": {"score": {"type": "boolean"}},
-            },
-        },
-    }
-
-    wrapped = wrap_manifest_for_hub_push(flat)
-
-    assert wrapped["id"] == ["langsmith", "playground", "PromptPlayground"]
-    assert wrapped["kwargs"]["first"] == flat
-    assert wrapped["kwargs"]["last"]["id"][-1] == "RunnableBinding"
-
-
-def test_wrap_manifest_for_hub_push_leaves_playground_manifest_unchanged() -> None:
-    manifest = {
-        "lc": 1,
-        "type": "constructor",
-        "id": ["langsmith", "playground", "PromptPlayground"],
-        "kwargs": {"first": {"id": ["prompt"]}, "last": {"id": ["model"]}},
-    }
-
-    assert wrap_manifest_for_hub_push(manifest) is manifest
-
-
-def test_wrap_manifest_for_hub_push_leaves_runnable_sequence_unchanged() -> None:
-    manifest = {
-        "lc": 1,
-        "type": "constructor",
-        "id": ["langchain", "schema", "runnable", "RunnableSequence"],
-        "kwargs": {"first": {"id": ["prompt"]}, "last": {"id": ["model"]}},
-    }
-
-    assert wrap_manifest_for_hub_push(manifest) is manifest
-
-
-def test_create_commit_wraps_flat_structured_prompt_manifest() -> None:
-    flat = {
-        "lc": 1,
-        "type": "constructor",
-        "id": ["langchain_core", "prompts", "structured", "StructuredPrompt"],
-        "kwargs": {
-            "input_variables": ["input"],
-            "messages": [],
-            "schema_": {
-                "type": "object",
-                "properties": {"score": {"type": "boolean"}},
-            },
-        },
-    }
-    posted: dict = {}
-    mock_session = mock.Mock()
-
-    def mock_request(method, url, **kwargs):
-        if method == "POST" and "/commits/" in url:
-            posted.update(kwargs.get("json", {}))
-            return mock.Mock(
-                json=lambda: {"commit": {"commit_hash": "new_hash", "id": "new_id"}}
-            )
-        return mock.Mock(json=lambda: {})
-
-    mock_session.request.side_effect = mock_request
-    client = Client(
-        api_url="http://localhost:1984",
-        api_key="fake_api_key",
-        session=mock_session,
-        auto_batch_tracing=False,
-    )
-
-    with (
-        mock.patch("langsmith.client.Client._prompt_exists", return_value=True),
-        mock.patch(
-            "langsmith.client.Client._get_latest_commit_hash",
-            return_value="parent_hash",
-        ),
-        mock.patch(
-            "langsmith.client.Client._get_settings",
-            return_value=ls_schemas.LangSmithSettings(
-                id="test-tenant-id",
-                display_name="Test Tenant",
-                created_at=_CREATED_AT,
-            ),
-        ),
-    ):
-        client.create_commit("owner/my-prompt", flat)
-
-    assert posted["manifest"]["id"] == ["langsmith", "playground", "PromptPlayground"]
-    assert posted["manifest"]["kwargs"]["first"] == flat
 
 
 def test_is_localhost() -> None:

--- a/python/tests/unit_tests/test_hub_manifest.py
+++ b/python/tests/unit_tests/test_hub_manifest.py
@@ -1,0 +1,50 @@
+"""Tests for Hub prompt manifest wrapping."""
+
+import pytest
+
+from langsmith._internal._hub import wrap_manifest_for_hub_push
+
+_FLAT_STRUCTURED_PROMPT = {
+    "lc": 1,
+    "type": "constructor",
+    "id": ["langchain_core", "prompts", "structured", "StructuredPrompt"],
+    "kwargs": {
+        "input_variables": ["input"],
+        "messages": [],
+        "schema_": {
+            "type": "object",
+            "properties": {"score": {"type": "boolean"}},
+        },
+    },
+}
+
+
+def test_wrap_manifest_for_hub_push_wraps_flat_structured_prompt() -> None:
+    wrapped = wrap_manifest_for_hub_push(_FLAT_STRUCTURED_PROMPT)
+
+    assert wrapped["id"] == ["langsmith", "playground", "PromptPlayground"]
+    assert wrapped["kwargs"]["first"] == _FLAT_STRUCTURED_PROMPT
+    assert wrapped["kwargs"]["last"]["id"][-1] == "RunnableBinding"
+
+
+@pytest.mark.parametrize(
+    "manifest",
+    [
+        {
+            "lc": 1,
+            "type": "constructor",
+            "id": ["langsmith", "playground", "PromptPlayground"],
+            "kwargs": {"first": {"id": ["prompt"]}, "last": {"id": ["model"]}},
+        },
+        {
+            "lc": 1,
+            "type": "constructor",
+            "id": ["langchain", "schema", "runnable", "RunnableSequence"],
+            "kwargs": {"first": {"id": ["prompt"]}, "last": {"id": ["model"]}},
+        },
+    ],
+)
+def test_wrap_manifest_for_hub_push_leaves_wrapped_manifests_unchanged(
+    manifest: dict,
+) -> None:
+    assert wrap_manifest_for_hub_push(manifest) is manifest


### PR DESCRIPTION
**Description**

SDK saves one prompt shape, Overview reads another. This fixes that.

While testing the online evaluator SDK, we found that evaluator prompts pushed via the SDK can show the wrong prompt and feedback settings in Overview - often falling back to a generic “correctness” rubric instead of the schema you defined.

<img width="1017" height="248" alt="Screenshot 2026-06-24 at 10 56 34 AM" src="https://github.com/user-attachments/assets/6e05f00f-2837-4b77-8a0f-23120c29d420" />

This PR updates the Python and JavaScript SDKs so SDK-pushed prompts are saved in the same format as Playground prompts.

1. You push an evaluator prompt via SDK → it becomes a Hub commit (JSON blob).
2. Playground saves prompt + model together; bare SDK push saves only the prompt (flat).
3. Overview reads the Playground-shaped commit → flat commits display wrong (generic rubric).
4. Fix: before saving, SDK wraps flat prompts into the same shape Playground uses (prompt in .first, default model in .last).

References [LSE-2494](https://linear.app/langchain/issue/LSE-2494/sdk-wrap-flat-hub-prompt-pushes-for-overview-display)

**Follow-up**

A separate langchainplus change will update Overview to also read prompts saved in the older flat format, so evaluators created before this SDK release display correctly without re-pushing.

**Test plan**

 Create an online evaluator via the SDK with a structured prompt; confirm Overview shows the correct prompt and feedback fields (not the default rubric)

 Confirm Playground-saved prompts and SDK pushes with a model still work as before