### PR TITLE
feat(integrations): voice tracing integrations (Pipecat, LiveKit, OpenAI Realtime, ADK Live)

### DIFF
--- a/python/langsmith/integrations/_voice/__init__.py
+++ b/python/langsmith/integrations/_voice/__init__.py
@@ -1,0 +1,42 @@
+"""Private shared machinery for the voice tracing integrations.
+
+Two independent bases live here, sharing only this namespace (not a common
+class):
+
+* ``base`` — Track A: :class:`BaseLangSmithSpanProcessor`, an OpenTelemetry
+  ``SpanProcessor`` shared by the framework integrations that emit their own
+  OTel spans (Pipecat, LiveKit).
+* ``session`` — Track B: :class:`EventSession`, a LangSmith ``RunTree`` builder
+  shared by the integrations that observe a remote event stream and construct
+  the trace themselves (OpenAI Realtime, OpenAI Agents realtime, ADK Live).
+
+Nothing in this package is part of the public API; import from the per-framework
+packages instead.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+
+class LangSmithVoiceBetaWarning(UserWarning):
+    """Warns that a LangSmith voice tracing integration is in development.
+
+    Filter it with ``warnings.filterwarnings("ignore",
+    category=LangSmithVoiceBetaWarning)``.
+    """
+
+
+def warn_in_development(integration: str) -> None:
+    """Emit a :class:`LangSmithVoiceBetaWarning` for a voice integration.
+
+    Called when one of the voice integration packages is imported, to signal
+    that these integrations are in development and their APIs may change.
+    """
+    warnings.warn(
+        f"langsmith.integrations.{integration} is in development; its API may "
+        "change in a future release.",
+        category=LangSmithVoiceBetaWarning,
+        stacklevel=3,
+    )
+

--- a/python/langsmith/integrations/_voice/audio.py
+++ b/python/langsmith/integrations/_voice/audio.py
@@ -1,0 +1,155 @@
+"""Payload scrubbing and stereo-WAV reconstruction for event-stream traces.
+
+Used by the Track B ``EventSession`` (and the per-framework adapters that feed
+it audio). Two concerns:
+
+* ``scrub`` / ``dump_event`` — turn an arbitrary event object into a compact,
+  safe payload (raw audio ``bytes`` → ``<N bytes>``, long strings truncated) so
+  a span never carries megabytes of audio or un-serializable junk.
+* ``build_stereo_session_wav`` — reconstruct one stereo conversation WAV from
+  the timestamped PCM16 chunks each side recorded (L=user, R=agent), laid out at
+  natural play time so bursts don't overlap.
+"""
+
+from __future__ import annotations
+
+import array
+import io
+import math
+import wave
+from typing import Any
+
+# Longest string kept on a span before truncating. Transcripts are short; this
+# only ever trims an unexpectedly large blob.
+MAX_STR = 2000
+
+
+def scrub(obj: Any) -> Any:
+    """Make an event payload safe and compact for a span.
+
+    Replaces raw ``bytes`` (audio / base64 blobs) with a ``<N bytes>``
+    placeholder and truncates very long strings, recursing through dicts and
+    sequences, so a span never ships megabytes of payload or breaks JSON
+    serialization.
+    """
+    if isinstance(obj, bytes):
+        return f"<{len(obj)} bytes>"
+    if isinstance(obj, str):
+        if len(obj) > MAX_STR:
+            return obj[:MAX_STR] + f"... <+{len(obj) - MAX_STR} chars>"
+        return obj
+    if isinstance(obj, dict):
+        return {k: scrub(v) for k, v in obj.items()}
+    if isinstance(obj, (list, tuple)):
+        return [scrub(v) for v in obj]
+    return obj
+
+
+def dump_event(event: Any) -> dict[str, Any]:
+    """Best-effort conversion of an event object to a plain dict."""
+    if hasattr(event, "model_dump"):
+        try:
+            return event.model_dump()
+        except Exception:
+            pass
+    if isinstance(event, dict):
+        return event
+    return {"repr": repr(event)}
+
+
+def pcm_to_wav(pcm: bytes, sample_rate: int, num_channels: int = 1) -> bytes:
+    """Wrap raw PCM16 bytes in a WAV container.
+
+    For already-merged PCM (e.g. the output of Pipecat's ``AudioBufferProcessor``,
+    where ``num_channels=2`` is user-left / bot-right). Returns ``b""`` for empty
+    input.
+    """
+    if not pcm:
+        return b""
+    buf = io.BytesIO()
+    with wave.open(buf, "wb") as wf:
+        wf.setnchannels(num_channels)
+        wf.setsampwidth(2)
+        wf.setframerate(sample_rate)
+        wf.writeframes(pcm)
+    return buf.getvalue()
+
+
+def _layout_chunks_to_play_time(
+    chunks: list[tuple[float, bytes]], sample_rate: int
+) -> list[tuple[float, bytes]]:
+    """Rewrite receipt timestamps into natural-play timestamps.
+
+    Receipt times reflect when bytes arrived from the source, not when they
+    play. The agent channel especially arrives in bursts faster than realtime —
+    multiple chunks can land within a few ms of each other, and placing them at
+    receipt time makes them overlap and overwrite each other (you hear scrambled
+    tail-ends). The correct natural play time for a chunk is the LATER of where
+    the previous chunk ended and when this chunk arrived, which preserves real
+    gaps between bursts and keeps consecutive bursts contiguous.
+    """
+    out: list[tuple[float, bytes]] = []
+    cur_time = 0.0
+    for i, (t_recv, data) in enumerate(chunks):
+        cur_time = t_recv if i == 0 else max(cur_time, t_recv)
+        out.append((cur_time, data))
+        cur_time += (len(data) // 2) / sample_rate
+    return out
+
+
+def build_stereo_session_wav(
+    user_chunks: list[tuple[float, bytes]],
+    agent_chunks: list[tuple[float, bytes]],
+    sample_rate: int,
+) -> bytes:
+    """Reconstruct a stereo WAV from timestamped PCM16 chunks.
+
+    Left channel = user, right channel = agent. Both channels are laid out at
+    natural play time (see ``_layout_chunks_to_play_time``). Gaps between bursts
+    are silence; overlap between user and agent (during a barge-in) is preserved
+    because they live on different channels.
+    """
+    if not user_chunks and not agent_chunks:
+        return b""
+
+    user = _layout_chunks_to_play_time(user_chunks, sample_rate)
+    agent = _layout_chunks_to_play_time(agent_chunks, sample_rate)
+
+    def chunk_end(t: float, data: bytes) -> float:
+        return t + (len(data) // 2) / sample_rate
+
+    user_end = max((chunk_end(t, d) for t, d in user), default=0.0)
+    agent_end = max((chunk_end(t, d) for t, d in agent), default=0.0)
+    total_samples = int(math.ceil(max(user_end, agent_end) * sample_rate))
+    if total_samples <= 0:
+        return b""
+
+    def mono_channel(chunks: list[tuple[float, bytes]]) -> array.array:
+        # One zero-filled PCM16 channel; each chunk is copied in at its offset.
+        # The layout guarantees chunks within a channel never overlap, so a
+        # plain slice assignment is correct.
+        chan = array.array("h", bytes(2 * total_samples))
+        for t, data in chunks:
+            offset = int(t * sample_rate)
+            samples = array.array("h", data[: 2 * (len(data) // 2)])
+            n = min(len(samples), total_samples - offset)
+            if n > 0:
+                chan[offset : offset + n] = samples[:n]
+        return chan
+
+    left = mono_channel(user)  # user channel
+    right = mono_channel(agent)  # agent channel
+
+    # Interleave L/R via extended-slice assignment (a C-level strided copy).
+    # Overlap between the two parties is preserved: they live on separate channels.
+    stereo = array.array("h", bytes(4 * total_samples))
+    stereo[0::2] = left
+    stereo[1::2] = right
+
+    wav_io = io.BytesIO()
+    with wave.open(wav_io, "wb") as wf:
+        wf.setnchannels(2)
+        wf.setsampwidth(2)
+        wf.setframerate(sample_rate)
+        wf.writeframes(stereo.tobytes())
+    return wav_io.getvalue()

--- a/python/langsmith/integrations/_voice/base.py
+++ b/python/langsmith/integrations/_voice/base.py
@@ -1,0 +1,280 @@
+"""``BaseLangSmithSpanProcessor`` — Track A's shared OTel span processor.
+
+The framework integrations that emit their own OpenTelemetry spans (Pipecat,
+LiveKit) translate those spans into the ``gen_ai.*`` / ``langsmith.*`` attribute
+namespaces LangSmith's OTLP ingester understands, then forward them to an
+exporter. This base owns everything that translation shares — the downstream
+wrapping, the LangSmith OTLP exporter default, opt-in ``thread_id`` injection,
+the ``gen_ai.*`` message writers, OpenAI→LangChain message normalization, and
+size-capped audio attachment — so each framework subclass implements only
+``_dispatch`` (classify a span by name, rewrite it, export it).
+
+The processor wraps a *downstream* processor rather than being added as a
+sibling: ``on_end`` rewrites attributes and then forwards to the downstream, so
+spans are always translated before export. The default downstream is a
+``BatchSpanProcessor`` around the LangSmith ``OtelExporter`` (see
+:mod:`langsmith.integrations.otel`), which targets LangSmith's
+``/otel/v1/traces`` endpoint with the right auth headers from standard LangSmith
+config — no OTLP env vars required.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+from typing import Any, Callable, Optional
+
+from opentelemetry.sdk.trace import ReadableSpan, SpanProcessor
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+# Default audio attachment cap (bytes) before base64 — guards against a long
+# call producing a multi-megabyte span attribute.
+DEFAULT_AUDIO_SIZE_LIMIT = 20_000_000
+
+
+class BaseLangSmithSpanProcessor(SpanProcessor):
+    """Shared base for the OTel→LangSmith framework span processors.
+
+    Subclasses implement :meth:`_dispatch` to classify each ended span, rewrite
+    its attributes via the helpers here, and call :meth:`_export`. The base
+    handles the downstream/exporter wiring, ``thread_id`` injection, and static
+    metadata stamping.
+    """
+
+    def __init__(
+        self,
+        downstream_processor: Optional[SpanProcessor] = None,
+        *,
+        api_key: Optional[str] = None,
+        project: Optional[str] = None,
+        endpoint: Optional[str] = None,
+        thread_id_provider: Optional[Callable[[], Optional[str]]] = None,
+        audio_size_limit_bytes: Optional[int] = DEFAULT_AUDIO_SIZE_LIMIT,
+        metadata: Optional[dict[str, Any]] = None,
+    ) -> None:
+        """Create the processor.
+
+        Args:
+            downstream_processor: where rewritten spans are forwarded. Defaults
+                to ``BatchSpanProcessor(OtelExporter(...))`` targeting LangSmith.
+            api_key: LangSmith API key for the default exporter. Defaults to
+                ``LANGSMITH_API_KEY``.
+            project: LangSmith project for the default exporter. Defaults to
+                ``LANGSMITH_PROJECT``.
+            endpoint: full OTLP traces URL for the default exporter. Defaults to
+                ``{LANGSMITH_ENDPOINT}/otel/v1/traces``.
+            thread_id_provider: opt-in conversation id for LangSmith thread
+                grouping; called per span, ``None`` disables.
+            audio_size_limit_bytes: skip attaching audio larger than this; set
+                ``None`` to disable the cap.
+            metadata: static ``langsmith.metadata.*`` stamped on every span.
+        """
+        super().__init__()
+        if downstream_processor is None:
+            from langsmith.integrations.otel.processor import OtelExporter
+
+            downstream_processor = BatchSpanProcessor(
+                OtelExporter(url=endpoint, api_key=api_key, project=project)
+            )
+        self.downstream = downstream_processor
+        self.thread_id_provider = thread_id_provider
+        self.audio_size_limit_bytes = audio_size_limit_bytes
+        self._static_metadata = metadata or {}
+
+    # -- span lifecycle -------------------------------------------------------
+
+    def on_start(self, span: Any, parent_context: Any = None) -> None:
+        for key, value in self._static_metadata.items():
+            if value is not None:
+                span.set_attribute(f"langsmith.metadata.{key}", value)
+        self.downstream.on_start(span, parent_context)
+
+    def on_end(self, span: ReadableSpan) -> None:
+        self._inject_thread_id(span)
+        self._dispatch(span)
+
+    def _dispatch(self, span: ReadableSpan) -> None:
+        """Classify the span, rewrite its attributes, and export it.
+
+        Subclasses MUST implement this and call :meth:`_export` for each span
+        they want exported (or defer it). The default raises.
+        """
+        raise NotImplementedError
+
+    def _export(self, span: ReadableSpan) -> None:
+        """Forward a (rewritten) span to the downstream processor."""
+        self._pre_export(span)
+        self.downstream.on_end(span)
+
+    def _pre_export(self, span: ReadableSpan) -> None:
+        """Run just before export (e.g. a blanket vendor-attribute pass-through)."""
+
+    def shutdown(self) -> None:
+        self.downstream.shutdown()
+
+    def force_flush(self, timeout_millis: int = 30000) -> bool:
+        return self.downstream.force_flush(timeout_millis)
+
+    # -- shared helpers -------------------------------------------------------
+
+    def _inject_thread_id(self, span: ReadableSpan) -> None:
+        """Stamp ``langsmith.metadata.thread_id`` from the provider (opt-in).
+
+        LangSmith needs the thread id on every run for thread-level filtering and
+        token/cost aggregation. Never clobbers an id set upstream.
+        """
+        if (
+            self.thread_id_provider is not None
+            and "langsmith.metadata.thread_id" not in span.attributes
+        ):
+            thread_id = self.thread_id_provider()
+            if thread_id:
+                span._attributes["langsmith.metadata.thread_id"] = str(thread_id)
+
+    @staticmethod
+    def _set_kind(span: ReadableSpan, kind: str) -> None:
+        span._attributes["langsmith.span.kind"] = kind
+
+    @staticmethod
+    def _exclude_from_message_view(span: ReadableSpan) -> None:
+        """Drop a span from the conversation Messages view (still in the tree).
+
+        That view reconstructs the chat from ``llm``/``tool`` runs. STT/TTS spans
+        are tagged ``llm``-kind for the tree but would inject fake turns (raw
+        transcripts, "Generated audio for: …"), so they opt out here.
+        """
+        span._attributes["langsmith.metadata.ls_message_view_exclude"] = True
+
+    @staticmethod
+    def _set_messages(
+        span: ReadableSpan,
+        *,
+        prompt: Optional[list[dict]] = None,
+        completion: Optional[list[dict]] = None,
+    ) -> None:
+        """Write simple role/content turns in the indexed + singular forms.
+
+        For plain conversation turns (STT, TTS, an exchange) where messages have
+        only role + content. Writes the indexed ``gen_ai.prompt.{n}.role/content``
+        attributes and the singular ``gen_ai.prompt`` JSON list. For messages
+        that carry structured fields (tool calls), use :meth:`_set_messages_json`
+        instead — the indexed form can't represent them.
+        """
+        if prompt is not None:
+            for i, msg in enumerate(prompt):
+                span._attributes[f"gen_ai.prompt.{i}.role"] = msg.get("role", "user")
+                span._attributes[f"gen_ai.prompt.{i}.content"] = str(
+                    msg.get("content", "")
+                )
+            span._attributes["gen_ai.prompt"] = json.dumps(prompt)
+        if completion is not None:
+            for i, msg in enumerate(completion):
+                span._attributes[f"gen_ai.completion.{i}.role"] = msg.get(
+                    "role", "assistant"
+                )
+                span._attributes[f"gen_ai.completion.{i}.content"] = str(
+                    msg.get("content", "")
+                )
+            span._attributes["gen_ai.completion"] = json.dumps(completion)
+
+    @staticmethod
+    def _set_messages_json(
+        span: ReadableSpan,
+        *,
+        prompt: Optional[list[dict]] = None,
+        completion: Optional[list[dict]] = None,
+    ) -> None:
+        """Write messages in the singular ``{"messages": [...]}`` JSON form only.
+
+        This is the form for LLM calls and the conversation root: it can carry
+        structured ``tool_calls`` / ``tool_call_id`` that the indexed
+        ``gen_ai.prompt.{n}.*`` attributes can't, and it takes precedence at
+        ingest — so the indexed form is deliberately *not* written here (it would
+        win and drop the tool calls).
+        """
+        if prompt is not None:
+            span._attributes["gen_ai.prompt"] = json.dumps({"messages": prompt})
+        if completion is not None:
+            span._attributes["gen_ai.completion"] = json.dumps({"messages": completion})
+
+    @staticmethod
+    def _flatten_tool_call(raw_call: Any) -> Optional[dict]:
+        """Normalize one OpenAI-shape tool call to LangChain's flat shape.
+
+        OpenAI:  ``{"id", "type": "function", "function": {"name", "arguments"}}``
+        (``arguments`` a JSON string). LangChain:
+        ``{"type": "tool_call", "id", "name", "args"}`` with ``args`` an object —
+        which is what LangSmith renders as a tool-call block.
+        """
+        if isinstance(raw_call, str):
+            try:
+                raw_call = json.loads(raw_call)
+            except json.JSONDecodeError:
+                return None
+        if not isinstance(raw_call, dict):
+            return None
+        fn = raw_call.get("function") or {}
+        args = fn.get("arguments")
+        if isinstance(args, str):
+            try:
+                args = json.loads(args)
+            except json.JSONDecodeError:
+                pass
+        return {
+            "type": "tool_call",
+            "id": raw_call.get("id"),
+            "name": fn.get("name"),
+            "args": args if isinstance(args, dict) else {},
+        }
+
+    @classmethod
+    def _to_langchain_message(cls, msg: dict) -> dict:
+        """Convert one OpenAI-format context message to LangChain flat format.
+
+        Flattens assistant ``tool_calls`` (see :meth:`_flatten_tool_call`) and
+        carries ``tool_call_id`` / ``name`` for tool-result messages so LangSmith
+        links them back to the call.
+        """
+        content = msg.get("content")
+        if not isinstance(content, str):
+            content = "" if content is None else json.dumps(content)
+        out: dict = {"role": str(msg.get("role", "")), "content": content}
+        tool_calls = [
+            tc
+            for raw in (msg.get("tool_calls") or [])
+            if (tc := cls._flatten_tool_call(raw)) is not None
+        ]
+        if tool_calls:
+            out["tool_calls"] = tool_calls
+        if msg.get("tool_call_id"):
+            out["tool_call_id"] = str(msg["tool_call_id"])
+        if msg.get("role") == "tool" and msg.get("name"):
+            out["name"] = str(msg["name"])
+        return out
+
+    def _attach_audio(
+        self, span: ReadableSpan, *, name: str, data: bytes, mime_type: str
+    ) -> bool:
+        """Attach audio bytes to a span via ``langsmith.attachments`` (base64).
+
+        Honors ``audio_size_limit_bytes`` (skips oversize audio). Returns whether
+        the audio was attached. Uses the OTel attachment path documented at
+        docs.langchain.com/langsmith/trace-with-opentelemetry.
+        """
+        if not data:
+            return False
+        if (
+            self.audio_size_limit_bytes is not None
+            and len(data) > self.audio_size_limit_bytes
+        ):
+            return False
+        span._attributes["langsmith.attachments"] = json.dumps(
+            [
+                {
+                    "name": name,
+                    "content": base64.b64encode(data).decode("ascii"),
+                    "mime_type": mime_type,
+                }
+            ]
+        )
+        return True

--- a/python/langsmith/integrations/_voice/session.py
+++ b/python/langsmith/integrations/_voice/session.py
@@ -1,0 +1,327 @@
+"""``EventSession`` — Track B's LangSmith ``RunTree`` builder.
+
+The integrations that observe a remote event stream (OpenAI Realtime, OpenAI
+Agents realtime, ADK Live) all face the same problem: the service hands them an
+event stream rather than emitting its own telemetry for the live loop, so the
+trace has to be built by hand with the LangSmith SDK — one root span per
+conversation, one child span per meaningful event.
+
+``EventSession`` is everything that pattern needs and would otherwise be
+duplicated across the adapters:
+
+* a root ``realtime_session`` span carrying the running transcript (``outputs``)
+  and the stereo conversation WAV (attachment);
+* a child span per event (``event_span``), optionally grouped into ``turn``
+  spans;
+* point-in-time ``llm`` spans for terminal model responses (``record_llm``);
+* timestamped audio recording and a ``finalize`` that rolls up stats + WAV.
+
+Each adapter keeps only what is genuinely provider-specific: which events count
+as ``inbound`` (user→model, so the payload lands in span ``inputs``) and how to
+label each event span.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from typing import Any, Literal, Optional, cast
+
+from langsmith import RunTree
+
+from .audio import build_stereo_session_wav, dump_event, scrub
+
+# The run kinds LangSmith recognizes (matches ``RunTree.create_child``).
+RunKind = Literal["tool", "chain", "llm", "retriever", "embedding", "prompt", "parser"]
+
+
+@dataclass
+class EventSession:
+    """Conversation-level tracing state. One per conversation.
+
+    The root span carries roll-up stats in metadata, the running conversation
+    transcript as its ``outputs`` (so the LangSmith preview pane shows the whole
+    exchange at a glance — see ``add_message``), and the stereo conversation WAV
+    as an attachment. Each received event becomes a child span via
+    ``event_span`` — nested under the current ``turn`` span if the adapter opted
+    into turn grouping (see ``start_turn``), otherwise directly under the root.
+    """
+
+    run: RunTree
+    thread_id: str
+    project_name: Optional[str]
+    sample_rate: int
+    # Monotonic clock origin. Everything else stores ``now() - t0``.
+    t0: float = field(default_factory=time.monotonic)
+    # Time-stamped audio chunks for the stereo session WAV. Each entry is
+    # (offset_seconds_from_t0, pcm16_bytes). Reconstructed at finalize.
+    user_chunks: list[tuple[float, bytes]] = field(default_factory=list)
+    agent_chunks: list[tuple[float, bytes]] = field(default_factory=list)
+    event_count: int = 0
+    # Conversation transcript, in turn order: {"role", "content"} per line.
+    # Surfaced as the root span's ``outputs`` at finalize.
+    messages: list[dict[str, str]] = field(default_factory=list)
+    # Optional turn grouping (see ``start_turn``). When a turn is open, event
+    # spans nest under it instead of directly under the root; adapters that
+    # never call ``start_turn`` get the original flat shape unchanged.
+    _current_turn: RunTree | None = field(default=None, init=False)
+    _turn_count: int = field(default=0, init=False)
+    _turn_msg_start: int = field(default=0, init=False)
+
+    def now(self) -> float:
+        """Seconds since the session started — the timeline used for the WAV."""
+        return time.monotonic() - self.t0
+
+    def start_turn(self) -> None:
+        """Open a new conversational-turn span, closing the previous one.
+
+        Subsequent ``event_span`` calls nest under this turn until the next
+        ``start_turn`` (or ``finalize``). The turn's ``outputs`` become the
+        transcript lines added during it, so each turn previews its own
+        exchange. Opt-in: an adapter that never calls this keeps the flat root
+        layout.
+        """
+        self._close_turn()
+        self._turn_count += 1
+        self._turn_msg_start = len(self.messages)
+        turn = self.run.create_child(
+            name="turn",
+            run_type="chain",
+            inputs={},
+            tags=["turn"],
+            extra={"metadata": {"turn": self._turn_count}},
+        )
+        turn.post()
+        self._current_turn = turn
+
+    def _close_turn(self) -> None:
+        """End the currently open turn span, if any, with its transcript."""
+        if self._current_turn is None:
+            return
+        msgs = self.messages[self._turn_msg_start :]
+        self._current_turn.end(outputs={"messages": msgs} if msgs else {})
+        self._current_turn.patch()
+        self._current_turn = None
+
+    def add_message(self, role: str, content: str) -> None:
+        """Append one transcript line to the conversation rollup.
+
+        Empty/whitespace content is ignored (failed transcriptions, silent
+        turns). Content is truncated like any other span payload (see ``scrub``)
+        so an unexpectedly large blob never bloats the root span.
+        """
+        content = (content or "").strip()
+        if content:
+            self.messages.append({"role": role, "content": scrub(content)})
+
+    def record_user(self, t: float, data: bytes) -> None:
+        """Record a timestamped chunk of user (mic) PCM16 for the stereo WAV."""
+        self.user_chunks.append((t, data))
+
+    def record_agent(self, t: float, data: bytes) -> None:
+        """Record a timestamped chunk of agent (playback) PCM16 for the WAV."""
+        self.agent_chunks.append((t, data))
+
+    def set_title(self, text: str) -> None:
+        """Give the conversation root a human-readable title (first one wins).
+
+        Set from the first user utterance so traces are scannable in the project
+        / threads list instead of all reading ``realtime_session``. Scrubbed
+        like any other payload.
+        """
+        text = (text or "").strip()
+        if not text:
+            return
+        extra = self.run.extra or {}
+        metadata = dict(extra.get("metadata") or {})
+        if metadata.get("title"):
+            return  # first non-empty user utterance wins
+        metadata["title"] = scrub(text)
+        extra["metadata"] = metadata
+        self.run.extra = extra
+
+    def add_turn_metadata(self, **kv: Any) -> None:
+        """Merge key/values into the open turn span's metadata (no-op if none).
+
+        For per-turn metrics not known when the turn opens — e.g.
+        ``latency_to_first_audio_ms``, ``was_interrupted``. Applied to the
+        currently open turn, so call it before the next ``start_turn`` closes
+        that turn.
+        """
+        if self._current_turn is None:
+            return
+        extra = self._current_turn.extra or {}
+        metadata = dict(extra.get("metadata") or {})
+        metadata.update(kv)
+        extra["metadata"] = metadata
+        self._current_turn.extra = extra
+
+    @contextmanager
+    def event_span(
+        self,
+        event: Any,
+        t_now: float,
+        *,
+        name: str,
+        inbound: bool,
+        run_type: RunKind = "chain",
+        inputs: dict[str, Any] | None = None,
+        outputs: dict[str, Any] | None = None,
+        usage_metadata: dict[str, Any] | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> Iterator[RunTree]:
+        """Open a child span for one received event; close it on body exit.
+
+        Wrapping the handler body means any real work done while handling the
+        event (e.g. tool execution) nests inside this span — the same way a tool
+        call nests under the step that triggered it in any traced app.
+
+        By default the raw (scrubbed) event payload is the span's I/O — in
+        ``inputs`` for user→model (``inbound``) events, in ``outputs`` otherwise.
+        Pass curated ``inputs``/``outputs`` (and optionally a ``run_type`` like
+        "llm" plus ``usage_metadata``) to give the span readable,
+        conversation-shaped I/O instead; the full wire payload is then preserved
+        under ``metadata.raw_event``. Curated values pass through ``scrub`` too,
+        so no un-scrubbed event data ever reaches a span.
+        """
+        self.event_count += 1
+        payload = scrub(dump_event(event))
+        # "Curated" = the caller supplied readable I/O or a non-default kind, so
+        # the raw wire payload is demoted to metadata rather than the headline.
+        curated = inputs is not None or outputs is not None or run_type != "chain"
+
+        md: dict[str, Any] = {"received_at_s": round(t_now, 3)}
+        if curated:
+            md["raw_event"] = payload
+        if metadata:
+            md.update(metadata)
+
+        if inputs is not None:
+            run_inputs: Any = scrub(inputs)
+        elif curated:
+            run_inputs = {}
+        else:
+            run_inputs = payload if inbound else {}
+
+        parent = self._current_turn or self.run
+        run = parent.create_child(
+            name=name,
+            run_type=run_type,
+            inputs=run_inputs,
+            tags=["event"],
+            extra={"metadata": md},
+        )
+        run.post()
+        try:
+            yield run
+        finally:
+            if usage_metadata is not None:
+                run.set(usage_metadata=cast("Any", usage_metadata))
+            if curated:
+                run.end(outputs=scrub(outputs) if outputs is not None else {})
+            else:
+                run.end(outputs={} if inbound else payload)
+            run.patch()
+
+    def record_llm(
+        self,
+        parent: RunTree | None = None,
+        *,
+        name: str = "model",
+        outputs: dict[str, Any],
+        inputs: dict[str, Any] | None = None,
+        usage_metadata: dict[str, Any] | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
+        """Record a point-in-time ``llm`` child span for a model response.
+
+        Voice services deliver a response as a *terminal* event (e.g. Realtime's
+        ``response.done``), so there's no model-inference duration to measure —
+        but the token usage, assistant message, and finish status still belong
+        on an ``llm``-kind run for cost rollup and readability. Kept
+        point-in-time and separate from the surrounding handler span so local
+        tool latency is never attributed to the model call. ``parent`` defaults
+        to the current turn (or the root).
+
+        When ``inputs`` is omitted, it defaults to the model's *effective
+        prompt* — the conversation transcript so far minus the response being
+        recorded (the trailing assistant message) — so the ``llm`` run reads like
+        a normal model call instead of having empty inputs.
+        """
+        parent = parent or self._current_turn or self.run
+        if inputs is None:
+            context = list(self.messages)
+            if context and context[-1].get("role") == "assistant":
+                context = context[:-1]  # drop the response we're recording
+            inputs = {"messages": context}
+        run = parent.create_child(
+            name=name,
+            run_type="llm",
+            inputs=scrub(inputs),
+            tags=["model"],
+            extra={"metadata": metadata or {}},
+        )
+        run.post()
+        if usage_metadata is not None:
+            run.set(usage_metadata=cast("Any", usage_metadata))
+        run.end(outputs=scrub(outputs))
+        run.patch()
+
+    def finalize(self) -> None:
+        """Roll up stats, attach the stereo WAV, and close the root span."""
+        # Close the last open turn (if any) before the root.
+        self._close_turn()
+        extra: dict[str, Any] = self.run.extra or {}
+        metadata: dict[str, Any] = dict(extra.get("metadata") or {})
+        metadata["event_count"] = self.event_count
+        metadata["duration_s"] = round(time.monotonic() - self.t0, 2)
+        extra["metadata"] = metadata
+        self.run.extra = extra
+
+        wav = build_stereo_session_wav(
+            self.user_chunks, self.agent_chunks, self.sample_rate
+        )
+        if wav:
+            # One audio asset for the whole conversation — stereo so you can
+            # hear both sides AND see interruption overlap.
+            self.run.attachments = {"conversation": ("audio/wav", wav)}
+        # The transcript is the conversation's natural "output": surfacing it on
+        # the root makes the whole exchange readable in the LangSmith preview
+        # pane without expanding a single child span.
+        self.run.end(outputs={"messages": self.messages} if self.messages else {})
+        self.run.patch()
+
+
+def start_session(
+    *,
+    thread_id: str,
+    sample_rate: int,
+    project_name: Optional[str] = None,
+    tags: Optional[list[str]] = None,
+    metadata: Optional[dict[str, Any]] = None,
+    name: str = "realtime_session",
+) -> EventSession:
+    """Create and post the conversation root span, returning an ``EventSession``.
+
+    ``project_name`` falls back to LangSmith's standard resolution
+    (``LANGSMITH_PROJECT``) when omitted, like any other ``RunTree``.
+    """
+    # Mark the root as an audio-modality run (these are voice conversations).
+    md = {"ls_modality": "audio", "thread_id": thread_id, **(metadata or {})}
+    run = RunTree(
+        name=name,
+        run_type="chain",
+        inputs={},
+        project_name=project_name,
+        tags=tags or [],
+        extra={"metadata": md},
+    )
+    run.post()
+    return EventSession(
+        run=run,
+        thread_id=thread_id,
+        project_name=project_name,
+        sample_rate=sample_rate,
+    )

--- a/python/langsmith/integrations/google_adk_live/__init__.py
+++ b/python/langsmith/integrations/google_adk_live/__init__.py
@@ -1,0 +1,32 @@
+"""LangSmith integration for Google ADK Live (Gemini Live voice).
+
+Provides :class:`LangSmithLivePlugin`, an ADK ``BasePlugin`` that traces
+``Runner.run_live`` voice conversations. Kept in its own package (and behind the
+``google-adk-live`` extra) so that users of the non-streaming
+``langsmith.integrations.google_adk`` integration do not take on its
+dependencies.
+
+The class is imported lazily so this package can be imported without
+``google-adk`` installed.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from .._voice import warn_in_development
+
+if TYPE_CHECKING:
+    from ._plugin import LangSmithLivePlugin
+
+warn_in_development("google_adk_live")
+
+__all__ = ["LangSmithLivePlugin"]
+
+
+def __getattr__(name: str) -> Any:
+    if name == "LangSmithLivePlugin":
+        from ._plugin import LangSmithLivePlugin
+
+        return LangSmithLivePlugin
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/python/langsmith/integrations/google_adk_live/_plugin.py
+++ b/python/langsmith/integrations/google_adk_live/_plugin.py
@@ -1,0 +1,235 @@
+"""LangSmith tracing for Google ADK Live (``Runner.run_live``).
+
+ADK emits ``gen_ai.*`` OTel spans for its non-live paths, but ``run_live`` — the
+whole voice loop — isn't instrumented, so an OTel-only setup yields an empty
+root. This integration builds the trace from the live event stream instead,
+using ADK's official plugin hook: :class:`LangSmithLivePlugin` is a
+``BasePlugin`` whose ``before_run`` / ``on_event`` / ``after_run`` callbacks open
+the conversation root span, span each meaningful event, and finalize.
+
+The plugin runs alongside the application's own ``run_live`` loop (which plays
+audio and reacts to barge-ins) — it carries no application logic. Audio for the
+stereo conversation WAV is fed by the app via :meth:`record_user_audio` /
+:meth:`record_agent_audio` (recording at the speaker/mic boundary captures what
+was actually *heard*, post-barge-in-truncation — more accurate than the audio
+embedded in events).
+
+Trace shape — one conversation = one trace::
+
+    realtime_session                       (root; transcript + stereo WAV)
+    ├── input_transcription                (event — user speech)
+    ├── function_call: get_weather         (event)
+    ├── function_response: get_weather     (event)
+    ├── output_transcription               (event — agent speech)
+    ├── turn_complete                      (event)
+    └── interrupted                        (event)
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any, Callable, Optional
+
+from google.adk.plugins.base_plugin import BasePlugin
+
+from .._voice.session import EventSession, start_session
+
+# ADK Live audio sample rate (used for the stereo conversation WAV).
+DEFAULT_SAMPLE_RATE = 24_000
+
+
+class _LiveEventView:
+    """A readable view over one raw ADK ``run_live`` event.
+
+    Every item the runner yields is the same ADK ``Event`` with all-optional
+    fields; "what kind of event is this" is implicit in which fields are
+    populated. This centralizes that field inspection.
+    """
+
+    def __init__(self, raw: Any) -> None:
+        self.raw = raw
+
+    @property
+    def interrupted(self) -> bool:
+        return bool(getattr(self.raw, "interrupted", False))
+
+    @property
+    def turn_complete(self) -> bool:
+        return bool(getattr(self.raw, "turn_complete", False))
+
+    @property
+    def _parts(self) -> list[Any]:
+        content = getattr(self.raw, "content", None)
+        parts = getattr(content, "parts", None) if content else None
+        return list(parts) if parts else []
+
+    @property
+    def audio_chunks(self) -> list[bytes]:
+        return [
+            p.inline_data.data
+            for p in self._parts
+            if getattr(p, "inline_data", None) and p.inline_data.data
+        ]
+
+    @property
+    def function_calls(self) -> list[Any]:
+        return [
+            p.function_call
+            for p in self._parts
+            if getattr(p, "function_call", None) and p.function_call.name
+        ]
+
+    @property
+    def function_responses(self) -> list[Any]:
+        return [
+            p.function_response
+            for p in self._parts
+            if getattr(p, "function_response", None) and p.function_response.name
+        ]
+
+    def _transcript(self, attr: str, *, final_only: bool) -> str | None:
+        tx = getattr(self.raw, attr, None)
+        if not (tx and getattr(tx, "text", None)):
+            return None
+        if final_only and not getattr(tx, "finished", False):
+            return None
+        return tx.text
+
+    @property
+    def user_transcript(self) -> str | None:
+        return self._transcript("input_transcription", final_only=False)
+
+    @property
+    def agent_transcript(self) -> str | None:
+        return self._transcript("output_transcription", final_only=False)
+
+    @property
+    def final_user_transcript(self) -> str | None:
+        return self._transcript("input_transcription", final_only=True)
+
+    @property
+    def final_agent_transcript(self) -> str | None:
+        return self._transcript("output_transcription", final_only=True)
+
+    @property
+    def is_audio_only(self) -> bool:
+        """True when the event's only payload is agent audio (a flood — not spanned)."""
+        return bool(self.audio_chunks) and not (
+            self.interrupted
+            or self.turn_complete
+            or self.user_transcript
+            or self.agent_transcript
+            or self.function_calls
+            or self.function_responses
+        )
+
+    @property
+    def is_inbound(self) -> bool:
+        return self.user_transcript is not None
+
+    @property
+    def label(self) -> str:
+        if self.interrupted:
+            return "interrupted"
+        if self.turn_complete:
+            return "turn_complete"
+        if self.user_transcript:
+            return "input_transcription"
+        if self.agent_transcript:
+            return "output_transcription"
+        if self.function_calls:
+            return f"function_call: {self.function_calls[0].name}"
+        if self.function_responses:
+            return f"function_response: {self.function_responses[0].name}"
+        return "event"
+
+
+class LangSmithLivePlugin(BasePlugin):
+    """An ADK ``BasePlugin`` that traces ``run_live`` conversations to LangSmith.
+
+    Register it on the ``Runner`` (``Runner(..., plugins=[plugin])``). One run =
+    one trace. Feed audio via :meth:`record_user_audio` / :meth:`record_agent_audio`
+    to attach the stereo conversation WAV.
+    """
+
+    def __init__(
+        self,
+        *,
+        name: str = "langsmith_live",
+        sample_rate: int = DEFAULT_SAMPLE_RATE,
+        thread_id_provider: Optional[Callable[[], Optional[str]]] = None,
+        project_name: Optional[str] = None,
+        tags: Optional[list[str]] = None,
+        metadata: Optional[dict[str, Any]] = None,
+    ) -> None:
+        """Create the plugin.
+
+        Args:
+            name: plugin name (required by ``BasePlugin``).
+            sample_rate: PCM sample rate of the audio (for the WAV).
+            thread_id_provider: zero-arg callable returning the LangSmith thread
+                id for the run; a random UUID per run if omitted.
+            project_name: LangSmith project; defaults to standard config.
+            tags / metadata: attached to the conversation root span.
+        """
+        super().__init__(name=name)
+        self._sample_rate = sample_rate
+        self._thread_id_provider = thread_id_provider
+        self._project_name = project_name
+        self._tags = tags
+        self._metadata = metadata
+        self._session: EventSession | None = None
+
+    # -- app-fed audio --------------------------------------------------------
+
+    def record_user_audio(self, pcm: bytes) -> None:
+        """Record a chunk of user (mic) PCM16 for the stereo conversation WAV."""
+        if self._session is not None:
+            self._session.record_user(self._session.now(), pcm)
+
+    def record_agent_audio(self, pcm: bytes) -> None:
+        """Record a chunk of agent (played) PCM16 for the stereo conversation WAV."""
+        if self._session is not None:
+            self._session.record_agent(self._session.now(), pcm)
+
+    # -- ADK plugin callbacks -------------------------------------------------
+
+    async def before_run_callback(self, *, invocation_context: Any) -> None:
+        thread_id = (
+            self._thread_id_provider() if self._thread_id_provider else None
+        ) or str(uuid.uuid4())
+        self._session = start_session(
+            thread_id=thread_id,
+            sample_rate=self._sample_rate,
+            project_name=self._project_name,
+            tags=self._tags,
+            metadata=self._metadata,
+        )
+
+    async def on_event_callback(self, *, invocation_context: Any, event: Any) -> None:
+        if self._session is None:
+            return
+        view = _LiveEventView(event)
+        if view.is_audio_only:
+            return  # the agent-audio flood: played by the app, not spanned
+
+        # Roll the finalized transcripts into the root preview / title.
+        if view.final_user_transcript:
+            self._session.add_message("user", view.final_user_transcript)
+            self._session.set_title(view.final_user_transcript)
+        if view.final_agent_transcript:
+            self._session.add_message("assistant", view.final_agent_transcript)
+
+        with self._session.event_span(
+            event, self._session.now(), name=view.label, inbound=view.is_inbound
+        ):
+            pass
+
+    async def after_run_callback(self, *, invocation_context: Any) -> None:
+        """Finalize the conversation trace (attach the transcript and audio).
+
+        Idempotent, so it is safe if ADK invokes it more than once.
+        """
+        session, self._session = self._session, None
+        if session is not None:
+            session.finalize()

--- a/python/langsmith/integrations/livekit/__init__.py
+++ b/python/langsmith/integrations/livekit/__init__.py
@@ -1,0 +1,79 @@
+"""LangSmith integration for LiveKit Agents."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any, Callable, Optional
+
+from .._voice import warn_in_development
+from .processor import LiveKitLangSmithSpanProcessor
+
+logger = logging.getLogger(__name__)
+
+warn_in_development("livekit")
+
+__all__ = ["LiveKitLangSmithSpanProcessor", "configure_livekit"]
+
+
+def configure_livekit(
+    *,
+    thread_id_provider: Optional[Callable[[], Optional[str]]] = None,
+    audio_path_provider: Optional[Callable[[], Optional[Path]]] = None,
+    api_key: Optional[str] = None,
+    project: Optional[str] = None,
+    endpoint: Optional[str] = None,
+    set_global_provider: bool = True,
+    **kwargs: Any,
+) -> Optional[LiveKitLangSmithSpanProcessor]:
+    """Enable LangSmith tracing for a LiveKit Agents worker.
+
+    Builds a ``TracerProvider`` with a :class:`LiveKitLangSmithSpanProcessor`
+    (which rewrites LiveKit's ``lk.*`` spans for LangSmith and exports them to
+    LangSmith's OTLP endpoint) and registers it as both LiveKit's tracer provider
+    and the OTel global. Call before starting the worker.
+
+    To manage your own ``TracerProvider`` instead, pass
+    ``set_global_provider=False`` and add the returned processor to your provider.
+
+    Args:
+        thread_id_provider: opt-in conversation id for LangSmith thread grouping.
+        audio_path_provider: zero-arg callable returning a local recording path
+            whose bytes are embedded in the root span (console/dev only). For
+            production, attach a LiveKit Egress recording via the returned
+            processor's ``expect_recording`` / ``complete_recording`` methods.
+        api_key / project / endpoint: LangSmith exporter config; default to the
+            standard ``LANGSMITH_*`` resolution.
+        set_global_provider: when ``True`` (default), create and register the
+            tracer provider for you.
+
+    Returns:
+        The processor, or ``None`` if LiveKit / OpenTelemetry aren't installed.
+    """
+    try:
+        from opentelemetry import trace as otel_trace
+        from opentelemetry.sdk.trace import TracerProvider
+    except ImportError as e:
+        logger.warning("Missing dependency for LiveKit tracing: %s", e)
+        return None
+
+    processor = LiveKitLangSmithSpanProcessor(
+        thread_id_provider=thread_id_provider,
+        audio_path_provider=audio_path_provider,
+        api_key=api_key,
+        project=project,
+        endpoint=endpoint,
+        **kwargs,
+    )
+
+    if set_global_provider:
+        try:
+            from livekit.agents.telemetry import set_tracer_provider
+        except ImportError as e:
+            logger.warning("Missing dependency for LiveKit tracing: %s", e)
+            return None
+        provider = TracerProvider()
+        provider.add_span_processor(processor)
+        set_tracer_provider(provider)  # LiveKit's hook
+        otel_trace.set_tracer_provider(provider)  # OTel global
+    return processor

--- a/python/langsmith/integrations/livekit/processor.py
+++ b/python/langsmith/integrations/livekit/processor.py
@@ -1,0 +1,620 @@
+"""OTel → LangSmith bridge for LiveKit Agents.
+
+LangSmith's OTel ingester reads the ``gen_ai.*`` / ``langsmith.*`` namespaces;
+LiveKit emits its data under a ``lk.*`` vendor prefix the ingester doesn't
+recognize — so without translation, transcripts, TTS metrics, EOU
+probabilities, latency numbers, etc. all evaporate at ingest. This
+:class:`LiveKitLangSmithSpanProcessor` rewrites ``lk.*`` into the keys LangSmith
+understands before each span is exported. It inherits the downstream wrapping,
+exporter, ``thread_id`` injection, and message helpers from
+:class:`BaseLangSmithSpanProcessor`.
+
+Generic to any LiveKit agent
+----------------------------
+The processor only reads LiveKit's own ``lk.*`` attributes and the span's
+name/position — it carries no knowledge of what the LLM stage is. Two rules:
+
+1. **Translate LiveKit spans from their own data.** Each known LiveKit span
+   (``user_turn``, ``llm_request``, ``tts_*``, ``agent_turn``,
+   ``function_tool``, …) is classified and rendered from the ``lk.*`` attributes
+   and ``gen_ai.*`` span events LiveKit sets on it.
+2. **Leave everything else untouched.** Any span that isn't a LiveKit span —
+   e.g. a LangChain/LangGraph run riding the same OTel provider when
+   ``LANGSMITH_TRACING_MODE=otel`` — already arrives in LangSmith's native
+   shape, so it's exported verbatim.
+
+Two translation layers for LiveKit spans
+----------------------------------------
+1. **Per-span classification** — set ``langsmith.span.kind`` and pull the
+   conversation into ``gen_ai.prompt`` / ``gen_ai.completion``. The genuine
+   inference nodes (STT ``user_turn``, ``llm_request``, ``tts_request``) are
+   ``llm``-kind; the framework wrappers (``llm_node``, ``tts_node``, retry
+   spans) are ``chain``.
+2. **Blanket ``lk.*`` pass-through** — every ``lk.*`` scalar lands as
+   ``langsmith.metadata.lk_<name>``, and JSON-object blobs are flattened so each
+   metric is its own field. Per-stage latencies surface this way too.
+
+The whole-conversation transcript on the root span is accumulated from the
+per-turn ``agent_turn`` spans, and the call recording is attached to the root.
+
+``thread_id_provider`` (opt-in) stamps ``langsmith.metadata.thread_id`` on every
+span. The call recording is embedded on the root as a LangSmith attachment one
+of two ways:
+
+* ``audio_path_provider`` — a local file whose bytes are read and embedded. This
+  suits console/dev, where LiveKit writes ``audio.ogg`` under
+  ``ctx.session_directory``. That directory is ephemeral in a deployed worker, so
+  it is not a production path.
+* :meth:`~LiveKitLangSmithSpanProcessor.expect_recording` /
+  :meth:`~LiveKitLangSmithSpanProcessor.complete_recording` — the production
+  path. `LiveKit Egress <https://docs.livekit.io/home/egress/overview/>`_ records
+  the room to your own storage, but only finishes uploading *after* the call. So
+  the host calls ``expect_recording`` at the start (we hold the root span open),
+  then downloads the finished file and calls ``complete_recording`` with the
+  bytes — embedded as a real attachment, just like the dev path.
+
+With neither set, the processor needs nothing from the host app.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Callable, Optional
+
+from opentelemetry.sdk.trace import ReadableSpan
+
+from .._voice.base import BaseLangSmithSpanProcessor
+
+# LiveKit's span names, grouped by how we treat them. The genuine inference
+# calls are ``llm``-kind; the framework wrappers around them are ``chain``.
+_STT_SPAN = "user_turn"  # audio → transcript (inference)
+_LLM_INFERENCE_SPAN = "llm_request"  # chat completion (inference)
+_LLM_WRAPPER_SPANS = {"llm_node", "llm_request_run"}
+_TTS_INFERENCE_SPAN = "tts_request"  # text → audio (inference)
+_TTS_WRAPPER_SPANS = {"tts_node", "tts_request_run"}
+_TURN_SPAN = "agent_turn"
+_SESSION_SPAN = "agent_session"
+_TOOL_SPAN = "function_tool"
+_REALTIME_METRICS_SPAN = "realtime_metrics"
+
+# LiveKit records each chat-context item sent to the model as a span event on
+# ``llm_request`` (the event name implies the message role), followed by a
+# ``gen_ai.choice`` event carrying the generated message.
+_LLM_EVENT_ROLES = {
+    "gen_ai.system.message": "system",
+    "gen_ai.user.message": "user",
+    "gen_ai.assistant.message": "assistant",
+    "gen_ai.tool.message": "tool",
+}
+_LLM_CHOICE_EVENT = "gen_ai.choice"
+
+
+class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
+    """Enriches LiveKit Agents' OTel spans with LangSmith-compatible attributes."""
+
+    def __init__(
+        self,
+        downstream_processor: Optional[Any] = None,
+        *,
+        api_key: Optional[str] = None,
+        project: Optional[str] = None,
+        endpoint: Optional[str] = None,
+        thread_id_provider: Optional[Callable[[], Optional[str]]] = None,
+        audio_path_provider: Optional[Callable[[], Optional[Path]]] = None,
+        audio_mime_type: str = "audio/ogg",
+        **kwargs: Any,
+    ) -> None:
+        """Create the processor.
+
+        Args:
+            audio_path_provider: zero-arg callable returning a local recording
+                path whose bytes are embedded in the root span; ``None`` disables.
+                Console/dev only — see the module docstring. For production, use
+                :meth:`expect_recording` / :meth:`complete_recording` to attach a
+                LiveKit Egress recording.
+            audio_mime_type: default MIME type for embedded recordings.
+            thread_id_provider: opt-in conversation id for LangSmith thread
+                grouping; ``None`` disables.
+        """
+        super().__init__(
+            downstream_processor,
+            api_key=api_key,
+            project=project,
+            endpoint=endpoint,
+            thread_id_provider=thread_id_provider,
+            **kwargs,
+        )
+        self.audio_path_provider = audio_path_provider
+        self._audio_mime_type = audio_mime_type
+        # Whole-conversation transcript, accumulated turn-by-turn from the
+        # ``agent_turn`` spans. trace_id (int) -> flat [{role, content}, ...].
+        self._conversation_by_trace: dict[int, list[dict]] = {}
+        # The trace root (job entrypoint) ends before the conversation completes
+        # when the agent greets first, so we hold it until ``agent_session`` ends
+        # with the full conversation. trace_id (hex str) -> ReadableSpan.
+        self._deferred_root_spans: dict[str, ReadableSpan] = {}
+        self._ended_sessions: set[str] = set()
+        # Production egress audio arrives *after* the call, so a conversation can
+        # ask us to hold its root until ``complete_recording`` supplies the bytes.
+        # All keyed by thread id (the conversation id the host controls).
+        self._awaiting_recording: set[str] = set()
+        self._pending_audio: dict[str, dict] = {}
+        self._thread_to_trace: dict[str, str] = {}
+        self._trace_to_thread: dict[str, str] = {}
+        # Realtime-model metrics cached from a ``realtime_metrics`` child span and
+        # drained onto its parent ``agent_turn``. Keyed by the parent span_id.
+        self._realtime_metrics_by_parent: dict[int, dict] = {}
+
+    # -- dispatch -------------------------------------------------------------
+
+    def _dispatch(self, span: ReadableSpan) -> None:
+        trace_id = format(span.context.trace_id, "032x")
+        name = span.name
+
+        if name == _STT_SPAN:
+            self._handle_stt(span)
+        elif name == _LLM_INFERENCE_SPAN:
+            self._handle_llm_request(span)
+        elif name in _LLM_WRAPPER_SPANS:
+            self._set_kind(span, "chain")  # wrappers: no fabricated I/O
+        elif name == _TTS_INFERENCE_SPAN or name in _TTS_WRAPPER_SPANS:
+            self._handle_tts(span)
+        elif name == _TURN_SPAN:
+            self._handle_turn(span)
+        elif name == _SESSION_SPAN:
+            # Session end: the conversation is complete — release the deferred
+            # root (if any), then export the session span itself.
+            self._set_kind(span, "chain")
+            self._ended_sessions.add(trace_id)
+            self._release_root_span(trace_id)
+        elif name == "eou_detection":
+            self._set_kind(span, "chain")  # framework step
+        elif name == _TOOL_SPAN:
+            self._handle_tool(span)
+        elif name == _REALTIME_METRICS_SPAN:
+            # These belong ON the turn, not as their own span: cache for the
+            # parent agent_turn and suppress this span entirely.
+            self._cache_realtime_metrics(span)
+            return
+        elif span.parent is None:
+            # The trace root (LiveKit's job entrypoint). Render, attach, export —
+            # or defer if the conversation hasn't started yet.
+            self._handle_root(span, trace_id)
+            return
+        # Any other span isn't a LiveKit span (e.g. a LangChain/LangGraph run);
+        # it already arrives in LangSmith's native shape — export untouched.
+
+        self._export(span)
+
+    # -- per-span-type handlers ----------------------------------------------
+
+    def _handle_stt(self, span: ReadableSpan) -> None:
+        """STT (``user_turn``): audio input → transcribed text."""
+        self._set_kind(span, "llm")
+        model = span.attributes.get("gen_ai.request.model")
+        if model:
+            span._attributes["langsmith.metadata.model_name"] = str(model)
+
+        transcript = span.attributes.get("lk.user_transcript")
+        self._set_messages(
+            span, prompt=[{"role": "user", "content": f'Audio for: "{transcript}"'}]
+        )
+        if transcript:
+            self._set_messages(
+                span, completion=[{"role": "assistant", "content": str(transcript)}]
+            )
+        self._exclude_from_message_view(span)
+
+    def _handle_llm_request(self, span: ReadableSpan) -> None:
+        """``llm_request``: the chat-completion call.
+
+        LiveKit records the request's I/O as span events: one
+        ``gen_ai.{system,user,assistant,tool}.message`` event per chat-context
+        item, then a ``gen_ai.choice`` with the generated message. We rebuild
+        ``gen_ai.prompt``/``gen_ai.completion`` (singular JSON, so tool calls
+        survive) and strip the translated events so the ingester doesn't render
+        them twice.
+        """
+        self._set_kind(span, "llm")
+
+        prompt: list[dict] = []
+        completion: list[dict] = []
+        for event in span.events:
+            if event.name == _LLM_CHOICE_EVENT:
+                completion.append(self._message_from_event("assistant", event))
+            elif (role := _LLM_EVENT_ROLES.get(event.name)) is not None:
+                prompt.append(self._message_from_event(role, event))
+        self._set_messages_json(
+            span, prompt=prompt or None, completion=completion or None
+        )
+
+        # Drop the translated events (keep others, e.g. exceptions).
+        span._events = [
+            e
+            for e in span.events
+            if e.name != _LLM_CHOICE_EVENT and e.name not in _LLM_EVENT_ROLES
+        ]
+
+    def _message_from_event(self, role: str, event: Any) -> dict:
+        """Build a LangChain-format message dict from a LiveKit gen_ai event."""
+        attrs = event.attributes or {}
+        msg: dict = {
+            "role": str(attrs.get("role") or role),
+            "content": str(attrs.get("content") or ""),
+        }
+        tool_calls = [
+            tc
+            for raw in (attrs.get("tool_calls") or ())
+            if (tc := self._flatten_tool_call(raw)) is not None
+        ]
+        if tool_calls:
+            msg["tool_calls"] = tool_calls
+        if role == "tool":
+            if attrs.get("id"):
+                msg["tool_call_id"] = str(attrs["id"])
+            if attrs.get("name"):
+                msg["name"] = str(attrs["name"])
+        return msg
+
+    def _handle_tts(self, span: ReadableSpan) -> None:
+        """Render the TTS spans.
+
+        ``tts_request`` is the synthesis call (``llm``); the ``tts_node`` /
+        ``tts_request_run`` wrappers are ``chain``s.
+        """
+        if span.name != _TTS_INFERENCE_SPAN:
+            self._set_kind(span, "chain")
+            return
+
+        self._set_kind(span, "llm")
+        self._exclude_from_message_view(span)
+
+        text = (
+            span.attributes.get("lk.input_text")
+            or span.attributes.get("lk.request.text")
+            or span.attributes.get("lk.text")
+            or ""
+        )
+        self._set_messages(
+            span,
+            prompt=[{"role": "user", "content": str(text)}],
+            completion=[
+                {"role": "assistant", "content": f'Generated audio for: "{text}"'}
+            ],
+        )
+
+        model = span.attributes.get("gen_ai.request.model")
+        if not model:
+            metrics = self._try_parse_json_object(span.attributes.get("lk.tts_metrics"))
+            if isinstance(metrics, dict):
+                model = (metrics.get("metadata") or {}).get(
+                    "model_name"
+                ) or metrics.get("model_name")
+        if model:
+            span._attributes["gen_ai.request.model"] = str(model)
+            span._attributes["langsmith.metadata.model_name"] = str(model)
+
+    def _handle_turn(self, span: ReadableSpan) -> None:
+        """Render an ``agent_turn``: one user/assistant exchange.
+
+        Appends the exchange to the running conversation the root rolls up. This
+        is the LiveKit-native turn boundary, so it works for both the cascade and
+        the speech-to-speech backends.
+        """
+        self._set_kind(span, "chain")
+        self._drain_realtime_metrics(span)
+
+        user_input = span.attributes.get("lk.user_input")
+        response = span.attributes.get("lk.response.text")
+        conversation = self._conversation_by_trace.setdefault(span.context.trace_id, [])
+        if user_input:
+            msg = {"role": "user", "content": str(user_input)}
+            self._set_messages(span, prompt=[msg])
+            conversation.append(msg)
+        if response:
+            msg = {"role": "assistant", "content": str(response)}
+            self._set_messages(span, completion=[msg])
+            conversation.append(msg)
+
+    def _handle_tool(self, span: ReadableSpan) -> None:
+        """``function_tool``: render as a proper ``tool`` run with its I/O."""
+        self._set_kind(span, "tool")
+        tool_name = span.attributes.get("lk.function_tool.name")
+        if tool_name:
+            span._attributes["langsmith.metadata.tool_name"] = str(tool_name)
+        args = span.attributes.get("lk.function_tool.arguments")
+        if args is not None:
+            span._attributes["gen_ai.prompt"] = (
+                args if isinstance(args, str) else json.dumps(args)
+            )
+        output = span.attributes.get("lk.function_tool.output")
+        if output is not None:
+            span._attributes["gen_ai.completion"] = (
+                output if isinstance(output, str) else json.dumps(output)
+            )
+
+    # -- production recording (egress) ---------------------------------------
+
+    def expect_recording(self, thread_id: str) -> None:
+        """Hold this conversation's root span until its recording is supplied.
+
+        LiveKit Egress finishes uploading *after* the call ends, so the bytes
+        don't exist when the root span would normally be exported. Call this at
+        the start of a conversation (when you start egress) to defer that export;
+        then call :meth:`complete_recording` once you have the file. Until then
+        the root is held (a worker shutdown flushes it without audio as a
+        fallback), so always pair this with a ``complete_recording`` call —
+        passing ``None`` to release without audio if the recording fails.
+
+        Args:
+            thread_id: the conversation id, matching ``thread_id_provider``.
+        """
+        self._awaiting_recording.add(str(thread_id))
+
+    def complete_recording(
+        self,
+        thread_id: str,
+        data: Optional[bytes],
+        *,
+        name: str = "recording.ogg",
+        mime_type: Optional[str] = None,
+    ) -> None:
+        """Attach an egress recording to a conversation and release its root.
+
+        Download the completed egress file from your storage and pass its bytes
+        here; they're embedded as a real LangSmith attachment on the root span.
+        Pass ``data=None`` to release the held root without audio (e.g. egress
+        failed). Safe to call before or after the session ends.
+
+        Args:
+            thread_id: the conversation id, matching :meth:`expect_recording`.
+            data: the recording bytes, or ``None`` to release without audio.
+            name: attachment filename.
+            mime_type: attachment MIME type; defaults to the processor's.
+        """
+        tid = str(thread_id)
+        if data:
+            self._pending_audio[tid] = {
+                "name": name,
+                "data": bytes(data),
+                "mime_type": mime_type or self._audio_mime_type,
+            }
+        self._awaiting_recording.discard(tid)
+        trace_id = self._thread_to_trace.get(tid)
+        if trace_id is not None:
+            self._maybe_release(trace_id)
+
+    # -- deferred root release ------------------------------------------------
+
+    def _handle_root(self, span: ReadableSpan, trace_id: str) -> None:
+        """Handle the trace root (job entrypoint), the conversation root.
+
+        The root ends before the conversation completes (the agent greets first),
+        so we always defer it and release it — complete, with audio — once the
+        session has ended and any awaited recording has arrived.
+        """
+        self._set_kind(span, "chain")
+        span._attributes["langsmith.root_span"] = True
+        span._attributes["langsmith.metadata.ls_modality"] = "audio"
+
+        thread = span.attributes.get("langsmith.metadata.thread_id")
+        if thread is not None:
+            self._thread_to_trace[str(thread)] = trace_id
+            self._trace_to_thread[trace_id] = str(thread)
+
+        self._deferred_root_spans[trace_id] = span
+        self._maybe_release(trace_id)
+
+    def _release_root_span(self, trace_id: str) -> None:
+        """Session ended: release the root if ready (see :meth:`_maybe_release`)."""
+        self._maybe_release(trace_id)
+
+    def _maybe_release(self, trace_id: str) -> None:
+        """Export the deferred root once the session ended and audio is ready.
+
+        Three conditions must hold: the root span has been seen, the
+        ``agent_session`` has ended, and the conversation isn't still awaiting an
+        egress recording. Any of the three call sites (root seen, session end,
+        ``complete_recording``) can be the one that satisfies the last condition.
+        """
+        span = self._deferred_root_spans.get(trace_id)
+        if span is None or trace_id not in self._ended_sessions:
+            return
+        thread = self._trace_to_thread.get(trace_id)
+        if thread is not None and thread in self._awaiting_recording:
+            return  # still waiting for complete_recording()
+
+        self._deferred_root_spans.pop(trace_id, None)
+        self._render_conversation(span)
+        self._attach_audio_recording(span)
+        if thread is not None:
+            self._attach_pending_audio(span, thread)
+        self._export(span)
+        self._cleanup_trace(trace_id)
+
+    def _render_conversation(self, span: ReadableSpan) -> bool:
+        """Render the accumulated conversation onto a root span.
+
+        Input = the opening message; output = everything after it. Returns
+        whether anything was rendered.
+        """
+        messages = self._conversation_by_trace.get(span.context.trace_id, [])
+        if not messages:
+            return False
+        self._set_messages(span, prompt=messages[:1])
+        if len(messages) > 1:
+            self._set_messages(span, completion=messages[1:])
+        return True
+
+    def _cleanup_trace(self, trace_id: str) -> None:
+        self._conversation_by_trace.pop(int(trace_id, 16), None)
+        self._ended_sessions.discard(trace_id)
+        thread = self._trace_to_thread.pop(trace_id, None)
+        if thread is not None:
+            self._thread_to_trace.pop(thread, None)
+            self._awaiting_recording.discard(thread)
+            self._pending_audio.pop(thread, None)
+
+    def shutdown(self) -> None:
+        """Flush any deferred root spans, then shut down the downstream."""
+        self._flush_deferred_root_spans()
+        super().shutdown()
+
+    def force_flush(self, timeout_millis: int = 30000) -> bool:
+        """Flush any deferred root spans, then force-flush the downstream."""
+        self._flush_deferred_root_spans()
+        return super().force_flush(timeout_millis)
+
+    def _flush_deferred_root_spans(self) -> None:
+        """Export any root spans still held.
+
+        Covers a session that ended abnormally, or an awaited recording that
+        never arrived before shutdown.
+        """
+        for trace_id, span in list(self._deferred_root_spans.items()):
+            if not self._render_conversation(span):
+                self._set_messages(
+                    span,
+                    prompt=[{"role": "system", "content": "Conversation not captured"}],
+                    completion=[
+                        {
+                            "role": "assistant",
+                            "content": "No conversation turns recorded.",
+                        }
+                    ],
+                )
+            self._attach_audio_recording(span)
+            thread = self._trace_to_thread.get(trace_id)
+            if thread is not None:
+                self._attach_pending_audio(span, thread)
+            self._export(span)
+            del self._deferred_root_spans[trace_id]
+
+    # -- audio attachment -----------------------------------------------------
+
+    def _attach_audio_recording(self, span: ReadableSpan) -> None:
+        if self.audio_path_provider is None:
+            return
+        audio_path = self.audio_path_provider()
+        if audio_path is None:
+            return
+        try:
+            if not audio_path.exists():
+                return
+            audio_bytes = audio_path.read_bytes()
+        except Exception:  # pragma: no cover
+            return
+        self._attach_audio(
+            span,
+            name=audio_path.name,
+            data=audio_bytes,
+            mime_type=self._audio_mime_type,
+        )
+
+    def _attach_pending_audio(self, span: ReadableSpan, thread: str) -> None:
+        """Embed a recording supplied via :meth:`complete_recording` (egress)."""
+        pending = self._pending_audio.pop(thread, None)
+        if not pending or not pending.get("data"):
+            return
+        self._attach_audio(
+            span,
+            name=pending["name"],
+            data=pending["data"],
+            mime_type=pending["mime_type"],
+        )
+
+    # -- realtime-model metrics ----------------------------------------------
+
+    def _cache_realtime_metrics(self, span: ReadableSpan) -> None:
+        """Stash a ``realtime_metrics`` span's data for its parent ``agent_turn``."""
+        parent_id = span.parent.span_id if span.parent else None
+        if parent_id is None:
+            return
+        cached = {
+            k: v
+            for k, v in span.attributes.items()
+            if k.startswith("lk.") or k.startswith("gen_ai.usage")
+        }
+        # Lift token counts into gen_ai.usage.* for cost tracking.
+        metrics = self._try_parse_json_object(
+            span.attributes.get("lk.realtime_model_metrics")
+        )
+        if isinstance(metrics, dict):
+            for src, dst in (
+                ("input_tokens", "gen_ai.usage.input_tokens"),
+                ("output_tokens", "gen_ai.usage.output_tokens"),
+                ("total_tokens", "gen_ai.usage.total_tokens"),
+            ):
+                v = metrics.get(src)
+                if isinstance(v, (int, float)):
+                    cached[dst] = v
+        if cached:
+            self._realtime_metrics_by_parent[parent_id] = cached
+
+    def _drain_realtime_metrics(self, span: ReadableSpan) -> None:
+        """Copy cached realtime metrics onto this (agent_turn) span (if absent)."""
+        cached = self._realtime_metrics_by_parent.pop(span.context.span_id, None)
+        if not cached:
+            return
+        for k, v in cached.items():
+            if k not in span._attributes:
+                span._attributes[k] = v
+
+    # -- blanket lk.* pass-through (runs just before export) ------------------
+
+    def _pre_export(self, span: ReadableSpan) -> None:
+        """Forward every ``lk.*`` attribute to ``langsmith.metadata.lk_<name>``.
+
+        Scalars and sequences of scalars are forwarded directly; JSON-object
+        blobs are flattened so each metric is its own field.
+        """
+        for key in list(span.attributes.keys()):
+            if not key.startswith("lk."):
+                continue
+            v = span.attributes[key]
+            if v is None or isinstance(v, dict):
+                continue
+            ms_key = f"langsmith.metadata.{key.replace('.', '_')}"
+            parsed = self._try_parse_json_object(v)
+            if parsed is not None:
+                self._flatten_into_metadata(span, ms_key, parsed)
+                continue
+            if ms_key in span._attributes:  # don't clobber what a branch set
+                continue
+            span._attributes[ms_key] = v
+
+    @staticmethod
+    def _try_parse_json_object(value: Any) -> Optional[dict]:
+        """Return ``value`` parsed as a dict if it's a JSON-object string, else None."""
+        if not isinstance(value, str):
+            return None
+        s = value.strip()
+        if not (s.startswith("{") and s.endswith("}")):
+            return None
+        try:
+            obj = json.loads(s)
+        except (json.JSONDecodeError, ValueError):
+            return None
+        return obj if isinstance(obj, dict) else None
+
+    def _flatten_into_metadata(
+        self, span: ReadableSpan, prefix: str, obj: dict, _depth: int = 0
+    ) -> None:
+        """Flatten a dict's scalar leaves to ``langsmith.metadata.<prefix>_<key>``."""
+        if _depth > 4:
+            return
+        for k, v in obj.items():
+            name = f"{prefix}_{k}"
+            if isinstance(v, dict):
+                self._flatten_into_metadata(span, name, v, _depth + 1)
+            elif isinstance(v, (str, int, float, bool)):
+                if name not in span._attributes:
+                    span._attributes[name] = v
+            elif (
+                isinstance(v, (list, tuple))
+                and v
+                and all(isinstance(item, (str, int, float, bool)) for item in v)
+            ):
+                if name not in span._attributes:
+                    span._attributes[name] = list(v)

--- a/python/langsmith/integrations/openai_realtime/__init__.py
+++ b/python/langsmith/integrations/openai_realtime/__init__.py
@@ -1,0 +1,22 @@
+"""LangSmith integration for the OpenAI Realtime API.
+
+There are two ways to build an OpenAI Realtime voice agent, each with its own
+wrapper here:
+
+* :func:`wrap_realtime` — for a raw ``client.realtime.connect()`` WebSocket loop.
+* :func:`wrap_realtime_session` — for an ``agents.realtime`` session built with
+  the OpenAI Agents SDK.
+
+Both build a single LangSmith trace from the provider's event stream and return
+a transparent proxy, so the caller's loop is unchanged.
+"""
+
+from __future__ import annotations
+
+from .._voice import warn_in_development
+from ._connection import wrap_realtime
+from ._session import wrap_realtime_session
+
+warn_in_development("openai_realtime")
+
+__all__ = ["wrap_realtime", "wrap_realtime_session"]

--- a/python/langsmith/integrations/openai_realtime/_connection.py
+++ b/python/langsmith/integrations/openai_realtime/_connection.py
@@ -1,0 +1,430 @@
+"""LangSmith tracing for the OpenAI Realtime API (raw WebSocket).
+
+OpenAI Realtime has no native telemetry — it's a raw WebSocket event stream of
+``input_audio_buffer.*`` / ``response.*`` events. :func:`wrap_realtime` wraps the
+``AsyncRealtimeConnection`` so the trace is built directly from that stream while
+the caller's ``async for event in connection`` loop is left untouched: each
+received event is observed, spanned where warranted, and grouped into turns; the
+running transcript and a stereo conversation WAV land on the root span.
+
+Tool nesting is preserved without wrapping the caller's loop body: an event's
+span is opened when the event is received and kept as the active LangSmith
+context until the *next* event arrives — so any ``@traceable`` work the caller
+does while handling the event (tool execution) nests under it.
+
+Trace shape — one conversation = one trace::
+
+    realtime_session                                   (root; transcript + WAV)
+    ├── session.created / session.updated              (setup)
+    ├── turn                                           (latency_ms, was_interrupted)
+    │   ├── conversation.item.input_audio_transcription.completed   (user message)
+    │   └── response.done                              (chain wrapper)
+    │       ├── model                                  (llm — message + tokens)
+    │       └── <your @traceable tools>                (nested under response.done)
+    └── turn …
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from typing import TYPE_CHECKING, Any, Callable, Optional
+
+from langsmith.run_helpers import tracing_context
+
+from .._voice.session import EventSession, start_session
+
+if TYPE_CHECKING:
+    from langsmith import RunTree
+
+# Default PCM sample rate for OpenAI Realtime audio (used for the stereo WAV).
+DEFAULT_SAMPLE_RATE = 24_000
+
+# Structural bookkeeping events that only duplicate state already captured by
+# ``response.done`` and the transcript events, so spanning them floods the trace.
+NOISE_EVENTS = frozenset(
+    {
+        "input_audio_buffer.committed",
+        "conversation.item.added",
+        "conversation.item.done",
+        "response.created",
+        "response.output_item.added",
+        "response.output_item.done",
+        "response.content_part.added",
+        "response.content_part.done",
+        "response.output_audio.done",
+        # Redundant with the model span's tool_calls + the tool span's args.
+        "response.function_call_arguments.done",
+    }
+)
+
+
+def is_inbound(event_type: str) -> bool:
+    """Direction of an event relative to the model.
+
+    Inbound = something the user sent toward the model (their speech buffer,
+    their transcription) → goes in span ``inputs``. Everything else is the
+    model/server talking back → span ``outputs``.
+    """
+    return (
+        event_type.startswith("input_audio_buffer")
+        or "input_audio_transcription" in event_type
+    )
+
+
+def _safe_json(raw: str | None) -> Any:
+    """Parse a JSON arguments string, falling back to ``{}`` on bad/missing input."""
+    try:
+        return json.loads(raw or "{}")
+    except (json.JSONDecodeError, TypeError):
+        return {}
+
+
+def response_assistant_output(response: Any) -> dict[str, Any]:
+    """Curated assistant message from a ``response.done`` payload.
+
+    The readable, AIMessage-shaped view of what the model returned this
+    response: the spoken text plus any tool calls it requested.
+    """
+    texts: list[str] = []
+    tool_calls: list[dict[str, Any]] = []
+    for item in getattr(response, "output", None) or []:
+        if getattr(item, "type", None) == "function_call":
+            tool_calls.append(
+                {
+                    "name": getattr(item, "name", None),
+                    "args": _safe_json(getattr(item, "arguments", None)),
+                    "id": getattr(item, "call_id", None),
+                }
+            )
+            continue
+        for part in getattr(item, "content", None) or []:
+            text = getattr(part, "transcript", None) or getattr(part, "text", None)
+            if text:
+                texts.append(text)
+    out: dict[str, Any] = {"role": "assistant", "content": " ".join(texts).strip()}
+    if tool_calls:
+        out["tool_calls"] = tool_calls
+    return out
+
+
+def response_usage_metadata(response: Any) -> dict[str, int] | None:
+    """Map Realtime token ``usage`` onto LangSmith ``usage_metadata`` (for cost).
+
+    Returns ``None`` when the response carries no usage (e.g. a cancelled turn).
+    """
+    usage = getattr(response, "usage", None)
+    if usage is None:
+        return None
+
+    def field(key: str) -> int | None:
+        val = getattr(usage, key, None)
+        if val is None and hasattr(usage, "get"):
+            val = usage.get(key)
+        return val
+
+    inp, out, total = (
+        field("input_tokens"),
+        field("output_tokens"),
+        field("total_tokens"),
+    )
+    if inp is None and out is None and total is None:
+        return None
+    return {
+        "input_tokens": inp or 0,
+        "output_tokens": out or 0,
+        "total_tokens": total if total is not None else (inp or 0) + (out or 0),
+    }
+
+
+class _RealtimeTracer:
+    """Turns the Realtime event stream into a LangSmith trace, one event at a time.
+
+    Decides — privately — whether to open a span, open/close a turn, append to
+    the transcript rollup, set the trace title, time first-audio latency, flag a
+    barge-in, and record the ``llm`` span. All trace writes go through the
+    injected :class:`EventSession`.
+
+    An event's span is held open (as the active LangSmith parent context) from
+    the moment the event is received until the next event arrives, so the
+    caller's tool calls nest under it.
+    """
+
+    def __init__(
+        self,
+        session: EventSession,
+        *,
+        is_agent_speaking: Optional[Callable[[], bool]] = None,
+    ) -> None:
+        self._session = session
+        # The only way to know the agent was still audible when the user spoke (a
+        # barge-in) is whether playback is still queued; the wire stream has no
+        # "playout finished" event. Optional — supplied by the app.
+        self._is_agent_speaking = is_agent_speaking
+        # Per-turn latency: end-of-user-speech → first agent audio. Armed at
+        # speech_stopped, recorded on the first audio chunk. None = not armed.
+        self._await_audio_since: float | None = None
+        # The currently open event span, kept active until the next event:
+        # (event_span_cm, tracing_context_cm). None = nothing open.
+        self._open: tuple[Any, Any] | None = None
+
+    def observe(self, event: Any) -> None:
+        """Observe one received event; span it where warranted.
+
+        Closes the previous event's span first (the caller has finished handling
+        it), then applies turn/transcript/latency side-state and, for meaningful
+        events, opens a new span kept active until the next call.
+        """
+        self._close_open()
+        received_at = self._session.now()
+        etype = event.type
+
+        # No-span events: observed for side-state only.
+        if etype == "response.output_audio.delta":
+            self._record_first_audio(received_at)
+            return
+        if etype.endswith(".delta") or etype in NOISE_EVENTS:
+            return
+        if etype == "response.output_audio_transcript.done":
+            # Already the model span's content; fold into the rollup, don't span.
+            self._session.add_message(
+                "assistant", getattr(event, "transcript", "") or ""
+            )
+            return
+
+        self._before_span(event, received_at)
+
+        cm_span = self._session.event_span(
+            event, received_at, name=etype, **self._span_kwargs(event)
+        )
+        run = cm_span.__enter__()
+        if etype == "conversation.item.input_audio_transcription.failed":
+            run.error = f"transcription_failed: {getattr(event, 'error', None)}"
+        elif etype == "response.done":
+            response = getattr(event, "response", None)
+            if response is not None:
+                self._record_response_llm(run, response)
+        cm_ctx = tracing_context(parent=run)
+        cm_ctx.__enter__()
+        self._open = (cm_span, cm_ctx)
+
+    def finalize_open(self) -> None:
+        """Close any still-open event span (called at teardown)."""
+        self._close_open()
+
+    def _close_open(self) -> None:
+        if self._open is None:
+            return
+        cm_span, cm_ctx = self._open
+        self._open = None
+        cm_ctx.__exit__(None, None, None)
+        cm_span.__exit__(None, None, None)
+
+    def _before_span(self, event: Any, received_at: float) -> None:
+        """Turn/transcript/title side-state applied as a span is about to open."""
+        etype = event.type
+        if etype == "input_audio_buffer.speech_started":
+            # A user starting to speak opens a new turn (also the barge-in
+            # signal). If the agent was still audible, the turn being closed was
+            # talked over — flag it before start_turn() closes it.
+            if self._is_agent_speaking is not None and self._is_agent_speaking():
+                self._session.add_turn_metadata(was_interrupted=True)
+            self._session.start_turn()
+            self._await_audio_since = None
+        elif etype == "input_audio_buffer.speech_stopped":
+            self._await_audio_since = received_at
+        elif etype == "conversation.item.input_audio_transcription.completed":
+            text = (getattr(event, "transcript", "") or "").strip()
+            if text:
+                self._session.add_message("user", text)
+                self._session.set_title(text)
+            else:
+                self._await_audio_since = None
+        elif etype == "conversation.item.input_audio_transcription.failed":
+            self._await_audio_since = None
+
+    def _span_kwargs(self, event: Any) -> dict[str, Any]:
+        """Curated, conversation-shaped I/O for the readable events."""
+        etype = event.type
+        kwargs: dict[str, Any] = {"inbound": is_inbound(etype)}
+        if etype == "conversation.item.input_audio_transcription.completed":
+            text = (getattr(event, "transcript", "") or "").strip()
+            if text:
+                kwargs["inputs"] = {"role": "user", "content": text}
+        elif etype == "response.done":
+            # Keep this a chain wrapper; the model payload goes on the child llm
+            # span so local tool latency isn't attributed to the model.
+            kwargs["outputs"] = {}
+        return kwargs
+
+    def _record_first_audio(self, received_at: float) -> None:
+        if self._await_audio_since is not None:
+            self._session.add_turn_metadata(
+                latency_to_first_audio_ms=round(
+                    (received_at - self._await_audio_since) * 1000
+                )
+            )
+            self._await_audio_since = None
+
+    def _record_response_llm(self, run: RunTree, response: Any) -> None:
+        self._session.record_llm(
+            run,
+            outputs=response_assistant_output(response),
+            usage_metadata=response_usage_metadata(response),
+            metadata={"status": getattr(response, "status", None)},
+        )
+
+
+class _TracedRealtimeConnection:
+    """Transparent proxy over an ``AsyncRealtimeConnection`` that traces events.
+
+    Delegates every attribute to the wrapped connection, so the caller uses it
+    exactly like the original (``connection.session.update(...)``,
+    ``connection.response.create()``, ``async for event in connection``). Each
+    received event is passed to the tracer. Also exposes
+    :meth:`record_user_audio` / :meth:`record_agent_audio` so the app can
+    (optionally) feed PCM for the stereo conversation WAV.
+    """
+
+    def __init__(
+        self, connection: Any, tracer: _RealtimeTracer, session: EventSession
+    ) -> None:
+        object.__setattr__(self, "_connection", connection)
+        object.__setattr__(self, "_tracer", tracer)
+        object.__setattr__(self, "_session", session)
+        object.__setattr__(self, "_aiter", None)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(object.__getattribute__(self, "_connection"), name)
+
+    def __aiter__(self) -> _TracedRealtimeConnection:
+        object.__setattr__(self, "_aiter", self._connection.__aiter__())
+        return self
+
+    async def __anext__(self) -> Any:
+        aiter = object.__getattribute__(self, "_aiter")
+        if aiter is None:
+            aiter = self._connection.__aiter__()
+            object.__setattr__(self, "_aiter", aiter)
+        event = await aiter.__anext__()
+        self._tracer.observe(event)
+        return event
+
+    async def recv(self) -> Any:
+        event = await self._connection.recv()
+        self._tracer.observe(event)
+        return event
+
+    def record_user_audio(self, pcm: bytes) -> None:
+        """Record a chunk of user (mic) PCM16 for the stereo conversation WAV."""
+        self._session.record_user(self._session.now(), pcm)
+
+    def record_agent_audio(self, pcm: bytes) -> None:
+        """Record a chunk of agent (played) PCM16 for the stereo conversation WAV."""
+        self._session.record_agent(self._session.now(), pcm)
+
+
+class _RealtimeTracingSession:
+    """Async context manager returned by :func:`wrap_realtime`.
+
+    On enter: starts the conversation root span and session-level LangSmith
+    context, returning a traced connection proxy. On exit: closes any open span,
+    records an error on the root if the body raised, and finalizes the root
+    (rolling up the transcript + attaching the stereo WAV).
+    """
+
+    def __init__(
+        self,
+        connection: Any,
+        *,
+        thread_id: Optional[str],
+        sample_rate: int,
+        project_name: Optional[str],
+        tags: Optional[list[str]],
+        metadata: Optional[dict[str, Any]],
+        is_agent_speaking: Optional[Callable[[], bool]],
+    ) -> None:
+        self._connection = connection
+        self._thread_id = thread_id or str(uuid.uuid4())
+        self._sample_rate = sample_rate
+        self._project_name = project_name
+        self._tags = tags
+        self._metadata = metadata
+        self._is_agent_speaking = is_agent_speaking
+        self._session: EventSession | None = None
+        self._tracer: _RealtimeTracer | None = None
+        self._ctx: Any = None
+
+    async def __aenter__(self) -> _TracedRealtimeConnection:
+        self._session = start_session(
+            thread_id=self._thread_id,
+            sample_rate=self._sample_rate,
+            project_name=self._project_name,
+            tags=self._tags,
+            metadata=self._metadata,
+        )
+        self._ctx = tracing_context(
+            metadata={"thread_id": self._thread_id},
+            tags=self._tags,
+            project_name=self._project_name,
+        )
+        self._ctx.__enter__()
+        self._tracer = _RealtimeTracer(
+            self._session, is_agent_speaking=self._is_agent_speaking
+        )
+        return _TracedRealtimeConnection(self._connection, self._tracer, self._session)
+
+    async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> bool:
+        if self._tracer is not None:
+            self._tracer.finalize_open()
+        if self._session is not None:
+            if exc is not None:
+                self._session.run.error = f"{exc_type.__name__}: {exc}"
+            self._session.finalize()
+        if self._ctx is not None:
+            self._ctx.__exit__(None, None, None)
+        return False
+
+
+def wrap_realtime(
+    connection: Any,
+    *,
+    thread_id: Optional[str] = None,
+    sample_rate: int = DEFAULT_SAMPLE_RATE,
+    project_name: Optional[str] = None,
+    tags: Optional[list[str]] = None,
+    metadata: Optional[dict[str, Any]] = None,
+    is_agent_speaking: Optional[Callable[[], bool]] = None,
+) -> _RealtimeTracingSession:
+    r"""Trace an OpenAI Realtime connection into LangSmith.
+
+    Returns an async context manager that yields a transparent proxy of
+    ``connection``; iterate and call it exactly as you would the original::
+
+        async with client.realtime.connect(model=...) as raw, \\
+                   wrap_realtime(raw, thread_id=tid) as connection:
+            async for event in connection:
+                ...
+
+    To capture the stereo conversation WAV, feed PCM via the proxy's
+    ``record_user_audio`` / ``record_agent_audio`` and (optionally) supply
+    ``is_agent_speaking`` so barge-ins are flagged.
+
+    Args:
+        connection: the ``AsyncRealtimeConnection`` from ``client.realtime.connect``.
+        thread_id: LangSmith thread id; a random UUID if omitted.
+        sample_rate: PCM sample rate of the audio (for the WAV).
+        project_name: LangSmith project; defaults to standard ``LANGSMITH_*`` config.
+        tags / metadata: attached to the conversation root span.
+        is_agent_speaking: zero-arg callable returning whether the agent is still
+            audible, used to flag a barge-in; ``None`` disables that flag.
+    """
+    return _RealtimeTracingSession(
+        connection,
+        thread_id=thread_id,
+        sample_rate=sample_rate,
+        project_name=project_name,
+        tags=tags,
+        metadata=metadata,
+        is_agent_speaking=is_agent_speaking,
+    )

--- a/python/langsmith/integrations/openai_realtime/_session.py
+++ b/python/langsmith/integrations/openai_realtime/_session.py
@@ -1,0 +1,502 @@
+"""LangSmith tracing for the OpenAI Agents SDK realtime backend.
+
+The Agents SDK's realtime sessions emit no local SDK trace spans (realtime
+tracing is server-side only), so the existing batch ``OpenAIAgentsTracingProcessor``
+captures nothing here. This is a separate, complementary integration:
+:func:`wrap_realtime_session` wraps the ``RealtimeSession`` so the trace is built
+from its **semantic event stream**, while the caller's ``async for event in
+session`` loop is left untouched.
+
+The conversation is reconstructed from the full ``history`` snapshot the session
+delivers on every ``history_updated`` — not from the streamed events, which
+mis-deliver user messages and emit the assistant transcript as growing partials.
+Snapshots are folded into an item map keyed by stable ``item_id`` (latest text
+per id wins → partials collapse); each finalized message emits one span (a
+curated ``user_message`` or an assistant ``model`` ``llm`` span), grouped into
+turns. ``tool_start``/``tool_end`` (SDK-run tools) become ``tool`` spans;
+``audio_interrupted`` flags the turn. (Token usage isn't available — the SDK has
+no per-response usage events yet.)
+
+Trace shape — one conversation = one trace::
+
+    realtime_session                                   (root; transcript + WAV)
+    ├── turn                                           (latency_ms, was_interrupted)
+    │   ├── user_message                               (curated user msg, from history)
+    │   ├── tool_end          (lookup_weather)         (tool — args in / output out)
+    │   └── model             (assistant message)      (llm — from history)
+    └── turn …
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import uuid
+from typing import Any, Callable, Optional
+
+from langsmith.run_helpers import tracing_context
+
+from .._voice.session import EventSession, start_session
+
+# Default PCM sample rate for OpenAI Realtime audio (used for the stereo WAV).
+DEFAULT_SAMPLE_RATE = 24_000
+
+_MAX_DEPTH = 4  # how deep we recurse into nested SDK objects before bailing
+_MAX_ITEMS = 50  # cap on collection width so one event never balloons a span
+_MAX_REPR = 200  # truncate the repr() fallback for exotic objects
+
+
+# ---------------------------------------------------------------------------
+# Payload shaping: turn the SDK's semantic event (a dataclass holding live SDK
+# objects) into a compact, JSON-able span payload.
+# ---------------------------------------------------------------------------
+
+
+def _stringify(value: Any) -> Any:
+    """Keep JSON-able values as-is; repr anything exotic so a span never breaks."""
+    if value is None or isinstance(value, (str, int, float, bool, dict, list)):
+        return value
+    return repr(value)
+
+
+def _shallow(value: Any) -> Any:
+    """Last-resort view of a value we won't (or can't) recurse into."""
+    name = getattr(value, "name", None)
+    if isinstance(name, str):
+        return name
+    text = repr(value)
+    return text if len(text) <= _MAX_REPR else text[:_MAX_REPR] + "…"
+
+
+def _public_fields(value: Any) -> dict[str, Any] | None:
+    """Public, non-callable attributes of a dataclass/object, or None."""
+    if dataclasses.is_dataclass(value) and not isinstance(value, type):
+        fields = {
+            f.name: getattr(value, f.name, None) for f in dataclasses.fields(value)
+        }
+    else:
+        fields = getattr(value, "__dict__", None)
+    if not fields:
+        return None
+    return {
+        k: v for k, v in fields.items() if not k.startswith("_") and not callable(v)
+    }
+
+
+def _clean(value: Any, depth: int = 0, seen: frozenset[int] = frozenset()) -> Any:
+    """Recursively coerce any value into a compact, JSON-able span payload.
+
+    Keeps readable data and strips what would break or bloat a span: raw bytes,
+    callables, private attributes, and anything past the depth/width caps. Cycles
+    are broken via ``seen``.
+    """
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, (bytes, bytearray, memoryview)):
+        return f"<{len(bytes(value))} bytes>"
+
+    if depth >= _MAX_DEPTH:
+        return _shallow(value)
+    if id(value) in seen:
+        return "<circular>"
+    seen = seen | {id(value)}
+
+    if isinstance(value, dict):
+        out: dict[str, Any] = {}
+        for i, (key, val) in enumerate(value.items()):
+            if i >= _MAX_ITEMS:
+                out["…"] = f"+{len(value) - _MAX_ITEMS} more"
+                break
+            if isinstance(key, str) and key.startswith("_"):
+                continue
+            out[str(key)] = _clean(val, depth + 1, seen)
+        return out
+
+    if isinstance(value, (list, tuple, set)):
+        items = list(value)
+        cleaned = [_clean(v, depth + 1, seen) for v in items[:_MAX_ITEMS]]
+        if len(items) > _MAX_ITEMS:
+            cleaned.append(f"… +{len(items) - _MAX_ITEMS} more")
+        return cleaned
+
+    fields = _public_fields(value)
+    if fields:
+        return {k: _clean(v, depth + 1, seen) for k, v in fields.items()}
+    return _shallow(value)
+
+
+def _tool_name(tool: Any) -> str | None:
+    return getattr(tool, "name", None) or (repr(tool) if tool is not None else None)
+
+
+def _item_text(item: Any) -> tuple[str | None, str | None]:
+    """Best-effort ``(role, text)`` for a realtime history item."""
+    if item is None:
+        return None, None
+    role = getattr(item, "role", None)
+    content = getattr(item, "content", None) or []
+    parts = []
+    for part in content:
+        text = getattr(part, "transcript", None) or getattr(part, "text", None)
+        if text:
+            parts.append(text)
+    return role, (" ".join(parts) or None)
+
+
+def raw_input_transcript(event: Any) -> tuple[str | None, str] | None:
+    """Extract the user transcript from a ``raw_model_event``.
+
+    Reads a ``raw_model_event`` wrapping an input-audio transcription completion
+    (the wire-level source ``history`` can omit on a barge-in). Returns
+    ``(item_id, transcript)`` or None.
+    """
+    data = getattr(event, "data", None)
+    if getattr(data, "type", None) != "input_audio_transcription_completed":
+        return None
+    transcript = (getattr(data, "transcript", None) or "").strip()
+    if not transcript:
+        return None
+    return getattr(data, "item_id", None), transcript
+
+
+def history_item(event: Any) -> tuple[str | None, str | None, str | None]:
+    """``(item_id, role, text)`` for a ``history_added`` event's single item."""
+    item = getattr(event, "item", None)
+    role, text = _item_text(item)
+    return getattr(item, "item_id", None), role, text
+
+
+def history_messages(event: Any) -> list[tuple[str | None, str | None, str | None]]:
+    """``(item_id, role, text)`` for every item in a ``history_updated`` snapshot."""
+    out: list[tuple[str | None, str | None, str | None]] = []
+    for item in getattr(event, "history", None) or []:
+        role, text = _item_text(item)
+        out.append((getattr(item, "item_id", None), role, text))
+    return out
+
+
+def describe_event(event: Any) -> tuple[str, dict[str, Any], bool]:
+    """Map a session event to ``(name, span_payload, inbound)``."""
+    etype = getattr(event, "type", None) or repr(event)
+    dumped = _clean(event)
+    payload: dict[str, Any] = dumped if isinstance(dumped, dict) else {"value": dumped}
+    payload["type"] = etype
+    inbound = False
+
+    if etype in ("agent_start", "agent_end"):
+        payload["agent"] = getattr(getattr(event, "agent", None), "name", None)
+    elif etype == "tool_start":
+        payload["tool"] = _tool_name(getattr(event, "tool", None))
+        payload["arguments"] = _stringify(getattr(event, "arguments", None))
+        inbound = True  # the model is asking us to run something → its input
+    elif etype == "tool_end":
+        payload["tool"] = _tool_name(getattr(event, "tool", None))
+        payload["arguments"] = _stringify(getattr(event, "arguments", None))
+        payload["output"] = _stringify(getattr(event, "output", None))
+    elif etype == "audio_interrupted":
+        payload["item_id"] = getattr(event, "item_id", None)
+    elif etype == "history_added":
+        role, text = _item_text(getattr(event, "item", None))
+        payload["role"], payload["text"] = role, text
+        inbound = role == "user"
+    elif etype == "history_updated":
+        history = getattr(event, "history", None) or []
+        role, text = _item_text(history[-1]) if history else (None, None)
+        payload["last_role"], payload["last_text"] = role, text
+        payload["length"] = len(history)
+        inbound = role == "user"
+    elif etype == "handoff":
+        payload["from_agent"] = getattr(
+            getattr(event, "from_agent", None), "name", None
+        )
+        payload["to_agent"] = getattr(getattr(event, "to_agent", None), "name", None)
+    elif etype == "guardrail_tripped":
+        payload["message"] = _stringify(getattr(event, "message", None))
+    elif etype == "error":
+        payload["error"] = _stringify(getattr(event, "error", None))
+
+    return etype, payload, inbound
+
+
+class _AgentsRealtimeTracer:
+    """Reconstructs the conversation from history snapshots and emits its spans.
+
+    Folds each ``history`` snapshot into a map keyed by stable ``item_id``
+    (latest non-empty text wins, so partials collapse), emits one span per
+    finalized message (a ``user_message`` or an assistant ``model`` ``llm`` span)
+    grouped into per-user-turn ``turn`` spans, and spans ``tool_end`` /
+    ``audio_interrupted`` from the live stream. Optionally notifies an
+    ``on_message`` callback as finalized transcript lines arrive.
+    """
+
+    def __init__(
+        self,
+        session: EventSession,
+        *,
+        on_message: Optional[Callable[[str, str], None]] = None,
+    ) -> None:
+        self._trace = session
+        self._on_message = on_message
+        # item_id → {"role", "text"}, in arrival order (dict preserves insertion).
+        self._items: dict[str, dict[str, Any]] = {}
+        self._emitted: set[str] = set()  # item_ids already turned into spans
+        self._notified: set[tuple[str, str]] = set()  # (role, text) already sent out
+        # Per-turn latency: when the current user turn opened; None = not armed.
+        self._latency_since: float | None = None
+
+    def observe(self, event: Any) -> None:
+        """Observe one session event: fold history, emit spans, time latency."""
+        received_at = self._trace.now()
+        etype = event.type
+
+        if etype == "audio":
+            self.record_first_audio(received_at)
+            return
+        if etype == "raw_model_event":
+            rec = raw_input_transcript(event)
+            if rec:
+                item_id, transcript = rec
+                self._observe_items([(item_id, "user", transcript)], received_at)
+                self._flush(hold_last=True)
+            return
+        if etype == "history_added":
+            self._observe_items([history_item(event)], received_at)
+            self._flush(hold_last=True)
+            return
+        if etype == "history_updated":
+            self._observe_items(history_messages(event), received_at)
+            self._flush(hold_last=True)
+            return
+        if etype in ("agent_start", "agent_end"):
+            return  # bookkeeping markers, no I/O
+
+        # Remaining live events get a span. tool_end → tool run; a barge-in flags
+        # the open turn.
+        name, payload, inbound = describe_event(event)
+        span_kwargs: dict[str, Any] = {"inbound": inbound}
+        if etype == "tool_end":
+            span_kwargs["run_type"] = "tool"
+            span_kwargs["inputs"] = {"arguments": payload.get("arguments")}
+            span_kwargs["outputs"] = {"output": payload.get("output")}
+        elif etype == "audio_interrupted":
+            self._trace.add_turn_metadata(was_interrupted=True)
+
+        # No nested work happens while handling these events, so open+close now.
+        with self._trace.event_span(payload, received_at, name=name, **span_kwargs):
+            pass
+
+    def flush_pending(self) -> None:
+        """Emit any messages still pending (called at teardown)."""
+        self._flush(hold_last=False)
+
+    def _observe_items(self, seq: list[tuple], received_at: float) -> None:
+        """Fold ``(item_id, role, text)`` tuples into the map.
+
+        A brand-new user item begins a turn: the previous turn's messages are
+        flushed first (so they stay grouped under it), then a new turn opens and
+        the latency timer is armed.
+        """
+        for iid, role, text in seq:
+            if not iid:
+                continue
+            if iid not in self._items and role == "user":
+                self._flush(hold_last=False)
+                self._trace.start_turn()
+                self._latency_since = received_at
+            cur = self._items.get(iid)
+            if cur is None:
+                self._items[iid] = {"role": role, "text": text}
+            else:
+                if role:
+                    cur["role"] = role
+                if text:  # latest non-empty text wins → collapses partials
+                    cur["text"] = text
+            if role in ("user", "assistant") and text:
+                self._notify(role, text)
+
+    def _flush(self, hold_last: bool) -> None:
+        """Emit not-yet-emitted items in order.
+
+        Optionally holds back the last (still-streaming) item until it is
+        superseded or the session ends.
+        """
+        ids = list(self._items)
+        cutoff = len(ids) - 1 if hold_last else len(ids)
+        for iid in ids[: max(0, cutoff)]:
+            if iid not in self._emitted:
+                self._record_item(iid)
+
+    def record_first_audio(self, received_at: float) -> None:
+        """Record ``latency_to_first_audio_ms`` on the open turn, once per turn."""
+        if self._latency_since is not None:
+            self._trace.add_turn_metadata(
+                latency_to_first_audio_ms=round(
+                    (received_at - self._latency_since) * 1000
+                )
+            )
+            self._latency_since = None
+
+    def _notify(self, role: str | None, text: str | None) -> None:
+        """Send one finalized transcript line to the on_message callback once."""
+        if self._on_message is None or not role or not text:
+            return
+        if (role, text) in self._notified:
+            return
+        self._notified.add((role, text))
+        self._on_message(role, text)
+
+    def _record_item(self, iid: str) -> None:
+        """Emit one message span for a finalized history item (once)."""
+        role = self._items[iid]["role"]
+        text = (self._items[iid]["text"] or "").strip()
+        if role not in ("user", "assistant"):
+            self._emitted.add(iid)  # tool/system items are never messages
+            return
+        if not text:
+            return  # text not in yet (may arrive late, e.g. a barge-in) — pending
+        self._emitted.add(iid)
+        self._notify(role, text)
+        self._trace.add_message(role, text)
+        if role == "user":
+            with self._trace.event_span(
+                {"item_id": iid, "role": "user", "content": text},
+                self._trace.now(),
+                name="user_message",
+                inbound=True,
+                inputs={"role": "user", "content": text},
+            ):
+                pass
+        else:
+            self._trace.record_llm(outputs={"role": "assistant", "content": text})
+
+
+class _TracedRealtimeSession:
+    """Async-context-manager proxy over a ``RealtimeSession`` that traces events.
+
+    Delegates the underlying session's ``async with`` and every attribute
+    (``send_audio``, …), iterates its events, and observes each. On exit it emits
+    any pending messages and finalizes the conversation root (transcript + WAV).
+    Exposes ``record_user_audio`` / ``record_agent_audio`` for the stereo WAV.
+    """
+
+    def __init__(
+        self,
+        session: Any,
+        *,
+        thread_id: Optional[str],
+        sample_rate: int,
+        project_name: Optional[str],
+        tags: Optional[list[str]],
+        metadata: Optional[dict[str, Any]],
+        on_message: Optional[Callable[[str, str], None]],
+    ) -> None:
+        object.__setattr__(self, "_session", session)
+        object.__setattr__(self, "_thread_id", thread_id or str(uuid.uuid4()))
+        object.__setattr__(self, "_sample_rate", sample_rate)
+        object.__setattr__(self, "_project_name", project_name)
+        object.__setattr__(self, "_tags", tags)
+        object.__setattr__(self, "_metadata", metadata)
+        object.__setattr__(self, "_on_message", on_message)
+        object.__setattr__(self, "_trace", None)
+        object.__setattr__(self, "_tracer", None)
+        object.__setattr__(self, "_ctx", None)
+        object.__setattr__(self, "_aiter", None)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(object.__getattribute__(self, "_session"), name)
+
+    async def __aenter__(self) -> _TracedRealtimeSession:
+        await self._session.__aenter__()
+        trace = start_session(
+            thread_id=self._thread_id,
+            sample_rate=self._sample_rate,
+            project_name=self._project_name,
+            tags=self._tags,
+            metadata=self._metadata,
+        )
+        object.__setattr__(self, "_trace", trace)
+        ctx = tracing_context(
+            metadata={"thread_id": self._thread_id},
+            tags=self._tags,
+            project_name=self._project_name,
+        )
+        ctx.__enter__()
+        object.__setattr__(self, "_ctx", ctx)
+        object.__setattr__(
+            self, "_tracer", _AgentsRealtimeTracer(trace, on_message=self._on_message)
+        )
+        return self
+
+    async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> Any:
+        if self._tracer is not None:
+            self._tracer.flush_pending()
+        if self._trace is not None:
+            if exc is not None:
+                self._trace.run.error = f"{exc_type.__name__}: {exc}"
+            self._trace.finalize()
+        if self._ctx is not None:
+            self._ctx.__exit__(None, None, None)
+        return await self._session.__aexit__(exc_type, exc, tb)
+
+    def __aiter__(self) -> _TracedRealtimeSession:
+        object.__setattr__(self, "_aiter", self._session.__aiter__())
+        return self
+
+    async def __anext__(self) -> Any:
+        aiter = object.__getattribute__(self, "_aiter")
+        if aiter is None:
+            aiter = self._session.__aiter__()
+            object.__setattr__(self, "_aiter", aiter)
+        event = await aiter.__anext__()
+        self._tracer.observe(event)
+        return event
+
+    def record_user_audio(self, pcm: bytes) -> None:
+        """Record a chunk of user (mic) PCM16 for the stereo conversation WAV."""
+        self._trace.record_user(self._trace.now(), pcm)
+
+    def record_agent_audio(self, pcm: bytes) -> None:
+        """Record a chunk of agent (played) PCM16 for the stereo conversation WAV."""
+        self._trace.record_agent(self._trace.now(), pcm)
+
+
+def wrap_realtime_session(
+    session: Any,
+    *,
+    thread_id: Optional[str] = None,
+    sample_rate: int = DEFAULT_SAMPLE_RATE,
+    project_name: Optional[str] = None,
+    tags: Optional[list[str]] = None,
+    metadata: Optional[dict[str, Any]] = None,
+    on_message: Optional[Callable[[str, str], None]] = None,
+) -> _TracedRealtimeSession:
+    """Trace an OpenAI Agents SDK ``RealtimeSession`` into LangSmith.
+
+    Returns an async-context-manager proxy that also enters the underlying
+    session; iterate and call it exactly as you would the original::
+
+        session = await runner.run()
+        async with wrap_realtime_session(session, thread_id=tid) as conn:
+            async for event in conn:
+                ...
+
+    To capture the stereo conversation WAV, feed PCM via the proxy's
+    ``record_user_audio`` / ``record_agent_audio``.
+
+    Args:
+        session: the ``RealtimeSession`` returned by ``RealtimeRunner.run()``.
+        thread_id: LangSmith thread id; a random UUID if omitted.
+        sample_rate: PCM sample rate of the audio (for the WAV).
+        project_name: LangSmith project; defaults to standard ``LANGSMITH_*`` config.
+        tags / metadata: attached to the conversation root span.
+        on_message: optional callback ``(role, text)`` invoked once per finalized
+            transcript line (e.g. to print to a console).
+    """
+    return _TracedRealtimeSession(
+        session,
+        thread_id=thread_id,
+        sample_rate=sample_rate,
+        project_name=project_name,
+        tags=tags,
+        metadata=metadata,
+        on_message=on_message,
+    )

--- a/python/langsmith/integrations/pipecat/__init__.py
+++ b/python/langsmith/integrations/pipecat/__init__.py
@@ -1,0 +1,82 @@
+"""LangSmith integration for Pipecat."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Callable, Optional
+
+from .._voice import warn_in_development
+from .processor import PipecatLangSmithSpanProcessor
+
+logger = logging.getLogger(__name__)
+
+warn_in_development("pipecat")
+
+__all__ = ["PipecatLangSmithSpanProcessor", "configure_pipecat"]
+
+
+def configure_pipecat(
+    *,
+    llm_span_kind: str = "llm",
+    thread_id_provider: Optional[Callable[[], Optional[str]]] = None,
+    api_key: Optional[str] = None,
+    project: Optional[str] = None,
+    endpoint: Optional[str] = None,
+    service_name: str = "pipecat",
+    **kwargs: Any,
+) -> Optional[PipecatLangSmithSpanProcessor]:
+    """Enable LangSmith tracing for a Pipecat pipeline.
+
+    Installs Pipecat's OTel ``TracerProvider`` (via ``setup_tracing``) and
+    registers a :class:`PipecatLangSmithSpanProcessor` that rewrites Pipecat's
+    spans for LangSmith and exports them to LangSmith's OTLP endpoint. Enable
+    tracing on the pipeline itself with
+    ``PipelineTask(..., enable_tracing=True, enable_turn_tracking=True,
+    params=PipelineParams(enable_metrics=True))``.
+
+    To manage your own ``TracerProvider`` instead, skip this function and add
+    ``PipecatLangSmithSpanProcessor(...)`` to your provider directly.
+
+    Args:
+        llm_span_kind: LangSmith run kind for Pipecat's ``llm`` span — ``"llm"``
+            for stock services that do their own inference, ``"chain"`` when it
+            orchestrates a nested LangGraph/LangChain brain (see the processor).
+        thread_id_provider: opt-in conversation id for LangSmith thread grouping.
+        api_key / project / endpoint: LangSmith exporter config; default to the
+            standard ``LANGSMITH_*`` resolution.
+        service_name: OTel service name for the provider.
+
+    Returns:
+        The registered processor (so callers can e.g. ``attach_audio_buffer``),
+        or ``None`` if Pipecat / OpenTelemetry aren't installed.
+    """
+    try:
+        from opentelemetry import trace
+        from opentelemetry.sdk.trace import TracerProvider
+
+        from pipecat.utils.tracing.setup import setup_tracing
+    except ImportError as e:
+        logger.warning("Missing dependency for Pipecat tracing: %s", e)
+        return None
+
+    # ``exporter=None`` creates/installs the TracerProvider without an export
+    # pipeline; our processor wraps the LangSmith exporter itself.
+    setup_tracing(service_name=service_name, exporter=None, console_export=False)
+
+    processor = PipecatLangSmithSpanProcessor(
+        llm_span_kind=llm_span_kind,
+        thread_id_provider=thread_id_provider,
+        api_key=api_key,
+        project=project,
+        endpoint=endpoint,
+        **kwargs,
+    )
+    provider = trace.get_tracer_provider()
+    if isinstance(provider, TracerProvider):
+        provider.add_span_processor(processor)
+    else:
+        logger.warning(
+            "Active OTel TracerProvider is not an SDK TracerProvider; "
+            "PipecatLangSmithSpanProcessor was not registered."
+        )
+    return processor

--- a/python/langsmith/integrations/pipecat/processor.py
+++ b/python/langsmith/integrations/pipecat/processor.py
@@ -1,0 +1,270 @@
+"""OTel → LangSmith bridge for Pipecat.
+
+Pipecat emits OTel spans named ``conversation``, ``turn``, ``stt``, ``llm``, and
+``tts`` with attributes (``transcript``, ``input``/``output``, ``text``,
+``turn.number``, …) that LangSmith's OTLP ingester doesn't recognize. This
+:class:`PipecatLangSmithSpanProcessor` rewrites each span type into the
+``gen_ai.*`` / ``langsmith.*`` namespaces LangSmith keys off, renders the whole
+conversation onto the root span, and (optionally) attaches the recorded audio
+there. It inherits the downstream wrapping, exporter, ``thread_id`` injection,
+and message helpers from :class:`BaseLangSmithSpanProcessor`.
+
+Trace shape in LangSmith::
+
+    conversation                      (root; whole transcript + conversation WAV)
+    └── turn × N                      (per exchange; carries was_interrupted)
+        ├── stt                       (audio → transcript)
+        ├── llm                       (the LLM stage; kind set by llm_span_kind)
+        └── tts                       (response text → audio)
+
+Audio recording uses Pipecat's own
+:class:`~pipecat.processors.audio.audio_buffer_processor.AudioBufferProcessor`:
+call :meth:`attach_audio_buffer` to wire its ``on_audio_data`` event, and the
+processor accumulates the merged PCM and attaches it (as a WAV) to the root span
+when the conversation ends. Place the ``AudioBufferProcessor`` *after*
+``transport.output()`` so it captures the bot audio as actually played
+(post-barge-in-truncation) plus the user audio.
+
+``llm_span_kind`` controls the kind of the span Pipecat names ``llm``. Keep the
+default ``"llm"`` when that stage does its own inference (stock services such as
+``OpenAILLMService``). Pass ``"chain"`` when it only orchestrates nested runs
+that are exported to LangSmith themselves (an in-process LangGraph/LangChain
+brain): the nested ``model`` runs are then the real ``llm`` inference, and
+tagging the wrapper ``llm`` too would double-count the conversation in the
+Messages view. This can't be auto-detected at span-end time (the nested runs are
+exported later, from a background queue), so the caller states it explicitly.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Callable, Optional
+
+from opentelemetry.sdk.trace import ReadableSpan
+
+from .._voice.audio import pcm_to_wav
+from .._voice.base import BaseLangSmithSpanProcessor
+
+
+class PipecatLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
+    """Enriches Pipecat's OTel spans with LangSmith-compatible attributes."""
+
+    def __init__(
+        self,
+        downstream_processor: Optional[Any] = None,
+        *,
+        llm_span_kind: str = "llm",
+        api_key: Optional[str] = None,
+        project: Optional[str] = None,
+        endpoint: Optional[str] = None,
+        thread_id_provider: Optional[Callable[[], Optional[str]]] = None,
+        audio_mime_type: str = "audio/wav",
+        **kwargs: Any,
+    ) -> None:
+        """Create the processor.
+
+        Args:
+            downstream_processor: where rewritten spans are forwarded; defaults
+                to a LangSmith OTLP exporter (see the base class).
+            llm_span_kind: LangSmith run kind for Pipecat's ``llm`` span (see the
+                module docstring).
+            audio_mime_type: MIME type for the attached conversation recording.
+            thread_id_provider: opt-in conversation id for LangSmith thread
+                grouping; ``None`` disables.
+        """
+        super().__init__(
+            downstream_processor,
+            api_key=api_key,
+            project=project,
+            endpoint=endpoint,
+            thread_id_provider=thread_id_provider,
+            **kwargs,
+        )
+        self._llm_span_kind = llm_span_kind
+        self._audio_mime_type = audio_mime_type
+        # The latest llm request's full context per trace — each request carries
+        # the whole history, so the last snapshot IS the conversation. Rendered
+        # onto the root ``conversation`` span, which ends last.
+        self._conversation_by_trace: dict[str, list] = {}
+        # Merged PCM accumulated from a Pipecat AudioBufferProcessor (see
+        # attach_audio_buffer), keyed by conversation id. Each value is
+        # {"pcm": bytearray, "sample_rate": int, "num_channels": int}.
+        self._audio_by_conversation: dict[str, dict[str, Any]] = {}
+
+    # -- audio buffer registration -------------------------------------------
+
+    def attach_audio_buffer(self, audio_buffer: Any, conversation_id: str) -> None:
+        """Record this conversation's audio from a Pipecat ``AudioBufferProcessor``.
+
+        Registers an ``on_audio_data`` handler on ``audio_buffer`` that
+        accumulates the merged PCM for ``conversation_id``; it's encoded to a WAV
+        and attached to the root span when the ``conversation`` span ends. The
+        ``conversation_id`` must match the one set on ``PipelineTask`` (so it
+        appears on the ``conversation`` span).
+
+        Place the ``AudioBufferProcessor`` after ``transport.output()`` and start
+        it with ``await audio_buffer.start_recording()`` once the session is
+        running. Construct it with a non-zero ``buffer_size`` so audio streams in
+        periodically — with the default single-shot emission, the final chunk can
+        arrive after the conversation span has already been exported.
+        """
+
+        async def _on_audio_data(
+            buffer: Any, audio: bytes, sample_rate: int, num_channels: int
+        ) -> None:
+            self._accumulate_audio(conversation_id, audio, sample_rate, num_channels)
+
+        audio_buffer.event_handler("on_audio_data")(_on_audio_data)
+
+    def _accumulate_audio(
+        self, conversation_id: str, audio: bytes, sample_rate: int, num_channels: int
+    ) -> None:
+        rec = self._audio_by_conversation.get(conversation_id)
+        if rec is None:
+            rec = {
+                "pcm": bytearray(),
+                "sample_rate": sample_rate,
+                "num_channels": num_channels,
+            }
+            self._audio_by_conversation[conversation_id] = rec
+        rec["pcm"].extend(audio)
+        rec["sample_rate"] = sample_rate
+        rec["num_channels"] = num_channels
+
+    # -- dispatch -------------------------------------------------------------
+
+    def _dispatch(self, span: ReadableSpan) -> None:
+        trace_id = format(span.context.trace_id, "032x")
+        name = span.name
+
+        if name == "stt":
+            self._handle_stt(span)
+            self._exclude_from_message_view(span)
+        elif name == "llm":
+            self._handle_llm(span, trace_id)
+        elif name == "tts":
+            self._handle_tts(span)
+            self._exclude_from_message_view(span)
+        elif name == "turn":
+            self._handle_turn(span)
+        elif name == "conversation":
+            self._handle_conversation(span, trace_id)
+        # Any other span (e.g. nested LangChain/LangGraph runs riding the same
+        # OTel provider) already arrives in LangSmith's native shape, so it's
+        # exported untouched.
+
+        self._export(span)
+
+    # -- per-span-type handlers ----------------------------------------------
+
+    def _handle_stt(self, span: ReadableSpan) -> None:
+        """STT span: audio input → transcribed text."""
+        transcript = span.attributes.get("transcript", "")
+        self._set_kind(span, "llm")
+        self._set_messages(
+            span, prompt=[{"role": "user", "content": f'Audio for: "{transcript}"'}]
+        )
+        if transcript:
+            self._set_messages(
+                span, completion=[{"role": "assistant", "content": str(transcript)}]
+            )
+
+    def _handle_llm(self, span: ReadableSpan, trace_id: str) -> None:
+        """Framework ``llm`` span: the LLM stage of the pipeline."""
+        input_data = span.attributes.get("input", "")
+        output_data = span.attributes.get("output", "")
+        self._set_kind(span, self._llm_span_kind)
+
+        try:
+            raw_messages = json.loads(input_data)
+        except (json.JSONDecodeError, TypeError):
+            raw_messages = []
+        messages = [
+            self._to_langchain_message(m)
+            for m in (raw_messages if isinstance(raw_messages, list) else [])
+            if isinstance(m, dict)
+        ]
+
+        if messages:
+            self._set_messages_json(span, prompt=messages)
+        if output_data:
+            self._set_messages_json(
+                span, completion=[{"role": "assistant", "content": output_data}]
+            )
+
+        # Each request's input carries the full history, so the latest snapshot
+        # IS the conversation — kept per trace for the root span to render.
+        transcript = [m for m in messages if m.get("role") != "system"]
+        if output_data:
+            transcript.append({"role": "assistant", "content": output_data})
+        if transcript:
+            self._conversation_by_trace[trace_id] = transcript
+
+    def _handle_tts(self, span: ReadableSpan) -> None:
+        """TTS span: text → audio. The voice is metadata, not content."""
+        text = span.attributes.get("text", "")
+        self._set_kind(span, "llm")
+        voice_id = span.attributes.get("voice_id")
+        if voice_id:
+            span._attributes["langsmith.metadata.voice_id"] = str(voice_id)
+        self._set_messages(
+            span,
+            prompt=[{"role": "user", "content": str(text)}],
+            completion=[
+                {"role": "assistant", "content": f'Generated audio for: "{text}"'}
+            ],
+        )
+
+    def _handle_turn(self, span: ReadableSpan) -> None:
+        """Turn span: a framework wrapper around one exchange (a ``chain``)."""
+        self._set_kind(span, "chain")
+        turn_number = span.attributes.get("turn.number")
+        if turn_number is not None:
+            span._attributes["langsmith.metadata.turn_number"] = turn_number
+        was_interrupted = span.attributes.get("turn.was_interrupted")
+        if was_interrupted is not None:
+            span._attributes["langsmith.metadata.turn_was_interrupted"] = (
+                was_interrupted
+            )
+
+    def _handle_conversation(self, span: ReadableSpan, trace_id: str) -> None:
+        """Conversation span: the whole session; the LangSmith root.
+
+        Input = the opening message; output = everything after it. Pipecat's
+        conversation span genuinely ends last, so no deferral is needed.
+        """
+        conversation_id = span.attributes.get(
+            "conversation.id", ""
+        ) or span.attributes.get("conversation_id", "")
+        self._set_kind(span, "chain")
+        span._attributes["langsmith.root_span"] = True
+        span._attributes["langsmith.metadata.ls_modality"] = "audio"
+
+        messages = self._conversation_by_trace.get(trace_id, [])
+        if messages:
+            self._set_messages_json(span, prompt=messages[:1])
+            if len(messages) > 1:
+                self._set_messages_json(span, completion=messages[1:])
+
+        self._attach_conversation_audio(span, conversation_id)
+        self._cleanup_conversation(trace_id, conversation_id)
+
+    # -- audio attachment -----------------------------------------------------
+
+    def _attach_conversation_audio(
+        self, span: ReadableSpan, conversation_id: Any
+    ) -> None:
+        """Encode the accumulated PCM (from the AudioBufferProcessor) and attach it."""
+        rec = self._audio_by_conversation.get(conversation_id)
+        if rec is None and len(self._audio_by_conversation) == 1:
+            rec = next(iter(self._audio_by_conversation.values()))
+        if not rec or not rec["pcm"]:
+            return
+        wav = pcm_to_wav(bytes(rec["pcm"]), rec["sample_rate"], rec["num_channels"])
+        self._attach_audio(
+            span, name="conversation.wav", data=wav, mime_type=self._audio_mime_type
+        )
+
+    def _cleanup_conversation(self, trace_id: str, conversation_id: Any) -> None:
+        self._conversation_by_trace.pop(trace_id, None)
+        self._audio_by_conversation.pop(conversation_id, None)

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -58,6 +58,30 @@ otel = [
     "opentelemetry-exporter-otlp-proto-http>=1.30.0",
 ]
 
+# Enabled via `pip install langsmith[pipecat]`
+pipecat = [
+    "pipecat-ai>=1.0",
+    "opentelemetry-sdk>=1.30.0",
+    "opentelemetry-api>=1.30.0",
+    "opentelemetry-exporter-otlp-proto-http>=1.30.0",
+]
+
+# Enabled via `pip install langsmith[livekit]`
+livekit = [
+    "livekit-agents>=1.0",
+    "opentelemetry-sdk>=1.30.0",
+    "opentelemetry-api>=1.30.0",
+    "opentelemetry-exporter-otlp-proto-http>=1.30.0",
+]
+
+# Enabled via `pip install langsmith[openai-realtime]`
+# Covers both OpenAI Realtime wrappers: the raw connection (wrap_realtime) and
+# the Agents SDK session (wrap_realtime_session).
+openai-realtime = [
+    "openai>=1.50",
+    "openai-agents>=0.2",
+]
+
 # Enabled via `pip install langsmith[openai-agents]`
 openai-agents = ["openai-agents>=0.0.3"]
 
@@ -66,6 +90,10 @@ claude-agent-sdk = ["claude-agent-sdk>=0.1.0; python_version>='3.10'"]
 
 # Enabled via `pip install langsmith[google-adk]`
 google-adk = ["google-adk>=1.0.0", "wrapt>=1.16.0"]
+
+# Enabled via `pip install langsmith[google-adk-live]`
+# ADK Live (Gemini Live voice) tracing via LangSmithLivePlugin.
+google-adk-live = ["google-adk>=1.0.0"]
 
 # Enabled via `pip install langsmith[strands-agents]`
 strands-agents = [


### PR DESCRIPTION
## Status: in development

These voice integrations are in development. Each voice package emits a `LangSmithVoiceBetaWarning` on import, and they are isolated from the core SDK: `import langsmith` loads none of them (verified) — they load only when you explicitly `from langsmith.integrations.<voice> import ...`, which requires the corresponding extra's framework dependency.

## Summary

Adds `langsmith.integrations` packages for tracing voice agents to LangSmith. Two mechanisms, matching how each provider exposes its data:

- **OTel span processors** (frameworks that emit OpenTelemetry):
  - `pipecat` — `PipecatLangSmithSpanProcessor` + `configure_pipecat` (extra: `pipecat`)
  - `livekit` — `LiveKitLangSmithSpanProcessor` + `configure_livekit` (extra: `livekit`)
- **RunTree event-stream tracers** (providers whose streaming paths emit no usable telemetry):
  - `openai_realtime` — both `wrap_realtime` (raw `client.realtime.connect()` loop) and `wrap_realtime_session` (`agents.realtime`), behind the **`openai-realtime`** extra
  - `google_adk_live` — `LangSmithLivePlugin` for `Runner.run_live`, behind the **`google-adk-live`** extra

Shared, private machinery lives in `integrations/_voice/`: an OTel `BaseLangSmithSpanProcessor` (dedupes the Pipecat/LiveKit processors) and a `RunTree` `EventSession` engine (root span, turn grouping, transcript rollup, stereo-WAV audio attachment).

## Design choices

- **One extra per provider concept.** `langsmith[openai-realtime]` provides *both* OpenAI Realtime wrappers from one package. ADK Live lives in its own `google_adk_live` package behind `langsmith[google-adk-live]`, **kept separate from the existing `google_adk` batch integration** so non-streaming ADK users take on no new dependencies. The existing `openai_agents_sdk` and `google_adk` packages are unchanged (batch-only).
- **No numpy dependency.** The stereo conversation WAV is built with the stdlib `array` module, so no extra pulls numpy.
- `google_adk_live` exposes its plugin lazily (`__getattr__`) so importing the package doesn't require `google-adk`.
- The OTel processors mutate `ReadableSpan._attributes` on `on_end` (the standard rewrite-on-export pattern from the reference processors); the RunTree engine builds spans explicitly.

## Validation

`ruff check` + `ruff format` clean; every package imports, the beta-warning/import-isolation behavior is verified, and the dispatch/parsing logic + numpy-free WAV builder are exercised offline. Not yet run through the repo's full type-check/test suite. Python only.

Authored with the help of an AI agent.