### PR TITLE
chore(release): bump version to 0.9.7

### DIFF
--- a/python/.bumpversion.cfg
+++ b/python/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.9.6
+current_version = 0.9.7
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
 serialize = {major}.{minor}.{patch}
 search = {current_version}

--- a/python/langsmith/__init__.py
+++ b/python/langsmith/__init__.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
 
 # Avoid calling into importlib on every call to __version__
 
-__version__ = "0.9.6"
+__version__ = "0.9.7"
 version = __version__  # for backwards compatibility
 
 # Metadata key to hide a traced run from LangSmith's Messages View.


### PR DESCRIPTION
Smallest (patch) version bump 0.9.6 → 0.9.7 so the voice-integration work can publish.

Stacked as a sibling of #3146 on top of `voice-cost-provider-model` (#3145) — mergeable independently of the usage-standardize branch.








#### PR Dependency Tree


* **PR #3153** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)