### PR TITLE
release(python): bump py version to 0.9.4

### DIFF
--- a/python/.bumpversion.cfg
+++ b/python/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.9.3
+current_version = 0.9.4
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
 serialize = {major}.{minor}.{patch}
 search = {current_version}

--- a/python/langsmith/__init__.py
+++ b/python/langsmith/__init__.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
 
 # Avoid calling into importlib on every call to __version__
 
-__version__ = "0.9.3"
+__version__ = "0.9.4"
 version = __version__  # for backwards compatibility
 
 # Metadata key to hide a traced run from LangSmith's Messages View.


### PR DESCRIPTION
## Summary
- Bump Python SDK patch version from `0.9.3` → `0.9.4`
- Updates `python/langsmith/__init__.py` and `python/.bumpversion.cfg`

🤖 Generated with [Claude Code](https://claude.com/claude-code)