### PR TITLE
fix(client): apply anonymizer to run error field (JS)

### DIFF
--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -881,6 +881,8 @@ export class Client implements LangSmithTracingClientInterface {
     | boolean
     | ((metadata: KVMap) => KVMap | Promise<KVMap>);
 
+  private anonymizer?: (values: KVMap) => KVMap | Promise<KVMap>;
+
   private omitTracedRuntimeInfo?: boolean;
 
   private tracingSampleRate?: number;
@@ -1266,6 +1268,7 @@ export class Client implements LangSmithTracingClientInterface {
     this.hideOutputs =
       config.hideOutputs ?? config.anonymizer ?? defaultConfig.hideOutputs;
     this.hideMetadata = config.hideMetadata ?? defaultConfig.hideMetadata;
+    this.anonymizer = config.anonymizer;
 
     this.omitTracedRuntimeInfo = config.omitTracedRuntimeInfo ?? false;
 
@@ -1509,6 +1512,24 @@ export class Client implements LangSmithTracingClientInterface {
   }
 
   /**
+   * Apply the configured anonymizer to a run's error string.
+   *
+   * Unlike inputs/outputs, `error` is a plain string (an exception message or
+   * traceback) that can carry credentials the user never explicitly logged --
+   * e.g. an HTTP-client error whose message embeds an `Authorization` header.
+   * The anonymizer is typed `(KVMap) => KVMap`, so the string is wrapped as
+   * `{ error }`, scrubbed, and unwrapped. Mirrors the Python SDK's
+   * `Client._hide_run_error`.
+   */
+  private async processError(error: string): Promise<string> {
+    if (this.anonymizer == null) {
+      return error;
+    }
+    const result = await this.anonymizer({ error });
+    return typeof result?.error === "string" ? result.error : error;
+  }
+
+  /**
    * Filter content from new_token events to prevent streaming LLM output
    * from being uploaded via events.
    */
@@ -1544,6 +1565,9 @@ export class Client implements LangSmithTracingClientInterface {
     }
     if (runParams.outputs !== undefined) {
       runParams.outputs = await this.processOutputs(runParams.outputs);
+    }
+    if (runParams.error !== undefined) {
+      runParams.error = await this.processError(runParams.error);
     }
     if (runParams.extra != null && "metadata" in runParams.extra) {
       runParams.extra = {
@@ -2670,6 +2694,9 @@ export class Client implements LangSmithTracingClientInterface {
 
     if (run.outputs) {
       run.outputs = await this.processOutputs(run.outputs);
+    }
+    if (run.error) {
+      run.error = await this.processError(run.error);
     }
     if (run.extra != null && "metadata" in run.extra) {
       run.extra = {

--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -158,6 +158,14 @@ export interface ClientConfig {
   callerOptions?: AsyncCallerParams;
   timeout_ms?: number;
   webUrl?: string;
+  /**
+   * A function applied for masking serialized run inputs and outputs,
+   * before sending to the API. Can be called with raw inputs, raw
+   * outputs, or a nested `{ error: string }` object for errors.
+   *
+   * If a `hideInputs` or `hideOutputs` function is present,
+   * the client will call it instead of the anonymizer as appropriate.
+   */
   anonymizer?: (values: KVMap) => KVMap | Promise<KVMap>;
   hideInputs?: boolean | ((inputs: KVMap) => KVMap | Promise<KVMap>);
   hideOutputs?: boolean | ((outputs: KVMap) => KVMap | Promise<KVMap>);
@@ -1520,6 +1528,8 @@ export class Client implements LangSmithTracingClientInterface {
    * The anonymizer is typed `(KVMap) => KVMap`, so the string is wrapped as
    * `{ error }`, scrubbed, and unwrapped. Mirrors the Python SDK's
    * `Client._hide_run_error`.
+   *
+   * TODO: Update anonymizer to always nest inputs/outputs/error for consistency
    */
   private async processError(error: string): Promise<string> {
     if (this.anonymizer == null) {

--- a/js/src/tests/anonymizer.test.ts
+++ b/js/src/tests/anonymizer.test.ts
@@ -211,6 +211,64 @@ describe("client", () => {
   });
 });
 
+describe("error field", () => {
+  // Assembled at runtime so no literal secret-shaped string sits in source.
+  const fakeKey = "sk-ant-api03-" + "A".repeat(30);
+  const errorWithSecret = `ClientResponseError: 401, headers={"Authorization": "Bearer ${fakeKey}"}`;
+
+  test("anonymizer redacts the error field on run create", async () => {
+    const { client, callSpy } = mockClient({
+      anonymizer: createSecretAnonymizer(),
+    });
+
+    await client.createRun({
+      id: uuid(),
+      name: "errored",
+      run_type: "llm",
+      inputs: { in: "put" },
+      error: errorWithSecret,
+    });
+
+    const { data } = await getAssumedTreeFromCalls(callSpy.mock.calls, client);
+    expect(data["errored:0"].error).not.toContain(fakeKey);
+    expect(data["errored:0"].error).toContain(SECRET_PLACEHOLDER);
+  });
+
+  test("anonymizer redacts the error field on run update", async () => {
+    const { client, callSpy } = mockClient({
+      anonymizer: createSecretAnonymizer(),
+    });
+
+    const id = uuid();
+    await client.createRun({
+      id,
+      name: "errored",
+      run_type: "llm",
+      inputs: { in: "put" },
+    });
+    await client.updateRun(id, { error: errorWithSecret });
+
+    const { data } = await getAssumedTreeFromCalls(callSpy.mock.calls, client);
+    expect(data["errored:0"].error).not.toContain(fakeKey);
+    expect(data["errored:0"].error).toContain(SECRET_PLACEHOLDER);
+  });
+
+  test("error is left unchanged when no anonymizer is configured", async () => {
+    const { client, callSpy } = mockClient({});
+
+    await client.createRun({
+      id: uuid(),
+      name: "errored",
+      run_type: "llm",
+      inputs: { in: "put" },
+      error: errorWithSecret,
+    });
+
+    const { data } = await getAssumedTreeFromCalls(callSpy.mock.calls, client);
+    expect(data["errored:0"].error).toBe(errorWithSecret);
+  });
+});
+
 describe("createSecretAnonymizer", () => {
   const redact = createSecretAnonymizer();
 


### PR DESCRIPTION
## Problem

JS parity for #3100. The client-side `anonymizer` (including `createSecretAnonymizer`) is aliased only to `hideInputs`/`hideOutputs` at construction (`client.ts`), so it never touches the `error` field. A secret captured in an exception message/traceback is therefore uploaded **unredacted**.

The two prep chokepoints both skipped `error`:
- `prepareRunCreateOrUpdateInputs` — processed inputs/outputs/metadata/events (create + batch + multipart paths)
- `updateRun` — processed inputs/outputs/metadata inline (the standalone patch path)

Errors land here raw — e.g. `runTree.end(undefined, String(error))` in `traceable`, or a user-supplied `run.error` / `err.stack`. (Same metadata nuance as Python: the anonymizer isn't aliased to `hideMetadata` either — out of scope here.)

## Fix

Retain the anonymizer reference (`this.anonymizer = config.anonymizer`) and add a `processError` mirroring `processInputs`/`processOutputs`. Since the anonymizer is typed `(KVMap) => KVMap`, the error string is wrapped as `{ error }`, scrubbed, and unwrapped — the same trick as the Python SDK's `Client._hide_run_error` (`{"error": …}`). Applied at both chokepoints:

- `prepareRunCreateOrUpdateInputs` → covers `createRun` + batch + multipart (create *and* update)
- `updateRun` → the inline patch path

No new public `hideError` toggle (matching #3100's minimal scope) — this only makes the existing anonymizer cover `error`.

## Tests

Three tests in `anonymizer.test.ts` (`describe("error field")`), using `mockClient({ anonymizer: createSecretAnonymizer() })` + `getAssumedTreeFromCalls`:
- redaction on the create path (POST)
- redaction on the update path (PATCH via `updateRun`)
- pass-through when no anonymizer is configured

`pnpm test:single` → 58 passed (3 new), `tsc --noEmit` clean, `oxlint` 0 errors.

Companion to the Python fix in #3100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
