### PR TITLE
release(py): 0.9.3

### DIFF
--- a/python/.bumpversion.cfg
+++ b/python/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.9.2
+current_version = 0.9.3
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
 serialize = {major}.{minor}.{patch}
 search = {current_version}

--- a/python/langsmith/__init__.py
+++ b/python/langsmith/__init__.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
 
 # Avoid calling into importlib on every call to __version__
 
-__version__ = "0.9.2"
+__version__ = "0.9.3"
 version = __version__  # for backwards compatibility
 
 # Metadata key to hide a traced run from LangSmith's Messages View.


### PR DESCRIPTION
## Description
Bumps the Python SDK version to 0.9.3 so the main-branch release workflow can publish the latest sandbox client changes.

## Release Note
Release langsmith Python SDK 0.9.3.

## Test Plan
- [ ] Confirm the release workflow publishes v0.9.3 after merge.

Made by [Open SWE](https://openswe.vercel.app/agents/6509c4e4-1ac9-468d-5a94-4abd45b3ff6a)

## References
- Plan: https://openswe.vercel.app/agents/6509c4e4-1ac9-468d-5a94-4abd45b3ff6a/plan