### PR TITLE
fix(sandbox): wrap all WS handshake failures as SandboxConnectionError

### DIFF
--- a/python/.bumpversion.cfg
+++ b/python/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.9.4
+current_version = 0.9.5
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
 serialize = {major}.{minor}.{patch}
 search = {current_version}

--- a/python/langsmith/__init__.py
+++ b/python/langsmith/__init__.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
 
 # Avoid calling into importlib on every call to __version__
 
-__version__ = "0.9.4"
+__version__ = "0.9.5"
 version = __version__  # for backwards compatibility
 
 # Metadata key to hide a traced run from LangSmith's Messages View.

--- a/python/langsmith/sandbox/_ws_execute.py
+++ b/python/langsmith/sandbox/_ws_execute.py
@@ -19,10 +19,10 @@ from langsmith.sandbox._helpers import merge_headers
 def _ensure_websockets():
     """Import websockets or raise a clear error."""
     try:
-        from websockets.exceptions import ConnectionClosed, InvalidStatus
+        from websockets.exceptions import ConnectionClosed, InvalidHandshake
         from websockets.sync.client import connect as ws_connect
 
-        return ws_connect, ConnectionClosed, InvalidStatus
+        return ws_connect, ConnectionClosed, InvalidHandshake
     except ImportError:
         raise ImportError(
             "WebSocket-based execution requires the 'websockets' package, "
@@ -35,9 +35,9 @@ def _ensure_websockets_async():
     """Import async websockets or raise a clear error."""
     try:
         from websockets.asyncio.client import connect as ws_connect_async
-        from websockets.exceptions import ConnectionClosed, InvalidStatus
+        from websockets.exceptions import ConnectionClosed, InvalidHandshake
 
-        return ws_connect_async, ConnectionClosed, InvalidStatus
+        return ws_connect_async, ConnectionClosed, InvalidHandshake
     except ImportError:
         raise ImportError(
             "WebSocket-based execution requires the 'websockets' package, "
@@ -158,11 +158,14 @@ class _AsyncWSStreamControl:
 # =============================================================================
 
 
-def _raise_for_invalid_status(exc: Exception, ws_url: str) -> None:
-    """Raise a clear error when the server rejects the WebSocket upgrade.
+def _raise_for_invalid_handshake(exc: Exception, ws_url: str) -> None:
+    """Raise a clear error when the WebSocket upgrade handshake fails.
 
-    The most common case is HTTP 404 — the server doesn't have the
-    /execute/ws endpoint, meaning it doesn't support WebSocket streaming.
+    Covers both a rejection carrying an HTTP status (``InvalidStatus`` — most
+    commonly 404 when the server lacks the /execute/ws endpoint) and a response
+    that isn't valid HTTP at all (``InvalidMessage``, "did not receive a valid
+    HTTP response") — e.g. a stopped or recycled sandbox dataplane answering the
+    upgrade with garbage. Both subclass ``InvalidHandshake``.
     """
     status = getattr(getattr(exc, "response", None), "status_code", None)
     if status == 404:
@@ -176,9 +179,15 @@ def _raise_for_invalid_status(exc: Exception, ws_url: str) -> None:
         raise SandboxNotReadyError(
             f"Sandbox is not ready for WebSocket command execution: {exc}"
         ) from exc
-    # For other HTTP status codes, include the status in the message
+    if status is not None:
+        raise SandboxConnectionError(
+            f"WebSocket upgrade rejected by server (HTTP {status}): {exc}"
+        ) from exc
+    # No HTTP status at all — the peer didn't return a valid HTTP response,
+    # typically a stopped/unreachable sandbox dataplane.
     raise SandboxConnectionError(
-        f"WebSocket upgrade rejected by server (HTTP {status}): {exc}"
+        f"WebSocket upgrade to {ws_url} failed (no valid HTTP response); "
+        f"the sandbox may be stopped or unreachable: {exc}"
     ) from exc
 
 
@@ -245,7 +254,7 @@ def run_ws_stream(
     If on_stdout/on_stderr callbacks are provided, they are invoked as
     data arrives in addition to yielding the messages.
     """
-    ws_connect, ConnectionClosed, InvalidStatus = _ensure_websockets()
+    ws_connect, ConnectionClosed, InvalidHandshake = _ensure_websockets()
     ws_url = _build_ws_url(dataplane_url)
     request_headers = _build_auth_headers(api_key, headers)
     control = _WSStreamControl()
@@ -305,8 +314,8 @@ def run_ws_stream(
                     elif msg_type == "error":
                         _raise_from_error_msg(msg)
 
-        except InvalidStatus as e:
-            _raise_for_invalid_status(e, ws_url)
+        except InvalidHandshake as e:
+            _raise_for_invalid_handshake(e, ws_url)
         except ConnectionClosed as e:
             if e.rcvd and e.rcvd.code == 1001:
                 raise SandboxServerReloadError(
@@ -344,7 +353,7 @@ def reconnect_ws_stream(
     from there. If the requested offset is older than the buffer's
     earliest data, the server sends from the earliest available offset.
     """
-    ws_connect, ConnectionClosed, InvalidStatus = _ensure_websockets()
+    ws_connect, ConnectionClosed, InvalidHandshake = _ensure_websockets()
     ws_url = _build_ws_url(dataplane_url)
     request_headers = _build_auth_headers(api_key, headers)
     control = _WSStreamControl()
@@ -388,8 +397,8 @@ def reconnect_ws_stream(
                     elif msg_type == "error":
                         _raise_from_error_msg(msg, command_id=command_id)
 
-        except InvalidStatus as e:
-            _raise_for_invalid_status(e, ws_url)
+        except InvalidHandshake as e:
+            _raise_for_invalid_handshake(e, ws_url)
         except ConnectionClosed as e:
             if e.rcvd and e.rcvd.code == 1001:
                 raise SandboxServerReloadError(
@@ -432,7 +441,7 @@ async def run_ws_stream_async(
 
     Returns (async_message_iterator, async_control).
     """
-    ws_connect_async, ConnectionClosed, InvalidStatus = _ensure_websockets_async()
+    ws_connect_async, ConnectionClosed, InvalidHandshake = _ensure_websockets_async()
     ws_url = _build_ws_url(dataplane_url)
     request_headers = _build_auth_headers(api_key, headers)
     control = _AsyncWSStreamControl()
@@ -486,8 +495,8 @@ async def run_ws_stream_async(
                     elif msg_type == "error":
                         _raise_from_error_msg(msg)
 
-        except InvalidStatus as e:
-            _raise_for_invalid_status(e, ws_url)
+        except InvalidHandshake as e:
+            _raise_for_invalid_handshake(e, ws_url)
         except ConnectionClosed as e:
             if e.rcvd and e.rcvd.code == 1001:
                 raise SandboxServerReloadError(
@@ -514,7 +523,7 @@ async def reconnect_ws_stream_async(
     headers: Optional[Mapping[str, str]] = None,
 ) -> tuple[AsyncIterator[dict], _AsyncWSStreamControl]:
     """Async equivalent of reconnect_ws_stream."""
-    ws_connect_async, ConnectionClosed, InvalidStatus = _ensure_websockets_async()
+    ws_connect_async, ConnectionClosed, InvalidHandshake = _ensure_websockets_async()
     ws_url = _build_ws_url(dataplane_url)
     request_headers = _build_auth_headers(api_key, headers)
     control = _AsyncWSStreamControl()
@@ -554,8 +563,8 @@ async def reconnect_ws_stream_async(
                     elif msg_type == "error":
                         _raise_from_error_msg(msg, command_id=command_id)
 
-        except InvalidStatus as e:
-            _raise_for_invalid_status(e, ws_url)
+        except InvalidHandshake as e:
+            _raise_for_invalid_handshake(e, ws_url)
         except ConnectionClosed as e:
             if e.rcvd and e.rcvd.code == 1001:
                 raise SandboxServerReloadError(

--- a/python/tests/unit_tests/sandbox/test_async_ws_execute.py
+++ b/python/tests/unit_tests/sandbox/test_async_ws_execute.py
@@ -19,7 +19,11 @@ from langsmith.sandbox._models import (
     ExecutionResult,
     OutputChunk,
 )
-from langsmith.sandbox._ws_execute import _AsyncWSStreamControl
+from langsmith.sandbox._ws_execute import (
+    _AsyncWSStreamControl,
+    reconnect_ws_stream_async,
+    run_ws_stream_async,
+)
 
 # =============================================================================
 # Helper: async fake message streams
@@ -909,3 +913,40 @@ class TestAsyncSandboxReconnect:
             stderr_offset=0,
             headers={"X-Test-Header": "sandbox-reconnect"},
         )
+
+
+# =============================================================================
+# Tests: async handshake failures are wrapped as SandboxConnectionError
+# =============================================================================
+
+
+class TestAsyncHandshakeFailureWrapping:
+    """A non-HTTP handshake response (InvalidMessage) must surface as the SDK's
+    typed SandboxConnectionError, not leak as a raw websockets exception."""
+
+    def _invalid_message(self):
+        from websockets.exceptions import InvalidMessage
+
+        return InvalidMessage("did not receive a valid HTTP response")
+
+    @pytest.mark.asyncio
+    async def test_run_ws_stream_async_wraps_invalid_message(self):
+        with patch("websockets.asyncio.client.connect") as mock_connect:
+            mock_connect.side_effect = self._invalid_message()
+            msg_stream, _ = await run_ws_stream_async(
+                "https://sb.example.com", "key", "echo hi"
+            )
+            with pytest.raises(SandboxConnectionError, match="no valid HTTP response"):
+                async for _ in msg_stream:
+                    pass
+
+    @pytest.mark.asyncio
+    async def test_reconnect_ws_stream_async_wraps_invalid_message(self):
+        with patch("websockets.asyncio.client.connect") as mock_connect:
+            mock_connect.side_effect = self._invalid_message()
+            msg_stream, _ = await reconnect_ws_stream_async(
+                "https://sb.example.com", "key", "cmd-123"
+            )
+            with pytest.raises(SandboxConnectionError, match="no valid HTTP response"):
+                async for _ in msg_stream:
+                    pass

--- a/python/tests/unit_tests/sandbox/test_ws_execute.py
+++ b/python/tests/unit_tests/sandbox/test_ws_execute.py
@@ -898,9 +898,7 @@ class TestRaiseForInvalidHandshake:
         exc = Exception("did not receive a valid HTTP response")
 
         with pytest.raises(SandboxConnectionError) as exc_info:
-            _raise_for_invalid_handshake(
-                exc, "ws://example.com/sb-123/execute/ws"
-            )
+            _raise_for_invalid_handshake(exc, "ws://example.com/sb-123/execute/ws")
         msg = str(exc_info.value)
         assert "no valid HTTP response" in msg
         assert "may be stopped or unreachable" in msg
@@ -925,9 +923,7 @@ class TestHandshakeFailureWrapping:
     def test_run_ws_stream_wraps_invalid_message(self):
         with patch("websockets.sync.client.connect") as mock_connect:
             mock_connect.side_effect = self._invalid_message()
-            msg_stream, _ = run_ws_stream(
-                "https://sb.example.com", "key", "echo hi"
-            )
+            msg_stream, _ = run_ws_stream("https://sb.example.com", "key", "echo hi")
             with pytest.raises(SandboxConnectionError, match="no valid HTTP response"):
                 list(msg_stream)
 

--- a/python/tests/unit_tests/sandbox/test_ws_execute.py
+++ b/python/tests/unit_tests/sandbox/test_ws_execute.py
@@ -25,6 +25,8 @@ from langsmith.sandbox._ws_execute import (
     _build_ws_url,
     _raise_from_error_msg,
     _WSStreamControl,
+    reconnect_ws_stream,
+    run_ws_stream,
 )
 
 # =============================================================================
@@ -844,13 +846,13 @@ class TestSandboxReconnect:
 
 
 # =============================================================================
-# Tests: _raise_for_invalid_status
+# Tests: _raise_for_invalid_handshake
 # =============================================================================
 
 
-class TestRaiseForInvalidStatus:
+class TestRaiseForInvalidHandshake:
     def test_404_gives_clear_message_with_url(self):
-        from langsmith.sandbox._ws_execute import _raise_for_invalid_status
+        from langsmith.sandbox._ws_execute import _raise_for_invalid_handshake
 
         mock_response = MagicMock()
         mock_response.status_code = 404
@@ -858,7 +860,7 @@ class TestRaiseForInvalidStatus:
         exc.response = mock_response
 
         with pytest.raises(SandboxConnectionError) as exc_info:
-            _raise_for_invalid_status(
+            _raise_for_invalid_handshake(
                 exc,
                 "ws://example.com/sb-123/execute/ws",
             )
@@ -868,7 +870,7 @@ class TestRaiseForInvalidStatus:
         assert exc_info.value.__cause__ is exc
 
     def test_non_404_includes_status_code(self):
-        from langsmith.sandbox._ws_execute import _raise_for_invalid_status
+        from langsmith.sandbox._ws_execute import _raise_for_invalid_handshake
 
         mock_response = MagicMock()
         mock_response.status_code = 403
@@ -876,10 +878,10 @@ class TestRaiseForInvalidStatus:
         exc.response = mock_response
 
         with pytest.raises(SandboxConnectionError, match="HTTP 403"):
-            _raise_for_invalid_status(exc, "ws://example.com/sb-123/execute/ws")
+            _raise_for_invalid_handshake(exc, "ws://example.com/sb-123/execute/ws")
 
     def test_503_raises_not_ready(self):
-        from langsmith.sandbox._ws_execute import _raise_for_invalid_status
+        from langsmith.sandbox._ws_execute import _raise_for_invalid_handshake
 
         mock_response = MagicMock()
         mock_response.status_code = 503
@@ -887,4 +889,53 @@ class TestRaiseForInvalidStatus:
         exc.response = mock_response
 
         with pytest.raises(SandboxNotReadyError, match="not ready"):
-            _raise_for_invalid_status(exc, "ws://example.com/sb-123/execute/ws")
+            _raise_for_invalid_handshake(exc, "ws://example.com/sb-123/execute/ws")
+
+    def test_no_http_response_gives_unreachable_message(self):
+        """InvalidMessage carries no .response — a stopped/unreachable peer."""
+        from langsmith.sandbox._ws_execute import _raise_for_invalid_handshake
+
+        exc = Exception("did not receive a valid HTTP response")
+
+        with pytest.raises(SandboxConnectionError) as exc_info:
+            _raise_for_invalid_handshake(
+                exc, "ws://example.com/sb-123/execute/ws"
+            )
+        msg = str(exc_info.value)
+        assert "no valid HTTP response" in msg
+        assert "may be stopped or unreachable" in msg
+        assert "HTTP None" not in msg
+        assert exc_info.value.__cause__ is exc
+
+
+# =============================================================================
+# Tests: handshake failures are wrapped as SandboxConnectionError
+# =============================================================================
+
+
+class TestHandshakeFailureWrapping:
+    """A non-HTTP handshake response (InvalidMessage) must surface as the SDK's
+    typed SandboxConnectionError, not leak as a raw websockets exception."""
+
+    def _invalid_message(self):
+        from websockets.exceptions import InvalidMessage
+
+        return InvalidMessage("did not receive a valid HTTP response")
+
+    def test_run_ws_stream_wraps_invalid_message(self):
+        with patch("websockets.sync.client.connect") as mock_connect:
+            mock_connect.side_effect = self._invalid_message()
+            msg_stream, _ = run_ws_stream(
+                "https://sb.example.com", "key", "echo hi"
+            )
+            with pytest.raises(SandboxConnectionError, match="no valid HTTP response"):
+                list(msg_stream)
+
+    def test_reconnect_ws_stream_wraps_invalid_message(self):
+        with patch("websockets.sync.client.connect") as mock_connect:
+            mock_connect.side_effect = self._invalid_message()
+            msg_stream, _ = reconnect_ws_stream(
+                "https://sb.example.com", "key", "cmd-123"
+            )
+            with pytest.raises(SandboxConnectionError, match="no valid HTTP response"):
+                list(msg_stream)


### PR DESCRIPTION
## What

The four WebSocket stream functions in `langsmith/sandbox/_ws_execute.py` (`run_ws_stream`, `reconnect_ws_stream`, and the two async variants) now catch the `InvalidHandshake` base class instead of only `InvalidStatus`, so **every** handshake failure is translated into the SDK's typed `SandboxConnectionError`.

## Why

These functions are the SDK's contract boundary for the WS transport: raw `websockets` errors go in, typed SDK errors (`SandboxConnectionError` / `SandboxNotReadyError`) come out. The `except` clauses caught `InvalidStatus`, `ConnectionClosed`, and `OSError` — but **not** `InvalidMessage` ("did not receive a valid HTTP response"), which is a *sibling* of `InvalidStatus` under `InvalidHandshake` and is **not** an `OSError`.

So when a stopped or recycled sandbox dataplane answers the WS upgrade with a non-HTTP response, the raw `websockets.exceptions.InvalidMessage` leaked out untyped:
- past `CommandHandle.__iter__`'s auto-reconnect loop (only catches `SandboxConnectionError`),
- past `Sandbox.execute()`'s WS→HTTP fallback (`except (SandboxConnectionError, ImportError, OSError, TypeError)`),

and surfaced as a hard failure in the caller. This was hitting a downstream consumer's background agent runs in prod (a mid-run exec would kill the whole run).

## Change

- Catch `InvalidHandshake` (parent of `InvalidStatus`, `InvalidMessage`, `InvalidHeader`, …) in all four stream functions — `InvalidStatus` behavior is preserved since it subclasses the base.
- Rename `_raise_for_invalid_status` → `_raise_for_invalid_handshake` and add a no-HTTP-status branch: a clear `"...failed (no valid HTTP response); the sandbox may be stopped or unreachable"` message instead of `"HTTP None"`. The 404 / 503 / other-status branches are unchanged.
- `InvalidHandshake` has existed in `websockets` far longer than `InvalidStatus`, so the import is safe across supported versions.

## Test plan

- [x] New `TestHandshakeFailureWrapping` / `TestAsyncHandshakeFailureWrapping`: mock `websockets` connect to raise `InvalidMessage`; assert `run_ws_stream` / `reconnect_ws_stream` (sync + async) raise `SandboxConnectionError`.
- [x] New `_raise_for_invalid_handshake` no-status test asserts the clean message (no `"HTTP None"`).
- [x] Existing `_raise_for_invalid_*` 404/403/503 tests updated to the new name and still pass.
- [x] `pytest tests/unit_tests/sandbox/test_ws_execute.py tests/unit_tests/sandbox/test_async_ws_execute.py` → 90 passed; ruff clean.