### PR TITLE
feat(sandbox): do not gate dataplane ops on sandbox status

### DIFF
--- a/js/src/sandbox/sandbox.ts
+++ b/js/src/sandbox/sandbox.ts
@@ -11,10 +11,7 @@ import type {
   Snapshot,
   StartSandboxOptions,
 } from "./types.js";
-import {
-  LangSmithDataplaneNotConfiguredError,
-  LangSmithSandboxNotReadyError,
-} from "./errors.js";
+import { LangSmithDataplaneNotConfiguredError } from "./errors.js";
 import { handleSandboxHttpError } from "./helpers.js";
 import { CommandHandle } from "./command_handle.js";
 import { reconnectWsStream, runWsStream } from "./ws_execute.js";
@@ -101,17 +98,16 @@ export class Sandbox {
   }
 
   /**
-   * Validate and return the dataplane URL.
-   * @throws LangSmithSandboxNotReadyError if sandbox status is not "ready".
+   * Return the dataplane URL.
+   *
+   * The client does not gate on lifecycle status: a stopped sandbox is resumed
+   * by the platform when the dataplane request arrives, so only the presence of
+   * a URL is required here. A genuinely not-ready box surfaces the server's
+   * LangSmithSandboxNotReadyError from the request itself.
+   *
    * @throws LangSmithDataplaneNotConfiguredError if dataplane_url is not configured.
    */
   private requireDataplaneUrl(): string {
-    if (this.status && this.status !== "ready") {
-      throw new LangSmithSandboxNotReadyError(
-        `Sandbox '${this.name}' is not ready (status: ${this.status}). ` +
-          "Use waitForSandbox() to wait for the sandbox to become ready.",
-      );
-    }
     if (!this.dataplane_url) {
       throw new LangSmithDataplaneNotConfiguredError(
         `Sandbox '${this.name}' does not have a dataplane_url configured. ` +

--- a/js/src/tests/sandbox.test.ts
+++ b/js/src/tests/sandbox.test.ts
@@ -32,7 +32,6 @@ import {
   LangSmithValidationError,
   LangSmithResourceTimeoutError,
   LangSmithSandboxCreationError,
-  LangSmithSandboxNotReadyError,
   LangSmithSandboxOperationError,
   LangSmithCommandTimeoutError,
   LangSmithSandboxServerReloadError,
@@ -1286,19 +1285,22 @@ describe("Sandbox - status fields and not-ready guard", () => {
     expect(sandbox.status_message).toBe("Waiting for resources");
   });
 
-  it("should throw LangSmithSandboxNotReadyError when status is not ready", async () => {
+  it("does not gate dataplane ops on status (stopped runs; platform resumes)", async () => {
+    const mockFetch = createMockFetch({
+      ok: true,
+      json: async () => ({ stdout: "ok\n", stderr: "", exit_code: 0 }),
+    });
     const sandbox = new (Sandbox as any)(
       {
         name: "test-sandbox",
         dataplane_url: "https://dp.example.com",
-        status: "provisioning",
+        status: "stopped",
       },
-      createMockClient(),
+      createMockClient({ _fetch: mockFetch }),
     );
 
-    await expect(sandbox.run("echo hello")).rejects.toThrow(
-      LangSmithSandboxNotReadyError,
-    );
+    const result = await sandbox.run("echo ok");
+    expect(result.stdout).toBe("ok\n");
   });
 
   it("should allow operations when status is ready", async () => {

--- a/python/langsmith/sandbox/_async_sandbox.py
+++ b/python/langsmith/sandbox/_async_sandbox.py
@@ -13,7 +13,6 @@ from langsmith.sandbox._exceptions import (
     DataplaneNotConfiguredError,
     ResourceNotFoundError,
     SandboxConnectionError,
-    SandboxNotReadyError,
 )
 from langsmith.sandbox._helpers import handle_sandbox_http_error
 from langsmith.sandbox._models import (
@@ -188,20 +187,19 @@ class AsyncSandbox:
                 pass
 
     def _require_dataplane_url(self) -> str:
-        """Validate and return the dataplane URL.
+        """Return the dataplane URL.
+
+        The client does not gate on lifecycle status: a stopped sandbox is
+        resumed by the platform when the dataplane request arrives, so only the
+        presence of a URL is required here. A genuinely not-ready box surfaces
+        the server's ``SandboxNotReadyError`` from the request itself.
 
         Returns:
             The dataplane URL.
 
         Raises:
-            SandboxNotReadyError: If sandbox status is not "ready".
             DataplaneNotConfiguredError: If dataplane_url is not configured.
         """
-        if self.status != "ready":
-            raise SandboxNotReadyError(
-                f"Sandbox '{self.name}' is not ready (status: {self.status}). "
-                "Wait for status 'ready' before running operations."
-            )
         if not self.dataplane_url:
             raise DataplaneNotConfiguredError(
                 f"Sandbox '{self.name}' does not have a dataplane_url configured. "

--- a/python/langsmith/sandbox/_sandbox.py
+++ b/python/langsmith/sandbox/_sandbox.py
@@ -12,7 +12,6 @@ from langsmith.sandbox._exceptions import (
     DataplaneNotConfiguredError,
     ResourceNotFoundError,
     SandboxConnectionError,
-    SandboxNotReadyError,
 )
 from langsmith.sandbox._helpers import handle_sandbox_http_error
 from langsmith.sandbox._models import (
@@ -185,20 +184,19 @@ class Sandbox:
                 pass
 
     def _require_dataplane_url(self) -> str:
-        """Validate and return the dataplane URL.
+        """Return the dataplane URL.
+
+        The client does not gate on lifecycle status: a stopped sandbox is
+        resumed by the platform when the dataplane request arrives, so only the
+        presence of a URL is required here. A genuinely not-ready box surfaces
+        the server's ``SandboxNotReadyError`` from the request itself.
 
         Returns:
             The dataplane URL.
 
         Raises:
-            SandboxNotReadyError: If sandbox status is not "ready".
             DataplaneNotConfiguredError: If dataplane_url is not configured.
         """
-        if self.status != "ready":
-            raise SandboxNotReadyError(
-                f"Sandbox '{self.name}' is not ready (status: {self.status}). "
-                "Wait for status 'ready' before running operations."
-            )
         if not self.dataplane_url:
             raise DataplaneNotConfiguredError(
                 f"Sandbox '{self.name}' does not have a dataplane_url configured. "

--- a/python/tests/unit_tests/sandbox/test_async_sandbox.py
+++ b/python/tests/unit_tests/sandbox/test_async_sandbox.py
@@ -149,46 +149,41 @@ class TestAsyncSandboxStatusFields:
         assert sb.status == "ready"
         assert sb.status_message is None
 
-    async def test_provisioning_sandbox_blocks_run(self, client):
-        """Test that run() raises SandboxNotReadyError for non-ready sandbox."""
+    async def test_dataplane_op_not_gated_on_status(
+        self, client, httpx_mock: HTTPXMock
+    ):
+        """The client does not pre-check status: a stopped sandbox still runs;
+        the platform resumes it when the dataplane request arrives."""
+        httpx_mock.add_response(
+            method="POST",
+            url="https://sandbox-router.example.com/sb-123/execute",
+            json={"stdout": "ok\n", "stderr": "", "exit_code": 0},
+        )
         sb = AsyncSandbox.from_dict(
             data={
                 "name": "test-sandbox",
-                "status": "provisioning",
+                "status": "stopped",
                 "dataplane_url": "https://sandbox-router.example.com/sb-123",
             },
             client=client,
             auto_delete=False,
         )
-        with pytest.raises(SandboxNotReadyError, match="not ready"):
+        result = await sb.run("echo ok")
+        assert result.stdout == "ok\n"
+
+    async def test_missing_dataplane_url_raises_regardless_of_status(self, client):
+        """Without a dataplane_url, dataplane ops raise
+        DataplaneNotConfiguredError — the only client-side precondition."""
+        sb = AsyncSandbox.from_dict(
+            data={"name": "test-sandbox", "status": "stopped"},
+            client=client,
+            auto_delete=False,
+        )
+        with pytest.raises(DataplaneNotConfiguredError):
             await sb.run("echo hello")
-
-    async def test_provisioning_sandbox_blocks_write(self, client):
-        """Test that write() raises SandboxNotReadyError for non-ready sandbox."""
-        sb = AsyncSandbox.from_dict(
-            data={
-                "name": "test-sandbox",
-                "status": "provisioning",
-                "dataplane_url": "https://sandbox-router.example.com/sb-123",
-            },
-            client=client,
-            auto_delete=False,
-        )
-        with pytest.raises(SandboxNotReadyError):
+        with pytest.raises(DataplaneNotConfiguredError):
             await sb.write("/tmp/test.txt", "hello")
-
-    async def test_provisioning_sandbox_blocks_read(self, client):
-        """Test that read() raises SandboxNotReadyError for non-ready sandbox."""
-        sb = AsyncSandbox.from_dict(
-            data={
-                "name": "test-sandbox",
-                "status": "provisioning",
-                "dataplane_url": "https://sandbox-router.example.com/sb-123",
-            },
-            client=client,
-            auto_delete=False,
-        )
-        with pytest.raises(SandboxNotReadyError):
+        with pytest.raises(DataplaneNotConfiguredError):
             await sb.read("/tmp/test.txt")
 
 

--- a/python/tests/unit_tests/sandbox/test_sandbox.py
+++ b/python/tests/unit_tests/sandbox/test_sandbox.py
@@ -161,61 +161,38 @@ class TestSandboxStatusFields:
         assert sb.status == "ready"
         assert sb.status_message is None
 
-    def test_provisioning_sandbox_blocks_run(self, client):
-        """Test that run() raises SandboxNotReadyError for non-ready sandbox."""
+    def test_dataplane_op_not_gated_on_status(self, client, httpx_mock: HTTPXMock):
+        """The client does not pre-check status: a stopped sandbox still runs;
+        the platform resumes it when the dataplane request arrives."""
+        httpx_mock.add_response(
+            method="POST",
+            url="https://sandbox-router.example.com/sb-123/execute",
+            json={"stdout": "ok\n", "stderr": "", "exit_code": 0},
+        )
         sb = Sandbox.from_dict(
             data={
                 "name": "test-sandbox",
-                "status": "provisioning",
+                "status": "stopped",
                 "dataplane_url": "https://sandbox-router.example.com/sb-123",
             },
             client=client,
             auto_delete=False,
         )
-        with pytest.raises(SandboxNotReadyError, match="not ready"):
-            sb.run("echo hello")
+        assert sb.run("echo ok").stdout == "ok\n"
 
-    def test_failed_sandbox_blocks_run(self, client):
-        """Test that run() raises SandboxNotReadyError for failed sandbox."""
+    def test_missing_dataplane_url_raises_regardless_of_status(self, client):
+        """Without a dataplane_url, dataplane ops raise
+        DataplaneNotConfiguredError — the only client-side precondition."""
         sb = Sandbox.from_dict(
-            data={
-                "name": "test-sandbox",
-                "status": "failed",
-                "status_message": "No capacity",
-                "dataplane_url": "https://sandbox-router.example.com/sb-123",
-            },
+            data={"name": "test-sandbox", "status": "stopped"},
             client=client,
             auto_delete=False,
         )
-        with pytest.raises(SandboxNotReadyError):
+        with pytest.raises(DataplaneNotConfiguredError):
             sb.run("echo hello")
-
-    def test_provisioning_sandbox_blocks_write(self, client):
-        """Test that write() raises SandboxNotReadyError for non-ready sandbox."""
-        sb = Sandbox.from_dict(
-            data={
-                "name": "test-sandbox",
-                "status": "provisioning",
-                "dataplane_url": "https://sandbox-router.example.com/sb-123",
-            },
-            client=client,
-            auto_delete=False,
-        )
-        with pytest.raises(SandboxNotReadyError):
+        with pytest.raises(DataplaneNotConfiguredError):
             sb.write("/tmp/test.txt", "hello")
-
-    def test_provisioning_sandbox_blocks_read(self, client):
-        """Test that read() raises SandboxNotReadyError for non-ready sandbox."""
-        sb = Sandbox.from_dict(
-            data={
-                "name": "test-sandbox",
-                "status": "provisioning",
-                "dataplane_url": "https://sandbox-router.example.com/sb-123",
-            },
-            client=client,
-            auto_delete=False,
-        )
-        with pytest.raises(SandboxNotReadyError):
+        with pytest.raises(DataplaneNotConfiguredError):
             sb.read("/tmp/test.txt")
 
 


### PR DESCRIPTION
## Summary

A stopped LangSmith sandbox is resumed **by the platform** when a dataplane request arrives, and its dataplane URL is derived from the sandbox id (stable across stop/resume). But the SDK refused client-side on any non-`ready` status (`SandboxNotReadyError`), so callers had to manage start/stop themselves and a box that idle-stopped between turns became a hard failure.

This makes the client stop caring about lifecycle status: it just sends the dataplane request and lets the platform decide.

## What changed

- The dataplane chokepoint (`_require_dataplane_url` / `requireDataplaneUrl`, Python sync + async and JS) no longer inspects `status`. It requires only that a `dataplane_url` is present.
- A stopped box now proceeds straight to the dataplane request — the platform resumes it.
- A genuinely not-ready box still surfaces the server's `SandboxNotReadyError` from the request itself (mapped from a `400 NotReady`); this path is unchanged.
- A missing dataplane URL raises `DataplaneNotConfiguredError` — the only client-side precondition.

The unused client-side `SandboxNotReadyError` import is removed from the sandbox classes (it's still raised server-side via the HTTP error mapper).

## Test plan

- [x] Python sandbox unit suite passes (`486 passed`), incl. updated tests: a stopped box runs (not gated on status); missing dataplane URL raises `DataplaneNotConfiguredError` for run/write/read; the existing server-`NotReady` mapping test still asserts `SandboxNotReadyError`.
- [x] JS sandbox unit suite passes (`130 passed`), incl. a stopped box running without a client-side status check.
- [x] `ruff check` + `ruff format` clean (Python); `oxlint` + `oxfmt` clean, `tsc --noEmit` no errors (JS).
