### PR TITLE
feat(integrations): add Pipecat voice tracing integration

### DIFF
--- a/python/langsmith/_internal/otel/_span_utils.py
+++ b/python/langsmith/_internal/otel/_span_utils.py
@@ -1,0 +1,43 @@
+"""Shared OpenTelemetry span helpers for the LangSmith OTel integrations.
+
+The framework integrations rewrite spans before export but must not mutate the
+original ``ReadableSpan`` (its attributes/events are meant to be read-only). The
+supported workaround is to build a *new* ``ReadableSpan`` carrying the original's
+fields with the rewritten attributes/events substituted. ``ReadableSpan``'s
+constructor is not part of OpenTelemetry's public API, so this helper isolates
+that one call site for every integration that needs it (voice, Strands).
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from opentelemetry.sdk.trace import Event, ReadableSpan
+
+
+def rebuild_readable_span(
+    span: ReadableSpan,
+    *,
+    attributes: dict,
+    events: Optional[list[Event]] = None,
+) -> ReadableSpan:
+    """Return a copy of ``span`` with rewritten ``attributes`` (and ``events``).
+
+    Copies every other field from ``span`` unchanged. ``events`` defaults to the
+    original span's events when not overridden. The original span is never
+    mutated.
+    """
+    return ReadableSpan(
+        name=span.name,
+        context=span.context,
+        parent=span.parent,
+        resource=span.resource,
+        attributes=attributes,
+        events=events if events is not None else (span.events or []),
+        links=span.links,
+        kind=span.kind,
+        status=span.status,
+        start_time=span.start_time,
+        end_time=span.end_time,
+        instrumentation_scope=span.instrumentation_scope,
+    )

--- a/python/langsmith/_internal/voice/__init__.py
+++ b/python/langsmith/_internal/voice/__init__.py
@@ -1,0 +1,46 @@
+"""Private shared machinery for the voice tracing integrations.
+
+Two independent bases live here, sharing only this namespace (not a common
+class):
+
+* ``base_span_processor`` — Track A: :class:`BaseLangSmithSpanProcessor`, an
+  OpenTelemetry ``SpanProcessor`` shared by the framework integrations that emit
+  their own OTel spans (Pipecat, LiveKit).
+* ``session`` — Track B: :class:`EventSession`, a LangSmith ``RunTree`` builder
+  shared by the integrations that observe a remote event stream and construct
+  the trace themselves (OpenAI Realtime, OpenAI Agents realtime, ADK Live).
+
+Nothing in this package is part of the public API; import from the per-framework
+packages instead.
+"""
+
+from __future__ import annotations
+
+import contextvars
+from typing import Optional
+
+# Per-conversation LangSmith thread id, read by the voice integrations via
+# ``thread_id_from_context``. A ``ContextVar`` — not a module global or a
+# closure — so that concurrent conversations running as separate asyncio tasks
+# each see their own value rather than clobbering a single shared one.
+_VOICE_THREAD_ID: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar(
+    "langsmith_voice_thread_id", default=None
+)
+
+
+def set_thread_id(thread_id: Optional[str]) -> None:
+    """Set the LangSmith thread id for the current (async) context.
+
+    Call this once per conversation, inside that conversation's asyncio task, to
+    group its spans into a LangSmith thread. The voice processors capture it as
+    the conversation's spans start and apply it across the whole trace, so no
+    wiring is needed beyond this call — and it holds even for spans finished on a
+    background task. Because it is stored in a :class:`~contextvars.ContextVar`,
+    concurrent conversations each see their own value; a shared closure would not.
+    """
+    _VOICE_THREAD_ID.set(thread_id)
+
+
+def thread_id_from_context() -> Optional[str]:
+    """Return the thread id set by :func:`set_thread_id` for this context."""
+    return _VOICE_THREAD_ID.get()

--- a/python/langsmith/_internal/voice/audio.py
+++ b/python/langsmith/_internal/voice/audio.py
@@ -1,0 +1,29 @@
+"""WAV reconstruction for the Track-A voice span processors.
+
+``pcm_to_wav`` wraps already-merged PCM16 bytes (e.g. the output of Pipecat's
+``AudioBufferProcessor``) in a WAV container so a processor can attach the
+recorded conversation to a span.
+"""
+
+from __future__ import annotations
+
+import io
+import wave
+
+
+def pcm_to_wav(pcm: bytes, sample_rate: int, num_channels: int = 1) -> bytes:
+    """Wrap raw PCM16 bytes in a WAV container.
+
+    For already-merged PCM (e.g. the output of Pipecat's ``AudioBufferProcessor``,
+    where ``num_channels=2`` is user-left / bot-right). Returns ``b""`` for empty
+    input.
+    """
+    if not pcm:
+        return b""
+    buf = io.BytesIO()
+    with wave.open(buf, "wb") as wf:
+        wf.setnchannels(num_channels)
+        wf.setsampwidth(2)
+        wf.setframerate(sample_rate)
+        wf.writeframes(pcm)
+    return buf.getvalue()

--- a/python/langsmith/_internal/voice/base_span_processor.py
+++ b/python/langsmith/_internal/voice/base_span_processor.py
@@ -1,0 +1,340 @@
+"""``BaseLangSmithSpanProcessor`` — Track A's shared OTel span processor.
+
+The framework integrations that emit their own OpenTelemetry spans (Pipecat,
+LiveKit) translate those spans into the ``gen_ai.*`` / ``langsmith.*`` attribute
+namespaces LangSmith's OTLP ingester understands, then forward them to an
+exporter. This base owns everything that translation shares — the downstream
+wrapping, the LangSmith OTLP exporter default, opt-in ``thread_id`` injection,
+the ``gen_ai.*`` message writers, and size-capped audio attachment — so each
+framework subclass implements only
+``_dispatch`` (classify a span by name and rewrite it); the base exports it.
+
+The processor wraps a *downstream* processor rather than being added as a
+sibling: ``on_end`` rewrites attributes and then forwards to the downstream, so
+spans are always translated before export. The default downstream is a
+``BatchSpanProcessor`` around the LangSmith ``OtelExporter`` (see
+:mod:`langsmith.integrations.otel`), which targets LangSmith's
+``/otel/v1/traces`` endpoint with the right auth headers from standard LangSmith
+config — no OTLP env vars required.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+from dataclasses import dataclass
+from typing import Any, Optional
+
+from opentelemetry.sdk.trace import Event, ReadableSpan, SpanProcessor
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+from langsmith._internal.otel._span_utils import rebuild_readable_span
+
+from . import thread_id_from_context
+
+logger = logging.getLogger(__name__)
+
+# Default cap (bytes) on raw audio before base64 encoding. The LangSmith
+# ingester accepts attachments up to ~200MB; base64 inflates by ~1.33x, so a
+# 150MB raw cap encodes to ~200MB — right at that ceiling. Override per
+# processor via ``audio_size_limit_bytes`` (or ``None`` to disable the cap).
+DEFAULT_AUDIO_SIZE_LIMIT = 150_000_000
+
+# Hard ceiling on the per-trace thread-id cache (see ``_remember_thread_id``).
+# Entries are tiny strings and are normally freed at conversation end via
+# ``_forget_thread_id``; this bounds memory for conversations that never reach
+# cleanup (crash, dropped connection), evicting oldest-first.
+_THREAD_ID_CACHE_MAXSIZE = 100_000
+
+
+@dataclass
+class TranslatedSpan:
+    """A span being translated into LangSmith's namespaces before export.
+
+    Wraps the original read-only OTel ``ReadableSpan`` with mutable
+    ``attributes`` and ``events`` seeded from it. Handlers rewrite the copies
+    while translating; :meth:`finalize` builds a fresh ``ReadableSpan`` from them
+    — so OpenTelemetry's private ``span._attributes`` / ``span._events`` are
+    never mutated.
+
+    Created per span in :meth:`BaseLangSmithSpanProcessor.on_end` and threaded
+    through dispatch — no global state. A processor that defers a span (see
+    :meth:`BaseLangSmithSpanProcessor._dispatch`) simply holds the
+    ``TranslatedSpan`` itself until it exports it later, so the in-progress
+    translation outlives the originating ``on_end`` call.
+    """
+
+    span: ReadableSpan
+    attributes: dict[str, Any]
+    events: list[Event]
+
+    @classmethod
+    def of(cls, span: ReadableSpan) -> TranslatedSpan:
+        """Seed a draft from a span's own (read-only) attributes and events."""
+        return cls(span, dict(span.attributes or {}), list(span.events or []))
+
+    def finalize(self) -> ReadableSpan:
+        """Build the export span: the original's fields + our rewritten attrs/events."""
+        return rebuild_readable_span(
+            self.span, attributes=self.attributes, events=self.events
+        )
+
+
+class BaseLangSmithSpanProcessor(SpanProcessor):
+    """Shared base for the OTel→LangSmith framework span processors.
+
+    Subclasses implement :meth:`_dispatch` to classify each ended span and
+    rewrite its attributes via the helpers here; the base exports it. The base
+    handles the downstream/exporter wiring, ``thread_id`` injection, and static
+    metadata stamping.
+    """
+
+    def __init__(
+        self,
+        downstream_processor: Optional[SpanProcessor] = None,
+        *,
+        api_key: Optional[str] = None,
+        project: Optional[str] = None,
+        endpoint: Optional[str] = None,
+        audio_size_limit_bytes: Optional[int] = DEFAULT_AUDIO_SIZE_LIMIT,
+        metadata: Optional[dict[str, Any]] = None,
+    ) -> None:
+        """Create the processor.
+
+        Args:
+            downstream_processor: where rewritten spans are forwarded. Defaults
+                to ``BatchSpanProcessor(OtelExporter(...))`` targeting LangSmith.
+            api_key: LangSmith API key for the default exporter. Defaults to
+                ``LANGSMITH_API_KEY``.
+            project: LangSmith project for the default exporter. Defaults to
+                ``LANGSMITH_PROJECT``.
+            endpoint: full OTLP traces URL for the default exporter. Defaults to
+                ``{LANGSMITH_ENDPOINT}/otel/v1/traces``.
+            audio_size_limit_bytes: skip attaching audio larger than this; set
+                ``None`` to disable the cap.
+            metadata: static ``langsmith.metadata.*`` stamped on every span.
+        """
+        super().__init__()
+        if downstream_processor is None:
+            from langsmith.integrations.otel.processor import OtelExporter
+
+            downstream_processor = BatchSpanProcessor(
+                OtelExporter(url=endpoint, api_key=api_key, project=project)
+            )
+        self.downstream = downstream_processor
+        self.audio_size_limit_bytes = audio_size_limit_bytes
+        self._static_metadata = metadata or {}
+        # Per-trace thread id, captured at ``on_start`` (in the conversation's
+        # task, where ``set_thread_id`` was called) and reused for every span in
+        # the trace at export — so spans that END in a detached framework task,
+        # where the ``set_thread_id`` ``ContextVar`` is invisible, still get it.
+        # Keyed by int trace_id. Not thread-safe (like the subclass caches): the
+        # voice frameworks drive on_start/on_end from a single asyncio loop.
+        self._thread_id_by_trace: dict[int, str] = {}
+
+    # -- span lifecycle -------------------------------------------------------
+
+    def on_start(self, span: Any, parent_context: Any = None) -> None:
+        for key, value in self._static_metadata.items():
+            if value is not None:
+                span.set_attribute(f"langsmith.metadata.{key}", value)
+        # Capture the thread id here, at the earliest in-context moment. on_start
+        # runs synchronously in the task that starts the span; the conversation's
+        # root span starts in the task where set_thread_id was called, so the
+        # ContextVar is visible now even when later spans END in detached tasks
+        # where it is not. _inject_thread_id then recovers it per trace.
+        thread_id = thread_id_from_context()
+        context = getattr(span, "context", None)
+        if thread_id and context is not None:
+            self._remember_thread_id(context.trace_id, str(thread_id))
+        self.downstream.on_start(span, parent_context)
+
+    def on_end(self, span: ReadableSpan) -> None:
+        # Isolate translation from export: a failure rewriting one span must
+        # never drop it or propagate into the OTel provider's span-ending path
+        # (which would disrupt other processors and the traced app). On error we
+        # log and still export the span untranslated — degraded, not lost.
+        #
+        # _dispatch returns whether the base should export the span now. A
+        # subclass that defers (returns False) owns its own later _export call;
+        # any other return value — including a dispatch failure — leaves
+        # export=True so the span is still forwarded exactly once.
+        tspan = TranslatedSpan.of(span)
+        export = True
+        try:
+            self._inject_thread_id(tspan)
+            export = self._dispatch(tspan) is not False
+        except Exception:
+            logger.warning(
+                "langsmith voice: failed processing span %r; "
+                "exporting it untranslated.",
+                getattr(span, "name", "?"),
+                exc_info=True,
+            )
+        if export:
+            try:
+                self._export(tspan)
+            except Exception:
+                logger.warning(
+                    "langsmith voice: failed exporting span %r.",
+                    getattr(span, "name", "?"),
+                    exc_info=True,
+                )
+
+    def _dispatch(self, tspan: TranslatedSpan) -> bool:
+        """Classify the span and rewrite its attributes on the draft.
+
+        Returns whether :meth:`on_end` should export the span. Return ``True``
+        (the common case) to have the base export it exactly once. Return
+        ``False`` to take ownership of the export — e.g. to defer the span until
+        a later event — in which case the subclass MUST hold ``tspan`` and call
+        :meth:`_export` with it itself, exactly once. Subclasses that return
+        ``True`` MUST NOT call :meth:`_export`. The default raises.
+        """
+        raise NotImplementedError
+
+    def _export(self, tspan: TranslatedSpan) -> None:
+        """Forward the translated span downstream.
+
+        Builds a fresh ``ReadableSpan`` from the draft (rewritten attributes/
+        events) rather than mutating the original — so we never poke
+        OpenTelemetry's private span internals.
+        """
+        self._pre_export(tspan)
+        self.downstream.on_end(tspan.finalize())
+
+    def _pre_export(self, tspan: TranslatedSpan) -> None:
+        """Run just before export (e.g. a blanket vendor-attribute pass-through)."""
+
+    def shutdown(self) -> None:
+        self.downstream.shutdown()
+
+    def force_flush(self, timeout_millis: int = 30000) -> bool:
+        return self.downstream.force_flush(timeout_millis)
+
+    # -- shared helpers -------------------------------------------------------
+
+    def _inject_thread_id(self, tspan: TranslatedSpan) -> None:
+        """Stamp ``langsmith.metadata.thread_id`` from the per-context id (opt-in).
+
+        LangSmith needs the thread id on every run for thread-level filtering and
+        token/cost aggregation. The id is set via
+        :func:`~langsmith._internal.voice.set_thread_id`, a ``ContextVar``, so
+        concurrent conversations each see their own value. Resolves it as:
+
+        1. leave any id already on the span untouched (never clobber upstream);
+        2. else the value captured for this trace at :meth:`on_start` — robust to
+           spans that end in a detached task where the ``ContextVar`` is unset;
+        3. else the ``ContextVar`` directly (this span IS in context and is the
+           first we've seen for the trace), backfilling the cache for its peers.
+
+        Injection is skipped (``None``) when no id was ever set for the trace.
+        """
+        if "langsmith.metadata.thread_id" in tspan.attributes:
+            return
+        trace_id = tspan.span.context.trace_id
+        thread_id = self._thread_id_by_trace.get(trace_id) or thread_id_from_context()
+        if thread_id:
+            thread_id = str(thread_id)
+            tspan.attributes["langsmith.metadata.thread_id"] = thread_id
+            self._remember_thread_id(trace_id, thread_id)
+
+    def _remember_thread_id(self, trace_id: int, thread_id: str) -> None:
+        """Cache a trace's thread id, evicting oldest-first when at capacity."""
+        cache = self._thread_id_by_trace
+        if trace_id not in cache and len(cache) >= _THREAD_ID_CACHE_MAXSIZE:
+            cache.pop(next(iter(cache)), None)
+        cache[trace_id] = thread_id
+
+    def _forget_thread_id(self, trace_id: int) -> None:
+        """Drop a trace's cached thread id (called from subclass cleanup)."""
+        self._thread_id_by_trace.pop(trace_id, None)
+
+    @staticmethod
+    def _set_kind(tspan: TranslatedSpan, kind: str) -> None:
+        tspan.attributes["langsmith.span.kind"] = kind
+
+    @staticmethod
+    def _exclude_from_message_view(tspan: TranslatedSpan) -> None:
+        """Drop a span from the conversation Messages view (still in the tree).
+
+        That view reconstructs the chat from ``llm``/``tool`` runs. STT/TTS spans
+        are tagged ``llm``-kind for the tree but would inject fake turns (raw
+        transcripts, "Generated audio for: …"), so they opt out here.
+        """
+        tspan.attributes["langsmith.metadata.ls_message_view_exclude"] = True
+
+    @staticmethod
+    def _set_messages(
+        tspan: TranslatedSpan,
+        *,
+        prompt: Optional[list[dict]] = None,
+        completion: Optional[list[dict]] = None,
+    ) -> None:
+        """Write simple role/content turns in the indexed + singular forms.
+
+        For plain conversation turns (STT, TTS, an exchange) where messages have
+        only role + content. Writes the indexed ``gen_ai.prompt.{n}.role/content``
+        attributes and the singular ``gen_ai.prompt`` JSON list. For messages
+        that carry structured fields (tool calls), use :meth:`_set_messages_json`
+        instead — the indexed form can't represent them.
+        """
+        attrs = tspan.attributes
+        if prompt is not None:
+            for i, msg in enumerate(prompt):
+                attrs[f"gen_ai.prompt.{i}.role"] = msg.get("role", "user")
+                attrs[f"gen_ai.prompt.{i}.content"] = str(msg.get("content", ""))
+            attrs["gen_ai.prompt"] = json.dumps(prompt)
+        if completion is not None:
+            for i, msg in enumerate(completion):
+                attrs[f"gen_ai.completion.{i}.role"] = msg.get("role", "assistant")
+                attrs[f"gen_ai.completion.{i}.content"] = str(msg.get("content", ""))
+            attrs["gen_ai.completion"] = json.dumps(completion)
+
+    @staticmethod
+    def _set_messages_json(
+        tspan: TranslatedSpan,
+        *,
+        prompt: Optional[list[dict]] = None,
+        completion: Optional[list[dict]] = None,
+    ) -> None:
+        """Write messages in the singular ``{"messages": [...]}`` JSON form only.
+
+        This is the form for LLM calls and the conversation root: it can carry
+        structured ``tool_calls`` / ``tool_call_id`` that the indexed
+        ``gen_ai.prompt.{n}.*`` attributes can't, and it takes precedence at
+        ingest — so the indexed form is deliberately *not* written here (it would
+        win and drop the tool calls).
+        """
+        if prompt is not None:
+            tspan.attributes["gen_ai.prompt"] = json.dumps({"messages": prompt})
+        if completion is not None:
+            tspan.attributes["gen_ai.completion"] = json.dumps({"messages": completion})
+
+    def _attach_audio(
+        self, tspan: TranslatedSpan, *, name: str, data: bytes, mime_type: str
+    ) -> bool:
+        """Attach audio bytes to a span via ``langsmith.attachments`` (base64).
+
+        Honors ``audio_size_limit_bytes`` (skips oversize audio). Returns whether
+        the audio was attached. Uses the OTel attachment path documented at
+        docs.langchain.com/langsmith/trace-with-opentelemetry.
+        """
+        if not data:
+            return False
+        if (
+            self.audio_size_limit_bytes is not None
+            and len(data) > self.audio_size_limit_bytes
+        ):
+            return False
+        tspan.attributes["langsmith.attachments"] = json.dumps(
+            [
+                {
+                    "name": name,
+                    "content": base64.b64encode(data).decode("ascii"),
+                    "mime_type": mime_type,
+                }
+            ]
+        )
+        return True

--- a/python/langsmith/integrations/pipecat/__init__.py
+++ b/python/langsmith/integrations/pipecat/__init__.py
@@ -1,0 +1,90 @@
+"""LangSmith integration for Pipecat."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+from langsmith._internal._beta_decorator import warn_beta
+from langsmith._internal.voice import set_thread_id, thread_id_from_context
+
+from .processor import PipecatLangSmithSpanProcessor
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "PipecatLangSmithSpanProcessor",
+    "configure_pipecat",
+    "set_thread_id",
+    "thread_id_from_context",
+]
+
+
+@warn_beta
+def configure_pipecat(
+    *,
+    llm_span_kind: str = "llm",
+    api_key: Optional[str] = None,
+    project: Optional[str] = None,
+    endpoint: Optional[str] = None,
+    service_name: str = "pipecat",
+    **kwargs: Any,
+) -> Optional[PipecatLangSmithSpanProcessor]:
+    """Enable LangSmith tracing for a Pipecat pipeline.
+
+    Installs Pipecat's OTel ``TracerProvider`` (via ``setup_tracing``) and
+    registers a :class:`PipecatLangSmithSpanProcessor` that rewrites Pipecat's
+    spans for LangSmith and exports them to LangSmith's OTLP endpoint. Enable
+    tracing on the pipeline itself with
+    ``PipelineTask(..., enable_tracing=True, enable_turn_tracking=True,
+    params=PipelineParams(enable_metrics=True))``.
+
+    To manage your own ``TracerProvider`` instead, skip this function and add
+    ``PipecatLangSmithSpanProcessor(...)`` to your provider directly.
+
+    To group a conversation's spans into a LangSmith thread, call
+    :func:`set_thread_id` once per conversation (inside that conversation's
+    asyncio task). The processor captures it as the conversation's spans start
+    and applies it to every span in the trace — so it holds even for spans
+    finished on a background task, and concurrent conversations stay separated.
+
+    Args:
+        llm_span_kind: LangSmith run kind for Pipecat's ``llm`` span; see the
+            :mod:`~langsmith.integrations.pipecat.processor` module docstring.
+        api_key / project / endpoint: LangSmith exporter config; default to the
+            standard ``LANGSMITH_*`` resolution.
+        service_name: OTel service name for the provider.
+
+    Returns:
+        The registered processor (so callers can e.g. ``attach_audio_buffer``),
+        or ``None`` if Pipecat / OpenTelemetry aren't installed.
+    """
+    try:
+        from opentelemetry import trace
+        from opentelemetry.sdk.trace import TracerProvider
+
+        from pipecat.utils.tracing import setup  # type: ignore[import-not-found]
+    except ImportError as e:
+        logger.warning("Missing dependency for Pipecat tracing: %s", e)
+        return None
+
+    # ``exporter=None`` creates/installs the TracerProvider without an export
+    # pipeline; our processor wraps the LangSmith exporter itself.
+    setup.setup_tracing(service_name=service_name, exporter=None, console_export=False)
+
+    processor = PipecatLangSmithSpanProcessor(
+        llm_span_kind=llm_span_kind,
+        api_key=api_key,
+        project=project,
+        endpoint=endpoint,
+        **kwargs,
+    )
+    provider = trace.get_tracer_provider()
+    if isinstance(provider, TracerProvider):
+        provider.add_span_processor(processor)
+    else:
+        logger.warning(
+            "Active OTel TracerProvider is not an SDK TracerProvider; "
+            "PipecatLangSmithSpanProcessor was not registered."
+        )
+    return processor

--- a/python/langsmith/integrations/pipecat/processor.py
+++ b/python/langsmith/integrations/pipecat/processor.py
@@ -1,0 +1,350 @@
+"""OTel → LangSmith bridge for Pipecat.
+
+Pipecat emits OTel spans named ``conversation``, ``turn``, ``stt``, ``llm``, and
+``tts`` with attributes (``transcript``, ``input``/``output``, ``text``,
+``turn.number``, …) that LangSmith's OTLP ingester doesn't recognize. This
+:class:`PipecatLangSmithSpanProcessor` rewrites each span type into the
+``gen_ai.*`` / ``langsmith.*`` namespaces LangSmith keys off, renders the whole
+conversation onto the root span, and (optionally) attaches the recorded audio
+there. It inherits the downstream wrapping, exporter, ``thread_id`` injection,
+and message helpers from :class:`BaseLangSmithSpanProcessor`.
+
+Trace shape in LangSmith::
+
+    conversation                      (root; whole transcript + conversation WAV)
+    └── turn × N                      (per exchange; carries was_interrupted)
+        ├── stt                       (audio → transcript)
+        ├── llm                       (the LLM stage; kind set by llm_span_kind)
+        └── tts                       (response text → audio)
+
+Audio recording uses Pipecat's own
+:class:`~pipecat.processors.audio.audio_buffer_processor.AudioBufferProcessor`:
+call :meth:`attach_audio_buffer` to wire its ``on_audio_data`` event, and the
+processor accumulates the merged PCM and attaches it (as a WAV) to the root span
+when the conversation ends. Place the ``AudioBufferProcessor`` *after*
+``transport.output()`` so it captures the bot audio as actually played
+(post-barge-in-truncation) plus the user audio.
+
+``llm_span_kind`` controls the kind of the span Pipecat names ``llm``. Keep the
+default ``"llm"`` when that stage does its own inference (stock services such as
+``OpenAILLMService``). Pass ``"chain"`` when it only orchestrates nested runs
+that are exported to LangSmith themselves (an in-process LangGraph/LangChain
+brain): the nested ``model`` runs are then the real ``llm`` inference, and
+tagging the wrapper ``llm`` too would double-count the conversation in the
+Messages view. This can't be auto-detected at span-end time (the nested runs are
+exported later, from a background queue), so the caller states it explicitly.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import MutableMapping
+from typing import Any, Optional
+
+from cachetools import TTLCache
+
+from langsmith._internal.voice.audio import pcm_to_wav
+from langsmith._internal.voice.base_span_processor import (
+    BaseLangSmithSpanProcessor,
+    TranslatedSpan,
+)
+
+logger = logging.getLogger(__name__)
+
+# Default lifetime (seconds) for the per-conversation state held between a
+# trace's first and last span. The normal path frees it when the conversation
+# span ends; the TTL bounds it for conversations that never emit that span
+# (crash, cancelled task, dropped connection).
+DEFAULT_STATE_TTL_SECONDS = 3600.0
+
+# Hard ceiling on tracked conversations, independent of the TTL — a backstop
+# against a flood of new conversations within one TTL window (oldest evicted
+# first). The TTL is the governing limit in practice.
+DEFAULT_STATE_MAXSIZE = 100_000
+
+
+class PipecatLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
+    """Enriches Pipecat's OTel spans with LangSmith-compatible attributes."""
+
+    def __init__(
+        self,
+        downstream_processor: Optional[Any] = None,
+        *,
+        llm_span_kind: str = "llm",
+        api_key: Optional[str] = None,
+        project: Optional[str] = None,
+        endpoint: Optional[str] = None,
+        audio_mime_type: str = "audio/wav",
+        state_ttl_seconds: float = DEFAULT_STATE_TTL_SECONDS,
+        **kwargs: Any,
+    ) -> None:
+        """Create the processor.
+
+        Args:
+            downstream_processor: where rewritten spans are forwarded; defaults
+                to a LangSmith OTLP exporter (see the base class).
+            llm_span_kind: LangSmith run kind for Pipecat's ``llm`` span (see the
+                module docstring).
+            audio_mime_type: MIME type for the attached conversation recording.
+            state_ttl_seconds: lifetime for the per-conversation state held
+                between a trace's first and last span; the backstop that frees
+                state for conversations that never emit their end span.
+        """
+        super().__init__(
+            downstream_processor,
+            api_key=api_key,
+            project=project,
+            endpoint=endpoint,
+            **kwargs,
+        )
+        self._llm_span_kind = llm_span_kind
+        self._audio_mime_type = audio_mime_type
+        # NB: ``TTLCache`` is not thread-safe. Both caches are mutated only from
+        # the single Pipecat asyncio event loop (``on_end`` and
+        # ``_accumulate_audio`` both run there); ending spans off that loop would
+        # need external synchronization.
+        # The latest llm request's full context per trace — each request carries
+        # the whole history, so the last snapshot IS the conversation. Rendered
+        # onto the root ``conversation`` span, which ends last. TTL-bounded so an
+        # abandoned conversation (no end span) can't leak it.
+        self._conversation_by_trace: MutableMapping[str, list] = TTLCache(
+            maxsize=DEFAULT_STATE_MAXSIZE, ttl=state_ttl_seconds
+        )
+        # Merged PCM accumulated from a Pipecat AudioBufferProcessor (see
+        # attach_audio_buffer), keyed by conversation id. Each value is
+        # {"pcm": bytearray, "sample_rate": int, "num_channels": int}. Also
+        # TTL-bounded — these entries hold the raw audio and are the larger leak.
+        self._audio_by_conversation: MutableMapping[str, dict[str, Any]] = TTLCache(
+            maxsize=DEFAULT_STATE_MAXSIZE, ttl=state_ttl_seconds
+        )
+
+    # -- audio buffer registration -------------------------------------------
+
+    def attach_audio_buffer(self, audio_buffer: Any, conversation_id: str) -> None:
+        """Record this conversation's audio from a Pipecat ``AudioBufferProcessor``.
+
+        Registers an ``on_audio_data`` handler on ``audio_buffer`` that
+        accumulates the merged PCM for ``conversation_id``; it's encoded to a WAV
+        and attached to the root span when the ``conversation`` span ends. The
+        ``conversation_id`` must match the one set on ``PipelineTask`` (so it
+        appears on the ``conversation`` span).
+
+        Place the ``AudioBufferProcessor`` after ``transport.output()`` and start
+        it with ``await audio_buffer.start_recording()`` once the session is
+        running. Construct it with a non-zero ``buffer_size`` so audio streams in
+        periodically — with the default single-shot emission, the final chunk can
+        arrive after the conversation span has already been exported.
+        """
+
+        async def _on_audio_data(
+            buffer: Any, audio: bytes, sample_rate: int, num_channels: int
+        ) -> None:
+            self._accumulate_audio(conversation_id, audio, sample_rate, num_channels)
+
+        audio_buffer.event_handler("on_audio_data")(_on_audio_data)
+
+    def _accumulate_audio(
+        self, conversation_id: str, audio: bytes, sample_rate: int, num_channels: int
+    ) -> None:
+        rec = self._audio_by_conversation.get(conversation_id)
+        if rec is None:
+            rec = {
+                "pcm": bytearray(),
+                "sample_rate": sample_rate,
+                "num_channels": num_channels,
+            }
+        rec["pcm"].extend(audio)
+        rec["sample_rate"] = sample_rate
+        rec["num_channels"] = num_channels
+        # Re-assign (not just mutate) so the TTL timestamp is refreshed — an
+        # active call streaming audio for longer than the TTL must not be
+        # evicted mid-conversation.
+        self._audio_by_conversation[conversation_id] = rec
+
+    # -- dispatch -------------------------------------------------------------
+
+    def _dispatch(self, tspan: TranslatedSpan) -> bool:
+        trace_id = format(tspan.span.context.trace_id, "032x")
+        name = tspan.span.name
+
+        if name == "stt":
+            self._handle_stt(tspan)
+            self._exclude_from_message_view(tspan)
+        elif name == "llm":
+            self._handle_llm(tspan, trace_id)
+        elif name == "tts":
+            self._handle_tts(tspan)
+            self._exclude_from_message_view(tspan)
+        elif name == "turn":
+            self._handle_turn(tspan)
+        elif name == "conversation":
+            self._handle_conversation(tspan, trace_id)
+        # Any other span (e.g. nested LangChain/LangGraph runs riding the same
+        # OTel provider) already arrives in LangSmith's native shape, so it's
+        # exported untouched.
+        #
+        # Pipecat's ``conversation`` span genuinely ends last, so nothing is
+        # deferred: return True to have the base export every span once.
+        return True
+
+    # -- per-span-type handlers ----------------------------------------------
+
+    def _handle_stt(self, tspan: TranslatedSpan) -> None:
+        """STT span: audio input → transcribed text."""
+        transcript = tspan.attributes.get("transcript", "")
+        self._set_kind(tspan, "llm")
+        self._set_messages(
+            tspan, prompt=[{"role": "user", "content": f'Audio for: "{transcript}"'}]
+        )
+        if transcript:
+            self._set_messages(
+                tspan, completion=[{"role": "assistant", "content": str(transcript)}]
+            )
+
+    @classmethod
+    def _completion_message(cls, output_data: Any) -> dict:
+        """Build the assistant completion message for the ``llm`` span.
+
+        Pipecat's ``output`` attribute is normally the assistant's text. But if a
+        service emits the structured response instead (a dict carrying
+        ``tool_calls``), forward it unchanged in its OpenAI shape so LangSmith
+        renders the tool calls rather than flattening them to a string. Anything
+        else — plain text, or JSON that isn't a tool-call message — stays as text
+        content, preserving the existing behavior.
+        """
+        parsed: Any = output_data
+        if isinstance(output_data, str):
+            try:
+                parsed = json.loads(output_data)
+            except json.JSONDecodeError:
+                parsed = None
+        if isinstance(parsed, dict) and parsed.get("tool_calls"):
+            return {"role": "assistant", **parsed}
+        content = output_data if isinstance(output_data, str) else str(output_data)
+        return {"role": "assistant", "content": content}
+
+    def _handle_llm(self, tspan: TranslatedSpan, trace_id: str) -> None:
+        """Framework ``llm`` span: the LLM stage of the pipeline.
+
+        Pipecat logs the request history in the LLM provider's own message format
+        (via the service's logging adapter). We forward it unchanged — LangSmith
+        reads the messages directly from ``gen_ai.prompt`` — so the trace mirrors
+        exactly what the model was sent.
+        """
+        input_data = tspan.attributes.get("input", "")
+        output_data = tspan.attributes.get("output", "")
+        self._set_kind(tspan, self._llm_span_kind)
+
+        try:
+            raw_messages = json.loads(input_data)
+        except (json.JSONDecodeError, TypeError):
+            raw_messages = []
+        messages = [
+            m
+            for m in (raw_messages if isinstance(raw_messages, list) else [])
+            if isinstance(m, dict)
+        ]
+
+        if messages:
+            self._set_messages_json(tspan, prompt=messages)
+        if output_data:
+            self._set_messages_json(
+                tspan, completion=[self._completion_message(output_data)]
+            )
+
+        # Each request's input carries the full history, so the latest snapshot
+        # IS the conversation — kept per trace for the root span to render. Reuse
+        # _completion_message so the root transcript and this span's completion
+        # render the assistant turn identically (tool calls included).
+        transcript = [m for m in messages if m.get("role") != "system"]
+        if output_data:
+            transcript.append(self._completion_message(output_data))
+        if transcript:
+            self._conversation_by_trace[trace_id] = transcript
+
+    def _handle_tts(self, tspan: TranslatedSpan) -> None:
+        """TTS span: text → audio. The voice is metadata, not content."""
+        text = tspan.attributes.get("text", "")
+        self._set_kind(tspan, "llm")
+        voice_id = tspan.attributes.get("voice_id")
+        if voice_id:
+            tspan.attributes["langsmith.metadata.voice_id"] = str(voice_id)
+        self._set_messages(
+            tspan,
+            prompt=[{"role": "user", "content": str(text)}],
+            completion=[
+                {"role": "assistant", "content": f'Generated audio for: "{text}"'}
+            ],
+        )
+
+    def _handle_turn(self, tspan: TranslatedSpan) -> None:
+        """Turn span: a framework wrapper around one exchange (a ``chain``)."""
+        self._set_kind(tspan, "chain")
+        turn_number = tspan.attributes.get("turn.number")
+        if turn_number is not None:
+            tspan.attributes["langsmith.metadata.turn_number"] = turn_number
+        was_interrupted = tspan.attributes.get("turn.was_interrupted")
+        if was_interrupted is not None:
+            tspan.attributes["langsmith.metadata.turn_was_interrupted"] = (
+                was_interrupted
+            )
+
+    def _handle_conversation(self, tspan: TranslatedSpan, trace_id: str) -> None:
+        """Conversation span: the whole session; the LangSmith root.
+
+        Input = the opening message; output = everything after it. Pipecat's
+        conversation span genuinely ends last, so no deferral is needed.
+        """
+        conversation_id = tspan.attributes.get(
+            "conversation.id", ""
+        ) or tspan.attributes.get("conversation_id", "")
+        self._set_kind(tspan, "chain")
+        tspan.attributes["langsmith.root_span"] = True
+        tspan.attributes["langsmith.metadata.ls_modality"] = "audio"
+
+        messages = self._conversation_by_trace.get(trace_id, [])
+        if messages:
+            self._set_messages_json(tspan, prompt=messages[:1])
+            if len(messages) > 1:
+                self._set_messages_json(tspan, completion=messages[1:])
+
+        self._attach_conversation_audio(tspan, conversation_id)
+        self._cleanup_conversation(trace_id, conversation_id)
+
+    # -- audio attachment -----------------------------------------------------
+
+    def _attach_conversation_audio(
+        self, tspan: TranslatedSpan, conversation_id: Any
+    ) -> None:
+        """Encode the accumulated PCM (from the AudioBufferProcessor) and attach it.
+
+        Looked up strictly by ``conversation_id`` — never by "the only recording
+        in flight": a heuristic match could attach a different caller's audio to
+        this trace (a privacy leak on a multi-tenant server). The id passed to
+        :meth:`attach_audio_buffer` must match the ``PipelineTask``
+        ``conversation_id``; a mismatch attaches nothing (logged below).
+        """
+        rec = self._audio_by_conversation.get(conversation_id)
+        if rec is None:
+            if len(self._audio_by_conversation) > 0:
+                logger.debug(
+                    "langsmith voice: no recording for conversation_id=%r "
+                    "(%d recording(s) in flight under other ids); audio not "
+                    "attached. Ensure the id passed to attach_audio_buffer "
+                    "matches the PipelineTask conversation_id.",
+                    conversation_id,
+                    len(self._audio_by_conversation),
+                )
+            return
+        if not rec["pcm"]:
+            return
+        wav = pcm_to_wav(bytes(rec["pcm"]), rec["sample_rate"], rec["num_channels"])
+        self._attach_audio(
+            tspan, name="conversation.wav", data=wav, mime_type=self._audio_mime_type
+        )
+
+    def _cleanup_conversation(self, trace_id: str, conversation_id: Any) -> None:
+        self._conversation_by_trace.pop(trace_id, None)
+        self._audio_by_conversation.pop(conversation_id, None)
+        self._forget_thread_id(int(trace_id, 16))

--- a/python/langsmith/integrations/strands_agents/exporter.py
+++ b/python/langsmith/integrations/strands_agents/exporter.py
@@ -27,6 +27,8 @@ from opentelemetry.sdk.trace.export import (
 )
 from strands.telemetry import StrandsTelemetry
 
+from langsmith._internal.otel._span_utils import rebuild_readable_span
+
 logger = logging.getLogger(__name__)
 
 __all__ = [
@@ -217,19 +219,8 @@ class LangSmithSpanExporter(SpanExporter):
             new_attrs["langsmith.metadata.ls_provider"] = "amazon_bedrock"
             new_attrs["langsmith.metadata.ls_model_type"] = "chat"
 
-        return ReadableSpan(
-            name=span.name,
-            context=span.context,
-            parent=span.parent,
-            resource=span.resource,
-            attributes=new_attrs,
-            events=remaining_events,
-            links=span.links,
-            kind=span.kind,
-            status=span.status,
-            start_time=span.start_time,
-            end_time=span.end_time,
-            instrumentation_scope=span.instrumentation_scope,
+        return rebuild_readable_span(
+            span, attributes=new_attrs, events=remaining_events
         )
 
     def _event_to_message(

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -58,6 +58,17 @@ otel = [
     "opentelemetry-exporter-otlp-proto-http>=1.30.0",
 ]
 
+# Enabled via `pip install langsmith[pipecat]`
+# pipecat-ai requires Python >=3.11; the marker keeps universal resolution
+# satisfiable on 3.10 (the extra is simply unavailable there).
+pipecat = [
+    "pipecat-ai>=1.0; python_version>='3.11'",
+    "opentelemetry-sdk>=1.30.0",
+    "opentelemetry-api>=1.30.0",
+    "opentelemetry-exporter-otlp-proto-http>=1.30.0",
+    "cachetools>=5.0.0",
+]
+
 # Enabled via `pip install langsmith[openai-agents]`
 openai-agents = ["openai-agents>=0.0.3"]
 
@@ -119,6 +130,7 @@ dev = [
     "opentelemetry-sdk>=1.34.1",
     "opentelemetry-exporter-otlp-proto-http>=1.34.1",
     "opentelemetry-api>=1.34.1",
+    "cachetools>=5.0.0",
     "bump2version>=1.0.1",
     "openai-agents>=0.2.4",
     "claude-agent-sdk>=0.1.0; python_version>='3.10'",

--- a/python/tests/unit_tests/test_span_utils.py
+++ b/python/tests/unit_tests/test_span_utils.py
@@ -1,0 +1,40 @@
+"""Unit tests for ``langsmith._internal.otel._span_utils``."""
+
+from opentelemetry.sdk.trace import Event, ReadableSpan
+
+from langsmith._internal.otel._span_utils import rebuild_readable_span
+
+
+def _span() -> ReadableSpan:
+    return ReadableSpan(
+        name="orig",
+        attributes={"a": 1},
+        events=[Event(name="e0")],
+        kind=None,
+        start_time=1,
+        end_time=2,
+    )
+
+
+def test_rebuild_overrides_attributes_and_events():
+    span = _span()
+    rebuilt = rebuild_readable_span(
+        span, attributes={"b": 2}, events=[Event(name="e1")]
+    )
+
+    # Overridden fields.
+    assert dict(rebuilt.attributes) == {"b": 2}
+    assert [e.name for e in rebuilt.events] == ["e1"]
+    # Copied-through fields.
+    assert rebuilt.name == "orig"
+    assert rebuilt.start_time == 1
+    assert rebuilt.end_time == 2
+    # The original span is never mutated.
+    assert dict(span.attributes) == {"a": 1}
+    assert [e.name for e in span.events] == ["e0"]
+
+
+def test_rebuild_defaults_events_to_original():
+    span = _span()
+    rebuilt = rebuild_readable_span(span, attributes={"b": 2})
+    assert [e.name for e in rebuilt.events] == ["e0"]

--- a/python/tests/unit_tests/wrappers/test_pipecat.py
+++ b/python/tests/unit_tests/wrappers/test_pipecat.py
@@ -1,0 +1,587 @@
+"""Unit tests for the Pipecat voice tracing integration.
+
+Covers everything shipped in the Pipecat PR: the ``PipecatLangSmithSpanProcessor``
+span rewriting, the shared ``BaseLangSmithSpanProcessor`` helpers, and the
+``voice.audio`` utilities. These are pure unit tests — they mock the OTel
+``ReadableSpan`` and the downstream processor, so no ``pipecat-ai`` install is
+required (only ``opentelemetry-sdk``, a dev dependency).
+"""
+
+import base64
+import io
+import json
+import sys
+import wave
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from langsmith._internal._beta_decorator import LangSmithBetaWarning, _warn_once
+from langsmith._internal.voice import audio as audio_utils
+from langsmith._internal.voice import set_thread_id, thread_id_from_context
+from langsmith._internal.voice.base_span_processor import (
+    DEFAULT_AUDIO_SIZE_LIMIT,
+    BaseLangSmithSpanProcessor,
+    TranslatedSpan,
+)
+from langsmith.integrations.pipecat.processor import PipecatLangSmithSpanProcessor
+
+
+def _make_span(name: str, attributes: dict | None = None, trace_id: int = 0x1):
+    """Build a mock span for the processor.
+
+    The processor only *reads* ``span.attributes`` (and a few read-only fields);
+    it never mutates the span. Translation accumulates on a ``TranslatedSpan``
+    draft, and a fresh span is built for export — so the rewritten attributes are
+    read off the exported span (see :func:`_exported_attrs`), not this input. The
+    remaining ``ReadableSpan`` fields are auto-mocked, which is all
+    ``TranslatedSpan.finalize`` needs to construct the export span.
+    """
+    span = MagicMock()
+    span.name = name
+    span.attributes = dict(attributes or {})
+    span.context = MagicMock()
+    span.context.trace_id = trace_id
+    span.events = []
+    return span
+
+
+def _processor(**kwargs) -> PipecatLangSmithSpanProcessor:
+    """Processor wired to a mock downstream so nothing is exported for real."""
+    return PipecatLangSmithSpanProcessor(downstream_processor=MagicMock(), **kwargs)
+
+
+def _exported_attrs(proc) -> dict:
+    """Attributes of the (last) finalized span the processor forwarded downstream.
+
+    The processor never mutates the incoming span; it accumulates the translation
+    on a ``TranslatedSpan`` and forwards a freshly built span. So the rewritten
+    attributes are read off that exported span, not the input.
+    """
+    assert proc.downstream.on_end.called, "nothing was exported downstream"
+    exported = proc.downstream.on_end.call_args.args[0]
+    return dict(exported.attributes or {})
+
+
+class TestPipecatDispatch:
+    """Span classification, rewriting, and unconditional export."""
+
+    def test_stt_span(self):
+        proc = _processor()
+        span = _make_span("stt", {"transcript": "hello there"})
+
+        proc.on_end(span)
+
+        attrs = _exported_attrs(proc)
+        assert attrs["langsmith.span.kind"] == "llm"
+        assert attrs["gen_ai.prompt.0.content"] == 'Audio for: "hello there"'
+        assert attrs["gen_ai.completion.0.content"] == "hello there"
+        # STT/TTS spans stay in the tree but are dropped from the Messages view.
+        assert attrs["langsmith.metadata.ls_message_view_exclude"] is True
+        proc.downstream.on_end.assert_called_once()
+
+    def test_stt_span_without_transcript_has_no_completion(self):
+        proc = _processor()
+        span = _make_span("stt", {})
+
+        proc.on_end(span)
+
+        assert "gen_ai.completion.0.content" not in _exported_attrs(proc)
+
+    def test_tts_span(self):
+        proc = _processor()
+        span = _make_span("tts", {"text": "hi", "voice_id": "voice-1"})
+
+        proc.on_end(span)
+
+        attrs = _exported_attrs(proc)
+        assert attrs["langsmith.span.kind"] == "llm"
+        assert attrs["langsmith.metadata.voice_id"] == "voice-1"
+        assert attrs["gen_ai.prompt.0.content"] == "hi"
+        assert attrs["gen_ai.completion.0.content"] == 'Generated audio for: "hi"'
+        assert attrs["langsmith.metadata.ls_message_view_exclude"] is True
+
+    def test_turn_span(self):
+        proc = _processor()
+        span = _make_span("turn", {"turn.number": 3, "turn.was_interrupted": True})
+
+        proc.on_end(span)
+
+        attrs = _exported_attrs(proc)
+        assert attrs["langsmith.span.kind"] == "chain"
+        assert attrs["langsmith.metadata.turn_number"] == 3
+        assert attrs["langsmith.metadata.turn_was_interrupted"] is True
+
+    def test_llm_span_default_kind_and_message_normalization(self):
+        proc = _processor()
+        context = [
+            {"role": "system", "content": "be brief"},
+            {"role": "user", "content": "what is 2+2?"},
+        ]
+        span = _make_span("llm", {"input": json.dumps(context), "output": "4"})
+
+        proc.on_end(span)
+
+        attrs = _exported_attrs(proc)
+        assert attrs["langsmith.span.kind"] == "llm"
+        prompt = json.loads(attrs["gen_ai.prompt"])
+        assert prompt["messages"][-1]["content"] == "what is 2+2?"
+        completion = json.loads(attrs["gen_ai.completion"])
+        assert completion["messages"][0]["content"] == "4"
+        # _set_messages_json must NOT write the indexed form (it would win at
+        # ingest and drop structured tool calls).
+        assert "gen_ai.prompt.0.role" not in attrs
+
+    def test_llm_input_messages_passed_through_verbatim(self):
+        # The request history is forwarded in the LLM provider's own message
+        # format, not rewritten — so the trace mirrors what the model was sent.
+        proc = _processor()
+        context = [
+            {"role": "user", "content": "weather?"},
+            {"role": "assistant", "content": [{"type": "text", "text": "checking"}]},
+        ]
+        span = _make_span("llm", {"input": json.dumps(context), "output": "sunny"})
+
+        proc.on_end(span)
+
+        prompt = json.loads(_exported_attrs(proc)["gen_ai.prompt"])
+        assert prompt["messages"] == context
+
+    def test_llm_span_kind_override(self):
+        proc = _processor(llm_span_kind="chain")
+        span = _make_span("llm", {"input": "[]", "output": ""})
+
+        proc.on_end(span)
+
+        assert _exported_attrs(proc)["langsmith.span.kind"] == "chain"
+
+    def test_llm_completion_plain_text_stays_text(self):
+        # A JSON-decodable scalar must NOT be treated as a structured message.
+        proc = _processor()
+        span = _make_span("llm", {"input": "[]", "output": "4"})
+
+        proc.on_end(span)
+
+        completion = json.loads(_exported_attrs(proc)["gen_ai.completion"])
+        assert completion["messages"][0] == {"role": "assistant", "content": "4"}
+
+    def test_llm_completion_preserves_tool_calls(self):
+        # When the framework emits the structured response with tool_calls, the
+        # message is forwarded unchanged in its OpenAI shape (LangSmith ingest
+        # renders it) rather than flattened to a string.
+        proc = _processor()
+        output = json.dumps(
+            {
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "lookup", "arguments": '{"q": "x"}'},
+                    }
+                ],
+            }
+        )
+        span = _make_span("llm", {"input": "[]", "output": output})
+
+        proc.on_end(span)
+
+        completion = json.loads(_exported_attrs(proc)["gen_ai.completion"])
+        msg = completion["messages"][0]
+        assert msg["role"] == "assistant"
+        assert msg["tool_calls"][0] == {
+            "id": "call_1",
+            "type": "function",
+            "function": {"name": "lookup", "arguments": '{"q": "x"}'},
+        }
+
+    def test_conversation_span_renders_root(self):
+        proc = _processor()
+        trace_id = 0xABC
+        # An llm span first populates the per-trace conversation snapshot...
+        llm = _make_span(
+            "llm",
+            {
+                "input": json.dumps([{"role": "user", "content": "hi"}]),
+                "output": "hello",
+            },
+            trace_id=trace_id,
+        )
+        proc.on_end(llm)
+        # ...then the conversation span renders it onto the root.
+        convo = _make_span("conversation", {"conversation.id": "c1"}, trace_id=trace_id)
+
+        proc.on_end(convo)
+
+        attrs = _exported_attrs(proc)
+        assert attrs["langsmith.span.kind"] == "chain"
+        assert attrs["langsmith.root_span"] is True
+        assert attrs["langsmith.metadata.ls_modality"] == "audio"
+        prompt = json.loads(attrs["gen_ai.prompt"])
+        assert prompt["messages"][0]["content"] == "hi"
+        completion = json.loads(attrs["gen_ai.completion"])
+        assert completion["messages"][0]["content"] == "hello"
+        # Per-trace state is cleaned up once the root is rendered.
+        assert trace_id not in proc._conversation_by_trace
+
+    def test_unknown_span_passed_through_untouched_but_exported(self):
+        proc = _processor()
+        span = _make_span("model", {"some.attr": "x"})
+
+        proc.on_end(span)
+
+        assert "langsmith.span.kind" not in _exported_attrs(proc)
+        proc.downstream.on_end.assert_called_once()
+
+
+class TestPipecatAudio:
+    """Audio-buffer registration, accumulation, and root attachment."""
+
+    def test_attach_audio_buffer_registers_and_accumulates(self):
+        proc = _processor()
+        captured = {}
+
+        class FakeBuffer:
+            def event_handler(self, event_name):
+                def register(fn):
+                    captured[event_name] = fn
+                    return fn
+
+                return register
+
+        proc.attach_audio_buffer(FakeBuffer(), "conv-1")
+        handler = captured["on_audio_data"]
+
+        # The Pipecat AudioBufferProcessor emits raw PCM in chunks.
+        import asyncio
+
+        asyncio.run(handler(None, b"\x01\x02", 16000, 2))
+        asyncio.run(handler(None, b"\x03\x04", 16000, 2))
+
+        rec = proc._audio_by_conversation["conv-1"]
+        assert bytes(rec["pcm"]) == b"\x01\x02\x03\x04"
+        assert rec["sample_rate"] == 16000
+        assert rec["num_channels"] == 2
+
+    def test_conversation_span_attaches_wav(self):
+        proc = _processor()
+        proc._accumulate_audio("c1", b"\x00\x01" * 8, 16000, 1)
+        span = _make_span("conversation", {"conversation.id": "c1"})
+
+        proc.on_end(span)
+
+        payload = json.loads(_exported_attrs(proc)["langsmith.attachments"])
+        assert payload[0]["name"] == "conversation.wav"
+        assert payload[0]["mime_type"] == "audio/wav"
+        decoded = base64.b64decode(payload[0]["content"])
+        assert decoded[:4] == b"RIFF"
+
+    def test_mismatched_conversation_id_attaches_nothing(self):
+        # A recording exists under a different id than the span carries. The
+        # lookup is strictly keyed (no "only one in flight" fallback), so no
+        # audio is attached — never another caller's recording.
+        proc = _processor()
+        proc._accumulate_audio("other-call", b"\x00\x01" * 8, 16000, 1)
+        span = _make_span("conversation", {"conversation.id": "this-call"})
+
+        proc.on_end(span)
+
+        assert "langsmith.attachments" not in _exported_attrs(proc)
+
+    def test_conversation_span_no_audio_no_attachment(self):
+        proc = _processor()
+        span = _make_span("conversation", {"conversation.id": "c1"})
+
+        proc.on_end(span)
+
+        assert "langsmith.attachments" not in _exported_attrs(proc)
+
+
+class TestBaseProcessorHelpers:
+    """Shared helpers in BaseLangSmithSpanProcessor."""
+
+    def _base(self, **kwargs) -> BaseLangSmithSpanProcessor:
+        return BaseLangSmithSpanProcessor(downstream_processor=MagicMock(), **kwargs)
+
+    def test_set_messages_writes_indexed_and_singular(self):
+        ls = TranslatedSpan.of(_make_span("x"))
+        BaseLangSmithSpanProcessor._set_messages(
+            ls, prompt=[{"role": "user", "content": "hi"}]
+        )
+        assert ls.attributes["gen_ai.prompt.0.role"] == "user"
+        assert json.loads(ls.attributes["gen_ai.prompt"]) == [
+            {"role": "user", "content": "hi"}
+        ]
+
+    def test_set_messages_json_writes_singular_only(self):
+        ls = TranslatedSpan.of(_make_span("x"))
+        BaseLangSmithSpanProcessor._set_messages_json(
+            ls, prompt=[{"role": "user", "content": "hi"}]
+        )
+        assert json.loads(ls.attributes["gen_ai.prompt"]) == {
+            "messages": [{"role": "user", "content": "hi"}]
+        }
+        assert "gen_ai.prompt.0.role" not in ls.attributes
+
+    def test_attach_audio_encodes_and_returns_true(self):
+        base = self._base()
+        ls = TranslatedSpan.of(_make_span("x"))
+        ok = base._attach_audio(
+            ls, name="a.wav", data=b"RIFFdata", mime_type="audio/wav"
+        )
+        assert ok is True
+        payload = json.loads(ls.attributes["langsmith.attachments"])
+        assert base64.b64decode(payload[0]["content"]) == b"RIFFdata"
+
+    def test_attach_audio_skips_oversize(self):
+        base = self._base(audio_size_limit_bytes=4)
+        ls = TranslatedSpan.of(_make_span("x"))
+        ok = base._attach_audio(
+            ls, name="a.wav", data=b"toolarge", mime_type="audio/wav"
+        )
+        assert ok is False
+        assert "langsmith.attachments" not in ls.attributes
+
+    def test_attach_audio_empty_returns_false(self):
+        base = self._base()
+        ls = TranslatedSpan.of(_make_span("x"))
+        assert (
+            base._attach_audio(ls, name="a.wav", data=b"", mime_type="audio/wav")
+            is False
+        )
+
+    def test_on_start_stamps_static_metadata(self):
+        base = self._base(metadata={"env": "test", "skip": None})
+        span = MagicMock()
+        base.on_start(span)
+        span.set_attribute.assert_any_call("langsmith.metadata.env", "test")
+        base.downstream.on_start.assert_called_once()
+
+    def test_shutdown_delegates(self):
+        base = self._base()
+        base.shutdown()
+        base.downstream.shutdown.assert_called_once()
+
+    def test_force_flush_delegates(self):
+        base = self._base()
+        base.downstream.force_flush.return_value = True
+        assert base.force_flush(5000) is True
+        base.downstream.force_flush.assert_called_once_with(5000)
+
+    def test_default_audio_size_limit_constant(self):
+        base = self._base()
+        assert base.audio_size_limit_bytes == DEFAULT_AUDIO_SIZE_LIMIT
+
+
+class TestVoiceAudioUtils:
+    """``pcm_to_wav`` — the only ``voice/audio.py`` helper Pipecat uses.
+
+    The Track-B helpers (``scrub``/``dump_event``/``build_stereo_session_wav``)
+    live with ``session.py`` in the OpenAI Realtime PR and are tested there.
+    """
+
+    def test_pcm_to_wav_empty(self):
+        assert audio_utils.pcm_to_wav(b"", 16000) == b""
+
+    def test_pcm_to_wav_produces_valid_wav(self):
+        pcm = b"\x00\x01" * 16
+        wav = audio_utils.pcm_to_wav(pcm, 16000, num_channels=2)
+        assert wav[:4] == b"RIFF"
+        with wave.open(io.BytesIO(wav), "rb") as wf:
+            assert wf.getnchannels() == 2
+            assert wf.getframerate() == 16000
+            assert wf.getsampwidth() == 2
+
+
+class TestStateLifecycle:
+    """TTL-bounded state and its normal cleanup."""
+
+    def test_state_cleaned_up_on_conversation_end(self):
+        proc = _processor()
+        trace_id = 0xABC
+        llm = _make_span(
+            "llm",
+            {"input": json.dumps([{"role": "user", "content": "hi"}]), "output": "ok"},
+            trace_id=trace_id,
+        )
+        proc.on_end(llm)
+        proc._accumulate_audio("c1", b"\x00\x01" * 8, 16000, 1)
+        assert len(proc._conversation_by_trace) == 1
+        assert len(proc._audio_by_conversation) == 1
+
+        convo = _make_span("conversation", {"conversation.id": "c1"}, trace_id=trace_id)
+        proc.on_end(convo)
+
+        # Both per-conversation stores are freed once the root renders.
+        assert len(proc._conversation_by_trace) == 0
+        assert len(proc._audio_by_conversation) == 0
+
+    def test_abandoned_state_expires_via_ttl(self):
+        # A conversation whose end span never arrives must not leak: the TTL
+        # store drops it. Use a zero TTL so the next write evicts it.
+        proc = _processor(state_ttl_seconds=0)
+        proc._accumulate_audio("c1", b"\x00\x01", 16000, 1)
+        # A later write to the (separate) store of a *different* conversation
+        # triggers eviction of the expired one.
+        proc._accumulate_audio("c2", b"\x00\x01", 16000, 1)
+
+        assert "c1" not in proc._audio_by_conversation
+
+    def test_active_call_not_evicted_mid_stream(self):
+        # Re-writing a key (each audio chunk) refreshes its TTL, so a long call
+        # streaming audio is never dropped mid-conversation.
+        proc = _processor(state_ttl_seconds=60)
+        proc._accumulate_audio("c1", b"\x00\x01", 16000, 1)
+        proc._accumulate_audio("c1", b"\x02\x03", 16000, 1)
+        assert bytes(proc._audio_by_conversation["c1"]["pcm"]) == b"\x00\x01\x02\x03"
+
+
+class TestExceptionIsolation:
+    """A translation failure must never drop a span or escape on_end."""
+
+    def test_dispatch_failure_still_exports_and_does_not_raise(self):
+        proc = _processor()
+        span = _make_span("conversation", {"conversation.id": "c1"})
+
+        # Force the handler to blow up after classification.
+        with patch.object(
+            proc, "_handle_conversation", side_effect=RuntimeError("boom")
+        ):
+            proc.on_end(span)  # must not raise
+
+        # The span is still forwarded downstream (untranslated, not lost).
+        proc.downstream.on_end.assert_called_once()
+
+    def test_export_failure_is_swallowed(self):
+        proc = _processor()
+        proc.downstream.on_end.side_effect = RuntimeError("export down")
+        span = _make_span("stt", {"transcript": "hi"})
+
+        proc.on_end(span)  # must not raise
+
+
+class TestContextVarThreadId:
+    """Thread-id injection from the per-context ``set_thread_id`` ContextVar."""
+
+    def teardown_method(self):
+        set_thread_id(None)
+
+    def test_set_thread_id_is_injected(self):
+        proc = _processor()
+        set_thread_id("conv-42")
+        span = _make_span("turn", {})
+
+        proc.on_end(span)
+
+        assert _exported_attrs(proc)["langsmith.metadata.thread_id"] == "conv-42"
+
+    def test_no_injection_when_unset(self):
+        proc = _processor()
+        assert thread_id_from_context() is None
+        span = _make_span("turn", {})
+
+        proc.on_end(span)
+
+        assert "langsmith.metadata.thread_id" not in _exported_attrs(proc)
+
+    def test_does_not_clobber_upstream_id(self):
+        proc = _processor()
+        set_thread_id("from-context")
+        span = _make_span("turn", {"langsmith.metadata.thread_id": "upstream"})
+
+        proc.on_end(span)
+
+        assert _exported_attrs(proc)["langsmith.metadata.thread_id"] == "upstream"
+
+    def test_thread_id_survives_out_of_context_end(self):
+        # The real failure mode: a span that ENDS in a detached task can't see
+        # the ContextVar. on_start captured it (in context) keyed by trace, so
+        # the span still gets the id at export. Simulate the detached end by
+        # clearing the ContextVar between on_start and on_end.
+        proc = _processor()
+        tid = 0xABC
+        set_thread_id("conv-7")
+        proc.on_start(_make_span("conversation", trace_id=tid))
+        set_thread_id(None)
+        proc.on_end(_make_span("stt", {"transcript": "hi"}, trace_id=tid))
+
+        assert _exported_attrs(proc)["langsmith.metadata.thread_id"] == "conv-7"
+
+    def test_in_context_end_backfills_for_trace_peers(self):
+        # No on_start capture: the first span seen in context resolves via the
+        # ContextVar and backfills the trace cache, so a later peer that ends
+        # out of context still resolves.
+        proc = _processor()
+        tid = 0xABC
+        set_thread_id("conv-8")
+        proc.on_end(_make_span("turn", {}, trace_id=tid))
+        set_thread_id(None)
+        proc.on_end(_make_span("stt", {"transcript": "hi"}, trace_id=tid))
+
+        assert _exported_attrs(proc)["langsmith.metadata.thread_id"] == "conv-8"
+
+    def test_cleanup_forgets_cached_thread_id(self):
+        proc = _processor()
+        tid = 0xABC
+        set_thread_id("conv-9")
+        proc.on_end(_make_span("turn", {}, trace_id=tid))
+        assert tid in proc._thread_id_by_trace
+        # Conversation end frees the per-trace state, the thread id included.
+        proc.on_end(_make_span("conversation", {"conversation.id": "c1"}, trace_id=tid))
+        assert tid not in proc._thread_id_by_trace
+
+
+class TestDispatchExportDisposition:
+    """``_dispatch``'s return value decides whether the base exports the span.
+
+    This is the contract a deferring subclass (e.g. LiveKit's egress
+    hold-the-root-open) relies on: return ``False`` to own/defer the export.
+    """
+
+    def _proc(self, dispatch_returns):
+        class _P(BaseLangSmithSpanProcessor):
+            def _dispatch(self, tspan):
+                return dispatch_returns
+
+        return _P(downstream_processor=MagicMock())
+
+    def test_true_exports_once(self):
+        proc = self._proc(True)
+        span = _make_span("x")
+        proc.on_end(span)
+        proc.downstream.on_end.assert_called_once()
+
+    def test_false_defers_export(self):
+        # The subclass takes ownership; the base must NOT export it.
+        proc = self._proc(False)
+        span = _make_span("x")
+        proc.on_end(span)
+        proc.downstream.on_end.assert_not_called()
+
+    def test_none_still_exports(self):
+        # A subclass that forgets to return must not silently drop the span.
+        proc = self._proc(None)
+        span = _make_span("x")
+        proc.on_end(span)
+        proc.downstream.on_end.assert_called_once()
+
+
+class TestConfigureAndWarning:
+    """Public surface: the beta warning and configure_pipecat."""
+
+    def test_configure_pipecat_emits_beta_warning(self):
+        from langsmith.integrations.pipecat import configure_pipecat
+
+        _warn_once.cache_clear()  # @warn_beta dedupes per message; reset it
+        # @warn_beta fires before the body, so it warns even when pipecat is
+        # absent (the call then returns None).
+        with patch.dict(sys.modules, {"pipecat": None}):
+            with pytest.warns(LangSmithBetaWarning):
+                assert configure_pipecat() is None
+
+    def test_configure_pipecat_returns_none_without_pipecat(self):
+        from langsmith.integrations.pipecat import configure_pipecat
+
+        # Force the lazy ``import pipecat`` to fail regardless of environment.
+        with patch.dict(sys.modules, {"pipecat": None}):
+            assert configure_pipecat() is None

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -5,13 +5,23 @@ resolution-markers = [
     "python_full_version >= '3.15'",
     "python_full_version == '3.14.*'",
     "python_full_version == '3.13.*'",
-    "python_full_version >= '3.11' and python_full_version < '3.13'",
+    "python_full_version == '3.12.*'",
+    "python_full_version == '3.11.*'",
     "python_full_version < '3.11'",
 ]
 
 [options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer = "2026-06-28T23:55:50.48028Z"
 exclude-newer-span = "P1D"
+
+[[package]]
+name = "aiofiles"
+version = "25.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/c3/534eac40372d8ee36ef40df62ec129bee4fdb5ad9706e58a29be53b2c970/aiofiles-25.1.0.tar.gz", hash = "sha256:a8d728f0a29de45dc521f18f07297428d56992a742f0cd2701ba86e44d23d5b2", size = 46354, upload-time = "2025-10-09T20:51:04.358Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/8a/340a1555ae33d7354dbca4faa54948d76d89a27ceef032c8c3bc661d003e/aiofiles-25.1.0-py3-none-any.whl", hash = "sha256:abe311e527c862958650f9438e859c1fa7568a141b22abcd015e120e86a85695", size = 14668, upload-time = "2025-10-09T20:51:03.174Z" },
+]
 
 [[package]]
 name = "aiohappyeyeballs"
@@ -291,6 +301,62 @@ wheels = [
 ]
 
 [[package]]
+name = "audioop-lts"
+version = "0.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/38/53/946db57842a50b2da2e0c1e34bd37f36f5aadba1a929a3971c5d7841dbca/audioop_lts-0.2.2.tar.gz", hash = "sha256:64d0c62d88e67b98a1a5e71987b7aa7b5bcffc7dcee65b635823dbdd0a8dbbd0", size = 30686, upload-time = "2025-08-05T16:43:17.409Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/d4/94d277ca941de5a507b07f0b592f199c22454eeaec8f008a286b3fbbacd6/audioop_lts-0.2.2-cp313-abi3-macosx_10_13_universal2.whl", hash = "sha256:fd3d4602dc64914d462924a08c1a9816435a2155d74f325853c1f1ac3b2d9800", size = 46523, upload-time = "2025-08-05T16:42:20.836Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/5a/656d1c2da4b555920ce4177167bfeb8623d98765594af59702c8873f60ec/audioop_lts-0.2.2-cp313-abi3-macosx_10_13_x86_64.whl", hash = "sha256:550c114a8df0aafe9a05442a1162dfc8fec37e9af1d625ae6060fed6e756f303", size = 27455, upload-time = "2025-08-05T16:42:22.283Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/83/ea581e364ce7b0d41456fb79d6ee0ad482beda61faf0cab20cbd4c63a541/audioop_lts-0.2.2-cp313-abi3-macosx_11_0_arm64.whl", hash = "sha256:9a13dc409f2564de15dd68be65b462ba0dde01b19663720c68c1140c782d1d75", size = 26997, upload-time = "2025-08-05T16:42:23.849Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/3b/e8964210b5e216e5041593b7d33e97ee65967f17c282e8510d19c666dab4/audioop_lts-0.2.2-cp313-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:51c916108c56aa6e426ce611946f901badac950ee2ddaf302b7ed35d9958970d", size = 85844, upload-time = "2025-08-05T16:42:25.208Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/2e/0a1c52faf10d51def20531a59ce4c706cb7952323b11709e10de324d6493/audioop_lts-0.2.2-cp313-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:47eba38322370347b1c47024defbd36374a211e8dd5b0dcbce7b34fdb6f8847b", size = 85056, upload-time = "2025-08-05T16:42:26.559Z" },
+    { url = "https://files.pythonhosted.org/packages/75/e8/cd95eef479656cb75ab05dfece8c1f8c395d17a7c651d88f8e6e291a63ab/audioop_lts-0.2.2-cp313-abi3-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ba7c3a7e5f23e215cb271516197030c32aef2e754252c4c70a50aaff7031a2c8", size = 93892, upload-time = "2025-08-05T16:42:27.902Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/1e/a0c42570b74f83efa5cca34905b3eef03f7ab09fe5637015df538a7f3345/audioop_lts-0.2.2-cp313-abi3-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:def246fe9e180626731b26e89816e79aae2276f825420a07b4a647abaa84becc", size = 96660, upload-time = "2025-08-05T16:42:28.9Z" },
+    { url = "https://files.pythonhosted.org/packages/50/d5/8a0ae607ca07dbb34027bac8db805498ee7bfecc05fd2c148cc1ed7646e7/audioop_lts-0.2.2-cp313-abi3-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e160bf9df356d841bb6c180eeeea1834085464626dc1b68fa4e1d59070affdc3", size = 79143, upload-time = "2025-08-05T16:42:29.929Z" },
+    { url = "https://files.pythonhosted.org/packages/12/17/0d28c46179e7910bfb0bb62760ccb33edb5de973052cb2230b662c14ca2e/audioop_lts-0.2.2-cp313-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:4b4cd51a57b698b2d06cb9993b7ac8dfe89a3b2878e96bc7948e9f19ff51dba6", size = 84313, upload-time = "2025-08-05T16:42:30.949Z" },
+    { url = "https://files.pythonhosted.org/packages/84/ba/bd5d3806641564f2024e97ca98ea8f8811d4e01d9b9f9831474bc9e14f9e/audioop_lts-0.2.2-cp313-abi3-musllinux_1_2_ppc64le.whl", hash = "sha256:4a53aa7c16a60a6857e6b0b165261436396ef7293f8b5c9c828a3a203147ed4a", size = 93044, upload-time = "2025-08-05T16:42:31.959Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/5e/435ce8d5642f1f7679540d1e73c1c42d933331c0976eb397d1717d7f01a3/audioop_lts-0.2.2-cp313-abi3-musllinux_1_2_riscv64.whl", hash = "sha256:3fc38008969796f0f689f1453722a0f463da1b8a6fbee11987830bfbb664f623", size = 78766, upload-time = "2025-08-05T16:42:33.302Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3b/b909e76b606cbfd53875693ec8c156e93e15a1366a012f0b7e4fb52d3c34/audioop_lts-0.2.2-cp313-abi3-musllinux_1_2_s390x.whl", hash = "sha256:15ab25dd3e620790f40e9ead897f91e79c0d3ce65fe193c8ed6c26cffdd24be7", size = 87640, upload-time = "2025-08-05T16:42:34.854Z" },
+    { url = "https://files.pythonhosted.org/packages/30/e7/8f1603b4572d79b775f2140d7952f200f5e6c62904585d08a01f0a70393a/audioop_lts-0.2.2-cp313-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:03f061a1915538fd96272bac9551841859dbb2e3bf73ebe4a23ef043766f5449", size = 86052, upload-time = "2025-08-05T16:42:35.839Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/96/c37846df657ccdda62ba1ae2b6534fa90e2e1b1742ca8dcf8ebd38c53801/audioop_lts-0.2.2-cp313-abi3-win32.whl", hash = "sha256:3bcddaaf6cc5935a300a8387c99f7a7fbbe212a11568ec6cf6e4bc458c048636", size = 26185, upload-time = "2025-08-05T16:42:37.04Z" },
+    { url = "https://files.pythonhosted.org/packages/34/a5/9d78fdb5b844a83da8a71226c7bdae7cc638861085fff7a1d707cb4823fa/audioop_lts-0.2.2-cp313-abi3-win_amd64.whl", hash = "sha256:a2c2a947fae7d1062ef08c4e369e0ba2086049a5e598fda41122535557012e9e", size = 30503, upload-time = "2025-08-05T16:42:38.427Z" },
+    { url = "https://files.pythonhosted.org/packages/34/25/20d8fde083123e90c61b51afb547bb0ea7e77bab50d98c0ab243d02a0e43/audioop_lts-0.2.2-cp313-abi3-win_arm64.whl", hash = "sha256:5f93a5db13927a37d2d09637ccca4b2b6b48c19cd9eda7b17a2e9f77edee6a6f", size = 24173, upload-time = "2025-08-05T16:42:39.704Z" },
+    { url = "https://files.pythonhosted.org/packages/58/a7/0a764f77b5c4ac58dc13c01a580f5d32ae8c74c92020b961556a43e26d02/audioop_lts-0.2.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:73f80bf4cd5d2ca7814da30a120de1f9408ee0619cc75da87d0641273d202a09", size = 47096, upload-time = "2025-08-05T16:42:40.684Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/ed/ebebedde1a18848b085ad0fa54b66ceb95f1f94a3fc04f1cd1b5ccb0ed42/audioop_lts-0.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:106753a83a25ee4d6f473f2be6b0966fc1c9af7e0017192f5531a3e7463dce58", size = 27748, upload-time = "2025-08-05T16:42:41.992Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/6e/11ca8c21af79f15dbb1c7f8017952ee8c810c438ce4e2b25638dfef2b02c/audioop_lts-0.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:fbdd522624141e40948ab3e8cdae6e04c748d78710e9f0f8d4dae2750831de19", size = 27329, upload-time = "2025-08-05T16:42:42.987Z" },
+    { url = "https://files.pythonhosted.org/packages/84/52/0022f93d56d85eec5da6b9da6a958a1ef09e80c39f2cc0a590c6af81dcbb/audioop_lts-0.2.2-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:143fad0311e8209ece30a8dbddab3b65ab419cbe8c0dde6e8828da25999be911", size = 92407, upload-time = "2025-08-05T16:42:44.336Z" },
+    { url = "https://files.pythonhosted.org/packages/87/1d/48a889855e67be8718adbc7a01f3c01d5743c325453a5e81cf3717664aad/audioop_lts-0.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dfbbc74ec68a0fd08cfec1f4b5e8cca3d3cd7de5501b01c4b5d209995033cde9", size = 91811, upload-time = "2025-08-05T16:42:45.325Z" },
+    { url = "https://files.pythonhosted.org/packages/98/a6/94b7213190e8077547ffae75e13ed05edc488653c85aa5c41472c297d295/audioop_lts-0.2.2-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:cfcac6aa6f42397471e4943e0feb2244549db5c5d01efcd02725b96af417f3fe", size = 100470, upload-time = "2025-08-05T16:42:46.468Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/e9/78450d7cb921ede0cfc33426d3a8023a3bda755883c95c868ee36db8d48d/audioop_lts-0.2.2-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:752d76472d9804ac60f0078c79cdae8b956f293177acd2316cd1e15149aee132", size = 103878, upload-time = "2025-08-05T16:42:47.576Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/e2/cd5439aad4f3e34ae1ee852025dc6aa8f67a82b97641e390bf7bd9891d3e/audioop_lts-0.2.2-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:83c381767e2cc10e93e40281a04852facc4cd9334550e0f392f72d1c0a9c5753", size = 84867, upload-time = "2025-08-05T16:42:49.003Z" },
+    { url = "https://files.pythonhosted.org/packages/68/4b/9d853e9076c43ebba0d411e8d2aa19061083349ac695a7d082540bad64d0/audioop_lts-0.2.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c0022283e9556e0f3643b7c3c03f05063ca72b3063291834cca43234f20c60bb", size = 90001, upload-time = "2025-08-05T16:42:50.038Z" },
+    { url = "https://files.pythonhosted.org/packages/58/26/4bae7f9d2f116ed5593989d0e521d679b0d583973d203384679323d8fa85/audioop_lts-0.2.2-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:a2d4f1513d63c795e82948e1305f31a6d530626e5f9f2605408b300ae6095093", size = 99046, upload-time = "2025-08-05T16:42:51.111Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/67/a9f4fb3e250dda9e9046f8866e9fa7d52664f8985e445c6b4ad6dfb55641/audioop_lts-0.2.2-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:c9c8e68d8b4a56fda8c025e538e639f8c5953f5073886b596c93ec9b620055e7", size = 84788, upload-time = "2025-08-05T16:42:52.198Z" },
+    { url = "https://files.pythonhosted.org/packages/70/f7/3de86562db0121956148bcb0fe5b506615e3bcf6e63c4357a612b910765a/audioop_lts-0.2.2-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:96f19de485a2925314f5020e85911fb447ff5fbef56e8c7c6927851b95533a1c", size = 94472, upload-time = "2025-08-05T16:42:53.59Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/32/fd772bf9078ae1001207d2df1eef3da05bea611a87dd0e8217989b2848fa/audioop_lts-0.2.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:e541c3ef484852ef36545f66209444c48b28661e864ccadb29daddb6a4b8e5f5", size = 92279, upload-time = "2025-08-05T16:42:54.632Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/41/affea7181592ab0ab560044632571a38edaf9130b84928177823fbf3176a/audioop_lts-0.2.2-cp313-cp313t-win32.whl", hash = "sha256:d5e73fa573e273e4f2e5ff96f9043858a5e9311e94ffefd88a3186a910c70917", size = 26568, upload-time = "2025-08-05T16:42:55.627Z" },
+    { url = "https://files.pythonhosted.org/packages/28/2b/0372842877016641db8fc54d5c88596b542eec2f8f6c20a36fb6612bf9ee/audioop_lts-0.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:9191d68659eda01e448188f60364c7763a7ca6653ed3f87ebb165822153a8547", size = 30942, upload-time = "2025-08-05T16:42:56.674Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/ca/baf2b9cc7e96c179bb4a54f30fcd83e6ecb340031bde68f486403f943768/audioop_lts-0.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:c174e322bb5783c099aaf87faeb240c8d210686b04bd61dfd05a8e5a83d88969", size = 24603, upload-time = "2025-08-05T16:42:57.571Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/73/413b5a2804091e2c7d5def1d618e4837f1cb82464e230f827226278556b7/audioop_lts-0.2.2-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:f9ee9b52f5f857fbaf9d605a360884f034c92c1c23021fb90b2e39b8e64bede6", size = 47104, upload-time = "2025-08-05T16:42:58.518Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/8c/daa3308dc6593944410c2c68306a5e217f5c05b70a12e70228e7dd42dc5c/audioop_lts-0.2.2-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:49ee1a41738a23e98d98b937a0638357a2477bc99e61b0f768a8f654f45d9b7a", size = 27754, upload-time = "2025-08-05T16:43:00.132Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/86/c2e0f627168fcf61781a8f72cab06b228fe1da4b9fa4ab39cfb791b5836b/audioop_lts-0.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5b00be98ccd0fc123dcfad31d50030d25fcf31488cde9e61692029cd7394733b", size = 27332, upload-time = "2025-08-05T16:43:01.666Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/bd/35dce665255434f54e5307de39e31912a6f902d4572da7c37582809de14f/audioop_lts-0.2.2-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:a6d2e0f9f7a69403e388894d4ca5ada5c47230716a03f2847cfc7bd1ecb589d6", size = 92396, upload-time = "2025-08-05T16:43:02.991Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/d2/deeb9f51def1437b3afa35aeb729d577c04bcd89394cb56f9239a9f50b6f/audioop_lts-0.2.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f9b0b8a03ef474f56d1a842af1a2e01398b8f7654009823c6d9e0ecff4d5cfbf", size = 91811, upload-time = "2025-08-05T16:43:04.096Z" },
+    { url = "https://files.pythonhosted.org/packages/76/3b/09f8b35b227cee28cc8231e296a82759ed80c1a08e349811d69773c48426/audioop_lts-0.2.2-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2b267b70747d82125f1a021506565bdc5609a2b24bcb4773c16d79d2bb260bbd", size = 100483, upload-time = "2025-08-05T16:43:05.085Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/15/05b48a935cf3b130c248bfdbdea71ce6437f5394ee8533e0edd7cfd93d5e/audioop_lts-0.2.2-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:0337d658f9b81f4cd0fdb1f47635070cc084871a3d4646d9de74fdf4e7c3d24a", size = 103885, upload-time = "2025-08-05T16:43:06.197Z" },
+    { url = "https://files.pythonhosted.org/packages/83/80/186b7fce6d35b68d3d739f228dc31d60b3412105854edb975aa155a58339/audioop_lts-0.2.2-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:167d3b62586faef8b6b2275c3218796b12621a60e43f7e9d5845d627b9c9b80e", size = 84899, upload-time = "2025-08-05T16:43:07.291Z" },
+    { url = "https://files.pythonhosted.org/packages/49/89/c78cc5ac6cb5828f17514fb12966e299c850bc885e80f8ad94e38d450886/audioop_lts-0.2.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:0d9385e96f9f6da847f4d571ce3cb15b5091140edf3db97276872647ce37efd7", size = 89998, upload-time = "2025-08-05T16:43:08.335Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/4b/6401888d0c010e586c2ca50fce4c903d70a6bb55928b16cfbdfd957a13da/audioop_lts-0.2.2-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:48159d96962674eccdca9a3df280e864e8ac75e40a577cc97c5c42667ffabfc5", size = 99046, upload-time = "2025-08-05T16:43:09.367Z" },
+    { url = "https://files.pythonhosted.org/packages/de/f8/c874ca9bb447dae0e2ef2e231f6c4c2b0c39e31ae684d2420b0f9e97ee68/audioop_lts-0.2.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:8fefe5868cd082db1186f2837d64cfbfa78b548ea0d0543e9b28935ccce81ce9", size = 84843, upload-time = "2025-08-05T16:43:10.749Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/c0/0323e66f3daebc13fd46b36b30c3be47e3fc4257eae44f1e77eb828c703f/audioop_lts-0.2.2-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:58cf54380c3884fb49fdd37dfb7a772632b6701d28edd3e2904743c5e1773602", size = 94490, upload-time = "2025-08-05T16:43:12.131Z" },
+    { url = "https://files.pythonhosted.org/packages/98/6b/acc7734ac02d95ab791c10c3f17ffa3584ccb9ac5c18fd771c638ed6d1f5/audioop_lts-0.2.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:088327f00488cdeed296edd9215ca159f3a5a5034741465789cad403fcf4bec0", size = 92297, upload-time = "2025-08-05T16:43:13.139Z" },
+    { url = "https://files.pythonhosted.org/packages/13/c3/c3dc3f564ce6877ecd2a05f8d751b9b27a8c320c2533a98b0c86349778d0/audioop_lts-0.2.2-cp314-cp314t-win32.whl", hash = "sha256:068aa17a38b4e0e7de771c62c60bbca2455924b67a8814f3b0dee92b5820c0b3", size = 27331, upload-time = "2025-08-05T16:43:14.19Z" },
+    { url = "https://files.pythonhosted.org/packages/72/bb/b4608537e9ffcb86449091939d52d24a055216a36a8bf66b936af8c3e7ac/audioop_lts-0.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:a5bf613e96f49712073de86f20dbdd4014ca18efd4d34ed18c75bd808337851b", size = 31697, upload-time = "2025-08-05T16:43:15.193Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/22/91616fe707a5c5510de2cac9b046a30defe7007ba8a0c04f9c08f27df312/audioop_lts-0.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:b492c3b040153e68b9fdaff5913305aaaba5bb433d8a7f73d5cf6a64ed3cc1dd", size = 25206, upload-time = "2025-08-05T16:43:16.444Z" },
+]
+
+[[package]]
 name = "authlib"
 version = "1.6.12"
 source = { registry = "https://pypi.org/simple" }
@@ -371,6 +437,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/29/2a/688aca6eeebfe8941235be53f4da780c6edee05dbbea5d7abaa3aab6fad2/bump2version-1.0.1.tar.gz", hash = "sha256:762cb2bfad61f4ec8e2bdf452c7c267416f8c70dd9ecb1653fd0bbb01fa936e6", size = 36236, upload-time = "2020-10-07T18:38:40.119Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1d/e3/fa60c47d7c344533142eb3af0b73234ef8ea3fb2da742ab976b947e717df/bump2version-1.0.1-py2.py3-none-any.whl", hash = "sha256:37f927ea17cde7ae2d7baf832f8e80ce3777624554a653006c9144f8017fe410", size = 22030, upload-time = "2020-10-07T18:38:38.148Z" },
+]
+
+[[package]]
+name = "cachetools"
+version = "7.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f4/8b/0d3945a13955303b81272f759a0331e54c5c793da455e6f5706b89d2639c/cachetools-7.1.4.tar.gz", hash = "sha256:437f55a4e0c1b01a4f3077cc470e6991d47430970e36fbcb77e2be0df4fc1cd6", size = 40085, upload-time = "2026-05-21T22:40:43.376Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8c/7b/1fc1c09cc0756cf25861a3be10565915953876da48bb228fb9a672b20a42/cachetools-7.1.4-py3-none-any.whl", hash = "sha256:323dc4127934744db5b54eb4924482d7edafbf9554e820d1531c2e08c0e4ef54", size = 16761, upload-time = "2026-05-21T22:40:41.845Z" },
 ]
 
 [[package]]
@@ -894,6 +969,14 @@ wheels = [
 ]
 
 [[package]]
+name = "flatbuffers"
+version = "25.12.19"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/2d/d2a548598be01649e2d46231d151a6c56d10b964d94043a335ae56ea2d92/flatbuffers-25.12.19-py2.py3-none-any.whl", hash = "sha256:7634f50c427838bb021c2d66a3d1168e9d199b0607e6329399f04846d42e20b4", size = 26661, upload-time = "2025-12-19T23:16:13.622Z" },
+]
+
+[[package]]
 name = "freezegun"
 version = "1.5.5"
 source = { registry = "https://pypi.org/simple" }
@@ -1316,6 +1399,15 @@ wheels = [
 ]
 
 [[package]]
+name = "joblib"
+version = "1.5.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/f2/d34e8b3a08a9cc79a50b2208a93dce981fe615b64d5a4d4abee421d898df/joblib-1.5.3.tar.gz", hash = "sha256:8561a3269e6801106863fd0d6d84bb737be9e7631e33aaed3fb9ce5953688da3", size = 331603, upload-time = "2025-12-15T08:41:46.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/91/984aca2ec129e2757d1e4e3c81c3fcda9d0f85b74670a094cc443d9ee949/joblib-1.5.3-py3-none-any.whl", hash = "sha256:5fc3c5039fc5ca8c0276333a188bbd59d6b7ab37fe6632daa76bc7f9ec18e713", size = 309071, upload-time = "2025-12-15T08:41:44.973Z" },
+]
+
+[[package]]
 name = "jsonpatch"
 version = "1.33"
 source = { registry = "https://pypi.org/simple" }
@@ -1462,6 +1554,13 @@ otel = [
     { name = "opentelemetry-exporter-otlp-proto-http" },
     { name = "opentelemetry-sdk" },
 ]
+pipecat = [
+    { name = "cachetools" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-http" },
+    { name = "opentelemetry-sdk" },
+    { name = "pipecat-ai", marker = "python_full_version >= '3.11'" },
+]
 pytest = [
     { name = "pytest" },
     { name = "rich" },
@@ -1481,6 +1580,7 @@ vcr = [
 [package.dev-dependencies]
 dev = [
     { name = "bump2version" },
+    { name = "cachetools" },
     { name = "claude-agent-sdk" },
     { name = "dataclasses-json" },
     { name = "debugpy" },
@@ -1540,6 +1640,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "anyio", specifier = ">=3.5.0" },
+    { name = "cachetools", marker = "extra == 'pipecat'", specifier = ">=5.0.0" },
     { name = "claude-agent-sdk", marker = "python_full_version >= '3.10' and extra == 'claude-agent-sdk'", specifier = ">=0.1.0" },
     { name = "distro", specifier = ">=1.7.0" },
     { name = "google-adk", marker = "extra == 'google-adk'", specifier = ">=1.0.0" },
@@ -1547,13 +1648,17 @@ requires-dist = [
     { name = "langsmith-pyo3", marker = "extra == 'langsmith-pyo3'", specifier = ">=0.1.0rc2" },
     { name = "openai-agents", marker = "extra == 'openai-agents'", specifier = ">=0.0.3" },
     { name = "opentelemetry-api", marker = "extra == 'otel'", specifier = ">=1.30.0" },
+    { name = "opentelemetry-api", marker = "extra == 'pipecat'", specifier = ">=1.30.0" },
     { name = "opentelemetry-api", marker = "extra == 'strands-agents'", specifier = ">=1.30.0" },
     { name = "opentelemetry-exporter-otlp-proto-http", marker = "extra == 'otel'", specifier = ">=1.30.0" },
+    { name = "opentelemetry-exporter-otlp-proto-http", marker = "extra == 'pipecat'", specifier = ">=1.30.0" },
     { name = "opentelemetry-exporter-otlp-proto-http", marker = "extra == 'strands-agents'", specifier = ">=1.30.0" },
     { name = "opentelemetry-sdk", marker = "extra == 'otel'", specifier = ">=1.30.0" },
+    { name = "opentelemetry-sdk", marker = "extra == 'pipecat'", specifier = ">=1.30.0" },
     { name = "opentelemetry-sdk", marker = "extra == 'strands-agents'", specifier = ">=1.30.0" },
     { name = "orjson", marker = "platform_python_implementation != 'PyPy'", specifier = ">=3.9.14" },
     { name = "packaging", specifier = ">=23.2" },
+    { name = "pipecat-ai", marker = "python_full_version >= '3.11' and extra == 'pipecat'", specifier = ">=1.0" },
     { name = "pydantic", specifier = ">=2,<3" },
     { name = "pytest", marker = "extra == 'pytest'", specifier = ">=7.0.0" },
     { name = "requests", specifier = ">=2.0.0" },
@@ -1571,11 +1676,12 @@ requires-dist = [
     { name = "xxhash", specifier = ">=3.0.0" },
     { name = "zstandard", specifier = ">=0.23.0" },
 ]
-provides-extras = ["claude-agent-sdk", "google-adk", "langsmith-pyo3", "openai-agents", "otel", "pytest", "sandbox", "strands-agents", "vcr"]
+provides-extras = ["claude-agent-sdk", "google-adk", "langsmith-pyo3", "openai-agents", "otel", "pipecat", "pytest", "sandbox", "strands-agents", "vcr"]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "bump2version", specifier = ">=1.0.1" },
+    { name = "cachetools", specifier = ">=5.0.0" },
     { name = "claude-agent-sdk", marker = "python_full_version >= '3.10'", specifier = ">=0.1.0" },
     { name = "dataclasses-json", specifier = ">=0.6.4" },
     { name = "debugpy", specifier = ">=1.8.17" },
@@ -1743,6 +1849,60 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/15/1f/dc6771a52592a4451be6effa200cbfc9cec61e4393d3033d81a9d307961d/librt-0.11.0-cp314-cp314t-win32.whl", hash = "sha256:2b481d846ac894c4e8403c5fd0e87c5d11d6499e404b474602508a224ff531c8", size = 103562, upload-time = "2026-05-10T18:17:03.99Z" },
     { url = "https://files.pythonhosted.org/packages/62/4a/7d1415567027286a75ba1093ec4aca11f073e0f559c530cf3e0a757ad55c/librt-0.11.0-cp314-cp314t-win_amd64.whl", hash = "sha256:28edb433edde181112a908c78907af28f964eabc15f4dd16c9d66c834302677c", size = 124327, upload-time = "2026-05-10T18:17:05.465Z" },
     { url = "https://files.pythonhosted.org/packages/ce/62/b40b382fa0c66fee1478073eb8db352a4a6beda4a1adccf1df911d8c289c/librt-0.11.0-cp314-cp314t-win_arm64.whl", hash = "sha256:dee008f20b542e3cd162ba338a7f9ec0f6d23d395f66fe8aeeec3c9d067ea253", size = 102572, upload-time = "2026-05-10T18:17:06.809Z" },
+]
+
+[[package]]
+name = "llvmlite"
+version = "0.47.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/88/a8952b6d5c21e74cbf158515b779666f692846502623e9e3c39d8e8ba25f/llvmlite-0.47.0.tar.gz", hash = "sha256:62031ce968ec74e95092184d4b0e857e444f8fdff0b8f9213707699570c33ccc", size = 193614, upload-time = "2026-03-31T18:29:53.497Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/f5/a1bde3aa8c43524b0acaf3f72fb3d80a32dd29dbb42d7dc434f84584cdcc/llvmlite-0.47.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:41270b0b1310717f717cf6f2a9c68d3c43bd7905c33f003825aebc361d0d1b17", size = 37232772, upload-time = "2026-03-31T18:28:12.198Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/fb/76d88fc05ee1f9c1a6efe39eb493c4a727e5d1690412469017cd23bcb776/llvmlite-0.47.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f9d118bc1dd7623e0e65ca9ac485ec6dd543c3b77bc9928ddc45ebd34e1e30a7", size = 56275179, upload-time = "2026-03-31T18:28:15.725Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/08/29da7f36217abd56a0c389ef9a18bea47960826e691ced1a36c92c6ce93c/llvmlite-0.47.0-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9ea5cfb04a6ab5b18e46be72b41b015975ba5980c4ddb41f1975b83e19031063", size = 55128632, upload-time = "2026-03-31T18:28:19.946Z" },
+    { url = "https://files.pythonhosted.org/packages/df/f8/5e12e9ed447d65f04acf6fcf2d79cded2355640b5131a46cee4c99a5949d/llvmlite-0.47.0-cp310-cp310-win_amd64.whl", hash = "sha256:166b896a2262a2039d5fc52df5ee1659bd1ccd081183df7a2fba1b74702dd5ea", size = 38138402, upload-time = "2026-03-31T18:28:23.327Z" },
+    { url = "https://files.pythonhosted.org/packages/34/0b/b9d1911cfefa61399821dfb37f486d83e0f42630a8d12f7194270c417002/llvmlite-0.47.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:74090f0dcfd6f24ebbef3f21f11e38111c4d7e6919b54c4416e1e357c3446b07", size = 37232770, upload-time = "2026-03-31T18:28:26.765Z" },
+    { url = "https://files.pythonhosted.org/packages/46/27/5799b020e4cdfb25a7c951c06a96397c135efcdc21b78d853bbd9c814c7d/llvmlite-0.47.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ca14f02e29134e837982497959a8e2193d6035235de1cb41a9cb2bd6da4eedbb", size = 56275177, upload-time = "2026-03-31T18:28:31.01Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/51/48a53fedf01cb1f3f43ef200be17ebf83c8d9a04018d3783c1a226c342c2/llvmlite-0.47.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:12a69d4bb05f402f30477e21eeabe81911e7c251cecb192bed82cd83c9db10d8", size = 55128631, upload-time = "2026-03-31T18:28:36.046Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/50/59227d06bdc96e23322713c381af4e77420949d8cd8a042c79e0043096cc/llvmlite-0.47.0-cp311-cp311-win_amd64.whl", hash = "sha256:c37d6eb7aaabfa83ab9c2ff5b5cdb95a5e6830403937b2c588b7490724e05327", size = 38138400, upload-time = "2026-03-31T18:28:40.076Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/48/4b7fe0e34c169fa2f12532916133e0b219d2823b540733651b34fdac509a/llvmlite-0.47.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:306a265f408c259067257a732c8e159284334018b4083a9e35f67d19792b164f", size = 37232769, upload-time = "2026-03-31T18:28:43.735Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/4b/e3f2cd17822cf772a4a51a0a8080b0032e6d37b2dbe8cfb724eac4e31c52/llvmlite-0.47.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5853bf26160857c0c2573415ff4efe01c4c651e59e2c55c2a088740acfee51cd", size = 56275178, upload-time = "2026-03-31T18:28:48.342Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/55/a3b4a543185305a9bdf3d9759d53646ed96e55e7dfd43f53e7a421b8fbae/llvmlite-0.47.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:003bcf7fa579e14db59c1a1e113f93ab8a06b56a4be31c7f08264d1d4072d077", size = 55128632, upload-time = "2026-03-31T18:28:52.901Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/f5/d281ae0f79378a5a91f308ea9fdb9f9cc068fddd09629edc0725a5a8fde1/llvmlite-0.47.0-cp312-cp312-win_amd64.whl", hash = "sha256:f3079f25bdc24cd9d27c4b2b5e68f5f60c4fdb7e8ad5ee2b9b006007558f9df7", size = 38138692, upload-time = "2026-03-31T18:28:57.147Z" },
+    { url = "https://files.pythonhosted.org/packages/77/6f/4615353e016799f80fa52ccb270a843c413b22361fadda2589b2922fb9b0/llvmlite-0.47.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:a3c6a735d4e1041808434f9d440faa3d78d9b4af2ee64d05a66f351883b6ceec", size = 37232771, upload-time = "2026-03-31T18:29:01.324Z" },
+    { url = "https://files.pythonhosted.org/packages/31/b8/69f5565f1a280d032525878a86511eebed0645818492feeb169dfb20ae8e/llvmlite-0.47.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2699a74321189e812d476a43d6d7f652f51811e7b5aad9d9bba842a1c7927acb", size = 56275178, upload-time = "2026-03-31T18:29:05.748Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/da/b32cafcb926fb0ce2aa25553bf32cb8764af31438f40e2481df08884c947/llvmlite-0.47.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6c6951e2b29930227963e53ee152441f0e14be92e9d4231852102d986c761e40", size = 55128632, upload-time = "2026-03-31T18:29:11.235Z" },
+    { url = "https://files.pythonhosted.org/packages/46/9f/4898b44e4042c60fafcb1162dfb7014f6f15b1ec19bf29cfea6bf26df90d/llvmlite-0.47.0-cp313-cp313-win_amd64.whl", hash = "sha256:c2e9adf8698d813a9a5efb2d4370caf344dbc1e145019851fee6a6f319ba760e", size = 38138695, upload-time = "2026-03-31T18:29:15.43Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/d4/33c8af00f0bf6f552d74f3a054f648af2c5bc6bece97972f3bfadce4f5ec/llvmlite-0.47.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:de966c626c35c9dff5ae7bf12db25637738d0df83fc370cf793bc94d43d92d14", size = 37232773, upload-time = "2026-03-31T18:29:19.453Z" },
+    { url = "https://files.pythonhosted.org/packages/64/1d/a760e993e0c0ba6db38d46b9f48f6c7dceb8ac838824997fb9e25f97bc04/llvmlite-0.47.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ddbccff2aeaff8670368340a158abefc032fe9b3ccf7d9c496639263d00151aa", size = 56275176, upload-time = "2026-03-31T18:29:24.149Z" },
+    { url = "https://files.pythonhosted.org/packages/84/3b/e679bc3b29127182a7f4aa2d2e9e5bea42adb93fb840484147d59c236299/llvmlite-0.47.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d4a7b778a2e144fc64468fb9bf509ac1226c9813a00b4d7afea5d988c4e22fca", size = 55128631, upload-time = "2026-03-31T18:29:29.536Z" },
+    { url = "https://files.pythonhosted.org/packages/be/f7/19e2a09c62809c9e63bbd14ce71fb92c6ff7b7b3045741bb00c781efc3c9/llvmlite-0.47.0-cp314-cp314-win_amd64.whl", hash = "sha256:694e3c2cdc472ed2bd8bd4555ca002eec4310961dd58ef791d508f57b5cc4c94", size = 39153826, upload-time = "2026-03-31T18:29:33.681Z" },
+    { url = "https://files.pythonhosted.org/packages/40/a1/581a8c707b5e80efdbbe1dd94527404d33fe50bceb71f39d5a7e11bd57b7/llvmlite-0.47.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:92ec8a169a20b473c1c54d4695e371bde36489fc1efa3688e11e99beba0abf9c", size = 37232772, upload-time = "2026-03-31T18:29:37.952Z" },
+    { url = "https://files.pythonhosted.org/packages/11/03/16090dd6f74ba2b8b922276047f15962fbeea0a75d5601607edb301ba945/llvmlite-0.47.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fa1cbd800edd3b20bc141521f7fd45a6185a5b84109aa6855134e81397ffe72b", size = 56275178, upload-time = "2026-03-31T18:29:42.58Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/cb/0abf1dd4c5286a95ffe0c1d8c67aec06b515894a0dd2ac97f5e27b82ab0b/llvmlite-0.47.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f6725179b89f03b17dabe236ff3422cb8291b4c1bf40af152826dfd34e350ae8", size = 55128632, upload-time = "2026-03-31T18:29:46.939Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/79/d3bbab197e86e0ff4f9c07122895b66a3e0d024247fcff7f12c473cb36d9/llvmlite-0.47.0-cp314-cp314t-win_amd64.whl", hash = "sha256:6842cf6f707ec4be3d985a385ad03f72b2d724439e118fcbe99b2929964f0453", size = 39153839, upload-time = "2026-03-31T18:29:51.004Z" },
+]
+
+[[package]]
+name = "loguru"
+version = "0.7.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "python_full_version >= '3.11' and sys_platform == 'win32'" },
+    { name = "win32-setctime", marker = "python_full_version >= '3.11' and sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3a/05/a1dae3dffd1116099471c643b8924f5aa6524411dc6c63fdae648c4f1aca/loguru-0.7.3.tar.gz", hash = "sha256:19480589e77d47b8d85b2c827ad95d49bf31b0dcde16593892eb51dd18706eb6", size = 63559, upload-time = "2024-12-06T11:20:56.608Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/29/0348de65b8cc732daa3e33e67806420b2ae89bdce2b04af740289c5c6c8c/loguru-0.7.3-py3-none-any.whl", hash = "sha256:31a33c10c8e1e10422bfd431aeb5d351c7cf7fa671e3c4df004162264b28220c", size = 61595, upload-time = "2024-12-06T11:20:54.538Z" },
+]
+
+[[package]]
+name = "markdown"
+version = "3.10.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2b/f4/69fa6ed85ae003c2378ffa8f6d2e3234662abd02c10d216c0ba96081a238/markdown-3.10.2.tar.gz", hash = "sha256:994d51325d25ad8aa7ce4ebaec003febcce822c3f8c911e3b17c52f7f589f950", size = 368805, upload-time = "2026-02-09T14:57:26.942Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/1f/77fa3081e4f66ca3576c896ae5d31c3002ac6607f9747d2e3aa49227e464/markdown-3.10.2-py3-none-any.whl", hash = "sha256:e91464b71ae3ee7afd3017d9f358ef0baf158fd9a298db92f1d4761133824c36", size = 108180, upload-time = "2026-02-09T14:57:25.787Z" },
 ]
 
 [[package]]
@@ -2041,6 +2201,57 @@ wheels = [
 ]
 
 [[package]]
+name = "nltk"
+version = "3.9.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click", marker = "python_full_version >= '3.11'" },
+    { name = "joblib", marker = "python_full_version >= '3.11'" },
+    { name = "regex", marker = "python_full_version >= '3.11'" },
+    { name = "tqdm", marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/74/a1/b3b4adf15585a5bc4c357adde150c01ebeeb642173ded4d871e89468767c/nltk-3.9.4.tar.gz", hash = "sha256:ed03bc098a40481310320808b2db712d95d13ca65b27372f8a403949c8b523d0", size = 2946864, upload-time = "2026-03-24T06:13:40.641Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/91/04e965f8e717ba0ab4bdca5c112deeab11c9e750d94c4d4602f050295d39/nltk-3.9.4-py3-none-any.whl", hash = "sha256:f2fa301c3a12718ce4a0e9305c5675299da5ad9e26068218b69d692fda84828f", size = 1552087, upload-time = "2026-03-24T06:13:38.47Z" },
+]
+
+[[package]]
+name = "numba"
+version = "0.65.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "llvmlite", marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f6/c5/db2ac3685833d626c0dcae6bd2330cd68433e1fd248d15f70998160d3ad7/numba-0.65.1.tar.gz", hash = "sha256:19357146c32fe9ed25059ab915e8465fb13951cf6b0aace3826b76886373ab23", size = 2765600, upload-time = "2026-04-24T02:02:56.551Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/1b/3c5a7daf683a95465bf23504bcd1a2d5db8cd5e5e276ca87505d020dffe9/numba-0.65.1-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:9d993ed0a257aa4116e6f553f114004bcfdee540c7276ab8ea48f650d514c452", size = 2680870, upload-time = "2026-04-24T02:02:10.623Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/a4/1831836814018a898e7d252aebe09c0f3ce1f26d145b68264b4ae0be6822/numba-0.65.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5f098109f361681e57295f7e84d8ab2426902539a141811de0703ace52826981", size = 3739780, upload-time = "2026-04-24T02:02:13.097Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/1b/a813ddc81def09e257d2b1f67521982ce4b06204a87268796ffc8187271c/numba-0.65.1-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:973fd8173f2312815e6b7aaae887c4ce8a817eeff46a4f8840b828305b75bc95", size = 3446722, upload-time = "2026-04-24T02:02:15.083Z" },
+    { url = "https://files.pythonhosted.org/packages/09/52/ee1d8b3becda384fe0552221641e05aa668a35e8a77470db4db7f6475000/numba-0.65.1-cp310-cp310-win_amd64.whl", hash = "sha256:c63aa0c4193694026452da55d0ef9d85156c1a7a333454c103bb30dec81b7bf8", size = 2747539, upload-time = "2026-04-24T02:02:16.79Z" },
+    { url = "https://files.pythonhosted.org/packages/96/b3/650500c2eab4534d98e9166f4298e0f3c69c742afdf24e6eabccd1f16ad8/numba-0.65.1-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:7020d74b19cdb8cff16506542fdd510756e28c5e7f3bd0b7f574f0f42272fcd9", size = 2680563, upload-time = "2026-04-24T02:02:18.414Z" },
+    { url = "https://files.pythonhosted.org/packages/44/0b/0615dbedb98f5b32a35a53290fbdc6e22306968109278d7e58df82d7a9f6/numba-0.65.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f80ed83774b5173abd6581cd8d2165d1d38e13d2e5c8155c0c0b421784745420", size = 3745018, upload-time = "2026-04-24T02:02:20.252Z" },
+    { url = "https://files.pythonhosted.org/packages/49/aa/4361698f35bf63bff67dfe6c90493731177f48ede954f77b0588731537bc/numba-0.65.1-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7ed425a43b0a5f9772f2f4e2dd0bbd12eabecae1af0b24efcfd4e053f012aac6", size = 3450962, upload-time = "2026-04-24T02:02:22.449Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9a/af61ec03b3116c161fd7a06b9e8a265729a8718458333e8ffbb06d9a3978/numba-0.65.1-cp311-cp311-win_amd64.whl", hash = "sha256:df40a5028a975b9ea66f6a2a3f7abbdbd541a863070e34ed367aff21141248e4", size = 2747417, upload-time = "2026-04-24T02:02:24.43Z" },
+    { url = "https://files.pythonhosted.org/packages/57/bc/76f8f8c5cf9adee47fdb7bbb03be8900f76f902d451d7477cf12b845e1de/numba-0.65.1-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:ac3f1e77c352dd0ea9712732c2d8f9ca507717435eec5b5013bf138ac33c4a08", size = 2681371, upload-time = "2026-04-24T02:02:26.105Z" },
+    { url = "https://files.pythonhosted.org/packages/69/47/a415af0283e4db0398104c6d1c11c9861a98dc67a7aa442a7769ed5d6196/numba-0.65.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:52bc6f3ceb8fcaff9b2ae26b4c6b1e9fee39db8d355534c0fe4f39a901246b84", size = 3802467, upload-time = "2026-04-24T02:02:27.712Z" },
+    { url = "https://files.pythonhosted.org/packages/46/36/246f73ec99cfeab2f2cb2ce7d4218766cc36a2da418901223f4f4da9c813/numba-0.65.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:90ca10b3463bae0bd70589726fe3c77d01d6b5fc86bee54bcdf9fb6b47c28977", size = 3502628, upload-time = "2026-04-24T02:02:29.763Z" },
+    { url = "https://files.pythonhosted.org/packages/db/9e/3c679b2ee078425b9e99a91e44f8d132a6830d8ccce5227bc5e9181aeed8/numba-0.65.1-cp312-cp312-win_amd64.whl", hash = "sha256:5971c632be2a2351500431f46213821dba8d02b18a9f7d02fd36bd2743e41a6a", size = 2750611, upload-time = "2026-04-24T02:02:31.477Z" },
+    { url = "https://files.pythonhosted.org/packages/79/37/14a4579049c1eb673afd0de0cb4842982acd55b9ce2643e763db858bcea0/numba-0.65.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:1735c15c1134a5108b4d6a5c77fc0947924ea066a738dc09a52008c13df9cad3", size = 2681344, upload-time = "2026-04-24T02:02:33.65Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/22/b8d873f6466b20aa563fc9b33acd48dec89a07803ddaa2f1c8ca1cd33126/numba-0.65.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c09f49117ef255e1f1c6dad0c7a1ed39868243862a73be5706793241a3755f1b", size = 3810619, upload-time = "2026-04-24T02:02:36.041Z" },
+    { url = "https://files.pythonhosted.org/packages/62/08/e16a8b5d9a018962ebb5c66be662317cde32b9f5dab08441f90bed5522fb/numba-0.65.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:594a8680b3fadac99e97e489b1fd89007177e5336713745c3b769528c635a464", size = 3509783, upload-time = "2026-04-24T02:02:38.245Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/a5/03c970d57f4c1741354837353ce39fb5206952ae1dba8922d29c86f64805/numba-0.65.1-cp313-cp313-win_amd64.whl", hash = "sha256:85be74c0d036842699a30058f82fb88fc5ffdc59f7615cab5792ea92914c9b62", size = 2750534, upload-time = "2026-04-24T02:02:39.903Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/2e/8aed9b726d9ba5f11ad287645fd479e88278db3060a25cb1225d730eb2b7/numba-0.65.1-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:33f5eb68eb1c843511615d14663ce60258525d6a4c65ab040e2c2b0c4cf17450", size = 2681554, upload-time = "2026-04-24T02:02:41.812Z" },
+    { url = "https://files.pythonhosted.org/packages/87/96/f3eb235fafa82a34e2ab5dd7dc9ffff998ebf5f0bbc23fa56a96aeb44da6/numba-0.65.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:71e73029bf53a62cc6afcf96be4bd942290d8b4c55f0a454fb536158115790f7", size = 3779602, upload-time = "2026-04-24T02:02:43.726Z" },
+    { url = "https://files.pythonhosted.org/packages/09/90/b0f09b48752d23640b8284f22aa597737e8adaddc7fbfacc4708b7f73a4c/numba-0.65.1-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a07635e0be926b9bdbffb09137c230fb13f6ec0e564914ba937cee12ce3eb35", size = 3479532, upload-time = "2026-04-24T02:02:45.427Z" },
+    { url = "https://files.pythonhosted.org/packages/56/46/3f7fc04fb853559e74b210e0b62c19974ec844cefec611f9e535f4da3761/numba-0.65.1-cp314-cp314-win_amd64.whl", hash = "sha256:2a20fcdabdefbdacf88d85caf70c3b18c4bcb7ebb8f82e6a19486383dd26ab63", size = 2752637, upload-time = "2026-04-24T02:02:47.664Z" },
+    { url = "https://files.pythonhosted.org/packages/81/7b/c1a341a9067367778f4152a5f01061cf281fb09582c92c510ec4918cabf6/numba-0.65.1-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:548dd4b3a4508d5062768d1514b2cd7b015f9a25ec7af651c50dee243965e652", size = 2684600, upload-time = "2026-04-24T02:02:49.653Z" },
+    { url = "https://files.pythonhosted.org/packages/03/36/98ddbcf3e4f04a6dd07e1c67249955920579ba4af6bb6868e3088f4ed282/numba-0.65.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:78abc28feff2c2ff8307fff3975b6438352759c9acb797ecd6b1fb6e7e39e31d", size = 3817198, upload-time = "2026-04-24T02:02:51.266Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/83/0dad21057ece5a835599f5d24099b091703995e23dbbf894f259e91c010b/numba-0.65.1-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee7676cb389555805f9b9a1840cbcd1ea6c8bd5376ab6918e3a29c5ea1dbda20", size = 3533862, upload-time = "2026-04-24T02:02:52.987Z" },
+    { url = "https://files.pythonhosted.org/packages/32/36/8be7118ffd4c8440881046eac3d0982cc5ab42909508cf5d67024d62a2e4/numba-0.65.1-cp314-cp314t-win_amd64.whl", hash = "sha256:20609346e3bd75204950dcbbfe383a8d7dbf4902f442aedbf00f97fef4aa8f38", size = 2758237, upload-time = "2026-04-24T02:02:54.612Z" },
+]
+
+[[package]]
 name = "numpy"
 version = "2.2.6"
 source = { registry = "https://pypi.org/simple" }
@@ -2113,7 +2324,8 @@ resolution-markers = [
     "python_full_version >= '3.15'",
     "python_full_version == '3.14.*'",
     "python_full_version == '3.13.*'",
-    "python_full_version >= '3.11' and python_full_version < '3.13'",
+    "python_full_version == '3.12.*'",
+    "python_full_version == '3.11.*'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d7/9f/b8cef5bffa569759033adda9481211426f12f53299629b410340795c2514/numpy-2.4.4.tar.gz", hash = "sha256:2d390634c5182175533585cc89f3608a4682ccb173cc9bb940b2881c8d6f8fa0", size = 20731587, upload-time = "2026-03-29T13:22:01.298Z" }
 wheels = [
@@ -2188,6 +2400,44 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/a8/379542d45a14f149444c5c4c4e7714707239ce9cc1de8c2803958889da14/numpy-2.4.4-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:19710a9ca9992d7174e9c52f643d4272dcd1558c5f7af7f6f8190f633bd651a7", size = 15804253, upload-time = "2026-03-29T13:21:50.753Z" },
     { url = "https://files.pythonhosted.org/packages/a2/c8/f0a45426d6d21e7ea3310a15cf90c43a14d9232c31a837702dba437f3373/numpy-2.4.4-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9b2aec6af35c113b05695ebb5749a787acd63cafc83086a05771d1e1cd1e555f", size = 16753552, upload-time = "2026-03-29T13:21:54.344Z" },
     { url = "https://files.pythonhosted.org/packages/04/74/f4c001f4714c3ad9ce037e18cf2b9c64871a84951eaa0baf683a9ca9301c/numpy-2.4.4-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:f2cf083b324a467e1ab358c105f6cad5ea950f50524668a80c486ff1db24e119", size = 12509075, upload-time = "2026-03-29T13:21:57.644Z" },
+]
+
+[[package]]
+name = "onnxruntime"
+version = "1.24.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "flatbuffers", marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "packaging", marker = "python_full_version >= '3.11'" },
+    { name = "protobuf", marker = "python_full_version >= '3.11'" },
+    { name = "sympy", marker = "python_full_version >= '3.11'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/69/6c40720201012c6af9aa7d4ecdd620e521bd806dc6269d636fdd5c5aeebe/onnxruntime-1.24.4-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:0bdfce8e9a6497cec584aab407b71bf697dac5e1b7b7974adc50bf7533bdb3a2", size = 17332131, upload-time = "2026-03-17T22:05:49.005Z" },
+    { url = "https://files.pythonhosted.org/packages/38/e9/8c901c150ce0c368da38638f44152fb411059c0c7364b497c9e5c957321a/onnxruntime-1.24.4-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:046ff290045a387676941a02a8ae5c3ebec6b4f551ae228711968c4a69d8f6b7", size = 15152472, upload-time = "2026-03-17T22:03:26.176Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/b6/7a4df417cdd01e8f067a509e123ac8b31af450a719fa7ed81787dd6057ec/onnxruntime-1.24.4-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e54ad52e61d2d4618dcff8fa1480ac66b24ee2eab73331322db1049f11ccf330", size = 17222993, upload-time = "2026-03-17T22:04:34.485Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/59/8febe015f391aa1757fa5ba82c759ea4b6c14ef970132efb5e316665ba61/onnxruntime-1.24.4-cp311-cp311-win_amd64.whl", hash = "sha256:b43b63eb24a2bc8fc77a09be67587a570967a412cccb837b6245ccb546691153", size = 12594863, upload-time = "2026-03-17T22:05:38.749Z" },
+    { url = "https://files.pythonhosted.org/packages/32/84/4155fcd362e8873eb6ce305acfeeadacd9e0e59415adac474bea3d9281bb/onnxruntime-1.24.4-cp311-cp311-win_arm64.whl", hash = "sha256:e26478356dba25631fb3f20112e345f8e8bf62c499bb497e8a559f7d69cf7e7b", size = 12259895, upload-time = "2026-03-17T22:05:28.812Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/38/31db1b232b4ba960065a90c1506ad7a56995cd8482033184e97fadca17cc/onnxruntime-1.24.4-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:cad1c2b3f455c55678ab2a8caa51fb420c25e6e3cf10f4c23653cdabedc8de78", size = 17341875, upload-time = "2026-03-17T22:05:51.669Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/60/c4d1c8043eb42f8a9aa9e931c8c293d289c48ff463267130eca97d13357f/onnxruntime-1.24.4-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1a5c5a544b22f90859c88617ecb30e161ee3349fcc73878854f43d77f00558b5", size = 15172485, upload-time = "2026-03-17T22:03:32.182Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/ab/5b68110e0460d73fad814d5bd11c7b1ddcce5c37b10177eb264d6a36e331/onnxruntime-1.24.4-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0d640eb9f3782689b55cfa715094474cd5662f2f137be6a6f847a594b6e9705c", size = 17244912, upload-time = "2026-03-17T22:04:37.251Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/f4/6b89e297b93704345f0f3f8c62229bee323ef25682a3f9b4f89a39324950/onnxruntime-1.24.4-cp312-cp312-win_amd64.whl", hash = "sha256:535b29475ca42b593c45fbb2152fbf1cdf3f287315bf650e6a724a0a1d065cdb", size = 12596856, upload-time = "2026-03-17T22:05:41.224Z" },
+    { url = "https://files.pythonhosted.org/packages/43/06/8b8ec6e9e6a474fcd5d772453f627ad4549dfe3ab8c0bf70af5afcde551b/onnxruntime-1.24.4-cp312-cp312-win_arm64.whl", hash = "sha256:e6214096e14b7b52e3bee1903dc12dc7ca09cb65e26664668a4620cc5e6f9a90", size = 12270275, upload-time = "2026-03-17T22:05:31.132Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/f0/8a21ec0a97e40abb7d8da1e8b20fb9e1af509cc6d191f6faa75f73622fb2/onnxruntime-1.24.4-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:e99a48078baaefa2b50fe5836c319499f71f13f76ed32d0211f39109147a49e0", size = 17341922, upload-time = "2026-03-17T22:03:56.364Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/25/d7908de8e08cee9abfa15b8aa82349b79733ae5865162a3609c11598805d/onnxruntime-1.24.4-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dc4aaed1e5e1aaacf2343c838a30a7c3ade78f13eeb16817411f929d04040a13", size = 15172290, upload-time = "2026-03-17T22:03:37.124Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/72/105ec27a78c5aa0154a7c0cd8c41c19a97799c3b12fc30392928997e3be3/onnxruntime-1.24.4-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e30c972bc02e072911aabb6891453ec73795386c0af2b761b65444b8a4c4745f", size = 17244738, upload-time = "2026-03-17T22:04:40.625Z" },
+    { url = "https://files.pythonhosted.org/packages/05/fb/a592736d968c2f58e12de4d52088dda8e0e724b26ad5c0487263adb45875/onnxruntime-1.24.4-cp313-cp313-win_amd64.whl", hash = "sha256:3b6ba8b0181a3aa88edab00eb01424ffc06f42e71095a91186c2249415fcff93", size = 12597435, upload-time = "2026-03-17T22:05:43.826Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/04/ae2479e9841b64bd2eb44f8a64756c62593f896514369a11243b1b86ca5c/onnxruntime-1.24.4-cp313-cp313-win_arm64.whl", hash = "sha256:71d6a5c1821d6e8586a024000ece458db8f2fc0ecd050435d45794827ce81e19", size = 12269852, upload-time = "2026-03-17T22:05:33.353Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/af/a479a536c4398ffaf49fbbe755f45d5b8726bdb4335ab31b537f3d7149b8/onnxruntime-1.24.4-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1700f559c8086d06b2a4d5de51e62cb4ff5e2631822f71a36db8c72383db71ee", size = 15176861, upload-time = "2026-03-17T22:03:40.143Z" },
+    { url = "https://files.pythonhosted.org/packages/be/13/19f5da70c346a76037da2c2851ecbf1266e61d7f0dcdb887c667210d4608/onnxruntime-1.24.4-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4c74e268dc808e61e63784d43f9ddcdaf50a776c2819e8bd1d1b11ef64bf7e36", size = 17247454, upload-time = "2026-03-17T22:04:46.643Z" },
+    { url = "https://files.pythonhosted.org/packages/89/db/b30dbbd6037847b205ab75d962bc349bf1e46d02a65b30d7047a6893ffd6/onnxruntime-1.24.4-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:fbff2a248940e3398ae78374c5a839e49a2f39079b488bc64439fa0ec327a3e4", size = 17343300, upload-time = "2026-03-17T22:03:59.223Z" },
+    { url = "https://files.pythonhosted.org/packages/61/88/1746c0e7959961475b84c776d35601a21d445f463c93b1433a409ec3e188/onnxruntime-1.24.4-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e2b7969e72d8cb53ffc88ab6d49dd5e75c1c663bda7be7eb0ece192f127343d1", size = 15175936, upload-time = "2026-03-17T22:03:43.671Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/ba/4699cde04a52cece66cbebc85bd8335a0d3b9ad485abc9a2e15946a1349d/onnxruntime-1.24.4-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:14ed1f197fab812b695a5eaddb536c635e58a2fbbe50a517c78f082cc6ce9177", size = 17246432, upload-time = "2026-03-17T22:04:49.58Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/60/4590910841bb28bd3b4b388a9efbedf4e2d2cca99ddf0c863642b4e87814/onnxruntime-1.24.4-cp314-cp314-win_amd64.whl", hash = "sha256:311e309f573bf3c12aa5723e23823077f83d5e412a18499d4485c7eb41040858", size = 12903276, upload-time = "2026-03-17T22:05:46.349Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/6f/60e2c0acea1e1ac09b3e794b5a19c166eebf91c0b860b3e6db8e74983fda/onnxruntime-1.24.4-cp314-cp314-win_arm64.whl", hash = "sha256:3f0b910e86b759a4732663ec61fd57ac42ee1b0066f68299de164220b660546d", size = 12594365, upload-time = "2026-03-17T22:05:35.795Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/68/0c05d10f8f6c40fe0912ebec0d5a33884aaa2af2053507e864dab0883208/onnxruntime-1.24.4-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:aa12ddc54c9c4594073abcaa265cd9681e95fb89dae982a6f508a794ca42e661", size = 15176889, upload-time = "2026-03-17T22:03:48.021Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/1d/1666dc64e78d8587d168fec4e3b7922b92eb286a2ddeebcf6acb55c7dc82/onnxruntime-1.24.4-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e1cc6a518255f012134bc791975a6294806be9a3b20c4a54cca25194c90cf731", size = 17247021, upload-time = "2026-03-17T22:04:52.377Z" },
 ]
 
 [[package]]
@@ -2453,7 +2703,8 @@ resolution-markers = [
     "python_full_version >= '3.15'",
     "python_full_version == '3.14.*'",
     "python_full_version == '3.13.*'",
-    "python_full_version >= '3.11' and python_full_version < '3.13'",
+    "python_full_version == '3.12.*'",
+    "python_full_version == '3.11.*'",
 ]
 dependencies = [
     { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
@@ -2568,6 +2819,39 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c3/28/ec0fc38107fc32536908034e990c47914c57cd7c5a3ece4d8d8f7ffd7e27/pillow-12.2.0-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4a6c9fa44005fa37a91ebfc95d081e8079757d2e904b27103f4f5fa6f0bf78c0", size = 5355404, upload-time = "2026-04-01T14:46:06.33Z" },
     { url = "https://files.pythonhosted.org/packages/5e/8b/51b0eddcfa2180d60e41f06bd6d0a62202b20b59c68f5a132e615b75aecf/pillow-12.2.0-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:25373b66e0dd5905ed63fa3cae13c82fbddf3079f2c8bf15c6fb6a35586324c1", size = 6002215, upload-time = "2026-04-01T14:46:08.83Z" },
     { url = "https://files.pythonhosted.org/packages/bc/60/5382c03e1970de634027cee8e1b7d39776b778b81812aaf45b694dfe9e28/pillow-12.2.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:bfa9c230d2fe991bed5318a5f119bd6780cda2915cca595393649fc118ab895e", size = 7080946, upload-time = "2026-04-01T14:46:11.734Z" },
+]
+
+[[package]]
+name = "pipecat-ai"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiofiles", marker = "python_full_version >= '3.11'" },
+    { name = "aiohttp", marker = "python_full_version >= '3.11'" },
+    { name = "audioop-lts", marker = "python_full_version >= '3.13'" },
+    { name = "docstring-parser", marker = "python_full_version >= '3.11'" },
+    { name = "loguru", marker = "python_full_version >= '3.11'" },
+    { name = "markdown", marker = "python_full_version >= '3.11'" },
+    { name = "nltk", marker = "python_full_version >= '3.11'" },
+    { name = "numba", marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "onnxruntime", marker = "python_full_version >= '3.11'" },
+    { name = "openai", marker = "python_full_version >= '3.11'" },
+    { name = "pillow", marker = "python_full_version >= '3.11'" },
+    { name = "protobuf", marker = "python_full_version >= '3.11'" },
+    { name = "pydantic", marker = "python_full_version >= '3.11'" },
+    { name = "pyloudnorm", marker = "python_full_version >= '3.11'" },
+    { name = "pyyaml", marker = "python_full_version >= '3.11'" },
+    { name = "pyyaml-include", marker = "python_full_version >= '3.11'" },
+    { name = "resampy", marker = "python_full_version >= '3.11'" },
+    { name = "soxr", marker = "python_full_version >= '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.11'" },
+    { name = "wait-for2", marker = "python_full_version == '3.11.*'" },
+    { name = "websockets", marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d5/ed/4bcf67703996ac6a0896dc64232e79fdfcb23eccff36929a7a234587a085/pipecat_ai-1.4.0.tar.gz", hash = "sha256:4d1e68da79e0632dcdaf66581fbf07e840249dfb715dc6e57b423d20fc3520d7", size = 11505429, upload-time = "2026-06-17T03:27:48.83Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/ab/9acf81effd93f6f6d1ededbe5db8fedb50d196363d75188dc21d8aa71d5a/pipecat_ai-1.4.0-py3-none-any.whl", hash = "sha256:d7e1f2ee6f2646720daed3a028835d0e26e5e93787d0424ab00f4c7b6034a170", size = 11171447, upload-time = "2026-06-17T03:27:46.367Z" },
 ]
 
 [[package]]
@@ -2965,6 +3249,20 @@ crypto = [
 ]
 
 [[package]]
+name = "pyloudnorm"
+version = "0.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "scipy", version = "1.18.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/23/00/f915eaa75326f4209941179c2b93ac477f2040e4aeff5bb21d16eb8058f9/pyloudnorm-0.2.0.tar.gz", hash = "sha256:8bf597658ea4e1975c275adf490f6deb5369ea409f2901f939915efa4b681b16", size = 14037, upload-time = "2026-01-04T11:43:35.265Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/aa/b6/65a49a05614b2548edbba3aab118f2ebe7441dfd778accdcdce9f6567f20/pyloudnorm-0.2.0-py3-none-any.whl", hash = "sha256:9bb69afb904f59d007a7f9ba3d75d16fb8aeef35c44d6df822a9f192d69cf13f", size = 10879, upload-time = "2026-01-04T11:43:34.534Z" },
+]
+
+[[package]]
 name = "pyopenssl"
 version = "26.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3266,6 +3564,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pyyaml-include"
+version = "1.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml", marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7f/be/2d07ad85e3d593d69640876a8686eae2c533db8cb7bf298d25c421b4d2d5/pyyaml-include-1.4.1.tar.gz", hash = "sha256:1a96e33a99a3e56235f5221273832464025f02ff3d8539309a3bf00dec624471", size = 20592, upload-time = "2024-03-25T14:56:43.748Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d5/ca/6a2cc3a73170d10b5af1f1613baa2ed1f8f46f62dd0bfab2bffd2c2fe260/pyyaml_include-1.4.1-py3-none-any.whl", hash = "sha256:323c7f3a19c82fbc4d73abbaab7ef4f793e146a13383866831631b26ccc7fb00", size = 19079, upload-time = "2024-03-25T14:56:41.274Z" },
+]
+
+[[package]]
 name = "referencing"
 version = "0.37.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3425,6 +3735,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f3/61/d7545dafb7ac2230c70d38d31cbfe4cc64f7144dc41f6e4e4b78ecd9f5bb/requests-toolbelt-1.0.0.tar.gz", hash = "sha256:7681a0a3d047012b5bdc0ee37d7f8f07ebe76ab08caeccfc3921ce23c88d5bc6", size = 206888, upload-time = "2023-05-01T04:11:33.229Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3f/51/d4db610ef29373b879047326cbf6fa98b6c1969d6f6dc423279de2b1be2c/requests_toolbelt-1.0.0-py2.py3-none-any.whl", hash = "sha256:cccfdd665f0a24fcf4726e690f65639d272bb0637b9b92dfd91a5568ccf6bd06", size = 54481, upload-time = "2023-05-01T04:11:28.427Z" },
+]
+
+[[package]]
+name = "resampy"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numba", marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/29/f1/34be702a69a5d272e844c98cee82351f880985cfbca0cc86378011078497/resampy-0.4.3.tar.gz", hash = "sha256:a0d1c28398f0e55994b739650afef4e3974115edbe96cd4bb81968425e916e47", size = 3080604, upload-time = "2024-03-05T20:36:08.119Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4d/b9/3b00ac340a1aab3389ebcc52c779914a44aadf7b0cb7a3bf053195735607/resampy-0.4.3-py3-none-any.whl", hash = "sha256:ad2ed64516b140a122d96704e32bc0f92b23f45419e8b8f478e5a05f83edcebd", size = 3076529, upload-time = "2024-03-05T20:36:02.439Z" },
 ]
 
 [[package]]
@@ -3600,6 +3923,137 @@ wheels = [
 ]
 
 [[package]]
+name = "scipy"
+version = "1.17.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.11.*'",
+]
+dependencies = [
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/75/b4ce781849931fef6fd529afa6b63711d5a733065722d0c3e2724af9e40a/scipy-1.17.1-cp311-cp311-macosx_10_14_x86_64.whl", hash = "sha256:1f95b894f13729334fb990162e911c9e5dc1ab390c58aa6cbecb389c5b5e28ec", size = 31613675, upload-time = "2026-02-23T00:16:00.13Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/58/bccc2861b305abdd1b8663d6130c0b3d7cc22e8d86663edbc8401bfd40d4/scipy-1.17.1-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:e18f12c6b0bc5a592ed23d3f7b891f68fd7f8241d69b7883769eb5d5dfb52696", size = 28162057, upload-time = "2026-02-23T00:16:09.456Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/ee/18146b7757ed4976276b9c9819108adbc73c5aad636e5353e20746b73069/scipy-1.17.1-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:a3472cfbca0a54177d0faa68f697d8ba4c80bbdc19908c3465556d9f7efce9ee", size = 20334032, upload-time = "2026-02-23T00:16:17.358Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/e6/cef1cf3557f0c54954198554a10016b6a03b2ec9e22a4e1df734936bd99c/scipy-1.17.1-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:766e0dc5a616d026a3a1cffa379af959671729083882f50307e18175797b3dfd", size = 22709533, upload-time = "2026-02-23T00:16:25.791Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/60/8804678875fc59362b0fb759ab3ecce1f09c10a735680318ac30da8cd76b/scipy-1.17.1-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:744b2bf3640d907b79f3fd7874efe432d1cf171ee721243e350f55234b4cec4c", size = 33062057, upload-time = "2026-02-23T00:16:36.931Z" },
+    { url = "https://files.pythonhosted.org/packages/09/7d/af933f0f6e0767995b4e2d705a0665e454d1c19402aa7e895de3951ebb04/scipy-1.17.1-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:43af8d1f3bea642559019edfe64e9b11192a8978efbd1539d7bc2aaa23d92de4", size = 35349300, upload-time = "2026-02-23T00:16:49.108Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/3d/7ccbbdcbb54c8fdc20d3b6930137c782a163fa626f0aef920349873421ba/scipy-1.17.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:cd96a1898c0a47be4520327e01f874acfd61fb48a9420f8aa9f6483412ffa444", size = 35127333, upload-time = "2026-02-23T00:17:01.293Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/19/f926cb11c42b15ba08e3a71e376d816ac08614f769b4f47e06c3580c836a/scipy-1.17.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:4eb6c25dd62ee8d5edf68a8e1c171dd71c292fdae95d8aeb3dd7d7de4c364082", size = 37741314, upload-time = "2026-02-23T00:17:12.576Z" },
+    { url = "https://files.pythonhosted.org/packages/95/da/0d1df507cf574b3f224ccc3d45244c9a1d732c81dcb26b1e8a766ae271a8/scipy-1.17.1-cp311-cp311-win_amd64.whl", hash = "sha256:d30e57c72013c2a4fe441c2fcb8e77b14e152ad48b5464858e07e2ad9fbfceff", size = 36607512, upload-time = "2026-02-23T00:17:23.424Z" },
+    { url = "https://files.pythonhosted.org/packages/68/7f/bdd79ceaad24b671543ffe0ef61ed8e659440eb683b66f033454dcee90eb/scipy-1.17.1-cp311-cp311-win_arm64.whl", hash = "sha256:9ecb4efb1cd6e8c4afea0daa91a87fbddbce1b99d2895d151596716c0b2e859d", size = 24599248, upload-time = "2026-02-23T00:17:34.561Z" },
+    { url = "https://files.pythonhosted.org/packages/35/48/b992b488d6f299dbe3f11a20b24d3dda3d46f1a635ede1c46b5b17a7b163/scipy-1.17.1-cp312-cp312-macosx_10_14_x86_64.whl", hash = "sha256:35c3a56d2ef83efc372eaec584314bd0ef2e2f0d2adb21c55e6ad5b344c0dcb8", size = 31610954, upload-time = "2026-02-23T00:17:49.855Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/02/cf107b01494c19dc100f1d0b7ac3cc08666e96ba2d64db7626066cee895e/scipy-1.17.1-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:fcb310ddb270a06114bb64bbe53c94926b943f5b7f0842194d585c65eb4edd76", size = 28172662, upload-time = "2026-02-23T00:18:01.64Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/a9/599c28631bad314d219cf9ffd40e985b24d603fc8a2f4ccc5ae8419a535b/scipy-1.17.1-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:cc90d2e9c7e5c7f1a482c9875007c095c3194b1cfedca3c2f3291cdc2bc7c086", size = 20344366, upload-time = "2026-02-23T00:18:12.015Z" },
+    { url = "https://files.pythonhosted.org/packages/35/f5/906eda513271c8deb5af284e5ef0206d17a96239af79f9fa0aebfe0e36b4/scipy-1.17.1-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:c80be5ede8f3f8eded4eff73cc99a25c388ce98e555b17d31da05287015ffa5b", size = 22704017, upload-time = "2026-02-23T00:18:21.502Z" },
+    { url = "https://files.pythonhosted.org/packages/da/34/16f10e3042d2f1d6b66e0428308ab52224b6a23049cb2f5c1756f713815f/scipy-1.17.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e19ebea31758fac5893a2ac360fedd00116cbb7628e650842a6691ba7ca28a21", size = 32927842, upload-time = "2026-02-23T00:18:35.367Z" },
+    { url = "https://files.pythonhosted.org/packages/01/8e/1e35281b8ab6d5d72ebe9911edcdffa3f36b04ed9d51dec6dd140396e220/scipy-1.17.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:02ae3b274fde71c5e92ac4d54bc06c42d80e399fec704383dcd99b301df37458", size = 35235890, upload-time = "2026-02-23T00:18:49.188Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/5c/9d7f4c88bea6e0d5a4f1bc0506a53a00e9fcb198de372bfe4d3652cef482/scipy-1.17.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8a604bae87c6195d8b1045eddece0514d041604b14f2727bbc2b3020172045eb", size = 35003557, upload-time = "2026-02-23T00:18:54.74Z" },
+    { url = "https://files.pythonhosted.org/packages/65/94/7698add8f276dbab7a9de9fb6b0e02fc13ee61d51c7c3f85ac28b65e1239/scipy-1.17.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:f590cd684941912d10becc07325a3eeb77886fe981415660d9265c4c418d0bea", size = 37625856, upload-time = "2026-02-23T00:19:00.307Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/84/dc08d77fbf3d87d3ee27f6a0c6dcce1de5829a64f2eae85a0ecc1f0daa73/scipy-1.17.1-cp312-cp312-win_amd64.whl", hash = "sha256:41b71f4a3a4cab9d366cd9065b288efc4d4f3c0b37a91a8e0947fb5bd7f31d87", size = 36549682, upload-time = "2026-02-23T00:19:07.67Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/98/fe9ae9ffb3b54b62559f52dedaebe204b408db8109a8c66fdd04869e6424/scipy-1.17.1-cp312-cp312-win_arm64.whl", hash = "sha256:f4115102802df98b2b0db3cce5cb9b92572633a1197c77b7553e5203f284a5b3", size = 24547340, upload-time = "2026-02-23T00:19:12.024Z" },
+    { url = "https://files.pythonhosted.org/packages/76/27/07ee1b57b65e92645f219b37148a7e7928b82e2b5dbeccecb4dff7c64f0b/scipy-1.17.1-cp313-cp313-macosx_10_14_x86_64.whl", hash = "sha256:5e3c5c011904115f88a39308379c17f91546f77c1667cea98739fe0fccea804c", size = 31590199, upload-time = "2026-02-23T00:19:17.192Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/ae/db19f8ab842e9b724bf5dbb7db29302a91f1e55bc4d04b1025d6d605a2c5/scipy-1.17.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:6fac755ca3d2c3edcb22f479fceaa241704111414831ddd3bc6056e18516892f", size = 28154001, upload-time = "2026-02-23T00:19:22.241Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/58/3ce96251560107b381cbd6e8413c483bbb1228a6b919fa8652b0d4090e7f/scipy-1.17.1-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:7ff200bf9d24f2e4d5dc6ee8c3ac64d739d3a89e2326ba68aaf6c4a2b838fd7d", size = 20325719, upload-time = "2026-02-23T00:19:26.329Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/83/15087d945e0e4d48ce2377498abf5ad171ae013232ae31d06f336e64c999/scipy-1.17.1-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:4b400bdc6f79fa02a4d86640310dde87a21fba0c979efff5248908c6f15fad1b", size = 22683595, upload-time = "2026-02-23T00:19:30.304Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/e0/e58fbde4a1a594c8be8114eb4aac1a55bcd6587047efc18a61eb1f5c0d30/scipy-1.17.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2b64ca7d4aee0102a97f3ba22124052b4bd2152522355073580bf4845e2550b6", size = 32896429, upload-time = "2026-02-23T00:19:35.536Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/5f/f17563f28ff03c7b6799c50d01d5d856a1d55f2676f537ca8d28c7f627cd/scipy-1.17.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:581b2264fc0aa555f3f435a5944da7504ea3a065d7029ad60e7c3d1ae09c5464", size = 35203952, upload-time = "2026-02-23T00:19:42.259Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/a5/9afd17de24f657fdfe4df9a3f1ea049b39aef7c06000c13db1530d81ccca/scipy-1.17.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:beeda3d4ae615106d7094f7e7cef6218392e4465cc95d25f900bebabfded0950", size = 34979063, upload-time = "2026-02-23T00:19:47.547Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/13/88b1d2384b424bf7c924f2038c1c409f8d88bb2a8d49d097861dd64a57b2/scipy-1.17.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6609bc224e9568f65064cfa72edc0f24ee6655b47575954ec6339534b2798369", size = 37598449, upload-time = "2026-02-23T00:19:53.238Z" },
+    { url = "https://files.pythonhosted.org/packages/35/e5/d6d0e51fc888f692a35134336866341c08655d92614f492c6860dc45bb2c/scipy-1.17.1-cp313-cp313-win_amd64.whl", hash = "sha256:37425bc9175607b0268f493d79a292c39f9d001a357bebb6b88fdfaff13f6448", size = 36510943, upload-time = "2026-02-23T00:20:50.89Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/fd/3be73c564e2a01e690e19cc618811540ba5354c67c8680dce3281123fb79/scipy-1.17.1-cp313-cp313-win_arm64.whl", hash = "sha256:5cf36e801231b6a2059bf354720274b7558746f3b1a4efb43fcf557ccd484a87", size = 24545621, upload-time = "2026-02-23T00:20:55.871Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/6b/17787db8b8114933a66f9dcc479a8272e4b4da75fe03b0c282f7b0ade8cd/scipy-1.17.1-cp313-cp313t-macosx_10_14_x86_64.whl", hash = "sha256:d59c30000a16d8edc7e64152e30220bfbd724c9bbb08368c054e24c651314f0a", size = 31936708, upload-time = "2026-02-23T00:19:58.694Z" },
+    { url = "https://files.pythonhosted.org/packages/38/2e/524405c2b6392765ab1e2b722a41d5da33dc5c7b7278184a8ad29b6cb206/scipy-1.17.1-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:010f4333c96c9bb1a4516269e33cb5917b08ef2166d5556ca2fd9f082a9e6ea0", size = 28570135, upload-time = "2026-02-23T00:20:03.934Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/c3/5bd7199f4ea8556c0c8e39f04ccb014ac37d1468e6cfa6a95c6b3562b76e/scipy-1.17.1-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:2ceb2d3e01c5f1d83c4189737a42d9cb2fc38a6eeed225e7515eef71ad301dce", size = 20741977, upload-time = "2026-02-23T00:20:07.935Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/b8/8ccd9b766ad14c78386599708eb745f6b44f08400a5fd0ade7cf89b6fc93/scipy-1.17.1-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:844e165636711ef41f80b4103ed234181646b98a53c8f05da12ca5ca289134f6", size = 23029601, upload-time = "2026-02-23T00:20:12.161Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/a0/3cb6f4d2fb3e17428ad2880333cac878909ad1a89f678527b5328b93c1d4/scipy-1.17.1-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:158dd96d2207e21c966063e1635b1063cd7787b627b6f07305315dd73d9c679e", size = 33019667, upload-time = "2026-02-23T00:20:17.208Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/c3/2d834a5ac7bf3a0c806ad1508efc02dda3c8c61472a56132d7894c312dea/scipy-1.17.1-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:74cbb80d93260fe2ffa334efa24cb8f2f0f622a9b9febf8b483c0b865bfb3475", size = 35264159, upload-time = "2026-02-23T00:20:23.087Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/77/d3ed4becfdbd217c52062fafe35a72388d1bd82c2d0ba5ca19d6fcc93e11/scipy-1.17.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:dbc12c9f3d185f5c737d801da555fb74b3dcfa1a50b66a1a93e09190f41fab50", size = 35102771, upload-time = "2026-02-23T00:20:28.636Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/12/d19da97efde68ca1ee5538bb261d5d2c062f0c055575128f11a2730e3ac1/scipy-1.17.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:94055a11dfebe37c656e70317e1996dc197e1a15bbcc351bcdd4610e128fe1ca", size = 37665910, upload-time = "2026-02-23T00:20:34.743Z" },
+    { url = "https://files.pythonhosted.org/packages/06/1c/1172a88d507a4baaf72c5a09bb6c018fe2ae0ab622e5830b703a46cc9e44/scipy-1.17.1-cp313-cp313t-win_amd64.whl", hash = "sha256:e30bdeaa5deed6bc27b4cc490823cd0347d7dae09119b8803ae576ea0ce52e4c", size = 36562980, upload-time = "2026-02-23T00:20:40.575Z" },
+    { url = "https://files.pythonhosted.org/packages/70/b0/eb757336e5a76dfa7911f63252e3b7d1de00935d7705cf772db5b45ec238/scipy-1.17.1-cp313-cp313t-win_arm64.whl", hash = "sha256:a720477885a9d2411f94a93d16f9d89bad0f28ca23c3f8daa521e2dcc3f44d49", size = 24856543, upload-time = "2026-02-23T00:20:45.313Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/83/333afb452af6f0fd70414dc04f898647ee1423979ce02efa75c3b0f2c28e/scipy-1.17.1-cp314-cp314-macosx_10_14_x86_64.whl", hash = "sha256:a48a72c77a310327f6a3a920092fa2b8fd03d7deaa60f093038f22d98e096717", size = 31584510, upload-time = "2026-02-23T00:21:01.015Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/a6/d05a85fd51daeb2e4ea71d102f15b34fedca8e931af02594193ae4fd25f7/scipy-1.17.1-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:45abad819184f07240d8a696117a7aacd39787af9e0b719d00285549ed19a1e9", size = 28170131, upload-time = "2026-02-23T00:21:05.888Z" },
+    { url = "https://files.pythonhosted.org/packages/db/7b/8624a203326675d7746a254083a187398090a179335b2e4a20e2ddc46e83/scipy-1.17.1-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:3fd1fcdab3ea951b610dc4cef356d416d5802991e7e32b5254828d342f7b7e0b", size = 20342032, upload-time = "2026-02-23T00:21:09.904Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/35/2c342897c00775d688d8ff3987aced3426858fd89d5a0e26e020b660b301/scipy-1.17.1-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:7bdf2da170b67fdf10bca777614b1c7d96ae3ca5794fd9587dce41eb2966e866", size = 22678766, upload-time = "2026-02-23T00:21:14.313Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/f2/7cdb8eb308a1a6ae1e19f945913c82c23c0c442a462a46480ce487fdc0ac/scipy-1.17.1-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:adb2642e060a6549c343603a3851ba76ef0b74cc8c079a9a58121c7ec9fe2350", size = 32957007, upload-time = "2026-02-23T00:21:19.663Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/2e/7eea398450457ecb54e18e9d10110993fa65561c4f3add5e8eccd2b9cd41/scipy-1.17.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:eee2cfda04c00a857206a4330f0c5e3e56535494e30ca445eb19ec624ae75118", size = 35221333, upload-time = "2026-02-23T00:21:25.278Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/77/5b8509d03b77f093a0d52e606d3c4f79e8b06d1d38c441dacb1e26cacf46/scipy-1.17.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d2650c1fb97e184d12d8ba010493ee7b322864f7d3d00d3f9bb97d9c21de4068", size = 35042066, upload-time = "2026-02-23T00:21:31.358Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/df/18f80fb99df40b4070328d5ae5c596f2f00fffb50167e31439e932f29e7d/scipy-1.17.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:08b900519463543aa604a06bec02461558a6e1cef8fdbb8098f77a48a83c8118", size = 37612763, upload-time = "2026-02-23T00:21:37.247Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/39/f0e8ea762a764a9dc52aa7dabcfad51a354819de1f0d4652b6a1122424d6/scipy-1.17.1-cp314-cp314-win_amd64.whl", hash = "sha256:3877ac408e14da24a6196de0ddcace62092bfc12a83823e92e49e40747e52c19", size = 37290984, upload-time = "2026-02-23T00:22:35.023Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/56/fe201e3b0f93d1a8bcf75d3379affd228a63d7e2d80ab45467a74b494947/scipy-1.17.1-cp314-cp314-win_arm64.whl", hash = "sha256:f8885db0bc2bffa59d5c1b72fad7a6a92d3e80e7257f967dd81abb553a90d293", size = 25192877, upload-time = "2026-02-23T00:22:39.798Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ad/f8c414e121f82e02d76f310f16db9899c4fcde36710329502a6b2a3c0392/scipy-1.17.1-cp314-cp314t-macosx_10_14_x86_64.whl", hash = "sha256:1cc682cea2ae55524432f3cdff9e9a3be743d52a7443d0cba9017c23c87ae2f6", size = 31949750, upload-time = "2026-02-23T00:21:42.289Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/b0/c741e8865d61b67c81e255f4f0a832846c064e426636cd7de84e74d209be/scipy-1.17.1-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:2040ad4d1795a0ae89bfc7e8429677f365d45aa9fd5e4587cf1ea737f927b4a1", size = 28585858, upload-time = "2026-02-23T00:21:47.706Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/1b/3985219c6177866628fa7c2595bfd23f193ceebbe472c98a08824b9466ff/scipy-1.17.1-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:131f5aaea57602008f9822e2115029b55d4b5f7c070287699fe45c661d051e39", size = 20757723, upload-time = "2026-02-23T00:21:52.039Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/19/2a04aa25050d656d6f7b9e7b685cc83d6957fb101665bfd9369ca6534563/scipy-1.17.1-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:9cdc1a2fcfd5c52cfb3045feb399f7b3ce822abdde3a193a6b9a60b3cb5854ca", size = 23043098, upload-time = "2026-02-23T00:21:56.185Z" },
+    { url = "https://files.pythonhosted.org/packages/86/f1/3383beb9b5d0dbddd030335bf8a8b32d4317185efe495374f134d8be6cce/scipy-1.17.1-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6e3dcd57ab780c741fde8dc68619de988b966db759a3c3152e8e9142c26295ad", size = 33030397, upload-time = "2026-02-23T00:22:01.404Z" },
+    { url = "https://files.pythonhosted.org/packages/41/68/8f21e8a65a5a03f25a79165ec9d2b28c00e66dc80546cf5eb803aeeff35b/scipy-1.17.1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a9956e4d4f4a301ebf6cde39850333a6b6110799d470dbbb1e25326ac447f52a", size = 35281163, upload-time = "2026-02-23T00:22:07.024Z" },
+    { url = "https://files.pythonhosted.org/packages/84/8d/c8a5e19479554007a5632ed7529e665c315ae7492b4f946b0deb39870e39/scipy-1.17.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:a4328d245944d09fd639771de275701ccadf5f781ba0ff092ad141e017eccda4", size = 35116291, upload-time = "2026-02-23T00:22:12.585Z" },
+    { url = "https://files.pythonhosted.org/packages/52/52/e57eceff0e342a1f50e274264ed47497b59e6a4e3118808ee58ddda7b74a/scipy-1.17.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a77cbd07b940d326d39a1d1b37817e2ee4d79cb30e7338f3d0cddffae70fcaa2", size = 37682317, upload-time = "2026-02-23T00:22:18.513Z" },
+    { url = "https://files.pythonhosted.org/packages/11/2f/b29eafe4a3fbc3d6de9662b36e028d5f039e72d345e05c250e121a230dd4/scipy-1.17.1-cp314-cp314t-win_amd64.whl", hash = "sha256:eb092099205ef62cd1782b006658db09e2fed75bffcae7cc0d44052d8aa0f484", size = 37345327, upload-time = "2026-02-23T00:22:24.442Z" },
+    { url = "https://files.pythonhosted.org/packages/07/39/338d9219c4e87f3e708f18857ecd24d22a0c3094752393319553096b98af/scipy-1.17.1-cp314-cp314t-win_arm64.whl", hash = "sha256:200e1050faffacc162be6a486a984a0497866ec54149a01270adc8a59b7c7d21", size = 25489165, upload-time = "2026-02-23T00:22:29.563Z" },
+]
+
+[[package]]
+name = "scipy"
+version = "1.18.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.15'",
+    "python_full_version == '3.14.*'",
+    "python_full_version == '3.13.*'",
+    "python_full_version == '3.12.*'",
+]
+dependencies = [
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a7/25/c2700dfaf6442b4effaa91af24ebce5dc9d31bb4a69706313aae70d72cd0/scipy-1.18.0.tar.gz", hash = "sha256:67b2ad2ad54c72ca6d04975a9b2df8c3638c34ddd5b28738e94fc2b57929d378", size = 30774447, upload-time = "2026-06-19T15:01:43.456Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/19/ca10ead60b0acc80b2b833c2c4a4f2ff753d0f58b811f70d911c7e94a25c/scipy-1.18.0-cp312-cp312-macosx_10_15_x86_64.whl", hash = "sha256:7bd21faaf5a1a3b2eff922d02db5f191b99a6518db9078a8fb23169f6d22259a", size = 31056519, upload-time = "2026-06-19T14:59:45.203Z" },
+    { url = "https://files.pythonhosted.org/packages/96/72/1e6442a00cd2924d361aa1b642ab6373ec35c6fabf311a760be9f76e0f13/scipy-1.18.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:265915e79107de9f946b855e50d7470d5893ec3f54b342e1aa6201cbdcd8bb6b", size = 28681889, upload-time = "2026-06-19T14:59:48.103Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/2d/11dd93d21e147a73ba22bd75c0b9208d3a2e0ec76d53170ce7d9029b1015/scipy-1.18.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:9ab7b758be6940954a713ee466e2043e9f6e2ed965c1fce5c91039f4be3d90a9", size = 20423580, upload-time = "2026-06-19T14:59:50.665Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/01/93552f75e0d2a7dd115a45e59209c51e8d514daff02fc887d2623be06fe1/scipy-1.18.0-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:97b6cddaaee0a779ef6b5ca83c9604b27cc16b2b8fc22c142652df8793319fb8", size = 23054441, upload-time = "2026-06-19T14:59:53.564Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/23/21f5e703643d66f21faa6b4c73195bfcad70c55efcb4f1ab327cd7c4101a/scipy-1.18.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:52a96e21517c7292375c0e27dd796a811f03fcea5fd4d108fdfea8145dcf17ab", size = 33968720, upload-time = "2026-06-19T14:59:56.415Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/aa/1b939f6c67ed68635bb538e6752d3dacc02f66535182e939a89581a44e9c/scipy-1.18.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1f55797419e16e7f30cf88ffb3113ce0467f00cfe3f70d5c281730b21769bfc2", size = 35287115, upload-time = "2026-06-19T14:59:59.411Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/ff/eec46be7e9234208f801062b53e1983085eddebd693f6c9bfb03b459830d/scipy-1.18.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:ad033410e2e0672ffdc1042110cef20e1c46f8fd0616cee1d44d8d58fad8fc11", size = 35577989, upload-time = "2026-06-19T15:00:02.235Z" },
+    { url = "https://files.pythonhosted.org/packages/84/ca/210d4759c7210bb7d269437421959b39a33434e2776b60c5cb8a763bb30a/scipy-1.18.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:4a55985d54c769c872e64b7f4c8a81cc30ef700cc04296abbbf3705439c126de", size = 37421717, upload-time = "2026-06-19T15:00:05.102Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/54/9a9edb45345bd6744da5ddfb6628e5d5185920494c6a67ec45b6381004cb/scipy-1.18.0-cp312-cp312-win_amd64.whl", hash = "sha256:71ccc8faa2dd16ac310233203474a8b5cb67f10dedd54a3116d34943f4b19132", size = 36597428, upload-time = "2026-06-19T15:00:08.112Z" },
+    { url = "https://files.pythonhosted.org/packages/99/0e/33f32a2a58987e26aec0f7df252cbbad1e90ae77bdbc76f40dd4ed0cf0ea/scipy-1.18.0-cp312-cp312-win_arm64.whl", hash = "sha256:d88363fd9d8fbd3511bd273f1a49efb2a540773ddf92a91d57498ce7dd7f3e76", size = 24351481, upload-time = "2026-06-19T15:00:11.103Z" },
+    { url = "https://files.pythonhosted.org/packages/05/52/9c0136c2de7ae0779b7b366447766cec6d9f0702c56bb8ffeb04c8fd3af4/scipy-1.18.0-cp313-cp313-macosx_10_15_x86_64.whl", hash = "sha256:09143f676d157d9f546d663504ef9c1becb819824f1afc018814176411942446", size = 31036107, upload-time = "2026-06-19T15:00:14.03Z" },
+    { url = "https://files.pythonhosted.org/packages/02/73/0291a64843270f4efb86cdcf2ee0f2048631b65ec6b405398b2b4dbf11bf/scipy-1.18.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:5efe260f69417b97ddae455bfb5a95e8359f7f66ad7fa9522a60feb66f169520", size = 28663303, upload-time = "2026-06-19T15:00:16.819Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/0f/10ffa0b697a572f4e0d48b92a88895d366422f019f723e7e14a84c050dac/scipy-1.18.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:68363b7eaacd8b5dd426df56d782cc156468ac79a127a1b87ca597d6e2e82197", size = 20404960, upload-time = "2026-06-19T15:00:19.635Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/d2/e896cea21ba8edd6c81d4c55b1ffcc717e79698dcbebf9641b4cfb4c6622/scipy-1.18.0-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:c5557d8be5da8e41353fcd4d21491fdbab83b062fc579e94dc09a7c8ab4f669b", size = 23034074, upload-time = "2026-06-19T15:00:22.107Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/b2/e83ea34279a52c03374477c74006256ec78df65fc877baa4617d6de1d202/scipy-1.18.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0d13bca67c096d89fb95ced0d8921807300fce0275643aef9533cc63a0773468", size = 33942038, upload-time = "2026-06-19T15:00:24.964Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/af/e8fe5fb136f51e2b01678b92cb4106d10d8cd68ec147ead2e7cb0ac75398/scipy-1.18.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a46f9273dbd0eb1cefba61c9b8648b4dfe3cbc14a080176f9a73e44b8336dc7f", size = 35266390, upload-time = "2026-06-19T15:00:28.059Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/49/2c5cbb907b56695fc67517811d1db234dfd83381a84814ec220aded2794d/scipy-1.18.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5aba46108853ddfc77906b6557aac839d2b52e900c1d72a1180adaaab58d265f", size = 35551324, upload-time = "2026-06-19T15:00:31.014Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/73/eda39f7a2d306ff0ffc574afd13c0bbb6d10a603d9a413998ee269487a80/scipy-1.18.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:b6f758e35f12757b5d95c00bc6de2438e229c2664b7a92e96f205959d9f2dfa4", size = 37404785, upload-time = "2026-06-19T15:00:34.072Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/d2/ae881ee28d014f38e0ccbfd974a06a919ba9af34f1f74bf42b5301891d63/scipy-1.18.0-cp313-cp313-win_amd64.whl", hash = "sha256:1afac4a847207c7ff8efd321734a50b06d0280b3b2a2c0fc2f413101747ad7c7", size = 36554943, upload-time = "2026-06-19T15:00:36.903Z" },
+    { url = "https://files.pythonhosted.org/packages/70/3a/21154e2d54eb3639c6bf4dbae2e531c68356bfe95990daa30df33b30d556/scipy-1.18.0-cp313-cp313-win_arm64.whl", hash = "sha256:c5dbddf60e58c2312316d097271a8e73d40eaf2eabfa4d95ed7d3695bbf2ce7b", size = 24350911, upload-time = "2026-06-19T15:00:40.062Z" },
+    { url = "https://files.pythonhosted.org/packages/78/b5/915a19b3de2f7430062b509653563db1633ddbb6f021b06731521115d4e2/scipy-1.18.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:4c256ee70c0d1a8a2ace807e199ccd4e3f57037433842abb3fb36bc17eaa9578", size = 31036253, upload-time = "2026-06-19T15:00:43.216Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/88/b72def7262e150d16be13fca37a96481138d624e700340bc3362a7588929/scipy-1.18.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:2ef3abc54a4ffc53765374b0d5728532dfdd2585ed23f6b11c206a1f0b1b9af8", size = 28673758, upload-time = "2026-06-19T15:00:46.663Z" },
+    { url = "https://files.pythonhosted.org/packages/91/02/2e636a61a525632c373cf6a9c24442a3ffb79e364d38e98b32042964ac32/scipy-1.18.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:f2a6af57bd9e4a75d70e4117e78a1bbee84f79ae3fbb6d0111005d6ebcc4cb8d", size = 20415514, upload-time = "2026-06-19T15:00:49.399Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/b6/2135974442f6aba159d9d39d774a1c8cb19947016725d69fecc685df45bf/scipy-1.18.0-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:3f1ac564d3bf6c03d861d2cd87a1bea0da2887136f7fb1bf519c05a8971452d6", size = 23034398, upload-time = "2026-06-19T15:00:51.941Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/e6/ba89ec5abf6ee9257c0d1ec985573f3ae32742c24bc03e016388a40b1b15/scipy-1.18.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:40395a5fcd1abee49a5c7aaa98c29db393eedc835138560a588c47ec16156690", size = 33998032, upload-time = "2026-06-19T15:00:54.838Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/c4/bc41eb19b0fd0db868f4132920879019318d80cc522ad8f2bca4611af808/scipy-1.18.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8ca01e8ae69f1b18e9a58d91afead31be3cef0dd905a10249dac559ee15460a0", size = 35283333, upload-time = "2026-06-19T15:00:58.152Z" },
+    { url = "https://files.pythonhosted.org/packages/53/a4/cbdeef6eb3830a8462a9d4ada814de5fc984345cc9ecf17cbec51a036f1e/scipy-1.18.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7a7f3b01647384dbc3a711e8c6778e0aabbe93959249fef5c7393396bcac0867", size = 35610216, upload-time = "2026-06-19T15:01:01.155Z" },
+    { url = "https://files.pythonhosted.org/packages/80/4d/b2b82502b65f661d1b789c1665dcdf315d5f12194e06fc0b37946294ebae/scipy-1.18.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:6aa94e78ec192a30063a5e72e561c28af769dc311190b24fe91774eff1969709", size = 37418960, upload-time = "2026-06-19T15:01:04.155Z" },
+    { url = "https://files.pythonhosted.org/packages/93/3e/902d836831474b0ab5a37d16404f7bc5fafd9efba632890e271ba952635f/scipy-1.18.0-cp314-cp314-win_amd64.whl", hash = "sha256:2d8bbdc6c817f5b4006a54d799d4f5bab6f910193cbb9a1ff310833d4d270f61", size = 37288845, upload-time = "2026-06-19T15:01:07.822Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/43/8d73b337a3bdb14daa0314f0434210747c02d79d729ce1777574a817dcf6/scipy-1.18.0-cp314-cp314-win_arm64.whl", hash = "sha256:18e9575f1569b2c54174e6159d32942e03731177f63dce7975f0a0c88d102f5b", size = 24988971, upload-time = "2026-06-19T15:01:11.076Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/b4/f11918b0508a2787031a0499a03fbe3546f3bb5ca05d01038c45b278c09a/scipy-1.18.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:f351e0dd702687d12a402b867a1b4146a256923e1c38317cbc472f6372b94707", size = 31399325, upload-time = "2026-06-19T15:01:13.723Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/d1/1f287b57c0ff0ee5185dff3946d92c8017d39b0e431f0ae79a3ff1859512/scipy-1.18.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:7c7a51b33ce387193c97f228320cf8e87361daa1bba750638677729598b3e677", size = 29092110, upload-time = "2026-06-19T15:01:16.908Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/1a/7b74eb6c392fdcb27d414c0e7558a6d0231eb3b6d73571f479bb81ea8794/scipy-1.18.0-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:84031d7b052a54fae2f8632e0ec802073d385476eb9a63079bce6e23ef9283d4", size = 20833811, upload-time = "2026-06-19T15:01:20.488Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/ad/f3941716320a7b9cb4d68734a903b45fe16eff5fb7da7e16f2e619304979/scipy-1.18.0-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:56abf29a7c067dde59be8b9a22d606a4ea1b2f2a4b756d9d903c62818f5dacce", size = 23396644, upload-time = "2026-06-19T15:01:23.364Z" },
+    { url = "https://files.pythonhosted.org/packages/22/22/1446b62ffe07f9719b7d9b1b6a4e05a772833ae8f441fe4c22c34c9b250f/scipy-1.18.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1ad44305cfa24b1ba5803cbbebf033590ccbac1aa5d612d727b785325ab408b0", size = 34079318, upload-time = "2026-06-19T15:01:26.002Z" },
+    { url = "https://files.pythonhosted.org/packages/56/3b/b87da667098bb470fa30c7011b0ba351ee976dd395c78798c66e941665a3/scipy-1.18.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:945c1761b93f38d7f99ae81ae80c63e621471608c7eeead563f6df025585cd58", size = 35324320, upload-time = "2026-06-19T15:01:28.881Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/a1/c7932f91909759b0267f75fdea34e91309f96b895757534b76a90b6b4344/scipy-1.18.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:1a4441f15d620578772a49e5ab48c0ee1f7a0220e387110283062729136b2553", size = 35699541, upload-time = "2026-06-19T15:01:31.968Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/86/5185061a1fcc41d18c5dc2463969b3a3964b31d9ac67b2fb05d4c7ff7670/scipy-1.18.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9aac6192fac56bf2ca534389d24623f07b39ff83317d58287285e7fbd622ff76", size = 37472480, upload-time = "2026-06-19T15:01:35.136Z" },
+    { url = "https://files.pythonhosted.org/packages/31/8e/f04c68e39919a010d34f2ee1367fd705b0a25a02f609d755f0bfbc0a15fc/scipy-1.18.0-cp314-cp314t-win_amd64.whl", hash = "sha256:e40baea28ae7f5475c779741e2d90b1247c78531207b49c7030e698ff81cee3f", size = 37365390, upload-time = "2026-06-19T15:01:38.091Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/19/969dc072906c84dd0a3b05dcf57ea750936087d7873549e408b35cfc3f97/scipy-1.18.0-cp314-cp314t-win_arm64.whl", hash = "sha256:368e0a705903c466aa5f08eefb39e6b1b6b2d659e7352a31fd9e2438365be0f8", size = 25279661, upload-time = "2026-06-19T15:01:40.817Z" },
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3645,6 +4099,37 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7b/ae/2d9c981590ed9999a0d91755b47fc74f74de286b0f5cee14c9269041e6c4/soupsieve-2.8.3.tar.gz", hash = "sha256:3267f1eeea4251fb42728b6dfb746edc9acaffc4a45b27e19450b676586e8349", size = 118627, upload-time = "2026-01-20T04:27:02.457Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/46/2c/1462b1d0a634697ae9e55b3cecdcb64788e8b7d63f54d923fcd0bb140aed/soupsieve-2.8.3-py3-none-any.whl", hash = "sha256:ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95", size = 37016, upload-time = "2026-01-20T04:27:01.012Z" },
+]
+
+[[package]]
+name = "soxr"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/7e/f4b461944662ad75036df65277d6130f9411002bfb79e9df7dff40a31db9/soxr-1.0.0.tar.gz", hash = "sha256:e07ee6c1d659bc6957034f4800c60cb8b98de798823e34d2a2bba1caa85a4509", size = 171415, upload-time = "2025-09-07T13:22:21.317Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/a7/11c36d71595b52fe84a220040ace679035953acf06b83bf2c7117c565d2c/soxr-1.0.0-cp310-cp310-macosx_10_14_x86_64.whl", hash = "sha256:b876a3156f67c76aef0cff1084eaf4088d9ca584bb569cb993f89a52ec5f399f", size = 206459, upload-time = "2025-09-07T13:21:46.904Z" },
+    { url = "https://files.pythonhosted.org/packages/43/5e/8962f2aeea7777d2a6e65a24a2b83c6aea1a28badeda027fd328f7f03bb7/soxr-1.0.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:4d3b957a7b0cc19ae6aa45d40b2181474e53a8dd00efd7bce6bcf4e60e020892", size = 164808, upload-time = "2025-09-07T13:21:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/91/00384166f110a3888ea8efd44523ba7168dd2dc39e3e43c931cc2d069fa9/soxr-1.0.0-cp310-cp310-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b89685faedebc45af71f08f9957b61cc6143bc94ba43fe38e97067f81e272969", size = 208586, upload-time = "2025-09-07T13:21:50.341Z" },
+    { url = "https://files.pythonhosted.org/packages/75/34/e18f1003e242aabed44ed8902534814d3e64209e4d1d874f5b9b67d73cde/soxr-1.0.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d255741b2f0084fd02d4a2ddd77cd495be9e7e7b6f9dba1c9494f86afefac65b", size = 242310, upload-time = "2025-09-07T13:21:51.56Z" },
+    { url = "https://files.pythonhosted.org/packages/61/9c/a1c5ed106b40cc1e2e12cd58831b7f1b61c5fbdb8eceeca4b3a0b0dbef6c/soxr-1.0.0-cp310-cp310-win_amd64.whl", hash = "sha256:158a4a9055958c4b95ef91dbbe280cabb00946b5423b25a9b0ce31bd9e0a271e", size = 173561, upload-time = "2025-09-07T13:21:53.03Z" },
+    { url = "https://files.pythonhosted.org/packages/65/ce/a3262bc8733d3a4ce5f660ed88c3d97f4b12658b0909e71334cba1721dcb/soxr-1.0.0-cp311-cp311-macosx_10_14_x86_64.whl", hash = "sha256:28e19d74a5ef45c0d7000f3c70ec1719e89077379df2a1215058914d9603d2d8", size = 206739, upload-time = "2025-09-07T13:21:54.572Z" },
+    { url = "https://files.pythonhosted.org/packages/64/dc/e8cbd100b652697cc9865dbed08832e7e135ff533f453eb6db9e6168d153/soxr-1.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f8dc69fc18884e53b72f6141fdf9d80997edbb4fec9dc2942edcb63abbe0d023", size = 165233, upload-time = "2025-09-07T13:21:55.887Z" },
+    { url = "https://files.pythonhosted.org/packages/75/12/4b49611c9ba5e9fe6f807d0a83352516808e8e573f8b4e712fc0c17f3363/soxr-1.0.0-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3f15450e6f65f22f02fcd4c5a9219c873b1e583a73e232805ff160c759a6b586", size = 208867, upload-time = "2025-09-07T13:21:57.076Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/70/92146ab970a3ef8c43ac160035b1e52fde5417f89adb10572f7e788d9596/soxr-1.0.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1f73f57452f9df37b4de7a4052789fcbd474a5b28f38bba43278ae4b489d4384", size = 242633, upload-time = "2025-09-07T13:21:58.621Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/a7/628479336206959463d08260bffed87905e7ba9e3bd83ca6b405a0736e94/soxr-1.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:9f417c3d69236051cf5a1a7bad7c4bff04eb3d8fcaa24ac1cb06e26c8d48d8dc", size = 173814, upload-time = "2025-09-07T13:21:59.798Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/c7/f92b81f1a151c13afb114f57799b86da9330bec844ea5a0d3fe6a8732678/soxr-1.0.0-cp312-abi3-macosx_10_14_x86_64.whl", hash = "sha256:abecf4e39017f3fadb5e051637c272ae5778d838e5c3926a35db36a53e3a607f", size = 205508, upload-time = "2025-09-07T13:22:01.252Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/1d/c945fea9d83ea1f2be9d116b3674dbaef26ed090374a77c394b31e3b083b/soxr-1.0.0-cp312-abi3-macosx_11_0_arm64.whl", hash = "sha256:e973d487ee46aa8023ca00a139db6e09af053a37a032fe22f9ff0cc2e19c94b4", size = 163568, upload-time = "2025-09-07T13:22:03.558Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/80/10640970998a1d2199bef6c4d92205f36968cddaf3e4d0e9fe35ddd405bd/soxr-1.0.0-cp312-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e8ce273cca101aff3d8c387db5a5a41001ba76ef1837883438d3c652507a9ccc", size = 204707, upload-time = "2025-09-07T13:22:05.125Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/87/2726603c13c2126cb8ded9e57381b7377f4f0df6ba4408e1af5ddbfdc3dd/soxr-1.0.0-cp312-abi3-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e8f2a69686f2856d37823bbb7b78c3d44904f311fe70ba49b893af11d6b6047b", size = 238032, upload-time = "2025-09-07T13:22:06.428Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/04/530252227f4d0721a5524a936336485dfb429bb206a66baf8e470384f4a2/soxr-1.0.0-cp312-abi3-win_amd64.whl", hash = "sha256:2a3b77b115ae7c478eecdbd060ed4f61beda542dfb70639177ac263aceda42a2", size = 172070, upload-time = "2025-09-07T13:22:07.62Z" },
+    { url = "https://files.pythonhosted.org/packages/99/77/d3b3c25b4f1b1aa4a73f669355edcaee7a52179d0c50407697200a0e55b9/soxr-1.0.0-cp314-cp314t-macosx_10_14_x86_64.whl", hash = "sha256:392a5c70c04eb939c9c176bd6f654dec9a0eaa9ba33d8f1024ed63cf68cdba0a", size = 209509, upload-time = "2025-09-07T13:22:08.773Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/ee/3ca73e18781bb2aff92b809f1c17c356dfb9a1870652004bd432e79afbfa/soxr-1.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:fdc41a1027ba46777186f26a8fba7893be913383414135577522da2fcc684490", size = 167690, upload-time = "2025-09-07T13:22:10.259Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/f0/eea8b5f587a2531657dc5081d2543a5a845f271a3bea1c0fdee5cebde021/soxr-1.0.0-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:449acd1dfaf10f0ce6dfd75c7e2ef984890df94008765a6742dafb42061c1a24", size = 209541, upload-time = "2025-09-07T13:22:11.739Z" },
+    { url = "https://files.pythonhosted.org/packages/64/59/2430a48c705565eb09e78346950b586f253a11bd5313426ced3ecd9b0feb/soxr-1.0.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:38b35c99e408b8f440c9376a5e1dd48014857cd977c117bdaa4304865ae0edd0", size = 243025, upload-time = "2025-09-07T13:22:12.877Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/1b/f84a2570a74094e921bbad5450b2a22a85d58585916e131d9b98029c3e69/soxr-1.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:a39b519acca2364aa726b24a6fd55acf29e4c8909102e0b858c23013c38328e5", size = 184850, upload-time = "2025-09-07T13:22:14.068Z" },
 ]
 
 [[package]]
@@ -4153,6 +4638,15 @@ wheels = [
 ]
 
 [[package]]
+name = "wait-for2"
+version = "0.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8f/7c/ea09d6a11990a8aa3ceac206fb7ea82366ea2c200caa87966611e0e18597/wait_for2-0.4.1.tar.gz", hash = "sha256:7f415415d21845c441391d6b4abe68f5959d2c0fbe927c2f61be28a297bc2acb", size = 17519, upload-time = "2025-06-13T19:45:00.081Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/56/0f88040567af7ff376ec9eaabe18fd980a4f5089d3bf8c7a32598ef06b8d/wait_for2-0.4.1-py3-none-any.whl", hash = "sha256:c694503e8c7420929e8a86bcffd9b00d55acaec2c14223a2b1e92bdc2ebf2154", size = 10985, upload-time = "2025-06-13T19:44:58.82Z" },
+]
+
+[[package]]
 name = "watchdog"
 version = "6.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4250,6 +4744,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/2b/fb/c492d6daa5ec067c2988ac80c61359ace5c4c674c532985ac5a123436cec/websockets-15.0.1-pp310-pypy310_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b359ed09954d7c18bbc1680f380c7301f92c60bf924171629c5db97febb12f04", size = 174155, upload-time = "2025-03-05T20:03:25.321Z" },
     { url = "https://files.pythonhosted.org/packages/68/a1/dcb68430b1d00b698ae7a7e0194433bce4f07ded185f0ee5fb21e2a2e91e/websockets-15.0.1-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:cad21560da69f4ce7658ca2cb83138fb4cf695a2ba3e475e0559e05991aa8122", size = 176884, upload-time = "2025-03-05T20:03:27.934Z" },
     { url = "https://files.pythonhosted.org/packages/fa/a8/5b41e0da817d64113292ab1f8247140aac61cbf6cfd085d6a0fa77f4984f/websockets-15.0.1-py3-none-any.whl", hash = "sha256:f7a866fbc1e97b5c617ee4116daaa09b722101d4a3c170c787450ba409f9736f", size = 169743, upload-time = "2025-03-05T20:03:39.41Z" },
+]
+
+[[package]]
+name = "win32-setctime"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b3/8f/705086c9d734d3b663af0e9bb3d4de6578d08f46b1b101c2442fd9aecaa2/win32_setctime-1.2.0.tar.gz", hash = "sha256:ae1fdf948f5640aae05c511ade119313fb6a30d7eabe25fef9764dca5873c4c0", size = 4867, upload-time = "2024-12-07T15:28:28.314Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/07/c6fe3ad3e685340704d314d765b7912993bcb8dc198f0e7a89382d37974b/win32_setctime-1.2.0-py3-none-any.whl", hash = "sha256:95d644c4e708aba81dc3704a116d8cbc974d70b3bdb8be1d150e36be6e9d1390", size = 4083, upload-time = "2024-12-07T15:28:26.465Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Pipecat voice tracing (plus shared voice foundation)

First of a 4-PR stack adding LangSmith tracing integrations for voice agents. This PR adds:

- **Shared foundation** under `langsmith.integrations._voice` (private): an in-development warning helper; the OTel `BaseLangSmithSpanProcessor` (downstream wrapping, LangSmith OTLP exporter default, thread-id injection, message + audio-attachment helpers); per-conversation thread grouping via `set_thread_id` (a `ContextVar`); and stdlib-only `pcm_to_wav` for encoding the recording (no numpy).
- **Pipecat integration** (`langsmith.integrations.pipecat`): `configure_pipecat` + `PipecatLangSmithSpanProcessor`, translating Pipecat's OTel spans (`conversation` / `turn` / `stt` / `llm` / `tts`) into LangSmith's `gen_ai.*` / `langsmith.*` shape and attaching the `AudioBufferProcessor` recording to the conversation root. Per-conversation state is TTL-bounded (via `cachetools`) so an abandoned call cannot leak it.

Install: `pip install "langsmith[pipecat]"`.

### In development

The voice integrations are in development: each package emits a `LangSmithVoiceBetaWarning` on import and is isolated from the core SDK (`import langsmith` loads none of them; they load only on an explicit `from langsmith.integrations.<voice> import ...`).

### Stack

Subsequent PRs add LiveKit (#3113), OpenAI Realtime (#3114), and Google ADK Live (#3115). This stack replaces #3107.

### Validation

- Unit tests in `tests/unit_tests/wrappers/test_pipecat.py` cover span rewriting, OpenAI→LangChain message normalization, audio attachment, TTL-bounded state, `set_thread_id` injection, and export/exception isolation.
- `ruff check` + `ruff format` + `mypy` clean.
- A `pipecat-ai>=1.0; python_version>='3.11'` marker keeps dependency resolution satisfiable on Python 3.10.

Python only. Authored with the help of an AI agent. :-)



#### PR Dependency Tree


* **PR #3112** 👈
  * **PR #3113**
    * **PR #3114**
      * **PR #3115**

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)



#### PR Dependency Tree


* **PR #3112** 👈
  * **PR #3113**
    * **PR #3114**
      * **PR #3115**

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)