### PR TITLE
release(js): bump js sdk version to 0.7.12

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langsmith",
-  "version": "0.7.11",
+  "version": "0.7.12",
   "description": "Client library to connect to the LangSmith Observability and Evaluation Platform.",
   "packageManager": "pnpm@10.33.0",
   "files": [

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -34,7 +34,7 @@ export {
 } from "./utils/prompt_cache/index.js";
 
 // Update using pnpm bump-version
-export const __version__ = "0.7.11";
+export const __version__ = "0.7.12";
 
 // Metadata key to hide a traced run from LangSmith's Messages View.
 export const LS_MESSAGE_VIEW_EXCLUDE = "ls_message_view_exclude" as const;


### PR DESCRIPTION
## Summary
- Bump JS SDK patch version from `0.7.11` → `0.7.12`
- Updates `js/package.json` and `js/src/index.ts`

## Test plan
- [ ] Merge to `main` — the `JS Release` workflow triggers on changes to `js/package.json` and will publish to NPM automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)