### PR TITLE
refactor(livekit + pipecat): Refactor for clarity

### DIFF
--- a/python/langsmith/_internal/voice/_helpers.py
+++ b/python/langsmith/_internal/voice/_helpers.py
@@ -1,0 +1,30 @@
+"""Integration-agnostic helpers shared by the voice span processors."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Optional
+
+
+def build_user_message(content: str) -> dict[str, Any]:
+    """Build a ``user`` chat message for the ``gen_ai.*`` message keys."""
+    return {"role": "user", "content": content}
+
+
+def build_assistant_message(content: str) -> dict[str, Any]:
+    """Build an ``assistant`` chat message for the ``gen_ai.*`` message keys."""
+    return {"role": "assistant", "content": content}
+
+
+def try_parse_json_object(value: Any) -> Optional[dict]:
+    """Return ``value`` parsed as a dict if it's a JSON-object string, else None."""
+    if not isinstance(value, str):
+        return None
+    s = value.strip()
+    if not (s.startswith("{") and s.endswith("}")):
+        return None
+    try:
+        obj = json.loads(s)
+    except (json.JSONDecodeError, ValueError):
+        return None
+    return obj if isinstance(obj, dict) else None

--- a/python/langsmith/_internal/voice/audio.py
+++ b/python/langsmith/_internal/voice/audio.py
@@ -1,8 +1,7 @@
 """WAV reconstruction for the voice integrations.
 
-* ``pcm_to_wav`` — wrap already-merged PCM16 bytes (e.g. the output of Pipecat's
-  ``AudioBufferProcessor``) in a WAV container. Used by the Track-A span
-  processors.
+* ``pcm_to_wav`` — wrap already-merged PCM16 bytes in a WAV container. Used by the
+  Pipecat processor (whose ``AudioBufferProcessor`` emits merged stereo audio).
 * ``build_stereo_session_wav`` — reconstruct one stereo conversation WAV from the
   timestamped PCM16 chunks each side recorded (L=user, R=agent), laid out at
   natural play time so bursts don't overlap. Used by the Track-B ``EventSession``.

--- a/python/langsmith/_internal/voice/base_span_processor.py
+++ b/python/langsmith/_internal/voice/base_span_processor.py
@@ -23,15 +23,16 @@ from __future__ import annotations
 import base64
 import json
 import logging
-from dataclasses import dataclass
 from typing import Any, Optional
 
-from opentelemetry.sdk.trace import Event, ReadableSpan, SpanProcessor
+from opentelemetry.context import Context
+from opentelemetry.sdk.trace import ReadableSpan, Span, SpanProcessor
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
 
-from langsmith._internal.otel._span_utils import rebuild_readable_span
-
 from . import thread_id_from_context
+from .translated_span import TranslatedSpan
+
+__all__ = ["BaseLangSmithSpanProcessor", "TranslatedSpan"]
 
 logger = logging.getLogger(__name__)
 
@@ -46,82 +47,6 @@ DEFAULT_AUDIO_SIZE_LIMIT = 150_000_000
 # ``_forget_thread_id``; this bounds memory for conversations that never reach
 # cleanup (crash, dropped connection), evicting oldest-first.
 _THREAD_ID_CACHE_MAXSIZE = 100_000
-
-
-@dataclass
-class TranslatedSpan:
-    """A span being translated into LangSmith's namespaces before export.
-
-    Wraps the original read-only OTel ``ReadableSpan`` with mutable
-    ``attributes`` and ``events`` seeded from it. Handlers rewrite the copies
-    while translating; :meth:`finalize` builds a fresh ``ReadableSpan`` from them
-    — so OpenTelemetry's private ``span._attributes`` / ``span._events`` are
-    never mutated.
-
-    Created per span in :meth:`BaseLangSmithSpanProcessor.on_end` and threaded
-    through dispatch — no global state. A processor that defers a span (see
-    :meth:`BaseLangSmithSpanProcessor._dispatch`) simply holds the
-    ``TranslatedSpan`` itself until it exports it later, so the in-progress
-    translation outlives the originating ``on_end`` call.
-    """
-
-    span: ReadableSpan
-    attributes: dict[str, Any]
-    events: list[Event]
-
-    @classmethod
-    def of(cls, span: ReadableSpan) -> TranslatedSpan:
-        """Seed a draft from a span's own (read-only) attributes and events."""
-        return cls(span, dict(span.attributes or {}), list(span.events or []))
-
-    def finalize(self) -> ReadableSpan:
-        """Build the export span: the original's fields + our rewritten attrs/events."""
-        return rebuild_readable_span(
-            self.span, attributes=self.attributes, events=self.events
-        )
-
-    def set_kind(self, kind: str) -> None:
-        """Set ``langsmith.span.kind`` (``llm`` / ``chain`` / ``tool`` / …)."""
-        self.attributes["langsmith.span.kind"] = kind
-
-    def set_thread_id(self, thread_id: str) -> None:
-        """Set ``langsmith.metadata.thread_id`` (the conversation/thread id)."""
-        self.attributes["langsmith.metadata.thread_id"] = thread_id
-
-    def exclude_from_message_view(self) -> None:
-        """Drop this span from the conversation Messages view (still in the tree).
-
-        That view reconstructs the chat from ``llm``/``tool`` runs. STT/TTS spans
-        are tagged ``llm``-kind for the tree but would otherwise add fake turns
-        (raw transcripts, "Generated audio for: …"), so they opt out here.
-        """
-        self.attributes["langsmith.metadata.ls_message_view_exclude"] = True
-
-    def set_root_span(self, is_root: bool) -> None:
-        """Mark the span as the trace root (``langsmith.root_span``)."""
-        self.attributes["langsmith.root_span"] = is_root
-
-    def set_metadata(self, key: str, value: Any) -> None:
-        """Set ``langsmith.metadata.<key>`` to the given value.
-
-        LangSmith surfaces everything under ``langsmith.metadata.*`` as run
-        metadata. Note ``langsmith.root_span`` and ``langsmith.span.kind`` are NOT
-        metadata — they live in the top-level ``langsmith.*`` namespace and have
-        their own setters / direct writes.
-        """
-        self.attributes[f"langsmith.metadata.{key}"] = value
-
-    def set_messages(
-        self,
-        *,
-        prompt: Optional[list[dict]] = None,
-        completion: Optional[list[dict]] = None,
-    ) -> None:
-        """Write ``gen_ai.prompt``/``gen_ai.completion`` as ``{"messages": [...]}``."""
-        if prompt is not None:
-            self.attributes["gen_ai.prompt"] = json.dumps({"messages": prompt})
-        if completion is not None:
-            self.attributes["gen_ai.completion"] = json.dumps({"messages": completion})
 
 
 class BaseLangSmithSpanProcessor(SpanProcessor):
@@ -178,34 +103,18 @@ class BaseLangSmithSpanProcessor(SpanProcessor):
 
     # -- span lifecycle -------------------------------------------------------
 
-    def on_start(self, span: Any, parent_context: Any = None) -> None:
-        for key, value in self._static_metadata.items():
-            if value is not None:
-                span.set_attribute(f"langsmith.metadata.{key}", value)
-        # Capture the thread id here, at the earliest in-context moment. on_start
-        # runs synchronously in the task that starts the span; the conversation's
-        # root span starts in the task where set_thread_id was called, so the
-        # ContextVar is visible now even when later spans END in detached tasks
-        # where it is not. _stamp_thread_id then recovers it per trace.
+    def on_start(self, span: Span, parent_context: Optional[Context] = None) -> None:
         thread_id = thread_id_from_context()
-        context = getattr(span, "context", None)
-        if thread_id and context is not None:
-            self._remember_thread_id(context.trace_id, str(thread_id))
+        if thread_id:
+            self._remember_thread_id(span.context.trace_id, str(thread_id))
         self.downstream.on_start(span, parent_context)
 
     def on_end(self, span: ReadableSpan) -> None:
-        # Isolate translation from export: a failure rewriting one span must
-        # never drop it or propagate into the OTel provider's span-ending path
-        # (which would disrupt other processors and the traced app). On error we
-        # log and still export the span untranslated — degraded, not lost.
-        #
-        # _dispatch returns whether the base should export the span now. A
-        # subclass that defers (returns False) owns its own later _export call;
-        # any other return value — including a dispatch failure — leaves
-        # export=True so the span is still forwarded exactly once.
         tspan = TranslatedSpan.of(span)
+
         export = True
         try:
+            self._stamp_static_metadata(tspan)
             self._stamp_thread_id(tspan)
             export = self._dispatch(tspan) is not False
         except Exception:
@@ -228,12 +137,8 @@ class BaseLangSmithSpanProcessor(SpanProcessor):
     def _dispatch(self, tspan: TranslatedSpan) -> bool:
         """Classify the span and rewrite its attributes on the draft.
 
-        Returns whether :meth:`on_end` should export the span. Return ``True``
-        (the common case) to have the base export it exactly once. Return
-        ``False`` to take ownership of the export — e.g. to defer the span until
-        a later event — in which case the subclass MUST hold ``tspan`` and call
-        :meth:`_export` with it itself, exactly once. Subclasses that return
-        ``True`` MUST NOT call :meth:`_export`. The default raises.
+        Returns True if ``on_end`` should export the span, or False to take
+        ownership of the export.
         """
         raise NotImplementedError
 
@@ -241,8 +146,7 @@ class BaseLangSmithSpanProcessor(SpanProcessor):
         """Forward the translated span downstream.
 
         Builds a fresh ``ReadableSpan`` from the draft (rewritten attributes/
-        events) rather than mutating the original — so we never poke
-        OpenTelemetry's private span internals.
+        events) rather than mutating the original.
         """
         self._pre_export(tspan)
         self.downstream.on_end(tspan.finalize())
@@ -258,30 +162,25 @@ class BaseLangSmithSpanProcessor(SpanProcessor):
 
     # -- shared helpers -------------------------------------------------------
 
+    def _stamp_static_metadata(self, tspan: TranslatedSpan) -> None:
+        """Stamp the processor's static ``langsmith.metadata.*`` (never clobbering)."""
+        for key, value in self._static_metadata.items():
+            attr = f"langsmith.metadata.{key}"
+            if value is not None and attr not in tspan.attributes:
+                tspan.attributes[attr] = value
+
     def _stamp_thread_id(self, tspan: TranslatedSpan) -> None:
-        """Stamp ``langsmith.metadata.thread_id`` from the per-context id (opt-in).
+        """Stamp ``langsmith.metadata.thread_id`` from the id captured at ``on_start``.
 
-        LangSmith needs the thread id on every run for thread-level filtering and
-        token/cost aggregation. The id is set via
-        :func:`~langsmith._internal.voice.set_thread_id`, a ``ContextVar``, so
-        concurrent conversations each see their own value. Resolves it as:
-
-        1. leave any id already on the span untouched (never clobber upstream);
-        2. else the value captured for this trace at :meth:`on_start` — robust to
-           spans that end in a detached task where the ``ContextVar`` is unset;
-        3. else the ``ContextVar`` directly (this span IS in context and is the
-           first we've seen for the trace), backfilling the cache for its peers.
-
-        Stamping is skipped (``None``) when no id was ever set for the trace.
+        Reads the per-trace id captured at :meth:`on_start` — so spans that end in
+        a detached task (where the ``ContextVar`` is unset) still get it. Leaves
+        any id already on the span untouched, and skips when none was set.
         """
         if "langsmith.metadata.thread_id" in tspan.attributes:
             return
-        trace_id = tspan.span.context.trace_id
-        thread_id = self._thread_id_by_trace.get(trace_id) or thread_id_from_context()
+        thread_id = self._thread_id_by_trace.get(tspan.span.context.trace_id)
         if thread_id:
-            thread_id = str(thread_id)
             tspan.set_thread_id(thread_id)
-            self._remember_thread_id(trace_id, thread_id)
 
     def _remember_thread_id(self, trace_id: int, thread_id: str) -> None:
         """Cache a trace's thread id, evicting oldest-first when at capacity."""

--- a/python/langsmith/_internal/voice/translated_span.py
+++ b/python/langsmith/_internal/voice/translated_span.py
@@ -1,0 +1,130 @@
+"""``TranslatedSpan`` — the mutable draft handlers rewrite before export.
+
+Split out of :mod:`langsmith._internal.voice.base_span_processor` so the base
+processor stays focused on span lifecycle and export wiring. The framework
+subclasses (Pipecat, LiveKit) rewrite one of these per span while translating
+``lk.*`` / ``pipecat.*`` data into LangSmith's ``gen_ai.*`` / ``langsmith.*``
+namespaces.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any, Optional
+
+from opentelemetry.sdk.trace import Event, ReadableSpan
+
+from langsmith._internal.otel._span_utils import rebuild_readable_span
+
+
+@dataclass
+class TranslatedSpan:
+    """A span being translated into LangSmith's namespaces before export.
+
+    Wraps the original read-only OTel ``ReadableSpan`` with mutable
+    ``attributes`` and ``events`` seeded from it. Handlers rewrite the copies
+    while translating; :meth:`finalize` builds a fresh ``ReadableSpan`` from them
+    — so OpenTelemetry's private ``span._attributes`` / ``span._events`` are
+    never mutated.
+
+    Created per span in :meth:`BaseLangSmithSpanProcessor.on_end` and threaded
+    through dispatch — no global state. A processor that defers a span (see
+    :meth:`BaseLangSmithSpanProcessor._dispatch`) simply holds the
+    ``TranslatedSpan`` itself until it exports it later, so the in-progress
+    translation outlives the originating ``on_end`` call.
+    """
+
+    span: ReadableSpan
+    attributes: dict[str, Any]
+    events: list[Event]
+
+    @classmethod
+    def of(cls, span: ReadableSpan) -> TranslatedSpan:
+        """Seed a draft from a span's own (read-only) attributes and events."""
+        return cls(span, dict(span.attributes or {}), list(span.events or []))
+
+    def finalize(self) -> ReadableSpan:
+        """Build the export span: the original's fields + our rewritten attrs/events."""
+        return rebuild_readable_span(
+            self.span, attributes=self.attributes, events=self.events
+        )
+
+    def set_kind(self, kind: str) -> None:
+        """Set ``langsmith.span.kind`` (``llm`` / ``chain`` / ``tool`` / …)."""
+        self.attributes["langsmith.span.kind"] = kind
+
+    def set_thread_id(self, thread_id: str) -> None:
+        """Set ``langsmith.metadata.thread_id`` (the conversation/thread id)."""
+        self.attributes["langsmith.metadata.thread_id"] = thread_id
+
+    def set_provider(self, provider: Optional[str]) -> None:
+        """Set ``provider`` on both gen_ai.* provider keys (no-op if empty).
+
+        LangSmith maps either ``gen_ai.provider.name`` (newer) or the legacy
+        ``gen_ai.system`` to ``ls_provider``; writing both is version-agnostic.
+        The caller passes an already-resolved slug — normalization is the
+        integration's concern.
+        """
+        if provider:
+            self.attributes["gen_ai.provider.name"] = provider
+            self.attributes["gen_ai.system"] = provider
+
+    def set_model(self, model: Optional[str]) -> None:
+        """Set the request model on ``gen_ai.request.model`` and its metadata mirror."""
+        if model:
+            self.attributes["gen_ai.request.model"] = str(model)
+            self.attributes["langsmith.metadata.model_name"] = str(model)
+
+    def exclude_from_message_view(self) -> None:
+        """Drop this span from the conversation Messages view (still in the tree).
+
+        That view reconstructs the chat from ``llm``/``tool`` runs. STT/TTS spans
+        are tagged ``llm``-kind for the tree but would otherwise add fake turns
+        (raw transcripts, "Generated audio for: …"), so they opt out here.
+        """
+        self.attributes["langsmith.metadata.ls_message_view_exclude"] = True
+
+    def set_root_span(self, is_root: bool) -> None:
+        """Mark the span as the trace root (``langsmith.root_span``)."""
+        self.attributes["langsmith.root_span"] = is_root
+
+    def set_metadata(self, key: str, value: Any) -> None:
+        """Set ``langsmith.metadata.<key>`` to the given value.
+
+        LangSmith surfaces everything under ``langsmith.metadata.*`` as run
+        metadata. Note ``langsmith.root_span`` and ``langsmith.span.kind`` are NOT
+        metadata — they live in the top-level ``langsmith.*`` namespace and have
+        their own setters / direct writes.
+        """
+        self.attributes[f"langsmith.metadata.{key}"] = value
+
+    def set_messages(
+        self,
+        *,
+        prompt: Optional[list[dict]] = None,
+        completion: Optional[list[dict]] = None,
+    ) -> None:
+        """Write ``gen_ai.prompt``/``gen_ai.completion`` as ``{"messages": [...]}``."""
+        if prompt is not None:
+            self.attributes["gen_ai.prompt"] = json.dumps({"messages": prompt})
+        if completion is not None:
+            self.attributes["gen_ai.completion"] = json.dumps({"messages": completion})
+
+    def set_tool_input(self, tool_input: Any) -> None:
+        """Write a tool run's input to ``gen_ai.prompt`` as raw I/O (not messages).
+
+        A ``str`` is passed through unchanged; any other value is JSON-encoded.
+        """
+        self.attributes["gen_ai.prompt"] = (
+            tool_input if isinstance(tool_input, str) else json.dumps(tool_input)
+        )
+
+    def set_tool_output(self, tool_output: Any) -> None:
+        """Write a tool run's output to ``gen_ai.completion`` as raw I/O (not messages).
+
+        A ``str`` is passed through unchanged; any other value is JSON-encoded.
+        """
+        self.attributes["gen_ai.completion"] = (
+            tool_output if isinstance(tool_output, str) else json.dumps(tool_output)
+        )

--- a/python/langsmith/integrations/livekit/_helpers.py
+++ b/python/langsmith/integrations/livekit/_helpers.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 import json
 from typing import Any, Optional
 
+from langsmith._internal.voice._helpers import try_parse_json_object
+
 # The instrumentation scope LiveKit's tracer is created under
 # (``get_tracer("livekit-agents")``). Every span LiveKit emits carries it, so it
 # is how we tell a LiveKit span apart from a non-LiveKit run riding the same OTel
@@ -66,31 +68,6 @@ def is_livekit_span(span: Any) -> bool:
     return getattr(scope, "name", None) == _LIVEKIT_INSTRUMENTATION_SCOPE
 
 
-def build_user_message(content: str) -> dict:
-    """Build a ``user`` chat message for the ``gen_ai.*`` message keys."""
-    return {"role": "user", "content": content}
-
-
-def build_assistant_message(content: str) -> dict:
-    """Build an ``assistant`` chat message for the ``gen_ai.*`` message keys."""
-    return {"role": "assistant", "content": content}
-
-
-def build_tool_message(
-    content: str,
-    *,
-    tool_call_id: Optional[str] = None,
-    name: Optional[str] = None,
-) -> dict:
-    """Build a ``tool`` result message, with its call id / name when present."""
-    msg: dict = {"role": "tool", "content": content}
-    if tool_call_id:
-        msg["tool_call_id"] = str(tool_call_id)
-    if name:
-        msg["name"] = str(name)
-    return msg
-
-
 def parse_tool_calls(raw_tool_calls: Any) -> list[dict]:
     """Parse an event's ``tool_calls`` to OpenAI-shape dicts (JSON strings decoded).
 
@@ -106,20 +83,6 @@ def parse_tool_calls(raw_tool_calls: Any) -> list[dict]:
         if isinstance(raw, dict):
             tool_calls.append(raw)
     return tool_calls
-
-
-def try_parse_json_object(value: Any) -> Optional[dict]:
-    """Return ``value`` parsed as a dict if it's a JSON-object string, else None."""
-    if not isinstance(value, str):
-        return None
-    s = value.strip()
-    if not (s.startswith("{") and s.endswith("}")):
-        return None
-    try:
-        obj = json.loads(s)
-    except (json.JSONDecodeError, ValueError):
-        return None
-    return obj if isinstance(obj, dict) else None
 
 
 def extract_provider_from_lk_metrics(metrics: Any) -> Optional[str]:
@@ -173,6 +136,21 @@ def flatten_lk_attributes_to_ls_metadata(
         ):
             flat[name] = list(v)
     return flat
+
+
+def build_tool_message(
+    content: str,
+    *,
+    tool_call_id: Optional[str] = None,
+    name: Optional[str] = None,
+) -> dict:
+    """Build a ``tool`` result message, with its call id / name when present."""
+    msg: dict = {"role": "tool", "content": content}
+    if tool_call_id:
+        msg["tool_call_id"] = str(tool_call_id)
+    if name:
+        msg["name"] = str(name)
+    return msg
 
 
 def build_message_from_event(role: str, event: Any) -> dict:

--- a/python/langsmith/integrations/livekit/_helpers.py
+++ b/python/langsmith/integrations/livekit/_helpers.py
@@ -1,0 +1,195 @@
+"""Small pure helpers for the LiveKit → LangSmith span processor.
+
+Split out of :mod:`langsmith.integrations.livekit.processor` to keep that module
+focused on span dispatch and lifecycle: provider-slug normalization, LiveKit
+span detection, and the tiny chat-message builders the handlers reuse.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Optional
+
+# The instrumentation scope LiveKit's tracer is created under
+# (``get_tracer("livekit-agents")``). Every span LiveKit emits carries it, so it
+# is how we tell a LiveKit span apart from a non-LiveKit run riding the same OTel
+# provider (e.g. a LangChain/LangGraph trace under ``LANGSMITH_TRACING_MODE=otel``).
+_LIVEKIT_INSTRUMENTATION_SCOPE = "livekit-agents"
+
+# LiveKit reports some providers as the API base-URL host (e.g. its OpenAI
+# plugin → ``api.openai.com``), but LangSmith's cost engine keys on provider
+# *slugs* (``openai`` / ``deepgram`` / …), so a hostname never matches a price.
+# We recover the slug by substring — so ``beta.anthropic.com`` still → ``anthropic``
+# — mirroring how LangSmith itself infers the provider from a model name.
+_PROVIDER_ALIASES = (
+    "openai",
+    "anthropic",
+    "gemini",
+    "google",
+    "deepgram",
+    "cartesia",
+    "elevenlabs",
+    "cohere",
+    "mistral",
+    "groq",
+)
+
+
+def normalize_provider(raw: Any) -> Optional[str]:
+    """Map a LiveKit provider (often an API host) to a LangSmith provider slug.
+
+    Matches a known provider slug as a substring (so ``api.openai.com`` and
+    ``beta.anthropic.com`` resolve to ``openai`` / ``anthropic``); otherwise
+    returns the value's host, stripped of scheme/path. Returns ``None`` for
+    empty input or LiveKit's ``"unknown"`` placeholder, so we never stamp a
+    non-matching provider.
+    """
+    if not raw:
+        return None
+    value = str(raw).strip().lower()
+    if not value or value == "unknown":
+        return None
+    for alias in _PROVIDER_ALIASES:
+        if alias in value:
+            return alias
+    return value.split("://", 1)[-1].split("/", 1)[0] or None
+
+
+def is_livekit_span(span: Any) -> bool:
+    """Whether a span came from LiveKit's tracer (its instrumentation scope).
+
+    Used to gate root detection: only a parentless span emitted by LiveKit is
+    the conversation root. Named LiveKit spans are matched by name above and
+    don't need this; it guards the broad ``parent is None`` case alone.
+    """
+    scope = getattr(span, "instrumentation_scope", None)
+    return getattr(scope, "name", None) == _LIVEKIT_INSTRUMENTATION_SCOPE
+
+
+def build_user_message(content: str) -> dict:
+    """Build a ``user`` chat message for the ``gen_ai.*`` message keys."""
+    return {"role": "user", "content": content}
+
+
+def build_assistant_message(content: str) -> dict:
+    """Build an ``assistant`` chat message for the ``gen_ai.*`` message keys."""
+    return {"role": "assistant", "content": content}
+
+
+def build_tool_message(
+    content: str,
+    *,
+    tool_call_id: Optional[str] = None,
+    name: Optional[str] = None,
+) -> dict:
+    """Build a ``tool`` result message, with its call id / name when present."""
+    msg: dict = {"role": "tool", "content": content}
+    if tool_call_id:
+        msg["tool_call_id"] = str(tool_call_id)
+    if name:
+        msg["name"] = str(name)
+    return msg
+
+
+def parse_tool_calls(raw_tool_calls: Any) -> list[dict]:
+    """Parse an event's ``tool_calls`` to OpenAI-shape dicts (JSON strings decoded).
+
+    Entries that are neither dicts nor JSON-object strings are dropped.
+    """
+    tool_calls: list[dict] = []
+    for raw in raw_tool_calls or ():
+        if isinstance(raw, str):
+            try:
+                raw = json.loads(raw)
+            except json.JSONDecodeError:
+                continue
+        if isinstance(raw, dict):
+            tool_calls.append(raw)
+    return tool_calls
+
+
+def try_parse_json_object(value: Any) -> Optional[dict]:
+    """Return ``value`` parsed as a dict if it's a JSON-object string, else None."""
+    if not isinstance(value, str):
+        return None
+    s = value.strip()
+    if not (s.startswith("{") and s.endswith("}")):
+        return None
+    try:
+        obj = json.loads(s)
+    except (json.JSONDecodeError, ValueError):
+        return None
+    return obj if isinstance(obj, dict) else None
+
+
+def extract_provider_from_lk_metrics(metrics: Any) -> Optional[str]:
+    """Read the provider (``metadata.model_provider``) from a LiveKit metrics blob.
+
+    LiveKit reports it as the API-base-URL host (its OpenAI plugin →
+    ``api.openai.com``); the caller normalizes it to a slug before setting it.
+    """
+    parsed = try_parse_json_object(metrics)
+    if isinstance(parsed, dict):
+        return (parsed.get("metadata") or {}).get("model_provider")
+    return None
+
+
+def extract_model_from_lk_metrics(metrics: Any) -> Optional[str]:
+    """Read the model name (``metadata.model_name`` or ``model_name``) from a blob.
+
+    LiveKit doesn't always set ``gen_ai.request.model`` (notably on ``tts_request``),
+    so the model is recovered from the metrics blob as a fallback.
+    """
+    parsed = try_parse_json_object(metrics)
+    if isinstance(parsed, dict):
+        return (parsed.get("metadata") or {}).get("model_name") or parsed.get(
+            "model_name"
+        )
+    return None
+
+
+def flatten_lk_attributes_to_ls_metadata(
+    obj: dict, prefix: str, _depth: int = 0
+) -> dict:
+    """Flatten a JSON-object blob's scalar leaves to ``{prefix_key: value}``.
+
+    Recurses into nested dicts (capped at depth 4); keeps scalars and lists of
+    scalars, dropping anything else. Returns a flat dict the caller stamps onto
+    the span — so this stays agnostic to the span itself.
+    """
+    flat: dict = {}
+    if _depth > 4:
+        return flat
+    for k, v in obj.items():
+        name = f"{prefix}_{k}"
+        if isinstance(v, dict):
+            flat.update(flatten_lk_attributes_to_ls_metadata(v, name, _depth + 1))
+        elif isinstance(v, (str, int, float, bool)):
+            flat[name] = v
+        elif (
+            isinstance(v, (list, tuple))
+            and v
+            and all(isinstance(item, (str, int, float, bool)) for item in v)
+        ):
+            flat[name] = list(v)
+    return flat
+
+
+def build_message_from_event(role: str, event: Any) -> dict:
+    """Build a chat message dict from a LiveKit ``gen_ai.*`` span event.
+
+    ``role`` is authoritative (the caller derives it from the event name). Tool
+    calls are forwarded in their OpenAI shape (JSON-string entries decoded) —
+    LangSmith's ingester renders them directly.
+    """
+    attrs = event.attributes or {}
+    content = str(attrs.get("content") or "")
+    if role == "tool":
+        return build_tool_message(
+            content, tool_call_id=attrs.get("id"), name=attrs.get("name")
+        )
+    msg: dict = {"role": role, "content": content}
+    tool_calls = parse_tool_calls(attrs.get("tool_calls"))
+    if tool_calls:
+        msg["tool_calls"] = tool_calls
+    return msg

--- a/python/langsmith/integrations/livekit/processor.py
+++ b/python/langsmith/integrations/livekit/processor.py
@@ -18,21 +18,23 @@ from cachetools import TTLCache
 from opentelemetry.sdk.trace import SpanProcessor
 
 from langsmith._internal._package_version import get_package_version
+from langsmith._internal.voice._helpers import (
+    build_assistant_message,
+    build_user_message,
+    try_parse_json_object,
+)
 from langsmith._internal.voice.base_span_processor import (
     BaseLangSmithSpanProcessor,
     TranslatedSpan,
 )
 
 from ._helpers import (
-    build_assistant_message,
     build_message_from_event,
-    build_user_message,
     extract_model_from_lk_metrics,
     extract_provider_from_lk_metrics,
     flatten_lk_attributes_to_ls_metadata,
     is_livekit_span,
     normalize_provider,
-    try_parse_json_object,
 )
 
 # Lifetime / cap for per-conversation state; bounds memory for calls that never end.

--- a/python/langsmith/integrations/livekit/processor.py
+++ b/python/langsmith/integrations/livekit/processor.py
@@ -1,69 +1,21 @@
 """OTel → LangSmith bridge for LiveKit Agents.
 
-LangSmith's OTel ingester reads the ``gen_ai.*`` / ``langsmith.*`` namespaces;
-LiveKit emits its data under a ``lk.*`` vendor prefix the ingester doesn't
-recognize — so without translation, transcripts, TTS metrics, EOU
-probabilities, latency numbers, etc. all evaporate at ingest. This
-:class:`LiveKitLangSmithSpanProcessor` rewrites ``lk.*`` into the keys LangSmith
-understands before each span is exported. It inherits the downstream wrapping,
-exporter, ``thread_id`` stamping, and message helpers from
-:class:`BaseLangSmithSpanProcessor`.
-
-Generic to any LiveKit agent
-----------------------------
-The processor only reads LiveKit's own ``lk.*`` attributes and the span's
-name/position — it carries no knowledge of what the LLM stage is. Two rules:
-
-1. **Translate LiveKit spans from their own data.** Each known LiveKit span
-   (``user_turn``, ``llm_request``, ``tts_*``, ``agent_turn``,
-   ``function_tool``, …) is classified and rendered from the ``lk.*`` attributes
-   and ``gen_ai.*`` span events LiveKit sets on it.
-2. **Leave everything else untouched.** Any span that isn't a LiveKit span —
-   e.g. a LangChain/LangGraph run riding the same OTel provider when
-   ``LANGSMITH_TRACING_MODE=otel`` — already arrives in LangSmith's native
-   shape, so it's exported verbatim.
-
-Two translation layers for LiveKit spans
-----------------------------------------
-1. **Per-span classification** — set ``langsmith.span.kind`` and pull the
-   conversation into ``gen_ai.prompt`` / ``gen_ai.completion``. The genuine
-   inference nodes (STT ``user_turn``, ``llm_request``, ``tts_request``) are
-   ``llm``-kind; the framework wrappers (``llm_node``, ``tts_node``, retry
-   spans) are ``chain``.
-2. **Blanket ``lk.*`` pass-through** — every ``lk.*`` scalar lands as
-   ``langsmith.metadata.lk_<name>``, and JSON-object blobs are flattened so each
-   metric is its own field. Per-stage latencies surface this way too.
-
-The whole-conversation transcript on the root span is accumulated from the
-per-turn ``agent_turn`` spans, and the call recording is attached to the root.
-
-The per-context ``set_thread_id`` (opt-in) stamps ``langsmith.metadata.thread_id``
-on every span. The call recording is embedded on the root as a LangSmith
-attachment one of two ways:
-
-* ``audio_path_provider`` — a local file whose bytes are read and embedded. This
-  suits console/dev, where LiveKit writes ``audio.ogg`` under
-  ``ctx.session_directory``. That directory is ephemeral in a deployed worker, so
-  it is not a production path.
-* :meth:`~LiveKitLangSmithSpanProcessor.expect_recording` /
-  :meth:`~LiveKitLangSmithSpanProcessor.complete_recording` — the production
-  path. `LiveKit Egress <https://docs.livekit.io/home/egress/overview/>`_ records
-  the room to your own storage, but only finishes uploading *after* the call. So
-  the host calls ``expect_recording`` at the start (we hold the root span open),
-  then downloads the finished file and calls ``complete_recording`` with the
-  bytes — embedded as a real attachment, just like the dev path.
-
-With neither set, the processor needs nothing from the host app.
+Rewrites LiveKit's ``lk.*`` span data into the ``gen_ai.*`` / ``langsmith.*``
+namespaces LangSmith ingests; non-LiveKit spans on the same provider pass
+through untouched. The call recording is attached to the root span, either from
+a local file (``audio_path_provider``, dev) or via :meth:`expect_recording` /
+:meth:`complete_recording` (LiveKit Egress, production). Shared export /
+``thread_id`` / message plumbing lives in :class:`BaseLangSmithSpanProcessor`.
 """
 
 from __future__ import annotations
 
-import json
 from collections.abc import MutableMapping
 from pathlib import Path
 from typing import Any, Callable, Optional
 
 from cachetools import TTLCache
+from opentelemetry.sdk.trace import SpanProcessor
 
 from langsmith._internal._package_version import get_package_version
 from langsmith._internal.voice.base_span_processor import (
@@ -71,26 +23,23 @@ from langsmith._internal.voice.base_span_processor import (
     TranslatedSpan,
 )
 
-# Default lifetime (seconds) for the per-conversation state held between a
-# trace's first and last span. The normal path frees it when the session ends
-# (and shutdown/force_flush flushes any still-held root); the TTL bounds it for
-# conversations that never end (crash, dropped connection) on a long-running
-# worker. Generous enough to outlast a slow Egress upload.
-DEFAULT_STATE_TTL_SECONDS = 3600.0
+from ._helpers import (
+    build_assistant_message,
+    build_message_from_event,
+    build_user_message,
+    extract_model_from_lk_metrics,
+    extract_provider_from_lk_metrics,
+    flatten_lk_attributes_to_ls_metadata,
+    is_livekit_span,
+    normalize_provider,
+    try_parse_json_object,
+)
 
-# Hard ceiling on tracked conversations, independent of the TTL — a backstop
-# against a flood of new conversations within one TTL window (oldest evicted
-# first). The TTL is the governing limit in practice.
+# Lifetime / cap for per-conversation state; bounds memory for calls that never end.
+DEFAULT_STATE_TTL_SECONDS = 3600.0
 DEFAULT_STATE_MAXSIZE = 100_000
 
-# The instrumentation scope LiveKit's tracer is created under
-# (``get_tracer("livekit-agents")``). Every span LiveKit emits carries it, so it
-# is how we tell a LiveKit span apart from a non-LiveKit run riding the same OTel
-# provider (e.g. a LangChain/LangGraph trace under ``LANGSMITH_TRACING_MODE=otel``).
-_LIVEKIT_INSTRUMENTATION_SCOPE = "livekit-agents"
-
-# LiveKit's span names, grouped by how we treat them. The genuine inference
-# calls are ``llm``-kind; the framework wrappers around them are ``chain``.
+# LiveKit span names. Inference calls are ``llm``-kind; framework wrappers ``chain``.
 _STT_SPAN = "user_turn"  # audio → transcript (inference)
 _LLM_INFERENCE_SPAN = "llm_request"  # chat completion (inference)
 _LLM_WRAPPER_SPANS = {"llm_node", "llm_request_run"}
@@ -101,9 +50,8 @@ _SESSION_SPAN = "agent_session"
 _TOOL_SPAN = "function_tool"
 _REALTIME_METRICS_SPAN = "realtime_metrics"
 
-# LiveKit records each chat-context item sent to the model as a span event on
-# ``llm_request`` (the event name implies the message role), followed by a
-# ``gen_ai.choice`` event carrying the generated message.
+# ``llm_request`` emits one ``gen_ai.<role>.message`` event per chat item, plus a
+# ``gen_ai.choice`` for the reply.
 _LLM_EVENT_ROLES = {
     "gen_ai.system.message": "system",
     "gen_ai.user.message": "user",
@@ -112,51 +60,13 @@ _LLM_EVENT_ROLES = {
 }
 _LLM_CHOICE_EVENT = "gen_ai.choice"
 
-# LiveKit reports some providers as the API base-URL host (e.g. its OpenAI
-# plugin → ``api.openai.com``), but LangSmith's cost engine keys on provider
-# *slugs* (``openai`` / ``deepgram`` / …), so a hostname never matches a price.
-# We recover the slug by substring — so ``beta.anthropic.com`` still → ``anthropic``
-# — mirroring how LangSmith itself infers the provider from a model name.
-_PROVIDER_ALIASES = (
-    "openai",
-    "anthropic",
-    "gemini",
-    "google",
-    "deepgram",
-    "cartesia",
-    "elevenlabs",
-    "cohere",
-    "mistral",
-    "groq",
-)
-
-
-def _normalize_provider(raw: Any) -> Optional[str]:
-    """Map a LiveKit provider (often an API host) to a LangSmith provider slug.
-
-    Matches a known provider slug as a substring (so ``api.openai.com`` and
-    ``beta.anthropic.com`` resolve to ``openai`` / ``anthropic``); otherwise
-    returns the value's host, stripped of scheme/path. Returns ``None`` for
-    empty input or LiveKit's ``"unknown"`` placeholder, so we never stamp a
-    non-matching provider.
-    """
-    if not raw:
-        return None
-    value = str(raw).strip().lower()
-    if not value or value == "unknown":
-        return None
-    for alias in _PROVIDER_ALIASES:
-        if alias in value:
-            return alias
-    return value.split("://", 1)[-1].split("/", 1)[0] or None
-
 
 class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
     """Enriches LiveKit Agents' OTel spans with LangSmith-compatible attributes."""
 
     def __init__(
         self,
-        downstream_processor: Optional[Any] = None,
+        downstream_processor: Optional[SpanProcessor] = None,
         *,
         api_key: Optional[str] = None,
         project: Optional[str] = None,
@@ -169,15 +79,11 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         """Create the processor.
 
         Args:
-            audio_path_provider: zero-arg callable returning a local recording
-                path whose bytes are embedded in the root span; ``None`` disables.
-                Console/dev only — see the module docstring. For production, use
-                :meth:`expect_recording` / :meth:`complete_recording` to attach a
-                LiveKit Egress recording.
+            audio_path_provider: returns a local recording path to embed on the
+                root (dev only); for production use :meth:`expect_recording` /
+                :meth:`complete_recording`.
             audio_mime_type: default MIME type for embedded recordings.
-            state_ttl_seconds: lifetime for the per-conversation state held
-                between a trace's first and last span; the backstop that frees
-                state for conversations that never end (no ``agent_session`` span).
+            state_ttl_seconds: lifetime for per-conversation state.
         """
         super().__init__(
             downstream_processor,
@@ -189,40 +95,68 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         self.audio_path_provider = audio_path_provider
         self._audio_mime_type = audio_mime_type
 
-        # All per-conversation state is TTL-bounded so a conversation that never
-        # ends (crash, dropped connection) can't leak it on a long-running
-        # worker — the held root span and pending egress audio are the largest.
-        # NB: ``TTLCache`` is not thread-safe; every cache here is mutated only
-        # from the single LiveKit/asyncio event loop (``on_end`` and the host's
-        # ``expect_recording`` / ``complete_recording`` calls all run there).
         def _cache() -> Any:
             return TTLCache(maxsize=DEFAULT_STATE_MAXSIZE, ttl=state_ttl_seconds)
 
-        # Whole-conversation transcript, accumulated turn-by-turn from the
-        # ``agent_turn`` spans. trace_id (int) -> flat [{role, content}, ...].
-        self._conversation_by_trace: MutableMapping[int, list[dict]] = _cache()
-        # The trace root (job entrypoint) ends before the conversation completes
-        # when the agent greets first, so we hold its draft until ``agent_session``
-        # ends with the full conversation. trace_id (hex str) -> TranslatedSpan.
-        self._deferred_root_spans: MutableMapping[str, TranslatedSpan] = _cache()
-        # Used as a set (trace_id -> True): sessions whose end span has arrived.
-        self._ended_sessions: MutableMapping[str, bool] = _cache()
-        # Production egress audio arrives *after* the call, so a conversation can
-        # ask us to hold its root until ``complete_recording`` supplies the bytes.
-        # Keyed by thread id (the conversation id the host controls);
-        # ``_awaiting_recording`` is used as a set (thread_id -> True).
-        self._awaiting_recording: MutableMapping[str, bool] = _cache()
-        self._pending_audio: MutableMapping[str, dict] = _cache()
-        self._thread_to_trace: MutableMapping[str, str] = _cache()
-        self._trace_to_thread: MutableMapping[str, str] = _cache()
-        # Realtime-model metrics cached from a ``realtime_metrics`` child span and
-        # drained onto its parent ``agent_turn``. Keyed by the parent span_id.
-        self._realtime_metrics_by_parent: MutableMapping[int, dict] = _cache()
+        # trace_id -> running transcript, rolled up onto the root at session end.
+        self._transcript_by_trace: MutableMapping[int, list[dict]] = _cache()
+        # trace_id -> root span held open until the session (and any egress) ends.
+        self._deferred_root_by_trace: MutableMapping[int, TranslatedSpan] = _cache()
+        # trace_ids whose ``agent_session`` end span has arrived (used as a set).
+        self._ended_session_traces: MutableMapping[int, bool] = _cache()
+        # thread ids awaiting an egress recording (used as a set).
+        self._threads_awaiting_recording: MutableMapping[str, bool] = _cache()
+        # thread id -> pending egress audio bytes.
+        self._pending_audio_by_thread: MutableMapping[str, dict] = _cache()
+        # thread id -> trace_id, so ``complete_recording`` can find the trace.
+        self._trace_by_thread: MutableMapping[str, int] = _cache()
+        # parent span_id -> realtime metrics to drain onto its ``agent_turn``.
+        self._realtime_metrics_by_parent_span: MutableMapping[int, dict] = _cache()
+
+    def _remember_thread_id(self, trace_id: int, thread_id: str) -> None:
+        """Also index thread→trace (so ``complete_recording`` can find the trace)."""
+        super()._remember_thread_id(trace_id, thread_id)
+        self._trace_by_thread[thread_id] = trace_id
+
+    # -- production recording (egress) ---------------------------------------
+
+    def expect_recording(self, thread_id: str) -> None:
+        """Hold the root span open until :meth:`complete_recording` supplies the audio.
+
+        Call at conversation start (with egress); always pair with a
+        ``complete_recording`` call. ``thread_id`` must match ``set_thread_id``.
+        """
+        self._threads_awaiting_recording[str(thread_id)] = True
+
+    def complete_recording(
+        self,
+        thread_id: str,
+        data: Optional[bytes],
+        *,
+        name: str = "recording.ogg",
+        mime_type: Optional[str] = None,
+    ) -> None:
+        """Attach an egress recording and release the held root.
+
+        ``data`` is the recording bytes (embedded as an attachment), or ``None``
+        to release without audio. ``thread_id`` must match :meth:`expect_recording`.
+        Safe to call before or after the session ends.
+        """
+        if data:
+            self._pending_audio_by_thread[str(thread_id)] = {
+                "name": name,
+                "data": bytes(data),
+                "mime_type": mime_type or self._audio_mime_type,
+            }
+        self._threads_awaiting_recording.pop(str(thread_id), None)
+        trace_id = self._trace_by_thread.get(str(thread_id))
+        if trace_id is not None:
+            self._maybe_release(trace_id)
 
     # -- dispatch -------------------------------------------------------------
 
     def _dispatch(self, tspan: TranslatedSpan) -> bool:
-        trace_id = format(tspan.span.context.trace_id, "032x")
+        trace_id = tspan.span.context.trace_id
         name = tspan.span.name
 
         if name == _STT_SPAN:
@@ -231,110 +165,58 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
             self._handle_llm_request(tspan)
         elif name in _LLM_WRAPPER_SPANS:
             tspan.set_kind("chain")  # wrappers: no fabricated I/O
-        elif name == _TTS_INFERENCE_SPAN or name in _TTS_WRAPPER_SPANS:
+        elif name == _TTS_INFERENCE_SPAN:
             self._handle_tts(tspan)
+        elif name in _TTS_WRAPPER_SPANS:
+            tspan.set_kind("chain")  # wrappers: no fabricated I/O
         elif name == _TURN_SPAN:
             self._handle_turn(tspan)
         elif name == _SESSION_SPAN:
-            # Session end: the conversation is complete — release the deferred
-            # root (if any), then export the session span itself.
+            # Session end: release the deferred root, then export this span.
             tspan.set_kind("chain")
-            self._ended_sessions[trace_id] = True
-            self._release_root_span(trace_id)
+            self._ended_session_traces[trace_id] = True
+            self._maybe_release(trace_id)
         elif name == "eou_detection":
             tspan.set_kind("chain")  # framework step
         elif name == _TOOL_SPAN:
             self._handle_tool(tspan)
         elif name == _REALTIME_METRICS_SPAN:
-            # These belong ON the turn, not as their own span: cache for the
-            # parent agent_turn and suppress this span entirely (False = the base
-            # must not export it; nothing else does either).
+            # Drained onto the parent agent_turn; suppress this span (False).
             self._cache_realtime_metrics(tspan)
             return False
-        elif tspan.span.parent is None and self._is_livekit_span(tspan.span):
-            # The trace root (LiveKit's job entrypoint). _handle_root owns its
-            # export: it renders/attaches and exports immediately, or defers
-            # until the session ends and egress audio is ready (via
-            # _maybe_release). Either way the base must not export it (False).
-            #
-            # Gated on the LiveKit scope so a *non-LiveKit* parentless span —
-            # e.g. a LangChain/LangGraph root riding the same OTel provider — is
-            # not mistaken for the conversation root, deferred, and mislabeled
-            # ``langsmith.root_span``/``ls_modality=audio``; it falls through and
-            # is exported untouched below.
+        elif tspan.span.parent is None and is_livekit_span(tspan.span):
+            # Conversation root — _handle_root owns its export (False). Gated on
+            # the LiveKit scope so a non-LiveKit parentless span isn't hijacked.
             self._handle_root(tspan, trace_id)
             return False
-        # Any other span isn't a LiveKit span (e.g. a LangChain/LangGraph run);
-        # it already arrives in LangSmith's native shape — export untouched.
-        #
-        # Return True so the base exports this span once (the session span
-        # included; _release_root_span above exports only the separate deferred
-        # root, never this one).
-        return True
-
-    @staticmethod
-    def _is_livekit_span(span: Any) -> bool:
-        """Whether a span came from LiveKit's tracer (its instrumentation scope).
-
-        Used to gate root detection: only a parentless span emitted by LiveKit is
-        the conversation root. Named LiveKit spans are matched by name above and
-        don't need this; it guards the broad ``parent is None`` case alone.
-        """
-        scope = getattr(span, "instrumentation_scope", None)
-        return getattr(scope, "name", None) == _LIVEKIT_INSTRUMENTATION_SCOPE
+        return True  # non-LiveKit span: export untouched
 
     # -- per-span-type handlers ----------------------------------------------
-
-    def _stamp_provider(self, tspan: TranslatedSpan, metrics_attr: str) -> None:
-        """Normalize the provider to a LangSmith slug for a LiveKit span.
-
-        LiveKit reports the provider as the API-base-URL host (its OpenAI plugin
-        → ``api.openai.com``) and, depending on version, under either
-        ``gen_ai.provider.name`` (livekit-agents ≥1.5) or ``gen_ai.system``.
-        LangSmith ingestion maps either to ``ls_provider``, so we resolve a slug
-        from the metric blob's ``metadata.model_provider`` or whichever key the
-        span carries, then write it back to *both* keys. No-ops when no usable
-        provider is available, rather than stamp ``"unknown"``.
-        """
-        provider = None
-        metrics = self._try_parse_json_object(tspan.attributes.get(metrics_attr))
-        if isinstance(metrics, dict):
-            provider = (metrics.get("metadata") or {}).get("model_provider")
-        provider = (
-            _normalize_provider(provider)
-            or _normalize_provider(tspan.attributes.get("gen_ai.provider.name"))
-            or _normalize_provider(tspan.attributes.get("gen_ai.system"))
-        )
-        if provider:
-            tspan.attributes["gen_ai.provider.name"] = provider
-            tspan.attributes["gen_ai.system"] = provider
 
     def _handle_stt(self, tspan: TranslatedSpan) -> None:
         """STT (``user_turn``): audio input → transcribed text."""
         tspan.set_kind("llm")
-        model = tspan.attributes.get("gen_ai.request.model")
-        if model:
-            tspan.attributes["langsmith.metadata.model_name"] = str(model)
-        self._stamp_provider(tspan, "lk.stt_metrics")
+        tspan.set_model(
+            tspan.attributes.get("gen_ai.request.model")
+            or extract_model_from_lk_metrics(tspan.attributes.get("lk.stt_metrics"))
+        )
+        provider = extract_provider_from_lk_metrics(
+            tspan.attributes.get("lk.stt_metrics")
+        )
+        tspan.set_provider(normalize_provider(provider))
 
         transcript = tspan.attributes.get("lk.user_transcript")
-        tspan.set_messages(
-            prompt=[{"role": "user", "content": f'Audio for: "{transcript}"'}]
-        )
         if transcript:
             tspan.set_messages(
-                completion=[{"role": "assistant", "content": str(transcript)}]
+                prompt=[build_user_message(f'Audio for: "{transcript}"')]
             )
+            tspan.set_messages(completion=[build_assistant_message(str(transcript))])
         tspan.exclude_from_message_view()
 
     def _handle_llm_request(self, tspan: TranslatedSpan) -> None:
-        """``llm_request``: the chat-completion call.
+        """``llm_request``: rebuild prompt/completion from the gen_ai.* events.
 
-        LiveKit records the request's I/O as span events: one
-        ``gen_ai.{system,user,assistant,tool}.message`` event per chat-context
-        item, then a ``gen_ai.choice`` with the generated message. We rebuild
-        ``gen_ai.prompt``/``gen_ai.completion`` (singular JSON, so tool calls
-        survive) and strip the translated events so the ingester doesn't render
+        The translated events are then stripped so the ingester doesn't render
         them twice.
         """
         tspan.set_kind("llm")
@@ -343,62 +225,24 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         completion: list[dict] = []
         for event in tspan.events:
             if event.name == _LLM_CHOICE_EVENT:
-                completion.append(self._message_from_event("assistant", event))
+                completion.append(build_message_from_event("assistant", event))
             elif (role := _LLM_EVENT_ROLES.get(event.name)) is not None:
-                prompt.append(self._message_from_event(role, event))
+                prompt.append(build_message_from_event(role, event))
         tspan.set_messages(prompt=prompt or None, completion=completion or None)
-        # Normalize the provider (LiveKit's OpenAI plugin reports the
-        # ``api.openai.com`` host, which won't match a LangSmith price).
-        self._stamp_provider(tspan, "lk.llm_metrics")
 
-        # Drop the translated events (keep others, e.g. exceptions) on the
-        # draft — finalize rebuilds the span from it, so span._events is left
-        # untouched.
+        provider = extract_provider_from_lk_metrics(
+            tspan.attributes.get("lk.llm_metrics")
+        )
+        tspan.set_provider(normalize_provider(provider))
+
         tspan.events[:] = [
             e
             for e in tspan.events
             if e.name != _LLM_CHOICE_EVENT and e.name not in _LLM_EVENT_ROLES
         ]
 
-    def _message_from_event(self, role: str, event: Any) -> dict:
-        """Build a message dict from a LiveKit gen_ai event.
-
-        Tool calls are forwarded in their OpenAI shape (parsing any JSON-string
-        entries to objects) — LangSmith's ingester renders them directly.
-        """
-        attrs = event.attributes or {}
-        msg: dict = {
-            "role": str(attrs.get("role") or role),
-            "content": str(attrs.get("content") or ""),
-        }
-        tool_calls = []
-        for raw in attrs.get("tool_calls") or ():
-            if isinstance(raw, str):
-                try:
-                    raw = json.loads(raw)
-                except json.JSONDecodeError:
-                    continue
-            if isinstance(raw, dict):
-                tool_calls.append(raw)
-        if tool_calls:
-            msg["tool_calls"] = tool_calls
-        if role == "tool":
-            if attrs.get("id"):
-                msg["tool_call_id"] = str(attrs["id"])
-            if attrs.get("name"):
-                msg["name"] = str(attrs["name"])
-        return msg
-
     def _handle_tts(self, tspan: TranslatedSpan) -> None:
-        """Render the TTS spans.
-
-        ``tts_request`` is the synthesis call (``llm``); the ``tts_node`` /
-        ``tts_request_run`` wrappers are ``chain``s.
-        """
-        if tspan.span.name != _TTS_INFERENCE_SPAN:
-            tspan.set_kind("chain")
-            return
-
+        """``tts_request``: synthesize text → audio (an ``llm`` inference)."""
         tspan.set_kind("llm")
         tspan.exclude_from_message_view()
 
@@ -409,131 +253,57 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
             or ""
         )
         tspan.set_messages(
-            prompt=[{"role": "user", "content": str(text)}],
-            completion=[
-                {"role": "assistant", "content": f'Generated audio for: "{text}"'}
-            ],
+            prompt=[build_user_message(str(text))],
+            completion=[build_assistant_message(f'Generated audio for: "{text}"')],
         )
 
-        model = tspan.attributes.get("gen_ai.request.model")
-        if not model:
-            metrics = self._try_parse_json_object(
-                tspan.attributes.get("lk.tts_metrics")
-            )
-            if isinstance(metrics, dict):
-                model = (metrics.get("metadata") or {}).get(
-                    "model_name"
-                ) or metrics.get("model_name")
-        if model:
-            tspan.attributes["gen_ai.request.model"] = str(model)
-            tspan.attributes["langsmith.metadata.model_name"] = str(model)
-        self._stamp_provider(tspan, "lk.tts_metrics")
+        tspan.set_model(
+            tspan.attributes.get("gen_ai.request.model")
+            or extract_model_from_lk_metrics(tspan.attributes.get("lk.tts_metrics"))
+        )
+        provider = extract_provider_from_lk_metrics(
+            tspan.attributes.get("lk.tts_metrics")
+        )
+        tspan.set_provider(normalize_provider(provider))
 
     def _handle_turn(self, tspan: TranslatedSpan) -> None:
-        """Render an ``agent_turn``: one user/assistant exchange.
-
-        Appends the exchange to the running conversation the root rolls up. This
-        is the LiveKit-native turn boundary, so it works for both the cascade and
-        the speech-to-speech backends.
-        """
+        """Render an ``agent_turn`` and append it to the running transcript."""
         tspan.set_kind("chain")
         self._drain_realtime_metrics(tspan)
 
         user_input = tspan.attributes.get("lk.user_input")
         response = tspan.attributes.get("lk.response.text")
         trace_id = tspan.span.context.trace_id
-        conversation = self._conversation_by_trace.get(trace_id) or []
+        conversation = self._transcript_by_trace.get(trace_id) or []
         if user_input:
-            msg = {"role": "user", "content": str(user_input)}
+            msg = build_user_message(str(user_input))
             tspan.set_messages(prompt=[msg])
             conversation.append(msg)
         if response:
-            msg = {"role": "assistant", "content": str(response)}
+            msg = build_assistant_message(str(response))
             tspan.set_messages(completion=[msg])
             conversation.append(msg)
-        # Re-assign (not just mutate) so each turn refreshes the TTL — an active
-        # call longer than the TTL is never evicted mid-conversation.
+        # Re-assign (not just mutate) so each turn refreshes the cache TTL.
         if conversation:
-            self._conversation_by_trace[trace_id] = conversation
+            self._transcript_by_trace[trace_id] = conversation
 
     def _handle_tool(self, tspan: TranslatedSpan) -> None:
         """``function_tool``: render as a proper ``tool`` run with its I/O."""
         tspan.set_kind("tool")
         tool_name = tspan.attributes.get("lk.function_tool.name")
         if tool_name:
-            tspan.attributes["langsmith.metadata.tool_name"] = str(tool_name)
+            tspan.set_metadata("tool_name", str(tool_name))
         args = tspan.attributes.get("lk.function_tool.arguments")
         if args is not None:
-            tspan.attributes["gen_ai.prompt"] = (
-                args if isinstance(args, str) else json.dumps(args)
-            )
+            tspan.set_tool_input(args)
         output = tspan.attributes.get("lk.function_tool.output")
         if output is not None:
-            tspan.attributes["gen_ai.completion"] = (
-                output if isinstance(output, str) else json.dumps(output)
-            )
-
-    # -- production recording (egress) ---------------------------------------
-
-    def expect_recording(self, thread_id: str) -> None:
-        """Hold this conversation's root span until its recording is supplied.
-
-        LiveKit Egress finishes uploading *after* the call ends, so the bytes
-        don't exist when the root span would normally be exported. Call this at
-        the start of a conversation (when you start egress) to defer that export;
-        then call :meth:`complete_recording` once you have the file. Until then
-        the root is held (a worker shutdown flushes it without audio as a
-        fallback), so always pair this with a ``complete_recording`` call —
-        passing ``None`` to release without audio if the recording fails.
-
-        Args:
-            thread_id: the conversation id, matching the one passed to
-                ``set_thread_id``.
-        """
-        self._awaiting_recording[str(thread_id)] = True
-
-    def complete_recording(
-        self,
-        thread_id: str,
-        data: Optional[bytes],
-        *,
-        name: str = "recording.ogg",
-        mime_type: Optional[str] = None,
-    ) -> None:
-        """Attach an egress recording to a conversation and release its root.
-
-        Download the completed egress file from your storage and pass its bytes
-        here; they're embedded as a real LangSmith attachment on the root span.
-        Pass ``data=None`` to release the held root without audio (e.g. egress
-        failed). Safe to call before or after the session ends.
-
-        Args:
-            thread_id: the conversation id, matching :meth:`expect_recording`.
-            data: the recording bytes, or ``None`` to release without audio.
-            name: attachment filename.
-            mime_type: attachment MIME type; defaults to the processor's.
-        """
-        tid = str(thread_id)
-        if data:
-            self._pending_audio[tid] = {
-                "name": name,
-                "data": bytes(data),
-                "mime_type": mime_type or self._audio_mime_type,
-            }
-        self._awaiting_recording.pop(tid, None)
-        trace_id = self._thread_to_trace.get(tid)
-        if trace_id is not None:
-            self._maybe_release(trace_id)
+            tspan.set_tool_output(output)
 
     # -- deferred root release ------------------------------------------------
 
-    def _handle_root(self, tspan: TranslatedSpan, trace_id: str) -> None:
-        """Handle the trace root (job entrypoint), the conversation root.
-
-        The root ends before the conversation completes (the agent greets first),
-        so we always defer it and release it — complete, with audio — once the
-        session has ended and any awaited recording has arrived.
-        """
+    def _handle_root(self, tspan: TranslatedSpan, trace_id: int) -> None:
+        """Mark the conversation root and defer it until the session ends."""
         tspan.set_kind("chain")
         tspan.set_root_span(True)
         tspan.set_metadata("ls_modality", "audio")
@@ -542,34 +312,27 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
             "ls_integration_version", (get_package_version("livekit-agents") or "")
         )
 
-        thread = tspan.attributes.get("langsmith.metadata.thread_id")
-        if thread is not None:
-            self._thread_to_trace[str(thread)] = trace_id
-            self._trace_to_thread[trace_id] = str(thread)
-
-        self._deferred_root_spans[trace_id] = tspan
+        self._deferred_root_by_trace[trace_id] = tspan
         self._maybe_release(trace_id)
 
-    def _release_root_span(self, trace_id: str) -> None:
-        """Session ended: release the root if ready (see :meth:`_maybe_release`)."""
-        self._maybe_release(trace_id)
-
-    def _maybe_release(self, trace_id: str) -> None:
+    def _maybe_release(self, trace_id: int, *, force: bool = False) -> None:
         """Export the deferred root once the session ended and audio is ready.
 
-        Three conditions must hold: the root span has been seen, the
-        ``agent_session`` has ended, and the conversation isn't still awaiting an
-        egress recording. Any of the three call sites (root seen, session end,
-        ``complete_recording``) can be the one that satisfies the last condition.
+        Requires the root seen, the session ended, and no awaited recording.
+        ``force`` skips the last two gates — the last-resort path at
+        :meth:`shutdown` for a root that never completed.
         """
-        tspan = self._deferred_root_spans.get(trace_id)
-        if tspan is None or trace_id not in self._ended_sessions:
+        tspan = self._deferred_root_by_trace.get(trace_id)
+        if tspan is None:
             return
-        thread = self._trace_to_thread.get(trace_id)
-        if thread is not None and thread in self._awaiting_recording:
-            return  # still waiting for complete_recording()
+        thread = self._thread_id_by_trace.get(trace_id)
+        if not force:
+            if trace_id not in self._ended_session_traces:
+                return
+            if thread is not None and thread in self._threads_awaiting_recording:
+                return  # still waiting for complete_recording()
 
-        self._deferred_root_spans.pop(trace_id, None)
+        self._deferred_root_by_trace.pop(trace_id, None)
         self._render_conversation(tspan)
         self._attach_audio_recording(tspan)
         if thread is not None:
@@ -578,82 +341,48 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         self._cleanup_trace(trace_id)
 
     def _render_conversation(self, tspan: TranslatedSpan) -> bool:
-        """Render the accumulated conversation onto a root span.
-
-        Input = the opening message; output = everything after it. Returns
-        whether anything was rendered.
-        """
-        messages = self._conversation_by_trace.get(tspan.span.context.trace_id, [])
+        """Set the whole transcript as the root's input messages; return if any."""
+        messages = self._transcript_by_trace.get(tspan.span.context.trace_id, [])
         if not messages:
             return False
-        tspan.set_messages(prompt=messages[:1])
-        if len(messages) > 1:
-            tspan.set_messages(completion=messages[1:])
+        tspan.set_messages(prompt=messages)
         return True
 
-    def _cleanup_trace(self, trace_id: str) -> None:
-        self._conversation_by_trace.pop(int(trace_id, 16), None)
-        self._forget_thread_id(int(trace_id, 16))
-        self._ended_sessions.pop(trace_id, None)
-        thread = self._trace_to_thread.pop(trace_id, None)
+    def _cleanup_trace(self, trace_id: int) -> None:
+        # Read the thread id before ``_forget_thread_id`` drops it from the base map.
+        thread = self._thread_id_by_trace.get(trace_id)
+        self._transcript_by_trace.pop(trace_id, None)
+        self._forget_thread_id(trace_id)
+        self._ended_session_traces.pop(trace_id, None)
         if thread is not None:
-            self._thread_to_trace.pop(thread, None)
-            self._awaiting_recording.pop(thread, None)
-            self._pending_audio.pop(thread, None)
+            self._trace_by_thread.pop(thread, None)
+            self._threads_awaiting_recording.pop(thread, None)
+            self._pending_audio_by_thread.pop(thread, None)
 
     def shutdown(self) -> None:
-        """Flush any deferred root spans, then shut down the downstream."""
-        self._flush_deferred_root_spans()
+        """Force-export any still-held roots (last resort), then shut down.
+
+        ``force_flush`` deliberately does not — a still-held root there is
+        legitimately in progress, not a buffered export waiting to drain.
+        """
+        for trace_id in list(self._deferred_root_by_trace):
+            self._maybe_release(trace_id, force=True)
         super().shutdown()
 
     def force_flush(self, timeout_millis: int = 30000) -> bool:
-        """Force-flush the downstream — deferred root spans are NOT finalized.
-
-        Unlike ``shutdown``, ``force_flush`` can fire *mid-conversation* (a
-        periodic flush, or any ``provider.force_flush()`` caller). A deferred root
-        is still being assembled — its ``agent_session`` hasn't ended — so
-        finalizing and exporting it here would emit a partial root and drop it,
-        losing the real root when the session later ends. So in-progress roots are
-        left held; only ``shutdown`` (terminal) flushes them as a last resort.
-        """
+        """Force-flush the downstream — deferred root spans are NOT finalized."""
         return super().force_flush(timeout_millis)
-
-    def _flush_deferred_root_spans(self) -> None:
-        """Export any root spans still held — last resort, ``shutdown`` only.
-
-        Covers a session that ended abnormally, or an awaited recording that
-        never arrived before shutdown. Not called from ``force_flush``: a still-held
-        root is legitimately in progress, not a buffered export waiting to drain.
-        """
-        for trace_id, tspan in list(self._deferred_root_spans.items()):
-            if not self._render_conversation(tspan):
-                tspan.set_messages(
-                    prompt=[{"role": "system", "content": "Conversation not captured"}],
-                    completion=[
-                        {
-                            "role": "assistant",
-                            "content": "No conversation turns recorded.",
-                        }
-                    ],
-                )
-            self._attach_audio_recording(tspan)
-            thread = self._trace_to_thread.get(trace_id)
-            if thread is not None:
-                self._attach_pending_audio(tspan, thread)
-            self._export(tspan)
-            del self._deferred_root_spans[trace_id]
 
     # -- audio attachment -----------------------------------------------------
 
     def _attach_audio_recording(self, tspan: TranslatedSpan) -> None:
+        """Embed audio from the local ``audio_path_provider`` file (dev)."""
         if self.audio_path_provider is None:
             return
         audio_path = self.audio_path_provider()
-        if audio_path is None:
+        if audio_path is None or not audio_path.exists():
             return
         try:
-            if not audio_path.exists():
-                return
             audio_bytes = audio_path.read_bytes()
         except Exception:  # pragma: no cover
             return
@@ -666,7 +395,7 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
 
     def _attach_pending_audio(self, tspan: TranslatedSpan, thread: str) -> None:
         """Embed a recording supplied via :meth:`complete_recording` (egress)."""
-        pending = self._pending_audio.pop(thread, None)
+        pending = self._pending_audio_by_thread.pop(thread, None)
         if not pending or not pending.get("data"):
             return
         self._attach_audio(
@@ -680,104 +409,62 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
 
     def _cache_realtime_metrics(self, tspan: TranslatedSpan) -> None:
         """Stash a ``realtime_metrics`` span's data for its parent ``agent_turn``."""
-        parent_id = tspan.span.parent.span_id if tspan.span.parent else None
-        if parent_id is None:
+        parent = tspan.span.parent
+        if parent is None:
             return
-        cached = {
-            k: v
-            for k, v in tspan.attributes.items()
-            if k.startswith("lk.") or k.startswith("gen_ai.usage")
+        carried_metrics = {
+            key: value
+            for key, value in tspan.attributes.items()
+            if key.startswith("lk.") or key.startswith("gen_ai.usage")
         }
         # Lift token counts into gen_ai.usage.* for cost tracking.
-        metrics = self._try_parse_json_object(
+        model_metrics = try_parse_json_object(
             tspan.attributes.get("lk.realtime_model_metrics")
         )
-        if isinstance(metrics, dict):
-            for src, dst in (
-                ("input_tokens", "gen_ai.usage.input_tokens"),
-                ("output_tokens", "gen_ai.usage.output_tokens"),
-                ("total_tokens", "gen_ai.usage.total_tokens"),
-            ):
-                v = metrics.get(src)
-                if isinstance(v, (int, float)):
-                    cached[dst] = v
-        if cached:
-            self._realtime_metrics_by_parent[parent_id] = cached
+        if isinstance(model_metrics, dict):
+            for token_key in ("input_tokens", "output_tokens", "total_tokens"):
+                count = model_metrics.get(token_key)
+                if isinstance(count, (int, float)):
+                    carried_metrics[f"gen_ai.usage.{token_key}"] = count
+        if carried_metrics:
+            self._realtime_metrics_by_parent_span[parent.span_id] = carried_metrics
 
     def _drain_realtime_metrics(self, tspan: TranslatedSpan) -> None:
-        """Copy cached realtime metrics onto this (agent_turn) span (if absent)."""
-        cached = self._realtime_metrics_by_parent.pop(tspan.span.context.span_id, None)
-        if not cached:
+        """Copy cached realtime metrics onto this ``agent_turn`` (never clobbering)."""
+        carried_metrics = self._realtime_metrics_by_parent_span.pop(
+            tspan.span.context.span_id, None
+        )
+        if not carried_metrics:
             return
-        for k, v in cached.items():
-            if k not in tspan.attributes:
-                tspan.attributes[k] = v
-
-    # -- blanket lk.* pass-through (runs just before export) ------------------
+        for key, value in carried_metrics.items():
+            if key not in tspan.attributes:
+                tspan.attributes[key] = value
 
     def _pre_export(self, tspan: TranslatedSpan) -> None:
-        """Forward every ``lk.*`` attribute to ``langsmith.metadata.lk_<name>``.
+        """Forward ``lk.*`` to ``langsmith.metadata.lk_*`` and normalize the provider.
 
-        Scalars and sequences of scalars are forwarded directly; JSON-object
-        blobs are flattened so each metric is its own field.
+        Scalars pass through; JSON-object blobs are flattened per field. Runs on
+        every exported span, so it also covers spans no handler classified.
         """
         for key in list(tspan.attributes.keys()):
             if not key.startswith("lk."):
                 continue
-            v = tspan.attributes[key]
-            if v is None or isinstance(v, dict):
-                continue
-            ms_key = f"langsmith.metadata.{key.replace('.', '_')}"
-            parsed = self._try_parse_json_object(v)
+            value = tspan.attributes[key]
+            flat_key = f"langsmith.metadata.{key.replace('.', '_')}"
+            parsed = try_parse_json_object(value)
             if parsed is not None:
-                self._flatten_into_metadata(tspan, ms_key, parsed)
+                for name, val in flatten_lk_attributes_to_ls_metadata(
+                    parsed, flat_key
+                ).items():
+                    if name not in tspan.attributes:  # don't clobber what a branch set
+                        tspan.attributes[name] = val
                 continue
-            if ms_key in tspan.attributes:  # don't clobber what a branch set
+            if flat_key in tspan.attributes:  # don't clobber what a branch set
                 continue
-            tspan.attributes[ms_key] = v
+            tspan.attributes[flat_key] = value
 
-        # Normalize the provider to a LangSmith slug on EVERY exported span,
-        # under both keys LiveKit/LangSmith use across versions —
-        # ``gen_ai.provider.name`` (livekit-agents ≥1.5) and the legacy
-        # ``gen_ai.system`` — so ``api.openai.com`` → ``openai`` regardless of
-        # which one carries it. Done at the single export chokepoint so it also
-        # catches spans that never reach the per-stage handlers.
-        for key in ("gen_ai.provider.name", "gen_ai.system"):
-            normalized = _normalize_provider(tspan.attributes.get(key))
-            if normalized:
-                tspan.attributes[key] = normalized
-
-    @staticmethod
-    def _try_parse_json_object(value: Any) -> Optional[dict]:
-        """Return ``value`` parsed as a dict if it's a JSON-object string, else None."""
-        if not isinstance(value, str):
-            return None
-        s = value.strip()
-        if not (s.startswith("{") and s.endswith("}")):
-            return None
-        try:
-            obj = json.loads(s)
-        except (json.JSONDecodeError, ValueError):
-            return None
-        return obj if isinstance(obj, dict) else None
-
-    def _flatten_into_metadata(
-        self, tspan: TranslatedSpan, prefix: str, obj: dict, _depth: int = 0
-    ) -> None:
-        """Flatten a dict's scalar leaves to ``langsmith.metadata.<prefix>_<key>``."""
-        if _depth > 4:
-            return
-        for k, v in obj.items():
-            name = f"{prefix}_{k}"
-            if isinstance(v, dict):
-                self._flatten_into_metadata(tspan, name, v, _depth + 1)
-            elif isinstance(v, (str, int, float, bool)):
-                if name not in tspan.attributes:
-                    tspan.attributes[name] = v
-            elif (
-                isinstance(v, (list, tuple))
-                and v
-                and all(isinstance(item, (str, int, float, bool)) for item in v)
-            ):
-                if name not in tspan.attributes:
-                    tspan.attributes[name] = list(v)
+        # Normalize + cross-fill both provider keys from whichever LiveKit set.
+        provider = normalize_provider(
+            tspan.attributes.get("gen_ai.provider.name")
+        ) or normalize_provider(tspan.attributes.get("gen_ai.system"))
+        tspan.set_provider(provider)

--- a/python/langsmith/integrations/pipecat/_helpers.py
+++ b/python/langsmith/integrations/pipecat/_helpers.py
@@ -1,0 +1,35 @@
+"""Small pure helpers for the Pipecat → LangSmith span processor."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from langsmith._internal.voice._helpers import (
+    build_assistant_message,
+    try_parse_json_object,
+)
+
+
+def parse_llm_messages(input_data: Any) -> list[dict[str, Any]]:
+    """Parse a Pipecat ``llm`` span's ``input`` (a JSON message list) to dicts."""
+    try:
+        raw = json.loads(input_data)
+    except (json.JSONDecodeError, TypeError):
+        return []
+    if not isinstance(raw, list):
+        return []
+    return [m for m in raw if isinstance(m, dict)]
+
+
+def build_completion_message(output_data: Any) -> dict[str, Any]:
+    """Build the assistant completion for a Pipecat ``llm`` span.
+
+    A structured response carrying ``tool_calls`` is forwarded in its OpenAI
+    shape; anything else becomes plain assistant text.
+    """
+    parsed = try_parse_json_object(output_data)
+    if isinstance(parsed, dict) and parsed.get("tool_calls"):
+        return {"role": "assistant", **parsed}
+    content = output_data if isinstance(output_data, str) else str(output_data)
+    return build_assistant_message(content)

--- a/python/langsmith/integrations/pipecat/processor.py
+++ b/python/langsmith/integrations/pipecat/processor.py
@@ -43,6 +43,7 @@ from collections.abc import MutableMapping
 from typing import Any, Optional
 
 from cachetools import TTLCache
+from opentelemetry.sdk.trace import SpanProcessor
 
 from langsmith._internal._package_version import get_package_version
 from langsmith._internal.voice.audio import pcm_to_wav
@@ -72,7 +73,7 @@ class PipecatLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
 
     def __init__(
         self,
-        downstream_processor: Optional[Any] = None,
+        downstream_processor: Optional[SpanProcessor] = None,
         *,
         llm_span_kind: str = "llm",
         api_key: Optional[str] = None,

--- a/python/langsmith/integrations/pipecat/processor.py
+++ b/python/langsmith/integrations/pipecat/processor.py
@@ -1,71 +1,101 @@
 """OTel → LangSmith bridge for Pipecat.
 
-Pipecat emits OTel spans named ``conversation``, ``turn``, ``stt``, ``llm``, and
-``tts`` with attributes (``transcript``, ``input``/``output``, ``text``,
-``turn.number``, …) that LangSmith's OTLP ingester doesn't recognize. This
-:class:`PipecatLangSmithSpanProcessor` rewrites each span type into the
-``gen_ai.*`` / ``langsmith.*`` namespaces LangSmith keys off, renders the whole
-conversation onto the root span, and (optionally) attaches the recorded audio
-there. It inherits the downstream wrapping, exporter, ``thread_id`` stamping,
-and message helpers from :class:`BaseLangSmithSpanProcessor`.
+Rewrites Pipecat's ``conversation`` / ``turn`` / ``stt`` / ``llm`` / ``tts`` OTel
+spans into the ``gen_ai.*`` / ``langsmith.*`` namespaces LangSmith ingests, rolls
+the whole conversation onto the root ``conversation`` span, and optionally
+attaches the recorded audio there; non-Pipecat spans pass through untouched.
+Shared export / ``thread_id`` / message plumbing lives in
+:class:`BaseLangSmithSpanProcessor`.
 
-Trace shape in LangSmith::
+Trace shape::
 
-    conversation                      (root; whole transcript + conversation WAV)
-    └── turn × N                      (per exchange; carries was_interrupted)
-        ├── stt                       (audio → transcript)
-        ├── llm                       (the LLM stage; kind set by llm_span_kind)
-        └── tts                       (response text → audio)
+    conversation                 (root; whole transcript + conversation WAV)
+    └── turn × N
+        ├── stt                  (audio → transcript)
+        ├── llm                  (the LLM stage; kind set by llm_span_kind)
+        └── tts                  (response text → audio)
 
-Audio recording uses Pipecat's own
-:class:`~pipecat.processors.audio.audio_buffer_processor.AudioBufferProcessor`:
-call :meth:`attach_audio_buffer` to wire its ``on_audio_data`` event, and the
-processor accumulates the merged PCM and attaches it (as a WAV) to the root span
-when the conversation ends. Place the ``AudioBufferProcessor`` *after*
-``transport.output()`` so it captures the bot audio as actually played
-(post-barge-in-truncation) plus the user audio.
+Audio uses Pipecat's ``AudioBufferProcessor``: wire it with
+:meth:`attach_audio_buffer` (placed after ``transport.output()``, constructed
+with ``num_channels=2``); the merged stereo (user-left / bot-right) it emits is
+attached as a WAV when the conversation ends.
 
-``llm_span_kind`` controls the kind of the span Pipecat names ``llm``. Keep the
-default ``"llm"`` when that stage does its own inference (stock services such as
-``OpenAILLMService``). Pass ``"chain"`` when it only orchestrates nested runs
-that are exported to LangSmith themselves (an in-process LangGraph/LangChain
-brain): the nested ``model`` runs are then the real ``llm`` inference, and
-tagging the wrapper ``llm`` too would double-count the conversation in the
-Messages view. This can't be auto-detected at span-end time (the nested runs are
-exported later, from a background queue), so the caller states it explicitly.
+``llm_span_kind`` sets the kind for Pipecat's ``llm`` span — keep ``"llm"`` for a
+service that does its own inference; pass ``"chain"`` when it only orchestrates
+nested runs exported separately (else the conversation double-counts).
 """
 
 from __future__ import annotations
 
-import json
 import logging
 from collections.abc import MutableMapping
-from typing import Any, Optional
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Optional
 
 from cachetools import TTLCache
 from opentelemetry.sdk.trace import SpanProcessor
 
 from langsmith._internal._package_version import get_package_version
+from langsmith._internal.voice._helpers import (
+    build_assistant_message,
+    build_user_message,
+)
 from langsmith._internal.voice.audio import pcm_to_wav
 from langsmith._internal.voice.base_span_processor import (
     BaseLangSmithSpanProcessor,
     TranslatedSpan,
 )
 
+from ._helpers import build_completion_message, parse_llm_messages
+
+if TYPE_CHECKING:
+    from pipecat.processors.audio.audio_buffer_processor import (  # type: ignore[import-not-found]
+        AudioBufferProcessor,
+    )
+
 logger = logging.getLogger(__name__)
 
-# Default lifetime (seconds) for the per-conversation state held between a
-# trace's first and last span. The normal path frees it when the conversation
-# span ends; the TTL bounds it for conversations that never emit that span
-# (crash, cancelled task, dropped connection).
+# Lifetime / cap for per-conversation state; bounds memory for calls that never end.
 DEFAULT_STATE_TTL_SECONDS = 3600.0
-
-# Hard ceiling on tracked conversations, independent of the TTL — a backstop
-# against a flood of new conversations within one TTL window (oldest evicted
-# first). The TTL is the governing limit in practice.
 DEFAULT_STATE_MAXSIZE = 100_000
 
 _WAV_HEADER_BYTES = 44
+
+
+@dataclass
+class _AudioRecord:
+    """Merged PCM accumulated for one conversation, plus its WAV parameters.
+
+    Pipecat's ``AudioBufferProcessor`` emits already-merged audio — stereo
+    (user-left / bot-right) when constructed with ``num_channels=2`` — so we just
+    accumulate and wrap it.
+    """
+
+    sample_rate: int
+    num_channels: int
+    pcm: bytearray = field(default_factory=bytearray)
+    audio_truncated: bool = False
+
+    def extend(
+        self,
+        audio: bytes,
+        sample_rate: int,
+        num_channels: int,
+        limit_bytes: Optional[int],
+    ) -> None:
+        """Append PCM (truncating at ``limit_bytes``) and refresh the WAV params."""
+        self.sample_rate = sample_rate
+        self.num_channels = num_channels
+        if limit_bytes is not None:
+            remaining = limit_bytes - len(self.pcm)
+            remaining -= remaining % (2 * num_channels)  # keep whole frames
+            if remaining <= 0:
+                self.audio_truncated = True
+                return
+            if len(audio) > remaining:
+                self.audio_truncated = True
+                audio = audio[:remaining]
+        self.pcm.extend(audio)
 
 
 class PipecatLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
@@ -86,14 +116,9 @@ class PipecatLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         """Create the processor.
 
         Args:
-            downstream_processor: where rewritten spans are forwarded; defaults
-                to a LangSmith OTLP exporter (see the base class).
-            llm_span_kind: LangSmith run kind for Pipecat's ``llm`` span (see the
-                module docstring).
+            llm_span_kind: LangSmith run kind for Pipecat's ``llm`` span.
             audio_mime_type: MIME type for the attached conversation recording.
-            state_ttl_seconds: lifetime for the per-conversation state held
-                between a trace's first and last span; the backstop that frees
-                state for conversations that never emit their end span.
+            state_ttl_seconds: lifetime for per-conversation state.
         """
         super().__init__(
             downstream_processor,
@@ -104,45 +129,37 @@ class PipecatLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         )
         self._llm_span_kind = llm_span_kind
         self._audio_mime_type = audio_mime_type
-        # NB: ``TTLCache`` is not thread-safe. Both caches are mutated only from
-        # the single Pipecat asyncio event loop (``on_end`` and
-        # ``_accumulate_audio`` both run there); ending spans off that loop would
-        # need external synchronization.
-        # The latest llm request's full context per trace — each request carries
-        # the whole history, so the last snapshot IS the conversation. Rendered
-        # onto the root ``conversation`` span, which ends last. TTL-bounded so an
-        # abandoned conversation (no end span) can't leak it.
-        self._conversation_by_trace: MutableMapping[str, list] = TTLCache(
+        # trace_id -> latest llm context (the full history == the conversation),
+        # rendered onto the root ``conversation`` span, which ends last.
+        self._transcript_by_trace: MutableMapping[int, list[dict[str, Any]]] = TTLCache(
             maxsize=DEFAULT_STATE_MAXSIZE, ttl=state_ttl_seconds
         )
-        # Merged PCM accumulated from a Pipecat AudioBufferProcessor (see
-        # attach_audio_buffer), keyed by conversation id. Each value carries the
-        # PCM bytearray, sample rate, channel count, and truncation flag. Also
-        # TTL-bounded — these entries hold the raw audio and are the larger leak.
-        self._audio_by_conversation: MutableMapping[str, dict[str, Any]] = TTLCache(
+        # conversation id -> merged PCM from an AudioBufferProcessor.
+        self._audio_by_conversation: MutableMapping[str, _AudioRecord] = TTLCache(
             maxsize=DEFAULT_STATE_MAXSIZE, ttl=state_ttl_seconds
         )
 
     # -- audio buffer registration -------------------------------------------
 
-    def attach_audio_buffer(self, audio_buffer: Any, conversation_id: str) -> None:
+    def attach_audio_buffer(
+        self, audio_buffer: AudioBufferProcessor, conversation_id: str
+    ) -> None:
         """Record this conversation's audio from a Pipecat ``AudioBufferProcessor``.
 
-        Registers an ``on_audio_data`` handler on ``audio_buffer`` that
-        accumulates the merged PCM for ``conversation_id``; it's encoded to a WAV
-        and attached to the root span when the ``conversation`` span ends. The
-        ``conversation_id`` must match the one set on ``PipelineTask`` (so it
-        appears on the ``conversation`` span).
-
-        Place the ``AudioBufferProcessor`` after ``transport.output()`` and start
-        it with ``await audio_buffer.start_recording()`` once the session is
-        running. Construct it with a non-zero ``buffer_size`` so audio streams in
-        periodically — with the default single-shot emission, the final chunk can
-        arrive after the conversation span has already been exported.
+        Registers an ``on_audio_data`` handler that accumulates the merged PCM
+        Pipecat emits — construct the buffer with ``num_channels=2`` for a stereo
+        (user-left / bot-right) recording that preserves barge-in overlap — and
+        attaches it as a WAV when the ``conversation`` span ends.
+        ``conversation_id`` must match the ``PipelineTask`` id. Place the buffer
+        after ``transport.output()`` and give it a non-zero ``buffer_size`` so the
+        final chunk arrives before the span is exported.
         """
 
         async def _on_audio_data(
-            buffer: Any, audio: bytes, sample_rate: int, num_channels: int
+            _buffer: AudioBufferProcessor,
+            audio: bytes,
+            sample_rate: int,
+            num_channels: int,
         ) -> None:
             self._accumulate_audio(conversation_id, audio, sample_rate, num_channels)
 
@@ -154,61 +171,42 @@ class PipecatLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         return max(0, self.audio_size_limit_bytes - _WAV_HEADER_BYTES)
 
     def _accumulate_audio(
-        self, conversation_id: str, audio: bytes, sample_rate: int, num_channels: int
+        self,
+        conversation_id: str,
+        audio: bytes,
+        sample_rate: int,
+        num_channels: int,
     ) -> None:
         rec = self._audio_by_conversation.get(conversation_id)
         if rec is None:
-            rec = {
-                "pcm": bytearray(),
-                "sample_rate": sample_rate,
-                "num_channels": num_channels,
-                "audio_truncated": False,
-            }
-        pcm_limit_bytes = self._pcm_audio_size_limit_bytes()
-        if pcm_limit_bytes is not None:
-            remaining = pcm_limit_bytes - len(rec["pcm"])
-            remaining -= remaining % 2
-            if remaining <= 0:
-                rec["audio_truncated"] = True
-                rec["sample_rate"] = sample_rate
-                rec["num_channels"] = num_channels
-                self._audio_by_conversation[conversation_id] = rec
-                return
-            if len(audio) > remaining:
-                rec["audio_truncated"] = True
-                audio = audio[:remaining]
-        rec["pcm"].extend(audio)
-        rec["sample_rate"] = sample_rate
-        rec["num_channels"] = num_channels
-        # Re-assign (not just mutate) so the TTL timestamp is refreshed — an
-        # active call streaming audio for longer than the TTL must not be
-        # evicted mid-conversation.
+            if num_channels != 2:
+                logger.warning(
+                    "langsmith voice: AudioBufferProcessor num_channels=%d; use "
+                    "num_channels=2 for a stereo (user-left/bot-right) recording "
+                    "that preserves barge-in overlap.",
+                    num_channels,
+                )
+            rec = _AudioRecord(sample_rate=sample_rate, num_channels=num_channels)
+        rec.extend(audio, sample_rate, num_channels, self._pcm_audio_size_limit_bytes())
+        # Re-assign (not just mutate) so each chunk refreshes the cache TTL.
         self._audio_by_conversation[conversation_id] = rec
 
     # -- dispatch -------------------------------------------------------------
 
     def _dispatch(self, tspan: TranslatedSpan) -> bool:
-        trace_id = format(tspan.span.context.trace_id, "032x")
+        trace_id = tspan.span.context.trace_id
         name = tspan.span.name
 
         if name == "stt":
             self._handle_stt(tspan)
-            tspan.exclude_from_message_view()
         elif name == "llm":
             self._handle_llm(tspan, trace_id)
         elif name == "tts":
             self._handle_tts(tspan)
-            tspan.exclude_from_message_view()
         elif name == "turn":
             self._handle_turn(tspan)
         elif name == "conversation":
             self._handle_conversation(tspan, trace_id)
-        # Any other span (e.g. nested LangChain/LangGraph runs riding the same
-        # OTel provider) already arrives in LangSmith's native shape, so it's
-        # exported untouched.
-        #
-        # Pipecat's ``conversation`` span genuinely ends last, so nothing is
-        # deferred: return True to have the base export every span once.
         return True
 
     # -- per-span-type handlers ----------------------------------------------
@@ -217,72 +215,32 @@ class PipecatLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         """STT span: audio input → transcribed text."""
         transcript = tspan.attributes.get("transcript", "")
         tspan.set_kind("llm")
-        tspan.set_messages(
-            prompt=[{"role": "user", "content": f'Audio for: "{transcript}"'}]
-        )
+        tspan.set_messages(prompt=[build_user_message(f'Audio for: "{transcript}"')])
         if transcript:
-            tspan.set_messages(
-                completion=[{"role": "assistant", "content": str(transcript)}]
-            )
+            tspan.set_messages(completion=[build_assistant_message(str(transcript))])
+        tspan.exclude_from_message_view()
 
-    @classmethod
-    def _completion_message(cls, output_data: Any) -> dict:
-        """Build the assistant completion message for the ``llm`` span.
+    def _handle_llm(self, tspan: TranslatedSpan, trace_id: int) -> None:
+        """``llm`` span: forward the request history and reply verbatim.
 
-        Pipecat's ``output`` attribute is normally the assistant's text. But if a
-        service emits the structured response instead (a dict carrying
-        ``tool_calls``), forward it unchanged in its OpenAI shape so LangSmith
-        renders the tool calls rather than flattening them to a string. Anything
-        else — plain text, or JSON that isn't a tool-call message — stays as text
-        content, preserving the existing behavior.
-        """
-        parsed: Any = output_data
-        if isinstance(output_data, str):
-            try:
-                parsed = json.loads(output_data)
-            except json.JSONDecodeError:
-                parsed = None
-        if isinstance(parsed, dict) and parsed.get("tool_calls"):
-            return {"role": "assistant", **parsed}
-        content = output_data if isinstance(output_data, str) else str(output_data)
-        return {"role": "assistant", "content": content}
-
-    def _handle_llm(self, tspan: TranslatedSpan, trace_id: str) -> None:
-        """Framework ``llm`` span: the LLM stage of the pipeline.
-
-        Pipecat logs the request history in the LLM provider's own message format
-        (via the service's logging adapter). We forward it unchanged — LangSmith
-        reads the messages directly from ``gen_ai.prompt`` — so the trace mirrors
-        exactly what the model was sent.
+        Each request's ``input`` carries the whole history, so the latest snapshot
+        is kept per trace as the conversation the root renders.
         """
         input_data = tspan.attributes.get("input", "")
         output_data = tspan.attributes.get("output", "")
         tspan.set_kind(self._llm_span_kind)
 
-        try:
-            raw_messages = json.loads(input_data)
-        except (json.JSONDecodeError, TypeError):
-            raw_messages = []
-        messages = [
-            m
-            for m in (raw_messages if isinstance(raw_messages, list) else [])
-            if isinstance(m, dict)
-        ]
-
+        messages = parse_llm_messages(input_data)
         if messages:
             tspan.set_messages(prompt=messages)
         if output_data:
-            tspan.set_messages(completion=[self._completion_message(output_data)])
+            tspan.set_messages(completion=[build_completion_message(output_data)])
 
-        # Each request's input carries the full history, so the latest snapshot
-        # IS the conversation — kept per trace for the root span to render. Reuse
-        # _completion_message so the root transcript and this span's completion
-        # render the assistant turn identically (tool calls included).
         transcript = [m for m in messages if m.get("role") != "system"]
         if output_data:
-            transcript.append(self._completion_message(output_data))
+            transcript.append(build_completion_message(output_data))
         if transcript:
-            self._conversation_by_trace[trace_id] = transcript
+            self._transcript_by_trace[trace_id] = transcript
 
     def _handle_tts(self, tspan: TranslatedSpan) -> None:
         """TTS span: text → audio. The voice is metadata, not content."""
@@ -290,50 +248,39 @@ class PipecatLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         tspan.set_kind("llm")
         voice_id = tspan.attributes.get("voice_id")
         if voice_id:
-            tspan.attributes["langsmith.metadata.voice_id"] = str(voice_id)
+            tspan.set_metadata("voice_id", str(voice_id))
         tspan.set_messages(
-            prompt=[{"role": "user", "content": str(text)}],
-            completion=[
-                {"role": "assistant", "content": f'Generated audio for: "{text}"'}
-            ],
+            prompt=[build_user_message(str(text))],
+            completion=[build_assistant_message(f'Generated audio for: "{text}"')],
         )
+        tspan.exclude_from_message_view()
 
     def _handle_turn(self, tspan: TranslatedSpan) -> None:
         """Turn span: a framework wrapper around one exchange (a ``chain``)."""
         tspan.set_kind("chain")
         turn_number = tspan.attributes.get("turn.number")
         if turn_number is not None:
-            tspan.attributes["langsmith.metadata.turn_number"] = turn_number
+            tspan.set_metadata("turn_number", turn_number)
         was_interrupted = tspan.attributes.get("turn.was_interrupted")
         if was_interrupted is not None:
-            tspan.attributes["langsmith.metadata.turn_was_interrupted"] = (
-                was_interrupted
-            )
+            tspan.set_metadata("turn_was_interrupted", was_interrupted)
 
-    def _handle_conversation(self, tspan: TranslatedSpan, trace_id: str) -> None:
-        """Conversation span: the whole session; the LangSmith root.
-
-        Input = the opening message; output = everything after it. Pipecat's
-        conversation span genuinely ends last, so no deferral is needed.
-        """
+    def _handle_conversation(self, tspan: TranslatedSpan, trace_id: int) -> None:
+        """Conversation span: the whole session; the LangSmith root."""
         conversation_id = tspan.attributes.get(
             "conversation.id", ""
         ) or tspan.attributes.get("conversation_id", "")
         tspan.set_kind("chain")
-        tspan.attributes["langsmith.root_span"] = True
-        tspan.attributes["langsmith.metadata.ls_modality"] = "audio"
-        tspan.attributes["langsmith.metadata.ls_integration"] = "pipecat"
-        # "" not None: OTel span attributes reject a null value (unlike the
-        # RunTree metadata path); pipecat-ai is a hard dep, so this is ~always set.
-        tspan.attributes["langsmith.metadata.ls_integration_version"] = (
-            get_package_version("pipecat-ai") or ""
+        tspan.set_root_span(True)
+        tspan.set_metadata("ls_modality", "audio")
+        tspan.set_metadata("ls_integration", "pipecat")
+        tspan.set_metadata(
+            "ls_integration_version", get_package_version("pipecat-ai") or ""
         )
 
-        messages = self._conversation_by_trace.get(trace_id, [])
+        messages = self._transcript_by_trace.get(trace_id, [])
         if messages:
-            tspan.set_messages(prompt=messages[:1])
-            if len(messages) > 1:
-                tspan.set_messages(completion=messages[1:])
+            tspan.set_messages(prompt=messages)
 
         self._attach_conversation_audio(tspan, conversation_id)
         self._cleanup_conversation(trace_id, conversation_id)
@@ -341,44 +288,42 @@ class PipecatLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
     # -- audio attachment -----------------------------------------------------
 
     def _attach_conversation_audio(
-        self, tspan: TranslatedSpan, conversation_id: Any
+        self, tspan: TranslatedSpan, conversation_id: str
     ) -> None:
-        """Encode the accumulated PCM (from the AudioBufferProcessor) and attach it.
+        """Encode the accumulated PCM and attach it, keyed strictly by id.
 
-        Looked up strictly by ``conversation_id`` — never by "the only recording
-        in flight": a heuristic match could attach a different caller's audio to
-        this trace (a privacy leak on a multi-tenant server). The id passed to
-        :meth:`attach_audio_buffer` must match the ``PipelineTask``
-        ``conversation_id``; a mismatch attaches nothing (logged below).
+        Never falls back to "the only recording in flight" — a heuristic match
+        could attach another caller's audio to this trace (a privacy leak).
         """
-        rec = self._audio_by_conversation.get(conversation_id)
-        if rec is None:
+        recording = self._audio_by_conversation.get(conversation_id)
+        if recording is None:
             if len(self._audio_by_conversation) > 0:
                 logger.debug(
                     "langsmith voice: no recording for conversation_id=%r "
-                    "(%d recording(s) in flight under other ids); audio not "
-                    "attached. Ensure the id passed to attach_audio_buffer "
-                    "matches the PipelineTask conversation_id.",
+                    "(%d in flight under other ids); audio not attached. Ensure "
+                    "attach_audio_buffer's id matches the PipelineTask id.",
                     conversation_id,
                     len(self._audio_by_conversation),
                 )
             return
-        if not rec["pcm"]:
+        if not recording.pcm:
             return
         pcm_limit_bytes = self._pcm_audio_size_limit_bytes()
-        if pcm_limit_bytes is not None and len(rec["pcm"]) > pcm_limit_bytes:
+        if pcm_limit_bytes is not None and len(recording.pcm) > pcm_limit_bytes:
             logger.warning(
                 "langsmith voice: skipped oversize pipecat audio for "
                 "conversation_id=%r",
                 conversation_id,
             )
             return
-        wav = pcm_to_wav(bytes(rec["pcm"]), rec["sample_rate"], rec["num_channels"])
+        wav = pcm_to_wav(
+            bytes(recording.pcm), recording.sample_rate, recording.num_channels
+        )
         self._attach_audio(
             tspan, name="conversation.wav", data=wav, mime_type=self._audio_mime_type
         )
 
-    def _cleanup_conversation(self, trace_id: str, conversation_id: Any) -> None:
-        self._conversation_by_trace.pop(trace_id, None)
+    def _cleanup_conversation(self, trace_id: int, conversation_id: str) -> None:
+        self._transcript_by_trace.pop(trace_id, None)
         self._audio_by_conversation.pop(conversation_id, None)
-        self._forget_thread_id(int(trace_id, 16))
+        self._forget_thread_id(trace_id)

--- a/python/tests/unit_tests/wrappers/test_livekit.py
+++ b/python/tests/unit_tests/wrappers/test_livekit.py
@@ -10,9 +10,12 @@ import json
 from unittest.mock import MagicMock
 
 from langsmith._internal.voice import set_thread_id
+from langsmith.integrations.livekit._helpers import (
+    build_message_from_event,
+    normalize_provider,
+)
 from langsmith.integrations.livekit.processor import (
     LiveKitLangSmithSpanProcessor,
-    _normalize_provider,
 )
 
 
@@ -85,7 +88,7 @@ class TestDispatchDisposition:
         exported = proc.downstream.on_end.call_args.args[0]
         assert "langsmith.root_span" not in exported._attributes
         assert "langsmith.metadata.ls_modality" not in exported._attributes
-        assert len(proc._deferred_root_spans) == 0
+        assert len(proc._deferred_root_by_trace) == 0
 
 
 class TestDeferredRootRelease:
@@ -118,11 +121,13 @@ class TestDeferredRootRelease:
         assert root._attributes["langsmith.metadata.ls_modality"] == "audio"
         # The root is attributed to this integration so usage is trackable.
         assert root._attributes["langsmith.metadata.ls_integration"] == "livekit"
-        completion = json.loads(root._attributes["gen_ai.completion"])["messages"]
-        assert completion[0]["content"] == "sunny"
+        # The whole transcript lands on the root's input.
+        prompt = json.loads(root._attributes["gen_ai.prompt"])["messages"]
+        assert [m["content"] for m in prompt] == ["weather?", "sunny"]
+        assert "gen_ai.completion" not in root._attributes
         # Per-conversation state freed after release.
-        assert len(proc._deferred_root_spans) == 0
-        assert len(proc._conversation_by_trace) == 0
+        assert len(proc._deferred_root_by_trace) == 0
+        assert len(proc._transcript_by_trace) == 0
 
 
 class TestForceFlush:
@@ -151,7 +156,7 @@ class TestForceFlush:
             c.args[0]._attributes.get("langsmith.root_span")
             for c in proc.downstream.on_end.call_args_list
         )
-        assert format(tid, "032x") in proc._deferred_root_spans
+        assert tid in proc._deferred_root_by_trace
 
         # When the session finally ends, the complete root is exported once.
         proc.on_end(_make_span("agent_session", trace_id=tid, span_id=0x3))
@@ -160,10 +165,8 @@ class TestForceFlush:
             for c in proc.downstream.on_end.call_args_list
             if c.args[0]._attributes.get("langsmith.root_span")
         )
-        assert (
-            json.loads(root._attributes["gen_ai.completion"])["messages"][0]["content"]
-            == "sunny"
-        )
+        prompt = json.loads(root._attributes["gen_ai.prompt"])["messages"]
+        assert prompt[-1]["content"] == "sunny"
 
     def test_shutdown_flushes_held_root(self):
         # shutdown IS terminal: a still-held root is flushed as a last resort.
@@ -180,18 +183,22 @@ class TestForceFlush:
 class TestEgressRecording:
     """expect_recording / complete_recording hold the root for late egress audio."""
 
+    def teardown_method(self):
+        set_thread_id(None)
+
+    def _start_conversation(self, proc, tid):
+        # The root's thread id comes from set_thread_id (captured at on_start),
+        # exactly as in production; clearing it after simulates the detached end.
+        set_thread_id("call-1")
+        proc.on_start(_make_span("job_entrypoint", parent=None, trace_id=tid))
+        set_thread_id(None)
+        proc.on_end(_make_span("job_entrypoint", parent=None, trace_id=tid))
+
     def test_expect_holds_until_complete_with_audio(self):
         proc = _processor()
         tid = 0xABC
         proc.expect_recording("call-1")
-        proc.on_end(
-            _make_span(
-                "job_entrypoint",
-                {"langsmith.metadata.thread_id": "call-1"},
-                parent=None,
-                trace_id=tid,
-            )
-        )
+        self._start_conversation(proc, tid)
         proc.on_end(_make_span("agent_session", trace_id=tid, span_id=0x3))
         # Session ended but recording still awaited → root NOT exported.
         assert not any(
@@ -213,14 +220,7 @@ class TestEgressRecording:
         proc = _processor()
         tid = 0xABC
         proc.expect_recording("call-1")
-        proc.on_end(
-            _make_span(
-                "job_entrypoint",
-                {"langsmith.metadata.thread_id": "call-1"},
-                parent=None,
-                trace_id=tid,
-            )
-        )
+        self._start_conversation(proc, tid)
         proc.on_end(_make_span("agent_session", trace_id=tid, span_id=0x3))
         proc.complete_recording("call-1", None)
 
@@ -242,7 +242,7 @@ class TestStateTTL:
         proc.on_end(_make_span("job_entrypoint", parent=None, trace_id=0xAAA))
         # A later, different conversation's root triggers eviction of the first.
         proc.on_end(_make_span("job_entrypoint", parent=None, trace_id=0xBBB))
-        assert format(0xAAA, "032x") not in proc._deferred_root_spans
+        assert 0xAAA not in proc._deferred_root_by_trace
 
     def test_active_call_refreshes_transcript_ttl(self):
         proc = _processor(state_ttl_seconds=60)
@@ -257,7 +257,7 @@ class TestStateTTL:
                 "agent_turn", {"lk.response.text": "two"}, trace_id=tid, span_id=0x3
             )
         )
-        assert [m["content"] for m in proc._conversation_by_trace[tid]] == [
+        assert [m["content"] for m in proc._transcript_by_trace[tid]] == [
             "one",
             "two",
         ]
@@ -272,6 +272,7 @@ class TestThreadId:
     def test_set_thread_id_injected(self):
         proc = _processor()
         set_thread_id("conv-9")
+        proc.on_start(_make_span("job_entrypoint", parent=None))
         span = _make_span("agent_turn", {"lk.user_input": "x"}, span_id=0x2)
         proc.on_end(span)
         exported = proc.downstream.on_end.call_args.args[0]
@@ -303,39 +304,35 @@ class TestMessageFromEvent:
         return event
 
     def test_tool_calls_forwarded_unchanged(self):
-        proc = _processor()
         call = {
             "id": "call_1",
             "type": "function",
             "function": {"name": "lookup", "arguments": '{"q": "x"}'},
         }
-        msg = proc._message_from_event(
+        msg = build_message_from_event(
             "assistant", self._event(role="assistant", tool_calls=[call])
         )
         assert msg["tool_calls"] == [call]
 
     def test_tool_calls_json_string_parsed_to_object(self):
-        proc = _processor()
         call = {
             "id": "call_1",
             "type": "function",
             "function": {"name": "lookup", "arguments": "{}"},
         }
-        msg = proc._message_from_event(
+        msg = build_message_from_event(
             "assistant", self._event(tool_calls=[json.dumps(call)])
         )
         assert msg["tool_calls"] == [call]
 
     def test_unparseable_tool_call_dropped(self):
-        proc = _processor()
-        msg = proc._message_from_event(
+        msg = build_message_from_event(
             "assistant", self._event(tool_calls=["not json"])
         )
         assert "tool_calls" not in msg
 
     def test_tool_result_carries_id_and_name(self):
-        proc = _processor()
-        msg = proc._message_from_event(
+        msg = build_message_from_event(
             "tool", self._event(content="done", id="call_1", name="lookup")
         )
         assert msg["tool_call_id"] == "call_1"
@@ -350,15 +347,15 @@ class TestProviderAttribution:
         return proc.downstream.on_end.call_args.args[0]._attributes
 
     def test_normalize_provider_substring_and_host(self):
-        assert _normalize_provider("api.openai.com") == "openai"
-        assert _normalize_provider("beta.anthropic.com") == "anthropic"
-        assert _normalize_provider("https://api.deepgram.com/v1") == "deepgram"
-        assert _normalize_provider("cartesia") == "cartesia"
+        assert normalize_provider("api.openai.com") == "openai"
+        assert normalize_provider("beta.anthropic.com") == "anthropic"
+        assert normalize_provider("https://api.deepgram.com/v1") == "deepgram"
+        assert normalize_provider("cartesia") == "cartesia"
         # No known slug → host, stripped of scheme/path.
-        assert _normalize_provider("https://my-proxy.internal/x") == "my-proxy.internal"
+        assert normalize_provider("https://my-proxy.internal/x") == "my-proxy.internal"
         # Empty / placeholder → None (never stamp a non-matching provider).
-        assert _normalize_provider("unknown") is None
-        assert _normalize_provider(None) is None
+        assert normalize_provider("unknown") is None
+        assert normalize_provider(None) is None
 
     def test_stt_provider_from_metrics_metadata(self):
         proc = _processor()

--- a/python/tests/unit_tests/wrappers/test_pipecat.py
+++ b/python/tests/unit_tests/wrappers/test_pipecat.py
@@ -380,11 +380,26 @@ class TestBaseProcessorHelpers:
             is False
         )
 
-    def test_on_start_stamps_static_metadata(self):
+    def test_stamp_static_metadata(self):
+        # Static metadata lands on the draft; None values are skipped.
         base = self._base(metadata={"env": "test", "skip": None})
-        span = MagicMock()
-        base.on_start(span)
-        span.set_attribute.assert_any_call("langsmith.metadata.env", "test")
+        tspan = TranslatedSpan.of(_make_span("x"))
+        base._stamp_static_metadata(tspan)
+        assert tspan.attributes["langsmith.metadata.env"] == "test"
+        assert "langsmith.metadata.skip" not in tspan.attributes
+
+    def test_stamp_static_metadata_never_clobbers(self):
+        # An attribute already on the span wins over the static default.
+        base = self._base(metadata={"env": "static"})
+        tspan = TranslatedSpan.of(
+            _make_span("x", {"langsmith.metadata.env": "explicit"})
+        )
+        base._stamp_static_metadata(tspan)
+        assert tspan.attributes["langsmith.metadata.env"] == "explicit"
+
+    def test_on_start_delegates_downstream(self):
+        base = self._base()
+        base.on_start(MagicMock())
         base.downstream.on_start.assert_called_once()
 
     def test_shutdown_delegates(self):
@@ -509,9 +524,8 @@ class TestContextVarThreadId:
     def test_set_thread_id_is_injected(self):
         proc = _processor()
         set_thread_id("conv-42")
-        span = _make_span("turn", {})
-
-        proc.on_end(span)
+        proc.on_start(_make_span("turn", {}))
+        proc.on_end(_make_span("turn", {}))
 
         assert _exported_attrs(proc)["langsmith.metadata.thread_id"] == "conv-42"
 
@@ -547,24 +561,11 @@ class TestContextVarThreadId:
 
         assert _exported_attrs(proc)["langsmith.metadata.thread_id"] == "conv-7"
 
-    def test_in_context_end_backfills_for_trace_peers(self):
-        # No on_start capture: the first span seen in context resolves via the
-        # ContextVar and backfills the trace cache, so a later peer that ends
-        # out of context still resolves.
-        proc = _processor()
-        tid = 0xABC
-        set_thread_id("conv-8")
-        proc.on_end(_make_span("turn", {}, trace_id=tid))
-        set_thread_id(None)
-        proc.on_end(_make_span("stt", {"transcript": "hi"}, trace_id=tid))
-
-        assert _exported_attrs(proc)["langsmith.metadata.thread_id"] == "conv-8"
-
     def test_cleanup_forgets_cached_thread_id(self):
         proc = _processor()
         tid = 0xABC
         set_thread_id("conv-9")
-        proc.on_end(_make_span("turn", {}, trace_id=tid))
+        proc.on_start(_make_span("turn", {}, trace_id=tid))
         assert tid in proc._thread_id_by_trace
         # Conversation end frees the per-trace state, the thread id included.
         proc.on_end(_make_span("conversation", {"conversation.id": "c1"}, trace_id=tid))

--- a/python/tests/unit_tests/wrappers/test_pipecat.py
+++ b/python/tests/unit_tests/wrappers/test_pipecat.py
@@ -24,7 +24,10 @@ from langsmith._internal.voice.base_span_processor import (
     BaseLangSmithSpanProcessor,
     TranslatedSpan,
 )
-from langsmith.integrations.pipecat.processor import PipecatLangSmithSpanProcessor
+from langsmith.integrations.pipecat.processor import (
+    PipecatLangSmithSpanProcessor,
+    _AudioRecord,
+)
 
 
 def _make_span(name: str, attributes: dict | None = None, trace_id: int = 0x1):
@@ -221,12 +224,12 @@ class TestPipecatDispatch:
         assert attrs["langsmith.metadata.ls_modality"] == "audio"
         # The root is attributed to this integration so usage is trackable.
         assert attrs["langsmith.metadata.ls_integration"] == "pipecat"
+        # The whole transcript lands on the root's input (like the livekit root).
         prompt = json.loads(attrs["gen_ai.prompt"])
-        assert prompt["messages"][0]["content"] == "hi"
-        completion = json.loads(attrs["gen_ai.completion"])
-        assert completion["messages"][0]["content"] == "hello"
+        assert [m["content"] for m in prompt["messages"]] == ["hi", "hello"]
+        assert "gen_ai.completion" not in attrs
         # Per-trace state is cleaned up once the root is rendered.
-        assert trace_id not in proc._conversation_by_trace
+        assert trace_id not in proc._transcript_by_trace
 
     def test_unknown_span_passed_through_untouched_but_exported(self):
         proc = _processor()
@@ -256,20 +259,20 @@ class TestPipecatAudio:
         proc.attach_audio_buffer(FakeBuffer(), "conv-1")
         handler = captured["on_audio_data"]
 
-        # The Pipecat AudioBufferProcessor emits raw PCM in chunks.
+        # The AudioBufferProcessor emits already-merged (stereo) PCM in chunks.
         import asyncio
 
-        asyncio.run(handler(None, b"\x01\x02", 16000, 2))
-        asyncio.run(handler(None, b"\x03\x04", 16000, 2))
+        asyncio.run(handler(None, b"\x01\x02\x0a\x0b", 16000, 2))
+        asyncio.run(handler(None, b"\x03\x04\x0c\x0d", 16000, 2))
 
         rec = proc._audio_by_conversation["conv-1"]
-        assert bytes(rec["pcm"]) == b"\x01\x02\x03\x04"
-        assert rec["sample_rate"] == 16000
-        assert rec["num_channels"] == 2
+        assert bytes(rec.pcm) == b"\x01\x02\x0a\x0b\x03\x04\x0c\x0d"
+        assert rec.sample_rate == 16000
+        assert rec.num_channels == 2
 
-    def test_conversation_span_attaches_wav(self):
+    def test_conversation_span_attaches_stereo_wav(self):
         proc = _processor()
-        proc._accumulate_audio("c1", b"\x00\x01" * 8, 16000, 1)
+        proc._accumulate_audio("c1", b"\x00\x01\x02\x03" * 8, 16000, 2)
         span = _make_span("conversation", {"conversation.id": "c1"})
 
         proc.on_end(span)
@@ -279,13 +282,15 @@ class TestPipecatAudio:
         assert payload[0]["mime_type"] == "audio/wav"
         decoded = base64.b64decode(payload[0]["content"])
         assert decoded[:4] == b"RIFF"
+        with wave.open(io.BytesIO(decoded)) as wf:
+            assert wf.getnchannels() == 2  # user left, bot right
 
     def test_mismatched_conversation_id_attaches_nothing(self):
         # A recording exists under a different id than the span carries. The
         # lookup is strictly keyed (no "only one in flight" fallback), so no
         # audio is attached — never another caller's recording.
         proc = _processor()
-        proc._accumulate_audio("other-call", b"\x00\x01" * 8, 16000, 1)
+        proc._accumulate_audio("other-call", b"\x00\x01\x02\x03" * 8, 16000, 2)
         span = _make_span("conversation", {"conversation.id": "this-call"})
 
         proc.on_end(span)
@@ -301,21 +306,21 @@ class TestPipecatAudio:
         assert "langsmith.attachments" not in _exported_attrs(proc)
 
     def test_accumulate_audio_truncates_before_extend(self):
+        # pcm budget = 50 - 44 header = 6, rounded down to a whole stereo frame (4).
         proc = _processor(audio_size_limit_bytes=50)
-        proc._accumulate_audio("c1", b"\x00\x01" * 2, 16000, 1)
-        proc._accumulate_audio("c1", b"\x02\x03" * 2, 16000, 1)
+        proc._accumulate_audio("c1", b"\x00\x01\x02\x03" * 8, 16000, 2)
 
         rec = proc._audio_by_conversation["c1"]
-        assert bytes(rec["pcm"]) == b"\x00\x01" * 2 + b"\x02\x03"
-        assert rec["audio_truncated"] is True
+        assert rec.audio_truncated is True
+        assert bytes(rec.pcm) == b"\x00\x01\x02\x03"
 
     def test_oversize_audio_skips_conversion(self):
         proc = _processor(audio_size_limit_bytes=50)
-        proc._audio_by_conversation["c1"] = {
-            "pcm": bytearray(b"\x00\x01" * 4),
-            "sample_rate": 16000,
-            "num_channels": 1,
-        }
+        proc._audio_by_conversation["c1"] = _AudioRecord(
+            sample_rate=16000,
+            num_channels=2,
+            pcm=bytearray(b"\x00\x01\x02\x03" * 4),
+        )
         span = _make_span("conversation", {"conversation.id": "c1"})
 
         with patch("langsmith.integrations.pipecat.processor.pcm_to_wav") as patched:
@@ -460,25 +465,25 @@ class TestStateLifecycle:
             trace_id=trace_id,
         )
         proc.on_end(llm)
-        proc._accumulate_audio("c1", b"\x00\x01" * 8, 16000, 1)
-        assert len(proc._conversation_by_trace) == 1
+        proc._accumulate_audio("c1", b"\x00\x01\x02\x03" * 8, 16000, 2)
+        assert len(proc._transcript_by_trace) == 1
         assert len(proc._audio_by_conversation) == 1
 
         convo = _make_span("conversation", {"conversation.id": "c1"}, trace_id=trace_id)
         proc.on_end(convo)
 
         # Both per-conversation stores are freed once the root renders.
-        assert len(proc._conversation_by_trace) == 0
+        assert len(proc._transcript_by_trace) == 0
         assert len(proc._audio_by_conversation) == 0
 
     def test_abandoned_state_expires_via_ttl(self):
         # A conversation whose end span never arrives must not leak: the TTL
         # store drops it. Use a zero TTL so the next write evicts it.
         proc = _processor(state_ttl_seconds=0)
-        proc._accumulate_audio("c1", b"\x00\x01", 16000, 1)
+        proc._accumulate_audio("c1", b"\x00\x01\x02\x03", 16000, 2)
         # A later write to the (separate) store of a *different* conversation
         # triggers eviction of the expired one.
-        proc._accumulate_audio("c2", b"\x00\x01", 16000, 1)
+        proc._accumulate_audio("c2", b"\x00\x01\x02\x03", 16000, 2)
 
         assert "c1" not in proc._audio_by_conversation
 
@@ -486,9 +491,12 @@ class TestStateLifecycle:
         # Re-writing a key (each audio chunk) refreshes its TTL, so a long call
         # streaming audio is never dropped mid-conversation.
         proc = _processor(state_ttl_seconds=60)
-        proc._accumulate_audio("c1", b"\x00\x01", 16000, 1)
-        proc._accumulate_audio("c1", b"\x02\x03", 16000, 1)
-        assert bytes(proc._audio_by_conversation["c1"]["pcm"]) == b"\x00\x01\x02\x03"
+        proc._accumulate_audio("c1", b"\x00\x01\x02\x03", 16000, 2)
+        proc._accumulate_audio("c1", b"\x04\x05\x06\x07", 16000, 2)
+        assert (
+            bytes(proc._audio_by_conversation["c1"].pcm)
+            == b"\x00\x01\x02\x03\x04\x05\x06\x07"
+        )
 
 
 class TestExceptionIsolation:


### PR DESCRIPTION
## Summary

- Moved TranslatedSpan to its own file
- Created livekit and pipecat helper files with helper functions
- Remove redundant code
- Renamed variables for clarity
- Created smaller functions with shared logic
- Add more robust typing
- Reduced comment length which had gotten out of control
- Updated pipecat audio recording to follow doc recommendation a bit more closely after noticing slight blips
- moved exported functions to the top of processors, with internal helpers below

## Test plan
- [x] `ruff format` / `ruff check` clean
- [x] `mypy` clean (voice + livekit + pipecat)
- [x] tested locally with voice demo repo 
- [x] voice unit tests pass (`test_pipecat`, `test_livekit`, `test_voice_session`, `test_voice_helpers`)





#### PR Dependency Tree


* **PR #3187** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)