### PR TITLE
release(py): 0.10.1

### DIFF
--- a/python/.bumpversion.cfg
+++ b/python/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.10.0
+current_version = 0.10.1
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
 serialize = {major}.{minor}.{patch}
 search = {current_version}

--- a/python/langsmith/__init__.py
+++ b/python/langsmith/__init__.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
 
 # Avoid calling into importlib on every call to __version__
 
-__version__ = "0.10.0"
+__version__ = "0.10.1"
 version = __version__  # for backwards compatibility
 
 # Metadata key to hide a traced run from LangSmith's Messages View.


### PR DESCRIPTION
## Summary
- Bump Python SDK version 0.10.0 → 0.10.1

## Changes since 0.10.0
- Fix URL Path Injection via Unencoded Resource Names in Python Sandbox Client (Sync) (#3177)
- Fix Stored XSS via InsightsReport._repr_html_ in Jupyter Notebooks (#3176)
- fix: bound voice streaming audio buffers (#3169)
- chore: bump _MIN_BACKEND_VERSION to 0.16.12rc1 (#3178)