### PR TITLE
fix(client): apply anonymizer to run error field

### DIFF
--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -2229,6 +2229,8 @@ class Client:
             run_create["outputs"] = self._hide_run_outputs(run_create["outputs"])
         if "events" in run_create and run_create["events"] is not None:
             run_create["events"] = self._filter_new_token_events(run_create["events"])
+        if "error" in run_create and run_create["error"] is not None:
+            run_create["error"] = self._hide_run_error(run_create["error"])
         # Hide metadata in extra if present
         if "extra" in run_create and isinstance(run_create["extra"], dict):
             extra = run_create["extra"]
@@ -2653,6 +2655,28 @@ class Client:
         if self._hide_outputs is False:
             return outputs
         return self._hide_outputs(outputs)
+
+    def _hide_run_error(self, error: Any):
+        """Apply the configured anonymizer to a run's error string.
+
+        Unlike inputs/outputs, ``error`` is a plain string (``repr(exc)`` plus a
+        formatted traceback, see ``run_helpers._format_error_with_exceptions_to_handle``)
+        that can capture credentials the user never explicitly logged -- e.g. an
+        HTTP client exception whose request-object repr includes an
+        ``Authorization`` header. Route it through the same anonymizer as
+        inputs/outputs so secrets are scrubbed client-side before upload.
+
+        The value is wrapped as ``{"error": ...}`` so that both
+        ``create_secret_anonymizer`` and a user-supplied anonymizer matching the
+        documented ``Callable[[dict], dict]`` signature receive a dict (a bare
+        string would break a dict-typed anonymizer), then unwrapped.
+        """
+        if not self._anonymizer or error is None:
+            return error
+        scrubbed = self._anonymizer({"error": error})
+        if isinstance(scrubbed, dict) and "error" in scrubbed:
+            return scrubbed["error"]
+        return error
 
     def _hide_run_metadata(self, metadata: dict) -> dict:
         if self._hide_metadata is True:
@@ -3572,7 +3596,7 @@ class Client:
         else:
             data["end_time"] = datetime.datetime.now(datetime.timezone.utc).isoformat()
         if error is not None:
-            data["error"] = error
+            data["error"] = self._hide_run_error(error)
         if inputs is not None:
             data["inputs"] = self._hide_run_inputs(inputs)
         if outputs is not None:

--- a/python/tests/unit_tests/test_client.py
+++ b/python/tests/unit_tests/test_client.py
@@ -1493,6 +1493,72 @@ def test_hide_metadata(
         )
 
 
+def test_anonymizer_redacts_error_field() -> None:
+    """The configured anonymizer must scrub ``error``, not just inputs/outputs.
+
+    A credential can land in the error field via an exception traceback (e.g. an
+    HTTP-client error whose request-object repr includes an ``Authorization``
+    header), and it must not be uploaded raw. Covers both the create/post path
+    (via ``_run_transform``) and the patch path (via ``_hide_run_error``).
+    """
+    from langsmith.anonymizer import SECRET_PLACEHOLDER, create_secret_anonymizer
+
+    # Assembled at runtime so no literal secret-shaped string sits in source.
+    fake_key = "sk-ant-api03-" + "A" * 30
+    traceback_str = (
+        "Traceback (most recent call last):\n"
+        '  ClientResponseError: 401, request_info=headers={"Authorization": '
+        f'"Bearer {fake_key}"}}'
+    )
+
+    session = mock.MagicMock(spec=requests.Session)
+    client = Client(
+        api_url="http://localhost:1984",
+        api_key="123",
+        auto_batch_tracing=False,  # Easier to inspect single calls
+        session=session,
+        anonymizer=create_secret_anonymizer(),
+    )
+
+    # ── create/post path goes through _run_transform ────────────────────────
+    client.create_run(
+        "errored_run",
+        inputs={"in": "put"},
+        run_type="llm",
+        id=uuid.uuid4(),
+        error=traceback_str,
+    )
+    post_call = None
+    for call in session.request.mock_calls:
+        if len(call.args) > 1 and call.args[0] == "POST" and "runs" in call.args[1]:
+            post_call = call
+            break
+    assert post_call is not None, "POST request to /runs not found"
+    payload_data = post_call.kwargs.get("data", b"{}")
+    payload = json.loads(
+        payload_data.decode("utf-8")
+        if isinstance(payload_data, bytes)
+        else payload_data
+    )
+    assert fake_key not in payload["error"]
+    assert SECRET_PLACEHOLDER in payload["error"]
+
+    # ── patch path uses _hide_run_error directly ────────────────────────────
+    scrubbed = client._hide_run_error(traceback_str)
+    assert fake_key not in scrubbed
+    assert SECRET_PLACEHOLDER in scrubbed
+
+    # ── no anonymizer configured -> error passes through unchanged ──────────
+    plain = Client(
+        api_url="http://localhost:1984",
+        api_key="123",
+        auto_batch_tracing=False,
+        session=mock.MagicMock(spec=requests.Session),
+    )
+    assert plain._hide_run_error(traceback_str) == traceback_str
+    assert plain._hide_run_error(None) is None
+
+
 def test_omit_traced_runtime_info() -> None:
     """Test that omit_traced_runtime_info prevents runtime info from being added."""
     session = mock.MagicMock(spec=requests.Session)

--- a/python/tests/unit_tests/test_client.py
+++ b/python/tests/unit_tests/test_client.py
@@ -38,6 +38,7 @@ from langsmith import schemas as ls_schemas
 from langsmith._internal import _orjson
 from langsmith._internal._multipart import MultipartPartsAndContext
 from langsmith._internal._serde import _serialize_json
+from langsmith.anonymizer import SECRET_PLACEHOLDER, create_secret_anonymizer
 from langsmith.client import (
     Client,
     _apply_auth_overrides,
@@ -1493,26 +1494,32 @@ def test_hide_metadata(
         )
 
 
-def test_anonymizer_redacts_error_field() -> None:
-    """The configured anonymizer must scrub ``error``, not just inputs/outputs.
-
-    A credential can land in the error field via an exception traceback (e.g. an
-    HTTP-client error whose request-object repr includes an ``Authorization``
-    header), and it must not be uploaded raw. Covers both the create/post path
-    (via ``_run_transform``) and the patch path (via ``_hide_run_error``).
-    """
-    from langsmith.anonymizer import SECRET_PLACEHOLDER, create_secret_anonymizer
-
-    # Assembled at runtime so no literal secret-shaped string sits in source.
+def _error_traceback_with_secret() -> tuple[str, str]:
+    """Return ``(fake_key, traceback_str)`` assembled at runtime so no literal
+    secret-shaped string sits in source (the repo secret-scanner would otherwise
+    rewrite it)."""
     fake_key = "sk-ant-api03-" + "A" * 30
     traceback_str = (
         "Traceback (most recent call last):\n"
         '  ClientResponseError: 401, request_info=headers={"Authorization": '
         f'"Bearer {fake_key}"}}'
     )
+    return fake_key, traceback_str
 
-    session = mock.MagicMock(spec=requests.Session)
-    client = Client(
+
+def _find_request_payload(
+    session: mock.MagicMock, method: str, url_substr: str
+) -> dict:
+    """Return the JSON body of the first mocked request matching method + URL."""
+    for call in session.request.mock_calls:
+        if len(call.args) > 1 and call.args[0] == method and url_substr in call.args[1]:
+            data = call.kwargs.get("data", b"{}")
+            return json.loads(data.decode("utf-8") if isinstance(data, bytes) else data)
+    raise AssertionError(f"{method} request matching {url_substr!r} not found")
+
+
+def _client_with_secret_anonymizer(session: mock.MagicMock) -> Client:
+    return Client(
         api_url="http://localhost:1984",
         api_key="123",
         auto_batch_tracing=False,  # Easier to inspect single calls
@@ -1520,7 +1527,19 @@ def test_anonymizer_redacts_error_field() -> None:
         anonymizer=create_secret_anonymizer(),
     )
 
-    # ── create/post path goes through _run_transform ────────────────────────
+
+def test_anonymizer_redacts_error_field_on_create() -> None:
+    """The anonymizer must scrub ``error`` on the create/post path, not just
+    inputs/outputs.
+
+    A credential can land in the error field via an exception traceback -- e.g.
+    an HTTP-client error whose request-object repr includes an ``Authorization``
+    header -- and it must not be uploaded raw.
+    """
+    fake_key, traceback_str = _error_traceback_with_secret()
+    session = mock.MagicMock(spec=requests.Session)
+    client = _client_with_secret_anonymizer(session)
+
     client.create_run(
         "errored_run",
         inputs={"in": "put"},
@@ -1528,35 +1547,36 @@ def test_anonymizer_redacts_error_field() -> None:
         id=uuid.uuid4(),
         error=traceback_str,
     )
-    post_call = None
-    for call in session.request.mock_calls:
-        if len(call.args) > 1 and call.args[0] == "POST" and "runs" in call.args[1]:
-            post_call = call
-            break
-    assert post_call is not None, "POST request to /runs not found"
-    payload_data = post_call.kwargs.get("data", b"{}")
-    payload = json.loads(
-        payload_data.decode("utf-8")
-        if isinstance(payload_data, bytes)
-        else payload_data
-    )
+
+    payload = _find_request_payload(session, "POST", "/runs")
     assert fake_key not in payload["error"]
     assert SECRET_PLACEHOLDER in payload["error"]
 
-    # ── patch path uses _hide_run_error directly ────────────────────────────
-    scrubbed = client._hide_run_error(traceback_str)
-    assert fake_key not in scrubbed
-    assert SECRET_PLACEHOLDER in scrubbed
 
-    # ── no anonymizer configured -> error passes through unchanged ──────────
-    plain = Client(
+def test_anonymizer_redacts_error_field_on_update() -> None:
+    """The anonymizer must also scrub ``error`` on the update/patch path."""
+    fake_key, traceback_str = _error_traceback_with_secret()
+    session = mock.MagicMock(spec=requests.Session)
+    client = _client_with_secret_anonymizer(session)
+
+    client.update_run(uuid.uuid4(), error=traceback_str)
+
+    payload = _find_request_payload(session, "PATCH", "/runs/")
+    assert fake_key not in payload["error"]
+    assert SECRET_PLACEHOLDER in payload["error"]
+
+
+def test_hide_run_error_passthrough_without_anonymizer() -> None:
+    """With no anonymizer configured, the error is left unchanged."""
+    _, traceback_str = _error_traceback_with_secret()
+    client = Client(
         api_url="http://localhost:1984",
         api_key="123",
         auto_batch_tracing=False,
         session=mock.MagicMock(spec=requests.Session),
     )
-    assert plain._hide_run_error(traceback_str) == traceback_str
-    assert plain._hide_run_error(None) is None
+    assert client._hide_run_error(traceback_str) == traceback_str
+    assert client._hide_run_error(None) is None
 
 
 def test_omit_traced_runtime_info() -> None:


### PR DESCRIPTION
## Problem

The client-side `anonymizer` (including `create_secret_anonymizer`) only covers run **inputs** and **outputs** — not the `error` field. A secret captured in an exception traceback is therefore uploaded **unredacted**.

From a customer report (SDK 0.8.16): an `aiohttp` call failed, the exception's request-object repr carried the full `Authorization` header, and it landed verbatim in the run's `error` field. The error string is built in `run_helpers._format_error_with_exceptions_to_handle` as `repr(exc)` + traceback and was assigned straight into the payload with no redaction pass.

There is also no `hide_error` toggle and no `process_error` hook, so on released versions there's no client-side way to scrub it (only `@traceable(exceptions_to_handle=...)`, which drops the error entirely).

## Fix

Route `error` through the same anonymizer as inputs/outputs via a new `Client._hide_run_error`, wired at the two ingestion chokepoints:

- **`_run_transform`** — covers `create_run`, `batch_ingest_runs`, and `multipart_ingest_runs` (create *and* update funnel through here)
- **`update_run`** — the one standalone patch path that hides inline

The value is wrapped as `{"error": ...}` before calling the anonymizer so that both `create_secret_anonymizer` and a user-supplied anonymizer matching the documented `Callable[[dict], dict]` signature receive a dict — a bare string would break a dict-typed anonymizer. No JSON round-trip (unlike inputs/outputs), since `error` is already a string.

Scoped intentionally minimal — **no** new `hide_error`/`HIDE_ERROR` toggle (happy to add if wanted; left out to avoid a public-API/naming decision in a fix PR).

## Tests

`test_anonymizer_redacts_error_field` verifies redaction on the create path (over-the-wire POST payload), the patch path (`_hide_run_error`), and pass-through when no anonymizer is configured. `ruff check`/`format` and the anonymizer + client suites pass.

## Performance

Negligible, including for the tracing plugins that ship `create_secret_anonymizer`: zero added cost on success spans (guarded on `error is not None`), and on error spans it's one regex pass over a single string — cheaper per-call than the inputs/outputs scrub, which does a full orjson serialize→parse round-trip.

## Follow-up (not in this PR)

`create_secret_anonymizer`'s docstring claims it redacts "inputs, outputs, **and metadata**", but `_hide_run_metadata` never consults `self._anonymizer` (metadata is gated only by the `hide_metadata` bool/callable). Either wire metadata through the anonymizer or fix the docstring — separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
