### PR TITLE
ci: pin all GitHub Actions to immutable SHA pins

### DIFF
--- a/.github/actions/js-integration-tests/action.yml
+++ b/.github/actions/js-integration-tests/action.yml
@@ -17,15 +17,15 @@ runs:
   using: "composite"
   steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
     - name: Setup pnpm
-      uses: pnpm/action-setup@v4
+      uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
       with:
         version: 10
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
       with:
         node-version: ${{ inputs.node-version }}
         cache: pnpm

--- a/.github/actions/js-vitest-eval-test/action.yml
+++ b/.github/actions/js-vitest-eval-test/action.yml
@@ -11,15 +11,15 @@ runs:
   using: "composite"
   steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
     - name: Setup pnpm
-      uses: pnpm/action-setup@v4
+      uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
       with:
         version: 10
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
       with:
         node-version: ${{ inputs.node-version }}
         cache: pnpm

--- a/.github/actions/python-integration-tests/action.yml
+++ b/.github/actions/python-integration-tests/action.yml
@@ -35,10 +35,10 @@ runs:
   using: "composite"
   steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v6
+      uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
       with:
         python-version: ${{ inputs.python-version }}
         working-directory: python

--- a/.github/workflows/auto-label-issues.yml
+++ b/.github/workflows/auto-label-issues.yml
@@ -13,7 +13,7 @@ jobs:
       issues: write
     steps:
       - name: Add SDK label
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             github.rest.issues.addLabels({

--- a/.github/workflows/js-perf.yml
+++ b/.github/workflows/js-perf.yml
@@ -16,18 +16,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout PR HEAD
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           path: pr
 
       - name: Checkout main
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: main
           path: base
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 20
 
@@ -70,7 +70,7 @@ jobs:
             -t "benchmark event loop" 2>&1 | tee "$GITHUB_WORKSPACE/pr-bench.log"
 
       - name: Compare and post PR comment
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             const fs = require("fs");

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: Check links in Markdown files
         uses: gaurav-nelson/github-action-markdown-link-check@5c5dfc0ac2e225883c0e5f03a85311ec2830d368 # v1
         with:

--- a/.github/workflows/py-baseline.yml
+++ b/.github/workflows/py-baseline.yml
@@ -18,7 +18,7 @@ jobs:
       run:
         working-directory: python
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - run: SHA=$(git rev-parse HEAD) && echo "SHA=$SHA" >> $GITHUB_ENV
       - name: Install uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
@@ -30,7 +30,7 @@ jobs:
       - name: Run benchmarks
         run: OUTPUT=out/benchmark-baseline.json make -s benchmark
       - name: Save outputs
-        uses: actions/cache/save@v5
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           key: ${{ runner.os }}-benchmark-baseline-${{ env.SHA }}
           path: |

--- a/.github/workflows/py-bench.yml
+++ b/.github/workflows/py-bench.yml
@@ -15,7 +15,7 @@ jobs:
       run:
         working-directory: python
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - id: files
         name: Get changed files
         uses: Ana06/get-changed-files@25f79e676e7ea1868813e21465014798211fad8c # v2.3.0
@@ -32,7 +32,7 @@ jobs:
         run: uv sync --group dev
 
       - name: Download baseline
-        uses: actions/cache/restore@v5
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           key: ${{ runner.os }}-benchmark-baseline
           restore-keys: |
@@ -59,7 +59,7 @@ jobs:
             echo EOF
           } >> "$GITHUB_OUTPUT"
       - name: Annotation
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             const file = JSON.parse(`${{ steps.files.outputs.added_modified_renamed }}`)[0]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
       contents: write
       id-token: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: Check if version already released
         id: version-check
         run: |

--- a/.github/workflows/release_js.yml
+++ b/.github/workflows/release_js.yml
@@ -30,14 +30,14 @@ jobs:
       run:
         working-directory: "js"
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       # JS Build
       - name: Setup pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
         with:
           version: 10
       - name: Use Node.js 24.x
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 24.x
           cache: pnpm


### PR DESCRIPTION
## Summary

Pin all GitHub Actions used in workflows and composite actions to immutable commit SHA pins instead of mutable version tags. This is a supply-chain security hardening measure that prevents tag repointing attacks.

## Actions pinned

| Action | Version | SHA |
|--------|---------|-----|
| `actions/checkout` | v4 | `34e114876b0b11c390a56381ad16ebd13914f8d5` |
| `actions/checkout` | v6 | `df4cb1c069e1874edd31b4311f1884172cec0e10` |
| `actions/setup-node` | v4 | `49933ea5288caeca8642d1e84afbd3f7d6820020` |
| `actions/setup-node` | v6 | `48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e` |
| `actions/github-script` | v9 | `3a2844b7e9c422d3c10d287c895573f7108da1b3` |
| `actions/cache/save` | v5 | `27d5ce7f107fe9357f9df03efb73ab90386fccae` |
| `actions/cache/restore` | v5 | `27d5ce7f107fe9357f9df03efb73ab90386fccae` |
| `pnpm/action-setup` | v4 | `b906affcce14559ad1aafd4ab0e942779e9f58b1` |
| `astral-sh/setup-uv` | v6 | `d0cc045d04ccac9d8b7881df0226f9e82c39688e` |

All SHAs were resolved via `gh api` and dereferenced from annotated tags where applicable. Each pin includes a `# vN` comment for readability and Dependabot compatibility.

## Files changed

- `.github/workflows/auto-label-issues.yml`
- `.github/workflows/js-perf.yml`
- `.github/workflows/link-check.yml`
- `.github/workflows/py-baseline.yml`
- `.github/workflows/py-bench.yml`
- `.github/workflows/release.yml`
- `.github/workflows/release_js.yml`
- `.github/actions/js-integration-tests/action.yml`
- `.github/actions/js-vitest-eval-test/action.yml`
- `.github/actions/python-integration-tests/action.yml`

Actions that were already SHA-pinned (e.g. in `ci.yml`, `release.yml` for `ncipollo/release-action`, `pypa/gh-action-pypi-publish`, `dorny/paths-filter`, `gaurav-nelson/github-action-markdown-link-check`, `Ana06/get-changed-files`, `oven-sh/setup-bun`) were left unchanged.