### PR TITLE
fix(google-adk): set tool span as active tracing context in wrap_tool_run_async

### DIFF
--- a/python/langsmith/integrations/google_adk/_client.py
+++ b/python/langsmith/integrations/google_adk/_client.py
@@ -301,7 +301,8 @@ async def wrap_tool_run_async(
         logger.debug(f"Failed to post tool run: {e}")
 
     try:
-        result = await wrapped(*args, **kwargs)
+        with set_tracing_parent(tool_run):
+            result = await wrapped(*args, **kwargs)
         if isinstance(result, dict):
             outputs = result
         elif isinstance(result, list):

--- a/python/tests/unit_tests/wrappers/test_google_adk.py
+++ b/python/tests/unit_tests/wrappers/test_google_adk.py
@@ -12,7 +12,7 @@ from pydantic import Field
 
 from langsmith import Client
 from langsmith.integrations.google_adk import configure_google_adk
-from langsmith.run_helpers import tracing_context
+from langsmith.run_helpers import trace, tracing_context
 from tests.unit_tests.test_run_helpers import _get_calls
 
 APP_NAME = "test_app"
@@ -383,3 +383,45 @@ def test_error_agent_sync_async_records_errors(mode: str, mock_ls_client: Client
     runs = _collect_runs(mock_ls_client)
     assert any(run.get("error") for run in runs), runs
     assert any("boom" in (run.get("error") or "") for run in runs), runs
+
+
+def test_wrap_tool_run_async_sets_tool_as_active_context(mock_ls_client: Client):
+    """get_current_run_tree() inside a tool body must return the tool span."""
+    from langsmith.integrations.google_adk._client import wrap_tool_run_async
+    from langsmith.run_helpers import get_current_run_tree
+
+    captured_run_id = None
+
+    async def _fake_body(*args, **kwargs):
+        nonlocal captured_run_id
+        run = get_current_run_tree()
+        if run:
+            captured_run_id = str(run.id)
+        return {"output": "ok"}
+
+    class _FakeTool:
+        name = "test_tool"
+
+    async def _run():
+        with tracing_context(client=mock_ls_client, enabled=True):
+            with trace("parent", run_type="chain"):
+                await wrap_tool_run_async(
+                    wrapped=_fake_body,
+                    instance=_FakeTool(),
+                    args=({"query": "hello"},),
+                    kwargs={},
+                )
+
+    asyncio.run(_run())
+    mock_ls_client.flush()
+
+    runs = _collect_runs(mock_ls_client)
+    tool_run = _find_run(runs, "test_tool")
+
+    assert captured_run_id is not None, (
+        "get_current_run_tree() returned None inside tool body"
+    )
+    assert captured_run_id == tool_run["id"], (
+        f"Expected active context inside tool to be the tool span "
+        f"({tool_run['id']}), got {captured_run_id}"
+    )


### PR DESCRIPTION
## Summary
Hi SDK team, this is a quick fix spotted from a support case, did a local test and it looked straightforward, but happy to defer to the team's judgment or close if there's a better approach already in flight. 

- `get_current_run_tree()` inside a tool body returned the **parent span** instead of the **tool span** because `set_tracing_parent` was not called after creating the child `tool_run`.
- Fix: wrap `await wrapped(*args, **kwargs)` with `with set_tracing_parent(tool_run):` so the `ContextVar` holds the tool span for the duration of the call (including nested LLM calls, callbacks, and exception paths).
- `set_tracing_parent` was already imported at line 14; this is a one-line change.
- Added a regression test: `test_wrap_tool_run_async_sets_tool_as_active_context` — verifies that `get_current_run_tree()` inside a tool body resolves to the tool span, not the parent.

> Quick fix spotted from a support case — did a local test and it looked straightforward, but happy to defer to the team's judgment or close if there's a better approach already in flight.

## Test plan

- [ ] New test `test_wrap_tool_run_async_sets_tool_as_active_context` passes with the fix and fails without it (verified locally)
- [ ] Full `make tests` suite run locally — all existing tests pass
- [ ] Note: 4 pre-existing sandbox test failures exist on `main` (`test_create_sandbox_merges_custom_headers`, `test_run_with_custom_headers`) due to `LANGSMITH_API_KEY` leaking from the environment — unrelated to this change, confirmed present on `main` before this branch

Closes [#25736 ](https://app.usepylon.com/support/issues/views/my-issues?issueNumber=25736&view=fs)(reported by Gong via support case)