### PR TITLE
feat(integrations): add OpenAI Realtime voice tracing integration

### DIFF
--- a/python/langsmith/_internal/_usage.py
+++ b/python/langsmith/_internal/_usage.py
@@ -1,0 +1,83 @@
+"""Shared token-usage mapping.
+
+``_create_usage_metadata`` normalizes an OpenAI-shaped token ``usage`` dict into
+LangSmith's canonical :class:`~langsmith.schemas.UsageMetadata`. It lives here —
+not in ``langsmith.wrappers._openai`` — so integrations can reuse it without
+importing the ``wrappers`` package (whose ``__init__`` eagerly imports a
+deprecated tombstone that warns at import time). ``wrappers._openai`` re-exports
+it for backwards compatibility.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from langsmith.schemas import InputTokenDetails, OutputTokenDetails, UsageMetadata
+
+
+def _create_usage_metadata(
+    oai_token_usage: dict, service_tier: Optional[str] = None
+) -> UsageMetadata:
+    recognized_service_tier = (
+        service_tier if service_tier in ["priority", "flex"] else None
+    )
+    service_tier_prefix = (
+        f"{recognized_service_tier}_" if recognized_service_tier else ""
+    )
+
+    input_tokens = (
+        oai_token_usage.get("prompt_tokens") or oai_token_usage.get("input_tokens") or 0
+    )
+    output_tokens = (
+        oai_token_usage.get("completion_tokens")
+        or oai_token_usage.get("output_tokens")
+        or 0
+    )
+    total_tokens = oai_token_usage.get("total_tokens") or input_tokens + output_tokens
+    input_token_details: dict = {
+        "audio": (
+            oai_token_usage.get("prompt_tokens_details")
+            or oai_token_usage.get("input_tokens_details")
+            or {}
+        ).get("audio_tokens"),
+        f"{service_tier_prefix}cache_read": (
+            oai_token_usage.get("prompt_tokens_details")
+            or oai_token_usage.get("input_tokens_details")
+            or {}
+        ).get("cached_tokens"),
+    }
+    output_token_details: dict = {
+        "audio": (
+            oai_token_usage.get("completion_tokens_details")
+            or oai_token_usage.get("output_tokens_details")
+            or {}
+        ).get("audio_tokens"),
+        f"{service_tier_prefix}reasoning": (
+            oai_token_usage.get("completion_tokens_details")
+            or oai_token_usage.get("output_tokens_details")
+            or {}
+        ).get("reasoning_tokens"),
+    }
+
+    if recognized_service_tier:
+        # Avoid counting cache read and reasoning tokens towards the
+        # service tier token count since service tier tokens are already
+        # priced differently
+        input_token_details[recognized_service_tier] = input_tokens - (
+            input_token_details.get(f"{service_tier_prefix}cache_read") or 0
+        )
+        output_token_details[recognized_service_tier] = output_tokens - (
+            output_token_details.get(f"{service_tier_prefix}reasoning") or 0
+        )
+
+    return UsageMetadata(
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        total_tokens=total_tokens,
+        input_token_details=InputTokenDetails(
+            **{k: v for k, v in input_token_details.items() if v is not None}
+        ),
+        output_token_details=OutputTokenDetails(
+            **{k: v for k, v in output_token_details.items() if v is not None}
+        ),
+    )

--- a/python/langsmith/_internal/voice/audio.py
+++ b/python/langsmith/_internal/voice/audio.py
@@ -1,13 +1,18 @@
-"""WAV reconstruction for the Track-A voice span processors.
+"""WAV reconstruction for the voice integrations.
 
-``pcm_to_wav`` wraps already-merged PCM16 bytes (e.g. the output of Pipecat's
-``AudioBufferProcessor``) in a WAV container so a processor can attach the
-recorded conversation to a span.
+* ``pcm_to_wav`` — wrap already-merged PCM16 bytes (e.g. the output of Pipecat's
+  ``AudioBufferProcessor``) in a WAV container. Used by the Track-A span
+  processors.
+* ``build_stereo_session_wav`` — reconstruct one stereo conversation WAV from the
+  timestamped PCM16 chunks each side recorded (L=user, R=agent), laid out at
+  natural play time so bursts don't overlap. Used by the Track-B ``EventSession``.
 """
 
 from __future__ import annotations
 
+import array
 import io
+import math
 import wave
 
 
@@ -27,3 +32,83 @@ def pcm_to_wav(pcm: bytes, sample_rate: int, num_channels: int = 1) -> bytes:
         wf.setframerate(sample_rate)
         wf.writeframes(pcm)
     return buf.getvalue()
+
+
+def _layout_chunks_to_play_time(
+    chunks: list[tuple[float, bytes]], sample_rate: int
+) -> list[tuple[float, bytes]]:
+    """Rewrite receipt timestamps into natural-play timestamps.
+
+    Receipt times reflect when bytes arrived from the source, not when they
+    play. The agent channel especially arrives in bursts faster than realtime —
+    multiple chunks can land within a few ms of each other, and placing them at
+    receipt time makes them overlap and overwrite each other (you hear scrambled
+    tail-ends). The correct natural play time for a chunk is the LATER of where
+    the previous chunk ended and when this chunk arrived, which preserves real
+    gaps between bursts and keeps consecutive bursts contiguous.
+    """
+    out: list[tuple[float, bytes]] = []
+    cur_time = 0.0
+    for i, (t_recv, data) in enumerate(chunks):
+        cur_time = t_recv if i == 0 else max(cur_time, t_recv)
+        out.append((cur_time, data))
+        cur_time += (len(data) // 2) / sample_rate
+    return out
+
+
+def build_stereo_session_wav(
+    user_chunks: list[tuple[float, bytes]],
+    agent_chunks: list[tuple[float, bytes]],
+    sample_rate: int,
+) -> bytes:
+    """Reconstruct a stereo WAV from timestamped PCM16 chunks.
+
+    Left channel = user, right channel = agent. Both channels are laid out at
+    natural play time (see ``_layout_chunks_to_play_time``). Gaps between bursts
+    are silence; overlap between user and agent (during a barge-in) is preserved
+    because they live on different channels.
+    """
+    if not user_chunks and not agent_chunks:
+        return b""
+
+    user = _layout_chunks_to_play_time(user_chunks, sample_rate)
+    agent = _layout_chunks_to_play_time(agent_chunks, sample_rate)
+
+    def chunk_end(t: float, data: bytes) -> float:
+        return t + (len(data) // 2) / sample_rate
+
+    user_end = max((chunk_end(t, d) for t, d in user), default=0.0)
+    agent_end = max((chunk_end(t, d) for t, d in agent), default=0.0)
+    total_samples = int(math.ceil(max(user_end, agent_end) * sample_rate))
+    if total_samples <= 0:
+        return b""
+
+    def mono_channel(chunks: list[tuple[float, bytes]]) -> array.array:
+        # One zero-filled PCM16 channel; each chunk is copied in at its offset.
+        # The layout guarantees chunks within a channel never overlap, so a
+        # plain slice assignment is correct.
+        chan = array.array("h", bytes(2 * total_samples))
+        for t, data in chunks:
+            offset = int(t * sample_rate)
+            samples = array.array("h", data[: 2 * (len(data) // 2)])
+            n = min(len(samples), total_samples - offset)
+            if n > 0:
+                chan[offset : offset + n] = samples[:n]
+        return chan
+
+    left = mono_channel(user)  # user channel
+    right = mono_channel(agent)  # agent channel
+
+    # Interleave L/R via extended-slice assignment (a C-level strided copy).
+    # Overlap between the two parties is preserved: they live on separate channels.
+    stereo = array.array("h", bytes(4 * total_samples))
+    stereo[0::2] = left
+    stereo[1::2] = right
+
+    wav_io = io.BytesIO()
+    with wave.open(wav_io, "wb") as wf:
+        wf.setnchannels(2)
+        wf.setsampwidth(2)
+        wf.setframerate(sample_rate)
+        wf.writeframes(stereo.tobytes())
+    return wav_io.getvalue()

--- a/python/langsmith/_internal/voice/helpers.py
+++ b/python/langsmith/_internal/voice/helpers.py
@@ -1,0 +1,68 @@
+"""Shared helpers for the Track-B ``EventSession`` adapters.
+
+* ``dump_event`` — best-effort conversion of an event object to a plain dict
+  (Pydantic ``model_dump`` → ``dict`` → ``repr`` fallback).
+* ``scrub`` — replace raw audio ``bytes`` with a ``<N bytes>`` placeholder and
+  truncate long strings, recursing through dicts and sequences, so a span never
+  carries megabytes of audio or un-serializable junk.
+* ``observe_safely`` — run an adapter's per-event ``observe`` so a tracing error
+  never escapes into the caller's live loop.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Callable
+
+logger = logging.getLogger(__name__)
+
+# Longest string kept on a span before truncating. Transcripts are short; this
+# only ever trims an unexpectedly large blob.
+MAX_STR = 2000
+
+
+def observe_safely(observe: Callable[[Any], None], event: Any) -> None:
+    """Run an adapter's ``observe`` over one event, swallowing any error.
+
+    Tracing must never break the live voice loop, so a failure building the
+    trace is logged and dropped and the caller still gets its event.
+    """
+    try:
+        observe(event)
+    except Exception:
+        logger.warning(
+            "voice tracing: failed to observe an event; skipping it", exc_info=True
+        )
+
+
+def scrub(obj: Any) -> Any:
+    """Make an event payload safe and compact for a span.
+
+    Replaces raw ``bytes`` (audio / base64 blobs) with a ``<N bytes>``
+    placeholder and truncates very long strings, recursing through dicts and
+    sequences, so a span never ships megabytes of payload or breaks JSON
+    serialization.
+    """
+    if isinstance(obj, bytes):
+        return f"<{len(obj)} bytes>"
+    if isinstance(obj, str):
+        if len(obj) > MAX_STR:
+            return obj[:MAX_STR] + f"... <+{len(obj) - MAX_STR} chars>"
+        return obj
+    if isinstance(obj, dict):
+        return {k: scrub(v) for k, v in obj.items()}
+    if isinstance(obj, (list, tuple)):
+        return [scrub(v) for v in obj]
+    return obj
+
+
+def dump_event(event: Any) -> dict[str, Any]:
+    """Best-effort conversion of an event object to a plain dict."""
+    if hasattr(event, "model_dump"):
+        try:
+            return event.model_dump()
+        except Exception:
+            pass
+    if isinstance(event, dict):
+        return event
+    return {"repr": repr(event)}

--- a/python/langsmith/_internal/voice/session.py
+++ b/python/langsmith/_internal/voice/session.py
@@ -1,0 +1,471 @@
+"""``EventSession`` — Track B's LangSmith ``RunTree`` builder.
+
+The integrations that observe a remote event stream (OpenAI Realtime, OpenAI
+Agents realtime, ADK Live) all face the same problem: the service hands them an
+event stream rather than emitting its own telemetry for the live loop, so the
+trace has to be built by hand with the LangSmith SDK — one root span per
+conversation, one child span per meaningful event.
+
+``EventSession`` is everything that pattern needs and would otherwise be
+duplicated across the adapters:
+
+* a root ``realtime_session`` span carrying the running transcript (``outputs``)
+  and the stereo conversation WAV (attachment);
+* a child span per event (``event_span``), optionally grouped into ``turn``
+  spans;
+* point-in-time ``llm`` spans for terminal model responses (``record_llm``);
+* timestamped audio recording and a ``finalize`` that rolls up stats + WAV.
+
+Each adapter keeps only what is genuinely provider-specific: which events count
+as ``inbound`` (user→model, so the payload lands in span ``inputs``) and how to
+label each event span.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections.abc import Iterator, Sequence
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Literal, Optional, cast
+
+from langsmith import RunTree
+from langsmith._internal.voice.audio import build_stereo_session_wav
+from langsmith._internal.voice.helpers import dump_event, scrub
+
+if TYPE_CHECKING:
+    from langsmith import Client
+    from langsmith.run_trees import WriteReplica
+
+logger = logging.getLogger(__name__)
+
+# The run kinds LangSmith recognizes (matches ``RunTree.create_child``).
+RunKind = Literal["tool", "chain", "llm", "retriever", "embedding", "prompt", "parser"]
+
+
+@dataclass
+class EventSession:
+    """Conversation-level tracing state. One per conversation.
+
+    The root span carries roll-up stats in metadata, the running conversation
+    transcript as its ``outputs`` (so the LangSmith preview pane shows the whole
+    exchange at a glance — see ``add_message``), and the stereo conversation WAV
+    as an attachment. Each received event becomes a child span via
+    ``event_span`` — nested under the current ``turn`` span if the adapter opted
+    into turn grouping (see ``start_turn``), otherwise directly under the root.
+    """
+
+    run: RunTree
+    thread_id: str
+    project_name: Optional[str]
+    sample_rate: int
+    # Per-channel cap on retained PCM, in bytes. Audio is buffered in memory for
+    # the whole conversation, so without a ceiling a long-running session grows
+    # unbounded (a 1h 24kHz/16-bit channel is ~170MB). Once a channel hits this,
+    # further chunks on it are dropped (the conversation's start is kept) and the
+    # root is flagged ``audio_truncated``. ``None`` disables the cap.
+    max_audio_bytes: Optional[int] = None
+    # Monotonic clock origin. Everything else stores ``now() - t0``.
+    t0: float = field(default_factory=time.monotonic)
+    # Time-stamped audio chunks for the stereo session WAV. Each entry is
+    # (offset_seconds_from_t0, pcm16_bytes). Reconstructed at finalize.
+    user_chunks: list[tuple[float, bytes]] = field(default_factory=list)
+    agent_chunks: list[tuple[float, bytes]] = field(default_factory=list)
+    # Running per-channel byte totals, checked against ``max_audio_bytes``.
+    _user_bytes: int = field(default=0, init=False)
+    _agent_bytes: int = field(default=0, init=False)
+    _audio_truncated: bool = field(default=False, init=False)
+    event_count: int = 0
+    # Conversation transcript, in turn order: {"role", "content"} per line.
+    # Surfaced as the root span's ``outputs`` at finalize.
+    messages: list[dict[str, str]] = field(default_factory=list)
+    # Optional turn grouping (see ``start_turn``). When a turn is open, event
+    # spans nest under it instead of directly under the root; adapters that
+    # never call ``start_turn`` get the original flat shape unchanged.
+    _current_turn: RunTree | None = field(default=None, init=False)
+    _turn_count: int = field(default=0, init=False)
+    _turn_msg_start: int = field(default=0, init=False)
+    # Whether the root has been named from an utterance yet (see ``set_title``).
+    _title_set: bool = field(default=False, init=False)
+
+    def now(self) -> float:
+        """Seconds since the session started — the timeline used for the WAV."""
+        return time.monotonic() - self.t0
+
+    def start_turn(self) -> None:
+        """Open a new conversational-turn span, closing the previous one.
+
+        Subsequent ``event_span`` calls nest under this turn until the next
+        ``start_turn`` (or ``finalize``). The turn's ``outputs`` become the
+        transcript lines added during it, so each turn previews its own
+        exchange. Opt-in: an adapter that never calls this keeps the flat root
+        layout.
+        """
+        self._close_turn()
+        self._turn_count += 1
+        self._turn_msg_start = len(self.messages)
+        turn = self.run.create_child(
+            name="turn",
+            run_type="chain",
+            inputs={},
+            tags=["turn"],
+            extra={"metadata": {"turn": self._turn_count}},
+        )
+        turn.post()
+        self._current_turn = turn
+
+    def _close_turn(self) -> None:
+        """End the currently open turn span, if any, with its transcript."""
+        if self._current_turn is None:
+            return
+        msgs = self.messages[self._turn_msg_start :]
+        self._current_turn.end(outputs={"messages": msgs} if msgs else {})
+        self._current_turn.patch()
+        self._current_turn = None
+
+    def add_message(self, role: str, content: str) -> None:
+        """Append one transcript line to the conversation rollup.
+
+        Empty/whitespace content is ignored (failed transcriptions, silent
+        turns). Content is truncated like any other span payload (see ``scrub``)
+        so an unexpectedly large blob never bloats the root span.
+        """
+        content = (content or "").strip()
+        if content:
+            self.messages.append({"role": role, "content": scrub(content)})
+
+    def record_user(self, t: float, data: bytes) -> None:
+        """Record a timestamped chunk of user (mic) PCM16 for the stereo WAV.
+
+        Dropped once the user channel reaches ``max_audio_bytes`` (see that
+        field) so a long session can't exhaust memory.
+        """
+        if (
+            self.max_audio_bytes is not None
+            and self._user_bytes >= self.max_audio_bytes
+        ):
+            self._note_audio_truncated()
+            return
+        self._user_bytes += len(data)
+        self.user_chunks.append((t, data))
+
+    def record_agent(self, t: float, data: bytes) -> None:
+        """Record a timestamped chunk of agent (playback) PCM16 for the WAV.
+
+        Dropped once the agent channel reaches ``max_audio_bytes`` (see that
+        field) so a long session can't exhaust memory.
+        """
+        if (
+            self.max_audio_bytes is not None
+            and self._agent_bytes >= self.max_audio_bytes
+        ):
+            self._note_audio_truncated()
+            return
+        self._agent_bytes += len(data)
+        self.agent_chunks.append((t, data))
+
+    def _note_audio_truncated(self) -> None:
+        """Flag (once) that recorded audio was capped at ``max_audio_bytes``."""
+        if self._audio_truncated:
+            return  # log once per session, not once per dropped chunk
+        self._audio_truncated = True
+        logger.warning(
+            "voice tracing: audio capture hit the %d-byte per-channel cap; "
+            "further audio for this conversation is dropped from the WAV",
+            self.max_audio_bytes,
+        )
+
+    def set_title(self, text: str) -> None:
+        """Name the conversation root from its first user utterance (first wins).
+
+        The root's ``name`` is what LangSmith shows in the trace / threads list,
+        so naming it after the opening utterance makes conversations scannable
+        instead of all reading ``realtime_session``. Only the first non-empty
+        utterance applies; scrubbed like any other payload. The new name rides
+        along on the root's ``patch`` at ``finalize``.
+        """
+        text = (text or "").strip()
+        if not text or self._title_set:
+            return  # first non-empty user utterance wins
+        self.run.name = cast("str", scrub(text))
+        self._title_set = True
+
+    def add_turn_metadata(self, **kv: Any) -> None:
+        """Merge key/values into the open turn span's metadata (no-op if none).
+
+        For per-turn metrics not known when the turn opens — e.g.
+        ``latency_to_first_audio_ms``, ``was_interrupted``. Applied to the
+        currently open turn, so call it before the next ``start_turn`` closes
+        that turn.
+        """
+        if self._current_turn is None:
+            return
+        extra = self._current_turn.extra or {}
+        metadata = dict(extra.get("metadata") or {})
+        metadata.update(kv)
+        extra["metadata"] = metadata
+        self._current_turn.extra = extra
+
+    @contextmanager
+    def event_span(
+        self,
+        event: Any,
+        t_now: float,
+        *,
+        name: str,
+        inbound: bool,
+        run_type: RunKind = "chain",
+        inputs: dict[str, Any] | None = None,
+        outputs: dict[str, Any] | None = None,
+        usage_metadata: dict[str, Any] | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> Iterator[RunTree]:
+        """Open a child span for one received event; close it on body exit.
+
+        Wrapping the handler body means any real work done while handling the
+        event (e.g. tool execution) nests inside this span — the same way a tool
+        call nests under the step that triggered it in any traced app.
+
+        By default the raw (scrubbed) event payload is the span's I/O — in
+        ``inputs`` for user→model (``inbound``) events, in ``outputs`` otherwise.
+        Pass curated ``inputs``/``outputs`` (and optionally a ``run_type`` like
+        "llm" plus ``usage_metadata``) to give the span readable,
+        conversation-shaped I/O instead; the full wire payload is then preserved
+        under ``metadata.raw_event``. Curated values pass through ``scrub`` too,
+        so no un-scrubbed event data ever reaches a span.
+        """
+        self.event_count += 1
+        payload = scrub(dump_event(event))
+        # "Curated" = the caller supplied readable I/O or a non-default kind, so
+        # the raw wire payload is demoted to metadata rather than the headline.
+        curated = inputs is not None or outputs is not None or run_type != "chain"
+
+        md: dict[str, Any] = {"received_at_s": round(t_now, 3)}
+        if curated:
+            md["raw_event"] = payload
+        if metadata:
+            md.update(metadata)
+
+        if inputs is not None:
+            run_inputs: Any = scrub(inputs)
+        elif curated:
+            run_inputs = {}
+        else:
+            run_inputs = payload if inbound else {}
+
+        parent = self._current_turn or self.run
+        run = parent.create_child(
+            name=name,
+            run_type=run_type,
+            inputs=run_inputs,
+            tags=["event"],
+            extra={"metadata": md},
+        )
+        run.post()
+        try:
+            yield run
+        finally:
+            if usage_metadata is not None:
+                run.set(usage_metadata=cast("Any", usage_metadata))
+            if curated:
+                run.end(outputs=scrub(outputs) if outputs is not None else {})
+            else:
+                run.end(outputs={} if inbound else payload)
+            run.patch()
+
+    def record_llm(
+        self,
+        parent: RunTree | None = None,
+        *,
+        name: str = "model",
+        outputs: dict[str, Any],
+        inputs: dict[str, Any] | None = None,
+        usage_metadata: dict[str, Any] | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
+        """Record a point-in-time ``llm`` child span for a model response.
+
+        Voice services deliver a response as a *terminal* event (e.g. Realtime's
+        ``response.done``), so there's no model-inference duration to measure —
+        but the token usage, assistant message, and finish status still belong
+        on an ``llm``-kind run for cost rollup and readability. Kept
+        point-in-time and separate from the surrounding handler span so local
+        tool latency is never attributed to the model call. ``parent`` defaults
+        to the current turn (or the root).
+
+        When ``inputs`` is omitted, it defaults to the model's *effective
+        prompt* — the conversation transcript so far minus the response being
+        recorded (the trailing assistant message) — so the ``llm`` run reads like
+        a normal model call instead of having empty inputs.
+        """
+        parent = parent or self._current_turn or self.run
+        if inputs is None:
+            context = list(self.messages)
+            if context and context[-1].get("role") == "assistant":
+                context = context[:-1]  # drop the response we're recording
+            inputs = {"messages": context}
+        run = parent.create_child(
+            name=name,
+            run_type="llm",
+            inputs=scrub(inputs),
+            tags=["model"],
+            extra={"metadata": metadata or {}},
+        )
+        run.post()
+        if usage_metadata is not None:
+            run.set(usage_metadata=cast("Any", usage_metadata))
+        run.end(outputs=scrub(outputs))
+        run.patch()
+
+    def open_span(
+        self,
+        *,
+        name: str,
+        run_type: RunKind = "chain",
+        inputs: dict[str, Any] | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> RunTree:
+        """Open a child span and return it for the caller to ``close_span`` later.
+
+        Unlike ``event_span`` (a context manager that fixes its ``outputs`` up
+        front), this is for work whose result is only known at a *later* event —
+        e.g. a tool call that spans a ``tool_start``/``tool_end`` pair, where the
+        wall-clock gap between the two events is the real tool latency. Nests
+        under the current turn (or the root) and counts toward ``event_count``,
+        like any other event span. The caller must pair every ``open_span`` with
+        a ``close_span`` (see the adapters' teardown, which closes any that were
+        left open).
+        """
+        self.event_count += 1
+        parent = self._current_turn or self.run
+        run = parent.create_child(
+            name=name,
+            run_type=run_type,
+            inputs=scrub(inputs) if inputs is not None else {},
+            tags=["event"],
+            extra={"metadata": metadata or {}},
+        )
+        run.post()
+        return run
+
+    def close_span(
+        self,
+        run: RunTree,
+        *,
+        outputs: dict[str, Any] | None = None,
+        usage_metadata: dict[str, Any] | None = None,
+    ) -> None:
+        """End and patch a span previously opened with ``open_span``.
+
+        Any error already set on ``run`` (``run.error``) is preserved. Outputs
+        pass through ``scrub`` like every other span payload.
+        """
+        if usage_metadata is not None:
+            run.set(usage_metadata=cast("Any", usage_metadata))
+        run.end(outputs=scrub(outputs) if outputs is not None else {})
+        run.patch()
+
+    def finalize(self) -> None:
+        """Roll up stats, attach the stereo WAV, and close the root span.
+
+        Best-effort: a failure building the WAV must not stop the root span from
+        being closed, and finalize as a whole must not raise into the caller's
+        teardown (see the adapters' ``__aexit__``).
+        """
+        # Close the last open turn (if any) before the root.
+        self._close_turn()
+        extra: dict[str, Any] = self.run.extra or {}
+        metadata: dict[str, Any] = dict(extra.get("metadata") or {})
+        metadata["event_count"] = self.event_count
+        metadata["duration_s"] = round(time.monotonic() - self.t0, 2)
+        if self._audio_truncated:
+            metadata["audio_truncated"] = True
+        extra["metadata"] = metadata
+        self.run.extra = extra
+
+        try:
+            wav = build_stereo_session_wav(
+                self.user_chunks, self.agent_chunks, self.sample_rate
+            )
+        except Exception:
+            # A WAV-build failure (e.g. an oversized buffer) must not lose the
+            # rest of the trace — drop the audio asset and close the root.
+            logger.warning("voice tracing: failed to build session WAV", exc_info=True)
+            wav = b""
+        if wav:
+            # One audio asset for the whole conversation — stereo so you can
+            # hear both sides AND see interruption overlap.
+            # ``(mime_type, bytes)`` is a valid attachment; the ignore is for
+            # mypy's invariant-dict-value false positive on the union type.
+            self.run.attachments = {  # type: ignore[assignment]
+                "conversation": ("audio/wav", wav)
+            }
+        # The transcript is the conversation's natural "output": surfacing it on
+        # the root makes the whole exchange readable in the LangSmith preview
+        # pane without expanding a single child span.
+        self.run.end(outputs={"messages": self.messages} if self.messages else {})
+        self.run.patch()
+
+
+def start_session(
+    *,
+    thread_id: str,
+    sample_rate: int,
+    project_name: Optional[str] = None,
+    tags: Optional[list[str]] = None,
+    metadata: Optional[dict[str, Any]] = None,
+    name: str = "realtime_session",
+    max_audio_seconds: Optional[float] = None,
+    client: Optional[Client] = None,
+    replicas: Optional[Sequence[WriteReplica]] = None,
+) -> EventSession:
+    """Create and post the conversation root span, returning an ``EventSession``.
+
+    ``project_name`` falls back to LangSmith's standard resolution
+    (``LANGSMITH_PROJECT``) when omitted, like any other ``RunTree``.
+
+    ``client`` is an optional LangSmith ``Client`` for all tracing writes; child
+    spans inherit it via ``create_child``. ``None`` uses the SDK's standard
+    env-based client resolution.
+
+    ``replicas`` mirrors the conversation trace to additional destinations
+    (see LangSmith's tracing replicas). Set on the root and inherited by child
+    spans via ``create_child``; ``None`` disables replication.
+
+    ``max_audio_seconds`` caps how much audio per channel is retained for the
+    stereo WAV, guarding memory on long-running sessions; ``None`` keeps all
+    audio. It is converted to a per-channel byte budget at PCM16 (2 bytes/sample).
+    """
+    # Mark the root as an audio-modality run (these are voice conversations).
+    md = {"ls_modality": "audio", "thread_id": thread_id, **(metadata or {})}
+    # ``RunTree.session_name`` (aliased ``project_name``) is a ``str`` with a
+    # default factory; passing ``None`` explicitly fails validation, so only
+    # forward it when set and let the SDK resolve ``LANGSMITH_PROJECT`` otherwise.
+    project_kwargs = {"project_name": project_name} if project_name is not None else {}
+    # Only forward an explicit client; omit it so ``RunTree`` keeps its standard
+    # env-based resolution when the caller didn't supply one.
+    client_kwargs = {"client": client} if client is not None else {}
+    run = RunTree(
+        name=name,
+        run_type="chain",
+        inputs={},
+        tags=tags or [],
+        extra={"metadata": md},
+        replicas=replicas,
+        **project_kwargs,
+        **client_kwargs,
+    )
+    run.post()
+    max_audio_bytes = (
+        int(max_audio_seconds * sample_rate * 2)
+        if max_audio_seconds is not None
+        else None
+    )
+    return EventSession(
+        run=run,
+        thread_id=thread_id,
+        project_name=project_name,
+        sample_rate=sample_rate,
+        max_audio_bytes=max_audio_bytes,
+    )

--- a/python/langsmith/integrations/openai_realtime/__init__.py
+++ b/python/langsmith/integrations/openai_realtime/__init__.py
@@ -1,0 +1,24 @@
+"""LangSmith integration for the OpenAI Realtime API.
+
+There are two ways to build an OpenAI Realtime voice agent, each with its own
+wrapper here:
+
+* :func:`wrap_realtime` — for a raw ``client.realtime.connect()`` WebSocket loop.
+* :func:`wrap_realtime_session` — for an ``agents.realtime`` session built with
+  the OpenAI Agents SDK.
+
+Both build a single LangSmith trace from the provider's event stream and return
+a transparent proxy, so the caller's loop is unchanged.
+"""
+
+from __future__ import annotations
+
+from langsmith._internal._beta_decorator import warn_beta
+from langsmith.integrations.openai_realtime._connection import wrap_realtime
+from langsmith.integrations.openai_realtime._session import wrap_realtime_session
+
+# In beta: warn once on first use (matches the SDK's warn_beta convention).
+wrap_realtime = warn_beta(wrap_realtime)
+wrap_realtime_session = warn_beta(wrap_realtime_session)
+
+__all__ = ["wrap_realtime", "wrap_realtime_session"]

--- a/python/langsmith/integrations/openai_realtime/_connection.py
+++ b/python/langsmith/integrations/openai_realtime/_connection.py
@@ -1,0 +1,497 @@
+"""LangSmith tracing for the OpenAI Realtime API (raw WebSocket).
+
+OpenAI Realtime has no native telemetry — it's a raw WebSocket event stream of
+``input_audio_buffer.*`` / ``response.*`` events. :func:`wrap_realtime` wraps the
+``AsyncRealtimeConnection`` so the trace is built directly from that stream while
+the caller's ``async for event in connection`` loop is left untouched: each
+received event is observed, spanned where warranted, and grouped into turns; the
+running transcript and a stereo conversation WAV land on the root span.
+
+Tool nesting is preserved without wrapping the caller's loop body: an event's
+span is opened when the event is received and kept as the active LangSmith
+context until the *next* event arrives — so any ``@traceable`` work the caller
+does while handling the event (tool execution) nests under it.
+
+Trace shape — one conversation = one trace::
+
+    realtime_session                                   (root; transcript + WAV)
+    ├── session.created / session.updated              (setup)
+    ├── turn                                           (latency_ms, was_interrupted)
+    │   ├── conversation.item.input_audio_transcription.completed   (user message)
+    │   └── response.done                              (chain wrapper)
+    │       ├── model                                  (llm — message + tokens)
+    │       └── <your @traceable tools>                (nested under response.done)
+    └── turn …
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from typing import TYPE_CHECKING, Any, Callable, Optional
+
+from langsmith._internal._usage import _create_usage_metadata
+from langsmith._internal.voice.helpers import observe_safely
+from langsmith._internal.voice.session import EventSession, start_session
+from langsmith.run_helpers import tracing_context
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from langsmith import Client, RunTree
+    from langsmith.run_trees import WriteReplica
+
+logger = logging.getLogger(__name__)
+
+# Default PCM sample rate for OpenAI Realtime audio (used for the stereo WAV).
+DEFAULT_SAMPLE_RATE = 24_000
+
+# Structural bookkeeping events that only duplicate state already captured by
+# ``response.done`` and the transcript events, so spanning them floods the trace.
+NOISE_EVENTS = frozenset(
+    {
+        "input_audio_buffer.committed",
+        "conversation.item.added",
+        "conversation.item.done",
+        "response.created",
+        "response.output_item.added",
+        "response.output_item.done",
+        "response.content_part.added",
+        "response.content_part.done",
+        "response.output_audio.done",
+        # Redundant with the model span's tool_calls + the tool span's args.
+        "response.function_call_arguments.done",
+    }
+)
+
+
+def is_inbound(event_type: str) -> bool:
+    """Direction of an event relative to the model.
+
+    Inbound = something the user sent toward the model (their speech buffer,
+    their transcription) → goes in span ``inputs``. Everything else is the
+    model/server talking back → span ``outputs``.
+    """
+    return (
+        event_type.startswith("input_audio_buffer")
+        or "input_audio_transcription" in event_type
+    )
+
+
+def response_assistant_output(response: Any) -> dict[str, Any]:
+    """Curated assistant message from a ``response.done`` payload.
+
+    The readable, AIMessage-shaped view of what the model returned this
+    response: the spoken text plus any tool calls it requested. Tool calls use
+    the OpenAI ChatCompletion shape (``type: "function"`` with a nested
+    ``function`` holding the name and the raw JSON ``arguments`` string) — that's
+    the format the LangSmith UI recognizes and renders inline on the model span;
+    a flatter ``{name, args, id}`` shape would instead spill into "Additional
+    Fields".
+    """
+    texts: list[str] = []
+    tool_calls: list[dict[str, Any]] = []
+    for item in getattr(response, "output", None) or []:
+        if getattr(item, "type", None) == "function_call":
+            tool_calls.append(
+                {
+                    "id": getattr(item, "call_id", None),
+                    "type": "function",
+                    "index": len(tool_calls),
+                    "function": {
+                        "name": getattr(item, "name", None),
+                        # The wire ``arguments`` JSON string is passed through
+                        # verbatim: the UI expects a string here, not an object.
+                        "arguments": getattr(item, "arguments", None) or "{}",
+                    },
+                }
+            )
+            continue
+        for part in getattr(item, "content", None) or []:
+            text = getattr(part, "transcript", None) or getattr(part, "text", None)
+            if text:
+                texts.append(text)
+    out: dict[str, Any] = {"role": "assistant", "content": " ".join(texts).strip()}
+    if tool_calls:
+        out["tool_calls"] = tool_calls
+    return out
+
+
+def _usage_to_dict(usage: Any) -> dict[str, Any]:
+    """Normalize a Realtime ``usage`` object into the dict the shared mapper reads.
+
+    Realtime spells its per-modality breakdowns ``input_token_details`` /
+    ``output_token_details`` (singular "token"), whereas
+    :func:`_create_usage_metadata` looks for the Chat-Completions
+    ``*_tokens_details`` spelling — so we alias them here to let it pick up audio
+    and cached-token detail (which dominate voice cost). Falls back to the
+    top-level token counts if the object can't be dumped, omitting the detail
+    blocks rather than risk passing non-dict values to the mapper.
+    """
+    if isinstance(usage, dict):
+        base = dict(usage)
+    else:
+        model_dump = getattr(usage, "model_dump", None)
+        try:
+            base = dict(model_dump()) if callable(model_dump) else {}
+        except Exception:
+            base = {}
+        if not base:
+            for key in ("input_tokens", "output_tokens", "total_tokens"):
+                val = getattr(usage, key, None)
+                if val is not None:
+                    base[key] = val
+    for realtime_key, mapper_key in (
+        ("input_token_details", "input_tokens_details"),
+        ("output_token_details", "output_tokens_details"),
+    ):
+        block = base.get(realtime_key)
+        if isinstance(block, dict) and mapper_key not in base:
+            base[mapper_key] = block
+    return base
+
+
+def response_usage_metadata(response: Any) -> dict[str, Any] | None:
+    """Map Realtime token ``usage`` onto LangSmith ``usage_metadata`` (for cost).
+
+    Delegates to the shared OpenAI usage mapper so the Realtime integration and
+    the Chat/Agents wrappers agree on the canonical shape (and so audio/cached
+    token detail is captured, not dropped). Returns ``None`` when the response
+    carries no usage (e.g. a cancelled turn).
+    """
+    usage = getattr(response, "usage", None)
+    if usage is None:
+        return None
+    usage_dict = _usage_to_dict(usage)
+    if not any(
+        usage_dict.get(key) is not None
+        for key in ("input_tokens", "output_tokens", "total_tokens")
+    ):
+        return None
+    return dict(_create_usage_metadata(usage_dict))
+
+
+class _RealtimeTracer:
+    """Turns the Realtime event stream into a LangSmith trace, one event at a time.
+
+    Decides — privately — whether to open a span, open/close a turn, append to
+    the transcript rollup, set the trace title, time first-audio latency, flag a
+    barge-in, and record the ``llm`` span. All trace writes go through the
+    injected :class:`EventSession`.
+
+    An event's span is held open (as the active LangSmith parent context) from
+    the moment the event is received until the next event arrives, so the
+    caller's tool calls nest under it.
+    """
+
+    def __init__(
+        self,
+        session: EventSession,
+        *,
+        is_agent_speaking: Optional[Callable[[], bool]] = None,
+    ) -> None:
+        self._session = session
+        # The only way to know the agent was still audible when the user spoke (a
+        # barge-in) is whether playback is still queued; the wire stream has no
+        # "playout finished" event. Optional — supplied by the app.
+        self._is_agent_speaking = is_agent_speaking
+        # Per-turn latency: end-of-user-speech → first agent audio. Armed at
+        # speech_stopped, recorded on the first audio chunk. None = not armed.
+        self._await_audio_since: float | None = None
+        # The currently open event span, kept active until the next event:
+        # (event_span_cm, tracing_context_cm). None = nothing open.
+        self._open: tuple[Any, Any] | None = None
+
+    def observe(self, event: Any) -> None:
+        """Observe one received event; span it where warranted.
+
+        Closes the previous event's span first (the caller has finished handling
+        it), then applies turn/transcript/latency side-state and, for meaningful
+        events, opens a new span kept active until the next call.
+        """
+        self._close_open()
+        received_at = self._session.now()
+        etype = getattr(event, "type", None)
+        if etype is None:
+            return  # not a recognizable Realtime event; nothing to span
+
+        # No-span events: observed for side-state only.
+        if etype == "response.output_audio.delta":
+            self._record_first_audio(received_at)
+            return
+        if etype.endswith(".delta") or etype in NOISE_EVENTS:
+            return
+        if etype == "response.output_audio_transcript.done":
+            # Already the model span's content; fold into the rollup, don't span.
+            self._session.add_message(
+                "assistant", getattr(event, "transcript", "") or ""
+            )
+            return
+
+        self._before_span(event, received_at)
+
+        cm_span = self._session.event_span(
+            event, received_at, name=etype, **self._span_kwargs(event)
+        )
+        run = cm_span.__enter__()
+        if etype == "conversation.item.input_audio_transcription.failed":
+            run.error = f"transcription_failed: {getattr(event, 'error', None)}"
+        elif etype == "response.done":
+            response = getattr(event, "response", None)
+            if response is not None:
+                self._record_response_llm(run, response)
+        cm_ctx = tracing_context(parent=run)
+        cm_ctx.__enter__()
+        self._open = (cm_span, cm_ctx)
+
+    def finalize_open(self) -> None:
+        """Close any still-open event span (called at teardown)."""
+        self._close_open()
+
+    def _close_open(self) -> None:
+        if self._open is None:
+            return
+        cm_span, cm_ctx = self._open
+        self._open = None
+        cm_ctx.__exit__(None, None, None)
+        cm_span.__exit__(None, None, None)
+
+    def _before_span(self, event: Any, received_at: float) -> None:
+        """Turn/transcript/title side-state applied as a span is about to open."""
+        etype = event.type
+        if etype == "input_audio_buffer.speech_started":
+            # A user starting to speak opens a new turn (also the barge-in
+            # signal). If the agent was still audible, the turn being closed was
+            # talked over — flag it before start_turn() closes it.
+            if self._is_agent_speaking is not None and self._is_agent_speaking():
+                self._session.add_turn_metadata(was_interrupted=True)
+            self._session.start_turn()
+            self._await_audio_since = None
+        elif etype == "input_audio_buffer.speech_stopped":
+            self._await_audio_since = received_at
+        elif etype == "conversation.item.input_audio_transcription.completed":
+            text = (getattr(event, "transcript", "") or "").strip()
+            if text:
+                self._session.add_message("user", text)
+                self._session.set_title(text)
+            else:
+                self._await_audio_since = None
+        elif etype == "conversation.item.input_audio_transcription.failed":
+            self._await_audio_since = None
+
+    def _span_kwargs(self, event: Any) -> dict[str, Any]:
+        """Curated, conversation-shaped I/O for the readable events."""
+        etype = event.type
+        kwargs: dict[str, Any] = {"inbound": is_inbound(etype)}
+        if etype == "conversation.item.input_audio_transcription.completed":
+            text = (getattr(event, "transcript", "") or "").strip()
+            if text:
+                kwargs["inputs"] = {"role": "user", "content": text}
+        elif etype == "response.done":
+            # Keep this a chain wrapper; the model payload goes on the child llm
+            # span so local tool latency isn't attributed to the model.
+            kwargs["outputs"] = {}
+        return kwargs
+
+    def _record_first_audio(self, received_at: float) -> None:
+        if self._await_audio_since is not None:
+            self._session.add_turn_metadata(
+                latency_to_first_audio_ms=round(
+                    (received_at - self._await_audio_since) * 1000
+                )
+            )
+            self._await_audio_since = None
+
+    def _record_response_llm(self, run: RunTree, response: Any) -> None:
+        self._session.record_llm(
+            run,
+            outputs=response_assistant_output(response),
+            usage_metadata=response_usage_metadata(response),
+            metadata={"status": getattr(response, "status", None)},
+        )
+
+
+class _TracedRealtimeConnection:
+    """Transparent proxy over an ``AsyncRealtimeConnection`` that traces events.
+
+    Delegates every attribute to the wrapped connection, so the caller uses it
+    exactly like the original (``connection.session.update(...)``,
+    ``connection.response.create()``, ``async for event in connection``). Each
+    received event is passed to the tracer. Also exposes
+    :meth:`record_user_audio` / :meth:`record_agent_audio` so the app can
+    (optionally) feed PCM for the stereo conversation WAV.
+    """
+
+    def __init__(
+        self, connection: Any, tracer: _RealtimeTracer, session: EventSession
+    ) -> None:
+        # Plain assignment is safe: this proxy only overrides ``__getattr__``
+        # (read miss) — not ``__setattr__`` — so writes never delegate.
+        self._connection = connection
+        self._tracer = tracer
+        self._session = session
+        self._aiter = None
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(object.__getattribute__(self, "_connection"), name)
+
+    def __aiter__(self) -> _TracedRealtimeConnection:
+        self._aiter = self._connection.__aiter__()
+        return self
+
+    async def __anext__(self) -> Any:
+        aiter = self._aiter
+        if aiter is None:
+            aiter = self._connection.__aiter__()
+            self._aiter = aiter
+        event = await aiter.__anext__()
+        observe_safely(self._tracer.observe, event)
+        return event
+
+    async def recv(self) -> Any:
+        event = await self._connection.recv()
+        observe_safely(self._tracer.observe, event)
+        return event
+
+    def record_user_audio(self, pcm: bytes) -> None:
+        """Record a chunk of user (mic) PCM16 for the stereo conversation WAV."""
+        self._session.record_user(self._session.now(), pcm)
+
+    def record_agent_audio(self, pcm: bytes) -> None:
+        """Record a chunk of agent (played) PCM16 for the stereo conversation WAV."""
+        self._session.record_agent(self._session.now(), pcm)
+
+
+class _RealtimeTracingSession:
+    """Async context manager returned by :func:`wrap_realtime`.
+
+    On enter: starts the conversation root span and session-level LangSmith
+    context, returning a traced connection proxy. On exit: closes any open span,
+    records an error on the root if the body raised, and finalizes the root
+    (rolling up the transcript + attaching the stereo WAV).
+    """
+
+    def __init__(
+        self,
+        connection: Any,
+        *,
+        thread_id: Optional[str],
+        sample_rate: int,
+        project_name: Optional[str],
+        tags: Optional[list[str]],
+        metadata: Optional[dict[str, Any]],
+        is_agent_speaking: Optional[Callable[[], bool]],
+        max_audio_seconds: Optional[float],
+        client: Optional[Client],
+        replicas: Optional[Sequence[WriteReplica]],
+    ) -> None:
+        self._connection = connection
+        self._thread_id = thread_id or str(uuid.uuid4())
+        self._sample_rate = sample_rate
+        self._project_name = project_name
+        self._tags = tags
+        self._metadata = metadata
+        self._is_agent_speaking = is_agent_speaking
+        self._max_audio_seconds = max_audio_seconds
+        self._client = client
+        self._replicas = replicas
+        self._session: EventSession | None = None
+        self._tracer: _RealtimeTracer | None = None
+        self._ctx: Any = None
+
+    async def __aenter__(self) -> _TracedRealtimeConnection:
+        self._session = start_session(
+            thread_id=self._thread_id,
+            sample_rate=self._sample_rate,
+            project_name=self._project_name,
+            tags=self._tags,
+            metadata=self._metadata,
+            max_audio_seconds=self._max_audio_seconds,
+            client=self._client,
+            replicas=self._replicas,
+        )
+        self._ctx = tracing_context(
+            metadata={"thread_id": self._thread_id},
+            tags=self._tags,
+            project_name=self._project_name,
+            replicas=self._replicas,
+        )
+        self._ctx.__enter__()
+        self._tracer = _RealtimeTracer(
+            self._session, is_agent_speaking=self._is_agent_speaking
+        )
+        return _TracedRealtimeConnection(self._connection, self._tracer, self._session)
+
+    async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> bool:
+        # Teardown is best-effort: closing the trace must neither mask the
+        # caller's own exception nor raise a new one. The tracing context is
+        # always restored (``finally``) so it can't leak past the session.
+        try:
+            if self._tracer is not None:
+                self._tracer.finalize_open()
+            if self._session is not None:
+                if exc is not None:
+                    self._session.run.error = f"{exc_type.__name__}: {exc}"
+                self._session.finalize()
+        except Exception:
+            logger.warning("voice tracing: failed to finalize session", exc_info=True)
+        finally:
+            if self._ctx is not None:
+                self._ctx.__exit__(None, None, None)
+        return False
+
+
+def wrap_realtime(
+    connection: Any,
+    *,
+    thread_id: Optional[str] = None,
+    sample_rate: int = DEFAULT_SAMPLE_RATE,
+    project_name: Optional[str] = None,
+    tags: Optional[list[str]] = None,
+    metadata: Optional[dict[str, Any]] = None,
+    is_agent_speaking: Optional[Callable[[], bool]] = None,
+    max_audio_seconds: Optional[float] = None,
+    client: Optional[Client] = None,
+    replicas: Optional[Sequence[WriteReplica]] = None,
+) -> _RealtimeTracingSession:
+    r"""Trace an OpenAI Realtime connection into LangSmith.
+
+    Returns an async context manager that yields a transparent proxy of
+    ``connection``; iterate and call it exactly as you would the original::
+
+        async with client.realtime.connect(model=...) as raw, \\
+                   wrap_realtime(raw, thread_id=tid) as connection:
+            async for event in connection:
+                ...
+
+    To capture the stereo conversation WAV, feed PCM via the proxy's
+    ``record_user_audio`` / ``record_agent_audio`` and (optionally) supply
+    ``is_agent_speaking`` so barge-ins are flagged.
+
+    Args:
+        connection: the ``AsyncRealtimeConnection`` from ``client.realtime.connect``.
+        thread_id: LangSmith thread id; a random UUID if omitted.
+        sample_rate: PCM sample rate of the audio (for the WAV).
+        project_name: LangSmith project; defaults to standard ``LANGSMITH_*`` config.
+        tags / metadata: attached to the conversation root span.
+        is_agent_speaking: zero-arg callable returning whether the agent is still
+            audible, used to flag a barge-in; ``None`` disables that flag.
+        max_audio_seconds: per-channel cap on audio retained for the WAV, to
+            bound memory on long sessions; ``None`` (default) keeps all audio.
+        client: LangSmith ``Client`` for tracing writes; ``None`` (default) uses
+            the SDK's standard env-based resolution (``LANGSMITH_*``).
+        replicas: tracing replicas to mirror the conversation trace to additional
+            destinations; ``None`` (default) disables replication.
+    """
+    return _RealtimeTracingSession(
+        connection,
+        thread_id=thread_id,
+        sample_rate=sample_rate,
+        project_name=project_name,
+        tags=tags,
+        metadata=metadata,
+        is_agent_speaking=is_agent_speaking,
+        max_audio_seconds=max_audio_seconds,
+        client=client,
+        replicas=replicas,
+    )

--- a/python/langsmith/integrations/openai_realtime/_session.py
+++ b/python/langsmith/integrations/openai_realtime/_session.py
@@ -1,0 +1,624 @@
+"""LangSmith tracing for the OpenAI Agents SDK realtime backend.
+
+The Agents SDK's realtime sessions emit no local SDK trace spans (realtime
+tracing is server-side only), so the existing batch ``OpenAIAgentsTracingProcessor``
+captures nothing here. This is a separate, complementary integration:
+:func:`wrap_realtime_session` wraps the ``RealtimeSession`` so the trace is built
+from its **semantic event stream**, while the caller's ``async for event in
+session`` loop is left untouched.
+
+The conversation is reconstructed from the full ``history`` snapshot the session
+delivers on every ``history_updated`` — not from the streamed events, which
+mis-deliver user messages and emit the assistant transcript as growing partials.
+Snapshots are folded into an item map keyed by stable ``item_id`` (latest text
+per id wins → partials collapse); each finalized message emits one span (a
+curated ``user_message`` or an assistant ``model`` ``llm`` span), grouped into
+turns. Each SDK-run tool becomes a single ``tool`` span spanning its
+``tool_start``→``tool_end`` pair (so the span duration is the real tool latency);
+``audio_interrupted`` flags the turn. (Token usage isn't available — the SDK has
+no per-response usage events yet.)
+
+Trace shape — one conversation = one trace::
+
+    realtime_session                                   (root; transcript + WAV)
+    ├── turn                                           (latency_ms, was_interrupted)
+    │   ├── user_message                               (curated user msg, from history)
+    │   ├── lookup_weather                             (tool — args in / output out)
+    │   └── model             (assistant message)      (llm — from history)
+    └── turn …
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import logging
+import sys
+import uuid
+from typing import TYPE_CHECKING, Any, Callable, Optional
+
+from langsmith._internal.voice.helpers import observe_safely
+from langsmith._internal.voice.session import EventSession, start_session
+from langsmith.run_helpers import tracing_context
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from langsmith import Client, RunTree
+    from langsmith.run_trees import WriteReplica
+
+logger = logging.getLogger(__name__)
+
+# Default PCM sample rate for OpenAI Realtime audio (used for the stereo WAV).
+DEFAULT_SAMPLE_RATE = 24_000
+
+_MAX_DEPTH = 4  # how deep we recurse into nested SDK objects before bailing
+_MAX_ITEMS = 50  # cap on collection width so one event never balloons a span
+_MAX_REPR = 200  # truncate the repr() fallback for exotic objects
+
+
+# ---------------------------------------------------------------------------
+# Payload shaping: turn the SDK's semantic event (a dataclass holding live SDK
+# objects) into a compact, JSON-able span payload.
+# ---------------------------------------------------------------------------
+
+
+def _stringify(value: Any) -> Any:
+    """Keep JSON-able values as-is; repr anything exotic so a span never breaks."""
+    if value is None or isinstance(value, (str, int, float, bool, dict, list)):
+        return value
+    return repr(value)
+
+
+def _shallow(value: Any) -> Any:
+    """Last-resort view of a value we won't (or can't) recurse into."""
+    name = getattr(value, "name", None)
+    if isinstance(name, str):
+        return name
+    text = repr(value)
+    return text if len(text) <= _MAX_REPR else text[:_MAX_REPR] + "…"
+
+
+def _public_fields(value: Any) -> dict[str, Any] | None:
+    """Public, non-callable attributes of a dataclass/object, or None."""
+    fields: dict[str, Any] | None
+    if dataclasses.is_dataclass(value) and not isinstance(value, type):
+        fields = {
+            f.name: getattr(value, f.name, None) for f in dataclasses.fields(value)
+        }
+    else:
+        fields = getattr(value, "__dict__", None)
+    if not fields:
+        return None
+    return {
+        k: v for k, v in fields.items() if not k.startswith("_") and not callable(v)
+    }
+
+
+def _clean(value: Any, depth: int = 0, seen: frozenset[int] = frozenset()) -> Any:
+    """Recursively coerce any value into a compact, JSON-able span payload.
+
+    Keeps readable data and strips what would break or bloat a span: raw bytes,
+    callables, private attributes, and anything past the depth/width caps. Cycles
+    are broken via ``seen``.
+    """
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, (bytes, bytearray, memoryview)):
+        return f"<{len(bytes(value))} bytes>"
+
+    if depth >= _MAX_DEPTH:
+        return _shallow(value)
+    if id(value) in seen:
+        return "<circular>"
+    seen = seen | {id(value)}
+
+    if isinstance(value, dict):
+        out: dict[str, Any] = {}
+        for i, (key, val) in enumerate(value.items()):
+            if i >= _MAX_ITEMS:
+                out["…"] = f"+{len(value) - _MAX_ITEMS} more"
+                break
+            if isinstance(key, str) and key.startswith("_"):
+                continue
+            out[str(key)] = _clean(val, depth + 1, seen)
+        return out
+
+    if isinstance(value, (list, tuple, set)):
+        items = list(value)
+        cleaned = [_clean(v, depth + 1, seen) for v in items[:_MAX_ITEMS]]
+        if len(items) > _MAX_ITEMS:
+            cleaned.append(f"… +{len(items) - _MAX_ITEMS} more")
+        return cleaned
+
+    fields = _public_fields(value)
+    if fields:
+        return {k: _clean(v, depth + 1, seen) for k, v in fields.items()}
+    return _shallow(value)
+
+
+def _tool_name(tool: Any) -> str | None:
+    return getattr(tool, "name", None) or (repr(tool) if tool is not None else None)
+
+
+def _item_text(item: Any) -> tuple[str | None, str | None]:
+    """Best-effort ``(role, text)`` for a realtime history item."""
+    if item is None:
+        return None, None
+    role = getattr(item, "role", None)
+    content = getattr(item, "content", None) or []
+    parts = []
+    for part in content:
+        text = getattr(part, "transcript", None) or getattr(part, "text", None)
+        if text:
+            parts.append(text)
+    return role, (" ".join(parts) or None)
+
+
+def raw_input_transcript(event: Any) -> tuple[str | None, str] | None:
+    """Extract the user transcript from a ``raw_model_event``.
+
+    Reads a ``raw_model_event`` wrapping an input-audio transcription completion
+    (the wire-level source ``history`` can omit on a barge-in). Returns
+    ``(item_id, transcript)`` or None.
+    """
+    data = getattr(event, "data", None)
+    if getattr(data, "type", None) != "input_audio_transcription_completed":
+        return None
+    transcript = (getattr(data, "transcript", None) or "").strip()
+    if not transcript:
+        return None
+    return getattr(data, "item_id", None), transcript
+
+
+def history_item(event: Any) -> tuple[str | None, str | None, str | None]:
+    """``(item_id, role, text)`` for a ``history_added`` event's single item."""
+    item = getattr(event, "item", None)
+    role, text = _item_text(item)
+    return getattr(item, "item_id", None), role, text
+
+
+def history_messages(event: Any) -> list[tuple[str | None, str | None, str | None]]:
+    """``(item_id, role, text)`` for every item in a ``history_updated`` snapshot."""
+    out: list[tuple[str | None, str | None, str | None]] = []
+    for item in getattr(event, "history", None) or []:
+        role, text = _item_text(item)
+        out.append((getattr(item, "item_id", None), role, text))
+    return out
+
+
+def describe_event(event: Any) -> tuple[str, dict[str, Any], bool]:
+    """Map a session event to ``(name, span_payload, inbound)``."""
+    etype = getattr(event, "type", None) or repr(event)
+    dumped = _clean(event)
+    payload: dict[str, Any] = dumped if isinstance(dumped, dict) else {"value": dumped}
+    payload["type"] = etype
+    inbound = False
+
+    if etype in ("agent_start", "agent_end"):
+        payload["agent"] = getattr(getattr(event, "agent", None), "name", None)
+    elif etype == "tool_start":
+        payload["tool"] = _tool_name(getattr(event, "tool", None))
+        payload["arguments"] = _stringify(getattr(event, "arguments", None))
+        inbound = True  # the model is asking us to run something → its input
+    elif etype == "tool_end":
+        payload["tool"] = _tool_name(getattr(event, "tool", None))
+        payload["arguments"] = _stringify(getattr(event, "arguments", None))
+        payload["output"] = _stringify(getattr(event, "output", None))
+    elif etype == "audio_interrupted":
+        payload["item_id"] = getattr(event, "item_id", None)
+    elif etype == "history_added":
+        role, text = _item_text(getattr(event, "item", None))
+        payload["role"], payload["text"] = role, text
+        inbound = role == "user"
+    elif etype == "history_updated":
+        history = getattr(event, "history", None) or []
+        role, text = _item_text(history[-1]) if history else (None, None)
+        payload["last_role"], payload["last_text"] = role, text
+        payload["length"] = len(history)
+        inbound = role == "user"
+    elif etype == "handoff":
+        payload["from_agent"] = getattr(
+            getattr(event, "from_agent", None), "name", None
+        )
+        payload["to_agent"] = getattr(getattr(event, "to_agent", None), "name", None)
+    elif etype == "guardrail_tripped":
+        payload["message"] = _stringify(getattr(event, "message", None))
+    elif etype == "error":
+        payload["error"] = _stringify(getattr(event, "error", None))
+
+    return etype, payload, inbound
+
+
+class _AgentsRealtimeTracer:
+    """Reconstructs the conversation from history snapshots and emits its spans.
+
+    Folds each ``history`` snapshot into a map keyed by stable ``item_id``
+    (latest non-empty text wins, so partials collapse), emits one span per
+    finalized message (a ``user_message`` or an assistant ``model`` ``llm`` span)
+    grouped into per-user-turn ``turn`` spans, and spans ``tool_end`` /
+    ``audio_interrupted`` from the live stream. Optionally notifies an
+    ``on_message`` callback as finalized transcript lines arrive.
+    """
+
+    def __init__(
+        self,
+        session: EventSession,
+        *,
+        on_message: Optional[Callable[[str, str], None]] = None,
+    ) -> None:
+        self._trace = session
+        self._on_message = on_message
+        # item_id → {"role", "text"}, in arrival order (dict preserves insertion).
+        self._items: dict[str, dict[str, Any]] = {}
+        self._emitted: set[str] = set()  # item_ids already turned into spans
+        self._notified: set[tuple[str, str]] = set()  # (role, text) already sent out
+        # Per-turn latency: when the current user turn opened; None = not armed.
+        self._latency_since: float | None = None
+        # Open tool spans, keyed by (tool_name, arguments). The SDK's
+        # tool_start/tool_end events carry no call_id, so start→end is matched on
+        # that pair; a FIFO list per key disambiguates the (rare) concurrent or
+        # repeated identical calls in async-tool mode.
+        self._open_tools: dict[tuple[str | None, str | None], list[RunTree]] = {}
+
+    def observe(self, event: Any) -> None:
+        """Observe one session event: fold history, emit spans, time latency."""
+        received_at = self._trace.now()
+        etype = getattr(event, "type", None)
+        if etype is None:
+            return  # not a recognizable session event; nothing to trace
+
+        if etype == "audio":
+            self.record_first_audio(received_at)
+            return
+        if etype == "raw_model_event":
+            rec = raw_input_transcript(event)
+            if rec:
+                item_id, transcript = rec
+                self._observe_items([(item_id, "user", transcript)], received_at)
+                self._flush(hold_last=True)
+            return
+        if etype == "history_added":
+            self._observe_items([history_item(event)], received_at)
+            self._flush(hold_last=True)
+            return
+        if etype == "history_updated":
+            self._observe_items(history_messages(event), received_at)
+            self._flush(hold_last=True)
+            return
+        if etype in ("agent_start", "agent_end"):
+            return  # bookkeeping markers, no I/O
+        # A tool call is one span spanning tool_start → tool_end: the gap between
+        # the two events is the real tool latency (the SDK runs the tool between
+        # them), so they're held open rather than spanned point-in-time.
+        if etype == "tool_start":
+            self._start_tool(event)
+            return
+        if etype == "tool_end":
+            self._end_tool(event, received_at)
+            return
+
+        # Remaining live events get a point-in-time span; a barge-in flags the
+        # open turn.
+        name, payload, inbound = describe_event(event)
+        if etype == "audio_interrupted":
+            self._trace.add_turn_metadata(was_interrupted=True)
+
+        # No nested work happens while handling these events, so open+close now.
+        with self._trace.event_span(payload, received_at, name=name, inbound=inbound):
+            pass
+
+    def _start_tool(self, event: Any) -> None:
+        """Open a held-open ``tool`` span for a ``tool_start`` event."""
+        name = _tool_name(getattr(event, "tool", None))
+        args = _stringify(getattr(event, "arguments", None))
+        run = self._trace.open_span(
+            name=name or "tool",
+            run_type="tool",
+            inputs={"arguments": args},
+        )
+        self._open_tools.setdefault((name, args), []).append(run)
+
+    def _end_tool(self, event: Any, received_at: float) -> None:
+        """Close the matching open tool span for a ``tool_end`` event.
+
+        Matched on ``(tool_name, arguments)`` FIFO. If no open start matches
+        (e.g. tracing began mid-call), fall back to a point-in-time tool span so
+        the call is still recorded.
+        """
+        name = _tool_name(getattr(event, "tool", None))
+        args = _stringify(getattr(event, "arguments", None))
+        output = _stringify(getattr(event, "output", None))
+        queue = self._open_tools.get((name, args))
+        if queue:
+            run = queue.pop(0)
+            if not queue:
+                del self._open_tools[(name, args)]
+            self._trace.close_span(run, outputs={"output": output})
+            return
+        with self._trace.event_span(
+            {"tool": name, "arguments": args, "output": output},
+            received_at,
+            name=name or "tool",
+            run_type="tool",
+            inbound=False,
+            inputs={"arguments": args},
+            outputs={"output": output},
+        ):
+            pass
+
+    def flush_pending(self) -> None:
+        """Emit any messages still pending and close orphaned tool spans.
+
+        Called at teardown. A ``tool_start`` whose tool raised (or a session torn
+        down mid-call) never gets a ``tool_end``; those spans are closed here with
+        an error so they don't dangle open forever.
+        """
+        self._flush(hold_last=False)
+        for queue in self._open_tools.values():
+            for run in queue:
+                run.error = "tool did not complete before the session ended"
+                self._trace.close_span(run)
+        self._open_tools.clear()
+
+    def _observe_items(self, seq: list[tuple], received_at: float) -> None:
+        """Fold ``(item_id, role, text)`` tuples into the map.
+
+        A brand-new user item begins a turn: the previous turn's messages are
+        flushed first (so they stay grouped under it), then a new turn opens and
+        the latency timer is armed.
+        """
+        for iid, role, text in seq:
+            if not iid:
+                continue
+            if iid not in self._items and role == "user":
+                self._flush(hold_last=False)
+                self._trace.start_turn()
+                self._latency_since = received_at
+            cur = self._items.get(iid)
+            if cur is None:
+                self._items[iid] = {"role": role, "text": text}
+            else:
+                if role:
+                    cur["role"] = role
+                if text:  # latest non-empty text wins → collapses partials
+                    cur["text"] = text
+            if role in ("user", "assistant") and text:
+                self._notify(role, text)
+
+    def _flush(self, hold_last: bool) -> None:
+        """Emit not-yet-emitted items in order.
+
+        Optionally holds back the last (still-streaming) item until it is
+        superseded or the session ends.
+        """
+        ids = list(self._items)
+        cutoff = len(ids) - 1 if hold_last else len(ids)
+        for iid in ids[: max(0, cutoff)]:
+            if iid not in self._emitted:
+                self._record_item(iid)
+
+    def record_first_audio(self, received_at: float) -> None:
+        """Record ``latency_to_first_audio_ms`` on the open turn, once per turn."""
+        if self._latency_since is not None:
+            self._trace.add_turn_metadata(
+                latency_to_first_audio_ms=round(
+                    (received_at - self._latency_since) * 1000
+                )
+            )
+            self._latency_since = None
+
+    def _notify(self, role: str | None, text: str | None) -> None:
+        """Send one finalized transcript line to the on_message callback once."""
+        if self._on_message is None or not role or not text:
+            return
+        if (role, text) in self._notified:
+            return
+        self._notified.add((role, text))
+        self._on_message(role, text)
+
+    def _record_item(self, iid: str) -> None:
+        """Emit one message span for a finalized history item (once)."""
+        role = self._items[iid]["role"]
+        text = (self._items[iid]["text"] or "").strip()
+        if role not in ("user", "assistant"):
+            self._emitted.add(iid)  # tool/system items are never messages
+            return
+        if not text:
+            return  # text not in yet (may arrive late, e.g. a barge-in) — pending
+        self._emitted.add(iid)
+        self._notify(role, text)
+        self._trace.add_message(role, text)
+        if role == "user":
+            with self._trace.event_span(
+                {"item_id": iid, "role": "user", "content": text},
+                self._trace.now(),
+                name="user_message",
+                inbound=True,
+                inputs={"role": "user", "content": text},
+            ):
+                pass
+        else:
+            self._trace.record_llm(outputs={"role": "assistant", "content": text})
+
+
+class _TracedRealtimeSession:
+    """Async-context-manager proxy over a ``RealtimeSession`` that traces events.
+
+    Delegates the underlying session's ``async with`` and every attribute
+    (``send_audio``, …), iterates its events, and observes each. On exit it emits
+    any pending messages and finalizes the conversation root (transcript + WAV).
+    Exposes ``record_user_audio`` / ``record_agent_audio`` for the stereo WAV.
+    """
+
+    def __init__(
+        self,
+        session: Any,
+        *,
+        thread_id: Optional[str],
+        sample_rate: int,
+        project_name: Optional[str],
+        tags: Optional[list[str]],
+        metadata: Optional[dict[str, Any]],
+        on_message: Optional[Callable[[str, str], None]],
+        max_audio_seconds: Optional[float],
+        client: Optional[Client],
+        replicas: Optional[Sequence[WriteReplica]],
+    ) -> None:
+        # Plain assignment is safe: this proxy only overrides ``__getattr__``
+        # (read miss) — not ``__setattr__`` — so writes never delegate.
+        self._session = session
+        self._thread_id = thread_id or str(uuid.uuid4())
+        self._sample_rate = sample_rate
+        self._project_name = project_name
+        self._tags = tags
+        self._metadata = metadata
+        self._on_message = on_message
+        self._max_audio_seconds = max_audio_seconds
+        self._client = client
+        self._replicas = replicas
+        # Created lazily in ``__aenter__``; annotate so their real types are
+        # known despite the ``None`` seed.
+        self._trace: Optional[EventSession] = None
+        self._tracer: Optional[_AgentsRealtimeTracer] = None
+        self._ctx: Any = None
+        self._aiter: Any = None
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(object.__getattribute__(self, "_session"), name)
+
+    async def __aenter__(self) -> _TracedRealtimeSession:
+        await self._session.__aenter__()
+        # The underlying session is now open. If our own tracing setup raises,
+        # Python won't call __aexit__ (the context was never successfully
+        # entered), so we must unwind the session here or it leaks.
+        try:
+            trace = start_session(
+                thread_id=self._thread_id,
+                sample_rate=self._sample_rate,
+                project_name=self._project_name,
+                tags=self._tags,
+                metadata=self._metadata,
+                max_audio_seconds=self._max_audio_seconds,
+                client=self._client,
+                replicas=self._replicas,
+            )
+            self._trace = trace
+            ctx = tracing_context(
+                metadata={"thread_id": self._thread_id},
+                tags=self._tags,
+                project_name=self._project_name,
+                replicas=self._replicas,
+            )
+            ctx.__enter__()
+            self._ctx = ctx
+            self._tracer = _AgentsRealtimeTracer(trace, on_message=self._on_message)
+        except BaseException:
+            if self._ctx is not None:
+                try:
+                    self._ctx.__exit__(*sys.exc_info())
+                except Exception:
+                    logger.debug(
+                        "voice tracing: error unwinding context after a failed "
+                        "session enter",
+                        exc_info=True,
+                    )
+            await self._session.__aexit__(*sys.exc_info())
+            raise
+        return self
+
+    async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> Any:
+        # Teardown is best-effort: closing the trace must neither mask the
+        # caller's exception nor stop the underlying session from being exited.
+        # The tracing context is always restored (``finally``) so it can't leak.
+        try:
+            if self._tracer is not None:
+                self._tracer.flush_pending()
+            if self._trace is not None:
+                if exc is not None:
+                    self._trace.run.error = f"{exc_type.__name__}: {exc}"
+                self._trace.finalize()
+        except Exception:
+            logger.warning("voice tracing: failed to finalize session", exc_info=True)
+        finally:
+            if self._ctx is not None:
+                self._ctx.__exit__(None, None, None)
+        return await self._session.__aexit__(exc_type, exc, tb)
+
+    def __aiter__(self) -> _TracedRealtimeSession:
+        self._aiter = self._session.__aiter__()
+        return self
+
+    async def __anext__(self) -> Any:
+        aiter = self._aiter
+        if aiter is None:
+            aiter = self._session.__aiter__()
+            self._aiter = aiter
+        event = await aiter.__anext__()
+        if self._tracer is not None:
+            observe_safely(self._tracer.observe, event)
+        return event
+
+    def record_user_audio(self, pcm: bytes) -> None:
+        """Record a chunk of user (mic) PCM16 for the stereo conversation WAV."""
+        if self._trace is not None:
+            self._trace.record_user(self._trace.now(), pcm)
+
+    def record_agent_audio(self, pcm: bytes) -> None:
+        """Record a chunk of agent (played) PCM16 for the stereo conversation WAV."""
+        if self._trace is not None:
+            self._trace.record_agent(self._trace.now(), pcm)
+
+
+def wrap_realtime_session(
+    session: Any,
+    *,
+    thread_id: Optional[str] = None,
+    sample_rate: int = DEFAULT_SAMPLE_RATE,
+    project_name: Optional[str] = None,
+    tags: Optional[list[str]] = None,
+    metadata: Optional[dict[str, Any]] = None,
+    on_message: Optional[Callable[[str, str], None]] = None,
+    max_audio_seconds: Optional[float] = None,
+    client: Optional[Client] = None,
+    replicas: Optional[Sequence[WriteReplica]] = None,
+) -> _TracedRealtimeSession:
+    """Trace an OpenAI Agents SDK ``RealtimeSession`` into LangSmith.
+
+    Returns an async-context-manager proxy that also enters the underlying
+    session; iterate and call it exactly as you would the original::
+
+        session = await runner.run()
+        async with wrap_realtime_session(session, thread_id=tid) as conn:
+            async for event in conn:
+                ...
+
+    To capture the stereo conversation WAV, feed PCM via the proxy's
+    ``record_user_audio`` / ``record_agent_audio``.
+
+    Args:
+        session: the ``RealtimeSession`` returned by ``RealtimeRunner.run()``.
+        thread_id: LangSmith thread id; a random UUID if omitted.
+        sample_rate: PCM sample rate of the audio (for the WAV).
+        project_name: LangSmith project; defaults to standard ``LANGSMITH_*`` config.
+        tags / metadata: attached to the conversation root span.
+        on_message: optional callback ``(role, text)`` invoked once per finalized
+            transcript line (e.g. to print to a console).
+        max_audio_seconds: per-channel cap on audio retained for the WAV, to
+            bound memory on long sessions; ``None`` (default) keeps all audio.
+        client: LangSmith ``Client`` for tracing writes; ``None`` (default) uses
+            the SDK's standard env-based resolution (``LANGSMITH_*``).
+        replicas: tracing replicas to mirror the conversation trace to additional
+            destinations; ``None`` (default) disables replication.
+    """
+    return _TracedRealtimeSession(
+        session,
+        thread_id=thread_id,
+        sample_rate=sample_rate,
+        project_name=project_name,
+        tags=tags,
+        metadata=metadata,
+        on_message=on_message,
+        max_audio_seconds=max_audio_seconds,
+        client=client,
+        replicas=replicas,
+    )

--- a/python/langsmith/wrappers/_openai.py
+++ b/python/langsmith/wrappers/_openai.py
@@ -17,7 +17,11 @@ from typing_extensions import TypedDict
 
 from langsmith import client as ls_client
 from langsmith import run_helpers
-from langsmith.schemas import InputTokenDetails, OutputTokenDetails, UsageMetadata
+
+# ``_create_usage_metadata`` lives in a non-deprecated internal module so
+# integrations can reuse it without importing the ``wrappers`` package (whose
+# ``__init__`` warns at import time). Re-exported here for backwards compat.
+from langsmith._internal._usage import _create_usage_metadata
 
 if TYPE_CHECKING:
     from openai import AsyncOpenAI, OpenAI
@@ -242,74 +246,6 @@ def _reduce_completions(all_chunks: list[Completion]) -> dict:
         d = {"choices": [{"text": content}]}
 
     return d
-
-
-def _create_usage_metadata(
-    oai_token_usage: dict, service_tier: Optional[str] = None
-) -> UsageMetadata:
-    recognized_service_tier = (
-        service_tier if service_tier in ["priority", "flex"] else None
-    )
-    service_tier_prefix = (
-        f"{recognized_service_tier}_" if recognized_service_tier else ""
-    )
-
-    input_tokens = (
-        oai_token_usage.get("prompt_tokens") or oai_token_usage.get("input_tokens") or 0
-    )
-    output_tokens = (
-        oai_token_usage.get("completion_tokens")
-        or oai_token_usage.get("output_tokens")
-        or 0
-    )
-    total_tokens = oai_token_usage.get("total_tokens") or input_tokens + output_tokens
-    input_token_details: dict = {
-        "audio": (
-            oai_token_usage.get("prompt_tokens_details")
-            or oai_token_usage.get("input_tokens_details")
-            or {}
-        ).get("audio_tokens"),
-        f"{service_tier_prefix}cache_read": (
-            oai_token_usage.get("prompt_tokens_details")
-            or oai_token_usage.get("input_tokens_details")
-            or {}
-        ).get("cached_tokens"),
-    }
-    output_token_details: dict = {
-        "audio": (
-            oai_token_usage.get("completion_tokens_details")
-            or oai_token_usage.get("output_tokens_details")
-            or {}
-        ).get("audio_tokens"),
-        f"{service_tier_prefix}reasoning": (
-            oai_token_usage.get("completion_tokens_details")
-            or oai_token_usage.get("output_tokens_details")
-            or {}
-        ).get("reasoning_tokens"),
-    }
-
-    if recognized_service_tier:
-        # Avoid counting cache read and reasoning tokens towards the
-        # service tier token count since service tier tokens are already
-        # priced differently
-        input_token_details[recognized_service_tier] = input_tokens - (
-            input_token_details.get(f"{service_tier_prefix}cache_read") or 0
-        )
-        output_token_details[recognized_service_tier] = output_tokens - (
-            output_token_details.get(f"{service_tier_prefix}reasoning") or 0
-        )
-
-    return UsageMetadata(
-        input_tokens=input_tokens,
-        output_tokens=output_tokens,
-        total_tokens=total_tokens,
-        input_token_details=InputTokenDetails(
-            **{k: v for k, v in input_token_details.items() if v is not None}
-        ),
-        output_token_details=OutputTokenDetails(
-            **{k: v for k, v in output_token_details.items() if v is not None}
-        ),
-    )
 
 
 def _process_chat_completion(outputs: Any):

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -78,6 +78,14 @@ livekit = [
     "cachetools>=5.0.0",
 ]
 
+# Enabled via `pip install langsmith[openai-realtime]`
+# Covers both OpenAI Realtime wrappers: the raw connection (wrap_realtime) and
+# the Agents SDK session (wrap_realtime_session).
+openai-realtime = [
+    "openai>=1.50",
+    "openai-agents>=0.2",
+]
+
 # Enabled via `pip install langsmith[openai-agents]`
 openai-agents = ["openai-agents>=0.0.3"]
 

--- a/python/tests/unit_tests/wrappers/test_openai_realtime.py
+++ b/python/tests/unit_tests/wrappers/test_openai_realtime.py
@@ -1,0 +1,309 @@
+"""Unit tests for the OpenAI Realtime raw-connection wrapper (``_connection.py``).
+
+Covers the pure payload-shaping helpers, the fail-open guard around the tracer,
+and an end-to-end pass of a fake Realtime event stream through ``wrap_realtime``
+(turn grouping, transcript rollup, first-audio latency, barge-in) — all against a
+mocked client so nothing hits the network.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace as NS
+from unittest import mock
+
+import pytest
+
+from langsmith import Client
+from langsmith._internal.voice import session as session_mod
+from langsmith._internal.voice.helpers import observe_safely
+from langsmith.integrations.openai_realtime import _connection as conn_mod
+from langsmith.integrations.openai_realtime._connection import (
+    is_inbound,
+    response_assistant_output,
+    response_usage_metadata,
+    wrap_realtime,
+)
+
+LS_TEST_CLIENT_INFO = {
+    "batch_ingest_config": {
+        "use_multipart_endpoint": False,
+        "scale_up_qsize_trigger": 1000,
+        "scale_up_nthreads_limit": 16,
+        "scale_down_nempty_trigger": 4,
+        "size_limit": 100,
+        "size_limit_bytes": 20971520,
+    },
+}
+
+
+@pytest.fixture
+def mock_client() -> Client:
+    return Client(session=mock.MagicMock(), info=LS_TEST_CLIENT_INFO, api_key="test")
+
+
+@pytest.fixture(autouse=True)
+def _patch_cached_client(mock_client, monkeypatch):
+    monkeypatch.setattr(
+        "langsmith.run_trees.get_cached_client", lambda **_: mock_client
+    )
+
+
+class FakeConnection:
+    """Minimal stand-in for an ``AsyncRealtimeConnection``: async-iterates events."""
+
+    def __init__(self, events):
+        self._events = list(events)
+        self._it = None
+
+    def __aiter__(self):
+        self._it = iter(self._events)
+        return self
+
+    async def __anext__(self):
+        try:
+            return next(self._it)
+        except StopIteration:
+            raise StopAsyncIteration
+
+
+def _response_done(text, *, tool=None, usage=None, status="completed"):
+    content = [NS(type="audio", transcript=text, text=None)] if text else []
+    output = [NS(type="message", content=content)]
+    if tool:
+        output.append(
+            NS(
+                type="function_call",
+                name=tool["name"],
+                arguments=tool["args"],
+                call_id=tool["id"],
+            )
+        )
+    response = NS(output=output, usage=usage, status=status)
+    return NS(type="response.done", response=response)
+
+
+# --------------------------------------------------------------------------- #
+# Pure helpers
+# --------------------------------------------------------------------------- #
+
+
+class TestHelpers:
+    def test_is_inbound(self):
+        assert is_inbound("input_audio_buffer.speech_started") is True
+        assert is_inbound("conversation.item.input_audio_transcription.completed")
+        assert is_inbound("response.done") is False
+        assert is_inbound("response.output_audio.delta") is False
+
+    def test_response_assistant_output_text_and_tools(self):
+        ev = _response_done(
+            "hello there",
+            tool={"name": "lookup", "args": '{"q": "x"}', "id": "call_1"},
+        )
+        out = response_assistant_output(ev.response)
+        assert out["role"] == "assistant"
+        assert out["content"] == "hello there"
+        # OpenAI ChatCompletion shape so the LangSmith UI renders the tool call
+        # inline on the model span (a flat {name, args, id} spills to "Additional
+        # Fields"). ``arguments`` stays the raw wire JSON string.
+        assert out["tool_calls"] == [
+            {
+                "id": "call_1",
+                "type": "function",
+                "index": 0,
+                "function": {"name": "lookup", "arguments": '{"q": "x"}'},
+            }
+        ]
+
+    def test_response_assistant_output_arguments_passthrough(self):
+        # Arguments are forwarded verbatim (the UI parses them); missing → "{}".
+        ev = _response_done("", tool={"name": "t", "args": None, "id": "c"})
+        out = response_assistant_output(ev.response)
+        assert out["tool_calls"][0]["function"]["arguments"] == "{}"
+
+    def test_response_usage_metadata_maps_tokens(self):
+        usage = NS(input_tokens=10, output_tokens=5, total_tokens=None)
+        md = response_usage_metadata(NS(usage=usage))
+        # Shared mapper always includes (possibly empty) detail blocks.
+        assert md == {
+            "input_tokens": 10,
+            "output_tokens": 5,
+            "total_tokens": 15,
+            "input_token_details": {},
+            "output_token_details": {},
+        }
+
+    def test_response_usage_metadata_captures_audio_and_cache_detail(self):
+        # Realtime spells detail blocks ``*_token_details`` (singular); the mapper
+        # should still surface audio / cached-token detail via the shared shape.
+        usage = {
+            "input_tokens": 100,
+            "output_tokens": 50,
+            "total_tokens": 150,
+            "input_token_details": {"audio_tokens": 80, "cached_tokens": 20},
+            "output_token_details": {"audio_tokens": 40},
+        }
+        md = response_usage_metadata(NS(usage=usage))
+        assert md["input_token_details"]["audio"] == 80
+        assert md["input_token_details"]["cache_read"] == 20
+        assert md["output_token_details"]["audio"] == 40
+
+    def test_response_usage_metadata_none_when_absent(self):
+        assert response_usage_metadata(NS(usage=None)) is None
+        assert (
+            response_usage_metadata(
+                NS(usage=NS(input_tokens=None, output_tokens=None, total_tokens=None))
+            )
+            is None
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Fail-open
+# --------------------------------------------------------------------------- #
+
+
+class TestFailOpen:
+    def test_observe_safely_swallows(self):
+        observe = mock.Mock(side_effect=RuntimeError("boom"))
+        # Must not raise.
+        observe_safely(observe, NS(type="whatever"))
+
+    async def test_broken_tracer_does_not_break_the_loop(self, monkeypatch):
+        events = [NS(type="session.created"), NS(type="x"), NS(type="y")]
+        # Every observe call blows up; the caller must still receive every event.
+        monkeypatch.setattr(
+            conn_mod._RealtimeTracer,
+            "observe",
+            mock.Mock(side_effect=RuntimeError("boom")),
+        )
+        seen = []
+        async with wrap_realtime(FakeConnection(events)) as connection:
+            async for event in connection:
+                seen.append(event.type)
+        assert seen == ["session.created", "x", "y"]
+
+    async def test_event_without_type_is_skipped(self):
+        # An object with no ``.type`` must not raise out of the loop.
+        events = [object(), NS(type="session.created")]
+        seen = []
+        async with wrap_realtime(FakeConnection(events)) as connection:
+            async for event in connection:
+                seen.append(event)
+        assert len(seen) == 2
+
+
+# --------------------------------------------------------------------------- #
+# End-to-end trace shape
+# --------------------------------------------------------------------------- #
+
+
+def _spy_children(monkeypatch):
+    """Capture every child span created on any RunTree during the test."""
+    created = []
+    real = session_mod.RunTree.create_child
+
+    def spy(self, **kwargs):
+        child = real(self, **kwargs)
+        created.append((kwargs.get("name"), child))
+        return child
+
+    monkeypatch.setattr(session_mod.RunTree, "create_child", spy)
+    return created
+
+
+class TestEndToEnd:
+    async def test_single_turn_transcript_latency_and_llm(self, monkeypatch):
+        created = _spy_children(monkeypatch)
+        usage = NS(input_tokens=3, output_tokens=4, total_tokens=7)
+        events = [
+            NS(type="session.created"),
+            NS(type="input_audio_buffer.speech_started"),
+            NS(type="input_audio_buffer.speech_stopped"),
+            NS(
+                type="conversation.item.input_audio_transcription.completed",
+                transcript="what's the weather?",
+            ),
+            NS(type="response.output_audio.delta", delta=b"\x00\x00"),
+            NS(type="response.output_audio_transcript.done", transcript="It's sunny."),
+            _response_done("It's sunny.", usage=usage),
+        ]
+        async with wrap_realtime(FakeConnection(events), thread_id="t") as connection:
+            async for _ in connection:
+                pass
+            session = connection._session
+
+        # Transcript rollup carries both sides.
+        assert session.messages == [
+            {"role": "user", "content": "what's the weather?"},
+            {"role": "assistant", "content": "It's sunny."},
+        ]
+        # First user utterance named the trace (the root run's display name).
+        assert session.run.name == "what's the weather?"
+
+        # Exactly one turn, and first-audio latency was timed onto it.
+        turns = [child for name, child in created if name == "turn"]
+        assert len(turns) == 1
+        turn_meta = (turns[0].extra or {}).get("metadata") or {}
+        assert "latency_to_first_audio_ms" in turn_meta
+
+        # An llm span recorded the assistant message.
+        llms = [child for name, child in created if name == "model"]
+        assert len(llms) == 1
+        assert llms[0].outputs == {"role": "assistant", "content": "It's sunny."}
+
+    async def test_barge_in_flags_interrupted_turn(self, monkeypatch):
+        created = _spy_children(monkeypatch)
+        events = [
+            NS(type="input_audio_buffer.speech_started"),  # turn 1 opens
+            NS(
+                type="conversation.item.input_audio_transcription.completed",
+                transcript="first",
+            ),
+            NS(type="input_audio_buffer.speech_started"),  # turn 2 — interrupts 1
+            NS(
+                type="conversation.item.input_audio_transcription.completed",
+                transcript="second",
+            ),
+        ]
+        # Agent is "still audible" → the second speech_started is a barge-in.
+        async with wrap_realtime(
+            FakeConnection(events), is_agent_speaking=lambda: True
+        ) as connection:
+            async for _ in connection:
+                pass
+
+        turns = [child for name, child in created if name == "turn"]
+        assert len(turns) == 2
+        meta_first = (turns[0].extra or {}).get("metadata") or {}
+        assert meta_first.get("was_interrupted") is True
+
+    async def test_max_audio_seconds_bounds_recording(self):
+        async with wrap_realtime(
+            FakeConnection([]), sample_rate=10, max_audio_seconds=1.0
+        ) as connection:
+            # cap = 1.0s * 10 * 2 = 20 bytes per channel.
+            connection.record_user_audio(b"\x00" * 16)  # under cap → kept
+            connection.record_user_audio(b"\x00" * 16)  # over cap → kept (pushes over)
+            connection.record_user_audio(b"\x00" * 16)  # dropped
+            session = connection._session
+        assert session.max_audio_bytes == 20
+        assert len(session.user_chunks) == 2
+        assert session._audio_truncated is True
+
+    async def test_replicas_propagate_to_root_and_children(self, monkeypatch):
+        created = _spy_children(monkeypatch)
+        replicas = [{"project_name": "replica-project"}]
+        # A speech_started event opens a "turn" child under the root.
+        events = [NS(type="input_audio_buffer.speech_started")]
+        async with wrap_realtime(
+            FakeConnection(events), replicas=replicas
+        ) as connection:
+            async for _ in connection:
+                pass
+            session = connection._session
+
+        # The root carries the replicas...
+        assert session.run.replicas == [{"project_name": "replica-project"}]
+        # ...and child spans inherit them via create_child.
+        turns = [child for name, child in created if name == "turn"]
+        assert turns and turns[0].replicas == [{"project_name": "replica-project"}]

--- a/python/tests/unit_tests/wrappers/test_openai_realtime_agents.py
+++ b/python/tests/unit_tests/wrappers/test_openai_realtime_agents.py
@@ -1,0 +1,446 @@
+"""Unit tests for the OpenAI Agents-SDK realtime wrapper (``_session.py``).
+
+Three layers: the pure event-shaping helpers (``_clean``, ``describe_event``, …),
+the ``_AgentsRealtimeTracer`` that reconstructs the conversation from ``history``
+snapshots (partial collapse, turn grouping, hold-last flushing, tool/barge-in
+spans), and the ``wrap_realtime_session`` proxy (delegation, fail-open). All run
+against a mocked client so nothing hits the network.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace as NS
+from unittest import mock
+
+import pytest
+
+from langsmith import Client
+from langsmith._internal.voice import session as voice_session_mod
+from langsmith._internal.voice.session import EventSession, start_session
+from langsmith.integrations.openai_realtime import _session as agents_mod
+from langsmith.integrations.openai_realtime._session import (
+    _AgentsRealtimeTracer,
+    _clean,
+    _item_text,
+    _stringify,
+    describe_event,
+    raw_input_transcript,
+    wrap_realtime_session,
+)
+
+LS_TEST_CLIENT_INFO = {
+    "batch_ingest_config": {
+        "use_multipart_endpoint": False,
+        "scale_up_qsize_trigger": 1000,
+        "scale_up_nthreads_limit": 16,
+        "scale_down_nempty_trigger": 4,
+        "size_limit": 100,
+        "size_limit_bytes": 20971520,
+    },
+}
+
+
+@pytest.fixture
+def mock_client() -> Client:
+    return Client(session=mock.MagicMock(), info=LS_TEST_CLIENT_INFO, api_key="test")
+
+
+@pytest.fixture(autouse=True)
+def _patch_cached_client(mock_client, monkeypatch):
+    monkeypatch.setattr(
+        "langsmith.run_trees.get_cached_client", lambda **_: mock_client
+    )
+
+
+def _item(iid, role, text):
+    """A realtime history item: id, role, and one content part."""
+    content = [NS(transcript=text, text=None)] if text else []
+    return NS(item_id=iid, role=role, content=content)
+
+
+def _history_updated(*items):
+    return NS(type="history_updated", history=list(items))
+
+
+def _spy_children(monkeypatch):
+    """Capture (name, child) for every span created on any RunTree."""
+    created = []
+    real = voice_session_mod.RunTree.create_child
+
+    def spy(self, **kwargs):
+        child = real(self, **kwargs)
+        created.append((kwargs.get("name"), child))
+        return child
+
+    monkeypatch.setattr(voice_session_mod.RunTree, "create_child", spy)
+    return created
+
+
+# --------------------------------------------------------------------------- #
+# Pure shaping helpers
+# --------------------------------------------------------------------------- #
+
+
+class TestCleanAndShape:
+    def test_clean_bytes_private_circular_and_width(self):
+        assert _clean(b"abcd") == "<4 bytes>"
+        # Private keys are dropped.
+        assert _clean({"a": 1, "_secret": 2}) == {"a": 1}
+        # Cycles are broken, not followed.
+        d: dict = {}
+        d["self"] = d
+        assert _clean(d) == {"self": "<circular>"}
+        # Wide collections are capped with a "+N more" marker.
+        out = _clean(list(range(60)))
+        assert len(out) == 51
+        assert out[:3] == [0, 1, 2]
+        assert out[-1] == "… +10 more"
+
+    def test_stringify(self):
+        assert _stringify(5) == 5
+        assert _stringify("x") == "x"
+        assert _stringify([1, 2]) == [1, 2]
+        assert _stringify(object()).startswith("<")  # exotic → repr
+
+    def test_item_text_joins_content_parts(self):
+        item = _item("i", "user", None)
+        item.content = [
+            NS(transcript="hello", text=None),
+            NS(transcript=None, text="world"),
+        ]
+        assert _item_text(item) == ("user", "hello world")
+        assert _item_text(None) == (None, None)
+        assert _item_text(_item("i", "assistant", None)) == ("assistant", None)
+
+    def test_raw_input_transcript(self):
+        ev = NS(
+            data=NS(
+                type="input_audio_transcription_completed",
+                transcript="  hi there  ",
+                item_id="u1",
+            )
+        )
+        assert raw_input_transcript(ev) == ("u1", "hi there")
+        # Wrong wrapped type, or empty transcript → None.
+        assert raw_input_transcript(NS(data=NS(type="other"))) is None
+        assert (
+            raw_input_transcript(
+                NS(data=NS(type="input_audio_transcription_completed", transcript=" "))
+            )
+            is None
+        )
+
+    def test_describe_event_variants(self):
+        name, payload, inbound = describe_event(
+            NS(type="tool_start", tool=NS(name="lookup"), arguments='{"q": 1}')
+        )
+        assert name == "tool_start"
+        assert inbound is True  # a tool call is the model's request → input
+        assert payload["tool"] == "lookup"
+
+        _, payload, inbound = describe_event(
+            NS(type="tool_end", tool=NS(name="lookup"), arguments="{}", output="sunny")
+        )
+        assert payload["output"] == "sunny"
+        assert inbound is False
+
+        _, payload, inbound = describe_event(
+            NS(type="history_added", item=_item("u", "user", "hi"))
+        )
+        assert (payload["role"], payload["text"]) == ("user", "hi")
+        assert inbound is True
+
+        _, payload, _ = describe_event(NS(type="error", error="boom"))
+        assert payload["error"] == "boom"
+
+
+# --------------------------------------------------------------------------- #
+# _AgentsRealtimeTracer — conversation reconstruction
+# --------------------------------------------------------------------------- #
+
+
+def _tracer(session, **kwargs):
+    return _AgentsRealtimeTracer(session, **kwargs)
+
+
+class TestTracer:
+    def test_history_turn_collapses_partials_and_emits_spans(self, monkeypatch):
+        session = start_session(thread_id="t", sample_rate=24_000)
+        created = _spy_children(monkeypatch)
+        tracer = _tracer(session)
+
+        # One user turn, then the assistant transcript arrives as growing partials
+        # across snapshots — the fold keeps only the final text.
+        tracer.observe(_history_updated(_item("u1", "user", "weather?")))
+        tracer.observe(NS(type="audio"))  # first audio → latency on the open turn
+        tracer.observe(
+            _history_updated(
+                _item("u1", "user", "weather?"), _item("a1", "assistant", "It's")
+            )
+        )
+        tracer.observe(
+            _history_updated(
+                _item("u1", "user", "weather?"), _item("a1", "assistant", "It's sunny.")
+            )
+        )
+        tracer.flush_pending()
+        session.finalize()
+
+        # Transcript collapsed to one line per side.
+        assert session.messages == [
+            {"role": "user", "content": "weather?"},
+            {"role": "assistant", "content": "It's sunny."},
+        ]
+        # Exactly one turn / user_message / model span.
+        names = [n for n, _ in created]
+        assert names.count("turn") == 1
+        assert names.count("user_message") == 1
+        assert names.count("model") == 1
+        model = next(c for n, c in created if n == "model")
+        assert model.outputs == {"role": "assistant", "content": "It's sunny."}
+        # Latency was timed onto the turn.
+        turn = next(c for n, c in created if n == "turn")
+        assert "latency_to_first_audio_ms" in (turn.extra or {}).get("metadata", {})
+
+    def test_hold_last_defers_final_message_until_teardown(self, monkeypatch):
+        session = start_session(thread_id="t", sample_rate=24_000)
+        created = _spy_children(monkeypatch)
+        tracer = _tracer(session)
+
+        # A lone user item is held back (it may still be streaming).
+        tracer.observe(_history_updated(_item("u1", "user", "hi")))
+        assert session.messages == []
+        assert not any(n == "user_message" for n, _ in created)
+
+        # A following assistant item supersedes the user one → user now emits.
+        tracer.observe(
+            _history_updated(_item("u1", "user", "hi"), _item("a1", "assistant", "yo"))
+        )
+        assert session.messages == [{"role": "user", "content": "hi"}]
+        assert any(n == "user_message" for n, _ in created)
+        assert not any(n == "model" for n, _ in created)  # assistant still held
+
+        # Teardown flushes the trailing assistant message.
+        tracer.flush_pending()
+        assert session.messages[-1] == {"role": "assistant", "content": "yo"}
+        assert any(n == "model" for n, _ in created)
+
+    def test_tool_start_and_end_become_one_tool_span(self, monkeypatch):
+        session = start_session(thread_id="t", sample_rate=24_000)
+        created = _spy_children(monkeypatch)
+        tracer = _tracer(session)
+
+        # A start/end pair collapses to a single tool span named for the tool,
+        # carrying the args (in) and output (out). Its duration is the real gap
+        # between the two events.
+        tracer.observe(
+            NS(type="tool_start", tool=NS(name="lookup"), arguments='{"city": "SF"}')
+        )
+        tracer.observe(
+            NS(
+                type="tool_end",
+                tool=NS(name="lookup"),
+                arguments='{"city": "SF"}',
+                output="sunny",
+            )
+        )
+        tools = [c for n, c in created if n == "lookup"]
+        assert len(tools) == 1  # one span, not a separate start + end
+        tool = tools[0]
+        assert tool.run_type == "tool"
+        assert tool.inputs == {"arguments": '{"city": "SF"}'}
+        assert tool.outputs == {"output": "sunny"}
+
+    def test_tool_end_without_start_falls_back_to_point_in_time(self, monkeypatch):
+        session = start_session(thread_id="t", sample_rate=24_000)
+        created = _spy_children(monkeypatch)
+        tracer = _tracer(session)
+
+        # tool_end with no matching open start (tracing began mid-call) is still
+        # recorded as a tool span.
+        tracer.observe(
+            NS(
+                type="tool_end",
+                tool=NS(name="lookup"),
+                arguments='{"city": "SF"}',
+                output="sunny",
+            )
+        )
+        tool = next(c for n, c in created if n == "lookup")
+        assert tool.run_type == "tool"
+        assert tool.outputs == {"output": "sunny"}
+
+    def test_orphan_tool_span_closed_with_error_at_teardown(self, monkeypatch):
+        session = start_session(thread_id="t", sample_rate=24_000)
+        created = _spy_children(monkeypatch)
+        tracer = _tracer(session)
+
+        # A tool_start whose tool never returns (no tool_end) is closed at
+        # teardown with an error rather than left dangling open.
+        tracer.observe(NS(type="tool_start", tool=NS(name="lookup"), arguments="{}"))
+        tool = next(c for n, c in created if n == "lookup")
+        assert tool.end_time is None  # still open
+        tracer.flush_pending()
+        assert tool.end_time is not None  # closed
+        assert tool.error
+
+    def test_audio_interrupted_flags_open_turn(self, monkeypatch):
+        session = start_session(thread_id="t", sample_rate=24_000)
+        created = _spy_children(monkeypatch)
+        tracer = _tracer(session)
+
+        tracer.observe(_history_updated(_item("u1", "user", "hi")))  # opens a turn
+        tracer.observe(NS(type="audio_interrupted", item_id="a1"))
+        turn = next(c for n, c in created if n == "turn")
+        assert (turn.extra or {}).get("metadata", {}).get("was_interrupted") is True
+        assert any(n == "audio_interrupted" for n, _ in created)
+
+    def test_raw_model_event_user_transcript(self, monkeypatch):
+        session = start_session(thread_id="t", sample_rate=24_000)
+        created = _spy_children(monkeypatch)
+        tracer = _tracer(session)
+
+        # On a barge-in the user transcript can arrive only as a raw_model_event.
+        tracer.observe(
+            NS(
+                type="raw_model_event",
+                data=NS(
+                    type="input_audio_transcription_completed",
+                    transcript="cancel that",
+                    item_id="u1",
+                ),
+            )
+        )
+        tracer.flush_pending()
+        assert session.messages == [{"role": "user", "content": "cancel that"}]
+        assert any(n == "user_message" for n, _ in created)
+
+    def test_on_message_called_once_per_finalized_line(self):
+        session = start_session(thread_id="t", sample_rate=24_000)
+        seen: list = []
+        tracer = _tracer(
+            session, on_message=lambda role, text: seen.append((role, text))
+        )
+
+        # The same finalized messages reappear across snapshots; each fires once.
+        tracer.observe(_history_updated(_item("u1", "user", "hi")))
+        tracer.observe(
+            _history_updated(
+                _item("u1", "user", "hi"), _item("a1", "assistant", "hello")
+            )
+        )
+        tracer.observe(
+            _history_updated(
+                _item("u1", "user", "hi"), _item("a1", "assistant", "hello")
+            )
+        )
+        tracer.flush_pending()
+        assert seen == [("user", "hi"), ("assistant", "hello")]
+
+
+# --------------------------------------------------------------------------- #
+# wrap_realtime_session proxy
+# --------------------------------------------------------------------------- #
+
+
+class FakeSession:
+    """Stand-in RealtimeSession: an async context manager that iterates events."""
+
+    def __init__(self, events):
+        self._events = list(events)
+        self._it = None
+        self.entered = False
+        self.exited = False
+
+    async def __aenter__(self):
+        self.entered = True
+        return self
+
+    async def __aexit__(self, *exc):
+        self.exited = True
+        return False
+
+    def __aiter__(self):
+        self._it = iter(self._events)
+        return self
+
+    async def __anext__(self):
+        try:
+            return next(self._it)
+        except StopIteration:
+            raise StopAsyncIteration
+
+    def send_audio(self):
+        return "delegated"
+
+
+class TestProxy:
+    async def test_enters_exits_underlying_and_traces(self):
+        fake = FakeSession(
+            [
+                _history_updated(
+                    _item("u1", "user", "hi"), _item("a1", "assistant", "yo")
+                )
+            ]
+        )
+        async with wrap_realtime_session(fake, thread_id="t") as conn:
+            assert fake.entered is True
+            assert conn.send_audio() == "delegated"  # attribute delegation
+            async for _ in conn:
+                pass
+            trace = conn._trace
+        # Underlying session was exited, and the conversation was traced.
+        assert fake.exited is True
+        assert trace.messages == [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "yo"},
+        ]
+
+    async def test_broken_tracer_does_not_break_loop(self, monkeypatch):
+        events = [NS(type="audio"), NS(type="other")]
+        monkeypatch.setattr(
+            agents_mod._AgentsRealtimeTracer,
+            "observe",
+            mock.Mock(side_effect=RuntimeError("boom")),
+        )
+        seen = []
+        async with wrap_realtime_session(FakeSession(events)) as conn:
+            async for event in conn:
+                seen.append(event)
+        assert len(seen) == 2
+
+    async def test_tracing_setup_failure_unwinds_underlying_session(self, monkeypatch):
+        # If our tracing setup raises after the underlying session was entered,
+        # __aenter__ must unwind it (Python won't call __aexit__) so it can't leak.
+        fake = FakeSession([])
+        monkeypatch.setattr(
+            agents_mod, "start_session", mock.Mock(side_effect=RuntimeError("boom"))
+        )
+        with pytest.raises(RuntimeError, match="boom"):
+            async with wrap_realtime_session(fake):
+                pass
+        assert fake.entered is True
+        assert fake.exited is True
+
+    async def test_finalize_failure_still_exits_underlying_session(self, monkeypatch):
+        fake = FakeSession([])
+        monkeypatch.setattr(
+            EventSession, "finalize", mock.Mock(side_effect=RuntimeError("boom"))
+        )
+        # __aexit__ must swallow the finalize error and still exit the session.
+        async with wrap_realtime_session(fake) as conn:
+            assert conn is not None
+        assert fake.exited is True
+
+    async def test_max_audio_seconds_bounds_recording(self):
+        async with wrap_realtime_session(
+            FakeSession([]), sample_rate=10, max_audio_seconds=1.0
+        ) as conn:
+            # cap = 1.0s * 10 * 2 = 20 bytes per channel.
+            conn.record_user_audio(b"\x00" * 16)  # kept
+            conn.record_user_audio(b"\x00" * 16)  # kept (pushes over)
+            conn.record_user_audio(b"\x00" * 16)  # dropped
+            trace = conn._trace
+        assert trace.max_audio_bytes == 20
+        assert len(trace.user_chunks) == 2
+        assert trace._audio_truncated is True

--- a/python/tests/unit_tests/wrappers/test_voice_helpers.py
+++ b/python/tests/unit_tests/wrappers/test_voice_helpers.py
@@ -1,0 +1,59 @@
+"""Unit tests for the shared Track-B ``_voice`` helpers.
+
+The stereo-WAV builder (``_voice/audio.py``) and the event-payload sanitizers
+(``_voice/helpers.py``) are used by ``EventSession`` and ship with it. Pure
+helpers — no framework import needed.
+"""
+
+import io
+import wave
+from unittest.mock import MagicMock
+
+from langsmith._internal.voice import audio as audio_utils
+from langsmith._internal.voice import helpers
+
+
+class TestVoiceAudio:
+    """Stereo session WAV reconstruction in ``_voice/audio.py``."""
+
+    def test_layout_chunks_to_play_time_keeps_bursts_contiguous(self):
+        # Two single-sample chunks (2 bytes each) received at t=0, sr=2 → the
+        # second is laid out at 0.5s so it does not overwrite the first.
+        chunks = [(0.0, b"\x00\x00"), (0.0, b"\x00\x00")]
+        out = audio_utils._layout_chunks_to_play_time(chunks, sample_rate=2)
+        assert [round(t, 3) for t, _ in out] == [0.0, 0.5]
+
+    def test_build_stereo_session_wav_empty(self):
+        assert audio_utils.build_stereo_session_wav([], [], 16000) == b""
+
+    def test_build_stereo_session_wav_produces_stereo(self):
+        user = [(0.0, b"\x01\x00" * 4)]
+        agent = [(0.0, b"\x02\x00" * 4)]
+        wav = audio_utils.build_stereo_session_wav(user, agent, 16000)
+        assert wav[:4] == b"RIFF"
+        with wave.open(io.BytesIO(wav), "rb") as wf:
+            assert wf.getnchannels() == 2
+
+
+class TestVoiceHelpers:
+    """Event payload sanitization in ``_voice/helpers.py``."""
+
+    def test_scrub_replaces_bytes_and_truncates(self):
+        assert helpers.scrub(b"abc") == "<3 bytes>"
+        long = "x" * (helpers.MAX_STR + 50)
+        scrubbed = helpers.scrub(long)
+        assert scrubbed.startswith("x" * helpers.MAX_STR)
+        assert "<+50 chars>" in scrubbed
+
+    def test_scrub_recurses(self):
+        assert helpers.scrub({"a": b"xy", "b": [b"z"]}) == {
+            "a": "<2 bytes>",
+            "b": ["<1 bytes>"],
+        }
+
+    def test_dump_event_variants(self):
+        model = MagicMock()
+        model.model_dump.return_value = {"k": "v"}
+        assert helpers.dump_event(model) == {"k": "v"}
+        assert helpers.dump_event({"already": "dict"}) == {"already": "dict"}
+        assert "repr" in helpers.dump_event(object())

--- a/python/tests/unit_tests/wrappers/test_voice_session.py
+++ b/python/tests/unit_tests/wrappers/test_voice_session.py
@@ -1,0 +1,181 @@
+"""Unit tests for the shared Track-B ``EventSession`` (``_voice/session.py``).
+
+``EventSession`` builds the LangSmith ``RunTree`` for an observed event stream:
+the conversation root, per-event/turn child spans, the transcript rollup, the
+audio buffers, and ``finalize``. These tests drive it against a mocked client so
+no network is touched, asserting the in-memory trace state it produces.
+"""
+
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+
+from langsmith import Client
+from langsmith._internal.voice import session as session_mod
+from langsmith._internal.voice.session import EventSession, start_session
+
+LS_TEST_CLIENT_INFO = {
+    "batch_ingest_config": {
+        "use_multipart_endpoint": False,
+        "scale_up_qsize_trigger": 1000,
+        "scale_up_nthreads_limit": 16,
+        "scale_down_nempty_trigger": 4,
+        "size_limit": 100,
+        "size_limit_bytes": 20971520,
+    },
+}
+
+
+@pytest.fixture
+def mock_client() -> Client:
+    return Client(session=mock.MagicMock(), info=LS_TEST_CLIENT_INFO, api_key="test")
+
+
+@pytest.fixture(autouse=True)
+def _patch_cached_client(mock_client, monkeypatch):
+    # Every RunTree built by start_session resolves its client lazily via
+    # run_trees.get_cached_client(); point it at the mock so .post()/.patch()
+    # enqueue to a fake session instead of the network.
+    monkeypatch.setattr(
+        "langsmith.run_trees.get_cached_client", lambda **_: mock_client
+    )
+
+
+def _session(**kwargs) -> EventSession:
+    return start_session(thread_id="t1", sample_rate=24_000, **kwargs)
+
+
+class TestAudioBound:
+    """``max_audio_seconds`` → bounded per-channel PCM retention."""
+
+    def test_start_session_converts_seconds_to_bytes(self):
+        # 2s at 24kHz PCM16 = 2 * 24000 * 2 bytes per channel.
+        s = _session(max_audio_seconds=2.0)
+        assert s.max_audio_bytes == 2 * 24_000 * 2
+
+    def test_no_cap_by_default(self):
+        s = _session()
+        assert s.max_audio_bytes is None
+        for _ in range(5):
+            s.record_user(0.0, b"\x00\x00" * 1000)
+        assert len(s.user_chunks) == 5
+        assert s._audio_truncated is False
+
+    def test_user_channel_capped_and_flagged_once(self):
+        s = _session()
+        s.max_audio_bytes = 100  # tiny cap for the test
+        s.record_user(0.0, b"\x00" * 80)  # under cap → kept
+        s.record_user(0.1, b"\x00" * 80)  # now at/over cap → kept, pushes over
+        s.record_user(0.2, b"\x00" * 80)  # dropped
+        s.record_user(0.3, b"\x00" * 80)  # dropped
+        assert len(s.user_chunks) == 2
+        assert s._user_bytes == 160
+        assert s._audio_truncated is True
+
+    def test_cap_is_per_channel(self):
+        s = _session()
+        s.max_audio_bytes = 100
+        s.record_user(0.0, b"\x00" * 200)  # user over cap
+        s.record_agent(0.0, b"\x00" * 50)  # agent still under
+        s.record_agent(0.1, b"\x00" * 50)
+        assert len(s.user_chunks) == 1
+        assert len(s.agent_chunks) == 2  # agent unaffected by the user cap
+
+    def test_truncation_surfaced_in_root_metadata(self):
+        s = _session()
+        s.max_audio_bytes = 10
+        s.record_user(0.0, b"\x00" * 20)
+        s.record_user(0.1, b"\x00" * 20)  # dropped → truncated
+        s.finalize()
+        meta = (s.run.extra or {}).get("metadata") or {}
+        assert meta.get("audio_truncated") is True
+
+
+class TestTranscriptAndTitle:
+    def test_add_message_strips_and_drops_empty(self):
+        s = _session()
+        s.add_message("user", "  hello  ")
+        s.add_message("assistant", "   ")  # whitespace only → dropped
+        assert s.messages == [{"role": "user", "content": "hello"}]
+
+    def test_set_title_first_nonempty_wins(self):
+        s = _session()
+        s.set_title("")  # ignored
+        s.set_title("first question")
+        s.set_title("second")  # ignored, first wins
+        # The title names the root run (what LangSmith displays), not metadata.
+        assert s.run.name == "first question"
+
+    def test_finalize_rolls_transcript_onto_root(self):
+        s = _session()
+        s.add_message("user", "hi")
+        s.add_message("assistant", "hello")
+        s.finalize()
+        assert s.run.outputs == {
+            "messages": [
+                {"role": "user", "content": "hi"},
+                {"role": "assistant", "content": "hello"},
+            ]
+        }
+
+
+class TestTurns:
+    def test_turn_groups_messages_and_carries_metadata(self):
+        s = _session()
+        s.start_turn()
+        s.add_message("user", "weather?")
+        s.add_turn_metadata(was_interrupted=True, latency_to_first_audio_ms=120)
+        # Read the open turn span before finalize closes it.
+        turn = s._current_turn
+        assert turn is not None
+        meta = (turn.extra or {}).get("metadata") or {}
+        assert meta["turn"] == 1
+        assert meta["was_interrupted"] is True
+        assert meta["latency_to_first_audio_ms"] == 120
+        s.finalize()
+        # Its messages were rolled up as the turn's outputs on close.
+        assert turn.outputs == {"messages": [{"role": "user", "content": "weather?"}]}
+
+    def test_add_turn_metadata_noop_without_open_turn(self):
+        s = _session()
+        # No start_turn called → nothing to attach to, must not raise.
+        s.add_turn_metadata(was_interrupted=True)
+
+
+class TestRecordLlm:
+    def test_default_inputs_drop_trailing_assistant(self):
+        s = _session()
+        s.add_message("user", "hi")
+        s.add_message("assistant", "the answer")  # the response being recorded
+        captured: list = []
+        real_create = session_mod.RunTree.create_child
+
+        def spy(self, **kwargs):
+            child = real_create(self, **kwargs)
+            if kwargs.get("run_type") == "llm":
+                captured.append(child)
+            return child
+
+        with mock.patch.object(session_mod.RunTree, "create_child", spy):
+            s.record_llm(outputs={"role": "assistant", "content": "the answer"})
+        # The effective prompt is history minus the trailing assistant response.
+        assert len(captured) == 1
+        assert captured[0].inputs == {"messages": [{"role": "user", "content": "hi"}]}
+
+
+class TestFinalizeFailOpen:
+    def test_wav_build_failure_does_not_break_finalize(self, monkeypatch):
+        s = _session()
+        s.add_message("user", "hi")
+        monkeypatch.setattr(
+            session_mod,
+            "build_stereo_session_wav",
+            mock.Mock(side_effect=RuntimeError("boom")),
+        )
+        s.finalize()  # must not raise
+        # Root still closed with the transcript despite the WAV failure, and no
+        # audio attachment was set.
+        assert s.run.outputs == {"messages": [{"role": "user", "content": "hi"}]}
+        assert not s.run.attachments

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -11,7 +11,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-06-28T23:56:09.130398Z"
+exclude-newer = "2026-06-28T23:56:46.539135Z"
 exclude-newer-span = "P1D"
 
 [[package]]
@@ -1663,6 +1663,10 @@ livekit = [
 openai-agents = [
     { name = "openai-agents" },
 ]
+openai-realtime = [
+    { name = "openai" },
+    { name = "openai-agents" },
+]
 otel = [
     { name = "opentelemetry-api" },
     { name = "opentelemetry-exporter-otlp-proto-http" },
@@ -1762,7 +1766,9 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.23.0,<1" },
     { name = "langsmith-pyo3", marker = "extra == 'langsmith-pyo3'", specifier = ">=0.1.0rc2" },
     { name = "livekit-agents", marker = "extra == 'livekit'", specifier = ">=1.0" },
+    { name = "openai", marker = "extra == 'openai-realtime'", specifier = ">=1.50" },
     { name = "openai-agents", marker = "extra == 'openai-agents'", specifier = ">=0.0.3" },
+    { name = "openai-agents", marker = "extra == 'openai-realtime'", specifier = ">=0.2" },
     { name = "opentelemetry-api", marker = "extra == 'livekit'", specifier = ">=1.30.0" },
     { name = "opentelemetry-api", marker = "extra == 'otel'", specifier = ">=1.30.0" },
     { name = "opentelemetry-api", marker = "extra == 'pipecat'", specifier = ">=1.30.0" },
@@ -1795,7 +1801,7 @@ requires-dist = [
     { name = "xxhash", specifier = ">=3.0.0" },
     { name = "zstandard", specifier = ">=0.23.0" },
 ]
-provides-extras = ["claude-agent-sdk", "google-adk", "langsmith-pyo3", "livekit", "openai-agents", "otel", "pipecat", "pytest", "sandbox", "strands-agents", "vcr"]
+provides-extras = ["claude-agent-sdk", "google-adk", "langsmith-pyo3", "livekit", "openai-agents", "openai-realtime", "otel", "pipecat", "pytest", "sandbox", "strands-agents", "vcr"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## OpenAI Realtime voice tracing

Adds the RunTree `EventSession` engine (`_voice/session.py`: root span, turn grouping, transcript rollup, stereo-WAV audio attachment) shared by the event-stream integrations, and `langsmith.integrations.openai_realtime`, which exposes **both** wrappers from one package:

- `wrap_realtime` — wraps the raw `client.realtime.connect()` event loop (transparent connection proxy).
- `wrap_realtime_session` — wraps the OpenAI Agents SDK `RealtimeSession` (reconstructs the transcript from `history` snapshots).

Both produce the same kind of trace. A single extra ships both: `pip install "langsmith[openai-realtime]"`. Builds on #3113.

Authored with the help of an AI agent.



#### PR Dependency Tree


* **PR #3112**
  * **PR #3113**
    * **PR #3114** 👈
      * **PR #3115**

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)






#### PR Dependency Tree


* **PR #3114** 👈
  * **PR #3115**

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)