### PR TITLE
fix(py,js)!: make trace sampling deterministic

### DIFF
--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -666,6 +666,33 @@ const getTracingSamplingRate = (configRate?: number) => {
   return samplingRate;
 };
 
+const SAMPLING_HASH_MODULUS = 1_000_000n;
+const FNV_64_OFFSET_BASIS = 14_695_981_039_346_656_037n;
+const FNV_64_PRIME = 1_099_511_628_211n;
+const FNV_64_MASK = (1n << 64n) - 1n;
+
+const isSampledById = (identifier?: string | null, samplingRate?: number) => {
+  if (samplingRate === undefined || samplingRate >= 1) {
+    return true;
+  }
+  if (samplingRate <= 0) {
+    return false;
+  }
+  if (identifier === undefined || identifier === null) {
+    return true;
+  }
+  let hashValue = FNV_64_OFFSET_BASIS;
+  const value = identifier.toLowerCase();
+  for (let i = 0; i < value.length; i += 1) {
+    hashValue ^= BigInt(value.charCodeAt(i));
+    hashValue = (hashValue * FNV_64_PRIME) & FNV_64_MASK;
+  }
+  const threshold = BigInt(
+    Math.floor(samplingRate * Number(SAMPLING_HASH_MODULUS)),
+  );
+  return hashValue % SAMPLING_HASH_MODULUS < threshold;
+};
+
 // utility functions
 const isLocalhost = (url: string): boolean => {
   const strippedUrl = url.replace("http://", "").replace("https://", "");
@@ -897,8 +924,6 @@ export class Client implements LangSmithTracingClientInterface {
   private omitTracedRuntimeInfo?: boolean;
 
   private tracingSampleRate?: number;
-
-  private filteredPostUuids = new Set();
 
   private autoBatchTracing = true;
 
@@ -1717,56 +1742,20 @@ export class Client implements LangSmithTracingClientInterface {
   }
 
   // Allows mocking for tests
-  private _shouldSample(): boolean {
-    if (this.tracingSampleRate === undefined) {
-      return true;
-    }
-    return Math.random() < this.tracingSampleRate;
+  private _shouldSample(identifier?: string | null): boolean {
+    return isSampledById(identifier, this.tracingSampleRate);
   }
 
   private _filterForSampling(
     runs: CreateRunParams[] | UpdateRunParams[],
     patch = false,
   ) {
+    void patch;
     if (this.tracingSampleRate === undefined) {
       return runs;
     }
 
-    if (patch) {
-      const sampled = [];
-      for (const run of runs) {
-        if (!this.filteredPostUuids.has(run.trace_id)) {
-          sampled.push(run);
-        } else if (run.id === run.trace_id) {
-          this.filteredPostUuids.delete(run.trace_id);
-        }
-      }
-      return sampled;
-    } else {
-      // For new runs, sample at trace level to maintain consistency
-      const sampled = [];
-      for (const run of runs) {
-        const traceId = run.trace_id ?? run.id;
-
-        // If we've already made a decision about this trace, follow it
-        if (this.filteredPostUuids.has(traceId)) {
-          continue;
-        }
-
-        // For new traces, apply sampling
-        if (run.id === traceId) {
-          if (this._shouldSample()) {
-            sampled.push(run);
-          } else {
-            this.filteredPostUuids.add(traceId);
-          }
-        } else {
-          // Child runs follow their trace's sampling decision
-          sampled.push(run);
-        }
-      }
-      return sampled;
-    }
+    return runs.filter((run) => this._shouldSample(run.id));
   }
 
   private async _getBatchSizeLimitBytes(): Promise<number> {
@@ -5069,6 +5058,9 @@ export class Client implements LangSmithTracingClientInterface {
       start_time: startTime,
       extend_trace_retention: extendTraceRetention,
     };
+    if (runId !== null && !this._shouldSample(runId)) {
+      return feedback as Feedback;
+    }
     const body = JSON.stringify(feedback);
     const url = `${this.apiUrl}/feedback`;
     await this.caller.call(async () => {

--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -483,6 +483,7 @@ interface feedback_source {
 interface FeedbackCreate {
   id: string;
   run_id: string | null;
+  trace_id?: string;
   key: string;
   score?: ScoreType;
   value?: ValueType;
@@ -563,6 +564,8 @@ export type CreateFeedbackOptions = {
   feedbackConfig?: FeedbackConfig;
   sourceRunId?: string;
   feedbackId?: string;
+  /** The trace the run belongs to. Omit for a root run. */
+  traceId?: string;
   comparativeExperimentId?: string;
   /**
    * The run's start time, ISO string or epoch ms. Better performance if provided.
@@ -2013,7 +2016,14 @@ export class Client implements LangSmithTracingClientInterface {
   }
 
   private _filterForSampling(runs: CreateRunParams[] | UpdateRunParams[]) {
-    return runs.filter((run) => this._shouldSample(run.trace_id ?? run.id));
+    // updateRun() may omit trace_id; dotted order's first segment is the root.
+    return runs.filter((run) =>
+      this._shouldSample(
+        run.trace_id ??
+          run.dotted_order?.split(".", 1)[0].split("Z")[1] ??
+          run.id,
+      ),
+    );
   }
 
   private async _getBatchSizeLimitBytes(): Promise<number> {
@@ -5474,6 +5484,7 @@ export class Client implements LangSmithTracingClientInterface {
       feedbackId,
       feedbackConfig,
       projectId,
+      traceId,
       comparativeExperimentId,
       sessionId,
       startTime,
@@ -5510,6 +5521,7 @@ export class Client implements LangSmithTracingClientInterface {
     const feedback: FeedbackCreate = {
       id: feedbackId ?? uuid.v7(),
       run_id: runId,
+      trace_id: traceId,
       key,
       score: _formatFeedbackScore(score),
       value,
@@ -5522,7 +5534,8 @@ export class Client implements LangSmithTracingClientInterface {
       start_time: startTime,
       extend_trace_retention: extendTraceRetention,
     };
-    if (runId !== null && !this._shouldSample(runId)) {
+    const samplingId = traceId ?? runId;
+    if (samplingId !== null && !this._shouldSample(samplingId)) {
       return feedback as Feedback;
     }
     const body = JSON.stringify(feedback);
@@ -5829,6 +5842,8 @@ export class Client implements LangSmithTracingClientInterface {
           feedbackSourceType: "model",
           sessionId: run?.session_id ?? sessionId,
           startTime: run?.start_time,
+          // A targetRunId may name a run in another trace.
+          traceId: runId_ === run?.id ? run?.trace_id : undefined,
         }),
       );
     }

--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -723,6 +723,33 @@ const getTracingSamplingRate = (configRate?: number) => {
   return samplingRate;
 };
 
+const SAMPLING_HASH_MODULUS = 1_000_000n;
+const FNV_64_OFFSET_BASIS = 14_695_981_039_346_656_037n;
+const FNV_64_PRIME = 1_099_511_628_211n;
+const FNV_64_MASK = (1n << 64n) - 1n;
+
+const isSampledById = (identifier?: string | null, samplingRate?: number) => {
+  if (samplingRate === undefined || samplingRate >= 1) {
+    return true;
+  }
+  if (samplingRate <= 0) {
+    return false;
+  }
+  if (identifier === undefined || identifier === null) {
+    return true;
+  }
+  let hashValue = FNV_64_OFFSET_BASIS;
+  const value = identifier.toLowerCase();
+  for (let i = 0; i < value.length; i += 1) {
+    hashValue ^= BigInt(value.charCodeAt(i));
+    hashValue = (hashValue * FNV_64_PRIME) & FNV_64_MASK;
+  }
+  const threshold = BigInt(
+    Math.floor(samplingRate * Number(SAMPLING_HASH_MODULUS)),
+  );
+  return hashValue % SAMPLING_HASH_MODULUS < threshold;
+};
+
 // utility functions
 const isLocalhost = (url: string): boolean => {
   const strippedUrl = url.replace("http://", "").replace("https://", "");
@@ -1042,8 +1069,6 @@ export class Client implements LangSmithTracingClientInterface {
   private omitTracedRuntimeInfo?: boolean;
 
   private tracingSampleRate?: number;
-
-  private filteredPostUuids = new Set();
 
   private autoBatchTracing = true;
 
@@ -2009,56 +2034,20 @@ export class Client implements LangSmithTracingClientInterface {
   }
 
   // Allows mocking for tests
-  private _shouldSample(): boolean {
-    if (this.tracingSampleRate === undefined) {
-      return true;
-    }
-    return Math.random() < this.tracingSampleRate;
+  private _shouldSample(identifier?: string | null): boolean {
+    return isSampledById(identifier, this.tracingSampleRate);
   }
 
   private _filterForSampling(
     runs: CreateRunParams[] | UpdateRunParams[],
     patch = false,
   ) {
+    void patch;
     if (this.tracingSampleRate === undefined) {
       return runs;
     }
 
-    if (patch) {
-      const sampled = [];
-      for (const run of runs) {
-        if (!this.filteredPostUuids.has(run.trace_id)) {
-          sampled.push(run);
-        } else if (run.id === run.trace_id) {
-          this.filteredPostUuids.delete(run.trace_id);
-        }
-      }
-      return sampled;
-    } else {
-      // For new runs, sample at trace level to maintain consistency
-      const sampled = [];
-      for (const run of runs) {
-        const traceId = run.trace_id ?? run.id;
-
-        // If we've already made a decision about this trace, follow it
-        if (this.filteredPostUuids.has(traceId)) {
-          continue;
-        }
-
-        // For new traces, apply sampling
-        if (run.id === traceId) {
-          if (this._shouldSample()) {
-            sampled.push(run);
-          } else {
-            this.filteredPostUuids.add(traceId);
-          }
-        } else {
-          // Child runs follow their trace's sampling decision
-          sampled.push(run);
-        }
-      }
-      return sampled;
-    }
+    return runs.filter((run) => this._shouldSample(run.id));
   }
 
   private async _getBatchSizeLimitBytes(): Promise<number> {
@@ -5567,6 +5556,9 @@ export class Client implements LangSmithTracingClientInterface {
       start_time: startTime,
       extend_trace_retention: extendTraceRetention,
     };
+    if (runId !== null && !this._shouldSample(runId)) {
+      return feedback as Feedback;
+    }
     const body = JSON.stringify(feedback);
     const url = `${this.apiUrl}/feedback`;
     await this.caller.call(async () => {

--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -85,6 +85,7 @@ import { Threads } from "./_openapi_client/resources/threads.js";
 import { Traces } from "./_openapi_client/resources/traces.js";
 import { Public } from "./_openapi_client/resources/public/public.js";
 import { assertUuid } from "./utils/_uuid.js";
+import { isSampledById } from "./utils/sampling.js";
 import { warnOnce } from "./utils/warn.js";
 import { getQueryBackend, QueryBackend } from "./utils/v2_migration.js";
 import { parseHubIdentifier } from "./utils/prompts.js";
@@ -721,33 +722,6 @@ const getTracingSamplingRate = (configRate?: number) => {
     );
   }
   return samplingRate;
-};
-
-const SAMPLING_HASH_MODULUS = 1_000_000n;
-const FNV_64_OFFSET_BASIS = 14_695_981_039_346_656_037n;
-const FNV_64_PRIME = 1_099_511_628_211n;
-const FNV_64_MASK = (1n << 64n) - 1n;
-
-const isSampledById = (identifier?: string | null, samplingRate?: number) => {
-  if (samplingRate === undefined || samplingRate >= 1) {
-    return true;
-  }
-  if (samplingRate <= 0) {
-    return false;
-  }
-  if (identifier === undefined || identifier === null) {
-    return true;
-  }
-  let hashValue = FNV_64_OFFSET_BASIS;
-  const value = identifier.toLowerCase();
-  for (let i = 0; i < value.length; i += 1) {
-    hashValue ^= BigInt(value.charCodeAt(i));
-    hashValue = (hashValue * FNV_64_PRIME) & FNV_64_MASK;
-  }
-  const threshold = BigInt(
-    Math.floor(samplingRate * Number(SAMPLING_HASH_MODULUS)),
-  );
-  return hashValue % SAMPLING_HASH_MODULUS < threshold;
 };
 
 // utility functions
@@ -2038,16 +2012,8 @@ export class Client implements LangSmithTracingClientInterface {
     return isSampledById(identifier, this.tracingSampleRate);
   }
 
-  private _filterForSampling(
-    runs: CreateRunParams[] | UpdateRunParams[],
-    patch = false,
-  ) {
-    void patch;
-    if (this.tracingSampleRate === undefined) {
-      return runs;
-    }
-
-    return runs.filter((run) => this._shouldSample(run.id));
+  private _filterForSampling(runs: CreateRunParams[] | UpdateRunParams[]) {
+    return runs.filter((run) => this._shouldSample(run.trace_id ?? run.id));
   }
 
   private async _getBatchSizeLimitBytes(): Promise<number> {
@@ -3113,7 +3079,7 @@ export class Client implements LangSmithTracingClientInterface {
     }
     // TODO: Untangle types
     const data: UpdateRunParams = { ...run, id: runId };
-    if (!this._filterForSampling([data], true).length) {
+    if (!this._filterForSampling([data]).length) {
       return;
     }
     if (

--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -5535,7 +5535,7 @@ export class Client implements LangSmithTracingClientInterface {
       extend_trace_retention: extendTraceRetention,
     };
     const samplingId = traceId ?? runId;
-    if (samplingId !== null && !this._shouldSample(samplingId)) {
+    if (samplingId != null && !this._shouldSample(samplingId)) {
       return feedback as Feedback;
     }
     const body = JSON.stringify(feedback);
@@ -5842,7 +5842,8 @@ export class Client implements LangSmithTracingClientInterface {
           feedbackSourceType: "model",
           sessionId: run?.session_id ?? sessionId,
           startTime: run?.start_time,
-          // A targetRunId may name a run in another trace.
+          // If an evaluator result targets a different run, we can't
+          // guarantee to know its trace ID.
           traceId: runId_ === run?.id ? run?.trace_id : undefined,
         }),
       );

--- a/js/src/evaluation/evaluate_comparative.ts
+++ b/js/src/evaluation/evaluate_comparative.ts
@@ -367,6 +367,8 @@ export async function evaluateComparative(
         comparativeExperimentId: comparativeExperiment.id,
         sessionId: run?.session_id,
         startTime: run?.start_time,
+        // `run` is the run being scored, so its trace is the right key.
+        traceId: run?.trace_id,
       });
     }
 

--- a/js/src/schemas.ts
+++ b/js/src/schemas.ts
@@ -370,6 +370,8 @@ export interface FeedbackBase {
   created_at: string;
   modified_at: string;
   run_id: string;
+  /** The trace the run belongs to. Equals run_id for a root run. */
+  trace_id?: string;
   key: string;
   score: ScoreType;
   value: ValueType;

--- a/js/src/tests/batch_client.test.ts
+++ b/js/src/tests/batch_client.test.ts
@@ -1185,11 +1185,6 @@ describe.each(ENDPOINT_TYPES)(
         },
         mockFetch,
       );
-      let counter = 0;
-      jest.spyOn(client as any, "_shouldSample").mockImplementation(() => {
-        counter += 1;
-        return counter % 2 !== 0;
-      });
       jest.spyOn(client as any, "_ensureServerInfo").mockResolvedValue({
         version: "foo",
         batch_ingest_config: { ...extraBatchIngestConfig },
@@ -1197,9 +1192,23 @@ describe.each(ENDPOINT_TYPES)(
       });
       const projectName = "__test_batch";
 
+      const sampledIds = [
+        "00000000-0000-0000-0000-000000000001",
+        "00000000-0000-0000-0000-000000000002",
+        "00000000-0000-0000-0000-000000000003",
+        "00000000-0000-0000-0000-000000000004",
+      ];
+      const childIds = [
+        "00000000-0000-0000-0000-000000000010",
+        "00000000-0000-0000-0000-000000000011",
+        "00000000-0000-0000-0000-000000000012",
+        "00000000-0000-0000-0000-000000000013",
+      ];
+      const isSampled = (runId?: string) =>
+        (client as any)._shouldSample(runId);
+
       const runParams = await Promise.all(
-        [...Array(4)].map(async (_, i) => {
-          const runId = uuidv4();
+        sampledIds.map(async (runId, i) => {
           const { dottedOrder } = convertToDottedOrderFormat(
             new Date().getTime() / 1000,
             runId,
@@ -1226,7 +1235,7 @@ describe.each(ENDPOINT_TYPES)(
 
       const childRunParams = await Promise.all(
         runParams.map(async (runParam, i) => {
-          const runId = uuidv4();
+          const runId = childIds[i];
           const { dottedOrder } = convertToDottedOrderFormat(
             new Date().getTime() / 1000,
             runId,
@@ -1261,7 +1270,7 @@ describe.each(ENDPOINT_TYPES)(
       expect(batchBody).toEqual({
         post: runParams
           .map((runParam, i) => {
-            if (i % 2 === 0) {
+            if (isSampled(runParam.id)) {
               return expect.objectContaining({
                 id: runParam.id,
                 run_type: "llm",
@@ -1278,36 +1287,38 @@ describe.each(ENDPOINT_TYPES)(
         patch: [],
       });
 
-      expect(batchBody2).toEqual({
-        post: childRunParams
-          .map((childRunParam, i) => {
-            if (i % 2 === 0) {
-              return expect.objectContaining({
-                id: childRunParam.id,
-                run_type: "llm",
-                inputs: {
-                  text: expect.stringContaining("child world " + i),
-                },
-                trace_id: runParams[i].id,
-              });
-            } else {
-              return undefined;
-            }
-          })
-          .filter((item) => item !== undefined),
-        patch: runParams
-          .map((runParam, i) => {
-            if (i % 2 === 0) {
-              return expect.objectContaining({
-                id: runParam.id,
-                trace_id: runParam.id,
-              });
-            } else {
-              return undefined;
-            }
-          })
-          .filter((item) => item !== undefined),
-      });
+      const expectedPosts = childRunParams
+        .map((childRunParam, i) => {
+          if (isSampled(childRunParam.id)) {
+            return expect.objectContaining({
+              id: childRunParam.id,
+              run_type: "llm",
+              inputs: {
+                text: expect.stringContaining("child world " + i),
+              },
+              trace_id: runParams[i].id,
+            });
+          } else {
+            return undefined;
+          }
+        })
+        .filter((item) => item !== undefined);
+      const expectedPatches = runParams
+        .map((runParam) => {
+          if (isSampled(runParam.id)) {
+            return expect.objectContaining({
+              id: runParam.id,
+              trace_id: runParam.id,
+            });
+          } else {
+            return undefined;
+          }
+        })
+        .filter((item) => item !== undefined);
+      expect(batchBody2.post).toHaveLength(expectedPosts.length);
+      expect(batchBody2.post).toEqual(expect.arrayContaining(expectedPosts));
+      expect(batchBody2.patch).toHaveLength(expectedPatches.length);
+      expect(batchBody2.patch).toEqual(expect.arrayContaining(expectedPatches));
     });
 
     it("should flush traces in batches with manualFlushMode enabled", async () => {

--- a/js/src/tests/batch_client.test.ts
+++ b/js/src/tests/batch_client.test.ts
@@ -1009,11 +1009,6 @@ describe.each(ENDPOINT_TYPES)(
         },
         mockFetch,
       );
-      let counter = 0;
-      jest.spyOn(client as any, "_shouldSample").mockImplementation(() => {
-        counter += 1;
-        return counter % 2 !== 0;
-      });
       jest.spyOn(client as any, "_ensureServerInfo").mockResolvedValue({
         version: "foo",
         batch_ingest_config: { ...extraBatchIngestConfig },
@@ -1021,9 +1016,23 @@ describe.each(ENDPOINT_TYPES)(
       });
       const projectName = "__test_batch";
 
+      const sampledIds = [
+        "00000000-0000-0000-0000-000000000001",
+        "00000000-0000-0000-0000-000000000002",
+        "00000000-0000-0000-0000-000000000003",
+        "00000000-0000-0000-0000-000000000004",
+      ];
+      const childIds = [
+        "00000000-0000-0000-0000-000000000010",
+        "00000000-0000-0000-0000-000000000011",
+        "00000000-0000-0000-0000-000000000012",
+        "00000000-0000-0000-0000-000000000013",
+      ];
+      const isSampled = (runId?: string) =>
+        (client as any)._shouldSample(runId);
+
       const runParams = await Promise.all(
-        [...Array(4)].map(async (_, i) => {
-          const runId = uuidv4();
+        sampledIds.map(async (runId, i) => {
           const { dottedOrder } = convertToDottedOrderFormat(
             new Date().getTime() / 1000,
             runId,
@@ -1050,7 +1059,7 @@ describe.each(ENDPOINT_TYPES)(
 
       const childRunParams = await Promise.all(
         runParams.map(async (runParam, i) => {
-          const runId = uuidv4();
+          const runId = childIds[i];
           const { dottedOrder } = convertToDottedOrderFormat(
             new Date().getTime() / 1000,
             runId,
@@ -1085,7 +1094,7 @@ describe.each(ENDPOINT_TYPES)(
       expect(batchBody).toEqual({
         post: runParams
           .map((runParam, i) => {
-            if (i % 2 === 0) {
+            if (isSampled(runParam.id)) {
               return expect.objectContaining({
                 id: runParam.id,
                 run_type: "llm",
@@ -1102,36 +1111,38 @@ describe.each(ENDPOINT_TYPES)(
         patch: [],
       });
 
-      expect(batchBody2).toEqual({
-        post: childRunParams
-          .map((childRunParam, i) => {
-            if (i % 2 === 0) {
-              return expect.objectContaining({
-                id: childRunParam.id,
-                run_type: "llm",
-                inputs: {
-                  text: expect.stringContaining("child world " + i),
-                },
-                trace_id: runParams[i].id,
-              });
-            } else {
-              return undefined;
-            }
-          })
-          .filter((item) => item !== undefined),
-        patch: runParams
-          .map((runParam, i) => {
-            if (i % 2 === 0) {
-              return expect.objectContaining({
-                id: runParam.id,
-                trace_id: runParam.id,
-              });
-            } else {
-              return undefined;
-            }
-          })
-          .filter((item) => item !== undefined),
-      });
+      const expectedPosts = childRunParams
+        .map((childRunParam, i) => {
+          if (isSampled(childRunParam.id)) {
+            return expect.objectContaining({
+              id: childRunParam.id,
+              run_type: "llm",
+              inputs: {
+                text: expect.stringContaining("child world " + i),
+              },
+              trace_id: runParams[i].id,
+            });
+          } else {
+            return undefined;
+          }
+        })
+        .filter((item) => item !== undefined);
+      const expectedPatches = runParams
+        .map((runParam) => {
+          if (isSampled(runParam.id)) {
+            return expect.objectContaining({
+              id: runParam.id,
+              trace_id: runParam.id,
+            });
+          } else {
+            return undefined;
+          }
+        })
+        .filter((item) => item !== undefined);
+      expect(batchBody2.post).toHaveLength(expectedPosts.length);
+      expect(batchBody2.post).toEqual(expect.arrayContaining(expectedPosts));
+      expect(batchBody2.patch).toHaveLength(expectedPatches.length);
+      expect(batchBody2.patch).toEqual(expect.arrayContaining(expectedPatches));
     });
 
     it("should flush traces in batches with manualFlushMode enabled", async () => {

--- a/js/src/tests/batch_client.test.ts
+++ b/js/src/tests/batch_client.test.ts
@@ -1192,10 +1192,13 @@ describe.each(ENDPOINT_TYPES)(
       });
       const projectName = "__test_batch";
 
+      // Two of these are sampled in at rate 0.5 and two are filtered out
+      // (XXH3-128 buckets: 10679, 87881, 769129, 982794), so the batch below
+      // exercises both paths. Keep the mix if these are ever changed.
       const sampledIds = [
+        "00000000-0000-0000-0000-000000000015",
+        "00000000-0000-0000-0000-000000000009",
         "00000000-0000-0000-0000-000000000001",
-        "00000000-0000-0000-0000-000000000002",
-        "00000000-0000-0000-0000-000000000003",
         "00000000-0000-0000-0000-000000000004",
       ];
       const childIds = [
@@ -1289,7 +1292,8 @@ describe.each(ENDPOINT_TYPES)(
 
       const expectedPosts = childRunParams
         .map((childRunParam, i) => {
-          if (isSampled(childRunParam.id)) {
+          // Sampling keys on trace_id, so a child follows its root's decision.
+          if (isSampled(runParams[i].id)) {
             return expect.objectContaining({
               id: childRunParam.id,
               run_type: "llm",

--- a/js/src/tests/client.test.ts
+++ b/js/src/tests/client.test.ts
@@ -47,6 +47,47 @@ describe("Client", () => {
         }),
       );
     });
+
+    it("applies run ID sampling before sending feedback", async () => {
+      const mockFetch = jest.fn<typeof fetch>().mockResolvedValue(
+        new Response("{}", {
+          status: 200,
+          statusText: "OK",
+          headers: { "content-type": "application/json" },
+        }),
+      );
+      const client = new Client({
+        apiUrl: "http://localhost:1984",
+        apiKey: "test-api-key",
+        fetchImplementation: mockFetch,
+        tracingSamplingRate: 0.5,
+      });
+
+      const sampledFeedback = await client.createFeedback(
+        "00000000-0000-0000-0000-000000000001",
+        "Foo",
+        { score: 1 },
+      );
+      const filteredFeedback = await client.createFeedback(
+        "00000000-0000-0000-0000-000000000002",
+        "Foo",
+        { score: 0 },
+      );
+
+      expect(sampledFeedback.run_id).toBe(
+        "00000000-0000-0000-0000-000000000001",
+      );
+      expect(filteredFeedback.run_id).toBe(
+        "00000000-0000-0000-0000-000000000002",
+      );
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      const [, init] = mockFetch.mock.calls[0];
+      expect(JSON.parse(init?.body as string)).toEqual(
+        expect.objectContaining({
+          run_id: "00000000-0000-0000-0000-000000000001",
+        }),
+      );
+    });
   });
 
   describe("evaluators", () => {
@@ -857,217 +898,60 @@ describe("Client", () => {
     });
   });
 
-  describe("_filterForSampling patch logic", () => {
-    it("should filter patch runs based on trace_id instead of run.id", () => {
-      const client = new Client({
-        apiKey: "test-api-key",
-        tracingSamplingRate: 0.5,
-      });
+  describe("_filterForSampling run ID logic", () => {
+    const sampledRunId = "00000000-0000-0000-0000-000000000001";
+    const filteredRunId = "00000000-0000-0000-0000-000000000002";
 
-      // Mock the _shouldSample method to control sampling decisions
-      let counter = 0;
-      jest.spyOn(client as any, "_shouldSample").mockImplementation(() => {
-        counter += 1;
-        return counter % 2 === 0; // Accept even-numbered calls (2nd, 4th, etc.)
-      });
-
-      // Create two traces
-      const traceId1 = "trace-1";
-      const traceId2 = "trace-2";
-      const childRunId1 = "child-1";
-      const childRunId2 = "child-2";
-
-      // Create root runs (these will be sampled)
-      const rootRuns = [
-        {
-          id: traceId1,
-          trace_id: traceId1,
-          name: "root_run_1",
-          run_type: "llm" as const,
-          inputs: { text: "hello" },
-        },
-        {
-          id: traceId2,
-          trace_id: traceId2,
-          name: "root_run_2",
-          run_type: "llm" as const,
-          inputs: { text: "world" },
-        },
-      ];
-
-      // Test POST filtering (initial sampling)
-      const postFiltered = (client as any)._filterForSampling(rootRuns, false);
-
-      // Based on our mock, first call returns false, second returns true
-      // So only root_run_2 should be sampled
-      expect(postFiltered).toHaveLength(1);
-      expect(postFiltered[0].id).toBe(traceId2);
-
-      // Verify that traceId1 is in filtered set, traceId2 is not
-      expect((client as any).filteredPostUuids.has(traceId1)).toBe(true);
-      expect((client as any).filteredPostUuids.has(traceId2)).toBe(false);
-
-      // Test PATCH filtering - child runs should follow their trace's sampling decision
-      const patchRuns = [
-        {
-          id: childRunId1,
-          trace_id: traceId1,
-          name: "child_run_1",
-          run_type: "tool" as const,
-          inputs: { text: "child hello" },
-          outputs: { result: "child result 1" },
-        },
-        {
-          id: childRunId2,
-          trace_id: traceId2,
-          name: "child_run_2",
-          run_type: "tool" as const,
-          inputs: { text: "child world" },
-          outputs: { result: "child result 2" },
-        },
-      ];
-
-      const patchFiltered = (client as any)._filterForSampling(patchRuns, true);
-
-      // Only child_run_2 should be included (its trace was sampled)
-      // child_run_1 should be filtered out (its trace was not sampled)
-      expect(patchFiltered).toHaveLength(1);
-      expect(patchFiltered[0].id).toBe(childRunId2);
-      expect(patchFiltered[0].trace_id).toBe(traceId2);
+    const run = (id: string, traceId = id) => ({
+      id,
+      trace_id: traceId,
+      name: `run-${id}`,
+      run_type: "llm" as const,
+      inputs: { text: id },
     });
 
-    it("should remove trace_id from filtered set when processing root run patches", () => {
+    it("should filter creates and patches by stable run ID", () => {
       const client = new Client({
         apiKey: "test-api-key",
         tracingSamplingRate: 0.5,
       });
 
-      // Mock the _shouldSample method to reject first trace, accept second
-      let counter = 0;
-      jest.spyOn(client as any, "_shouldSample").mockImplementation(() => {
-        counter += 1;
-        return counter % 2 === 0;
-      });
+      const sampledCreate = run(sampledRunId);
+      const filteredCreate = run(filteredRunId);
+      const sampledUpdate = {
+        ...sampledCreate,
+        outputs: { result: "sampled" },
+      };
+      const filteredUpdate = {
+        ...filteredCreate,
+        outputs: { result: "filtered" },
+      };
 
-      const traceId1 = "trace-1";
-      const traceId2 = "trace-2";
-
-      // Create root runs and sample them
-      const rootRuns = [
-        {
-          id: traceId1,
-          trace_id: traceId1,
-          name: "root_run_1",
-          run_type: "llm" as const,
-          inputs: { text: "hello" },
-        },
-        {
-          id: traceId2,
-          trace_id: traceId2,
-          name: "root_run_2",
-          run_type: "llm" as const,
-          inputs: { text: "world" },
-        },
-      ];
-
-      (client as any)._filterForSampling(rootRuns, false);
-
-      // Verify initial state
-      expect((client as any).filteredPostUuids.has(traceId1)).toBe(true);
-      expect((client as any).filteredPostUuids.has(traceId2)).toBe(false);
-
-      // Test PATCH filtering for root runs (updates to the root runs themselves)
-      const rootPatchRuns = [
-        {
-          id: traceId1,
-          trace_id: traceId1,
-          name: "root_run_1",
-          run_type: "llm" as const,
-          inputs: { text: "hello" },
-          outputs: { result: "root result 1" },
-        },
-        {
-          id: traceId2,
-          trace_id: traceId2,
-          name: "root_run_2",
-          run_type: "llm" as const,
-          inputs: { text: "world" },
-          outputs: { result: "root result 2" },
-        },
-      ];
-
-      const rootPatchFiltered = (client as any)._filterForSampling(
-        rootPatchRuns,
-        true,
-      );
-
-      // Only root_run_2 should be included, and traceId1 should be removed from filtered set
-      // since we're updating the root run that was originally filtered
-      expect(rootPatchFiltered).toHaveLength(1);
-      expect(rootPatchFiltered[0].id).toBe(traceId2);
-
-      // traceId1 should be removed from filtered set since we processed its root run
-      expect((client as any).filteredPostUuids.has(traceId1)).toBe(false);
-      expect((client as any).filteredPostUuids.has(traceId2)).toBe(false);
+      expect(
+        (client as any)._filterForSampling([sampledCreate, filteredCreate]),
+      ).toEqual([sampledCreate]);
+      expect(
+        (client as any)._filterForSampling(
+          [sampledUpdate, filteredUpdate],
+          true,
+        ),
+      ).toEqual([sampledUpdate]);
+      expect((client as any)._shouldSample(sampledRunId)).toBe(true);
+      expect((client as any)._shouldSample(filteredRunId)).toBe(false);
     });
 
-    it("should handle mixed traces with patch sampling", () => {
+    it("should use run ID rather than trace ID", () => {
       const client = new Client({
         apiKey: "test-api-key",
         tracingSamplingRate: 0.5,
       });
 
-      // Mock sampling to accept every other trace
-      let counter = 0;
-      jest.spyOn(client as any, "_shouldSample").mockImplementation(() => {
-        counter += 1;
-        return counter % 2 === 1; // Accept odd-numbered calls (1st, 3rd, etc.)
-      });
+      const sampledChild = run(sampledRunId, filteredRunId);
+      const filteredChild = run(filteredRunId, sampledRunId);
 
-      // Create multiple traces
-      const traceIds = ["trace-0", "trace-1", "trace-2", "trace-3"];
-      const childRunIds = ["child-0", "child-1", "child-2", "child-3"];
-
-      // Create root runs
-      const rootRuns = traceIds.map((traceId, i) => ({
-        id: traceId,
-        trace_id: traceId,
-        name: `root_run_${i}`,
-        run_type: "llm" as const,
-        inputs: { text: `hello ${i}` },
-      }));
-
-      // Sample the root runs
-      const postFiltered = (client as any)._filterForSampling(rootRuns, false);
-
-      // Based on our mock: 1st and 3rd calls return true (indices 0, 2)
-      expect(postFiltered).toHaveLength(2);
-      const sampledTraceIds = new Set(postFiltered.map((run: any) => run.id));
-      expect(sampledTraceIds.has(traceIds[0])).toBe(true);
-      expect(sampledTraceIds.has(traceIds[2])).toBe(true);
-
-      // Create child runs for all traces
-      const childRuns = traceIds.map((traceId, i) => ({
-        id: childRunIds[i],
-        trace_id: traceId,
-        name: `child_run_${i}`,
-        run_type: "tool" as const,
-        inputs: { text: `child ${i}` },
-        outputs: { result: `child result ${i}` },
-      }));
-
-      // Test patch filtering for child runs
-      const patchFiltered = (client as any)._filterForSampling(childRuns, true);
-
-      // Only children of sampled traces should be included
-      expect(patchFiltered).toHaveLength(2);
-      const patchTraceIds = new Set(
-        patchFiltered.map((run: any) => run.trace_id),
-      );
-      expect(patchTraceIds.has(traceIds[0])).toBe(true);
-      expect(patchTraceIds.has(traceIds[2])).toBe(true);
-      expect(patchTraceIds.has(traceIds[1])).toBe(false);
-      expect(patchTraceIds.has(traceIds[3])).toBe(false);
+      expect(
+        (client as any)._filterForSampling([sampledChild, filteredChild]),
+      ).toEqual([sampledChild]);
     });
   });
 

--- a/js/src/tests/client.test.ts
+++ b/js/src/tests/client.test.ts
@@ -133,6 +133,50 @@ describe("Client", () => {
       );
     });
 
+    it("applies run ID sampling before sending feedback", async () => {
+      const mockFetch = jest.fn<typeof fetch>().mockResolvedValue(
+        new Response("{}", {
+          status: 200,
+          statusText: "OK",
+          headers: { "content-type": "application/json" },
+        }),
+      );
+      const client = new Client({
+        apiUrl: "http://localhost:1984",
+        apiKey: "test-api-key",
+        fetchImplementation: mockFetch,
+        tracingSamplingRate: 0.5,
+      });
+
+      // sessionId is supplied so the call never consults GET /info, leaving
+      // mockFetch to count feedback requests alone.
+      const sessionId = "550e8400-e29b-41d4-a716-446655440001";
+      const sampledFeedback = await client.createFeedback(
+        "00000000-0000-0000-0000-000000000001",
+        "Foo",
+        { score: 1, sessionId },
+      );
+      const filteredFeedback = await client.createFeedback(
+        "00000000-0000-0000-0000-000000000002",
+        "Foo",
+        { score: 0, sessionId },
+      );
+
+      expect(sampledFeedback.run_id).toBe(
+        "00000000-0000-0000-0000-000000000001",
+      );
+      expect(filteredFeedback.run_id).toBe(
+        "00000000-0000-0000-0000-000000000002",
+      );
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      const [, init] = mockFetch.mock.calls[0];
+      expect(JSON.parse(init?.body as string)).toEqual(
+        expect.objectContaining({
+          run_id: "00000000-0000-0000-0000-000000000001",
+        }),
+      );
+    });
+
     const infoClient = (smithdbOnly: boolean) => {
       const instance_flags = smithdbOnly
         ? { ch_query_enabled: false, sdb_query_enabled: true }
@@ -1185,217 +1229,60 @@ describe("Client", () => {
     });
   });
 
-  describe("_filterForSampling patch logic", () => {
-    it("should filter patch runs based on trace_id instead of run.id", () => {
-      const client = new Client({
-        apiKey: "test-api-key",
-        tracingSamplingRate: 0.5,
-      });
+  describe("_filterForSampling run ID logic", () => {
+    const sampledRunId = "00000000-0000-0000-0000-000000000001";
+    const filteredRunId = "00000000-0000-0000-0000-000000000002";
 
-      // Mock the _shouldSample method to control sampling decisions
-      let counter = 0;
-      jest.spyOn(client as any, "_shouldSample").mockImplementation(() => {
-        counter += 1;
-        return counter % 2 === 0; // Accept even-numbered calls (2nd, 4th, etc.)
-      });
-
-      // Create two traces
-      const traceId1 = "trace-1";
-      const traceId2 = "trace-2";
-      const childRunId1 = "child-1";
-      const childRunId2 = "child-2";
-
-      // Create root runs (these will be sampled)
-      const rootRuns = [
-        {
-          id: traceId1,
-          trace_id: traceId1,
-          name: "root_run_1",
-          run_type: "llm" as const,
-          inputs: { text: "hello" },
-        },
-        {
-          id: traceId2,
-          trace_id: traceId2,
-          name: "root_run_2",
-          run_type: "llm" as const,
-          inputs: { text: "world" },
-        },
-      ];
-
-      // Test POST filtering (initial sampling)
-      const postFiltered = (client as any)._filterForSampling(rootRuns, false);
-
-      // Based on our mock, first call returns false, second returns true
-      // So only root_run_2 should be sampled
-      expect(postFiltered).toHaveLength(1);
-      expect(postFiltered[0].id).toBe(traceId2);
-
-      // Verify that traceId1 is in filtered set, traceId2 is not
-      expect((client as any).filteredPostUuids.has(traceId1)).toBe(true);
-      expect((client as any).filteredPostUuids.has(traceId2)).toBe(false);
-
-      // Test PATCH filtering - child runs should follow their trace's sampling decision
-      const patchRuns = [
-        {
-          id: childRunId1,
-          trace_id: traceId1,
-          name: "child_run_1",
-          run_type: "tool" as const,
-          inputs: { text: "child hello" },
-          outputs: { result: "child result 1" },
-        },
-        {
-          id: childRunId2,
-          trace_id: traceId2,
-          name: "child_run_2",
-          run_type: "tool" as const,
-          inputs: { text: "child world" },
-          outputs: { result: "child result 2" },
-        },
-      ];
-
-      const patchFiltered = (client as any)._filterForSampling(patchRuns, true);
-
-      // Only child_run_2 should be included (its trace was sampled)
-      // child_run_1 should be filtered out (its trace was not sampled)
-      expect(patchFiltered).toHaveLength(1);
-      expect(patchFiltered[0].id).toBe(childRunId2);
-      expect(patchFiltered[0].trace_id).toBe(traceId2);
+    const run = (id: string, traceId = id) => ({
+      id,
+      trace_id: traceId,
+      name: `run-${id}`,
+      run_type: "llm" as const,
+      inputs: { text: id },
     });
 
-    it("should remove trace_id from filtered set when processing root run patches", () => {
+    it("should filter creates and patches by stable run ID", () => {
       const client = new Client({
         apiKey: "test-api-key",
         tracingSamplingRate: 0.5,
       });
 
-      // Mock the _shouldSample method to reject first trace, accept second
-      let counter = 0;
-      jest.spyOn(client as any, "_shouldSample").mockImplementation(() => {
-        counter += 1;
-        return counter % 2 === 0;
-      });
+      const sampledCreate = run(sampledRunId);
+      const filteredCreate = run(filteredRunId);
+      const sampledUpdate = {
+        ...sampledCreate,
+        outputs: { result: "sampled" },
+      };
+      const filteredUpdate = {
+        ...filteredCreate,
+        outputs: { result: "filtered" },
+      };
 
-      const traceId1 = "trace-1";
-      const traceId2 = "trace-2";
-
-      // Create root runs and sample them
-      const rootRuns = [
-        {
-          id: traceId1,
-          trace_id: traceId1,
-          name: "root_run_1",
-          run_type: "llm" as const,
-          inputs: { text: "hello" },
-        },
-        {
-          id: traceId2,
-          trace_id: traceId2,
-          name: "root_run_2",
-          run_type: "llm" as const,
-          inputs: { text: "world" },
-        },
-      ];
-
-      (client as any)._filterForSampling(rootRuns, false);
-
-      // Verify initial state
-      expect((client as any).filteredPostUuids.has(traceId1)).toBe(true);
-      expect((client as any).filteredPostUuids.has(traceId2)).toBe(false);
-
-      // Test PATCH filtering for root runs (updates to the root runs themselves)
-      const rootPatchRuns = [
-        {
-          id: traceId1,
-          trace_id: traceId1,
-          name: "root_run_1",
-          run_type: "llm" as const,
-          inputs: { text: "hello" },
-          outputs: { result: "root result 1" },
-        },
-        {
-          id: traceId2,
-          trace_id: traceId2,
-          name: "root_run_2",
-          run_type: "llm" as const,
-          inputs: { text: "world" },
-          outputs: { result: "root result 2" },
-        },
-      ];
-
-      const rootPatchFiltered = (client as any)._filterForSampling(
-        rootPatchRuns,
-        true,
-      );
-
-      // Only root_run_2 should be included, and traceId1 should be removed from filtered set
-      // since we're updating the root run that was originally filtered
-      expect(rootPatchFiltered).toHaveLength(1);
-      expect(rootPatchFiltered[0].id).toBe(traceId2);
-
-      // traceId1 should be removed from filtered set since we processed its root run
-      expect((client as any).filteredPostUuids.has(traceId1)).toBe(false);
-      expect((client as any).filteredPostUuids.has(traceId2)).toBe(false);
+      expect(
+        (client as any)._filterForSampling([sampledCreate, filteredCreate]),
+      ).toEqual([sampledCreate]);
+      expect(
+        (client as any)._filterForSampling(
+          [sampledUpdate, filteredUpdate],
+          true,
+        ),
+      ).toEqual([sampledUpdate]);
+      expect((client as any)._shouldSample(sampledRunId)).toBe(true);
+      expect((client as any)._shouldSample(filteredRunId)).toBe(false);
     });
 
-    it("should handle mixed traces with patch sampling", () => {
+    it("should use run ID rather than trace ID", () => {
       const client = new Client({
         apiKey: "test-api-key",
         tracingSamplingRate: 0.5,
       });
 
-      // Mock sampling to accept every other trace
-      let counter = 0;
-      jest.spyOn(client as any, "_shouldSample").mockImplementation(() => {
-        counter += 1;
-        return counter % 2 === 1; // Accept odd-numbered calls (1st, 3rd, etc.)
-      });
+      const sampledChild = run(sampledRunId, filteredRunId);
+      const filteredChild = run(filteredRunId, sampledRunId);
 
-      // Create multiple traces
-      const traceIds = ["trace-0", "trace-1", "trace-2", "trace-3"];
-      const childRunIds = ["child-0", "child-1", "child-2", "child-3"];
-
-      // Create root runs
-      const rootRuns = traceIds.map((traceId, i) => ({
-        id: traceId,
-        trace_id: traceId,
-        name: `root_run_${i}`,
-        run_type: "llm" as const,
-        inputs: { text: `hello ${i}` },
-      }));
-
-      // Sample the root runs
-      const postFiltered = (client as any)._filterForSampling(rootRuns, false);
-
-      // Based on our mock: 1st and 3rd calls return true (indices 0, 2)
-      expect(postFiltered).toHaveLength(2);
-      const sampledTraceIds = new Set(postFiltered.map((run: any) => run.id));
-      expect(sampledTraceIds.has(traceIds[0])).toBe(true);
-      expect(sampledTraceIds.has(traceIds[2])).toBe(true);
-
-      // Create child runs for all traces
-      const childRuns = traceIds.map((traceId, i) => ({
-        id: childRunIds[i],
-        trace_id: traceId,
-        name: `child_run_${i}`,
-        run_type: "tool" as const,
-        inputs: { text: `child ${i}` },
-        outputs: { result: `child result ${i}` },
-      }));
-
-      // Test patch filtering for child runs
-      const patchFiltered = (client as any)._filterForSampling(childRuns, true);
-
-      // Only children of sampled traces should be included
-      expect(patchFiltered).toHaveLength(2);
-      const patchTraceIds = new Set(
-        patchFiltered.map((run: any) => run.trace_id),
-      );
-      expect(patchTraceIds.has(traceIds[0])).toBe(true);
-      expect(patchTraceIds.has(traceIds[2])).toBe(true);
-      expect(patchTraceIds.has(traceIds[1])).toBe(false);
-      expect(patchTraceIds.has(traceIds[3])).toBe(false);
+      expect(
+        (client as any)._filterForSampling([sampledChild, filteredChild]),
+      ).toEqual([sampledChild]);
     });
   });
 

--- a/js/src/tests/client.test.ts
+++ b/js/src/tests/client.test.ts
@@ -19,6 +19,7 @@ import {
 } from "../utils/env.js";
 import { parseHubIdentifier } from "../utils/prompts.js";
 import { _resetWarnedMessages } from "../utils/warn.js";
+import { isSampledById } from "../utils/sampling.js";
 
 describe("Client", () => {
   describe("resource tags on create", () => {
@@ -152,27 +153,27 @@ describe("Client", () => {
       // mockFetch to count feedback requests alone.
       const sessionId = "550e8400-e29b-41d4-a716-446655440001";
       const sampledFeedback = await client.createFeedback(
-        "00000000-0000-0000-0000-000000000001",
+        "00000000-0000-0000-0000-000000000015",
         "Foo",
         { score: 1, sessionId },
       );
       const filteredFeedback = await client.createFeedback(
-        "00000000-0000-0000-0000-000000000002",
+        "00000000-0000-0000-0000-000000000004",
         "Foo",
         { score: 0, sessionId },
       );
 
       expect(sampledFeedback.run_id).toBe(
-        "00000000-0000-0000-0000-000000000001",
+        "00000000-0000-0000-0000-000000000015",
       );
       expect(filteredFeedback.run_id).toBe(
-        "00000000-0000-0000-0000-000000000002",
+        "00000000-0000-0000-0000-000000000004",
       );
       expect(mockFetch).toHaveBeenCalledTimes(1);
       const [, init] = mockFetch.mock.calls[0];
       expect(JSON.parse(init?.body as string)).toEqual(
         expect.objectContaining({
-          run_id: "00000000-0000-0000-0000-000000000001",
+          run_id: "00000000-0000-0000-0000-000000000015",
         }),
       );
     });
@@ -1229,9 +1230,61 @@ describe("Client", () => {
     });
   });
 
+  describe("cross-SDK sampling agreement", () => {
+    // Golden decisions at rate 0.5. The Python SDK asserts this exact table in
+    // python/tests/unit_tests/test_client.py: both must agree, or a trace
+    // sampled in by one SDK is dropped by the other. Regenerate both sides
+    // together, never one.
+    const decisionsAtHalf: [string, boolean][] = [
+      ["00000000-0000-0000-0000-000000000001", false],
+      ["00000000-0000-0000-0000-000000000004", false],
+      ["00000000-0000-0000-0000-000000000015", true],
+      ["0198f8a0-1234-7000-8000-000000000042", false],
+      ["b3d2c1a0-5f6e-7d8c-9b0a-1e2f3d4c5b6a", false],
+      ["abc", true],
+      ["", false],
+      ["trace-1", true],
+      ["trace-2", false],
+      // Non-ASCII pins the UTF-8 encoding: a UTF-16 implementation diverges.
+      ["\u00fcn\u00efc\u00f8d\u00e9-trace", false],
+      ["\u65e5\u672c\u8a9e", false],
+      // Case folding happens before hashing.
+      ["MiXeD-CaSe-ID", true],
+    ];
+
+    it.each(decisionsAtHalf)(
+      "matches the Python SDK for %p",
+      (identifier, expected) => {
+        expect(isSampledById(identifier, 0.5)).toBe(expected);
+      },
+    );
+
+    it("skips hashing at the rate bounds", () => {
+      for (const identifier of ["anything", "", null, undefined]) {
+        expect(isSampledById(identifier, undefined)).toBe(true);
+        expect(isSampledById(identifier, 1)).toBe(true);
+        expect(isSampledById(identifier, 0)).toBe(false);
+      }
+    });
+
+    it("honours the rate across many ids", () => {
+      const ids = Array.from(
+        { length: 20_000 },
+        (_, i) => `0198f8a0-1234-7000-8000-${String(i).padStart(12, "0")}`,
+      );
+      for (const rate of [0.1, 0.25, 0.75]) {
+        const kept =
+          ids.filter((id) => isSampledById(id, rate)).length / ids.length;
+        expect(Math.abs(kept - rate)).toBeLessThan(0.02);
+      }
+    });
+  });
+
   describe("_filterForSampling run ID logic", () => {
-    const sampledRunId = "00000000-0000-0000-0000-000000000001";
-    const filteredRunId = "00000000-0000-0000-0000-000000000002";
+    // Buckets under XXH3-128 % 1_000_000: 10679 and 982794, so these stay on
+    // opposite sides of the threshold for any rate between 0.02 and 0.98.
+    const sampledRunId = "00000000-0000-0000-0000-000000000015";
+    const filteredRunId = "00000000-0000-0000-0000-000000000004";
 
     const run = (id: string, traceId = id) => ({
       id,

--- a/js/src/tests/client.test.ts
+++ b/js/src/tests/client.test.ts
@@ -178,6 +178,86 @@ describe("Client", () => {
       );
     });
 
+    it("passes the run's trace ID through evaluation feedback", async () => {
+      const client = new Client({
+        apiUrl: "http://localhost:1984",
+        apiKey: "test-api-key",
+      });
+      const createFeedback = jest
+        .spyOn(client, "createFeedback")
+        .mockResolvedValue({} as any);
+      const run = {
+        id: "550e8400-e29b-41d4-a716-446655440000",
+        trace_id: "550e8400-e29b-41d4-a716-4466554400ff",
+      } as any;
+
+      // Scoring the run itself: its trace is known, so it is forwarded.
+      await client.logEvaluationFeedback({ key: "quality", score: 1 }, run);
+      expect(createFeedback).toHaveBeenLastCalledWith(
+        run.id,
+        "quality",
+        expect.objectContaining({ traceId: run.trace_id }),
+      );
+
+      // targetRunId names a different run, whose trace we cannot know from
+      // `run`. Sampling must fall back to the run id rather than guess.
+      await client.logEvaluationFeedback(
+        {
+          key: "quality",
+          score: 1,
+          targetRunId: "550e8400-e29b-41d4-a716-446655440099",
+        },
+        run,
+      );
+      expect(createFeedback).toHaveBeenLastCalledWith(
+        "550e8400-e29b-41d4-a716-446655440099",
+        "quality",
+        expect.objectContaining({ traceId: undefined }),
+      );
+    });
+
+    it("samples feedback by trace ID, not run ID", async () => {
+      const mockFetch = jest.fn<typeof fetch>().mockResolvedValue(
+        new Response("{}", {
+          status: 200,
+          statusText: "OK",
+          headers: { "content-type": "application/json" },
+        }),
+      );
+      const client = new Client({
+        apiUrl: "http://localhost:1984",
+        apiKey: "test-api-key",
+        fetchImplementation: mockFetch,
+        tracingSamplingRate: 0.5,
+      });
+      const sessionId = "550e8400-e29b-41d4-a716-446655440001";
+      // A child run whose own id would be filtered out on its own.
+      const childId = "00000000-0000-0000-0000-000000000004";
+
+      // Sampled-in trace: the child's feedback goes out with it.
+      await client.createFeedback(childId, "Foo", {
+        score: 1,
+        sessionId,
+        traceId: "00000000-0000-0000-0000-000000000015",
+      });
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      const [, init] = mockFetch.mock.calls[0];
+      expect(JSON.parse(init?.body as string)).toEqual(
+        expect.objectContaining({
+          run_id: childId,
+          trace_id: "00000000-0000-0000-0000-000000000015",
+        }),
+      );
+
+      // Filtered-out trace: nothing further is sent.
+      await client.createFeedback(childId, "Foo", {
+        score: 0,
+        sessionId,
+        traceId: "00000000-0000-0000-0000-000000000004",
+      });
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
     const infoClient = (smithdbOnly: boolean) => {
       const instance_flags = smithdbOnly
         ? { ch_query_enabled: false, sdb_query_enabled: true }
@@ -1227,6 +1307,46 @@ describe("Client", () => {
           description: undefined,
         },
       );
+    });
+  });
+
+  describe("update sampling", () => {
+    // A child whose own id would be filtered out if hashed on its own.
+    const childId = "00000000-0000-0000-0000-000000000004";
+    const sampledRoot = "00000000-0000-0000-0000-000000000015";
+    const filteredRoot = "00000000-0000-0000-0000-000000000004";
+    const dotted = (root: string) =>
+      `20240101T000000000000Z${root}.20240101T000000000001Z${childId}`;
+
+    const updateWith = (dottedOrder: string) => {
+      const client = new Client({
+        apiKey: "test-api-key",
+        tracingSamplingRate: 0.5,
+      });
+      const filtered = (client as any)._filterForSampling([
+        { id: childId, dotted_order: dottedOrder, outputs: { a: 1 } },
+      ]);
+      return filtered.length;
+    };
+
+    it("recovers the trace from dotted_order when trace_id is absent", () => {
+      // Root sampled in -> the child's patch goes out with it.
+      expect(updateWith(dotted(sampledRoot))).toBe(1);
+      // Root filtered out -> no orphan patch.
+      expect(updateWith(dotted(filteredRoot))).toBe(0);
+    });
+
+    it("still falls back to the run id with neither trace_id nor dotted order", () => {
+      const client = new Client({
+        apiKey: "test-api-key",
+        tracingSamplingRate: 0.5,
+      });
+      expect(
+        (client as any)._filterForSampling([{ id: sampledRoot }]),
+      ).toHaveLength(1);
+      expect(
+        (client as any)._filterForSampling([{ id: filteredRoot }]),
+      ).toHaveLength(0);
     });
   });
 

--- a/js/src/tests/client.test.ts
+++ b/js/src/tests/client.test.ts
@@ -1262,27 +1262,29 @@ describe("Client", () => {
         (client as any)._filterForSampling([sampledCreate, filteredCreate]),
       ).toEqual([sampledCreate]);
       expect(
-        (client as any)._filterForSampling(
-          [sampledUpdate, filteredUpdate],
-          true,
-        ),
+        (client as any)._filterForSampling([sampledUpdate, filteredUpdate]),
       ).toEqual([sampledUpdate]);
       expect((client as any)._shouldSample(sampledRunId)).toBe(true);
       expect((client as any)._shouldSample(filteredRunId)).toBe(false);
     });
 
-    it("should use run ID rather than trace ID", () => {
+    it("should follow trace ID rather than run ID", () => {
       const client = new Client({
         apiKey: "test-api-key",
         tracingSamplingRate: 0.5,
       });
 
-      const sampledChild = run(sampledRunId, filteredRunId);
-      const filteredChild = run(filteredRunId, sampledRunId);
+      // Child's own id would be filtered, but its trace is sampled -> kept.
+      const childInSampledTrace = run(filteredRunId, sampledRunId);
+      // Child's own id would be sampled, but its trace is filtered -> dropped.
+      const childInFilteredTrace = run(sampledRunId, filteredRunId);
 
       expect(
-        (client as any)._filterForSampling([sampledChild, filteredChild]),
-      ).toEqual([sampledChild]);
+        (client as any)._filterForSampling([
+          childInSampledTrace,
+          childInFilteredTrace,
+        ]),
+      ).toEqual([childInSampledTrace]);
     });
   });
 

--- a/js/src/utils/sampling.ts
+++ b/js/src/utils/sampling.ts
@@ -1,0 +1,48 @@
+/**
+ * Deterministic trace sampling, kept consistent across LangSmith SDKs.
+ */
+
+const SAMPLING_HASH_MODULUS = 1_000_000n;
+const FNV_64_OFFSET_BASIS = 14_695_981_039_346_656_037n;
+const FNV_64_PRIME = 1_099_511_628_211n;
+const FNV_64_MASK = (1n << 64n) - 1n;
+
+/**
+ * Compute the 64-bit FNV-1a hash of a string.
+ *
+ * Implemented explicitly so the result matches other SDKs byte-for-byte,
+ * keeping sampling decisions consistent across SDKs.
+ */
+const fnv1a64 = (value: string): bigint => {
+  let hashValue = FNV_64_OFFSET_BASIS;
+  for (let i = 0; i < value.length; i += 1) {
+    hashValue ^= BigInt(value.charCodeAt(i));
+    hashValue = (hashValue * FNV_64_PRIME) & FNV_64_MASK;
+  }
+  return hashValue;
+};
+
+/**
+ * Decide whether `identifier` is sampled in at `samplingRate`.
+ *
+ * The decision is a pure function of the identifier, so every process and
+ * every SDK agrees on it, and a run's create and patch never disagree.
+ */
+export const isSampledById = (
+  identifier: string | null | undefined,
+  samplingRate: number | undefined
+): boolean => {
+  if (samplingRate === undefined || samplingRate >= 1) {
+    return true;
+  }
+  if (samplingRate <= 0) {
+    return false;
+  }
+  if (identifier === undefined || identifier === null) {
+    return true;
+  }
+  // The identifier is sampled in when its fraction of the modulus falls below
+  // the rate, which is also expressed in [0, 1).
+  const bucket = fnv1a64(identifier.toLowerCase()) % SAMPLING_HASH_MODULUS;
+  return Number(bucket) / Number(SAMPLING_HASH_MODULUS) < samplingRate;
+};

--- a/js/src/utils/sampling.ts
+++ b/js/src/utils/sampling.ts
@@ -2,25 +2,13 @@
  * Deterministic trace sampling, kept consistent across LangSmith SDKs.
  */
 
-const SAMPLING_HASH_MODULUS = 1_000_000n;
-const FNV_64_OFFSET_BASIS = 14_695_981_039_346_656_037n;
-const FNV_64_PRIME = 1_099_511_628_211n;
-const FNV_64_MASK = (1n << 64n) - 1n;
+import { XXH3_128 } from "./xxhash/xxhash.js";
 
-/**
- * Compute the 64-bit FNV-1a hash of a string.
- *
- * Implemented explicitly so the result matches other SDKs byte-for-byte,
- * keeping sampling decisions consistent across SDKs.
- */
-const fnv1a64 = (value: string): bigint => {
-  let hashValue = FNV_64_OFFSET_BASIS;
-  for (let i = 0; i < value.length; i += 1) {
-    hashValue ^= BigInt(value.charCodeAt(i));
-    hashValue = (hashValue * FNV_64_PRIME) & FNV_64_MASK;
-  }
-  return hashValue;
-};
+const SAMPLING_HASH_MODULUS = 1_000_000n;
+
+// Reused across calls: constructing a TextEncoder per hash costs more than the
+// hash itself.
+const encoder = new TextEncoder();
 
 /**
  * Decide whether `identifier` is sampled in at `samplingRate`.
@@ -30,7 +18,7 @@ const fnv1a64 = (value: string): bigint => {
  */
 export const isSampledById = (
   identifier: string | null | undefined,
-  samplingRate: number | undefined
+  samplingRate: number | undefined,
 ): boolean => {
   if (samplingRate === undefined || samplingRate >= 1) {
     return true;
@@ -41,8 +29,10 @@ export const isSampledById = (
   if (identifier === undefined || identifier === null) {
     return true;
   }
+  // XXH3-128 over the UTF-8 bytes, matching the Python SDK's `xxhash.xxh3_128`.
   // The identifier is sampled in when its fraction of the modulus falls below
   // the rate, which is also expressed in [0, 1).
-  const bucket = fnv1a64(identifier.toLowerCase()) % SAMPLING_HASH_MODULUS;
+  const bucket =
+    XXH3_128(encoder.encode(identifier.toLowerCase())) % SAMPLING_HASH_MODULUS;
   return Number(bucket) / Number(SAMPLING_HASH_MODULUS) < samplingRate;
 };

--- a/js/src/utils/sampling.ts
+++ b/js/src/utils/sampling.ts
@@ -26,7 +26,7 @@ export const isSampledById = (
   if (samplingRate <= 0) {
     return false;
   }
-  if (identifier === undefined || identifier === null) {
+  if (identifier == null) {
     return true;
   }
   // XXH3-128 over the UTF-8 bytes, matching the Python SDK's `xxhash.xxh3_128`.

--- a/python/langsmith/_internal/_sampling.py
+++ b/python/langsmith/_internal/_sampling.py
@@ -4,23 +4,9 @@ from __future__ import annotations
 
 from typing import Any, Optional
 
+import xxhash
+
 _SAMPLING_HASH_MODULUS = 1_000_000
-_FNV_64_OFFSET_BASIS = 14_695_981_039_346_656_037
-_FNV_64_PRIME = 1_099_511_628_211
-_FNV_64_MASK = (1 << 64) - 1
-
-
-def _fnv_1a_64(value: str) -> int:
-    """Compute the 64-bit FNV-1a hash of a string.
-
-    Implemented explicitly so the result matches other SDKs byte-for-byte,
-    keeping sampling decisions consistent across SDKs.
-    """
-    hash_value = _FNV_64_OFFSET_BASIS
-    for byte in value.encode("utf-8"):
-        hash_value ^= byte
-        hash_value = (hash_value * _FNV_64_PRIME) & _FNV_64_MASK
-    return hash_value
 
 
 def is_sampled_by_id(identifier: Any, sampling_rate: Optional[float]) -> bool:
@@ -35,7 +21,9 @@ def is_sampled_by_id(identifier: Any, sampling_rate: Optional[float]) -> bool:
         return False
     if identifier is None:
         return True
+    # XXH3-128 over the UTF-8 bytes, matching the JS SDK's vendored xxh3-ts.
     # The identifier is sampled in when its fraction of the modulus falls below
     # the rate, which is also expressed in [0, 1).
-    bucket = _fnv_1a_64(str(identifier).lower()) % _SAMPLING_HASH_MODULUS
+    digest = xxhash.xxh3_128(str(identifier).lower().encode("utf-8")).intdigest()
+    bucket = digest % _SAMPLING_HASH_MODULUS
     return bucket / _SAMPLING_HASH_MODULUS < sampling_rate

--- a/python/langsmith/_internal/_sampling.py
+++ b/python/langsmith/_internal/_sampling.py
@@ -1,0 +1,41 @@
+"""Deterministic trace sampling, kept consistent across LangSmith SDKs."""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+_SAMPLING_HASH_MODULUS = 1_000_000
+_FNV_64_OFFSET_BASIS = 14_695_981_039_346_656_037
+_FNV_64_PRIME = 1_099_511_628_211
+_FNV_64_MASK = (1 << 64) - 1
+
+
+def _fnv_1a_64(value: str) -> int:
+    """Compute the 64-bit FNV-1a hash of a string.
+
+    Implemented explicitly so the result matches other SDKs byte-for-byte,
+    keeping sampling decisions consistent across SDKs.
+    """
+    hash_value = _FNV_64_OFFSET_BASIS
+    for byte in value.encode("utf-8"):
+        hash_value ^= byte
+        hash_value = (hash_value * _FNV_64_PRIME) & _FNV_64_MASK
+    return hash_value
+
+
+def is_sampled_by_id(identifier: Any, sampling_rate: Optional[float]) -> bool:
+    """Decide whether `identifier` is sampled in at `sampling_rate`.
+
+    The decision is a pure function of the identifier, so every process and
+    every SDK agrees on it, and a run's create and patch never disagree.
+    """
+    if sampling_rate is None or sampling_rate >= 1:
+        return True
+    if sampling_rate <= 0:
+        return False
+    if identifier is None:
+        return True
+    # The identifier is sampled in when its fraction of the modulus falls below
+    # the rate, which is also expressed in [0, 1).
+    bucket = _fnv_1a_64(str(identifier).lower()) % _SAMPLING_HASH_MODULUS
+    return bucket / _SAMPLING_HASH_MODULUS < sampling_rate

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -697,6 +697,28 @@ def _get_tracing_sampling_rate(
     return sampling_rate
 
 
+_SAMPLING_HASH_MODULUS = 1_000_000
+_FNV_64_OFFSET_BASIS = 14_695_981_039_346_656_037
+_FNV_64_PRIME = 1_099_511_628_211
+_FNV_64_MASK = (1 << 64) - 1
+
+
+def _is_sampled_by_id(identifier: Any, sampling_rate: float | None) -> bool:
+    if sampling_rate is None or sampling_rate >= 1:
+        return True
+    if sampling_rate <= 0:
+        return False
+    if identifier is None:
+        return True
+    value = str(identifier).lower()
+    hash_value = _FNV_64_OFFSET_BASIS
+    for byte in value.encode("utf-8"):
+        hash_value ^= byte
+        hash_value = (hash_value * _FNV_64_PRIME) & _FNV_64_MASK
+    threshold = int(sampling_rate * _SAMPLING_HASH_MODULUS)
+    return hash_value % _SAMPLING_HASH_MODULUS < threshold
+
+
 def _get_write_api_urls(_write_api_urls: Optional[dict[str, str]]) -> dict[str, str]:
     # Note: LANGSMITH_RUNS_ENDPOINTS is now handled via replicas, not _write_api_urls
     _write_api_urls = _write_api_urls or {}
@@ -853,7 +875,6 @@ class Client:
         "_web_url",
         "_tenant_id",
         "tracing_sample_rate",
-        "_filtered_post_uuids",
         "tracing_queue",
         "_anonymizer",
         "_hide_inputs",
@@ -1155,7 +1176,6 @@ class Client:
         self._profile_auth_headers: dict[str, str] = {}
 
         self.tracing_sample_rate = _get_tracing_sampling_rate(tracing_sampling_rate)
-        self._filtered_post_uuids: set[uuid.UUID] = set()
         self._write_api_urls: Mapping[str, Optional[str]] = _get_write_api_urls(
             api_urls
         )
@@ -2299,10 +2319,8 @@ class Client:
                 {k: v for k, v in langchain_metadata.items() if k not in metadata}
             )
 
-    def _should_sample(self) -> bool:
-        if self.tracing_sample_rate is None:
-            return True
-        return random.random() < self.tracing_sample_rate
+    def _should_sample(self, identifier: Any = None) -> bool:
+        return _is_sampled_by_id(identifier, self.tracing_sample_rate)
 
     def _filter_for_sampling(
         self,
@@ -2321,34 +2339,7 @@ class Client:
                     return getattr(run, key)
                 return getattr(run, key, default)
 
-        if patch:
-            sampled = []
-            for run in runs:
-                trace_id = _as_uuid(_val(run, "trace_id"))
-                if trace_id not in self._filtered_post_uuids:
-                    sampled.append(run)
-                elif _val(run, "id") == trace_id:
-                    self._filtered_post_uuids.remove(trace_id)
-            return sampled
-        else:
-            sampled = []
-            for run in runs:
-                trace_id = _val(run, "trace_id", None) or _val(run, "id")
-
-                # If we've already made a decision about this trace, follow it
-                if trace_id in self._filtered_post_uuids:
-                    continue
-
-                # For new traces, apply sampling
-                if _val(run, "id") == trace_id:
-                    if self._should_sample():
-                        sampled.append(run)
-                    else:
-                        self._filtered_post_uuids.add(trace_id)
-                else:
-                    # Child runs follow their trace's sampling decision
-                    sampled.append(run)
-            return sampled
+        return [run for run in runs if self._should_sample(_val(run, "id", None))]
 
     @property
     def tracing_mode(self) -> TracingMode:
@@ -7842,6 +7833,9 @@ class Client:
                 error=error,
                 extend_trace_retention=extend_trace_retention,
             )
+
+            if feedback.run_id is not None and not self._should_sample(feedback.run_id):
+                return ls_schemas.Feedback(**feedback.model_dump())
 
             use_multipart = not self._multipart_disabled and (
                 self.info.batch_ingest_config or {}

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -795,6 +795,28 @@ def _get_tracing_sampling_rate(
     return sampling_rate
 
 
+_SAMPLING_HASH_MODULUS = 1_000_000
+_FNV_64_OFFSET_BASIS = 14_695_981_039_346_656_037
+_FNV_64_PRIME = 1_099_511_628_211
+_FNV_64_MASK = (1 << 64) - 1
+
+
+def _is_sampled_by_id(identifier: Any, sampling_rate: float | None) -> bool:
+    if sampling_rate is None or sampling_rate >= 1:
+        return True
+    if sampling_rate <= 0:
+        return False
+    if identifier is None:
+        return True
+    value = str(identifier).lower()
+    hash_value = _FNV_64_OFFSET_BASIS
+    for byte in value.encode("utf-8"):
+        hash_value ^= byte
+        hash_value = (hash_value * _FNV_64_PRIME) & _FNV_64_MASK
+    threshold = int(sampling_rate * _SAMPLING_HASH_MODULUS)
+    return hash_value % _SAMPLING_HASH_MODULUS < threshold
+
+
 def _get_write_api_urls(_write_api_urls: Optional[dict[str, str]]) -> dict[str, str]:
     # Note: LANGSMITH_RUNS_ENDPOINTS is now handled via replicas, not _write_api_urls
     _write_api_urls = _write_api_urls or {}
@@ -976,7 +998,6 @@ class Client:
         "_web_url",
         "_tenant_id",
         "tracing_sample_rate",
-        "_filtered_post_uuids",
         "tracing_queue",
         "_anonymizer",
         "_hide_inputs",
@@ -1288,7 +1309,6 @@ class Client:
         self._profile_auth_headers: dict[str, str] = {}
 
         self.tracing_sample_rate = _get_tracing_sampling_rate(tracing_sampling_rate)
-        self._filtered_post_uuids: set[uuid.UUID] = set()
         self._write_api_urls: Mapping[str, Optional[str]] = _get_write_api_urls(
             api_urls
         )
@@ -2484,10 +2504,8 @@ class Client:
             if added:
                 metadata.update(self._hide_run_metadata(added))
 
-    def _should_sample(self) -> bool:
-        if self.tracing_sample_rate is None:
-            return True
-        return random.random() < self.tracing_sample_rate
+    def _should_sample(self, identifier: Any = None) -> bool:
+        return _is_sampled_by_id(identifier, self.tracing_sample_rate)
 
     def _filter_for_sampling(
         self,
@@ -2506,34 +2524,7 @@ class Client:
                     return getattr(run, key)
                 return getattr(run, key, default)
 
-        if patch:
-            sampled = []
-            for run in runs:
-                trace_id = _as_uuid(_val(run, "trace_id"))
-                if trace_id not in self._filtered_post_uuids:
-                    sampled.append(run)
-                elif _val(run, "id") == trace_id:
-                    self._filtered_post_uuids.remove(trace_id)
-            return sampled
-        else:
-            sampled = []
-            for run in runs:
-                trace_id = _val(run, "trace_id", None) or _val(run, "id")
-
-                # If we've already made a decision about this trace, follow it
-                if trace_id in self._filtered_post_uuids:
-                    continue
-
-                # For new traces, apply sampling
-                if _val(run, "id") == trace_id:
-                    if self._should_sample():
-                        sampled.append(run)
-                    else:
-                        self._filtered_post_uuids.add(trace_id)
-                else:
-                    # Child runs follow their trace's sampling decision
-                    sampled.append(run)
-            return sampled
+        return [run for run in runs if self._should_sample(_val(run, "id", None))]
 
     @property
     def tracing_mode(self) -> TracingMode:
@@ -8378,6 +8369,9 @@ class Client:
                 error=error,
                 extend_trace_retention=extend_trace_retention,
             )
+
+            if feedback.run_id is not None and not self._should_sample(feedback.run_id):
+                return ls_schemas.Feedback(**feedback.model_dump())
 
             use_multipart = not self._multipart_disabled and (
                 self.info.batch_ingest_config or {}

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -2498,11 +2498,18 @@ class Client:
                     return getattr(run, key)
                 return getattr(run, key, default)
 
-        return [
-            run
-            for run in runs
-            if self._should_sample(_val(run, "trace_id", None) or _val(run, "id", None))
-        ]
+        def _sampling_key(run: Any) -> Any:
+            trace_id = _val(run, "trace_id", None)
+            if trace_id is not None:
+                return trace_id
+            # update_run() may omit trace_id; dotted order's first segment
+            # is the root.
+            dotted_order = _val(run, "dotted_order", None)
+            if dotted_order and "Z" in dotted_order:
+                return dotted_order.split(".", 1)[0].split("Z", 1)[1]
+            return _val(run, "id", None)
+
+        return [run for run in runs if self._should_sample(_sampling_key(run))]
 
     @property
     def tracing_mode(self) -> TracingMode:
@@ -3697,6 +3704,9 @@ class Client:
         **kwargs: Any,
     ) -> None:
         """Update a run in the LangSmith API.
+
+        Sampling keys on the run's trace: pass `trace_id` or `dotted_order` when
+        updating a child run, or its own ID is hashed and may disagree.
 
         Args:
             run_id (Union[UUID, str]): The ID of the run to update.
@@ -8047,7 +8057,12 @@ class Client:
                 feedback_source_type=ls_schemas.FeedbackSourceType.MODEL,
                 project_id=project_id if run is None else None,
                 extra=res.extra,
-                trace_id=getattr(run, "trace_id", None) if run else None,
+                # A target_run_id may name a run in another trace.
+                trace_id=(
+                    getattr(run, "trace_id", None)
+                    if run is not None and run_id_ == run.id
+                    else None
+                ),
                 session_id=run_session_id or project_id,
                 start_time=run.start_time if run else None,
                 error=error,
@@ -8348,7 +8363,8 @@ class Client:
                 extend_trace_retention=extend_trace_retention,
             )
 
-            if feedback.run_id is not None and not self._should_sample(feedback.run_id):
+            sampling_id = feedback.trace_id or feedback.run_id
+            if sampling_id is not None and not self._should_sample(sampling_id):
                 return ls_schemas.Feedback(**feedback.model_dump())
 
             use_multipart = not self._multipart_disabled and (

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -114,6 +114,7 @@ from langsmith._internal._operations import (
     serialized_feedback_operation_to_multipart_parts_and_context,
     serialized_run_operation_to_multipart_parts_and_context,
 )
+from langsmith._internal._sampling import is_sampled_by_id
 from langsmith._internal._serde import dumps_json as _dumps_json
 from langsmith._internal._uuid import uuid7
 from langsmith._internal._v2_migration_utils import QueryBackend, get_query_backend
@@ -793,28 +794,6 @@ def _get_tracing_sampling_rate(
             f" Got: {sampling_rate}"
         )
     return sampling_rate
-
-
-_SAMPLING_HASH_MODULUS = 1_000_000
-_FNV_64_OFFSET_BASIS = 14_695_981_039_346_656_037
-_FNV_64_PRIME = 1_099_511_628_211
-_FNV_64_MASK = (1 << 64) - 1
-
-
-def _is_sampled_by_id(identifier: Any, sampling_rate: float | None) -> bool:
-    if sampling_rate is None or sampling_rate >= 1:
-        return True
-    if sampling_rate <= 0:
-        return False
-    if identifier is None:
-        return True
-    value = str(identifier).lower()
-    hash_value = _FNV_64_OFFSET_BASIS
-    for byte in value.encode("utf-8"):
-        hash_value ^= byte
-        hash_value = (hash_value * _FNV_64_PRIME) & _FNV_64_MASK
-    threshold = int(sampling_rate * _SAMPLING_HASH_MODULUS)
-    return hash_value % _SAMPLING_HASH_MODULUS < threshold
 
 
 def _get_write_api_urls(_write_api_urls: Optional[dict[str, str]]) -> dict[str, str]:
@@ -2505,17 +2484,12 @@ class Client:
                 metadata.update(self._hide_run_metadata(added))
 
     def _should_sample(self, identifier: Any = None) -> bool:
-        return _is_sampled_by_id(identifier, self.tracing_sample_rate)
+        return is_sampled_by_id(identifier, self.tracing_sample_rate)
 
     def _filter_for_sampling(
         self,
         runs: Iterable[Union[dict, ls_schemas.Run, ls_schemas.RunLikeDict]],
-        *,
-        patch: bool = False,
     ) -> list:
-        if self.tracing_sample_rate is None:
-            return list(runs)
-
         def _val(run: Any, key: str, default: Any = _UNSET) -> Any:
             try:
                 return run[key]
@@ -2524,7 +2498,11 @@ class Client:
                     return getattr(run, key)
                 return getattr(run, key, default)
 
-        return [run for run in runs if self._should_sample(_val(run, "id", None))]
+        return [
+            run
+            for run in runs
+            if self._should_sample(_val(run, "trace_id", None) or _val(run, "id", None))
+        ]
 
     @property
     def tracing_mode(self) -> TracingMode:
@@ -3164,7 +3142,7 @@ class Client:
             return
         # filter out runs that are not sampled
         create = self._filter_for_sampling(create or EMPTY_SEQ)
-        update = self._filter_for_sampling(update or EMPTY_SEQ, patch=True)
+        update = self._filter_for_sampling(update or EMPTY_SEQ)
         if not create and not update:
             return
         # transform and convert to dicts
@@ -3433,7 +3411,7 @@ class Client:
             return
         # filter out runs that are not sampled
         create = self._filter_for_sampling(create or EMPTY_SEQ)
-        update = self._filter_for_sampling(update or EMPTY_SEQ, patch=True)
+        update = self._filter_for_sampling(update or EMPTY_SEQ)
         if not create and not update:
             return
         # transform and convert to dicts
@@ -3802,7 +3780,7 @@ class Client:
             and data["trace_id"] is not None
             and data["dotted_order"] is not None
         )
-        if not self._filter_for_sampling([data], patch=True):
+        if not self._filter_for_sampling([data]):
             return
         if end_time is not None:
             data["end_time"] = end_time.isoformat()

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -8057,7 +8057,8 @@ class Client:
                 feedback_source_type=ls_schemas.FeedbackSourceType.MODEL,
                 project_id=project_id if run is None else None,
                 extra=res.extra,
-                # A target_run_id may name a run in another trace.
+                # If an evaluator result targets a different run, we can't
+                # guarantee to know its trace_id.
                 trace_id=(
                     getattr(run, "trace_id", None)
                     if run is not None and run_id_ == run.id

--- a/python/langsmith/utils.py
+++ b/python/langsmith/utils.py
@@ -795,6 +795,7 @@ class ContextThreadPoolExecutor(ThreadPoolExecutor):
         *iterables: Iterable[Any],
         timeout: Optional[float] = None,
         chunksize: int = 1,
+        buffersize: Optional[int] = None,
     ) -> Iterator[T]:
         """Return an iterator equivalent to stdlib map.
 
@@ -809,6 +810,8 @@ class ContextThreadPoolExecutor(ThreadPoolExecutor):
                 before being passed to a child process. This argument is only
                 used by ProcessPoolExecutor; it is ignored by
                 ThreadPoolExecutor.
+            buffersize: The number of submitted tasks whose results have not
+                yet been yielded.
 
         Returns:
             An iterator equivalent to: map(func, *iterables) but the calls may
@@ -824,11 +827,13 @@ class ContextThreadPoolExecutor(ThreadPoolExecutor):
         def _wrapped_fn(*args: Any) -> T:
             return contexts.pop().run(fn, *args)
 
+        kwargs: dict[str, Any] = {"timeout": timeout, "chunksize": chunksize}
+        if sys.version_info >= (3, 14):
+            kwargs["buffersize"] = buffersize
         return super().map(
             _wrapped_fn,
             *iterables,
-            timeout=timeout,
-            chunksize=chunksize,
+            **kwargs,
         )
 
 

--- a/python/tests/unit_tests/test_client.py
+++ b/python/tests/unit_tests/test_client.py
@@ -2389,428 +2389,144 @@ def test_batch_ingest_run_splits_large_batches(
         assert len(request_bodies) == len(set([body["id"] for body in request_bodies]))
 
 
+SAMPLED_RUN_ID = uuid.UUID("00000000-0000-0000-0000-000000000001")
+FILTERED_RUN_ID = uuid.UUID("00000000-0000-0000-0000-000000000002")
+
+
+def _sampling_run(run_id: uuid.UUID, trace_id: Optional[uuid.UUID] = None) -> dict:
+    return {
+        "id": run_id,
+        "trace_id": trace_id or run_id,
+        "name": f"run-{run_id}",
+        "run_type": "llm",
+        "inputs": {"text": str(run_id)},
+        "dotted_order": f"20210101T000000000000Z{trace_id or run_id}",
+        "start_time": "2021-01-01T00:00:00Z",
+    }
+
+
 def test_sampling_and_batching():
-    """Test that sampling and batching work correctly."""
-    # Setup mock client
+    """Test that sampling and batching filter runs by stable run ID."""
     mock_session = MagicMock()
     mock_response = MagicMock()
     mock_response.status_code = 200
     mock_session.request.return_value = mock_response
 
-    counter = 0
+    client = Client(
+        api_key="test-api-key",
+        auto_batch_tracing=True,
+        tracing_sampling_rate=0.5,
+        session=mock_session,
+    )
 
-    def mock_should_sample():
-        nonlocal counter
-        counter += 1
-        return counter % 2 != 0
+    client.create_run(**_sampling_run(SAMPLED_RUN_ID, trace_id=SAMPLED_RUN_ID))
+    client.create_run(**_sampling_run(FILTERED_RUN_ID, trace_id=FILTERED_RUN_ID))
+    client.flush()
 
-    with patch(
-        "langsmith.client.Client._should_sample", side_effect=mock_should_sample
-    ):
-        client = Client(
-            api_key="test-api-key",
-            auto_batch_tracing=True,
-            tracing_sampling_rate=0.5,
-            session=mock_session,
+    post_calls = [
+        call
+        for call in mock_session.request.mock_calls
+        if call.args
+        and call.args[0] == "POST"
+        and call.args[1].endswith("/runs/multipart")
+    ]
+    assert len(post_calls) == 1
+    data = post_calls[0].kwargs["data"]
+    if isinstance(data, bytes):
+        data = data.decode("utf-8")
+    batch_data = parse_request_data(data)
+    assert [post["id"] for post in batch_data.get("post", [])] == [str(SAMPLED_RUN_ID)]
+
+
+def test_run_sampling_is_consistent_for_create_and_update():
+    client = Client(api_key="test-api-key", tracing_sampling_rate=0.5)
+
+    sampled_create = _sampling_run(SAMPLED_RUN_ID)
+    filtered_create = _sampling_run(FILTERED_RUN_ID)
+    sampled_update = {**sampled_create, "outputs": {"result": "sampled"}}
+    filtered_update = {**filtered_create, "outputs": {"result": "filtered"}}
+
+    assert client._filter_for_sampling([sampled_create, filtered_create]) == [
+        sampled_create
+    ]
+    assert client._filter_for_sampling(
+        [sampled_update, filtered_update], patch=True
+    ) == [sampled_update]
+    assert client._should_sample(SAMPLED_RUN_ID)
+    assert not client._should_sample(FILTERED_RUN_ID)
+
+
+def test_sampling_uses_run_id_not_trace_id():
+    client = Client(api_key="test-api-key", tracing_sampling_rate=0.5)
+
+    sampled_child = _sampling_run(SAMPLED_RUN_ID, trace_id=FILTERED_RUN_ID)
+    filtered_child = _sampling_run(FILTERED_RUN_ID, trace_id=SAMPLED_RUN_ID)
+
+    assert client._filter_for_sampling([sampled_child, filtered_child]) == [
+        sampled_child
+    ]
+
+
+def test_feedback_sampling_follows_run_id():
+    client = Client(api_key="test-api-key", tracing_sampling_rate=0.5)
+    client._info = ls_schemas.LangSmithInfo()
+
+    with patch.object(Client, "request_with_retries") as mock_request:
+        sampled_feedback = client.create_feedback(
+            run_id=SAMPLED_RUN_ID,
+            key="correctness",
+            score=1,
         )
+        assert sampled_feedback.run_id == SAMPLED_RUN_ID
+        mock_request.assert_called_once()
 
-        project_name = "__test_batch"
-
-        # Create parent runs
-        run_params = []
-        for i in range(4):
-            run_id = uuid.uuid4()
-            params = {
-                "id": run_id,
-                "project_name": project_name,
-                "name": f"test_run {i}",
-                "run_type": "llm",
-                "inputs": {"text": f"hello world {i}"},
-                "dotted_order": "foo",
-                "trace_id": run_id,
-            }
-            client.create_run(**params)
-            run_params.append(params)
-
-
-def test_patch_sampling_follows_trace_logic():
-    """Test that patch runs correctly follow post logic by checking trace_id instead of run.id."""
-    mock_session = MagicMock()
-    mock_response = MagicMock()
-    mock_response.status_code = 200
-    mock_session.request.return_value = mock_response
-
-    # Mock sampling to reject first trace, accept second trace
-    counter = 0
-
-    def mock_should_sample():
-        nonlocal counter
-        counter += 1
-        return counter % 2 == 0  # Accept even-numbered calls (2nd, 4th, etc.)
-
-    with patch(
-        "langsmith.client.Client._should_sample", side_effect=mock_should_sample
-    ):
-        client = Client(
-            api_key="test-api-key",
-            tracing_sampling_rate=0.5,
-            session=mock_session,
+    with patch.object(Client, "request_with_retries") as mock_request:
+        filtered_feedback = client.create_feedback(
+            run_id=FILTERED_RUN_ID,
+            key="correctness",
+            score=0,
         )
-
-        # Create two traces
-        trace_id_1 = uuid.uuid4()
-        trace_id_2 = uuid.uuid4()
-        child_run_id_1 = uuid.uuid4()
-        child_run_id_2 = uuid.uuid4()
-
-        # Create root runs (these will be sampled)
-        root_run_1 = {
-            "id": trace_id_1,
-            "trace_id": trace_id_1,
-            "name": "root_run_1",
-            "run_type": "llm",
-            "inputs": {"text": "hello"},
-        }
-        root_run_2 = {
-            "id": trace_id_2,
-            "trace_id": trace_id_2,
-            "name": "root_run_2",
-            "run_type": "llm",
-            "inputs": {"text": "world"},
-        }
-
-        # Create child runs
-        child_run_1 = {
-            "id": child_run_id_1,
-            "trace_id": trace_id_1,
-            "name": "child_run_1",
-            "run_type": "tool",
-            "inputs": {"text": "child hello"},
-        }
-        child_run_2 = {
-            "id": child_run_id_2,
-            "trace_id": trace_id_2,
-            "name": "child_run_2",
-            "run_type": "tool",
-            "inputs": {"text": "child world"},
-        }
-
-        # Test POST filtering (initial sampling)
-        post_filtered = client._filter_for_sampling(
-            [root_run_1, root_run_2], patch=False
-        )
-
-        # Based on our mock, first call returns False, second returns True
-        # So only root_run_2 should be sampled
-        assert len(post_filtered) == 1
-        assert post_filtered[0]["id"] == trace_id_2
-
-        # Verify that trace_id_1 is in filtered set, trace_id_2 is not
-        assert trace_id_1 in client._filtered_post_uuids
-        assert trace_id_2 not in client._filtered_post_uuids
-
-        # Test PATCH filtering - child runs should follow their trace's sampling decision
-        patch_runs = [
-            {**child_run_1, "outputs": {"result": "child result 1"}},
-            {**child_run_2, "outputs": {"result": "child result 2"}},
-        ]
-
-        patch_filtered = client._filter_for_sampling(patch_runs, patch=True)
-
-        # Only child_run_2 should be included (its trace was sampled)
-        # child_run_1 should be filtered out (its trace was not sampled)
-        assert len(patch_filtered) == 1
-        assert patch_filtered[0]["id"] == child_run_id_2
-        assert patch_filtered[0]["trace_id"] == trace_id_2
-
-        # Test PATCH filtering for root runs (updates to the root runs themselves)
-        root_patch_runs = [
-            {**root_run_1, "outputs": {"result": "root result 1"}},
-            {**root_run_2, "outputs": {"result": "root result 2"}},
-        ]
-
-        root_patch_filtered = client._filter_for_sampling(root_patch_runs, patch=True)
-
-        # Only root_run_2 should be included, and trace_id_1 should be removed from filtered set
-        # since we're updating the root run that was originally filtered
-        assert len(root_patch_filtered) == 1
-        assert root_patch_filtered[0]["id"] == trace_id_2
-
-        # trace_id_1 should be removed from filtered set since we processed its root run
-        assert trace_id_1 not in client._filtered_post_uuids
-        assert (
-            trace_id_2 not in client._filtered_post_uuids
-        )  # Still not in filtered set
-
-
-def test_patch_sampling_mixed_traces():
-    """Test patch sampling with a mix of sampled and unsampled traces."""
-    mock_session = MagicMock()
-    mock_response = MagicMock()
-    mock_response.status_code = 200
-    mock_session.request.return_value = mock_response
-
-    # Mock sampling to accept every other trace
-    counter = 0
-
-    def mock_should_sample():
-        nonlocal counter
-        counter += 1
-        return counter % 2 == 1  # Accept odd-numbered calls (1st, 3rd, etc.)
-
-    with patch(
-        "langsmith.client.Client._should_sample", side_effect=mock_should_sample
-    ):
-        client = Client(
-            api_key="test-api-key",
-            tracing_sampling_rate=0.5,
-            session=mock_session,
-        )
-
-        # Create multiple traces
-        trace_ids = [uuid.uuid4() for _ in range(4)]
-        child_run_ids = [uuid.uuid4() for _ in range(4)]
-
-        # Create root runs
-        root_runs = []
-        for i, trace_id in enumerate(trace_ids):
-            root_runs.append(
-                {
-                    "id": trace_id,
-                    "trace_id": trace_id,
-                    "name": f"root_run_{i}",
-                    "run_type": "llm",
-                    "inputs": {"text": f"hello {i}"},
-                }
-            )
-
-        # Sample the root runs
-        post_filtered = client._filter_for_sampling(root_runs, patch=False)
-
-        # Based on our mock: 1st and 3rd calls return True (indices 0, 2)
-        assert len(post_filtered) == 2
-        sampled_trace_ids = {run["id"] for run in post_filtered}
-        assert trace_ids[0] in sampled_trace_ids
-        assert trace_ids[2] in sampled_trace_ids
-
-        # Create child runs for all traces
-        child_runs = []
-        for i, (trace_id, child_id) in enumerate(zip(trace_ids, child_run_ids)):
-            child_runs.append(
-                {
-                    "id": child_id,
-                    "trace_id": trace_id,
-                    "name": f"child_run_{i}",
-                    "run_type": "tool",
-                    "inputs": {"text": f"child {i}"},
-                    "outputs": {"result": f"child result {i}"},
-                }
-            )
-
-        # Test patch filtering for child runs
-        patch_filtered = client._filter_for_sampling(child_runs, patch=True)
-
-        # Only children of sampled traces should be included
-        assert len(patch_filtered) == 2
-        patch_trace_ids = {run["trace_id"] for run in patch_filtered}
-        assert trace_ids[0] in patch_trace_ids
-        assert trace_ids[2] in patch_trace_ids
-        assert trace_ids[1] not in patch_trace_ids
-        assert trace_ids[3] not in patch_trace_ids
-
-
-def test_original_sampling_and_batching():
-    """Test that sampling and batching work correctly (continuation of original test)."""
-    # Setup mock client
-    mock_session = MagicMock()
-    mock_response = MagicMock()
-    mock_response.status_code = 200
-    mock_session.request.return_value = mock_response
-
-    counter = 0
-
-    def mock_should_sample():
-        nonlocal counter
-        counter += 1
-        return counter % 2 != 0
-
-    with patch(
-        "langsmith.client.Client._should_sample", side_effect=mock_should_sample
-    ):
-        client = Client(
-            api_key="test-api-key",
-            auto_batch_tracing=True,
-            tracing_sampling_rate=0.5,
-            session=mock_session,
-        )
-
-        project_name = "__test_batch"
-
-        # Create parent runs
-        run_params = []
-        for i in range(4):
-            run_id = uuid.uuid4()
-            params = {
-                "id": run_id,
-                "project_name": project_name,
-                "name": f"test_run {i}",
-                "run_type": "llm",
-                "inputs": {"text": f"hello world {i}"},
-                "dotted_order": "foo",
-                "trace_id": run_id,
-            }
-            client.create_run(**params)
-            run_params.append(params)
-
-        client.flush()
-
-        # Create child runs and update parent runs
-        child_run_params = []
-        for i, run_param in enumerate(run_params):
-            child_run_id = uuid.uuid4()
-            child_params = {
-                "id": child_run_id,
-                "project_name": project_name,
-                "name": f"test_child_run {i}",
-                "run_type": "llm",
-                "inputs": {"text": f"child world {i}"},
-                "dotted_order": "foo",
-                "trace_id": run_param["id"],
-            }
-            client.create_run(**child_params)
-            child_run_params.append(child_params)
-
-        client.flush()
-
-        # Verify all requests
-        post_calls = [
-            call
-            for call in mock_session.request.mock_calls
-            if call.args and call.args[0] == "POST"
-        ]
-        assert len(post_calls) >= 2
-
-        # Verify that only odd-numbered runs were sampled (due to our counter logic)
-        assert post_calls[0].args[1].endswith("/runs/multipart")
-        assert post_calls[1].args[1].endswith("/runs/multipart")
-
-        data = post_calls[0].kwargs["data"]
-        if isinstance(data, bytes):
-            data = data.decode("utf-8")
-        batch_data = parse_request_data(data)
-
-        # Verify posts only contain odd-numbered runs
-        assert len(batch_data.get("post", [])) == 2
-        for post in batch_data.get("post", []):
-            assert "text" in post["inputs"]
-            if "hello world" in post["inputs"]["text"]:
-                i = int(post["inputs"]["text"].split()[-1])
-                assert i % 2 == 0
-            elif "child world" in post["inputs"]["text"]:
-                i = int(post["inputs"]["text"].split()[-1])
-                assert i % 2 == 0
-
-        data = post_calls[1].kwargs["data"]
-        if isinstance(data, bytes):
-            data = data.decode("utf-8")
-        batch_data = parse_request_data(data)
-        assert len(batch_data.get("post", [])) == 2
-        for p in batch_data.get("post", []):
-            run_id = p["id"]
-            original_run = next((r for r in run_params if str(r["id"]) == run_id), None)
-            if original_run:
-                i = int(original_run["name"].split()[-1])
-                assert i % 2 == 0
+        assert filtered_feedback.run_id == FILTERED_RUN_ID
+        mock_request.assert_not_called()
 
 
 @pytest.mark.parametrize("method", ["batch_ingest_runs", "multipart_ingest"])
 def test_sampling_before_transform_in_batch_and_multipart(method: str):
-    """Verify that _run_transform is only called for runs that survive sampling.
-
-    When sampling is enabled, runs filtered out should never be transformed
-    (i.e., _run_transform should not be called for them).
-    """
+    """Verify that _run_transform is only called for runs that survive sampling."""
     mock_session = MagicMock()
     mock_response = MagicMock()
     mock_response.status_code = 200
     mock_session.request.return_value = mock_response
 
-    sample_count = 0
+    client = Client(
+        api_key="test-api-key",
+        tracing_sampling_rate=0.5,
+        session=mock_session,
+    )
 
-    def mock_should_sample():
-        nonlocal sample_count
-        sample_count += 1
-        return sample_count % 2 == 1  # Accept 1st, reject 2nd
+    creates = [_sampling_run(SAMPLED_RUN_ID), _sampling_run(FILTERED_RUN_ID)]
+    updates = [
+        {**_sampling_run(SAMPLED_RUN_ID), "outputs": {"result": "sampled output"}},
+        {**_sampling_run(FILTERED_RUN_ID), "outputs": {"result": "filtered output"}},
+    ]
 
-    with patch(
-        "langsmith.client.Client._should_sample", side_effect=mock_should_sample
-    ):
-        client = Client(
-            api_key="test-api-key",
-            tracing_sampling_rate=0.5,
-            session=mock_session,
-        )
+    original_run_transform = Client._run_transform
+    transformed_ids: list[uuid.UUID] = []
 
-        sampled_trace_id = uuid.uuid4()
-        filtered_trace_id = uuid.uuid4()
+    def tracking_transform(self, run, **kwargs):
+        result = original_run_transform(self, run, **kwargs)
+        transformed_ids.append(result["id"])
+        return result
 
-        creates = [
-            {
-                "id": sampled_trace_id,
-                "trace_id": sampled_trace_id,
-                "dotted_order": f"20210101T000000000000Z{sampled_trace_id}",
-                "name": "sampled_root",
-                "run_type": "llm",
-                "inputs": {"text": "sampled"},
-                "start_time": "2021-01-01T00:00:00Z",
-            },
-            {
-                "id": filtered_trace_id,
-                "trace_id": filtered_trace_id,
-                "dotted_order": f"20210101T000000000000Z{filtered_trace_id}",
-                "name": "filtered_root",
-                "run_type": "llm",
-                "inputs": {"text": "filtered"},
-                "start_time": "2021-01-01T00:00:00Z",
-            },
-        ]
+    with patch.object(Client, "_run_transform", tracking_transform):
+        fn = getattr(client, method)
+        fn(create=creates, update=updates)
 
-        updates = [
-            {
-                "id": sampled_trace_id,
-                "trace_id": sampled_trace_id,
-                "dotted_order": f"20210101T000000000000Z{sampled_trace_id}",
-                "outputs": {"result": "sampled output"},
-                "end_time": "2021-01-01T00:00:01Z",
-            },
-            {
-                "id": filtered_trace_id,
-                "trace_id": filtered_trace_id,
-                "dotted_order": f"20210101T000000000000Z{filtered_trace_id}",
-                "outputs": {"result": "filtered output"},
-                "end_time": "2021-01-01T00:00:01Z",
-            },
-        ]
-
-        original_run_transform = Client._run_transform
-        transformed_ids: list[uuid.UUID] = []
-
-        def tracking_transform(self, run, **kwargs):
-            result = original_run_transform(self, run, **kwargs)
-            transformed_ids.append(result["id"])
-            return result
-
-        with patch.object(Client, "_run_transform", tracking_transform):
-            fn = getattr(client, method)
-            fn(create=creates, update=updates)
-
-        # Only the sampled trace should have been transformed
-        assert sampled_trace_id in transformed_ids
-        assert filtered_trace_id not in transformed_ids, (
-            f"{method} called _run_transform on a filtered-out run"
-        )
-        # The sampled trace should appear twice (once for create, once for update)
-        assert transformed_ids.count(sampled_trace_id) == 2
+    assert SAMPLED_RUN_ID in transformed_ids
+    assert FILTERED_RUN_ID not in transformed_ids, (
+        f"{method} called _run_transform on a filtered-out run"
+    )
+    assert transformed_ids.count(SAMPLED_RUN_ID) == 2
 
 
 @mock.patch("langsmith.client.requests.Session")

--- a/python/tests/unit_tests/test_client.py
+++ b/python/tests/unit_tests/test_client.py
@@ -3007,6 +3007,88 @@ def test_feedback_sampling_follows_run_id():
         mock_request.assert_not_called()
 
 
+def test_evaluation_feedback_forwards_trace_id_only_for_its_own_run():
+    client = Client(api_key="test-api-key")
+    run = ls_schemas.Run(
+        id=uuid.uuid4(),
+        trace_id=uuid.uuid4(),
+        name="target",
+        run_type="chain",
+        start_time=datetime(2024, 1, 1, tzinfo=timezone.utc),
+    )
+
+    with patch.object(Client, "create_feedback") as mock_create:
+        # Scoring the run itself: its trace is known, so it is forwarded.
+        client._log_evaluation_feedback({"key": "quality", "score": 1}, run=run)
+        assert mock_create.call_args.kwargs["trace_id"] == run.trace_id
+
+    with patch.object(Client, "create_feedback") as mock_create:
+        # target_run_id names a different run, whose trace we cannot know from
+        # `run`. Sampling must fall back to the run id rather than guess.
+        other_id = uuid.uuid4()
+        client._log_evaluation_feedback(
+            {"key": "quality", "score": 1, "target_run_id": other_id}, run=run
+        )
+        assert mock_create.call_args.kwargs["run_id"] == other_id
+        assert mock_create.call_args.kwargs["trace_id"] is None
+
+
+def test_update_sampling_recovers_trace_from_dotted_order():
+    client = Client(api_key="test-api-key", tracing_sampling_rate=0.5)
+    client._info = ls_schemas.LangSmithInfo()
+    # A child whose own id would be filtered out if hashed on its own.
+    child_id = FILTERED_RUN_ID
+
+    def _dotted(root: uuid.UUID) -> str:
+        return f"20240101T000000000000Z{root}.20240101T000000000001Z{child_id}"
+
+    # Root sampled in -> the child's patch goes out with it.
+    with patch.object(Client, "request_with_retries") as mock_request:
+        client.update_run(
+            child_id,
+            trace_id=None,
+            dotted_order=_dotted(SAMPLED_RUN_ID),
+            outputs={"a": 1},
+        )
+        mock_request.assert_called_once()
+
+    # Root filtered out -> no orphan patch.
+    with patch.object(Client, "request_with_retries") as mock_request:
+        client.update_run(
+            child_id,
+            trace_id=None,
+            dotted_order=_dotted(FILTERED_RUN_ID),
+            outputs={"a": 1},
+        )
+        mock_request.assert_not_called()
+
+
+def test_feedback_sampling_follows_trace_id_not_run_id():
+    client = Client(api_key="test-api-key", tracing_sampling_rate=0.5)
+    client._info = ls_schemas.LangSmithInfo()
+    child_id = uuid.uuid4()
+
+    # The child's own id is irrelevant: its trace was sampled in.
+    with patch.object(Client, "request_with_retries") as mock_request:
+        client.create_feedback(
+            run_id=child_id,
+            trace_id=SAMPLED_RUN_ID,
+            key="correctness",
+            score=1,
+        )
+        mock_request.assert_called_once()
+
+    # Same child, filtered trace -> nothing sent.
+    with patch.object(Client, "request_with_retries") as mock_request:
+        client.create_feedback(
+            run_id=child_id,
+            trace_id=FILTERED_RUN_ID,
+            key="correctness",
+            score=0,
+        )
+        mock_request.assert_not_called()
+
+
 @pytest.mark.parametrize("method", ["batch_ingest_runs", "multipart_ingest"])
 def test_sampling_before_transform_in_batch_and_multipart(method: str):
     """Verify that _run_transform is only called for runs that survive sampling."""

--- a/python/tests/unit_tests/test_client.py
+++ b/python/tests/unit_tests/test_client.py
@@ -2920,22 +2920,24 @@ def test_run_sampling_is_consistent_for_create_and_update():
     assert client._filter_for_sampling([sampled_create, filtered_create]) == [
         sampled_create
     ]
-    assert client._filter_for_sampling(
-        [sampled_update, filtered_update], patch=True
-    ) == [sampled_update]
+    assert client._filter_for_sampling([sampled_update, filtered_update]) == [
+        sampled_update
+    ]
     assert client._should_sample(SAMPLED_RUN_ID)
     assert not client._should_sample(FILTERED_RUN_ID)
 
 
-def test_sampling_uses_run_id_not_trace_id():
+def test_sampling_follows_trace_id_not_run_id():
     client = Client(api_key="test-api-key", tracing_sampling_rate=0.5)
 
-    sampled_child = _sampling_run(SAMPLED_RUN_ID, trace_id=FILTERED_RUN_ID)
-    filtered_child = _sampling_run(FILTERED_RUN_ID, trace_id=SAMPLED_RUN_ID)
+    # Child's own id would be filtered, but its trace is sampled -> kept.
+    child_in_sampled_trace = _sampling_run(FILTERED_RUN_ID, trace_id=SAMPLED_RUN_ID)
+    # Child's own id would be sampled, but its trace is filtered -> dropped.
+    child_in_filtered_trace = _sampling_run(SAMPLED_RUN_ID, trace_id=FILTERED_RUN_ID)
 
-    assert client._filter_for_sampling([sampled_child, filtered_child]) == [
-        sampled_child
-    ]
+    assert client._filter_for_sampling(
+        [child_in_sampled_trace, child_in_filtered_trace]
+    ) == [child_in_sampled_trace]
 
 
 def test_feedback_sampling_follows_run_id():

--- a/python/tests/unit_tests/test_client.py
+++ b/python/tests/unit_tests/test_client.py
@@ -53,6 +53,7 @@ from langsmith._internal._beta_decorator import (
     suppress_deprecation_warning as _suppress_deprecation_warning,
 )
 from langsmith._internal._multipart import MultipartPartsAndContext
+from langsmith._internal._sampling import is_sampled_by_id
 from langsmith._internal._serde import _serialize_json
 from langsmith.anonymizer import SECRET_PLACEHOLDER, create_secret_anonymizer
 from langsmith.client import (
@@ -2860,8 +2861,10 @@ def test_batch_ingest_run_splits_large_batches(
         assert len(request_bodies) == len(set([body["id"] for body in request_bodies]))
 
 
-SAMPLED_RUN_ID = uuid.UUID("00000000-0000-0000-0000-000000000001")
-FILTERED_RUN_ID = uuid.UUID("00000000-0000-0000-0000-000000000002")
+# Buckets under XXH3-128 % 1_000_000: 10679 and 982794, so these stay on
+# opposite sides of the threshold for any rate between 0.02 and 0.98.
+SAMPLED_RUN_ID = uuid.UUID("00000000-0000-0000-0000-000000000015")
+FILTERED_RUN_ID = uuid.UUID("00000000-0000-0000-0000-000000000004")
 
 
 def _sampling_run(run_id: uuid.UUID, trace_id: Optional[uuid.UUID] = None) -> dict:
@@ -2907,6 +2910,47 @@ def test_sampling_and_batching():
         data = data.decode("utf-8")
     batch_data = parse_request_data(data)
     assert [post["id"] for post in batch_data.get("post", [])] == [str(SAMPLED_RUN_ID)]
+
+
+# Golden decisions at rate 0.5. The JS SDK asserts this exact table in
+# js/src/tests/client.test.ts: both must agree, or a trace sampled in by one
+# SDK is dropped by the other. Regenerate both sides together, never one.
+CROSS_SDK_SAMPLING_AT_HALF = [
+    ("00000000-0000-0000-0000-000000000001", False),
+    ("00000000-0000-0000-0000-000000000004", False),
+    ("00000000-0000-0000-0000-000000000015", True),
+    ("0198f8a0-1234-7000-8000-000000000042", False),
+    ("b3d2c1a0-5f6e-7d8c-9b0a-1e2f3d4c5b6a", False),
+    ("abc", True),
+    ("", False),
+    ("trace-1", True),
+    ("trace-2", False),
+    # Non-ASCII pins the UTF-8 encoding: a UTF-16 implementation diverges here.
+    ("\u00fcn\u00efc\u00f8d\u00e9-trace", False),
+    ("\u65e5\u672c\u8a9e", False),
+    # Case folding happens before hashing.
+    ("MiXeD-CaSe-ID", True),
+]
+
+
+@pytest.mark.parametrize(("identifier", "expected"), CROSS_SDK_SAMPLING_AT_HALF)
+def test_sampling_matches_js_sdk(identifier: str, expected: bool):
+    assert is_sampled_by_id(identifier, 0.5) is expected
+
+
+def test_sampling_rate_bounds_skip_hashing():
+    # None/>=1 keep everything, <=0 drops everything, whatever the identifier.
+    for identifier in ("anything", "", None):
+        assert is_sampled_by_id(identifier, None) is True
+        assert is_sampled_by_id(identifier, 1.0) is True
+        assert is_sampled_by_id(identifier, 0.0) is False
+
+
+def test_sampling_rate_is_roughly_honoured():
+    ids = [str(uuid.uuid4()) for _ in range(20_000)]
+    for rate in (0.1, 0.25, 0.75):
+        kept = sum(is_sampled_by_id(i, rate) for i in ids) / len(ids)
+        assert abs(kept - rate) < 0.02, f"rate {rate} kept {kept}"
 
 
 def test_run_sampling_is_consistent_for_create_and_update():

--- a/python/tests/unit_tests/test_client.py
+++ b/python/tests/unit_tests/test_client.py
@@ -2860,428 +2860,144 @@ def test_batch_ingest_run_splits_large_batches(
         assert len(request_bodies) == len(set([body["id"] for body in request_bodies]))
 
 
+SAMPLED_RUN_ID = uuid.UUID("00000000-0000-0000-0000-000000000001")
+FILTERED_RUN_ID = uuid.UUID("00000000-0000-0000-0000-000000000002")
+
+
+def _sampling_run(run_id: uuid.UUID, trace_id: Optional[uuid.UUID] = None) -> dict:
+    return {
+        "id": run_id,
+        "trace_id": trace_id or run_id,
+        "name": f"run-{run_id}",
+        "run_type": "llm",
+        "inputs": {"text": str(run_id)},
+        "dotted_order": f"20210101T000000000000Z{trace_id or run_id}",
+        "start_time": "2021-01-01T00:00:00Z",
+    }
+
+
 def test_sampling_and_batching():
-    """Test that sampling and batching work correctly."""
-    # Setup mock client
+    """Test that sampling and batching filter runs by stable run ID."""
     mock_session = MagicMock()
     mock_response = MagicMock()
     mock_response.status_code = 200
     mock_session.request.return_value = mock_response
 
-    counter = 0
+    client = Client(
+        api_key="test-api-key",
+        auto_batch_tracing=True,
+        tracing_sampling_rate=0.5,
+        session=mock_session,
+    )
 
-    def mock_should_sample():
-        nonlocal counter
-        counter += 1
-        return counter % 2 != 0
+    client.create_run(**_sampling_run(SAMPLED_RUN_ID, trace_id=SAMPLED_RUN_ID))
+    client.create_run(**_sampling_run(FILTERED_RUN_ID, trace_id=FILTERED_RUN_ID))
+    client.flush()
 
-    with patch(
-        "langsmith.client.Client._should_sample", side_effect=mock_should_sample
-    ):
-        client = Client(
-            api_key="test-api-key",
-            auto_batch_tracing=True,
-            tracing_sampling_rate=0.5,
-            session=mock_session,
+    post_calls = [
+        call
+        for call in mock_session.request.mock_calls
+        if call.args
+        and call.args[0] == "POST"
+        and call.args[1].endswith("/runs/multipart")
+    ]
+    assert len(post_calls) == 1
+    data = post_calls[0].kwargs["data"]
+    if isinstance(data, bytes):
+        data = data.decode("utf-8")
+    batch_data = parse_request_data(data)
+    assert [post["id"] for post in batch_data.get("post", [])] == [str(SAMPLED_RUN_ID)]
+
+
+def test_run_sampling_is_consistent_for_create_and_update():
+    client = Client(api_key="test-api-key", tracing_sampling_rate=0.5)
+
+    sampled_create = _sampling_run(SAMPLED_RUN_ID)
+    filtered_create = _sampling_run(FILTERED_RUN_ID)
+    sampled_update = {**sampled_create, "outputs": {"result": "sampled"}}
+    filtered_update = {**filtered_create, "outputs": {"result": "filtered"}}
+
+    assert client._filter_for_sampling([sampled_create, filtered_create]) == [
+        sampled_create
+    ]
+    assert client._filter_for_sampling(
+        [sampled_update, filtered_update], patch=True
+    ) == [sampled_update]
+    assert client._should_sample(SAMPLED_RUN_ID)
+    assert not client._should_sample(FILTERED_RUN_ID)
+
+
+def test_sampling_uses_run_id_not_trace_id():
+    client = Client(api_key="test-api-key", tracing_sampling_rate=0.5)
+
+    sampled_child = _sampling_run(SAMPLED_RUN_ID, trace_id=FILTERED_RUN_ID)
+    filtered_child = _sampling_run(FILTERED_RUN_ID, trace_id=SAMPLED_RUN_ID)
+
+    assert client._filter_for_sampling([sampled_child, filtered_child]) == [
+        sampled_child
+    ]
+
+
+def test_feedback_sampling_follows_run_id():
+    client = Client(api_key="test-api-key", tracing_sampling_rate=0.5)
+    client._info = ls_schemas.LangSmithInfo()
+
+    with patch.object(Client, "request_with_retries") as mock_request:
+        sampled_feedback = client.create_feedback(
+            run_id=SAMPLED_RUN_ID,
+            key="correctness",
+            score=1,
         )
+        assert sampled_feedback.run_id == SAMPLED_RUN_ID
+        mock_request.assert_called_once()
 
-        project_name = "__test_batch"
-
-        # Create parent runs
-        run_params = []
-        for i in range(4):
-            run_id = uuid.uuid4()
-            params = {
-                "id": run_id,
-                "project_name": project_name,
-                "name": f"test_run {i}",
-                "run_type": "llm",
-                "inputs": {"text": f"hello world {i}"},
-                "dotted_order": "foo",
-                "trace_id": run_id,
-            }
-            client.create_run(**params)
-            run_params.append(params)
-
-
-def test_patch_sampling_follows_trace_logic():
-    """Test that patch runs correctly follow post logic by checking trace_id instead of run.id."""
-    mock_session = MagicMock()
-    mock_response = MagicMock()
-    mock_response.status_code = 200
-    mock_session.request.return_value = mock_response
-
-    # Mock sampling to reject first trace, accept second trace
-    counter = 0
-
-    def mock_should_sample():
-        nonlocal counter
-        counter += 1
-        return counter % 2 == 0  # Accept even-numbered calls (2nd, 4th, etc.)
-
-    with patch(
-        "langsmith.client.Client._should_sample", side_effect=mock_should_sample
-    ):
-        client = Client(
-            api_key="test-api-key",
-            tracing_sampling_rate=0.5,
-            session=mock_session,
+    with patch.object(Client, "request_with_retries") as mock_request:
+        filtered_feedback = client.create_feedback(
+            run_id=FILTERED_RUN_ID,
+            key="correctness",
+            score=0,
         )
-
-        # Create two traces
-        trace_id_1 = uuid.uuid4()
-        trace_id_2 = uuid.uuid4()
-        child_run_id_1 = uuid.uuid4()
-        child_run_id_2 = uuid.uuid4()
-
-        # Create root runs (these will be sampled)
-        root_run_1 = {
-            "id": trace_id_1,
-            "trace_id": trace_id_1,
-            "name": "root_run_1",
-            "run_type": "llm",
-            "inputs": {"text": "hello"},
-        }
-        root_run_2 = {
-            "id": trace_id_2,
-            "trace_id": trace_id_2,
-            "name": "root_run_2",
-            "run_type": "llm",
-            "inputs": {"text": "world"},
-        }
-
-        # Create child runs
-        child_run_1 = {
-            "id": child_run_id_1,
-            "trace_id": trace_id_1,
-            "name": "child_run_1",
-            "run_type": "tool",
-            "inputs": {"text": "child hello"},
-        }
-        child_run_2 = {
-            "id": child_run_id_2,
-            "trace_id": trace_id_2,
-            "name": "child_run_2",
-            "run_type": "tool",
-            "inputs": {"text": "child world"},
-        }
-
-        # Test POST filtering (initial sampling)
-        post_filtered = client._filter_for_sampling(
-            [root_run_1, root_run_2], patch=False
-        )
-
-        # Based on our mock, first call returns False, second returns True
-        # So only root_run_2 should be sampled
-        assert len(post_filtered) == 1
-        assert post_filtered[0]["id"] == trace_id_2
-
-        # Verify that trace_id_1 is in filtered set, trace_id_2 is not
-        assert trace_id_1 in client._filtered_post_uuids
-        assert trace_id_2 not in client._filtered_post_uuids
-
-        # Test PATCH filtering - child runs should follow their trace's sampling decision
-        patch_runs = [
-            {**child_run_1, "outputs": {"result": "child result 1"}},
-            {**child_run_2, "outputs": {"result": "child result 2"}},
-        ]
-
-        patch_filtered = client._filter_for_sampling(patch_runs, patch=True)
-
-        # Only child_run_2 should be included (its trace was sampled)
-        # child_run_1 should be filtered out (its trace was not sampled)
-        assert len(patch_filtered) == 1
-        assert patch_filtered[0]["id"] == child_run_id_2
-        assert patch_filtered[0]["trace_id"] == trace_id_2
-
-        # Test PATCH filtering for root runs (updates to the root runs themselves)
-        root_patch_runs = [
-            {**root_run_1, "outputs": {"result": "root result 1"}},
-            {**root_run_2, "outputs": {"result": "root result 2"}},
-        ]
-
-        root_patch_filtered = client._filter_for_sampling(root_patch_runs, patch=True)
-
-        # Only root_run_2 should be included, and trace_id_1 should be removed from filtered set
-        # since we're updating the root run that was originally filtered
-        assert len(root_patch_filtered) == 1
-        assert root_patch_filtered[0]["id"] == trace_id_2
-
-        # trace_id_1 should be removed from filtered set since we processed its root run
-        assert trace_id_1 not in client._filtered_post_uuids
-        assert (
-            trace_id_2 not in client._filtered_post_uuids
-        )  # Still not in filtered set
-
-
-def test_patch_sampling_mixed_traces():
-    """Test patch sampling with a mix of sampled and unsampled traces."""
-    mock_session = MagicMock()
-    mock_response = MagicMock()
-    mock_response.status_code = 200
-    mock_session.request.return_value = mock_response
-
-    # Mock sampling to accept every other trace
-    counter = 0
-
-    def mock_should_sample():
-        nonlocal counter
-        counter += 1
-        return counter % 2 == 1  # Accept odd-numbered calls (1st, 3rd, etc.)
-
-    with patch(
-        "langsmith.client.Client._should_sample", side_effect=mock_should_sample
-    ):
-        client = Client(
-            api_key="test-api-key",
-            tracing_sampling_rate=0.5,
-            session=mock_session,
-        )
-
-        # Create multiple traces
-        trace_ids = [uuid.uuid4() for _ in range(4)]
-        child_run_ids = [uuid.uuid4() for _ in range(4)]
-
-        # Create root runs
-        root_runs = []
-        for i, trace_id in enumerate(trace_ids):
-            root_runs.append(
-                {
-                    "id": trace_id,
-                    "trace_id": trace_id,
-                    "name": f"root_run_{i}",
-                    "run_type": "llm",
-                    "inputs": {"text": f"hello {i}"},
-                }
-            )
-
-        # Sample the root runs
-        post_filtered = client._filter_for_sampling(root_runs, patch=False)
-
-        # Based on our mock: 1st and 3rd calls return True (indices 0, 2)
-        assert len(post_filtered) == 2
-        sampled_trace_ids = {run["id"] for run in post_filtered}
-        assert trace_ids[0] in sampled_trace_ids
-        assert trace_ids[2] in sampled_trace_ids
-
-        # Create child runs for all traces
-        child_runs = []
-        for i, (trace_id, child_id) in enumerate(zip(trace_ids, child_run_ids)):
-            child_runs.append(
-                {
-                    "id": child_id,
-                    "trace_id": trace_id,
-                    "name": f"child_run_{i}",
-                    "run_type": "tool",
-                    "inputs": {"text": f"child {i}"},
-                    "outputs": {"result": f"child result {i}"},
-                }
-            )
-
-        # Test patch filtering for child runs
-        patch_filtered = client._filter_for_sampling(child_runs, patch=True)
-
-        # Only children of sampled traces should be included
-        assert len(patch_filtered) == 2
-        patch_trace_ids = {run["trace_id"] for run in patch_filtered}
-        assert trace_ids[0] in patch_trace_ids
-        assert trace_ids[2] in patch_trace_ids
-        assert trace_ids[1] not in patch_trace_ids
-        assert trace_ids[3] not in patch_trace_ids
-
-
-def test_original_sampling_and_batching():
-    """Test that sampling and batching work correctly (continuation of original test)."""
-    # Setup mock client
-    mock_session = MagicMock()
-    mock_response = MagicMock()
-    mock_response.status_code = 200
-    mock_session.request.return_value = mock_response
-
-    counter = 0
-
-    def mock_should_sample():
-        nonlocal counter
-        counter += 1
-        return counter % 2 != 0
-
-    with patch(
-        "langsmith.client.Client._should_sample", side_effect=mock_should_sample
-    ):
-        client = Client(
-            api_key="test-api-key",
-            auto_batch_tracing=True,
-            tracing_sampling_rate=0.5,
-            session=mock_session,
-        )
-
-        project_name = "__test_batch"
-
-        # Create parent runs
-        run_params = []
-        for i in range(4):
-            run_id = uuid.uuid4()
-            params = {
-                "id": run_id,
-                "project_name": project_name,
-                "name": f"test_run {i}",
-                "run_type": "llm",
-                "inputs": {"text": f"hello world {i}"},
-                "dotted_order": "foo",
-                "trace_id": run_id,
-            }
-            client.create_run(**params)
-            run_params.append(params)
-
-        client.flush()
-
-        # Create child runs and update parent runs
-        child_run_params = []
-        for i, run_param in enumerate(run_params):
-            child_run_id = uuid.uuid4()
-            child_params = {
-                "id": child_run_id,
-                "project_name": project_name,
-                "name": f"test_child_run {i}",
-                "run_type": "llm",
-                "inputs": {"text": f"child world {i}"},
-                "dotted_order": "foo",
-                "trace_id": run_param["id"],
-            }
-            client.create_run(**child_params)
-            child_run_params.append(child_params)
-
-        client.flush()
-
-        # Verify all requests
-        post_calls = [
-            call
-            for call in mock_session.request.mock_calls
-            if call.args and call.args[0] == "POST"
-        ]
-        assert len(post_calls) >= 2
-
-        # Verify that only odd-numbered runs were sampled (due to our counter logic)
-        assert post_calls[0].args[1].endswith("/runs/multipart")
-        assert post_calls[1].args[1].endswith("/runs/multipart")
-
-        data = post_calls[0].kwargs["data"]
-        if isinstance(data, bytes):
-            data = data.decode("utf-8")
-        batch_data = parse_request_data(data)
-
-        # Verify posts only contain odd-numbered runs
-        assert len(batch_data.get("post", [])) == 2
-        for post in batch_data.get("post", []):
-            assert "text" in post["inputs"]
-            if "hello world" in post["inputs"]["text"]:
-                i = int(post["inputs"]["text"].split()[-1])
-                assert i % 2 == 0
-            elif "child world" in post["inputs"]["text"]:
-                i = int(post["inputs"]["text"].split()[-1])
-                assert i % 2 == 0
-
-        data = post_calls[1].kwargs["data"]
-        if isinstance(data, bytes):
-            data = data.decode("utf-8")
-        batch_data = parse_request_data(data)
-        assert len(batch_data.get("post", [])) == 2
-        for p in batch_data.get("post", []):
-            run_id = p["id"]
-            original_run = next((r for r in run_params if str(r["id"]) == run_id), None)
-            if original_run:
-                i = int(original_run["name"].split()[-1])
-                assert i % 2 == 0
+        assert filtered_feedback.run_id == FILTERED_RUN_ID
+        mock_request.assert_not_called()
 
 
 @pytest.mark.parametrize("method", ["batch_ingest_runs", "multipart_ingest"])
 def test_sampling_before_transform_in_batch_and_multipart(method: str):
-    """Verify that _run_transform is only called for runs that survive sampling.
-
-    When sampling is enabled, runs filtered out should never be transformed
-    (i.e., _run_transform should not be called for them).
-    """
+    """Verify that _run_transform is only called for runs that survive sampling."""
     mock_session = MagicMock()
     mock_response = MagicMock()
     mock_response.status_code = 200
     mock_session.request.return_value = mock_response
 
-    sample_count = 0
+    client = Client(
+        api_key="test-api-key",
+        tracing_sampling_rate=0.5,
+        session=mock_session,
+    )
 
-    def mock_should_sample():
-        nonlocal sample_count
-        sample_count += 1
-        return sample_count % 2 == 1  # Accept 1st, reject 2nd
+    creates = [_sampling_run(SAMPLED_RUN_ID), _sampling_run(FILTERED_RUN_ID)]
+    updates = [
+        {**_sampling_run(SAMPLED_RUN_ID), "outputs": {"result": "sampled output"}},
+        {**_sampling_run(FILTERED_RUN_ID), "outputs": {"result": "filtered output"}},
+    ]
 
-    with patch(
-        "langsmith.client.Client._should_sample", side_effect=mock_should_sample
-    ):
-        client = Client(
-            api_key="test-api-key",
-            tracing_sampling_rate=0.5,
-            session=mock_session,
-        )
+    original_run_transform = Client._run_transform
+    transformed_ids: list[uuid.UUID] = []
 
-        sampled_trace_id = uuid.uuid4()
-        filtered_trace_id = uuid.uuid4()
+    def tracking_transform(self, run, **kwargs):
+        result = original_run_transform(self, run, **kwargs)
+        transformed_ids.append(result["id"])
+        return result
 
-        creates = [
-            {
-                "id": sampled_trace_id,
-                "trace_id": sampled_trace_id,
-                "dotted_order": f"20210101T000000000000Z{sampled_trace_id}",
-                "name": "sampled_root",
-                "run_type": "llm",
-                "inputs": {"text": "sampled"},
-                "start_time": "2021-01-01T00:00:00Z",
-            },
-            {
-                "id": filtered_trace_id,
-                "trace_id": filtered_trace_id,
-                "dotted_order": f"20210101T000000000000Z{filtered_trace_id}",
-                "name": "filtered_root",
-                "run_type": "llm",
-                "inputs": {"text": "filtered"},
-                "start_time": "2021-01-01T00:00:00Z",
-            },
-        ]
+    with patch.object(Client, "_run_transform", tracking_transform):
+        fn = getattr(client, method)
+        fn(create=creates, update=updates)
 
-        updates = [
-            {
-                "id": sampled_trace_id,
-                "trace_id": sampled_trace_id,
-                "dotted_order": f"20210101T000000000000Z{sampled_trace_id}",
-                "outputs": {"result": "sampled output"},
-                "end_time": "2021-01-01T00:00:01Z",
-            },
-            {
-                "id": filtered_trace_id,
-                "trace_id": filtered_trace_id,
-                "dotted_order": f"20210101T000000000000Z{filtered_trace_id}",
-                "outputs": {"result": "filtered output"},
-                "end_time": "2021-01-01T00:00:01Z",
-            },
-        ]
-
-        original_run_transform = Client._run_transform
-        transformed_ids: list[uuid.UUID] = []
-
-        def tracking_transform(self, run, **kwargs):
-            result = original_run_transform(self, run, **kwargs)
-            transformed_ids.append(result["id"])
-            return result
-
-        with patch.object(Client, "_run_transform", tracking_transform):
-            fn = getattr(client, method)
-            fn(create=creates, update=updates)
-
-        # Only the sampled trace should have been transformed
-        assert sampled_trace_id in transformed_ids
-        assert filtered_trace_id not in transformed_ids, (
-            f"{method} called _run_transform on a filtered-out run"
-        )
-        # The sampled trace should appear twice (once for create, once for update)
-        assert transformed_ids.count(sampled_trace_id) == 2
+    assert SAMPLED_RUN_ID in transformed_ids
+    assert FILTERED_RUN_ID not in transformed_ids, (
+        f"{method} called _run_transform on a filtered-out run"
+    )
+    assert transformed_ids.count(SAMPLED_RUN_ID) == 2
 
 
 @mock.patch("langsmith.client.requests.Session")


### PR DESCRIPTION
## Description
Use stable run-ID hashing for tracing sampling in both Python and JS SDKs, and apply the same decision when creating run feedback. This prevents feedback for sampled-out runs from being ingested and retried.

## Release Note
Tracing sampling is now deterministic by run ID and also filters feedback for sampled-out runs.

Sampling now keys on the trace, not the individual run. With sampling enabled, direct `create_run`/`update_run` (`createRun`/`updateRun`) calls **on child runs** must pass a `trace_id` (or `dotted_order`) to stay consistent with their trace; without one the child's own ID is hashed and can land on the opposite side of the sample. Runs traced via `@traceable`/`RunTree` are unaffected.

## Test Plan
- [x] Python focused sampling tests: `TEST='tests/unit_tests/test_client.py -k sampling' make -C /workspace/langsmith-sdk/python tests`
- [x] JS client/batch sampling tests: `NODE_OPTIONS=--experimental-vm-modules pnpm --dir /workspace/langsmith-sdk/js exec jest src/tests/client.test.ts src/tests/batch_client.test.ts --runInBand --no-colors`
- [x] Python lint: `make -C /workspace/langsmith-sdk/python lint`
- [x] JS lint/typecheck: `pnpm --dir /workspace/langsmith-sdk/js lint && pnpm --dir /workspace/langsmith-sdk/js exec tsc --noEmit`

Linear: LIN-369

Made with [Open SWE](https://github.com/langchain-ai/open-swe)
