### PR TITLE
fix(js): Avoid setting usage_metadata on parent chain runs for Claude Agent SDK runs

### DIFF
--- a/js/src/experimental/anthropic/context.ts
+++ b/js/src/experimental/anthropic/context.ts
@@ -99,7 +99,11 @@ export class StreamManager {
 
       this.namespaces["root"].extra ??= {};
       this.namespaces["root"].extra.metadata ??= {};
-      this.namespaces["root"].extra.metadata.usage_metadata = usage;
+      // Keep the SDK's final aggregate usage available for inspection, but do not
+      // store it as `usage_metadata` on the parent chain. LangSmith rollups
+      // already aggregate child LLM usage, so parent `usage_metadata` would be
+      // counted again (notably doubling Anthropic cache-read/cache-write tokens).
+      this.namespaces["root"].extra.metadata.raw_usage = usage;
 
       this.namespaces["root"].extra.metadata.is_error = message.is_error;
       this.namespaces["root"].extra.metadata.num_turns = message.num_turns;

--- a/js/src/experimental/anthropic/context.ts
+++ b/js/src/experimental/anthropic/context.ts
@@ -103,7 +103,7 @@ export class StreamManager {
       // store it as `usage_metadata` on the parent chain. LangSmith rollups
       // already aggregate child LLM usage, so parent `usage_metadata` would be
       // counted again (notably doubling Anthropic cache-read/cache-write tokens).
-      this.namespaces["root"].extra.metadata.raw_usage = usage;
+      this.namespaces["root"].extra.metadata.ls_aggregated_usage = usage;
 
       this.namespaces["root"].extra.metadata.is_error = message.is_error;
       this.namespaces["root"].extra.metadata.num_turns = message.num_turns;

--- a/js/src/tests/claude_agent_sdk.test.ts
+++ b/js/src/tests/claude_agent_sdk.test.ts
@@ -625,7 +625,7 @@ describe("wrapClaudeAgentSDK", () => {
           run_type: "chain",
           extra: {
             metadata: {
-              raw_usage: {
+              ls_aggregated_usage: {
                 input_tokens: 10,
                 output_tokens: 15,
                 total_tokens: 25,
@@ -768,7 +768,7 @@ describe("wrapClaudeAgentSDK", () => {
           inputs: { messages: [{ content: "Test", role: "user" }] },
           extra: {
             metadata: {
-              raw_usage: {
+              ls_aggregated_usage: {
                 input_tokens: 13,
                 output_tokens: 8,
                 total_tokens: 21,
@@ -895,7 +895,7 @@ describe("wrapClaudeAgentSDK", () => {
               duration_ms: 1500,
               duration_api_ms: 1200,
 
-              raw_usage: {
+              ls_aggregated_usage: {
                 input_tokens: 10,
                 output_tokens: 5,
                 total_tokens: 15,
@@ -1429,7 +1429,7 @@ describe("wrapClaudeAgentSDK", () => {
     }
   });
 
-  test("stores aggregate modelUsage as raw_usage without parent rollup usage", async () => {
+  test("stores aggregate modelUsage as ls_aggregated_usage without parent rollup usage", async () => {
     const { client, callSpy } = mockClient();
     const mockSDK = {
       ...createMockSDK(),
@@ -1517,7 +1517,7 @@ describe("wrapClaudeAgentSDK", () => {
           },
           extra: {
             metadata: {
-              raw_usage: {
+              ls_aggregated_usage: {
                 input_tokens: 120,
                 output_tokens: 50,
                 total_tokens: 170,

--- a/js/src/tests/claude_agent_sdk.test.ts
+++ b/js/src/tests/claude_agent_sdk.test.ts
@@ -625,7 +625,7 @@ describe("wrapClaudeAgentSDK", () => {
           run_type: "chain",
           extra: {
             metadata: {
-              usage_metadata: {
+              raw_usage: {
                 input_tokens: 10,
                 output_tokens: 15,
                 total_tokens: 25,
@@ -768,7 +768,7 @@ describe("wrapClaudeAgentSDK", () => {
           inputs: { messages: [{ content: "Test", role: "user" }] },
           extra: {
             metadata: {
-              usage_metadata: {
+              raw_usage: {
                 input_tokens: 13,
                 output_tokens: 8,
                 total_tokens: 21,
@@ -895,7 +895,7 @@ describe("wrapClaudeAgentSDK", () => {
               duration_ms: 1500,
               duration_api_ms: 1200,
 
-              usage_metadata: {
+              raw_usage: {
                 input_tokens: 10,
                 output_tokens: 5,
                 total_tokens: 15,
@@ -1429,7 +1429,7 @@ describe("wrapClaudeAgentSDK", () => {
     }
   });
 
-  test("captures per-model usage from modelUsage", async () => {
+  test("stores aggregate modelUsage as raw_usage without parent rollup usage", async () => {
     const { client, callSpy } = mockClient();
     const mockSDK = {
       ...createMockSDK(),
@@ -1502,6 +1502,9 @@ describe("wrapClaudeAgentSDK", () => {
     ]);
 
     const res = await getAssumedTreeFromCalls(callSpy.mock.calls, client);
+    expect(
+      res.data["claude.conversation:0"].extra?.metadata?.usage_metadata,
+    ).toBeUndefined();
     expect(res).toMatchObject({
       nodes: ["claude.conversation:0", "claude.assistant.turn:1"],
       edges: [["claude.conversation:0", "claude.assistant.turn:1"]],
@@ -1514,7 +1517,7 @@ describe("wrapClaudeAgentSDK", () => {
           },
           extra: {
             metadata: {
-              usage_metadata: {
+              raw_usage: {
                 input_tokens: 120,
                 output_tokens: 50,
                 total_tokens: 170,


### PR DESCRIPTION
We were setting `metadata.usage_metadata` on the parent chain runs of Claude Agent SDK runs unnecessarily. For run details, the LangSmith backend combines with the natural child run aggregation and double counts special tokens. This PR renames this clientside aggregation to a non-reserved name `ls_aggregated_usage`.

Before: https://smith.langchain.com/public/909833a1-803d-491b-b0f8-a602766c91e0/r/019f16e6-1b38-7000-8000-0349a8905c2d

After: https://smith.langchain.com/public/04c95b33-734e-4ef9-bdf5-c59f95f9923e/r/019f16e7-044b-7000-8000-0355f64c11d1