### PR TITLE
fix(google_adk): capture LLM inputs after before_model_callback runs [LSDK-279]

### DIFF
--- a/python/langsmith/integrations/google_adk/_client.py
+++ b/python/langsmith/integrations/google_adk/_client.py
@@ -349,36 +349,45 @@ async def wrap_flow_call_llm_async(
         return
 
     llm_request = args[1] if len(args) > 1 else kwargs.get("llm_request")
-    model_name = extract_model_name(llm_request) if llm_request else None
-    messages = convert_llm_request_to_messages(llm_request) if llm_request else None
-    tools = extract_tools_from_llm_request(llm_request) if llm_request else []
-
-    inputs: dict[str, Any] = {}
-    if messages:
-        inputs["messages"] = messages
-
-    metadata: dict[str, Any] = {"ls_provider": _get_ls_provider()}
-    if model_name:
-        metadata["ls_model_name"] = model_name
-
-    # Build extra dict with invocation_params if tools exist
-    extra: dict[str, Any] = {"metadata": metadata}
-    if tools:
-        extra["invocation_params"] = {"tools": tools}
 
     start_time = time.time()
+    # Anchor start time now, but capture inputs later:
+    # ADK's before_model_callback mutates llm_request in-place in wrapped().
     llm_run = parent.create_child(
-        name=model_name or "google_adk_llm",
+        name="google_adk_llm",
         run_type="llm",
-        inputs=inputs,
-        extra=extra,
+        inputs={},
+        extra={"metadata": {"ls_provider": _get_ls_provider()}},
         start_time=datetime.fromtimestamp(start_time, tz=timezone.utc),
     )
 
-    try:
-        llm_run.post()
-    except Exception as e:
-        logger.debug(f"Failed to post LLM run: {e}")
+    posted = False
+
+    def _capture_inputs_and_post() -> None:
+        """Capture the final llm_request state and post the run (idempotent)."""
+        nonlocal posted
+        if posted:
+            return
+        posted = True
+
+        model_name = extract_model_name(llm_request) if llm_request else None
+        messages = (
+            convert_llm_request_to_messages(llm_request) if llm_request else None
+        )
+        tools = extract_tools_from_llm_request(llm_request) if llm_request else []
+
+        if messages:
+            llm_run.inputs = {"messages": messages}
+        if model_name:
+            llm_run.name = model_name
+            llm_run.extra.setdefault("metadata", {})["ls_model_name"] = model_name
+        if tools:
+            llm_run.extra.setdefault("invocation_params", {})["tools"] = tools
+
+        try:
+            llm_run.post()
+        except Exception as e:
+            logger.debug(f"Failed to post LLM run: {e}")
 
     first_token_time: Optional[float] = None
     last_event = None
@@ -387,6 +396,9 @@ async def wrap_flow_call_llm_async(
     try:
         async with aclosing(wrapped(*args, **kwargs)) as agen:
             async for event in agen:
+                # Callbacks have run; llm_request now reflects the final request.
+                _capture_inputs_and_post()
+
                 is_partial = getattr(event, "partial", False)
 
                 if first_token_time is None and is_partial:
@@ -407,6 +419,9 @@ async def wrap_flow_call_llm_async(
                 if hasattr(event, "content") and event.content is not None:
                     event_with_content = event
                 yield event
+
+        # Record the run even if no event was yielded.
+        _capture_inputs_and_post()
 
         outputs: dict[str, Any] = {"role": "assistant"}
         content_source = event_with_content or last_event
@@ -462,6 +477,8 @@ async def wrap_flow_call_llm_async(
             logger.debug(f"Failed to patch LLM run: {e}")
 
     except Exception as e:
+        # Record the run even if wrapped() raised before yielding.
+        _capture_inputs_and_post()
         llm_run.end(error=str(e))
         try:
             llm_run.patch()

--- a/python/langsmith/integrations/google_adk/_client.py
+++ b/python/langsmith/integrations/google_adk/_client.py
@@ -368,7 +368,6 @@ async def wrap_flow_call_llm_async(
         nonlocal posted
         if posted:
             return
-        posted = True
 
         model_name = extract_model_name(llm_request) if llm_request else None
         messages = convert_llm_request_to_messages(llm_request) if llm_request else None
@@ -382,6 +381,7 @@ async def wrap_flow_call_llm_async(
         if tools:
             llm_run.extra.setdefault("invocation_params", {})["tools"] = tools
 
+        posted = True
         try:
             llm_run.post()
         except Exception as e:

--- a/python/langsmith/integrations/google_adk/_client.py
+++ b/python/langsmith/integrations/google_adk/_client.py
@@ -371,9 +371,7 @@ async def wrap_flow_call_llm_async(
         posted = True
 
         model_name = extract_model_name(llm_request) if llm_request else None
-        messages = (
-            convert_llm_request_to_messages(llm_request) if llm_request else None
-        )
+        messages = convert_llm_request_to_messages(llm_request) if llm_request else None
         tools = extract_tools_from_llm_request(llm_request) if llm_request else []
 
         if messages:

--- a/python/tests/unit_tests/wrappers/test_google_adk.py
+++ b/python/tests/unit_tests/wrappers/test_google_adk.py
@@ -288,6 +288,77 @@ def test_sequential_agent_sync_async_inputs_outputs_no_errors(
         assert not run.get("error"), run
 
 
+def _build_llm_agent_with_before_callback(injected_instruction: str):
+    """Build an LlmAgent backed by a fake model with a before_model_callback.
+
+    The callback mutates ``llm_request`` in place (as real ADK plugins do via
+    ``llm_request.append_instructions(...)``) inside ``_call_llm_async``, after
+    the LangSmith wrapper has already created the LLM run.
+    """
+    from google.adk.agents import LlmAgent
+    from google.adk.models.base_llm import BaseLlm
+    from google.adk.models.llm_response import LlmResponse
+    from google.genai import types
+
+    class _FakeLlm(BaseLlm):
+        model: str = "fake-model"
+
+        async def generate_content_async(self, llm_request, stream=False):
+            # Echo the system instruction so we can confirm the model received it.
+            sys_inst = ""
+            if getattr(llm_request, "config", None):
+                sys_inst = str(llm_request.config.system_instruction or "")
+            yield LlmResponse(
+                content=types.Content(
+                    role="model",
+                    parts=[types.Part(text=f"ok::{sys_inst}")],
+                )
+            )
+
+    def _before_model(callback_context, llm_request):
+        llm_request.append_instructions([injected_instruction])
+        return None
+
+    return LlmAgent(
+        name="haiku_agent",
+        model=_FakeLlm(),
+        description="agent with before_model_callback",
+        before_model_callback=_before_model,
+    )
+
+
+@pytest.mark.parametrize("mode", ["sync", "async"])
+def test_before_model_callback_mutations_reflected_in_llm_inputs(
+    mode: str, mock_ls_client: Client
+):
+    """LLM run inputs must reflect before_model_callback mutations (LSDK-279).
+
+    ADK runs before_model_callback inside ``_call_llm_async`` and lets it mutate
+    ``llm_request`` in place. The wrapper must capture inputs *after* those
+    callbacks run, otherwise injected instructions never appear in the trace.
+    """
+    injected = "Always respond in Haiku."
+    agent = _build_llm_agent_with_before_callback(injected)
+
+    response, runs = _run_agent(mode, agent, mock_ls_client, input_text="hi")
+
+    # Sanity check: the model actually received the injected instruction.
+    assert response is not None and injected in response
+
+    llm_run = next((r for r in runs if r.get("run_type") == "llm"), None)
+    assert llm_run is not None, (
+        f"No LLM run found. Present: {[r.get('name') for r in runs]}"
+    )
+
+    messages = (llm_run.get("inputs") or {}).get("messages") or []
+    system_text = " ".join(
+        str(m.get("content") or "") for m in messages if m.get("role") == "system"
+    )
+    assert injected in system_text, (
+        f"Injected instruction missing from LLM inputs. messages={messages}"
+    )
+
+
 @pytest.mark.parametrize("mode", ["sync", "async"])
 @pytest.mark.filterwarnings("ignore::pytest.PytestUnhandledThreadExceptionWarning")
 def test_error_agent_sync_async_records_errors(mode: str, mock_ls_client: Client):


### PR DESCRIPTION
## Summary

Fixes incomplete LLM traces in the Google ADK Python integration when a `before_model_callback` (ADK plugin or agent callback) modifies the request.

The wrapper captured the LLM inputs and called `post()` **before** invoking ADK's `_call_llm_async`. But ADK runs `before_model_callback` *inside* `_call_llm_async`, and those callbacks mutate `llm_request` in place (e.g. `llm_request.append_instructions(...)`). As a result, any dynamic changes - injected system instructions, guardrails, skills blocks - were sent to the model but **never reflected in the trace**, so replaying the LLM run in the Playground produced a different response.

The fix defers input capture and `post()` until the wrapped coroutine has yielded, by which point the before-model callbacks have run and `llm_request` reflects what was actually sent.

## Changes

- `langsmith/integrations/google_adk/_client.py` - `wrap_flow_call_llm_async`:
  - Create the LLM child run up front (to anchor the real start time) but **defer** capturing `messages`/`tools`/`model_name` and calling `post()` until after the wrapped coroutine yields its first event (after `before_model_callback` has mutated `llm_request`).
  - Capture + post is idempotent and also invoked in the no-event and exception paths, so the run is always recorded (even if a callback raises before the model is called).
- `tests/unit_tests/wrappers/test_google_adk.py` - new regression test (sync + async) using a fake `BaseLlm` model and a `before_model_callback` that injects an instruction; asserts the injected text appears in the traced LLM run inputs.

## Self-hosted release note

Fixed a bug in the Google ADK Python integration where LLM run inputs did not reflect modifications made by `before_model_callback` (ADK plugins/agent callbacks), such as dynamically injected system instructions. Traces now capture the final request sent to the model.

## Testing

- **Python:** `pytest tests/unit_tests/wrappers/test_google_adk.py` - 8 passing (includes 2 new sync/async regression tests).
- Verified the new test fails without the fix (system message missing the injected instruction) and passes with it.
- Lint/format clean (`ruff`).