### PR TITLE
release(js): 0.8.1

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langsmith",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Client library to connect to the LangSmith Observability and Evaluation Platform.",
   "packageManager": "pnpm@10.33.0",
   "files": [

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -50,7 +50,7 @@ export {
 } from "./_openapi_client/core/error.js";
 
 // Update using pnpm bump-version
-export const __version__ = "0.8.0";
+export const __version__ = "0.8.1";
 
 // Metadata key to hide a traced run from LangSmith's Messages View.
 export const LS_MESSAGE_VIEW_EXCLUDE = "ls_message_view_exclude" as const;


### PR DESCRIPTION
## Summary
- Bump JS SDK version 0.8.0 → 0.8.1

## Changes since 0.8.0
- feat(js): expose openapi client error classes (#3181)
- fix: bound voice streaming audio buffers (#3169)