### PR TITLE
feat(sandbox): expose registries via generated v2 client

### DIFF
--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -77,6 +77,7 @@ import { __version__ } from "./index.js";
 import { Langsmith as OpenAPILangsmith } from "./_openapi_client/index.js";
 import { OnlineEvaluators } from "./_openapi_client/resources/online-evaluators.js";
 import { Runs as OpenAPIRuns } from "./_openapi_client/resources/runs.js";
+import { Sandboxes } from "./_openapi_client/resources/sandboxes/sandboxes.js";
 import { assertUuid } from "./utils/_uuid.js";
 import { warnOnce } from "./utils/warn.js";
 import { _MIN_BACKEND_VERSION } from "./utils/constants.js";
@@ -1461,6 +1462,11 @@ export class Client implements LangSmithTracingClientInterface {
 
   public get runs(): OpenAPIRuns {
     return this.openAPIClient.runs;
+  }
+
+  /** Access the v2 sandboxes resource (registries, snapshots, boxes). */
+  public get sandboxes(): Sandboxes {
+    return this.openAPIClient.sandboxes;
   }
 
   private async processInputs(inputs: KVMap): Promise<KVMap> {

--- a/js/src/sandbox/README.md
+++ b/js/src/sandbox/README.md
@@ -635,16 +635,12 @@ const snapshot = await client.createSnapshot(
   1_073_741_824, // 1 GiB
 );
 
-// Build from a private registry (use registryId or explicit credentials)
+// Build from a private registry
 const privateSnapshot = await client.createSnapshot(
   "internal-python",
   "registry.example.com/internal/python:3.12",
   2_147_483_648,
-  {
-    registryUrl: "https://registry.example.com",
-    registryUsername: "me",
-    registryPassword: process.env.REGISTRY_PASSWORD,
-  },
+  { registryId: "registry-id" },
 );
 
 // Capture the state of a running sandbox for later reuse. Persistent paths
@@ -848,9 +844,6 @@ try {
 | Property | Description |
 |----------|-------------|
 | `registryId?` | Private registry ID |
-| `registryUrl?` | Registry URL for private images |
-| `registryUsername?` | Registry username |
-| `registryPassword?` | Registry password |
 | `timeout?` | Wait timeout in seconds (default: 60) |
 | `signal?` | `AbortSignal` for cancellation |
 

--- a/js/src/sandbox/README.md
+++ b/js/src/sandbox/README.md
@@ -635,12 +635,21 @@ const snapshot = await client.createSnapshot(
   1_073_741_824, // 1 GiB
 );
 
+// Create a private registry once, then reference it by id. Store the password
+// in a secret, not in source.
+const registry = await client.sandboxes.registries.create({
+  name: "internal",
+  url: "registry.example.com",
+  username: "robot",
+  password: "...",
+});
+
 // Build from a private registry
 const privateSnapshot = await client.createSnapshot(
   "internal-python",
   "registry.example.com/internal/python:3.12",
   2_147_483_648,
-  { registryId: "registry-id" },
+  { registryId: registry.id },
 );
 
 // Capture the state of a running sandbox for later reuse. Persistent paths

--- a/js/src/sandbox/client.ts
+++ b/js/src/sandbox/client.ts
@@ -867,7 +867,7 @@ export class SandboxClient {
    * @param name - Snapshot name.
    * @param dockerImage - Docker image to build from (e.g., "python:3.12-slim").
    * @param fsCapacityBytes - Filesystem capacity in bytes.
-   * @param options - Additional options (registry credentials, timeout).
+   * @param options - Additional options (registry ID, timeout).
    * @returns Snapshot in "ready" status.
    */
   async createSnapshot(
@@ -876,14 +876,7 @@ export class SandboxClient {
     fsCapacityBytes: number,
     options: CreateSnapshotOptions = {},
   ): Promise<Snapshot> {
-    const {
-      registryId,
-      registryUrl,
-      registryUsername,
-      registryPassword,
-      timeout = 60,
-      signal,
-    } = options;
+    const { registryId, timeout = 60, signal } = options;
     const url = `${this._baseUrl}/snapshots`;
 
     const payload: Record<string, unknown> = {
@@ -893,15 +886,6 @@ export class SandboxClient {
     };
     if (registryId !== undefined) {
       payload.registry_id = registryId;
-    }
-    if (registryUrl !== undefined) {
-      payload.registry_url = registryUrl;
-    }
-    if (registryUsername !== undefined) {
-      payload.registry_username = registryUsername;
-    }
-    if (registryPassword !== undefined) {
-      payload.registry_password = registryPassword;
     }
 
     const response = await this._postJson(url, payload, { signal });

--- a/js/src/sandbox/client.ts
+++ b/js/src/sandbox/client.ts
@@ -5,6 +5,8 @@
 import { getLangSmithEnvironmentVariable } from "../utils/env.js";
 import { _getFetchImplementation } from "../singletons/fetch.js";
 import { AsyncCaller } from "../utils/async_caller.js";
+import { Langsmith as OpenAPILangsmith } from "../_openapi_client/index.js";
+import { Registries } from "../_openapi_client/resources/sandboxes/registries.js";
 import type {
   CaptureSnapshotOptions,
   CreateDockerfileSnapshotOptions,
@@ -363,6 +365,7 @@ export class SandboxClient {
   private _defaultHeaders: Record<string, string>;
   private _fetchImpl: typeof fetch;
   private _caller: AsyncCaller;
+  private _registriesClient?: OpenAPILangsmith;
 
   constructor(config: SandboxClientConfig = {}) {
     this._baseUrl = (config.apiEndpoint ?? getDefaultApiEndpoint()).replace(
@@ -376,6 +379,53 @@ export class SandboxClient {
       maxRetries: config.maxRetries ?? 3,
       maxConcurrency: config.maxConcurrency ?? Infinity,
     });
+  }
+
+  private _apiRoot(): string {
+    const suffix = "/v2/sandboxes";
+    return this._baseUrl.endsWith(suffix)
+      ? this._baseUrl.slice(0, -suffix.length)
+      : this._baseUrl;
+  }
+
+  /**
+   * Manage sandbox image registries: create, list, retrieve, update, delete.
+   *
+   * A registry stores credentials for pulling private images. Create one, then
+   * pass its `id` as `registryId` when building a snapshot.
+   *
+   * @example
+   * ```typescript
+   * const registry = await client.registries.create({
+   *   name: "internal",
+   *   url: "registry.example.com",
+   *   username: "robot",
+   *   password: process.env.REGISTRY_PASSWORD,
+   * });
+   * const snapshot = await client.createSnapshot(
+   *   "internal-python",
+   *   "registry.example.com/internal/python:3.12",
+   *   2_147_483_648,
+   *   { registryId: registry.id },
+   * );
+   * ```
+   */
+  get registries(): Registries {
+    if (!this._registriesClient) {
+      const defaultHeaders: Record<string, string | null> = {
+        ...this._defaultHeaders,
+      };
+      if (this._apiKey === undefined) {
+        defaultHeaders["X-API-Key"] = null;
+      }
+      this._registriesClient = new OpenAPILangsmith({
+        apiKey: this._apiKey,
+        baseURL: this._apiRoot(),
+        defaultHeaders,
+        fetch: this._fetchImpl,
+      });
+    }
+    return this._registriesClient.sandboxes.registries;
   }
 
   /**

--- a/js/src/sandbox/types.ts
+++ b/js/src/sandbox/types.ts
@@ -512,14 +512,8 @@ export interface CreateSandboxOptions {
  * Options for creating a snapshot from a Docker image.
  */
 export interface CreateSnapshotOptions {
-  /** Private registry ID (alternative to URL/credentials). */
+  /** Private registry ID. */
   registryId?: string;
-  /** Registry URL for private images. */
-  registryUrl?: string;
-  /** Registry username. */
-  registryUsername?: string;
-  /** Registry password. */
-  registryPassword?: string;
   /** Timeout in seconds when waiting for ready. Default: 60. */
   timeout?: number;
   /** AbortSignal for cancellation. */

--- a/js/src/tests/sandbox.test.ts
+++ b/js/src/tests/sandbox.test.ts
@@ -2442,3 +2442,16 @@ describe("Sandbox - start/stop/captureSnapshot", () => {
     );
   });
 });
+
+describe("SandboxClient registries", () => {
+  it("exposes a cached registries accessor backed by the generated client", () => {
+    const client = new SandboxClient({
+      apiEndpoint: "https://api.smith.langchain.com/v2/sandboxes",
+      apiKey: "k",
+    });
+    const first = client.registries;
+    expect(first).toBeDefined();
+    // Lazily built once and reused.
+    expect(client.registries).toBe(first);
+  });
+});

--- a/js/src/tests/sandbox.test.ts
+++ b/js/src/tests/sandbox.test.ts
@@ -1961,11 +1961,20 @@ describe("SandboxClient - snapshot operations", () => {
       "my-env",
       "python:3.12-slim",
       4294967296,
+      { registryId: "reg-1" },
     );
 
     expect(snapshot.id).toBe("snap-1");
     expect(snapshot.status).toBe("ready");
     expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(
+      JSON.parse((mockFetch.mock.calls[0][1] as RequestInit).body as string),
+    ).toEqual({
+      name: "my-env",
+      docker_image: "python:3.12-slim",
+      fs_capacity_bytes: 4294967296,
+      registry_id: "reg-1",
+    });
   });
 
   it("createSnapshotFromDockerfile should sync, build, and capture", async () => {

--- a/python/langsmith/async_client.py
+++ b/python/langsmith/async_client.py
@@ -49,6 +49,9 @@ if TYPE_CHECKING:
     from langsmith._openapi_client.resources.online_evaluators import (
         AsyncOnlineEvaluatorsResource,
     )
+    from langsmith._openapi_client.resources.sandboxes.sandboxes import (
+        AsyncSandboxesResource,
+    )
 
 
 class AsyncClient:
@@ -310,6 +313,11 @@ class AsyncClient:
     def online_evaluators(self) -> AsyncOnlineEvaluatorsResource:
         """Access generated async online evaluator CRUD methods."""
         return self._langsmith_api.online_evaluators
+
+    @property
+    def sandboxes(self) -> AsyncSandboxesResource:
+        """Access generated async sandbox resources (registries, snapshots, boxes)."""
+        return self._langsmith_api.sandboxes
 
     async def __aenter__(self) -> AsyncClient:
         """Enter the async client."""

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -268,6 +268,9 @@ if TYPE_CHECKING:
         AsyncOnlineEvaluatorsResource,
     )
     from langsmith._openapi_client.resources.runs import AsyncRunsResource
+    from langsmith._openapi_client.resources.sandboxes.sandboxes import (
+        AsyncSandboxesResource,
+    )
 
     # OTEL imports for type hints
     try:
@@ -1458,6 +1461,12 @@ class Client:
         """Access generated online evaluator CRUD methods."""
         _check_backend_version(self.info.version)
         return self._langsmith_api.online_evaluators
+
+    @property
+    def sandboxes(self) -> AsyncSandboxesResource:
+        """Access the v2 sandboxes resource (registries, snapshots, boxes)."""
+        _check_backend_version(self.info.version)
+        return self._langsmith_api.sandboxes
 
     def _dump_failed_trace(
         self,

--- a/python/langsmith/sandbox/_async_client.py
+++ b/python/langsmith/sandbox/_async_client.py
@@ -777,9 +777,6 @@ class AsyncSandboxClient:
         fs_capacity_bytes: int,
         *,
         registry_id: Optional[str] = None,
-        registry_url: Optional[str] = None,
-        registry_username: Optional[str] = None,
-        registry_password: Optional[str] = None,
         timeout: int = 60,
         headers: RequestHeaders = None,
     ) -> Snapshot:
@@ -791,10 +788,7 @@ class AsyncSandboxClient:
             name: Snapshot name.
             docker_image: Docker image to build from (e.g., "python:3.12-slim").
             fs_capacity_bytes: Filesystem capacity in bytes.
-            registry_id: Private registry ID (alternative to URL/credentials).
-            registry_url: Registry URL for private images.
-            registry_username: Registry username.
-            registry_password: Registry password.
+            registry_id: Private registry ID.
             timeout: Timeout in seconds when waiting for ready.
 
         Returns:
@@ -814,12 +808,6 @@ class AsyncSandboxClient:
         }
         if registry_id is not None:
             payload["registry_id"] = registry_id
-        if registry_url is not None:
-            payload["registry_url"] = registry_url
-        if registry_username is not None:
-            payload["registry_username"] = registry_username
-        if registry_password is not None:
-            payload["registry_password"] = registry_password
 
         try:
             response = await self._http.post(

--- a/python/langsmith/sandbox/_async_client.py
+++ b/python/langsmith/sandbox/_async_client.py
@@ -7,11 +7,12 @@ import os
 import posixpath
 import uuid
 from collections.abc import Callable, Mapping
-from typing import Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 import httpx
 
 from langsmith import utils as ls_utils
+from langsmith._openapi_client import AsyncLangsmith
 from langsmith.sandbox._async_sandbox import AsyncSandbox
 from langsmith.sandbox._client import (
     SandboxClient,
@@ -44,6 +45,11 @@ from langsmith.sandbox._mounts import (
 )
 from langsmith.sandbox._proxy_config import SandboxProxyConfig
 from langsmith.sandbox._transport import AsyncRetryTransport
+
+if TYPE_CHECKING:
+    from langsmith._openapi_client.resources.sandboxes.registries import (
+        AsyncRegistriesResource,
+    )
 
 
 def _get_default_api_endpoint() -> str:
@@ -117,6 +123,43 @@ class AsyncSandboxClient:
         self._http = httpx.AsyncClient(
             transport=transport, timeout=timeout, headers=client_headers
         )
+        self._registries_client: Optional[AsyncLangsmith] = None
+
+    def _api_root(self) -> str:
+        """Return the API root URL, without the ``/v2/sandboxes`` suffix."""
+        suffix = "/v2/sandboxes"
+        if self._base_url.endswith(suffix):
+            return self._base_url[: -len(suffix)]
+        return self._base_url
+
+    @property
+    def registries(self) -> AsyncRegistriesResource:
+        """Manage sandbox image registries: create, list, retrieve, update, delete.
+
+        A registry stores credentials for pulling private images. Create one,
+        then pass its ``id`` as ``registry_id`` when building a snapshot.
+
+        Example:
+            registry = await client.registries.create(
+                name="internal",
+                url="registry.example.com",
+                username="robot",
+                password=os.environ["REGISTRY_PASSWORD"],
+            )
+            snapshot = await client.create_snapshot(
+                "internal-python",
+                docker_image="registry.example.com/internal/python:3.12",
+                fs_capacity_bytes=2 * 1024**3,
+                registry_id=registry.id,
+            )
+        """
+        if self._registries_client is None:
+            self._registries_client = AsyncLangsmith(
+                api_key=self._api_key,
+                base_url=self._api_root(),
+                default_headers=self._default_headers or None,
+            )
+        return self._registries_client.sandboxes.registries
 
     def _request_headers(self, headers: RequestHeaders) -> Optional[dict[str, str]]:
         """Merge default client headers with per-request overrides."""
@@ -155,6 +198,8 @@ class AsyncSandboxClient:
     async def aclose(self) -> None:
         """Close the async HTTP client."""
         await self._http.aclose()
+        if self._registries_client is not None:
+            await self._registries_client.close()
 
     def __del__(self) -> None:
         """Best-effort cleanup of the async HTTP client on garbage collection.

--- a/python/langsmith/sandbox/_client.py
+++ b/python/langsmith/sandbox/_client.py
@@ -858,9 +858,6 @@ class SandboxClient:
         fs_capacity_bytes: int,
         *,
         registry_id: Optional[str] = None,
-        registry_url: Optional[str] = None,
-        registry_username: Optional[str] = None,
-        registry_password: Optional[str] = None,
         timeout: int = 60,
         headers: RequestHeaders = None,
     ) -> Snapshot:
@@ -872,10 +869,7 @@ class SandboxClient:
             name: Snapshot name.
             docker_image: Docker image to build from (e.g., "python:3.12-slim").
             fs_capacity_bytes: Filesystem capacity in bytes.
-            registry_id: Private registry ID (alternative to URL/credentials).
-            registry_url: Registry URL for private images.
-            registry_username: Registry username.
-            registry_password: Registry password.
+            registry_id: Private registry ID.
             timeout: Timeout in seconds when waiting for ready.
 
         Returns:
@@ -895,12 +889,6 @@ class SandboxClient:
         }
         if registry_id is not None:
             payload["registry_id"] = registry_id
-        if registry_url is not None:
-            payload["registry_url"] = registry_url
-        if registry_username is not None:
-            payload["registry_username"] = registry_username
-        if registry_password is not None:
-            payload["registry_password"] = registry_password
 
         try:
             response = self._http.post(

--- a/python/langsmith/sandbox/_client.py
+++ b/python/langsmith/sandbox/_client.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING, Any, Optional, Union
 import httpx
 
 from langsmith import utils as ls_utils
+from langsmith._openapi_client import Langsmith
 from langsmith.sandbox._exceptions import (
     ResourceCreationError,
     ResourceNameConflictError,
@@ -43,6 +44,9 @@ from langsmith.sandbox._sandbox import Sandbox
 from langsmith.sandbox._transport import RetryTransport
 
 if TYPE_CHECKING:
+    from langsmith._openapi_client.resources.sandboxes.registries import (
+        RegistriesResource,
+    )
     from langsmith.sandbox._async_client import AsyncSandboxClient
 
 
@@ -221,6 +225,43 @@ class SandboxClient:
         self._http = httpx.Client(
             transport=transport, timeout=timeout, headers=client_headers
         )
+        self._registries_client: Optional[Langsmith] = None
+
+    def _api_root(self) -> str:
+        """Return the API root URL, without the ``/v2/sandboxes`` suffix."""
+        suffix = "/v2/sandboxes"
+        if self._base_url.endswith(suffix):
+            return self._base_url[: -len(suffix)]
+        return self._base_url
+
+    @property
+    def registries(self) -> RegistriesResource:
+        """Manage sandbox image registries: create, list, retrieve, update, delete.
+
+        A registry stores credentials for pulling private images. Create one,
+        then pass its ``id`` as ``registry_id`` when building a snapshot.
+
+        Example:
+            registry = client.registries.create(
+                name="internal",
+                url="registry.example.com",
+                username="robot",
+                password=os.environ["REGISTRY_PASSWORD"],
+            )
+            snapshot = client.create_snapshot(
+                "internal-python",
+                docker_image="registry.example.com/internal/python:3.12",
+                fs_capacity_bytes=2 * 1024**3,
+                registry_id=registry.id,
+            )
+        """
+        if self._registries_client is None:
+            self._registries_client = Langsmith(
+                api_key=self._api_key,
+                base_url=self._api_root(),
+                default_headers=self._default_headers or None,
+            )
+        return self._registries_client.sandboxes.registries
 
     def _request_headers(self, headers: RequestHeaders) -> Optional[dict[str, str]]:
         """Merge default client headers with per-request overrides."""
@@ -261,12 +302,16 @@ class SandboxClient:
     def close(self) -> None:
         """Close the HTTP client."""
         self._http.close()
+        if self._registries_client is not None:
+            self._registries_client.close()
 
     def __del__(self) -> None:
         """Close the HTTP client on garbage collection."""
         try:
             if not self._http.is_closed:
                 self._http.close()
+            if self._registries_client is not None:
+                self._registries_client.close()
         except Exception:
             pass
 

--- a/python/tests/unit_tests/sandbox/test_client.py
+++ b/python/tests/unit_tests/sandbox/test_client.py
@@ -1582,3 +1582,45 @@ class TestSandboxClientRepr:
             == "SandboxClient (API URL: https://api.smith.langchain.com/v2/sandboxes)"
         )
         client.close()
+
+
+class TestRegistries:
+    """Registry management exposed via the generated client."""
+
+    def test_api_root_strips_sandbox_suffix(self):
+        client = SandboxClient(
+            api_endpoint="https://api.smith.langchain.com/v2/sandboxes",
+            api_key="k",
+        )
+        assert client._api_root() == "https://api.smith.langchain.com"
+        client.close()
+
+    def test_api_root_without_suffix(self):
+        client = SandboxClient(api_endpoint="http://test-server:8080", api_key="k")
+        assert client._api_root() == "http://test-server:8080"
+        client.close()
+
+    def test_registries_resource_is_cached(self):
+        client = SandboxClient(api_endpoint="http://test-server:8080", api_key="k")
+        first = client.registries
+        second = client.registries
+        assert client._registries_client is not None
+        assert first is second
+        client.close()
+
+    def test_registries_create(self, httpx_mock: HTTPXMock):
+        httpx_mock.add_response(
+            method="POST",
+            url="http://test-server:8080/v2/sandboxes/registries",
+            json={"id": "reg-1", "name": "internal", "url": "registry.example.com"},
+        )
+        client = SandboxClient(api_endpoint="http://test-server:8080", api_key="k")
+        registry = client.registries.create(
+            name="internal",
+            url="registry.example.com",
+            username="me",
+            password="secret",
+        )
+        assert registry.id == "reg-1"
+        assert registry.name == "internal"
+        client.close()

--- a/python/tests/unit_tests/sandbox/test_client.py
+++ b/python/tests/unit_tests/sandbox/test_client.py
@@ -1000,10 +1000,21 @@ class TestSnapshotOperations:
             },
         )
 
-        snapshot = client.create_snapshot("my-env", "python:3.12-slim", 4294967296)
+        import json
+
+        snapshot = client.create_snapshot(
+            "my-env", "python:3.12-slim", 4294967296, registry_id="reg-1"
+        )
 
         assert snapshot.id == "snap-1"
         assert snapshot.status == "ready"
+        request = httpx_mock.get_requests()[0]
+        assert json.loads(request.content) == {
+            "name": "my-env",
+            "docker_image": "python:3.12-slim",
+            "fs_capacity_bytes": 4294967296,
+            "registry_id": "reg-1",
+        }
 
     def test_capture_snapshot(self, client: SandboxClient, httpx_mock: HTTPXMock):
         """Test capturing a snapshot from a running sandbox."""


### PR DESCRIPTION
## Description

Expose sandbox registry CRUD on the SDK clients by delegating to the generated `_openapi_client` v2 sandboxes resource, and drop the unsupported inline snapshot registry credentials.

- **`SandboxClient.registries`** (Python `SandboxClient`/`AsyncSandboxClient`, JS `SandboxClient`) → `client.registries.create / retrieve / list / update / delete`, backed by the generated client and available from the same client used for sandboxes and snapshots (no separate `langsmith.Client` needed). The sync `SandboxClient` uses the sync generated client (no `await`); `AsyncSandboxClient` uses the async one.
- **`Client.sandboxes` accessor** (main Python `Client`/`AsyncClient`, JS `Client`) → `client.sandboxes.registries.*` (plus `.snapshots`, `.boxes`), mirroring the existing `runs`/`online_evaluators` accessors.
- **Remove inline snapshot registry creds**: drop `registry_url` / `registry_username` / `registry_password` from snapshot creation, keeping only `registry_id` (Go and Java already expose only registry IDs).

Depends on the generated client sync (#3095, merged).

## Test Plan

- Python: `ruff check` + format clean; sandbox unit tests pass (including new `TestRegistries`); verified **live against dev** (api-key profile) — both sync and async `SandboxClient().registries` create → retrieve → list → delete round-trip, self-cleaning.
- JS: `tsc --noEmit` clean, `oxlint` + `oxfmt` clean, sandbox jest tests pass (including a new registries accessor test).
