### PR TITLE
refactor(voice): move span attribute setters onto TranslatedSpan

### DIFF
--- a/python/langsmith/_internal/voice/base_span_processor.py
+++ b/python/langsmith/_internal/voice/base_span_processor.py
@@ -4,7 +4,7 @@ The framework integrations that emit their own OpenTelemetry spans (Pipecat,
 LiveKit) translate those spans into the ``gen_ai.*`` / ``langsmith.*`` attribute
 namespaces LangSmith's OTLP ingester understands, then forward them to an
 exporter. This base owns everything that translation shares — the downstream
-wrapping, the LangSmith OTLP exporter default, opt-in ``thread_id`` injection,
+wrapping, the LangSmith OTLP exporter default, opt-in ``thread_id`` stamping,
 the ``gen_ai.*`` message writers, and size-capped audio attachment — so each
 framework subclass implements only
 ``_dispatch`` (classify a span by name and rewrite it); the base exports it.
@@ -80,13 +80,56 @@ class TranslatedSpan:
             self.span, attributes=self.attributes, events=self.events
         )
 
+    def set_kind(self, kind: str) -> None:
+        """Set ``langsmith.span.kind`` (``llm`` / ``chain`` / ``tool`` / …)."""
+        self.attributes["langsmith.span.kind"] = kind
+
+    def set_thread_id(self, thread_id: str) -> None:
+        """Set ``langsmith.metadata.thread_id`` (the conversation/thread id)."""
+        self.attributes["langsmith.metadata.thread_id"] = thread_id
+
+    def exclude_from_message_view(self) -> None:
+        """Drop this span from the conversation Messages view (still in the tree).
+
+        That view reconstructs the chat from ``llm``/``tool`` runs. STT/TTS spans
+        are tagged ``llm``-kind for the tree but would otherwise add fake turns
+        (raw transcripts, "Generated audio for: …"), so they opt out here.
+        """
+        self.attributes["langsmith.metadata.ls_message_view_exclude"] = True
+
+    def set_root_span(self, is_root: bool) -> None:
+        """Mark the span as the trace root (``langsmith.root_span``)."""
+        self.attributes["langsmith.root_span"] = is_root
+
+    def set_metadata(self, key: str, value: Any) -> None:
+        """Set ``langsmith.metadata.<key>`` to the given value.
+
+        LangSmith surfaces everything under ``langsmith.metadata.*`` as run
+        metadata. Note ``langsmith.root_span`` and ``langsmith.span.kind`` are NOT
+        metadata — they live in the top-level ``langsmith.*`` namespace and have
+        their own setters / direct writes.
+        """
+        self.attributes[f"langsmith.metadata.{key}"] = value
+
+    def set_messages(
+        self,
+        *,
+        prompt: Optional[list[dict]] = None,
+        completion: Optional[list[dict]] = None,
+    ) -> None:
+        """Write ``gen_ai.prompt``/``gen_ai.completion`` as ``{"messages": [...]}``."""
+        if prompt is not None:
+            self.attributes["gen_ai.prompt"] = json.dumps({"messages": prompt})
+        if completion is not None:
+            self.attributes["gen_ai.completion"] = json.dumps({"messages": completion})
+
 
 class BaseLangSmithSpanProcessor(SpanProcessor):
     """Shared base for the OTel→LangSmith framework span processors.
 
     Subclasses implement :meth:`_dispatch` to classify each ended span and
     rewrite its attributes via the helpers here; the base exports it. The base
-    handles the downstream/exporter wiring, ``thread_id`` injection, and static
+    handles the downstream/exporter wiring, ``thread_id`` stamping, and static
     metadata stamping.
     """
 
@@ -143,7 +186,7 @@ class BaseLangSmithSpanProcessor(SpanProcessor):
         # runs synchronously in the task that starts the span; the conversation's
         # root span starts in the task where set_thread_id was called, so the
         # ContextVar is visible now even when later spans END in detached tasks
-        # where it is not. _inject_thread_id then recovers it per trace.
+        # where it is not. _stamp_thread_id then recovers it per trace.
         thread_id = thread_id_from_context()
         context = getattr(span, "context", None)
         if thread_id and context is not None:
@@ -163,7 +206,7 @@ class BaseLangSmithSpanProcessor(SpanProcessor):
         tspan = TranslatedSpan.of(span)
         export = True
         try:
-            self._inject_thread_id(tspan)
+            self._stamp_thread_id(tspan)
             export = self._dispatch(tspan) is not False
         except Exception:
             logger.warning(
@@ -215,7 +258,7 @@ class BaseLangSmithSpanProcessor(SpanProcessor):
 
     # -- shared helpers -------------------------------------------------------
 
-    def _inject_thread_id(self, tspan: TranslatedSpan) -> None:
+    def _stamp_thread_id(self, tspan: TranslatedSpan) -> None:
         """Stamp ``langsmith.metadata.thread_id`` from the per-context id (opt-in).
 
         LangSmith needs the thread id on every run for thread-level filtering and
@@ -229,7 +272,7 @@ class BaseLangSmithSpanProcessor(SpanProcessor):
         3. else the ``ContextVar`` directly (this span IS in context and is the
            first we've seen for the trace), backfilling the cache for its peers.
 
-        Injection is skipped (``None``) when no id was ever set for the trace.
+        Stamping is skipped (``None``) when no id was ever set for the trace.
         """
         if "langsmith.metadata.thread_id" in tspan.attributes:
             return
@@ -237,7 +280,7 @@ class BaseLangSmithSpanProcessor(SpanProcessor):
         thread_id = self._thread_id_by_trace.get(trace_id) or thread_id_from_context()
         if thread_id:
             thread_id = str(thread_id)
-            tspan.attributes["langsmith.metadata.thread_id"] = thread_id
+            tspan.set_thread_id(thread_id)
             self._remember_thread_id(trace_id, thread_id)
 
     def _remember_thread_id(self, trace_id: int, thread_id: str) -> None:
@@ -250,67 +293,6 @@ class BaseLangSmithSpanProcessor(SpanProcessor):
     def _forget_thread_id(self, trace_id: int) -> None:
         """Drop a trace's cached thread id (called from subclass cleanup)."""
         self._thread_id_by_trace.pop(trace_id, None)
-
-    @staticmethod
-    def _set_kind(tspan: TranslatedSpan, kind: str) -> None:
-        tspan.attributes["langsmith.span.kind"] = kind
-
-    @staticmethod
-    def _exclude_from_message_view(tspan: TranslatedSpan) -> None:
-        """Drop a span from the conversation Messages view (still in the tree).
-
-        That view reconstructs the chat from ``llm``/``tool`` runs. STT/TTS spans
-        are tagged ``llm``-kind for the tree but would inject fake turns (raw
-        transcripts, "Generated audio for: …"), so they opt out here.
-        """
-        tspan.attributes["langsmith.metadata.ls_message_view_exclude"] = True
-
-    @staticmethod
-    def _set_messages(
-        tspan: TranslatedSpan,
-        *,
-        prompt: Optional[list[dict]] = None,
-        completion: Optional[list[dict]] = None,
-    ) -> None:
-        """Write simple role/content turns in the indexed + singular forms.
-
-        For plain conversation turns (STT, TTS, an exchange) where messages have
-        only role + content. Writes the indexed ``gen_ai.prompt.{n}.role/content``
-        attributes and the singular ``gen_ai.prompt`` JSON list. For messages
-        that carry structured fields (tool calls), use :meth:`_set_messages_json`
-        instead — the indexed form can't represent them.
-        """
-        attrs = tspan.attributes
-        if prompt is not None:
-            for i, msg in enumerate(prompt):
-                attrs[f"gen_ai.prompt.{i}.role"] = msg.get("role", "user")
-                attrs[f"gen_ai.prompt.{i}.content"] = str(msg.get("content", ""))
-            attrs["gen_ai.prompt"] = json.dumps(prompt)
-        if completion is not None:
-            for i, msg in enumerate(completion):
-                attrs[f"gen_ai.completion.{i}.role"] = msg.get("role", "assistant")
-                attrs[f"gen_ai.completion.{i}.content"] = str(msg.get("content", ""))
-            attrs["gen_ai.completion"] = json.dumps(completion)
-
-    @staticmethod
-    def _set_messages_json(
-        tspan: TranslatedSpan,
-        *,
-        prompt: Optional[list[dict]] = None,
-        completion: Optional[list[dict]] = None,
-    ) -> None:
-        """Write messages in the singular ``{"messages": [...]}`` JSON form only.
-
-        This is the form for LLM calls and the conversation root: it can carry
-        structured ``tool_calls`` / ``tool_call_id`` that the indexed
-        ``gen_ai.prompt.{n}.*`` attributes can't, and it takes precedence at
-        ingest — so the indexed form is deliberately *not* written here (it would
-        win and drop the tool calls).
-        """
-        if prompt is not None:
-            tspan.attributes["gen_ai.prompt"] = json.dumps({"messages": prompt})
-        if completion is not None:
-            tspan.attributes["gen_ai.completion"] = json.dumps({"messages": completion})
 
     def _attach_audio(
         self, tspan: TranslatedSpan, *, name: str, data: bytes, mime_type: str

--- a/python/langsmith/integrations/livekit/__init__.py
+++ b/python/langsmith/integrations/livekit/__init__.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Any, Callable, Optional
 
 from langsmith._internal._beta_decorator import warn_beta
-from langsmith._internal.voice import set_thread_id, thread_id_from_context
+from langsmith._internal.voice import set_thread_id
 
 from .processor import LiveKitLangSmithSpanProcessor
 
@@ -17,7 +17,6 @@ __all__ = [
     "LiveKitLangSmithSpanProcessor",
     "configure_livekit",
     "set_thread_id",
-    "thread_id_from_context",
 ]
 
 

--- a/python/langsmith/integrations/livekit/processor.py
+++ b/python/langsmith/integrations/livekit/processor.py
@@ -6,7 +6,7 @@ recognize — so without translation, transcripts, TTS metrics, EOU
 probabilities, latency numbers, etc. all evaporate at ingest. This
 :class:`LiveKitLangSmithSpanProcessor` rewrites ``lk.*`` into the keys LangSmith
 understands before each span is exported. It inherits the downstream wrapping,
-exporter, ``thread_id`` injection, and message helpers from
+exporter, ``thread_id`` stamping, and message helpers from
 :class:`BaseLangSmithSpanProcessor`.
 
 Generic to any LiveKit agent
@@ -230,7 +230,7 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         elif name == _LLM_INFERENCE_SPAN:
             self._handle_llm_request(tspan)
         elif name in _LLM_WRAPPER_SPANS:
-            self._set_kind(tspan, "chain")  # wrappers: no fabricated I/O
+            tspan.set_kind("chain")  # wrappers: no fabricated I/O
         elif name == _TTS_INFERENCE_SPAN or name in _TTS_WRAPPER_SPANS:
             self._handle_tts(tspan)
         elif name == _TURN_SPAN:
@@ -238,11 +238,11 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         elif name == _SESSION_SPAN:
             # Session end: the conversation is complete — release the deferred
             # root (if any), then export the session span itself.
-            self._set_kind(tspan, "chain")
+            tspan.set_kind("chain")
             self._ended_sessions[trace_id] = True
             self._release_root_span(trace_id)
         elif name == "eou_detection":
-            self._set_kind(tspan, "chain")  # framework step
+            tspan.set_kind("chain")  # framework step
         elif name == _TOOL_SPAN:
             self._handle_tool(tspan)
         elif name == _REALTIME_METRICS_SPAN:
@@ -311,21 +311,21 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
 
     def _handle_stt(self, tspan: TranslatedSpan) -> None:
         """STT (``user_turn``): audio input → transcribed text."""
-        self._set_kind(tspan, "llm")
+        tspan.set_kind("llm")
         model = tspan.attributes.get("gen_ai.request.model")
         if model:
             tspan.attributes["langsmith.metadata.model_name"] = str(model)
         self._stamp_provider(tspan, "lk.stt_metrics")
 
         transcript = tspan.attributes.get("lk.user_transcript")
-        self._set_messages(
-            tspan, prompt=[{"role": "user", "content": f'Audio for: "{transcript}"'}]
+        tspan.set_messages(
+            prompt=[{"role": "user", "content": f'Audio for: "{transcript}"'}]
         )
         if transcript:
-            self._set_messages(
-                tspan, completion=[{"role": "assistant", "content": str(transcript)}]
+            tspan.set_messages(
+                completion=[{"role": "assistant", "content": str(transcript)}]
             )
-        self._exclude_from_message_view(tspan)
+        tspan.exclude_from_message_view()
 
     def _handle_llm_request(self, tspan: TranslatedSpan) -> None:
         """``llm_request``: the chat-completion call.
@@ -337,7 +337,7 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         survive) and strip the translated events so the ingester doesn't render
         them twice.
         """
-        self._set_kind(tspan, "llm")
+        tspan.set_kind("llm")
 
         prompt: list[dict] = []
         completion: list[dict] = []
@@ -346,9 +346,7 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
                 completion.append(self._message_from_event("assistant", event))
             elif (role := _LLM_EVENT_ROLES.get(event.name)) is not None:
                 prompt.append(self._message_from_event(role, event))
-        self._set_messages_json(
-            tspan, prompt=prompt or None, completion=completion or None
-        )
+        tspan.set_messages(prompt=prompt or None, completion=completion or None)
         # Normalize the provider (LiveKit's OpenAI plugin reports the
         # ``api.openai.com`` host, which won't match a LangSmith price).
         self._stamp_provider(tspan, "lk.llm_metrics")
@@ -398,11 +396,11 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         ``tts_request_run`` wrappers are ``chain``s.
         """
         if tspan.span.name != _TTS_INFERENCE_SPAN:
-            self._set_kind(tspan, "chain")
+            tspan.set_kind("chain")
             return
 
-        self._set_kind(tspan, "llm")
-        self._exclude_from_message_view(tspan)
+        tspan.set_kind("llm")
+        tspan.exclude_from_message_view()
 
         text = (
             tspan.attributes.get("lk.input_text")
@@ -410,8 +408,7 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
             or tspan.attributes.get("lk.text")
             or ""
         )
-        self._set_messages(
-            tspan,
+        tspan.set_messages(
             prompt=[{"role": "user", "content": str(text)}],
             completion=[
                 {"role": "assistant", "content": f'Generated audio for: "{text}"'}
@@ -439,7 +436,7 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         is the LiveKit-native turn boundary, so it works for both the cascade and
         the speech-to-speech backends.
         """
-        self._set_kind(tspan, "chain")
+        tspan.set_kind("chain")
         self._drain_realtime_metrics(tspan)
 
         user_input = tspan.attributes.get("lk.user_input")
@@ -448,11 +445,11 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         conversation = self._conversation_by_trace.get(trace_id) or []
         if user_input:
             msg = {"role": "user", "content": str(user_input)}
-            self._set_messages(tspan, prompt=[msg])
+            tspan.set_messages(prompt=[msg])
             conversation.append(msg)
         if response:
             msg = {"role": "assistant", "content": str(response)}
-            self._set_messages(tspan, completion=[msg])
+            tspan.set_messages(completion=[msg])
             conversation.append(msg)
         # Re-assign (not just mutate) so each turn refreshes the TTL — an active
         # call longer than the TTL is never evicted mid-conversation.
@@ -461,7 +458,7 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
 
     def _handle_tool(self, tspan: TranslatedSpan) -> None:
         """``function_tool``: render as a proper ``tool`` run with its I/O."""
-        self._set_kind(tspan, "tool")
+        tspan.set_kind("tool")
         tool_name = tspan.attributes.get("lk.function_tool.name")
         if tool_name:
             tspan.attributes["langsmith.metadata.tool_name"] = str(tool_name)
@@ -537,14 +534,12 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         so we always defer it and release it — complete, with audio — once the
         session has ended and any awaited recording has arrived.
         """
-        self._set_kind(tspan, "chain")
-        tspan.attributes["langsmith.root_span"] = True
-        tspan.attributes["langsmith.metadata.ls_modality"] = "audio"
-        tspan.attributes["langsmith.metadata.ls_integration"] = "livekit"
-        # "" not None: OTel span attributes reject a null value (unlike the
-        # RunTree metadata path); livekit-agents is a hard dep, so ~always set.
-        tspan.attributes["langsmith.metadata.ls_integration_version"] = (
-            get_package_version("livekit-agents") or ""
+        tspan.set_kind("chain")
+        tspan.set_root_span(True)
+        tspan.set_metadata("ls_modality", "audio")
+        tspan.set_metadata("ls_integration", "livekit")
+        tspan.set_metadata(
+            "ls_integration_version", (get_package_version("livekit-agents") or "")
         )
 
         thread = tspan.attributes.get("langsmith.metadata.thread_id")
@@ -591,9 +586,9 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         messages = self._conversation_by_trace.get(tspan.span.context.trace_id, [])
         if not messages:
             return False
-        self._set_messages(tspan, prompt=messages[:1])
+        tspan.set_messages(prompt=messages[:1])
         if len(messages) > 1:
-            self._set_messages(tspan, completion=messages[1:])
+            tspan.set_messages(completion=messages[1:])
         return True
 
     def _cleanup_trace(self, trace_id: str) -> None:
@@ -632,8 +627,7 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         """
         for trace_id, tspan in list(self._deferred_root_spans.items()):
             if not self._render_conversation(tspan):
-                self._set_messages(
-                    tspan,
+                tspan.set_messages(
                     prompt=[{"role": "system", "content": "Conversation not captured"}],
                     completion=[
                         {

--- a/python/langsmith/integrations/pipecat/processor.py
+++ b/python/langsmith/integrations/pipecat/processor.py
@@ -6,7 +6,7 @@ Pipecat emits OTel spans named ``conversation``, ``turn``, ``stt``, ``llm``, and
 :class:`PipecatLangSmithSpanProcessor` rewrites each span type into the
 ``gen_ai.*`` / ``langsmith.*`` namespaces LangSmith keys off, renders the whole
 conversation onto the root span, and (optionally) attaches the recorded audio
-there. It inherits the downstream wrapping, exporter, ``thread_id`` injection,
+there. It inherits the downstream wrapping, exporter, ``thread_id`` stamping,
 and message helpers from :class:`BaseLangSmithSpanProcessor`.
 
 Trace shape in LangSmith::
@@ -192,12 +192,12 @@ class PipecatLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
 
         if name == "stt":
             self._handle_stt(tspan)
-            self._exclude_from_message_view(tspan)
+            tspan.exclude_from_message_view()
         elif name == "llm":
             self._handle_llm(tspan, trace_id)
         elif name == "tts":
             self._handle_tts(tspan)
-            self._exclude_from_message_view(tspan)
+            tspan.exclude_from_message_view()
         elif name == "turn":
             self._handle_turn(tspan)
         elif name == "conversation":
@@ -215,13 +215,13 @@ class PipecatLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
     def _handle_stt(self, tspan: TranslatedSpan) -> None:
         """STT span: audio input → transcribed text."""
         transcript = tspan.attributes.get("transcript", "")
-        self._set_kind(tspan, "llm")
-        self._set_messages(
-            tspan, prompt=[{"role": "user", "content": f'Audio for: "{transcript}"'}]
+        tspan.set_kind("llm")
+        tspan.set_messages(
+            prompt=[{"role": "user", "content": f'Audio for: "{transcript}"'}]
         )
         if transcript:
-            self._set_messages(
-                tspan, completion=[{"role": "assistant", "content": str(transcript)}]
+            tspan.set_messages(
+                completion=[{"role": "assistant", "content": str(transcript)}]
             )
 
     @classmethod
@@ -256,7 +256,7 @@ class PipecatLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         """
         input_data = tspan.attributes.get("input", "")
         output_data = tspan.attributes.get("output", "")
-        self._set_kind(tspan, self._llm_span_kind)
+        tspan.set_kind(self._llm_span_kind)
 
         try:
             raw_messages = json.loads(input_data)
@@ -269,11 +269,9 @@ class PipecatLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         ]
 
         if messages:
-            self._set_messages_json(tspan, prompt=messages)
+            tspan.set_messages(prompt=messages)
         if output_data:
-            self._set_messages_json(
-                tspan, completion=[self._completion_message(output_data)]
-            )
+            tspan.set_messages(completion=[self._completion_message(output_data)])
 
         # Each request's input carries the full history, so the latest snapshot
         # IS the conversation — kept per trace for the root span to render. Reuse
@@ -288,12 +286,11 @@ class PipecatLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
     def _handle_tts(self, tspan: TranslatedSpan) -> None:
         """TTS span: text → audio. The voice is metadata, not content."""
         text = tspan.attributes.get("text", "")
-        self._set_kind(tspan, "llm")
+        tspan.set_kind("llm")
         voice_id = tspan.attributes.get("voice_id")
         if voice_id:
             tspan.attributes["langsmith.metadata.voice_id"] = str(voice_id)
-        self._set_messages(
-            tspan,
+        tspan.set_messages(
             prompt=[{"role": "user", "content": str(text)}],
             completion=[
                 {"role": "assistant", "content": f'Generated audio for: "{text}"'}
@@ -302,7 +299,7 @@ class PipecatLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
 
     def _handle_turn(self, tspan: TranslatedSpan) -> None:
         """Turn span: a framework wrapper around one exchange (a ``chain``)."""
-        self._set_kind(tspan, "chain")
+        tspan.set_kind("chain")
         turn_number = tspan.attributes.get("turn.number")
         if turn_number is not None:
             tspan.attributes["langsmith.metadata.turn_number"] = turn_number
@@ -321,7 +318,7 @@ class PipecatLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         conversation_id = tspan.attributes.get(
             "conversation.id", ""
         ) or tspan.attributes.get("conversation_id", "")
-        self._set_kind(tspan, "chain")
+        tspan.set_kind("chain")
         tspan.attributes["langsmith.root_span"] = True
         tspan.attributes["langsmith.metadata.ls_modality"] = "audio"
         tspan.attributes["langsmith.metadata.ls_integration"] = "pipecat"
@@ -333,9 +330,9 @@ class PipecatLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
 
         messages = self._conversation_by_trace.get(trace_id, [])
         if messages:
-            self._set_messages_json(tspan, prompt=messages[:1])
+            tspan.set_messages(prompt=messages[:1])
             if len(messages) > 1:
-                self._set_messages_json(tspan, completion=messages[1:])
+                tspan.set_messages(completion=messages[1:])
 
         self._attach_conversation_audio(tspan, conversation_id)
         self._cleanup_conversation(trace_id, conversation_id)

--- a/python/tests/unit_tests/wrappers/test_livekit.py
+++ b/python/tests/unit_tests/wrappers/test_livekit.py
@@ -118,7 +118,7 @@ class TestDeferredRootRelease:
         assert root._attributes["langsmith.metadata.ls_modality"] == "audio"
         # The root is attributed to this integration so usage is trackable.
         assert root._attributes["langsmith.metadata.ls_integration"] == "livekit"
-        completion = json.loads(root._attributes["gen_ai.completion"])
+        completion = json.loads(root._attributes["gen_ai.completion"])["messages"]
         assert completion[0]["content"] == "sunny"
         # Per-conversation state freed after release.
         assert len(proc._deferred_root_spans) == 0
@@ -161,7 +161,8 @@ class TestForceFlush:
             if c.args[0]._attributes.get("langsmith.root_span")
         )
         assert (
-            json.loads(root._attributes["gen_ai.completion"])[0]["content"] == "sunny"
+            json.loads(root._attributes["gen_ai.completion"])["messages"][0]["content"]
+            == "sunny"
         )
 
     def test_shutdown_flushes_held_root(self):

--- a/python/tests/unit_tests/wrappers/test_pipecat.py
+++ b/python/tests/unit_tests/wrappers/test_pipecat.py
@@ -74,8 +74,10 @@ class TestPipecatDispatch:
 
         attrs = _exported_attrs(proc)
         assert attrs["langsmith.span.kind"] == "llm"
-        assert attrs["gen_ai.prompt.0.content"] == 'Audio for: "hello there"'
-        assert attrs["gen_ai.completion.0.content"] == "hello there"
+        prompt = json.loads(attrs["gen_ai.prompt"])["messages"]
+        completion = json.loads(attrs["gen_ai.completion"])["messages"]
+        assert prompt[0]["content"] == 'Audio for: "hello there"'
+        assert completion[0]["content"] == "hello there"
         # STT/TTS spans stay in the tree but are dropped from the Messages view.
         assert attrs["langsmith.metadata.ls_message_view_exclude"] is True
         proc.downstream.on_end.assert_called_once()
@@ -86,7 +88,7 @@ class TestPipecatDispatch:
 
         proc.on_end(span)
 
-        assert "gen_ai.completion.0.content" not in _exported_attrs(proc)
+        assert "gen_ai.completion" not in _exported_attrs(proc)
 
     def test_tts_span(self):
         proc = _processor()
@@ -97,8 +99,11 @@ class TestPipecatDispatch:
         attrs = _exported_attrs(proc)
         assert attrs["langsmith.span.kind"] == "llm"
         assert attrs["langsmith.metadata.voice_id"] == "voice-1"
-        assert attrs["gen_ai.prompt.0.content"] == "hi"
-        assert attrs["gen_ai.completion.0.content"] == 'Generated audio for: "hi"'
+        assert json.loads(attrs["gen_ai.prompt"])["messages"][0]["content"] == "hi"
+        assert (
+            json.loads(attrs["gen_ai.completion"])["messages"][0]["content"]
+            == 'Generated audio for: "hi"'
+        )
         assert attrs["langsmith.metadata.ls_message_view_exclude"] is True
 
     def test_turn_span(self):
@@ -124,13 +129,10 @@ class TestPipecatDispatch:
 
         attrs = _exported_attrs(proc)
         assert attrs["langsmith.span.kind"] == "llm"
-        prompt = json.loads(attrs["gen_ai.prompt"])
-        assert prompt["messages"][-1]["content"] == "what is 2+2?"
-        completion = json.loads(attrs["gen_ai.completion"])
-        assert completion["messages"][0]["content"] == "4"
-        # _set_messages_json must NOT write the indexed form (it would win at
-        # ingest and drop structured tool calls).
-        assert "gen_ai.prompt.0.role" not in attrs
+        assert json.loads(attrs["gen_ai.prompt"])["messages"][-1]["content"] == (
+            "what is 2+2?"
+        )
+        assert json.loads(attrs["gen_ai.completion"])["messages"][0]["content"] == "4"
 
     def test_llm_input_messages_passed_through_verbatim(self):
         # The request history is forwarded in the LLM provider's own message
@@ -329,25 +331,27 @@ class TestBaseProcessorHelpers:
     def _base(self, **kwargs) -> BaseLangSmithSpanProcessor:
         return BaseLangSmithSpanProcessor(downstream_processor=MagicMock(), **kwargs)
 
-    def test_set_messages_writes_indexed_and_singular(self):
+    def test_set_messages_writes_json_messages_form(self):
+        # One form for everything: the singular {"messages": [...]} JSON, and NOT
+        # the indexed gen_ai.prompt.{n}.* attributes (which win at ingest and can
+        # only express plain role/string-content).
         ls = TranslatedSpan.of(_make_span("x"))
-        BaseLangSmithSpanProcessor._set_messages(
-            ls, prompt=[{"role": "user", "content": "hi"}]
-        )
-        assert ls.attributes["gen_ai.prompt.0.role"] == "user"
-        assert json.loads(ls.attributes["gen_ai.prompt"]) == [
-            {"role": "user", "content": "hi"}
-        ]
-
-    def test_set_messages_json_writes_singular_only(self):
-        ls = TranslatedSpan.of(_make_span("x"))
-        BaseLangSmithSpanProcessor._set_messages_json(
-            ls, prompt=[{"role": "user", "content": "hi"}]
-        )
+        ls.set_messages(prompt=[{"role": "user", "content": "hi"}])
         assert json.loads(ls.attributes["gen_ai.prompt"]) == {
             "messages": [{"role": "user", "content": "hi"}]
         }
         assert "gen_ai.prompt.0.role" not in ls.attributes
+
+    def test_set_messages_preserves_structured_fields(self):
+        # tool_calls survive verbatim in the {"messages": [...]} form.
+        ls = TranslatedSpan.of(_make_span("x"))
+        tool_call = {"id": "c1", "function": {"name": "f", "arguments": "{}"}}
+        ls.set_messages(
+            completion=[{"role": "assistant", "content": "", "tool_calls": [tool_call]}]
+        )
+        payload = json.loads(ls.attributes["gen_ai.completion"])
+        assert payload["messages"][0]["tool_calls"] == [tool_call]
+        assert "gen_ai.completion.0.role" not in ls.attributes
 
     def test_attach_audio_encodes_and_returns_true(self):
         base = self._base()


### PR DESCRIPTION
Move the shared span-mutation helpers off the base processor onto `TranslatedSpan`, and collapse `set_messages`/`set_messages_json` into a single `{"messages": [...]}` JSON form.

#### PR Dependency Tree


* **PR #3179** 👈
  * **PR #3180**

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)



#### PR Dependency Tree


* **PR #3179** 👈
  * **PR #3180**

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)