### PR TITLE
release(python): bump py version to 0.9.8

### DIFF
--- a/python/.bumpversion.cfg
+++ b/python/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.9.7
+current_version = 0.9.8
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
 serialize = {major}.{minor}.{patch}
 search = {current_version}

--- a/python/langsmith/__init__.py
+++ b/python/langsmith/__init__.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
 
 # Avoid calling into importlib on every call to __version__
 
-__version__ = "0.9.7"
+__version__ = "0.9.8"
 version = __version__  # for backwards compatibility
 
 # Metadata key to hide a traced run from LangSmith's Messages View.


### PR DESCRIPTION
## Summary
- Bump Python SDK patch version from \`0.9.7\` → \`0.9.8\`
- Updates \`python/.bumpversion.cfg\` and \`python/langsmith/__init__.py\`

### Changes since 0.9.7
- feat(client): add \`aread_project\` async method
- fix(client): route \`aread_project\` through \`aio_to_thread\` override hook
- fix(client): remove projects accessor from Python and JS clients

🤖 Generated with [Claude Code](https://claude.com/claude-code)