### PR TITLE
fix(py): serialize tuple-keyed trace dictionaries

### DIFF
--- a/python/langsmith/_internal/_serde.py
+++ b/python/langsmith/_internal/_serde.py
@@ -151,7 +151,7 @@ def _normalize_json_keys(obj: Any) -> Any:
             norm_key: Any = (
                 key if isinstance(key, _JSON_KEY_TYPES) else str(_simple_default(key))
             )
-            if norm_key in new and norm_key != key:
+            if norm_key in new:
                 logger.debug(
                     "Dict key collision during JSON key normalization: "
                     f"{key!r} maps to {norm_key!r}, which already exists; "

--- a/python/langsmith/_internal/_serde.py
+++ b/python/langsmith/_internal/_serde.py
@@ -153,9 +153,8 @@ def _normalize_json_keys(obj: Any) -> Any:
             )
             if norm_key in new:
                 logger.debug(
-                    "Dict key collision during JSON key normalization: "
-                    f"{key!r} maps to {norm_key!r}, which already exists; "
-                    f"the previous value will be overwritten."
+                    "Dict key collision during JSON key normalization; "
+                    "an existing value will be overwritten."
                 )
             new[norm_key] = _normalize_json_keys(value)
         return new

--- a/python/langsmith/_internal/_serde.py
+++ b/python/langsmith/_internal/_serde.py
@@ -124,13 +124,8 @@ def _serialize_json(obj: Any) -> Any:
         return str(obj)
 
 
-def _normalize_json_keys(obj: Any) -> tuple[Any, bool]:
+def _normalize_json_keys(obj: Any) -> Any:
     """Recursively stringify dict keys that orjson will reject.
-
-    Returns the normalized object and whether any key was actually coerced
-    (the flag lets callers such as ``dumps_json`` skip a guaranteed-to-fail
-    orjson retry when the original failure was unrelated to keys, e.g. lone
-    UTF-16 surrogates in a value).
 
     Walks ``dict``, ``list``, ``tuple`` and ``deque`` so that unsupported keys
     hidden at any depth are coerced before serialization. Tuples and deques
@@ -145,34 +140,28 @@ def _normalize_json_keys(obj: Any) -> tuple[Any, bool]:
     match the formats the fast path would produce (e.g. ``datetime`` -> ISO
     8601, ``bytes`` -> base64) rather than Python's ``str()`` or ``repr()``.
     """
-    changed = False
-
-    def _normalize(o: Any) -> Any:
-        nonlocal changed
-        if isinstance(o, dict):
-            new = {}
-            for key, value in o.items():
-                if not isinstance(key, _JSON_KEY_TYPES):
-                    changed = True
-                    key = str(_simple_default(key))
-                new[key] = _normalize(value)
-            return new
-        if isinstance(o, list):
-            return [_normalize(value) for value in o]
-        if isinstance(o, tuple) and not (hasattr(o, "_asdict") and callable(o._asdict)):
-            # Plain tuples recurse; NamedTuples are left for _serialize_json,
-            # which converts them to dicts (preserving field names) before the
-            # default hook re-normalizes them.
-            return tuple(_normalize(value) for value in o)
-        if isinstance(o, collections.deque):
-            return collections.deque(_normalize(value) for value in o)
-        return o
-
-    return _normalize(obj), changed
+    if isinstance(obj, dict):
+        return {
+            (
+                key if isinstance(key, _JSON_KEY_TYPES) else str(_simple_default(key))
+            ): _normalize_json_keys(value)
+            for key, value in obj.items()
+        }
+    if isinstance(obj, list):
+        return [_normalize_json_keys(value) for value in obj]
+    if isinstance(obj, tuple) and not (
+        hasattr(obj, "_asdict") and callable(obj._asdict)
+    ):
+        # Plain tuples recurse; NamedTuples are left for _serialize_json, which
+        # converts them to dicts (preserving field names) before normalization.
+        return tuple(_normalize_json_keys(value) for value in obj)
+    if isinstance(obj, collections.deque):
+        return collections.deque(_normalize_json_keys(value) for value in obj)
+    return obj
 
 
 def _serialize_json_with_normalized_keys(obj: Any) -> Any:
-    return _normalize_json_keys(_serialize_json(obj))[0]
+    return _normalize_json_keys(_serialize_json(obj))
 
 
 def _elide_surrogates(s: bytes) -> bytes:
@@ -205,26 +194,18 @@ def dumps_json(obj: Any) -> bytes:
     except TypeError as e:
         # Usually caused by UTF surrogate characters
         logger.debug(f"Orjson serialization failed: {repr(e)}. Falling back to json.")
-        normalized_obj, keys_changed = _normalize_json_keys(obj)
-        # Retry orjson only when key normalization could plausibly fix the
-        # failure; otherwise we go straight to stdlib ``json`` (which tolerates
-        # lone UTF-16 surrogates via ensure_ascii=True). ``keys_changed`` covers
-        # bad keys visible at the top level; the message check additionally
-        # catches bad keys hidden behind an object's ``to_dict``/``model_dump``
-        # (which only surface once ``_serialize_json`` runs inside orjson).
-        error_hinted_at_keys = "Dict key" in str(e)
-        if keys_changed or error_hinted_at_keys:
-            try:
-                return _orjson.dumps(
-                    normalized_obj,
-                    default=_serialize_json_with_normalized_keys,
-                    option=_ORJSON_OPTIONS,
-                )
-            except TypeError as retry_e:
-                logger.debug(
-                    "Orjson serialization with normalized keys failed: "
-                    f"{repr(retry_e)}. Falling back to json."
-                )
+        normalized_obj = _normalize_json_keys(obj)
+        try:
+            return _orjson.dumps(
+                normalized_obj,
+                default=_serialize_json_with_normalized_keys,
+                option=_ORJSON_OPTIONS,
+            )
+        except TypeError as retry_e:
+            logger.debug(
+                "Orjson serialization with normalized keys failed: "
+                f"{repr(retry_e)}. Falling back to json."
+            )
         result = json.dumps(
             normalized_obj,
             default=_serialize_json_with_normalized_keys,

--- a/python/langsmith/_internal/_serde.py
+++ b/python/langsmith/_internal/_serde.py
@@ -125,60 +125,43 @@ def _serialize_json(obj: Any) -> Any:
 
 
 def _stringify_json_key(key: Any) -> Any:
+    """Coerce a dict key into a type that orjson/``json`` accepts natively.
+
+    ``OPT_NON_STR_KEYS`` already covers ``int``/``float``/``datetime``/``UUID``
+    /``bytes``/etc., so those pass through untouched; anything else (e.g. tuples,
+    arbitrary objects) falls back to its ``str`` representation.
+    """
     if isinstance(key, _JSON_KEY_TYPES):
         return key
-    return str(_simple_default(key))
+    return str(key)
 
 
-def _normalize_json_keys(obj: Any, seen: set[int] | None = None) -> Any:
-    if seen is None:
-        seen = set()
+def _normalize_json_keys(obj: Any) -> Any:
+    """Recursively stringify dict keys that orjson will reject.
 
+    Walks ``dict``, ``list``, ``tuple`` and ``deque`` so that unsupported keys
+    hidden at any depth are coerced before serialization. Tuples and deques
+    are covered here even though they're only ever *values*: orjson serializes
+    them natively (as arrays) and therefore never routes them through the
+    ``default`` hook, so a bad-keyed dict nested inside one would otherwise
+    slip past normalization. Cycles are handled downstream by
+    ``_serialize_json`` (which collapses them to ``str``), not here.
+    """
     if isinstance(obj, dict):
-        obj_id = id(obj)
-        if obj_id in seen:
-            return obj
-        seen.add(obj_id)
-        try:
-            return {
-                _stringify_json_key(key): _normalize_json_keys(value, seen)
-                for key, value in obj.items()
-            }
-        finally:
-            seen.remove(obj_id)
-
+        return {
+            _stringify_json_key(key): _normalize_json_keys(value)
+            for key, value in obj.items()
+        }
     if isinstance(obj, list):
-        obj_id = id(obj)
-        if obj_id in seen:
-            return obj
-        seen.add(obj_id)
-        try:
-            return [_normalize_json_keys(value, seen) for value in obj]
-        finally:
-            seen.remove(obj_id)
-
-    if isinstance(obj, tuple):
-        if hasattr(obj, "_asdict") and callable(obj._asdict):
-            return obj
-        obj_id = id(obj)
-        if obj_id in seen:
-            return obj
-        seen.add(obj_id)
-        try:
-            return tuple(_normalize_json_keys(value, seen) for value in obj)
-        finally:
-            seen.remove(obj_id)
-
+        return [_normalize_json_keys(value) for value in obj]
+    if isinstance(obj, tuple) and not (
+        hasattr(obj, "_asdict") and callable(obj._asdict)
+    ):
+        # Plain tuples recurse; NamedTuples are left for _serialize_json, which
+        # converts them to dicts (preserving field names) before normalization.
+        return tuple(_normalize_json_keys(value) for value in obj)
     if isinstance(obj, collections.deque):
-        obj_id = id(obj)
-        if obj_id in seen:
-            return obj
-        seen.add(obj_id)
-        try:
-            return collections.deque(_normalize_json_keys(value, seen) for value in obj)
-        finally:
-            seen.remove(obj_id)
-
+        return collections.deque(_normalize_json_keys(value) for value in obj)
     return obj
 
 

--- a/python/langsmith/_internal/_serde.py
+++ b/python/langsmith/_internal/_serde.py
@@ -124,20 +124,13 @@ def _serialize_json(obj: Any) -> Any:
         return str(obj)
 
 
-def _stringify_json_key(key: Any) -> Any:
-    """Coerce a dict key into a type that orjson/``json`` accepts natively.
-
-    ``OPT_NON_STR_KEYS`` already covers ``int``/``float``/``datetime``/``UUID``
-    /``bytes``/etc., so those pass through untouched; anything else (e.g. tuples,
-    arbitrary objects) falls back to its ``str`` representation.
-    """
-    if isinstance(key, _JSON_KEY_TYPES):
-        return key
-    return str(key)
-
-
-def _normalize_json_keys(obj: Any) -> Any:
+def _normalize_json_keys(obj: Any) -> tuple[Any, bool]:
     """Recursively stringify dict keys that orjson will reject.
+
+    Returns the normalized object and whether any key was actually coerced
+    (the flag lets callers such as ``dumps_json`` skip a guaranteed-to-fail
+    orjson retry when the original failure was unrelated to keys, e.g. lone
+    UTF-16 surrogates in a value).
 
     Walks ``dict``, ``list``, ``tuple`` and ``deque`` so that unsupported keys
     hidden at any depth are coerced before serialization. Tuples and deques
@@ -146,27 +139,40 @@ def _normalize_json_keys(obj: Any) -> Any:
     ``default`` hook, so a bad-keyed dict nested inside one would otherwise
     slip past normalization. Cycles are handled downstream by
     ``_serialize_json`` (which collapses them to ``str``), not here.
+
+    JSON object keys must ultimately be ``str``/``int``/``float``/``bool``/
+    ``None``; other key types are stringified via ``_simple_default`` so they
+    match the formats the fast path would produce (e.g. ``datetime`` -> ISO
+    8601, ``bytes`` -> base64) rather than Python's ``str()`` or ``repr()``.
     """
-    if isinstance(obj, dict):
-        return {
-            _stringify_json_key(key): _normalize_json_keys(value)
-            for key, value in obj.items()
-        }
-    if isinstance(obj, list):
-        return [_normalize_json_keys(value) for value in obj]
-    if isinstance(obj, tuple) and not (
-        hasattr(obj, "_asdict") and callable(obj._asdict)
-    ):
-        # Plain tuples recurse; NamedTuples are left for _serialize_json, which
-        # converts them to dicts (preserving field names) before normalization.
-        return tuple(_normalize_json_keys(value) for value in obj)
-    if isinstance(obj, collections.deque):
-        return collections.deque(_normalize_json_keys(value) for value in obj)
-    return obj
+    changed = False
+
+    def _normalize(o: Any) -> Any:
+        nonlocal changed
+        if isinstance(o, dict):
+            new = {}
+            for key, value in o.items():
+                if not isinstance(key, _JSON_KEY_TYPES):
+                    changed = True
+                    key = str(_simple_default(key))
+                new[key] = _normalize(value)
+            return new
+        if isinstance(o, list):
+            return [_normalize(value) for value in o]
+        if isinstance(o, tuple) and not (hasattr(o, "_asdict") and callable(o._asdict)):
+            # Plain tuples recurse; NamedTuples are left for _serialize_json,
+            # which converts them to dicts (preserving field names) before the
+            # default hook re-normalizes them.
+            return tuple(_normalize(value) for value in o)
+        if isinstance(o, collections.deque):
+            return collections.deque(_normalize(value) for value in o)
+        return o
+
+    return _normalize(obj), changed
 
 
 def _serialize_json_with_normalized_keys(obj: Any) -> Any:
-    return _normalize_json_keys(_serialize_json(obj))
+    return _normalize_json_keys(_serialize_json(obj))[0]
 
 
 def _elide_surrogates(s: bytes) -> bytes:
@@ -199,18 +205,26 @@ def dumps_json(obj: Any) -> bytes:
     except TypeError as e:
         # Usually caused by UTF surrogate characters
         logger.debug(f"Orjson serialization failed: {repr(e)}. Falling back to json.")
-        normalized_obj = _normalize_json_keys(obj)
-        try:
-            return _orjson.dumps(
-                normalized_obj,
-                default=_serialize_json_with_normalized_keys,
-                option=_ORJSON_OPTIONS,
-            )
-        except TypeError as retry_e:
-            logger.debug(
-                "Orjson serialization with normalized keys failed: "
-                f"{repr(retry_e)}. Falling back to json."
-            )
+        normalized_obj, keys_changed = _normalize_json_keys(obj)
+        # Retry orjson only when key normalization could plausibly fix the
+        # failure; otherwise we go straight to stdlib ``json`` (which tolerates
+        # lone UTF-16 surrogates via ensure_ascii=True). ``keys_changed`` covers
+        # bad keys visible at the top level; the message check additionally
+        # catches bad keys hidden behind an object's ``to_dict``/``model_dump``
+        # (which only surface once ``_serialize_json`` runs inside orjson).
+        error_hinted_at_keys = "Dict key" in str(e)
+        if keys_changed or error_hinted_at_keys:
+            try:
+                return _orjson.dumps(
+                    normalized_obj,
+                    default=_serialize_json_with_normalized_keys,
+                    option=_ORJSON_OPTIONS,
+                )
+            except TypeError as retry_e:
+                logger.debug(
+                    "Orjson serialization with normalized keys failed: "
+                    f"{repr(retry_e)}. Falling back to json."
+                )
         result = json.dumps(
             normalized_obj,
             default=_serialize_json_with_normalized_keys,

--- a/python/langsmith/_internal/_serde.py
+++ b/python/langsmith/_internal/_serde.py
@@ -139,14 +139,26 @@ def _normalize_json_keys(obj: Any) -> Any:
     ``None``; other key types are stringified via ``_simple_default`` so they
     match the formats the fast path would produce (e.g. ``datetime`` -> ISO
     8601, ``bytes`` -> base64) rather than Python's ``str()`` or ``repr()``.
+
+    Note: stringifying a non-str key can collide with another key (e.g. a
+    literal ``"(1, 2)"`` and a coerced ``(1, 2)``). When that happens one entry
+    overwrites the other (last-in-iteration-order wins); the collision is
+    logged at debug level so the data loss is traceable.
     """
     if isinstance(obj, dict):
-        return {
-            (
+        new: dict[Any, Any] = {}
+        for key, value in obj.items():
+            norm_key: Any = (
                 key if isinstance(key, _JSON_KEY_TYPES) else str(_simple_default(key))
-            ): _normalize_json_keys(value)
-            for key, value in obj.items()
-        }
+            )
+            if norm_key in new and norm_key != key:
+                logger.debug(
+                    "Dict key collision during JSON key normalization: "
+                    f"{key!r} maps to {norm_key!r}, which already exists; "
+                    f"the previous value will be overwritten."
+                )
+            new[norm_key] = _normalize_json_keys(value)
+        return new
     if isinstance(obj, list):
         return [_normalize_json_keys(value) for value in obj]
     if isinstance(obj, tuple) and not (

--- a/python/langsmith/_internal/_serde.py
+++ b/python/langsmith/_internal/_serde.py
@@ -23,6 +23,13 @@ except ImportError:
 
 
 logger = logging.getLogger(__name__)
+_ORJSON_OPTIONS = (
+    _orjson.OPT_SERIALIZE_NUMPY
+    | _orjson.OPT_SERIALIZE_DATACLASS
+    | _orjson.OPT_SERIALIZE_UUID
+    | _orjson.OPT_NON_STR_KEYS
+)
+_JSON_KEY_TYPES = (str, int, float, bool, type(None))
 
 
 def _simple_default(obj):
@@ -117,6 +124,68 @@ def _serialize_json(obj: Any) -> Any:
         return str(obj)
 
 
+def _stringify_json_key(key: Any) -> Any:
+    if isinstance(key, _JSON_KEY_TYPES):
+        return key
+    return str(_simple_default(key))
+
+
+def _normalize_json_keys(obj: Any, seen: set[int] | None = None) -> Any:
+    if seen is None:
+        seen = set()
+
+    if isinstance(obj, dict):
+        obj_id = id(obj)
+        if obj_id in seen:
+            return obj
+        seen.add(obj_id)
+        try:
+            return {
+                _stringify_json_key(key): _normalize_json_keys(value, seen)
+                for key, value in obj.items()
+            }
+        finally:
+            seen.remove(obj_id)
+
+    if isinstance(obj, list):
+        obj_id = id(obj)
+        if obj_id in seen:
+            return obj
+        seen.add(obj_id)
+        try:
+            return [_normalize_json_keys(value, seen) for value in obj]
+        finally:
+            seen.remove(obj_id)
+
+    if isinstance(obj, tuple):
+        if hasattr(obj, "_asdict") and callable(obj._asdict):
+            return obj
+        obj_id = id(obj)
+        if obj_id in seen:
+            return obj
+        seen.add(obj_id)
+        try:
+            return tuple(_normalize_json_keys(value, seen) for value in obj)
+        finally:
+            seen.remove(obj_id)
+
+    if isinstance(obj, collections.deque):
+        obj_id = id(obj)
+        if obj_id in seen:
+            return obj
+        seen.add(obj_id)
+        try:
+            return collections.deque(_normalize_json_keys(value, seen) for value in obj)
+        finally:
+            seen.remove(obj_id)
+
+    return obj
+
+
+def _serialize_json_with_normalized_keys(obj: Any) -> Any:
+    return _normalize_json_keys(_serialize_json(obj))
+
+
 def _elide_surrogates(s: bytes) -> bytes:
     pattern = re.compile(rb"\\ud[89a-f][0-9a-f]{2}", re.IGNORECASE)
     result = pattern.sub(b"", s)
@@ -142,17 +211,26 @@ def dumps_json(obj: Any) -> bytes:
         return _orjson.dumps(
             obj,
             default=_serialize_json,
-            option=_orjson.OPT_SERIALIZE_NUMPY
-            | _orjson.OPT_SERIALIZE_DATACLASS
-            | _orjson.OPT_SERIALIZE_UUID
-            | _orjson.OPT_NON_STR_KEYS,
+            option=_ORJSON_OPTIONS,
         )
     except TypeError as e:
         # Usually caused by UTF surrogate characters
         logger.debug(f"Orjson serialization failed: {repr(e)}. Falling back to json.")
+        normalized_obj = _normalize_json_keys(obj)
+        try:
+            return _orjson.dumps(
+                normalized_obj,
+                default=_serialize_json_with_normalized_keys,
+                option=_ORJSON_OPTIONS,
+            )
+        except TypeError as retry_e:
+            logger.debug(
+                "Orjson serialization with normalized keys failed: "
+                f"{repr(retry_e)}. Falling back to json."
+            )
         result = json.dumps(
-            obj,
-            default=_serialize_json,
+            normalized_obj,
+            default=_serialize_json_with_normalized_keys,
             ensure_ascii=True,
         ).encode("utf-8")
         try:

--- a/python/tests/unit_tests/test_client.py
+++ b/python/tests/unit_tests/test_client.py
@@ -2087,6 +2087,27 @@ def test__dumps_json():
     assert "\\uDC00" not in serialized_str
 
 
+def test__dumps_json_normalizes_unsupported_dict_keys():
+    class TupleKeyedDict:
+        def to_dict(self) -> Dict:
+            return {(1, 2): "custom"}
+
+    serialized_json = _dumps_json(
+        {
+            (1, 2): "value",
+            "nested": [{("a", "b"): pathlib.Path("c")}],
+            "custom": TupleKeyedDict(),
+        }
+    )
+
+    assert isinstance(serialized_json, bytes)
+    assert _orjson.loads(serialized_json) == {
+        "(1, 2)": "value",
+        "nested": [{"('a', 'b')": "c"}],
+        "custom": {"(1, 2)": "custom"},
+    }
+
+
 @patch("langsmith.client.requests.Session", autospec=True)
 def test_host_url(_: MagicMock) -> None:
     client = Client(api_url="https://api.foobar.com/api", api_key="API_KEY")

--- a/python/tests/unit_tests/test_client.py
+++ b/python/tests/unit_tests/test_client.py
@@ -2095,6 +2095,8 @@ def test__dumps_json_normalizes_unsupported_dict_keys():
     serialized_json = _dumps_json(
         {
             (1, 2): "value",
+            pathlib.Path("path-key"): "path",
+            frozenset({1}): "frozen",
             "nested": [{("a", "b"): pathlib.Path("c")}],
             "custom": TupleKeyedDict(),
         }
@@ -2103,6 +2105,8 @@ def test__dumps_json_normalizes_unsupported_dict_keys():
     assert isinstance(serialized_json, bytes)
     assert _orjson.loads(serialized_json) == {
         "(1, 2)": "value",
+        "path-key": "path",
+        "[1]": "frozen",
         "nested": [{"('a', 'b')": "c"}],
         "custom": {"(1, 2)": "custom"},
     }


### PR DESCRIPTION
### Description
Fixes #3071 by keeping the normal orjson path unchanged, then retrying serialization with unsupported dict keys normalized to strings so tuple-keyed run I/O is not dropped. The wrapped fallback also handles tuple-keyed dicts returned from `to_dict`/`model_dump`.

### Test Plan
- [x] Added coverage for top-level, nested, and custom-serializer tuple-keyed dicts
- [x] `make -C /workspace/langsmith-sdk/python format`
- [x] `TEST="tests/unit_tests/test_client.py::test__dumps_json_normalizes_unsupported_dict_keys tests/unit_tests/test_client.py::test__dumps_json" make -C /workspace/langsmith-sdk/python tests`
- [x] `make -C /workspace/langsmith-sdk/python lint` (ruff passed; mypy fails on unrelated Python 3.14 `Executor.map` signature in `langsmith/utils.py`)

Made by [Open SWE](https://openswe.vercel.app/agents/c25a00bb-7509-d577-aed4-c3bca4139d1f)