### PR TITLE
fix(python): remove projects accessor from AsyncClient

### DIFF
--- a/python/langsmith/async_client.py
+++ b/python/langsmith/async_client.py
@@ -55,7 +55,6 @@ if TYPE_CHECKING:
     from langsmith._openapi_client.resources.sandboxes.sandboxes import (
         AsyncSandboxesResource,
     )
-    from langsmith._openapi_client.resources.sessions import AsyncSessionsResource
 
 
 class AsyncClient:
@@ -322,11 +321,6 @@ class AsyncClient:
     def sandboxes(self) -> AsyncSandboxesResource:
         """Access the sandboxes resource (registries, snapshots, boxes)."""
         return self._langsmith_api.sandboxes
-
-    @property
-    def projects(self) -> AsyncSessionsResource:
-        """Access the projects resource."""
-        return self._langsmith_api.sessions
 
     @property
     def datasets(self) -> AsyncDatasetsResource:


### PR DESCRIPTION
## Summary
- Removes the `projects` property from `AsyncClient`.
- This accessor depended on the generated `sessions` resource in `langsmith._openapi_client`, which is dropped by the langsmith_api sync in #3162 (per langchain-ai/langchainplus#29257), currently failing `Python Lint` (mypy) on that PR.
- The equivalent accessor on the sync `Client` (`client.py`) and the JS `Client` (`client.ts`) was already removed in #3157 — this brings the async Python client in line. No TypeScript changes are needed.
