### PR TITLE
feat(py): re-export OpenAPI client exceptions from langsmith package

### DIFF
--- a/python/langsmith/__init__.py
+++ b/python/langsmith/__init__.py
@@ -199,6 +199,8 @@ def __getattr__(name: str) -> Any:
         "RateLimitError",
         "InternalServerError",
     ):
+        import langsmith._openapi_client._exceptions as _exceptions
+
         exception = getattr(_exceptions, name)
         exception.__module__ = __name__
         return exception

--- a/python/langsmith/__init__.py
+++ b/python/langsmith/__init__.py
@@ -199,9 +199,9 @@ def __getattr__(name: str) -> Any:
         "RateLimitError",
         "InternalServerError",
     ):
-        import langsmith._openapi_client._exceptions as _exceptions
-
-        return getattr(_exceptions, name)
+        exception = getattr(_exceptions, name)
+        exception.__module__ = __name__
+        return exception
 
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 

--- a/python/langsmith/__init__.py
+++ b/python/langsmith/__init__.py
@@ -4,6 +4,22 @@ from typing import TYPE_CHECKING, Any, Final
 
 if TYPE_CHECKING:
     from langsmith._expect import expect
+    from langsmith._openapi_client._exceptions import (
+        APIConnectionError,
+        APIError,
+        APIResponseValidationError,
+        APIStatusError,
+        APITimeoutError,
+        AuthenticationError,
+        BadRequestError,
+        ConflictError,
+        InternalServerError,
+        LangsmithError,
+        NotFoundError,
+        PermissionDeniedError,
+        RateLimitError,
+        UnprocessableEntityError,
+    )
     from langsmith.async_client import AsyncClient
     from langsmith.client import Client, TracingMode
     from langsmith.evaluation import (
@@ -167,6 +183,26 @@ def __getattr__(name: str) -> Any:
 
         return set_runtime_overrides
 
+    elif name in (
+        "LangsmithError",
+        "APIError",
+        "APIResponseValidationError",
+        "APIStatusError",
+        "APIConnectionError",
+        "APITimeoutError",
+        "BadRequestError",
+        "AuthenticationError",
+        "PermissionDeniedError",
+        "NotFoundError",
+        "ConflictError",
+        "UnprocessableEntityError",
+        "RateLimitError",
+        "InternalServerError",
+    ):
+        import langsmith._openapi_client._exceptions as _exceptions
+
+        return getattr(_exceptions, name)
+
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
@@ -204,4 +240,18 @@ __all__ = [
     "uuid7_from_datetime",
     "set_runtime_overrides",
     "LS_MESSAGE_VIEW_EXCLUDE",
+    "LangsmithError",
+    "APIError",
+    "APIResponseValidationError",
+    "APIStatusError",
+    "APIConnectionError",
+    "APITimeoutError",
+    "BadRequestError",
+    "AuthenticationError",
+    "PermissionDeniedError",
+    "NotFoundError",
+    "ConflictError",
+    "UnprocessableEntityError",
+    "RateLimitError",
+    "InternalServerError",
 ]


### PR DESCRIPTION
## Summary
- Re-export the OpenAPI-generated exception classes (`LangsmithError`, `APIError`, `APIStatusError`, `APIConnectionError`, `APITimeoutError`, `BadRequestError`, `AuthenticationError`, `PermissionDeniedError`, `NotFoundError`, `ConflictError`, `UnprocessableEntityError`, `RateLimitError`, `InternalServerError`, `APIResponseValidationError`) from the top-level `langsmith` package.
- Mirrors the JS SDK, which already re-exports these from `_openapi_client/core/error.js` in `js/src/index.ts`.
- Uses the existing lazy `__getattr__`/`TYPE_CHECKING` pattern already used for other symbols in `langsmith/__init__.py`, so there's no eager import cost.

## Test plan
- [x] `from langsmith import NotFoundError, APIError, LangsmithError, RateLimitError` resolves correctly and matches the classes defined in `langsmith._openapi_client._exceptions`