### PR TITLE
fix(client): lazily initialize sync OpenAPI client

### DIFF
--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -1472,7 +1472,7 @@ class Client:
     def sandboxes(self) -> AsyncSandboxesResource:
         """Access the v2 sandboxes resource (registries, snapshots, boxes)."""
         _check_backend_version(self.info.version)
-        return self._langsmith_api.sandboxes
+        return self._get_langsmith_api().sandboxes
 
     def _dump_failed_trace(
         self,

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -892,6 +892,7 @@ class Client:
     _manual_cleanup: bool
     _profile_auth: Optional[_profiles.ProfileAuth]
     _profile_auth_headers: dict[str, str]
+    _langsmith_api: Optional[LangsmithOpenAPIClient]
 
     def __init__(
         self,
@@ -1430,18 +1431,7 @@ class Client:
             )
             self._failed_traces_max_bytes = 100 * 1024 * 1024
 
-        self._langsmith_api = LangsmithOpenAPIClient(
-            api_key=self._api_key,
-            tenant_id=str(self._workspace_id) if self._workspace_id else None,
-            base_url=self.api_url,
-            timeout=_httpx.Timeout(
-                connect=self._timeout[0],
-                read=self._timeout[1],
-                write=self._timeout[1],
-                pool=self._timeout[0],
-            ),
-            default_headers=self._headers or None,
-        )
+        self._langsmith_api = None
 
     # ------------------------------------------------------------------
     # Stainless v2 resource accessors
@@ -1450,17 +1440,33 @@ class Client:
     # __dict__; the stainless client caches each resource internally.
     # ------------------------------------------------------------------
 
+    def _get_langsmith_api(self) -> LangsmithOpenAPIClient:
+        if self._langsmith_api is None:
+            self._langsmith_api = LangsmithOpenAPIClient(
+                api_key=self._api_key,
+                tenant_id=str(self._workspace_id) if self._workspace_id else None,
+                base_url=self.api_url,
+                timeout=_httpx.Timeout(
+                    connect=self._timeout[0],
+                    read=self._timeout[1],
+                    write=self._timeout[1],
+                    pool=self._timeout[0],
+                ),
+                default_headers=self._headers or None,
+            )
+        return self._langsmith_api
+
     @property
     def runs(self) -> AsyncRunsResource:
         """Access the v2 runs resource."""
         _check_backend_version(self.info.version)
-        return self._langsmith_api.runs
+        return self._get_langsmith_api().runs
 
     @property
     def online_evaluators(self) -> AsyncOnlineEvaluatorsResource:
         """Access generated online evaluator CRUD methods."""
         _check_backend_version(self.info.version)
-        return self._langsmith_api.online_evaluators
+        return self._get_langsmith_api().online_evaluators
 
     @property
     def sandboxes(self) -> AsyncSandboxesResource:

--- a/python/tests/unit_tests/test_client.py
+++ b/python/tests/unit_tests/test_client.py
@@ -163,6 +163,21 @@ def test_validate_api_url(monkeypatch: pytest.MonkeyPatch) -> None:
     assert client.api_url == "https://api.smith.langsmith-endpoint.com"
 
 
+def test_client_init_does_not_eagerly_initialize_openapi_client(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("NO_PROXY", "::/0")
+    monkeypatch.setenv("no_proxy", "::/0")
+
+    client = Client(
+        api_url="https://api.smith.langchain.com",
+        api_key="test-api-key",
+        auto_batch_tracing=False,
+    )
+
+    assert client._langsmith_api is None
+
+
 def test_validate_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
     # Scenario 1: Both LANGCHAIN_API_KEY and LANGSMITH_API_KEY are set,
     # but api_key is not


### PR DESCRIPTION
## Description

Closes [LIN-407](https://linear.app/langchain/issue/LIN-407/featclient-integrate-v2-stainless-openapi-client-with-lazy)

Cherry-pick of the fix authored by @sunfayao in #3097.

The sync `Client` now defers construction of the generated OpenAPI client until a v2 resource (`client.runs`, `client.online_evaluators`) is first accessed, rather than eagerly constructing it during `__init__`. This prevents `httpx.InvalidURL: Invalid port: ':'` failures in environments where `NO_PROXY`/`no_proxy` contains IPv6 CIDR entries such as `::/0`.

## Changes

- Set `self._langsmith_api` to `None` during `Client.__init__`
- Add `_get_langsmith_api()` to construct and cache the generated OpenAPI client on first use
- Add a regression test for `Client(...)` initialization with `NO_PROXY=::/0`

Fixes #3096