### PR TITLE
fix: default to 'latest' for prompt identifier with trailing colon

### DIFF
--- a/python/langsmith/utils.py
+++ b/python/langsmith/utils.py
@@ -728,7 +728,9 @@ def parse_prompt_identifier(identifier: str) -> tuple[str, str, str]:
 
     parts = identifier.split(":", 1)
     owner_name = parts[0]
-    commit = parts[1] if len(parts) > 1 else "latest"
+    # A trailing colon with no commit (e.g. "name:") splits to ["name", ""];
+    # treat the empty commit as "latest" (matches the JS SDK's `commit || "latest"`).
+    commit = parts[1] if len(parts) > 1 and parts[1] else "latest"
 
     if "/" in owner_name:
         owner, name = owner_name.split("/", 1)

--- a/python/tests/unit_tests/test_utils.py
+++ b/python/tests/unit_tests/test_utils.py
@@ -309,6 +309,13 @@ def test_parse_prompt_identifier():
         "commit",
     )
     assert ls_utils.parse_prompt_identifier("name:commit") == ("-", "name", "commit")
+    # A trailing colon with no commit defaults to "latest" (not "").
+    assert ls_utils.parse_prompt_identifier("name:") == ("-", "name", "latest")
+    assert ls_utils.parse_prompt_identifier("owner/name:") == (
+        "owner",
+        "name",
+        "latest",
+    )
 
     # Invalid cases
     invalid_identifiers = [


### PR DESCRIPTION
### Problem

`parse_prompt_identifier` (`python/langsmith/utils.py`, also reached via `parse_hub_identifier`) resolves the commit part of a prompt identifier:

```python
parts = identifier.split(":", 1)
owner_name = parts[0]
commit = parts[1] if len(parts) > 1 else "latest"
```

For an identifier with a **trailing colon and no commit** — e.g. `"name:"` or `"owner/name:"` — `split(":", 1)` yields `["name", ""]`, so `len(parts) > 1` is `True` and `commit` becomes the **empty string** instead of defaulting to `"latest"`.

That empty commit flows into prompt URL/path building: `Client._get_prompt_url` produces a URL ending in a bare colon (`.../hub/-/name:`), and `pull_prompt` only treats `"latest"`/`None` as "fetch latest", so an empty string is used as a literal commit ref.

```
parse_prompt_identifier("name")        -> ("-", "name", "latest")   ✓
parse_prompt_identifier("name:")       -> ("-", "name", "")         ✗  (should be "latest")
parse_prompt_identifier("owner/name:") -> ("owner", "name", "")     ✗
```

The JS SDK (`js/src/utils/prompts.ts`) with the same docstring already handles this correctly via `commit || "latest"` — this is a Python/JS parity divergence.

### Fix

```python
commit = parts[1] if len(parts) > 1 and parts[1] else "latest"
```

### Tests

Extended `test_parse_prompt_identifier` with the trailing-colon cases (`"name:"`, `"owner/name:"` → `"latest"`). Fails before the fix, passes after; existing cases unchanged.
