### PR TITLE
release(js): bump js sdk version to 0.7.13

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langsmith",
-  "version": "0.7.12",
+  "version": "0.7.13",
   "description": "Client library to connect to the LangSmith Observability and Evaluation Platform.",
   "packageManager": "pnpm@10.33.0",
   "files": [

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -34,7 +34,7 @@ export {
 } from "./utils/prompt_cache/index.js";
 
 // Update using pnpm bump-version
-export const __version__ = "0.7.12";
+export const __version__ = "0.7.13";
 
 // Metadata key to hide a traced run from LangSmith's Messages View.
 export const LS_MESSAGE_VIEW_EXCLUDE = "ls_message_view_exclude" as const;


### PR DESCRIPTION
Publishes the JS sandbox registry accessors from #3087 (`client.registries` on SandboxClient and `client.sandboxes.registries` on the main Client).

Merging to main triggers the npm publish via `release_js.yml` (npm `langsmith` is currently 0.7.12).