### PR TITLE
feat(livekit): capture realtime user transcript and tool-call output

### DIFF
--- a/python/langsmith/_internal/voice/base_span_processor.py
+++ b/python/langsmith/_internal/voice/base_span_processor.py
@@ -4,7 +4,7 @@ The framework integrations that emit their own OpenTelemetry spans (Pipecat,
 LiveKit) translate those spans into the ``gen_ai.*`` / ``langsmith.*`` attribute
 namespaces LangSmith's OTLP ingester understands, then forward them to an
 exporter. This base owns everything that translation shares — the downstream
-wrapping, the LangSmith OTLP exporter default, opt-in ``thread_id`` injection,
+wrapping, the LangSmith OTLP exporter default, opt-in ``thread_id`` stamping,
 the ``gen_ai.*`` message writers, and size-capped audio attachment — so each
 framework subclass implements only
 ``_dispatch`` (classify a span by name and rewrite it); the base exports it.
@@ -80,13 +80,56 @@ class TranslatedSpan:
             self.span, attributes=self.attributes, events=self.events
         )
 
+    def set_kind(self, kind: str) -> None:
+        """Set ``langsmith.span.kind`` (``llm`` / ``chain`` / ``tool`` / …)."""
+        self.attributes["langsmith.span.kind"] = kind
+
+    def set_thread_id(self, thread_id: str) -> None:
+        """Set ``langsmith.metadata.thread_id`` (the conversation/thread id)."""
+        self.attributes["langsmith.metadata.thread_id"] = thread_id
+
+    def exclude_from_message_view(self) -> None:
+        """Drop this span from the conversation Messages view (still in the tree).
+
+        That view reconstructs the chat from ``llm``/``tool`` runs. STT/TTS spans
+        are tagged ``llm``-kind for the tree but would otherwise add fake turns
+        (raw transcripts, "Generated audio for: …"), so they opt out here.
+        """
+        self.attributes["langsmith.metadata.ls_message_view_exclude"] = True
+
+    def set_root_span(self, is_root: bool) -> None:
+        """Mark the span as the trace root (``langsmith.root_span``)."""
+        self.attributes["langsmith.root_span"] = is_root
+
+    def set_metadata(self, key: str, value: Any) -> None:
+        """Set ``langsmith.metadata.<key>`` to the given value.
+
+        LangSmith surfaces everything under ``langsmith.metadata.*`` as run
+        metadata. Note ``langsmith.root_span`` and ``langsmith.span.kind`` are NOT
+        metadata — they live in the top-level ``langsmith.*`` namespace and have
+        their own setters / direct writes.
+        """
+        self.attributes[f"langsmith.metadata.{key}"] = value
+
+    def set_messages(
+        self,
+        *,
+        prompt: Optional[list[dict]] = None,
+        completion: Optional[list[dict]] = None,
+    ) -> None:
+        """Write ``gen_ai.prompt``/``gen_ai.completion`` as ``{"messages": [...]}``."""
+        if prompt is not None:
+            self.attributes["gen_ai.prompt"] = json.dumps({"messages": prompt})
+        if completion is not None:
+            self.attributes["gen_ai.completion"] = json.dumps({"messages": completion})
+
 
 class BaseLangSmithSpanProcessor(SpanProcessor):
     """Shared base for the OTel→LangSmith framework span processors.
 
     Subclasses implement :meth:`_dispatch` to classify each ended span and
     rewrite its attributes via the helpers here; the base exports it. The base
-    handles the downstream/exporter wiring, ``thread_id`` injection, and static
+    handles the downstream/exporter wiring, ``thread_id`` stamping, and static
     metadata stamping.
     """
 
@@ -143,7 +186,7 @@ class BaseLangSmithSpanProcessor(SpanProcessor):
         # runs synchronously in the task that starts the span; the conversation's
         # root span starts in the task where set_thread_id was called, so the
         # ContextVar is visible now even when later spans END in detached tasks
-        # where it is not. _inject_thread_id then recovers it per trace.
+        # where it is not. _stamp_thread_id then recovers it per trace.
         thread_id = thread_id_from_context()
         context = getattr(span, "context", None)
         if thread_id and context is not None:
@@ -163,7 +206,7 @@ class BaseLangSmithSpanProcessor(SpanProcessor):
         tspan = TranslatedSpan.of(span)
         export = True
         try:
-            self._inject_thread_id(tspan)
+            self._stamp_thread_id(tspan)
             export = self._dispatch(tspan) is not False
         except Exception:
             logger.warning(
@@ -215,7 +258,7 @@ class BaseLangSmithSpanProcessor(SpanProcessor):
 
     # -- shared helpers -------------------------------------------------------
 
-    def _inject_thread_id(self, tspan: TranslatedSpan) -> None:
+    def _stamp_thread_id(self, tspan: TranslatedSpan) -> None:
         """Stamp ``langsmith.metadata.thread_id`` from the per-context id (opt-in).
 
         LangSmith needs the thread id on every run for thread-level filtering and
@@ -229,7 +272,7 @@ class BaseLangSmithSpanProcessor(SpanProcessor):
         3. else the ``ContextVar`` directly (this span IS in context and is the
            first we've seen for the trace), backfilling the cache for its peers.
 
-        Injection is skipped (``None``) when no id was ever set for the trace.
+        Stamping is skipped (``None``) when no id was ever set for the trace.
         """
         if "langsmith.metadata.thread_id" in tspan.attributes:
             return
@@ -237,7 +280,7 @@ class BaseLangSmithSpanProcessor(SpanProcessor):
         thread_id = self._thread_id_by_trace.get(trace_id) or thread_id_from_context()
         if thread_id:
             thread_id = str(thread_id)
-            tspan.attributes["langsmith.metadata.thread_id"] = thread_id
+            tspan.set_thread_id(thread_id)
             self._remember_thread_id(trace_id, thread_id)
 
     def _remember_thread_id(self, trace_id: int, thread_id: str) -> None:
@@ -250,67 +293,6 @@ class BaseLangSmithSpanProcessor(SpanProcessor):
     def _forget_thread_id(self, trace_id: int) -> None:
         """Drop a trace's cached thread id (called from subclass cleanup)."""
         self._thread_id_by_trace.pop(trace_id, None)
-
-    @staticmethod
-    def _set_kind(tspan: TranslatedSpan, kind: str) -> None:
-        tspan.attributes["langsmith.span.kind"] = kind
-
-    @staticmethod
-    def _exclude_from_message_view(tspan: TranslatedSpan) -> None:
-        """Drop a span from the conversation Messages view (still in the tree).
-
-        That view reconstructs the chat from ``llm``/``tool`` runs. STT/TTS spans
-        are tagged ``llm``-kind for the tree but would inject fake turns (raw
-        transcripts, "Generated audio for: …"), so they opt out here.
-        """
-        tspan.attributes["langsmith.metadata.ls_message_view_exclude"] = True
-
-    @staticmethod
-    def _set_messages(
-        tspan: TranslatedSpan,
-        *,
-        prompt: Optional[list[dict]] = None,
-        completion: Optional[list[dict]] = None,
-    ) -> None:
-        """Write simple role/content turns in the indexed + singular forms.
-
-        For plain conversation turns (STT, TTS, an exchange) where messages have
-        only role + content. Writes the indexed ``gen_ai.prompt.{n}.role/content``
-        attributes and the singular ``gen_ai.prompt`` JSON list. For messages
-        that carry structured fields (tool calls), use :meth:`_set_messages_json`
-        instead — the indexed form can't represent them.
-        """
-        attrs = tspan.attributes
-        if prompt is not None:
-            for i, msg in enumerate(prompt):
-                attrs[f"gen_ai.prompt.{i}.role"] = msg.get("role", "user")
-                attrs[f"gen_ai.prompt.{i}.content"] = str(msg.get("content", ""))
-            attrs["gen_ai.prompt"] = json.dumps(prompt)
-        if completion is not None:
-            for i, msg in enumerate(completion):
-                attrs[f"gen_ai.completion.{i}.role"] = msg.get("role", "assistant")
-                attrs[f"gen_ai.completion.{i}.content"] = str(msg.get("content", ""))
-            attrs["gen_ai.completion"] = json.dumps(completion)
-
-    @staticmethod
-    def _set_messages_json(
-        tspan: TranslatedSpan,
-        *,
-        prompt: Optional[list[dict]] = None,
-        completion: Optional[list[dict]] = None,
-    ) -> None:
-        """Write messages in the singular ``{"messages": [...]}`` JSON form only.
-
-        This is the form for LLM calls and the conversation root: it can carry
-        structured ``tool_calls`` / ``tool_call_id`` that the indexed
-        ``gen_ai.prompt.{n}.*`` attributes can't, and it takes precedence at
-        ingest — so the indexed form is deliberately *not* written here (it would
-        win and drop the tool calls).
-        """
-        if prompt is not None:
-            tspan.attributes["gen_ai.prompt"] = json.dumps({"messages": prompt})
-        if completion is not None:
-            tspan.attributes["gen_ai.completion"] = json.dumps({"messages": completion})
 
     def _attach_audio(
         self, tspan: TranslatedSpan, *, name: str, data: bytes, mime_type: str

--- a/python/langsmith/integrations/livekit/__init__.py
+++ b/python/langsmith/integrations/livekit/__init__.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Any, Callable, Optional
 
 from langsmith._internal._beta_decorator import warn_beta
-from langsmith._internal.voice import set_thread_id, thread_id_from_context
+from langsmith._internal.voice import set_thread_id
 
 from .processor import LiveKitLangSmithSpanProcessor
 
@@ -17,7 +17,6 @@ __all__ = [
     "LiveKitLangSmithSpanProcessor",
     "configure_livekit",
     "set_thread_id",
-    "thread_id_from_context",
 ]
 
 

--- a/python/langsmith/integrations/livekit/processor.py
+++ b/python/langsmith/integrations/livekit/processor.py
@@ -6,7 +6,7 @@ recognize — so without translation, transcripts, TTS metrics, EOU
 probabilities, latency numbers, etc. all evaporate at ingest. This
 :class:`LiveKitLangSmithSpanProcessor` rewrites ``lk.*`` into the keys LangSmith
 understands before each span is exported. It inherits the downstream wrapping,
-exporter, ``thread_id`` injection, and message helpers from
+exporter, ``thread_id`` stamping, and message helpers from
 :class:`BaseLangSmithSpanProcessor`.
 
 Generic to any LiveKit agent
@@ -230,7 +230,7 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         elif name == _LLM_INFERENCE_SPAN:
             self._handle_llm_request(tspan)
         elif name in _LLM_WRAPPER_SPANS:
-            self._set_kind(tspan, "chain")  # wrappers: no fabricated I/O
+            tspan.set_kind("chain")  # wrappers: no fabricated I/O
         elif name == _TTS_INFERENCE_SPAN or name in _TTS_WRAPPER_SPANS:
             self._handle_tts(tspan)
         elif name == _TURN_SPAN:
@@ -238,11 +238,11 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         elif name == _SESSION_SPAN:
             # Session end: the conversation is complete — release the deferred
             # root (if any), then export the session span itself.
-            self._set_kind(tspan, "chain")
+            tspan.set_kind("chain")
             self._ended_sessions[trace_id] = True
             self._release_root_span(trace_id)
         elif name == "eou_detection":
-            self._set_kind(tspan, "chain")  # framework step
+            tspan.set_kind("chain")  # framework step
         elif name == _TOOL_SPAN:
             self._handle_tool(tspan)
         elif name == _REALTIME_METRICS_SPAN:
@@ -311,21 +311,21 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
 
     def _handle_stt(self, tspan: TranslatedSpan) -> None:
         """STT (``user_turn``): audio input → transcribed text."""
-        self._set_kind(tspan, "llm")
+        tspan.set_kind("llm")
         model = tspan.attributes.get("gen_ai.request.model")
         if model:
             tspan.attributes["langsmith.metadata.model_name"] = str(model)
         self._stamp_provider(tspan, "lk.stt_metrics")
 
         transcript = tspan.attributes.get("lk.user_transcript")
-        self._set_messages(
-            tspan, prompt=[{"role": "user", "content": f'Audio for: "{transcript}"'}]
+        tspan.set_messages(
+            prompt=[{"role": "user", "content": f'Audio for: "{transcript}"'}]
         )
         if transcript:
-            self._set_messages(
-                tspan, completion=[{"role": "assistant", "content": str(transcript)}]
+            tspan.set_messages(
+                completion=[{"role": "assistant", "content": str(transcript)}]
             )
-        self._exclude_from_message_view(tspan)
+        tspan.exclude_from_message_view()
 
     def _handle_llm_request(self, tspan: TranslatedSpan) -> None:
         """``llm_request``: the chat-completion call.
@@ -337,7 +337,7 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         survive) and strip the translated events so the ingester doesn't render
         them twice.
         """
-        self._set_kind(tspan, "llm")
+        tspan.set_kind("llm")
 
         prompt: list[dict] = []
         completion: list[dict] = []
@@ -346,9 +346,7 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
                 completion.append(self._message_from_event("assistant", event))
             elif (role := _LLM_EVENT_ROLES.get(event.name)) is not None:
                 prompt.append(self._message_from_event(role, event))
-        self._set_messages_json(
-            tspan, prompt=prompt or None, completion=completion or None
-        )
+        tspan.set_messages(prompt=prompt or None, completion=completion or None)
         # Normalize the provider (LiveKit's OpenAI plugin reports the
         # ``api.openai.com`` host, which won't match a LangSmith price).
         self._stamp_provider(tspan, "lk.llm_metrics")
@@ -398,11 +396,11 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         ``tts_request_run`` wrappers are ``chain``s.
         """
         if tspan.span.name != _TTS_INFERENCE_SPAN:
-            self._set_kind(tspan, "chain")
+            tspan.set_kind("chain")
             return
 
-        self._set_kind(tspan, "llm")
-        self._exclude_from_message_view(tspan)
+        tspan.set_kind("llm")
+        tspan.exclude_from_message_view()
 
         text = (
             tspan.attributes.get("lk.input_text")
@@ -410,8 +408,7 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
             or tspan.attributes.get("lk.text")
             or ""
         )
-        self._set_messages(
-            tspan,
+        tspan.set_messages(
             prompt=[{"role": "user", "content": str(text)}],
             completion=[
                 {"role": "assistant", "content": f'Generated audio for: "{text}"'}
@@ -439,7 +436,7 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         is the LiveKit-native turn boundary, so it works for both the cascade and
         the speech-to-speech backends.
         """
-        self._set_kind(tspan, "chain")
+        tspan.set_kind("chain")
         self._drain_realtime_metrics(tspan)
 
         user_input = tspan.attributes.get("lk.user_input")
@@ -448,11 +445,11 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         conversation = self._conversation_by_trace.get(trace_id) or []
         if user_input:
             msg = {"role": "user", "content": str(user_input)}
-            self._set_messages(tspan, prompt=[msg])
+            tspan.set_messages(prompt=[msg])
             conversation.append(msg)
         if response:
             msg = {"role": "assistant", "content": str(response)}
-            self._set_messages(tspan, completion=[msg])
+            tspan.set_messages(completion=[msg])
             conversation.append(msg)
         # Re-assign (not just mutate) so each turn refreshes the TTL — an active
         # call longer than the TTL is never evicted mid-conversation.
@@ -461,7 +458,7 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
 
     def _handle_tool(self, tspan: TranslatedSpan) -> None:
         """``function_tool``: render as a proper ``tool`` run with its I/O."""
-        self._set_kind(tspan, "tool")
+        tspan.set_kind("tool")
         tool_name = tspan.attributes.get("lk.function_tool.name")
         if tool_name:
             tspan.attributes["langsmith.metadata.tool_name"] = str(tool_name)
@@ -537,14 +534,12 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         so we always defer it and release it — complete, with audio — once the
         session has ended and any awaited recording has arrived.
         """
-        self._set_kind(tspan, "chain")
-        tspan.attributes["langsmith.root_span"] = True
-        tspan.attributes["langsmith.metadata.ls_modality"] = "audio"
-        tspan.attributes["langsmith.metadata.ls_integration"] = "livekit"
-        # "" not None: OTel span attributes reject a null value (unlike the
-        # RunTree metadata path); livekit-agents is a hard dep, so ~always set.
-        tspan.attributes["langsmith.metadata.ls_integration_version"] = (
-            get_package_version("livekit-agents") or ""
+        tspan.set_kind("chain")
+        tspan.set_root_span(True)
+        tspan.set_metadata("ls_modality", "audio")
+        tspan.set_metadata("ls_integration", "livekit")
+        tspan.set_metadata(
+            "ls_integration_version", (get_package_version("livekit-agents") or "")
         )
 
         thread = tspan.attributes.get("langsmith.metadata.thread_id")
@@ -591,9 +586,9 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         messages = self._conversation_by_trace.get(tspan.span.context.trace_id, [])
         if not messages:
             return False
-        self._set_messages(tspan, prompt=messages[:1])
+        tspan.set_messages(prompt=messages[:1])
         if len(messages) > 1:
-            self._set_messages(tspan, completion=messages[1:])
+            tspan.set_messages(completion=messages[1:])
         return True
 
     def _cleanup_trace(self, trace_id: str) -> None:
@@ -632,8 +627,7 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         """
         for trace_id, tspan in list(self._deferred_root_spans.items()):
             if not self._render_conversation(tspan):
-                self._set_messages(
-                    tspan,
+                tspan.set_messages(
                     prompt=[{"role": "system", "content": "Conversation not captured"}],
                     completion=[
                         {

--- a/python/langsmith/integrations/livekit/processor.py
+++ b/python/langsmith/integrations/livekit/processor.py
@@ -100,6 +100,7 @@ _TURN_SPAN = "agent_turn"
 _SESSION_SPAN = "agent_session"
 _TOOL_SPAN = "function_tool"
 _REALTIME_METRICS_SPAN = "realtime_metrics"
+_USER_SPEAKING_SPAN = "user_speaking"  # realtime user turn (no STT span)
 
 # LiveKit records each chat-context item sent to the model as a span event on
 # ``llm_request`` (the event name implies the message role), followed by a
@@ -151,6 +152,41 @@ def _normalize_provider(raw: Any) -> Optional[str]:
     return value.split("://", 1)[-1].split("/", 1)[0] or None
 
 
+def _parse_lk_response_function_calls(raw: Any) -> list[dict]:
+    """Convert ``lk.response.function_calls`` JSON to OpenAI tool calls."""
+    if not isinstance(raw, str):
+        return []
+    try:
+        calls = json.loads(raw)
+    except (json.JSONDecodeError, ValueError):
+        return []
+    if not isinstance(calls, list):
+        return []
+    tool_calls = []
+    for fc in calls:
+        if not isinstance(fc, dict):
+            continue
+        tool_calls.append(
+            {
+                "id": fc.get("call_id") or fc.get("id"),
+                "type": "function",
+                "function": {"name": fc.get("name"), "arguments": fc.get("arguments")},
+            }
+        )
+    return tool_calls
+
+
+def _is_livekit_span(span: Any) -> bool:
+    """Whether a span came from LiveKit's tracer (its instrumentation scope).
+
+    Used to gate root detection: only a parentless span emitted by LiveKit is
+    the conversation root. Named LiveKit spans are matched by name above and
+    don't need this; it guards the broad ``parent is None`` case alone.
+    """
+    scope = getattr(span, "instrumentation_scope", None)
+    return getattr(scope, "name", None) == _LIVEKIT_INSTRUMENTATION_SCOPE
+
+
 class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
     """Enriches LiveKit Agents' OTel spans with LangSmith-compatible attributes."""
 
@@ -198,9 +234,11 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         def _cache() -> Any:
             return TTLCache(maxsize=DEFAULT_STATE_MAXSIZE, ttl=state_ttl_seconds)
 
-        # Whole-conversation transcript, accumulated turn-by-turn from the
-        # ``agent_turn`` spans. trace_id (int) -> flat [{role, content}, ...].
-        self._conversation_by_trace: MutableMapping[int, list[dict]] = _cache()
+        # Whole-conversation transcript the root rolls up. trace_id ->
+        # [(sort_key, message)]
+        self._conversation_by_trace: MutableMapping[int, list[tuple[int, dict]]] = (
+            _cache()
+        )
         # The trace root (job entrypoint) ends before the conversation completes
         # when the agent greets first, so we hold its draft until ``agent_session``
         # ends with the full conversation. trace_id (hex str) -> TranslatedSpan.
@@ -218,6 +256,94 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         # Realtime-model metrics cached from a ``realtime_metrics`` child span and
         # drained onto its parent ``agent_turn``. Keyed by the parent span_id.
         self._realtime_metrics_by_parent: MutableMapping[int, dict] = _cache()
+        # Realtime user transcripts, paired FIFO with their held ``user_speaking``
+        # spans, keyed by thread id. ``_deferred_user_speaking`` holds spans
+        # awaiting a transcript; ``_pending_user_transcripts`` buffers transcripts
+        # that arrived before their span ended.
+        self._deferred_user_speaking: MutableMapping[str, list[TranslatedSpan]] = (
+            _cache()
+        )
+        self._pending_user_transcripts: MutableMapping[str, list[str]] = _cache()
+
+    # -- public host API ------------------------------------------------------
+
+    def instrument_session(self, session: Any, thread_id: str) -> None:
+        """Subscribe this processor to a LiveKit ``AgentSession``'s events.
+
+        The realtime user transcript arrives via ``user_input_transcribed`` — a
+        session event, never on a span — so the processor can't see it alone. Call
+        this once after creating the session to wire it in::
+
+            processor = configure_livekit(...)
+            session = AgentSession(llm=...)
+            set_thread_id(conversation_id)
+            processor.instrument_session(session, conversation_id)
+
+        No-op in the cascade pipeline (the transcript rides the STT ``user_turn``).
+
+        Args:
+            session: the LiveKit ``AgentSession`` to subscribe to.
+            thread_id: the conversation id, matching :func:`set_thread_id`.
+        """
+
+        @session.on("user_input_transcribed")
+        def _on_user_input_transcribed(ev: Any) -> None:
+            # Feed every *final* transcript (including empty ones) so the FIFO
+            # pairing with user_speaking spans stays aligned; skip interim results.
+            if getattr(ev, "is_final", False):
+                self._record_user_transcript(
+                    str(thread_id), getattr(ev, "transcript", "") or ""
+                )
+
+    def expect_recording(self, thread_id: str) -> None:
+        """Hold this conversation's root span until its recording is supplied.
+
+        LiveKit Egress finishes uploading *after* the call ends, so the bytes
+        don't exist when the root span would normally be exported. Call this at
+        the start of a conversation (when you start egress) to defer that export;
+        then call :meth:`complete_recording` once you have the file. Until then
+        the root is held (a worker shutdown flushes it without audio as a
+        fallback), so always pair this with a ``complete_recording`` call —
+        passing ``None`` to release without audio if the recording fails.
+
+        Args:
+            thread_id: the conversation id, matching the one passed to
+                ``set_thread_id``.
+        """
+        self._awaiting_recording[str(thread_id)] = True
+
+    def complete_recording(
+        self,
+        thread_id: str,
+        data: Optional[bytes],
+        *,
+        name: str = "recording.ogg",
+        mime_type: Optional[str] = None,
+    ) -> None:
+        """Attach an egress recording to a conversation and release its root.
+
+        Download the completed egress file from your storage and pass its bytes
+        here; they're embedded as a real LangSmith attachment on the root span.
+        Pass ``data=None`` to release the held root without audio (e.g. egress
+        failed). Safe to call before or after the session ends.
+
+        Args:
+            thread_id: the conversation id, matching :meth:`expect_recording`.
+            data: the recording bytes, or ``None`` to release without audio.
+            name: attachment filename.
+            mime_type: attachment MIME type; defaults to the processor's.
+        """
+        tid = str(thread_id)
+        if data:
+            self._pending_audio[tid] = {
+                "name": name,
+                "data": bytes(data),
+                "mime_type": mime_type or self._audio_mime_type,
+            }
+        self._awaiting_recording.pop(tid, None)
+        trace_id = self._thread_to_trace.get(tid)
+        if trace_id is not None:
+            self._maybe_release(trace_id)
 
     # -- dispatch -------------------------------------------------------------
 
@@ -230,16 +356,18 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         elif name == _LLM_INFERENCE_SPAN:
             self._handle_llm_request(tspan)
         elif name in _LLM_WRAPPER_SPANS:
-            tspan.set_kind("chain")  # wrappers: no fabricated I/O
+            tspan.set_kind("chain")
         elif name == _TTS_INFERENCE_SPAN or name in _TTS_WRAPPER_SPANS:
             self._handle_tts(tspan)
         elif name == _TURN_SPAN:
             self._handle_turn(tspan)
+        elif name == _USER_SPEAKING_SPAN:
+            return self._handle_user_speaking(tspan)
         elif name == _SESSION_SPAN:
-            # Session end: the conversation is complete — release the deferred
-            # root (if any), then export the session span itself.
+            # Session end: release the deferred root and export the session span.
             tspan.set_kind("chain")
             self._ended_sessions[trace_id] = True
+            self._flush_user_speaking(self._trace_to_thread.get(trace_id))
             self._release_root_span(trace_id)
         elif name == "eou_detection":
             tspan.set_kind("chain")  # framework step
@@ -251,7 +379,7 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
             # must not export it; nothing else does either).
             self._cache_realtime_metrics(tspan)
             return False
-        elif tspan.span.parent is None and self._is_livekit_span(tspan.span):
+        elif tspan.span.parent is None and _is_livekit_span(tspan.span):
             # The trace root (LiveKit's job entrypoint). _handle_root owns its
             # export: it renders/attaches and exports immediately, or defers
             # until the session ends and egress audio is ready (via
@@ -271,17 +399,6 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         # included; _release_root_span above exports only the separate deferred
         # root, never this one).
         return True
-
-    @staticmethod
-    def _is_livekit_span(span: Any) -> bool:
-        """Whether a span came from LiveKit's tracer (its instrumentation scope).
-
-        Used to gate root detection: only a parentless span emitted by LiveKit is
-        the conversation root. Named LiveKit spans are matched by name above and
-        don't need this; it guards the broad ``parent is None`` case alone.
-        """
-        scope = getattr(span, "instrumentation_scope", None)
-        return getattr(scope, "name", None) == _LIVEKIT_INSTRUMENTATION_SCOPE
 
     # -- per-span-type handlers ----------------------------------------------
 
@@ -432,29 +549,128 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
     def _handle_turn(self, tspan: TranslatedSpan) -> None:
         """Render an ``agent_turn``: one user/assistant exchange.
 
-        Appends the exchange to the running conversation the root rolls up. This
-        is the LiveKit-native turn boundary, so it works for both the cascade and
-        the speech-to-speech backends.
+        Appends the exchange to the conversation the root rolls up (both backends).
+        Kind differs: cascade turns are ``chain`` containers around a child
+        ``llm_request``; realtime turns have no such child — the turn itself carries
+        the model, usage, and response, so they're ``llm`` (detected by the
+        ``lk.realtime_model_metrics`` drained on just above).
         """
-        tspan.set_kind("chain")
         self._drain_realtime_metrics(tspan)
+        is_realtime = "lk.realtime_model_metrics" in tspan.attributes
+        tspan.set_kind("llm" if is_realtime else "chain")
 
         user_input = tspan.attributes.get("lk.user_input")
         response = tspan.attributes.get("lk.response.text")
+        tool_calls = _parse_lk_response_function_calls(
+            tspan.attributes.get("lk.response.function_calls")
+        )
         trace_id = tspan.span.context.trace_id
-        conversation = self._conversation_by_trace.get(trace_id) or []
+        start = tspan.span.start_time
+        # Cascade turns carry the user input; realtime turns don't (it rides the
+        # user_speaking span, appended by _apply_user_transcript).
         if user_input:
-            msg = {"role": "user", "content": str(user_input)}
-            tspan.set_messages(prompt=[msg])
-            conversation.append(msg)
-        if response:
-            msg = {"role": "assistant", "content": str(response)}
-            tspan.set_messages(completion=[msg])
-            conversation.append(msg)
-        # Re-assign (not just mutate) so each turn refreshes the TTL — an active
-        # call longer than the TTL is never evicted mid-conversation.
-        if conversation:
-            self._conversation_by_trace[trace_id] = conversation
+            user_msg = {"role": "user", "content": str(user_input)}
+            tspan.set_messages(prompt=[user_msg])
+            self._append_conversation(trace_id, user_msg, start)
+        # Emit the reply for text and/or tool calls (a tool-only turn has no text).
+        if response or tool_calls:
+            reply: dict[str, Any] = {
+                "role": "assistant",
+                "content": str(response or ""),
+            }
+            if tool_calls:
+                reply["tool_calls"] = tool_calls
+            tspan.set_messages(completion=[reply])
+            self._append_conversation(trace_id, reply, start)
+
+    def _append_conversation(self, trace_id: int, message: dict, sort_key: Any) -> None:
+        """Append a message to the conversation the root rolls up."""
+        conversation = self._conversation_by_trace.get(trace_id) or []
+        conversation.append((sort_key, message))
+        # Re-assign (not just mutate) so each turn refreshes the TTL.
+        self._conversation_by_trace[trace_id] = conversation
+
+    # -- realtime user transcript (speech-to-speech) --------------------------
+
+    def _handle_user_speaking(self, tspan: TranslatedSpan) -> bool:
+        """Handle a ``user_speaking`` span — the realtime user turn.
+
+        Deferred (``False``): stamp+export now if the transcript was already
+        buffered, else hold until it's fed (or flushed untouched at session end).
+        Exported as-is (``True``) when there's no thread id to pair against.
+        """
+        tspan.set_kind("chain")
+        thread = tspan.attributes.get("langsmith.metadata.thread_id")
+        if thread is None:
+            return True  # no conversation id to pair a transcript against
+        thread = str(thread)
+
+        pending = self._pending_user_transcripts.get(thread)
+        if pending:
+            transcript = pending.pop(0)
+            # pop(0) mutates in place: refresh the TTL if any remain, else drop it.
+            if pending:
+                self._pending_user_transcripts[thread] = pending
+            else:
+                self._pending_user_transcripts.pop(thread, None)
+            self._apply_user_transcript(tspan, transcript)
+            self._export(tspan)
+            return False
+
+        held = self._deferred_user_speaking.get(thread) or []
+        held.append(tspan)
+        self._deferred_user_speaking[thread] = held  # re-assign to refresh TTL
+        return False
+
+    def _record_user_transcript(self, thread_id: str, transcript: str) -> None:
+        """Pair a realtime transcript (from ``instrument_session``) with its span.
+
+        Applies it to the held ``user_speaking`` span, or buffers it if the span
+        hasn't ended yet. Keyed by thread id.
+        """
+        tid = str(thread_id)
+        held = self._deferred_user_speaking.get(tid)
+        if held:
+            tspan = held.pop(0)
+            # pop(0) mutates in place: refresh the TTL if any remain, else drop it.
+            if held:
+                self._deferred_user_speaking[tid] = held
+            else:
+                self._deferred_user_speaking.pop(tid, None)
+            self._apply_user_transcript(tspan, transcript)
+            self._export(tspan)
+            return
+        # The span hasn't ended yet — buffer until _handle_user_speaking sees it.
+        pending = self._pending_user_transcripts.get(tid) or []
+        pending.append(transcript)
+        self._pending_user_transcripts[tid] = pending  # re-assign to refresh TTL
+
+    def _apply_user_transcript(self, tspan: TranslatedSpan, transcript: str) -> None:
+        """Render a fed transcript onto a ``user_speaking`` span as the user's turn.
+
+        Unlike the cascade STT ``user_turn`` (which is excluded), this is the only
+        record of the realtime user's words, so it's shown — as a plain ``user``
+        message, attributed to the user, not the assistant. Empty renders no I/O.
+        """
+        tspan.set_kind("llm")
+        if transcript:
+            tspan.attributes["lk.user_transcript"] = transcript
+            tspan.set_messages(prompt=[{"role": "user", "content": transcript}])
+            # Root rollup, keyed by start_time so it sorts before the reply.
+            self._append_conversation(
+                tspan.span.context.trace_id,
+                {"role": "user", "content": transcript},
+                tspan.span.start_time,
+            )
+
+    def _flush_user_speaking(self, thread_id: Optional[str]) -> None:
+        """Export held ``user_speaking`` spans untranscribed (no transcript arrived)."""
+        if thread_id is None:
+            return
+        tid = str(thread_id)
+        for tspan in self._deferred_user_speaking.pop(tid, None) or []:
+            self._export(tspan)
+        self._pending_user_transcripts.pop(tid, None)
 
     def _handle_tool(self, tspan: TranslatedSpan) -> None:
         """``function_tool``: render as a proper ``tool`` run with its I/O."""
@@ -472,58 +688,6 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
             tspan.attributes["gen_ai.completion"] = (
                 output if isinstance(output, str) else json.dumps(output)
             )
-
-    # -- production recording (egress) ---------------------------------------
-
-    def expect_recording(self, thread_id: str) -> None:
-        """Hold this conversation's root span until its recording is supplied.
-
-        LiveKit Egress finishes uploading *after* the call ends, so the bytes
-        don't exist when the root span would normally be exported. Call this at
-        the start of a conversation (when you start egress) to defer that export;
-        then call :meth:`complete_recording` once you have the file. Until then
-        the root is held (a worker shutdown flushes it without audio as a
-        fallback), so always pair this with a ``complete_recording`` call —
-        passing ``None`` to release without audio if the recording fails.
-
-        Args:
-            thread_id: the conversation id, matching the one passed to
-                ``set_thread_id``.
-        """
-        self._awaiting_recording[str(thread_id)] = True
-
-    def complete_recording(
-        self,
-        thread_id: str,
-        data: Optional[bytes],
-        *,
-        name: str = "recording.ogg",
-        mime_type: Optional[str] = None,
-    ) -> None:
-        """Attach an egress recording to a conversation and release its root.
-
-        Download the completed egress file from your storage and pass its bytes
-        here; they're embedded as a real LangSmith attachment on the root span.
-        Pass ``data=None`` to release the held root without audio (e.g. egress
-        failed). Safe to call before or after the session ends.
-
-        Args:
-            thread_id: the conversation id, matching :meth:`expect_recording`.
-            data: the recording bytes, or ``None`` to release without audio.
-            name: attachment filename.
-            mime_type: attachment MIME type; defaults to the processor's.
-        """
-        tid = str(thread_id)
-        if data:
-            self._pending_audio[tid] = {
-                "name": name,
-                "data": bytes(data),
-                "mime_type": mime_type or self._audio_mime_type,
-            }
-        self._awaiting_recording.pop(tid, None)
-        trace_id = self._thread_to_trace.get(tid)
-        if trace_id is not None:
-            self._maybe_release(trace_id)
 
     # -- deferred root release ------------------------------------------------
 
@@ -580,12 +744,15 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
     def _render_conversation(self, tspan: TranslatedSpan) -> bool:
         """Render the accumulated conversation onto a root span.
 
-        Input = the opening message; output = everything after it. Returns
-        whether anything was rendered.
+        Messages are ordered by their source span's start_time (with a monotonic
+        seq tie-break) so a realtime user turn — fed late, out of order — lands in
+        its correct position. Input = the opening message; output = everything
+        after it. Returns whether anything was rendered.
         """
-        messages = self._conversation_by_trace.get(tspan.span.context.trace_id, [])
-        if not messages:
+        entries = self._conversation_by_trace.get(tspan.span.context.trace_id, [])
+        if not entries:
             return False
+        messages = [msg for _, msg in sorted(entries, key=lambda e: e[0])]
         tspan.set_messages(prompt=messages[:1])
         if len(messages) > 1:
             tspan.set_messages(completion=messages[1:])
@@ -600,10 +767,15 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
             self._thread_to_trace.pop(thread, None)
             self._awaiting_recording.pop(thread, None)
             self._pending_audio.pop(thread, None)
+            # Backstop: normally flushed at session end, but cover a root released
+            # without an agent_session span having flushed first.
+            self._flush_user_speaking(thread)
 
     def shutdown(self) -> None:
-        """Flush any deferred root spans, then shut down the downstream."""
+        """Flush any deferred root and user_speaking spans, then shut down."""
         self._flush_deferred_root_spans()
+        for thread in list(self._deferred_user_speaking.keys()):
+            self._flush_user_speaking(thread)
         super().shutdown()
 
     def force_flush(self, timeout_millis: int = 30000) -> bool:

--- a/python/langsmith/integrations/pipecat/processor.py
+++ b/python/langsmith/integrations/pipecat/processor.py
@@ -6,7 +6,7 @@ Pipecat emits OTel spans named ``conversation``, ``turn``, ``stt``, ``llm``, and
 :class:`PipecatLangSmithSpanProcessor` rewrites each span type into the
 ``gen_ai.*`` / ``langsmith.*`` namespaces LangSmith keys off, renders the whole
 conversation onto the root span, and (optionally) attaches the recorded audio
-there. It inherits the downstream wrapping, exporter, ``thread_id`` injection,
+there. It inherits the downstream wrapping, exporter, ``thread_id`` stamping,
 and message helpers from :class:`BaseLangSmithSpanProcessor`.
 
 Trace shape in LangSmith::
@@ -192,12 +192,12 @@ class PipecatLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
 
         if name == "stt":
             self._handle_stt(tspan)
-            self._exclude_from_message_view(tspan)
+            tspan.exclude_from_message_view()
         elif name == "llm":
             self._handle_llm(tspan, trace_id)
         elif name == "tts":
             self._handle_tts(tspan)
-            self._exclude_from_message_view(tspan)
+            tspan.exclude_from_message_view()
         elif name == "turn":
             self._handle_turn(tspan)
         elif name == "conversation":
@@ -215,13 +215,13 @@ class PipecatLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
     def _handle_stt(self, tspan: TranslatedSpan) -> None:
         """STT span: audio input → transcribed text."""
         transcript = tspan.attributes.get("transcript", "")
-        self._set_kind(tspan, "llm")
-        self._set_messages(
-            tspan, prompt=[{"role": "user", "content": f'Audio for: "{transcript}"'}]
+        tspan.set_kind("llm")
+        tspan.set_messages(
+            prompt=[{"role": "user", "content": f'Audio for: "{transcript}"'}]
         )
         if transcript:
-            self._set_messages(
-                tspan, completion=[{"role": "assistant", "content": str(transcript)}]
+            tspan.set_messages(
+                completion=[{"role": "assistant", "content": str(transcript)}]
             )
 
     @classmethod
@@ -256,7 +256,7 @@ class PipecatLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         """
         input_data = tspan.attributes.get("input", "")
         output_data = tspan.attributes.get("output", "")
-        self._set_kind(tspan, self._llm_span_kind)
+        tspan.set_kind(self._llm_span_kind)
 
         try:
             raw_messages = json.loads(input_data)
@@ -269,11 +269,9 @@ class PipecatLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         ]
 
         if messages:
-            self._set_messages_json(tspan, prompt=messages)
+            tspan.set_messages(prompt=messages)
         if output_data:
-            self._set_messages_json(
-                tspan, completion=[self._completion_message(output_data)]
-            )
+            tspan.set_messages(completion=[self._completion_message(output_data)])
 
         # Each request's input carries the full history, so the latest snapshot
         # IS the conversation — kept per trace for the root span to render. Reuse
@@ -288,12 +286,11 @@ class PipecatLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
     def _handle_tts(self, tspan: TranslatedSpan) -> None:
         """TTS span: text → audio. The voice is metadata, not content."""
         text = tspan.attributes.get("text", "")
-        self._set_kind(tspan, "llm")
+        tspan.set_kind("llm")
         voice_id = tspan.attributes.get("voice_id")
         if voice_id:
             tspan.attributes["langsmith.metadata.voice_id"] = str(voice_id)
-        self._set_messages(
-            tspan,
+        tspan.set_messages(
             prompt=[{"role": "user", "content": str(text)}],
             completion=[
                 {"role": "assistant", "content": f'Generated audio for: "{text}"'}
@@ -302,7 +299,7 @@ class PipecatLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
 
     def _handle_turn(self, tspan: TranslatedSpan) -> None:
         """Turn span: a framework wrapper around one exchange (a ``chain``)."""
-        self._set_kind(tspan, "chain")
+        tspan.set_kind("chain")
         turn_number = tspan.attributes.get("turn.number")
         if turn_number is not None:
             tspan.attributes["langsmith.metadata.turn_number"] = turn_number
@@ -321,7 +318,7 @@ class PipecatLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         conversation_id = tspan.attributes.get(
             "conversation.id", ""
         ) or tspan.attributes.get("conversation_id", "")
-        self._set_kind(tspan, "chain")
+        tspan.set_kind("chain")
         tspan.attributes["langsmith.root_span"] = True
         tspan.attributes["langsmith.metadata.ls_modality"] = "audio"
         tspan.attributes["langsmith.metadata.ls_integration"] = "pipecat"
@@ -333,9 +330,9 @@ class PipecatLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
 
         messages = self._conversation_by_trace.get(trace_id, [])
         if messages:
-            self._set_messages_json(tspan, prompt=messages[:1])
+            tspan.set_messages(prompt=messages[:1])
             if len(messages) > 1:
-                self._set_messages_json(tspan, completion=messages[1:])
+                tspan.set_messages(completion=messages[1:])
 
         self._attach_conversation_audio(tspan, conversation_id)
         self._cleanup_conversation(trace_id, conversation_id)

--- a/python/tests/unit_tests/wrappers/test_livekit.py
+++ b/python/tests/unit_tests/wrappers/test_livekit.py
@@ -24,6 +24,7 @@ def _make_span(
     span_id=0x1,
     parent=True,
     scope="livekit-agents",
+    start_time=None,
 ):
     """Build a mock LiveKit span.
 
@@ -43,6 +44,9 @@ def _make_span(
     span.context = MagicMock()
     span.context.trace_id = trace_id
     span.context.span_id = span_id
+    # start_time (ns) is the root's conversation-ordering key; default to span_id
+    # so spans sort in a stable, explicit order without every test setting it.
+    span.start_time = span_id if start_time is None else start_time
     span.parent = MagicMock() if parent else None
     span.instrumentation_scope = MagicMock()
     span.instrumentation_scope.name = scope
@@ -123,6 +127,374 @@ class TestDeferredRootRelease:
         # Per-conversation state freed after release.
         assert len(proc._deferred_root_spans) == 0
         assert len(proc._conversation_by_trace) == 0
+
+
+class TestRealtimeUserTranscript:
+    """Realtime (speech-to-speech) user transcripts fed via instrument_session.
+
+    In the realtime pipeline there is no STT ``user_turn`` span; LiveKit emits a
+    bare ``user_speaking`` span and delivers the transcript out of band via the
+    ``user_input_transcribed`` event. The host forwards it to the processor, which
+    holds the span open until the transcript arrives, then stamps it on.
+    """
+
+    def _speaking(self, *, thread="call-1", trace_id=0xABC, span_id=0x2):
+        return _make_span(
+            "user_speaking",
+            {"langsmith.metadata.thread_id": thread},
+            trace_id=trace_id,
+            span_id=span_id,
+        )
+
+    def _exported(self, proc, name):
+        return [
+            c.args[0]
+            for c in proc.downstream.on_end.call_args_list
+            if c.args[0].name == name
+        ]
+
+    def test_transcript_after_span_stamps_and_exports(self):
+        # Span ends empty first (held), then the transcript arrives.
+        proc = _processor()
+        proc.on_end(self._speaking())
+        # Held open — nothing exported yet.
+        assert self._exported(proc, "user_speaking") == []
+
+        proc._record_user_transcript("call-1", "what's the weather?")
+
+        exported = self._exported(proc, "user_speaking")
+        assert len(exported) == 1
+        span = exported[0]
+        assert span._attributes["lk.user_transcript"] == "what's the weather?"
+        assert span._attributes["langsmith.span.kind"] == "llm"
+        # Rendered as the user's turn (not excluded, not attributed to assistant).
+        assert "langsmith.metadata.ls_message_view_exclude" not in span._attributes
+        assert json.loads(span._attributes["gen_ai.prompt"])["messages"][0] == {
+            "role": "user",
+            "content": "what's the weather?",
+        }
+        assert "gen_ai.completion" not in span._attributes
+        # No state left behind.
+        assert len(proc._deferred_user_speaking) == 0
+        assert len(proc._pending_user_transcripts) == 0
+
+    def test_transcript_before_span_is_buffered(self):
+        # Transcript can race ahead of the span's on_end — buffer, then apply.
+        proc = _processor()
+        proc._record_user_transcript("call-1", "hello there")
+        assert self._exported(proc, "user_speaking") == []
+
+        proc.on_end(self._speaking())
+
+        exported = self._exported(proc, "user_speaking")
+        assert len(exported) == 1
+        assert exported[0]._attributes["lk.user_transcript"] == "hello there"
+        assert len(proc._pending_user_transcripts) == 0
+
+    def test_fifo_pairing_within_conversation(self):
+        # Two utterances, two transcripts — paired in order.
+        proc = _processor()
+        proc.on_end(self._speaking(span_id=0x2))
+        proc.on_end(self._speaking(span_id=0x3))
+        proc._record_user_transcript("call-1", "first")
+        proc._record_user_transcript("call-1", "second")
+
+        transcripts = [
+            s._attributes["lk.user_transcript"]
+            for s in self._exported(proc, "user_speaking")
+        ]
+        assert transcripts == ["first", "second"]
+
+    def test_no_thread_id_exports_untouched(self):
+        # Without a thread id there is nothing to pair against — export as-is.
+        proc = _processor()
+        proc.on_end(_make_span("user_speaking", trace_id=0xABC, span_id=0x2))
+        exported = self._exported(proc, "user_speaking")
+        assert len(exported) == 1
+        assert exported[0]._attributes["langsmith.span.kind"] == "chain"
+        assert "lk.user_transcript" not in exported[0]._attributes
+
+    def test_empty_transcript_consumes_slot_without_fake_io(self):
+        # A final-but-empty transcript still pairs (keeping FIFO aligned) but
+        # renders no fabricated I/O.
+        proc = _processor()
+        proc.on_end(self._speaking())
+        proc._record_user_transcript("call-1", "")
+
+        exported = self._exported(proc, "user_speaking")
+        assert len(exported) == 1
+        assert "gen_ai.completion" not in exported[0]._attributes
+        assert "lk.user_transcript" not in exported[0]._attributes
+
+    def test_session_end_flushes_untranscribed_span(self):
+        # Realtime input transcription disabled: no transcript ever arrives, so
+        # the held span must still be exported (untouched) at session end.
+        proc = _processor()
+        tid = 0xABC
+        proc.on_end(
+            _make_span(
+                "job_entrypoint",
+                {"langsmith.metadata.thread_id": "call-1"},
+                parent=None,
+                trace_id=tid,
+            )
+        )
+        proc.on_end(self._speaking(trace_id=tid))
+        assert self._exported(proc, "user_speaking") == []  # held
+
+        proc.on_end(_make_span("agent_session", trace_id=tid, span_id=0x3))
+
+        assert len(self._exported(proc, "user_speaking")) == 1
+        assert len(proc._deferred_user_speaking) == 0
+
+    def test_shutdown_flushes_untranscribed_span(self):
+        proc = _processor()
+        proc.on_end(self._speaking())
+        proc.shutdown()
+        assert len(self._exported(proc, "user_speaking")) == 1
+
+
+class TestRealtimeRootRollup:
+    """A late realtime user transcript sorts into its place in the root rollup.
+
+    The transcript arrives after its turn's ``agent_turn`` reply is already
+    recorded, so ordering keys off each message's source-span start_time — the
+    ``user_speaking`` span (earlier) before the ``agent_turn`` reply (later).
+    """
+
+    def _root(self, proc):
+        return next(
+            c.args[0]
+            for c in proc.downstream.on_end.call_args_list
+            if c.args[0]._attributes.get("langsmith.root_span")
+        )
+
+    def test_user_sorts_before_reply_despite_late_arrival(self):
+        proc = _processor()
+        tid = 0xABC
+        proc.on_end(
+            _make_span(
+                "job_entrypoint",
+                {"langsmith.metadata.thread_id": "call-1"},
+                parent=None,
+                trace_id=tid,
+            )
+        )
+        # User speaks (early span), then the reply turn lands and is recorded...
+        proc.on_end(
+            _make_span(
+                "user_speaking",
+                {"langsmith.metadata.thread_id": "call-1"},
+                trace_id=tid,
+                span_id=0x2,
+                start_time=10,
+            )
+        )
+        proc.on_end(
+            _make_span(
+                "agent_turn",
+                {"lk.response.text": "sunny"},
+                trace_id=tid,
+                span_id=0x3,
+                start_time=20,
+            )
+        )
+        # ...only *then* does the transcript arrive (out of order).
+        proc._record_user_transcript("call-1", "weather?")
+        proc.on_end(_make_span("agent_session", trace_id=tid, span_id=0x4))
+
+        root = self._root(proc)
+        # Input = the user's opening turn; output = the assistant reply.
+        assert json.loads(root._attributes["gen_ai.prompt"]) == {
+            "messages": [{"role": "user", "content": "weather?"}]
+        }
+        assert (
+            json.loads(root._attributes["gen_ai.completion"])["messages"][0]["content"]
+            == "sunny"
+        )
+
+    def test_greeting_then_user_turn_ordered(self):
+        # Agent greets first (agent_turn, no user_speaking), then a user turn.
+        # The greeting must not steal the user's transcript, and order holds.
+        proc = _processor()
+        tid = 0xABC
+        proc.on_end(
+            _make_span(
+                "job_entrypoint",
+                {"langsmith.metadata.thread_id": "call-1"},
+                parent=None,
+                trace_id=tid,
+            )
+        )
+        proc.on_end(
+            _make_span(
+                "agent_turn",
+                {"lk.response.text": "hi there!"},
+                trace_id=tid,
+                span_id=0x2,
+                start_time=5,
+            )
+        )
+        proc.on_end(
+            _make_span(
+                "user_speaking",
+                {"langsmith.metadata.thread_id": "call-1"},
+                trace_id=tid,
+                span_id=0x3,
+                start_time=10,
+            )
+        )
+        proc.on_end(
+            _make_span(
+                "agent_turn",
+                {"lk.response.text": "sunny"},
+                trace_id=tid,
+                span_id=0x4,
+                start_time=20,
+            )
+        )
+        proc._record_user_transcript("call-1", "weather?")
+        proc.on_end(_make_span("agent_session", trace_id=tid, span_id=0x5))
+
+        root = self._root(proc)
+        contents = [
+            m["content"]
+            for m in json.loads(root._attributes["gen_ai.prompt"])["messages"]
+        ]
+        contents += [
+            m["content"]
+            for m in json.loads(root._attributes["gen_ai.completion"])["messages"]
+        ]
+        assert contents == ["hi there!", "weather?", "sunny"]
+
+
+class TestAgentTurnKind:
+    """agent_turn is llm in realtime (it IS the inference), chain in cascade."""
+
+    def _turn_kind(self, attributes):
+        proc = _processor()
+        proc.on_end(_make_span("agent_turn", attributes, span_id=0x2))
+        exported = next(
+            c.args[0]
+            for c in proc.downstream.on_end.call_args_list
+            if c.args[0].name == "agent_turn"
+        )
+        return exported._attributes["langsmith.span.kind"]
+
+    def test_realtime_turn_is_llm(self):
+        # A realtime turn carries lk.realtime_model_metrics (drained from its
+        # realtime_metrics child) — no child llm_request, so the turn itself is
+        # the inference node.
+        assert (
+            self._turn_kind(
+                {"lk.response.text": "sunny", "lk.realtime_model_metrics": "{}"}
+            )
+            == "llm"
+        )
+
+    def test_cascade_turn_is_chain(self):
+        # Cascade turn carries user_input/response but no realtime metrics (the
+        # real inference is the child llm_request span) — it's just a container.
+        assert (
+            self._turn_kind({"lk.user_input": "weather?", "lk.response.text": "sunny"})
+            == "chain"
+        )
+
+    def test_response_function_calls_render_as_tool_calls(self):
+        # A realtime turn whose reply is a tool call must show the tool call on
+        # the assistant completion, not an empty/text-only output.
+        proc = _processor()
+        fcs = json.dumps(
+            [
+                {
+                    "call_id": "call_1",
+                    "name": "lookup_weather",
+                    "arguments": '{"city":"x"}',
+                }
+            ]
+        )
+        proc.on_end(
+            _make_span(
+                "agent_turn",
+                {"lk.response.function_calls": fcs, "lk.realtime_model_metrics": "{}"},
+                span_id=0x2,
+            )
+        )
+        turn = next(
+            c.args[0]
+            for c in proc.downstream.on_end.call_args_list
+            if c.args[0].name == "agent_turn"
+        )
+        msg = json.loads(turn._attributes["gen_ai.completion"])["messages"][0]
+        assert msg["tool_calls"] == [
+            {
+                "id": "call_1",
+                "type": "function",
+                "function": {"name": "lookup_weather", "arguments": '{"city":"x"}'},
+            }
+        ]
+
+
+class TestInstrumentSession:
+    """instrument_session subscribes the SDK to a session's events itself."""
+
+    class _FakeSession:
+        """Minimal stand-in for a LiveKit AgentSession's event emitter."""
+
+        def __init__(self):
+            self.handlers = {}
+
+        def on(self, name):
+            def _register(fn):
+                self.handlers[name] = fn
+                return fn
+
+            return _register
+
+    @staticmethod
+    def _event(*, is_final, transcript):
+        ev = MagicMock()
+        ev.is_final = is_final
+        ev.transcript = transcript
+        return ev
+
+    def _instrument(self, session, thread_id, proc):
+        proc.instrument_session(session, thread_id)
+
+    def test_final_transcript_wired_to_processor(self):
+        proc = _processor()
+        session = self._FakeSession()
+        self._instrument(session, "call-1", proc)
+
+        proc.on_end(
+            _make_span(
+                "user_speaking",
+                {"langsmith.metadata.thread_id": "call-1"},
+                span_id=0x2,
+            )
+        )
+        session.handlers["user_input_transcribed"](
+            self._event(is_final=True, transcript="hello there")
+        )
+
+        exported = [
+            c.args[0]
+            for c in proc.downstream.on_end.call_args_list
+            if c.args[0].name == "user_speaking"
+        ]
+        assert len(exported) == 1
+        assert exported[0]._attributes["lk.user_transcript"] == "hello there"
+
+    def test_interim_transcript_ignored(self):
+        proc = _processor()
+        session = self._FakeSession()
+        self._instrument(session, "call-1", proc)
+
+        session.handlers["user_input_transcribed"](
+            self._event(is_final=False, transcript="partial")
+        )
+        # Interim result buffered nothing; a later span has no transcript to pair.
+        assert len(proc._pending_user_transcripts) == 0
 
 
 class TestForceFlush:
@@ -257,7 +629,8 @@ class TestStateTTL:
                 "agent_turn", {"lk.response.text": "two"}, trace_id=tid, span_id=0x3
             )
         )
-        assert [m["content"] for m in proc._conversation_by_trace[tid]] == [
+        # Store holds (sort_key, seq, message) tuples.
+        assert [m["content"] for _, m in proc._conversation_by_trace[tid]] == [
             "one",
             "two",
         ]

--- a/python/tests/unit_tests/wrappers/test_livekit.py
+++ b/python/tests/unit_tests/wrappers/test_livekit.py
@@ -118,7 +118,7 @@ class TestDeferredRootRelease:
         assert root._attributes["langsmith.metadata.ls_modality"] == "audio"
         # The root is attributed to this integration so usage is trackable.
         assert root._attributes["langsmith.metadata.ls_integration"] == "livekit"
-        completion = json.loads(root._attributes["gen_ai.completion"])
+        completion = json.loads(root._attributes["gen_ai.completion"])["messages"]
         assert completion[0]["content"] == "sunny"
         # Per-conversation state freed after release.
         assert len(proc._deferred_root_spans) == 0
@@ -161,7 +161,8 @@ class TestForceFlush:
             if c.args[0]._attributes.get("langsmith.root_span")
         )
         assert (
-            json.loads(root._attributes["gen_ai.completion"])[0]["content"] == "sunny"
+            json.loads(root._attributes["gen_ai.completion"])["messages"][0]["content"]
+            == "sunny"
         )
 
     def test_shutdown_flushes_held_root(self):

--- a/python/tests/unit_tests/wrappers/test_pipecat.py
+++ b/python/tests/unit_tests/wrappers/test_pipecat.py
@@ -74,8 +74,10 @@ class TestPipecatDispatch:
 
         attrs = _exported_attrs(proc)
         assert attrs["langsmith.span.kind"] == "llm"
-        assert attrs["gen_ai.prompt.0.content"] == 'Audio for: "hello there"'
-        assert attrs["gen_ai.completion.0.content"] == "hello there"
+        prompt = json.loads(attrs["gen_ai.prompt"])["messages"]
+        completion = json.loads(attrs["gen_ai.completion"])["messages"]
+        assert prompt[0]["content"] == 'Audio for: "hello there"'
+        assert completion[0]["content"] == "hello there"
         # STT/TTS spans stay in the tree but are dropped from the Messages view.
         assert attrs["langsmith.metadata.ls_message_view_exclude"] is True
         proc.downstream.on_end.assert_called_once()
@@ -86,7 +88,7 @@ class TestPipecatDispatch:
 
         proc.on_end(span)
 
-        assert "gen_ai.completion.0.content" not in _exported_attrs(proc)
+        assert "gen_ai.completion" not in _exported_attrs(proc)
 
     def test_tts_span(self):
         proc = _processor()
@@ -97,8 +99,11 @@ class TestPipecatDispatch:
         attrs = _exported_attrs(proc)
         assert attrs["langsmith.span.kind"] == "llm"
         assert attrs["langsmith.metadata.voice_id"] == "voice-1"
-        assert attrs["gen_ai.prompt.0.content"] == "hi"
-        assert attrs["gen_ai.completion.0.content"] == 'Generated audio for: "hi"'
+        assert json.loads(attrs["gen_ai.prompt"])["messages"][0]["content"] == "hi"
+        assert (
+            json.loads(attrs["gen_ai.completion"])["messages"][0]["content"]
+            == 'Generated audio for: "hi"'
+        )
         assert attrs["langsmith.metadata.ls_message_view_exclude"] is True
 
     def test_turn_span(self):
@@ -124,13 +129,10 @@ class TestPipecatDispatch:
 
         attrs = _exported_attrs(proc)
         assert attrs["langsmith.span.kind"] == "llm"
-        prompt = json.loads(attrs["gen_ai.prompt"])
-        assert prompt["messages"][-1]["content"] == "what is 2+2?"
-        completion = json.loads(attrs["gen_ai.completion"])
-        assert completion["messages"][0]["content"] == "4"
-        # _set_messages_json must NOT write the indexed form (it would win at
-        # ingest and drop structured tool calls).
-        assert "gen_ai.prompt.0.role" not in attrs
+        assert json.loads(attrs["gen_ai.prompt"])["messages"][-1]["content"] == (
+            "what is 2+2?"
+        )
+        assert json.loads(attrs["gen_ai.completion"])["messages"][0]["content"] == "4"
 
     def test_llm_input_messages_passed_through_verbatim(self):
         # The request history is forwarded in the LLM provider's own message
@@ -329,25 +331,27 @@ class TestBaseProcessorHelpers:
     def _base(self, **kwargs) -> BaseLangSmithSpanProcessor:
         return BaseLangSmithSpanProcessor(downstream_processor=MagicMock(), **kwargs)
 
-    def test_set_messages_writes_indexed_and_singular(self):
+    def test_set_messages_writes_json_messages_form(self):
+        # One form for everything: the singular {"messages": [...]} JSON, and NOT
+        # the indexed gen_ai.prompt.{n}.* attributes (which win at ingest and can
+        # only express plain role/string-content).
         ls = TranslatedSpan.of(_make_span("x"))
-        BaseLangSmithSpanProcessor._set_messages(
-            ls, prompt=[{"role": "user", "content": "hi"}]
-        )
-        assert ls.attributes["gen_ai.prompt.0.role"] == "user"
-        assert json.loads(ls.attributes["gen_ai.prompt"]) == [
-            {"role": "user", "content": "hi"}
-        ]
-
-    def test_set_messages_json_writes_singular_only(self):
-        ls = TranslatedSpan.of(_make_span("x"))
-        BaseLangSmithSpanProcessor._set_messages_json(
-            ls, prompt=[{"role": "user", "content": "hi"}]
-        )
+        ls.set_messages(prompt=[{"role": "user", "content": "hi"}])
         assert json.loads(ls.attributes["gen_ai.prompt"]) == {
             "messages": [{"role": "user", "content": "hi"}]
         }
         assert "gen_ai.prompt.0.role" not in ls.attributes
+
+    def test_set_messages_preserves_structured_fields(self):
+        # tool_calls survive verbatim in the {"messages": [...]} form.
+        ls = TranslatedSpan.of(_make_span("x"))
+        tool_call = {"id": "c1", "function": {"name": "f", "arguments": "{}"}}
+        ls.set_messages(
+            completion=[{"role": "assistant", "content": "", "tool_calls": [tool_call]}]
+        )
+        payload = json.loads(ls.attributes["gen_ai.completion"])
+        assert payload["messages"][0]["tool_calls"] == [tool_call]
+        assert "gen_ai.completion.0.role" not in ls.attributes
 
     def test_attach_audio_encodes_and_returns_true(self):
         base = self._base()


### PR DESCRIPTION
Capture the LiveKit realtime (speech-to-speech) user transcript — which arrives as a session event, not on a span — and render it as the user's turn in the trace.

#### PR Dependency Tree


* **PR #3179**
  * **PR #3180** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)



#### PR Dependency Tree


* **PR #3179**
  * **PR #3180** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)