### PR TITLE
refactor: Client -> sync and AsyncClient -> async for evaluators SDK

### DIFF
--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -112,7 +112,7 @@ from langsmith._internal._operations import (
 )
 from langsmith._internal._serde import dumps_json as _dumps_json
 from langsmith._internal._uuid import uuid7
-from langsmith._openapi_client import AsyncLangsmith as LangsmithOpenAPIClient
+from langsmith._openapi_client import Langsmith as LangsmithOpenAPIClient
 from langsmith.prompt_cache import PromptCache, prompt_cache_singleton
 from langsmith.schemas import AttachmentInfo, ExampleWithRuns
 
@@ -267,14 +267,14 @@ if TYPE_CHECKING:
 
     from langsmith import schemas
     from langsmith._openapi_client.resources.datasets.datasets import (
-        AsyncDatasetsResource,
+        DatasetsResource,
     )
     from langsmith._openapi_client.resources.online_evaluators import (
-        AsyncOnlineEvaluatorsResource as AsyncEvaluatorsResource,
+        OnlineEvaluatorsResource as EvaluatorsResource,
     )
-    from langsmith._openapi_client.resources.runs import AsyncRunsResource
+    from langsmith._openapi_client.resources.runs import RunsResource
     from langsmith._openapi_client.resources.sandboxes.sandboxes import (
-        AsyncSandboxesResource,
+        SandboxesResource,
     )
 
     # OTEL imports for type hints
@@ -1462,25 +1462,25 @@ class Client:
         return self._langsmith_api
 
     @property
-    def runs(self) -> AsyncRunsResource:
+    def runs(self) -> RunsResource:
         """Access the runs resource."""
         _check_backend_version(self.info.version)
         return self._get_langsmith_api().runs
 
     @property
-    def evaluators(self) -> AsyncEvaluatorsResource:
+    def evaluators(self) -> EvaluatorsResource:
         """Access the evaluator resource."""
         _check_backend_version(self.info.version)
         return self._get_langsmith_api().online_evaluators
 
     @property
-    def sandboxes(self) -> AsyncSandboxesResource:
+    def sandboxes(self) -> SandboxesResource:
         """Access the sandboxes resource (registries, snapshots, boxes)."""
         _check_backend_version(self.info.version)
         return self._get_langsmith_api().sandboxes
 
     @property
-    def datasets(self) -> AsyncDatasetsResource:
+    def datasets(self) -> DatasetsResource:
         """Access the v2 datasets resource (experiment_runs, etc.)."""
         _check_backend_version(self.info.version)
         return self._get_langsmith_api().datasets

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -114,6 +114,8 @@ from langsmith._internal._serde import dumps_json as _dumps_json
 from langsmith._internal._uuid import uuid7
 from langsmith._openapi_client import (
     AsyncLangsmith as LangsmithOpenAPIClient,
+)
+from langsmith._openapi_client import (
     Langsmith as SyncLangsmithOpenAPIClient,
 )
 from langsmith.prompt_cache import PromptCache, prompt_cache_singleton

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -112,7 +112,10 @@ from langsmith._internal._operations import (
 )
 from langsmith._internal._serde import dumps_json as _dumps_json
 from langsmith._internal._uuid import uuid7
-from langsmith._openapi_client import Langsmith as LangsmithOpenAPIClient
+from langsmith._openapi_client import (
+    AsyncLangsmith as LangsmithOpenAPIClient,
+    Langsmith as SyncLangsmithOpenAPIClient,
+)
 from langsmith.prompt_cache import PromptCache, prompt_cache_singleton
 from langsmith.schemas import AttachmentInfo, ExampleWithRuns
 
@@ -267,14 +270,14 @@ if TYPE_CHECKING:
 
     from langsmith import schemas
     from langsmith._openapi_client.resources.datasets.datasets import (
-        DatasetsResource,
+        AsyncDatasetsResource,
     )
     from langsmith._openapi_client.resources.online_evaluators import (
         OnlineEvaluatorsResource as EvaluatorsResource,
     )
-    from langsmith._openapi_client.resources.runs import RunsResource
+    from langsmith._openapi_client.resources.runs import AsyncRunsResource
     from langsmith._openapi_client.resources.sandboxes.sandboxes import (
-        SandboxesResource,
+        AsyncSandboxesResource,
     )
 
     # OTEL imports for type hints
@@ -887,6 +890,7 @@ class Client:
         "_profile_auth",
         "_profile_auth_headers",
         "_langsmith_api",
+        "_sync_langsmith_api",
     ]
 
     _api_key: Optional[str]
@@ -898,6 +902,7 @@ class Client:
     _profile_auth: Optional[_profiles.ProfileAuth]
     _profile_auth_headers: dict[str, str]
     _langsmith_api: Optional[LangsmithOpenAPIClient]
+    _sync_langsmith_api: Optional[SyncLangsmithOpenAPIClient]
 
     def __init__(
         self,
@@ -1437,6 +1442,7 @@ class Client:
             self._failed_traces_max_bytes = 100 * 1024 * 1024
 
         self._langsmith_api = None
+        self._sync_langsmith_api = None
 
     # ------------------------------------------------------------------
     # Stainless v2 resource accessors
@@ -1461,8 +1467,24 @@ class Client:
             )
         return self._langsmith_api
 
+    def _get_sync_langsmith_api(self) -> SyncLangsmithOpenAPIClient:
+        if self._sync_langsmith_api is None:
+            self._sync_langsmith_api = SyncLangsmithOpenAPIClient(
+                api_key=self._api_key,
+                tenant_id=str(self._workspace_id) if self._workspace_id else None,
+                base_url=self.api_url,
+                timeout=_httpx.Timeout(
+                    connect=self._timeout[0],
+                    read=self._timeout[1],
+                    write=self._timeout[1],
+                    pool=self._timeout[0],
+                ),
+                default_headers=self._headers or None,
+            )
+        return self._sync_langsmith_api
+
     @property
-    def runs(self) -> RunsResource:
+    def runs(self) -> AsyncRunsResource:
         """Access the runs resource."""
         _check_backend_version(self.info.version)
         return self._get_langsmith_api().runs
@@ -1471,16 +1493,16 @@ class Client:
     def evaluators(self) -> EvaluatorsResource:
         """Access the evaluator resource."""
         _check_backend_version(self.info.version)
-        return self._get_langsmith_api().online_evaluators
+        return self._get_sync_langsmith_api().online_evaluators
 
     @property
-    def sandboxes(self) -> SandboxesResource:
+    def sandboxes(self) -> AsyncSandboxesResource:
         """Access the sandboxes resource (registries, snapshots, boxes)."""
         _check_backend_version(self.info.version)
         return self._get_langsmith_api().sandboxes
 
     @property
-    def datasets(self) -> DatasetsResource:
+    def datasets(self) -> AsyncDatasetsResource:
         """Access the v2 datasets resource (experiment_runs, etc.)."""
         _check_backend_version(self.info.version)
         return self._get_langsmith_api().datasets

--- a/python/tests/integration_tests/test_client.py
+++ b/python/tests/integration_tests/test_client.py
@@ -122,7 +122,7 @@ def parameterized_multipart_client(request) -> Client:
     )
 
 
-async def test_evaluators_generated_client_crud(
+def test_evaluators_generated_client_crud(
     langchain_client: Client,
 ) -> None:
     """Exercise the generated OpenAPI evaluators resource end to end."""
@@ -132,7 +132,7 @@ async def test_evaluators_generated_client_crud(
     )
 
     try:
-        created = await langchain_client.evaluators.create(
+        created = langchain_client.evaluators.create(
             name=name,
             type="code",
             code_evaluator={
@@ -146,28 +146,25 @@ async def test_evaluators_generated_client_crud(
         assert evaluator.name == name
         assert evaluator.type == "code"
 
-        retrieved = await langchain_client.evaluators.retrieve(evaluator.id)
+        retrieved = langchain_client.evaluators.retrieve(evaluator.id)
         assert retrieved.id == evaluator.id
         assert retrieved.name == name
 
         updated_name = f"{name}_updated"
-        updated = await langchain_client.evaluators.update(
+        updated = langchain_client.evaluators.update(
             evaluator.id,
             name=updated_name,
         )
         assert updated.evaluator is not None
         assert updated.evaluator.name == updated_name
 
-        evaluators = [
-            item
-            async for item in langchain_client.evaluators.list(
-                name_contains=updated_name, limit=10
-            )
-        ]
+        evaluators = list(
+            langchain_client.evaluators.list(name_contains=updated_name, limit=10)
+        )
         assert evaluator.id in {item.id for item in evaluators}
     finally:
         if evaluator is not None and evaluator.id is not None:
-            await langchain_client.evaluators.delete(
+            langchain_client.evaluators.delete(
                 evaluator.id, delete_run_rules=True
             )
 

--- a/python/tests/integration_tests/test_client.py
+++ b/python/tests/integration_tests/test_client.py
@@ -37,6 +37,7 @@ from langsmith._internal._operations import serialize_run_dict
 from langsmith._internal._serde import dumps_json
 from langsmith._internal.otel import _otel_exporter
 from langsmith._internal.otel._otel_client import get_otlp_tracer_provider
+from langsmith.async_client import AsyncClient
 from langsmith.client import ID_TYPE, Client, _close_files
 from langsmith.evaluation import aevaluate, evaluate
 from langsmith.run_helpers import traceable
@@ -125,7 +126,7 @@ def parameterized_multipart_client(request) -> Client:
 def test_evaluators_generated_client_crud(
     langchain_client: Client,
 ) -> None:
-    """Exercise the generated OpenAPI evaluators resource end to end."""
+    """Exercise sync Client evaluator CRUD end to end."""
     evaluator = None
     name = "__sdk_evaluator_integration_" + "".join(
         random.sample(string.ascii_lowercase, 10)
@@ -167,6 +168,51 @@ def test_evaluators_generated_client_crud(
             langchain_client.evaluators.delete(
                 evaluator.id, delete_run_rules=True
             )
+
+
+async def test_async_evaluators_generated_client_crud() -> None:
+    """Exercise async AsyncClient evaluator CRUD end to end."""
+    evaluator = None
+    client = AsyncClient()
+    name = "__sdk_async_evaluator_integration_" + "".join(
+        random.sample(string.ascii_lowercase, 10)
+    )
+
+    try:
+        created = await client.evaluators.create(
+            name=name,
+            type="code",
+            code_evaluator={
+                "code": "def perform_eval(run, example):\n    return {'score': 1}",
+                "language": "python",
+            },
+        )
+        evaluator = created.evaluator
+        assert evaluator is not None
+        assert evaluator.id is not None
+        assert evaluator.name == name
+        assert evaluator.type == "code"
+
+        retrieved = await client.evaluators.retrieve(evaluator.id)
+        assert retrieved.id == evaluator.id
+        assert retrieved.name == name
+
+        updated_name = f"{name}_updated"
+        updated = await client.evaluators.update(evaluator.id, name=updated_name)
+        assert updated.evaluator is not None
+        assert updated.evaluator.name == updated_name
+
+        evaluators = [
+            item
+            async for item in client.evaluators.list(
+                name_contains=updated_name, limit=10
+            )
+        ]
+        assert evaluator.id in {item.id for item in evaluators}
+    finally:
+        if evaluator is not None and evaluator.id is not None:
+            await client.evaluators.delete(evaluator.id, delete_run_rules=True)
+        await client.aclose()
 
 
 async def test_aread_project(langchain_client: Client) -> None:

--- a/python/tests/integration_tests/test_client.py
+++ b/python/tests/integration_tests/test_client.py
@@ -165,9 +165,7 @@ def test_evaluators_generated_client_crud(
         assert evaluator.id in {item.id for item in evaluators}
     finally:
         if evaluator is not None and evaluator.id is not None:
-            langchain_client.evaluators.delete(
-                evaluator.id, delete_run_rules=True
-            )
+            langchain_client.evaluators.delete(evaluator.id, delete_run_rules=True)
 
 
 async def test_async_evaluators_generated_client_crud() -> None:

--- a/python/tests/unit_tests/test_client.py
+++ b/python/tests/unit_tests/test_client.py
@@ -881,10 +881,11 @@ def test_evaluators_uses_generated_openapi_resource() -> None:
     import langsmith._openapi_client as openapi_module
     from langsmith import client as client_module
 
-    assert client_module.LangsmithOpenAPIClient is openapi_module.Langsmith
+    assert client_module.LangsmithOpenAPIClient is openapi_module.AsyncLangsmith
+    assert client_module.SyncLangsmithOpenAPIClient is openapi_module.Langsmith
     resource = object()
 
-    with mock.patch("langsmith.client.LangsmithOpenAPIClient") as openapi_client:
+    with mock.patch("langsmith.client.SyncLangsmithOpenAPIClient") as openapi_client:
         openapi_client.return_value.online_evaluators = resource
 
         client = Client(

--- a/python/tests/unit_tests/test_client.py
+++ b/python/tests/unit_tests/test_client.py
@@ -878,6 +878,10 @@ def test_create_run_unicode() -> None:
 
 
 def test_evaluators_uses_generated_openapi_resource() -> None:
+    import langsmith._openapi_client as openapi_module
+    from langsmith import client as client_module
+
+    assert client_module.LangsmithOpenAPIClient is openapi_module.Langsmith
     resource = object()
 
     with mock.patch("langsmith.client.LangsmithOpenAPIClient") as openapi_client:


### PR DESCRIPTION
## Description
- Add a separate sync generated OpenAPI client cache only for Python `Client().evaluators`, so sync users can call evaluator CRUD without `await`.
- Keep `AsyncClient().evaluators` on the async generated resource, so async users can keep using `await`.
- Leave the existing `Client` generated resource cache untouched for other resources.
- Add integration coverage for both `Client().evaluators` and `AsyncClient().evaluators` CRUD.

## Test plan
- `cd python && TEST='tests/unit_tests/test_client.py -k evaluators' make tests`
- `cd python && uv run python -m py_compile tests/integration_tests/test_client.py`