### PR TITLE
fix: bound voice streaming audio buffers

### DIFF
--- a/python/langsmith/_internal/voice/audio.py
+++ b/python/langsmith/_internal/voice/audio.py
@@ -15,6 +15,8 @@ import io
 import math
 import wave
 
+DEFAULT_MAX_AUDIO_SECONDS = 10 * 60
+
 
 def pcm_to_wav(pcm: bytes, sample_rate: int, num_channels: int = 1) -> bytes:
     """Wrap raw PCM16 bytes in a WAV container.
@@ -60,8 +62,10 @@ def build_stereo_session_wav(
     user_chunks: list[tuple[float, bytes]],
     agent_chunks: list[tuple[float, bytes]],
     sample_rate: int,
+    *,
+    max_duration_seconds: float | None = DEFAULT_MAX_AUDIO_SECONDS,
 ) -> bytes:
-    """Reconstruct a stereo WAV from timestamped PCM16 chunks.
+    """Reconstruct a duration-capped stereo WAV from timestamped PCM16 chunks.
 
     Left channel = user, right channel = agent. Both channels are laid out at
     natural play time (see ``_layout_chunks_to_play_time``). Gaps between bursts
@@ -80,6 +84,9 @@ def build_stereo_session_wav(
     user_end = max((chunk_end(t, d) for t, d in user), default=0.0)
     agent_end = max((chunk_end(t, d) for t, d in agent), default=0.0)
     total_samples = int(math.ceil(max(user_end, agent_end) * sample_rate))
+    if max_duration_seconds is not None:
+        max_samples = int(math.ceil(max_duration_seconds * sample_rate))
+        total_samples = min(total_samples, max_samples)
     if total_samples <= 0:
         return b""
 

--- a/python/langsmith/_internal/voice/audio.py
+++ b/python/langsmith/_internal/voice/audio.py
@@ -58,6 +58,26 @@ def _layout_chunks_to_play_time(
     return out
 
 
+def _chunk_end(t: float, data: bytes, sample_rate: int) -> float:
+    return t + (len(data) // 2) / sample_rate
+
+
+def session_wav_exceeds_duration_cap(
+    user_chunks: list[tuple[float, bytes]],
+    agent_chunks: list[tuple[float, bytes]],
+    sample_rate: int,
+    max_duration_seconds: float | None,
+) -> bool:
+    """Return whether natural-play WAV layout exceeds the duration cap."""
+    if max_duration_seconds is None:
+        return False
+    user = _layout_chunks_to_play_time(user_chunks, sample_rate)
+    agent = _layout_chunks_to_play_time(agent_chunks, sample_rate)
+    user_end = max((_chunk_end(t, d, sample_rate) for t, d in user), default=0.0)
+    agent_end = max((_chunk_end(t, d, sample_rate) for t, d in agent), default=0.0)
+    return max(user_end, agent_end) > max_duration_seconds
+
+
 def build_stereo_session_wav(
     user_chunks: list[tuple[float, bytes]],
     agent_chunks: list[tuple[float, bytes]],
@@ -78,11 +98,8 @@ def build_stereo_session_wav(
     user = _layout_chunks_to_play_time(user_chunks, sample_rate)
     agent = _layout_chunks_to_play_time(agent_chunks, sample_rate)
 
-    def chunk_end(t: float, data: bytes) -> float:
-        return t + (len(data) // 2) / sample_rate
-
-    user_end = max((chunk_end(t, d) for t, d in user), default=0.0)
-    agent_end = max((chunk_end(t, d) for t, d in agent), default=0.0)
+    user_end = max((_chunk_end(t, d, sample_rate) for t, d in user), default=0.0)
+    agent_end = max((_chunk_end(t, d, sample_rate) for t, d in agent), default=0.0)
     total_samples = int(math.ceil(max(user_end, agent_end) * sample_rate))
     if max_duration_seconds is not None:
         max_samples = int(math.ceil(max_duration_seconds * sample_rate))

--- a/python/langsmith/_internal/voice/session.py
+++ b/python/langsmith/_internal/voice/session.py
@@ -31,7 +31,10 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Literal, Optional, cast
 
 from langsmith import RunTree
-from langsmith._internal.voice.audio import build_stereo_session_wav
+from langsmith._internal.voice.audio import (
+    DEFAULT_MAX_AUDIO_SECONDS,
+    build_stereo_session_wav,
+)
 from langsmith._internal.voice.helpers import dump_event, scrub
 
 if TYPE_CHECKING:
@@ -66,6 +69,7 @@ class EventSession:
     # further chunks on it are dropped (the conversation's start is kept) and the
     # root is flagged ``audio_truncated``. ``None`` disables the cap.
     max_audio_bytes: Optional[int] = None
+    max_audio_seconds: Optional[float] = DEFAULT_MAX_AUDIO_SECONDS
     # Monotonic clock origin. Everything else stores ``now() - t0``.
     t0: float = field(default_factory=time.monotonic)
     # Time-stamped audio chunks for the stereo session WAV. Each entry is
@@ -141,14 +145,11 @@ class EventSession:
         Dropped once the user channel reaches ``max_audio_bytes`` (see that
         field) so a long session can't exhaust memory.
         """
-        if (
-            self.max_audio_bytes is not None
-            and self._user_bytes >= self.max_audio_bytes
-        ):
-            self._note_audio_truncated()
+        chunk = self._bounded_audio_chunk(self._user_bytes, data)
+        if not chunk:
             return
-        self._user_bytes += len(data)
-        self.user_chunks.append((t, data))
+        self._user_bytes += len(chunk)
+        self.user_chunks.append((t, chunk))
 
     def record_agent(self, t: float, data: bytes) -> None:
         """Record a timestamped chunk of agent (playback) PCM16 for the WAV.
@@ -156,24 +157,33 @@ class EventSession:
         Dropped once the agent channel reaches ``max_audio_bytes`` (see that
         field) so a long session can't exhaust memory.
         """
-        if (
-            self.max_audio_bytes is not None
-            and self._agent_bytes >= self.max_audio_bytes
-        ):
-            self._note_audio_truncated()
+        chunk = self._bounded_audio_chunk(self._agent_bytes, data)
+        if not chunk:
             return
-        self._agent_bytes += len(data)
-        self.agent_chunks.append((t, data))
+        self._agent_bytes += len(chunk)
+        self.agent_chunks.append((t, chunk))
+
+    def _bounded_audio_chunk(self, current_bytes: int, data: bytes) -> bytes:
+        if self.max_audio_bytes is None:
+            return data
+        remaining = self.max_audio_bytes - current_bytes
+        remaining -= remaining % 2
+        if remaining <= 0:
+            self._note_audio_truncated()
+            return b""
+        if len(data) <= remaining:
+            return data
+        self._note_audio_truncated()
+        return data[:remaining]
 
     def _note_audio_truncated(self) -> None:
-        """Flag (once) that recorded audio was capped at ``max_audio_bytes``."""
+        """Flag once that recorded audio was capped."""
         if self._audio_truncated:
-            return  # log once per session, not once per dropped chunk
+            return
         self._audio_truncated = True
         logger.warning(
-            "voice tracing: audio capture hit the %d-byte per-channel cap; "
-            "further audio for this conversation is dropped from the WAV",
-            self.max_audio_bytes,
+            "voice tracing: audio capture hit the configured cap; "
+            "further audio for this conversation is dropped from the WAV"
         )
 
     def set_title(self, text: str) -> None:
@@ -377,6 +387,15 @@ class EventSession:
         run.end(outputs=scrub(outputs) if outputs is not None else {})
         run.patch()
 
+    def _audio_exceeds_duration_cap(self) -> bool:
+        if self.max_audio_seconds is None:
+            return False
+        for t, data in [*self.user_chunks, *self.agent_chunks]:
+            duration = (len(data) // 2) / self.sample_rate
+            if t >= self.max_audio_seconds or t + duration > self.max_audio_seconds:
+                return True
+        return False
+
     def finalize(self) -> None:
         """Roll up stats, attach the stereo WAV, and close the root span.
 
@@ -386,6 +405,8 @@ class EventSession:
         """
         # Close the last open turn (if any) before the root.
         self._close_turn()
+        if self._audio_exceeds_duration_cap():
+            self._note_audio_truncated()
         extra: dict[str, Any] = self.run.extra or {}
         metadata: dict[str, Any] = dict(extra.get("metadata") or {})
         metadata["event_count"] = self.event_count
@@ -397,7 +418,10 @@ class EventSession:
 
         try:
             wav = build_stereo_session_wav(
-                self.user_chunks, self.agent_chunks, self.sample_rate
+                self.user_chunks,
+                self.agent_chunks,
+                self.sample_rate,
+                max_duration_seconds=self.max_audio_seconds,
             )
         except Exception:
             # A WAV-build failure (e.g. an oversized buffer) must not lose the
@@ -427,7 +451,7 @@ def start_session(
     tags: Optional[list[str]] = None,
     metadata: Optional[dict[str, Any]] = None,
     name: str = "realtime_session",
-    max_audio_seconds: Optional[float] = None,
+    max_audio_seconds: Optional[float] = DEFAULT_MAX_AUDIO_SECONDS,
     client: Optional[Client] = None,
     replicas: Optional[Sequence[WriteReplica]] = None,
     integration: str,
@@ -446,9 +470,10 @@ def start_session(
     (see LangSmith's tracing replicas). Set on the root and inherited by child
     spans via ``create_child``; ``None`` disables replication.
 
-    ``max_audio_seconds`` caps how much audio per channel is retained for the
-    stereo WAV, guarding memory on long-running sessions; ``None`` keeps all
-    audio. It is converted to a per-channel byte budget at PCM16 (2 bytes/sample).
+    ``max_audio_seconds`` caps how much audio per channel is retained and how far
+    into the session the stereo WAV can extend, guarding memory on long-running
+    sessions. The default is bounded; pass ``None`` to keep all audio. It is
+    converted to a per-channel byte budget at PCM16 (2 bytes/sample).
 
     ``integration`` / ``integration_version`` stamp ``ls_integration`` and
     ``ls_integration_version`` on the root (the convention the batch integrations
@@ -496,4 +521,5 @@ def start_session(
         project_name=project_name,
         sample_rate=sample_rate,
         max_audio_bytes=max_audio_bytes,
+        max_audio_seconds=max_audio_seconds,
     )

--- a/python/langsmith/_internal/voice/session.py
+++ b/python/langsmith/_internal/voice/session.py
@@ -34,6 +34,7 @@ from langsmith import RunTree
 from langsmith._internal.voice.audio import (
     DEFAULT_MAX_AUDIO_SECONDS,
     build_stereo_session_wav,
+    session_wav_exceeds_duration_cap,
 )
 from langsmith._internal.voice.helpers import dump_event, scrub
 
@@ -388,13 +389,12 @@ class EventSession:
         run.patch()
 
     def _audio_exceeds_duration_cap(self) -> bool:
-        if self.max_audio_seconds is None:
-            return False
-        for t, data in [*self.user_chunks, *self.agent_chunks]:
-            duration = (len(data) // 2) / self.sample_rate
-            if t >= self.max_audio_seconds or t + duration > self.max_audio_seconds:
-                return True
-        return False
+        return session_wav_exceeds_duration_cap(
+            self.user_chunks,
+            self.agent_chunks,
+            self.sample_rate,
+            self.max_audio_seconds,
+        )
 
     def finalize(self) -> None:
         """Roll up stats, attach the stereo WAV, and close the root span.

--- a/python/langsmith/integrations/google_adk_live/_plugin.py
+++ b/python/langsmith/integrations/google_adk_live/_plugin.py
@@ -54,7 +54,11 @@ from langsmith._internal.voice.helpers import (
     observe_safely,
     scrub,
 )
-from langsmith._internal.voice.session import EventSession, start_session
+from langsmith._internal.voice.session import (
+    DEFAULT_MAX_AUDIO_SECONDS,
+    EventSession,
+    start_session,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -362,7 +366,7 @@ class LangSmithGoogleADKLivePlugin(BasePlugin):
         project_name: Optional[str] = None,
         tags: Optional[list[str]] = None,
         metadata: Optional[dict[str, Any]] = None,
-        max_audio_seconds: Optional[float] = None,
+        max_audio_seconds: Optional[float] = DEFAULT_MAX_AUDIO_SECONDS,
         client: Optional[Client] = None,
         replicas: Optional[Sequence[WriteReplica]] = None,
     ) -> None:
@@ -377,8 +381,8 @@ class LangSmithGoogleADKLivePlugin(BasePlugin):
             tags / metadata: attached to the conversation root span.
             max_audio_seconds: per-channel cap on audio retained for the WAV, to
                 bound memory. Since one shared plugin can trace many (and
-                long-running) conversations, set this on a server to keep audio
-                buffers from growing unbounded; ``None`` (default) keeps all audio.
+                long-running) conversations, pass ``None`` only when all audio
+                should be kept.
             client: LangSmith ``Client`` for tracing writes; ``None`` (default)
                 uses the SDK's standard env-based resolution (``LANGSMITH_*``).
             replicas: tracing replicas to mirror the conversation trace to

--- a/python/langsmith/integrations/openai_realtime/_connection.py
+++ b/python/langsmith/integrations/openai_realtime/_connection.py
@@ -33,7 +33,11 @@ from typing import TYPE_CHECKING, Any, Callable, Optional
 from langsmith._internal._package_version import get_package_version
 from langsmith._internal._usage import _create_usage_metadata
 from langsmith._internal.voice.helpers import observe_safely
-from langsmith._internal.voice.session import EventSession, start_session
+from langsmith._internal.voice.session import (
+    DEFAULT_MAX_AUDIO_SECONDS,
+    EventSession,
+    start_session,
+)
 from langsmith.run_helpers import tracing_context
 
 if TYPE_CHECKING:
@@ -466,7 +470,7 @@ def wrap_realtime(
     tags: Optional[list[str]] = None,
     metadata: Optional[dict[str, Any]] = None,
     is_agent_speaking: Optional[Callable[[], bool]] = None,
-    max_audio_seconds: Optional[float] = None,
+    max_audio_seconds: Optional[float] = DEFAULT_MAX_AUDIO_SECONDS,
     client: Optional[Client] = None,
     replicas: Optional[Sequence[WriteReplica]] = None,
 ) -> _RealtimeTracingSession:
@@ -493,7 +497,7 @@ def wrap_realtime(
         is_agent_speaking: zero-arg callable returning whether the agent is still
             audible, used to flag a barge-in; ``None`` disables that flag.
         max_audio_seconds: per-channel cap on audio retained for the WAV, to
-            bound memory on long sessions; ``None`` (default) keeps all audio.
+            bound memory on long sessions; pass ``None`` to keep all audio.
         client: LangSmith ``Client`` for tracing writes; ``None`` (default) uses
             the SDK's standard env-based resolution (``LANGSMITH_*``).
         replicas: tracing replicas to mirror the conversation trace to additional

--- a/python/langsmith/integrations/openai_realtime/_session.py
+++ b/python/langsmith/integrations/openai_realtime/_session.py
@@ -38,7 +38,11 @@ from typing import TYPE_CHECKING, Any, Callable, Optional
 
 from langsmith._internal._package_version import get_package_version
 from langsmith._internal.voice.helpers import observe_safely
-from langsmith._internal.voice.session import EventSession, start_session
+from langsmith._internal.voice.session import (
+    DEFAULT_MAX_AUDIO_SECONDS,
+    EventSession,
+    start_session,
+)
 from langsmith.run_helpers import tracing_context
 
 if TYPE_CHECKING:
@@ -605,7 +609,7 @@ def wrap_realtime_session(
     tags: Optional[list[str]] = None,
     metadata: Optional[dict[str, Any]] = None,
     on_message: Optional[Callable[[str, str], None]] = None,
-    max_audio_seconds: Optional[float] = None,
+    max_audio_seconds: Optional[float] = DEFAULT_MAX_AUDIO_SECONDS,
     client: Optional[Client] = None,
     replicas: Optional[Sequence[WriteReplica]] = None,
 ) -> _TracedRealtimeSession:
@@ -631,7 +635,7 @@ def wrap_realtime_session(
         on_message: optional callback ``(role, text)`` invoked once per finalized
             transcript line (e.g. to print to a console).
         max_audio_seconds: per-channel cap on audio retained for the WAV, to
-            bound memory on long sessions; ``None`` (default) keeps all audio.
+            bound memory on long sessions; pass ``None`` to keep all audio.
         client: LangSmith ``Client`` for tracing writes; ``None`` (default) uses
             the SDK's standard env-based resolution (``LANGSMITH_*``).
         replicas: tracing replicas to mirror the conversation trace to additional

--- a/python/langsmith/integrations/pipecat/processor.py
+++ b/python/langsmith/integrations/pipecat/processor.py
@@ -64,6 +64,8 @@ DEFAULT_STATE_TTL_SECONDS = 3600.0
 # first). The TTL is the governing limit in practice.
 DEFAULT_STATE_MAXSIZE = 100_000
 
+_WAV_HEADER_BYTES = 44
+
 
 class PipecatLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
     """Enriches Pipecat's OTel spans with LangSmith-compatible attributes."""
@@ -113,8 +115,8 @@ class PipecatLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
             maxsize=DEFAULT_STATE_MAXSIZE, ttl=state_ttl_seconds
         )
         # Merged PCM accumulated from a Pipecat AudioBufferProcessor (see
-        # attach_audio_buffer), keyed by conversation id. Each value is
-        # {"pcm": bytearray, "sample_rate": int, "num_channels": int}. Also
+        # attach_audio_buffer), keyed by conversation id. Each value carries the
+        # PCM bytearray, sample rate, channel count, and truncation flag. Also
         # TTL-bounded — these entries hold the raw audio and are the larger leak.
         self._audio_by_conversation: MutableMapping[str, dict[str, Any]] = TTLCache(
             maxsize=DEFAULT_STATE_MAXSIZE, ttl=state_ttl_seconds
@@ -145,6 +147,11 @@ class PipecatLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
 
         audio_buffer.event_handler("on_audio_data")(_on_audio_data)
 
+    def _pcm_audio_size_limit_bytes(self) -> Optional[int]:
+        if self.audio_size_limit_bytes is None:
+            return None
+        return max(0, self.audio_size_limit_bytes - _WAV_HEADER_BYTES)
+
     def _accumulate_audio(
         self, conversation_id: str, audio: bytes, sample_rate: int, num_channels: int
     ) -> None:
@@ -154,7 +161,21 @@ class PipecatLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
                 "pcm": bytearray(),
                 "sample_rate": sample_rate,
                 "num_channels": num_channels,
+                "audio_truncated": False,
             }
+        pcm_limit_bytes = self._pcm_audio_size_limit_bytes()
+        if pcm_limit_bytes is not None:
+            remaining = pcm_limit_bytes - len(rec["pcm"])
+            remaining -= remaining % 2
+            if remaining <= 0:
+                rec["audio_truncated"] = True
+                rec["sample_rate"] = sample_rate
+                rec["num_channels"] = num_channels
+                self._audio_by_conversation[conversation_id] = rec
+                return
+            if len(audio) > remaining:
+                rec["audio_truncated"] = True
+                audio = audio[:remaining]
         rec["pcm"].extend(audio)
         rec["sample_rate"] = sample_rate
         rec["num_channels"] = num_channels
@@ -345,6 +366,14 @@ class PipecatLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
                 )
             return
         if not rec["pcm"]:
+            return
+        pcm_limit_bytes = self._pcm_audio_size_limit_bytes()
+        if pcm_limit_bytes is not None and len(rec["pcm"]) > pcm_limit_bytes:
+            logger.warning(
+                "langsmith voice: skipped oversize pipecat audio for "
+                "conversation_id=%r",
+                conversation_id,
+            )
             return
         wav = pcm_to_wav(bytes(rec["pcm"]), rec["sample_rate"], rec["num_channels"])
         self._attach_audio(

--- a/python/tests/integration_tests/test_runs.py
+++ b/python/tests/integration_tests/test_runs.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 import time
 import uuid
 from collections import defaultdict
@@ -21,6 +22,8 @@ from langsmith.run_helpers import (
 from langsmith.run_trees import RunTree
 from langsmith.schemas import Attachment
 from tests.integration_tests.conftest import skip_if_rate_limited
+
+logger = logging.getLogger(__name__)
 
 
 @pytest.fixture
@@ -56,7 +59,7 @@ def poll_runs_until_count(
                 ):
                     return runs
         except ls_utils.LangSmithError:
-            pass
+            logger.debug("Error polling runs", exc_info=True)
         time.sleep(sleep_time)
         retries += 1
     raise AssertionError(f"Failed to get {count} runs after {max_retries} attempts.")
@@ -149,6 +152,7 @@ async def test_list_runs_multi_project(langchain_client: Client):
     assert runs[0].session_id != runs[1].session_id
 
 
+@skip_if_rate_limited
 async def test_nested_async_runs_with_threadpool(langchain_client: Client):
     """Test nested runs with a mix of async and sync functions."""
     project_name = (
@@ -206,10 +210,9 @@ async def test_nested_async_runs_with_threadpool(langchain_client: Client):
     )
     executor.shutdown(wait=True)
     filter_ = f'and(eq(metadata_key, "test_run"), eq(metadata_value, "{meta}"))'
-    poll_runs_until_count(
+    runs = poll_runs_until_count(
         langchain_client, project_name, 17, filter_=filter_, max_retries=30
     )
-    runs = list(langchain_client.list_runs(project_name=project_name, filter=filter_))
     trace_runs = list(
         langchain_client.list_runs(
             trace_id=runs[0].trace_id, project_name=project_name, filter=filter_

--- a/python/tests/integration_tests/test_v2_threads.py
+++ b/python/tests/integration_tests/test_v2_threads.py
@@ -29,7 +29,7 @@ def _wait_for_sync(
             if condition():
                 return
         except Exception:
-            pass
+            logger.debug("Error checking sync condition", exc_info=True)
         time.sleep(sleep_time)
     raise ValueError(f"Condition not met within {max_sleep_time}s")
 
@@ -47,7 +47,7 @@ async def _wait_for_async(
             if result:
                 return result
         except Exception:
-            pass
+            logger.debug("Error checking async condition", exc_info=True)
         time.sleep(sleep_time)
     raise ValueError(f"Condition not met within {max_sleep_time}s")
 
@@ -102,7 +102,7 @@ def project_with_thread(langchain_client: Client):
             is not None
         )
 
-    _wait_for_sync(_runs_indexed, max_sleep_time=30, sleep_time=2)
+    _wait_for_sync(_runs_indexed, max_sleep_time=90, sleep_time=2)
 
     project = langchain_client.read_project(project_name=project_name)
     min_start_time = now - timedelta(hours=1)

--- a/python/tests/integration_tests/test_v2_traces.py
+++ b/python/tests/integration_tests/test_v2_traces.py
@@ -29,7 +29,7 @@ def _wait_for_sync(
             if condition():
                 return
         except Exception:
-            pass
+            logger.debug("Error checking sync condition", exc_info=True)
         time.sleep(sleep_time)
     raise ValueError(f"Condition not met within {max_sleep_time}s")
 
@@ -47,7 +47,7 @@ async def _wait_for_async(
             if result:
                 return result
         except Exception:
-            pass
+            logger.debug("Error checking async condition", exc_info=True)
         time.sleep(sleep_time)
     raise ValueError(f"Condition not met within {max_sleep_time}s")
 
@@ -90,7 +90,7 @@ def project_with_runs(langchain_client: Client):
             is not None
         )
 
-    _wait_for_sync(_runs_indexed, max_sleep_time=30, sleep_time=2)
+    _wait_for_sync(_runs_indexed, max_sleep_time=90, sleep_time=2)
 
     project = langchain_client.read_project(project_name=project_name)
     min_start_time = now - timedelta(hours=1)

--- a/python/tests/unit_tests/wrappers/test_pipecat.py
+++ b/python/tests/unit_tests/wrappers/test_pipecat.py
@@ -298,6 +298,30 @@ class TestPipecatAudio:
 
         assert "langsmith.attachments" not in _exported_attrs(proc)
 
+    def test_accumulate_audio_truncates_before_extend(self):
+        proc = _processor(audio_size_limit_bytes=50)
+        proc._accumulate_audio("c1", b"\x00\x01" * 2, 16000, 1)
+        proc._accumulate_audio("c1", b"\x02\x03" * 2, 16000, 1)
+
+        rec = proc._audio_by_conversation["c1"]
+        assert bytes(rec["pcm"]) == b"\x00\x01" * 2 + b"\x02\x03"
+        assert rec["audio_truncated"] is True
+
+    def test_oversize_audio_skips_conversion(self):
+        proc = _processor(audio_size_limit_bytes=50)
+        proc._audio_by_conversation["c1"] = {
+            "pcm": bytearray(b"\x00\x01" * 4),
+            "sample_rate": 16000,
+            "num_channels": 1,
+        }
+        span = _make_span("conversation", {"conversation.id": "c1"})
+
+        with patch("langsmith.integrations.pipecat.processor.pcm_to_wav") as patched:
+            proc.on_end(span)
+
+        patched.assert_not_called()
+        assert "langsmith.attachments" not in _exported_attrs(proc)
+
 
 class TestBaseProcessorHelpers:
     """Shared helpers in BaseLangSmithSpanProcessor."""
@@ -393,6 +417,16 @@ class TestVoiceAudioUtils:
             assert wf.getnchannels() == 2
             assert wf.getframerate() == 16000
             assert wf.getsampwidth() == 2
+
+    def test_stereo_session_wav_duration_cap_bounds_frames(self):
+        wav = audio_utils.build_stereo_session_wav(
+            [(0.0, b"\x01\x02" * 20), (60.0, b"\x03\x04" * 20)],
+            [],
+            10,
+            max_duration_seconds=1.0,
+        )
+        with wave.open(io.BytesIO(wav), "rb") as wf:
+            assert wf.getnframes() == 10
 
 
 class TestStateLifecycle:

--- a/python/tests/unit_tests/wrappers/test_voice_session.py
+++ b/python/tests/unit_tests/wrappers/test_voice_session.py
@@ -43,9 +43,9 @@ def _patch_cached_client(mock_client, monkeypatch):
     )
 
 
-def _session(**kwargs) -> EventSession:
+def _session(sample_rate: int = 24_000, **kwargs) -> EventSession:
     kwargs.setdefault("integration", "test-integration")
-    return start_session(thread_id="t1", sample_rate=24_000, **kwargs)
+    return start_session(thread_id="t1", sample_rate=sample_rate, **kwargs)
 
 
 class TestAudioBound:
@@ -108,6 +108,21 @@ class TestAudioBound:
         monkeypatch.setattr(session_mod, "build_stereo_session_wav", fake_build)
         s.finalize()
         assert calls[0]["max_duration_seconds"] == 1.0
+
+    def test_natural_play_duration_cap_marks_audio_truncated(self, monkeypatch):
+        s = _session(sample_rate=10, max_audio_seconds=600)
+        chunk = b"\x00\x00" * 150
+        s.record_agent(570.0, chunk)
+        s.record_agent(571.0, chunk)
+        s.record_agent(572.0, chunk)
+        monkeypatch.setattr(
+            session_mod, "build_stereo_session_wav", lambda *_, **__: b""
+        )
+
+        s.finalize()
+
+        meta = (s.run.extra or {}).get("metadata") or {}
+        assert meta.get("audio_truncated") is True
 
 
 class TestIntegrationMetadata:

--- a/python/tests/unit_tests/wrappers/test_voice_session.py
+++ b/python/tests/unit_tests/wrappers/test_voice_session.py
@@ -56,23 +56,28 @@ class TestAudioBound:
         s = _session(max_audio_seconds=2.0)
         assert s.max_audio_bytes == 2 * 24_000 * 2
 
-    def test_no_cap_by_default(self):
+    def test_bounded_cap_by_default(self):
         s = _session()
-        assert s.max_audio_bytes is None
+        assert s.max_audio_bytes == session_mod.DEFAULT_MAX_AUDIO_SECONDS * 24_000 * 2
         for _ in range(5):
             s.record_user(0.0, b"\x00\x00" * 1000)
         assert len(s.user_chunks) == 5
         assert s._audio_truncated is False
 
+    def test_none_disables_cap(self):
+        s = _session(max_audio_seconds=None)
+        assert s.max_audio_bytes is None
+        assert s.max_audio_seconds is None
+
     def test_user_channel_capped_and_flagged_once(self):
         s = _session()
-        s.max_audio_bytes = 100  # tiny cap for the test
-        s.record_user(0.0, b"\x00" * 80)  # under cap → kept
-        s.record_user(0.1, b"\x00" * 80)  # now at/over cap → kept, pushes over
-        s.record_user(0.2, b"\x00" * 80)  # dropped
-        s.record_user(0.3, b"\x00" * 80)  # dropped
+        s.max_audio_bytes = 100
+        s.record_user(0.0, b"\x00" * 80)
+        s.record_user(0.1, b"\x00" * 80)
+        s.record_user(0.2, b"\x00" * 80)
         assert len(s.user_chunks) == 2
-        assert s._user_bytes == 160
+        assert s.user_chunks[1][1] == b"\x00" * 20
+        assert s._user_bytes == 100
         assert s._audio_truncated is True
 
     def test_cap_is_per_channel(self):
@@ -88,10 +93,21 @@ class TestAudioBound:
         s = _session()
         s.max_audio_bytes = 10
         s.record_user(0.0, b"\x00" * 20)
-        s.record_user(0.1, b"\x00" * 20)  # dropped → truncated
         s.finalize()
         meta = (s.run.extra or {}).get("metadata") or {}
         assert meta.get("audio_truncated") is True
+
+    def test_finalize_caps_wav_duration(self, monkeypatch):
+        s = _session(max_audio_seconds=1.0)
+        calls = []
+
+        def fake_build(*args, **kwargs):
+            calls.append(kwargs)
+            return b""
+
+        monkeypatch.setattr(session_mod, "build_stereo_session_wav", fake_build)
+        s.finalize()
+        assert calls[0]["max_duration_seconds"] == 1.0
 
 
 class TestIntegrationMetadata:


### PR DESCRIPTION
### Description
Bounds voice tracing audio capture by default, caps timestamp-driven WAV allocation, and truncates Pipecat buffers before accumulation/conversion to prevent long sessions from exhausting memory.

### Test Plan
- [x] `UV_PYTHON=/usr/bin/python3.13 make -C python format`
- [x] `UV_PYTHON=/usr/bin/python3.13 make -C python lint`
- [x] `UV_PYTHON=/usr/bin/python3.13 TEST="tests/unit_tests/wrappers/test_voice_session.py tests/unit_tests/wrappers/test_openai_realtime.py tests/unit_tests/wrappers/test_openai_realtime_agents.py tests/unit_tests/wrappers/test_google_adk_live.py tests/unit_tests/wrappers/test_pipecat.py" make -C python tests`

Made by [Open SWE](https://openswe.vercel.app/agents/459f0ad9-2b2f-d798-8600-724d729e8232)