### PR TITLE
release(python): bump py version to 0.10.2

### DIFF
--- a/python/.bumpversion.cfg
+++ b/python/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.10.1
+current_version = 0.10.2
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
 serialize = {major}.{minor}.{patch}
 search = {current_version}

--- a/python/langsmith/__init__.py
+++ b/python/langsmith/__init__.py
@@ -45,7 +45,7 @@ if TYPE_CHECKING:
 
 # Avoid calling into importlib on every call to __version__
 
-__version__ = "0.10.1"
+__version__ = "0.10.2"
 version = __version__  # for backwards compatibility
 
 # Metadata key to hide a traced run from LangSmith's Messages View.


### PR DESCRIPTION
## Summary
- Bump Python SDK patch version from \`0.10.1\` → \`0.10.2\`
- Updates \`python/.bumpversion.cfg\` and \`python/langsmith/__init__.py\`

### Changes since 0.10.1
- feat(py): re-export OpenAPI client exceptions from langsmith package (#3188)
- feat: add SmithDB by-key path to add_runs_to_annotation_queue (runs= param) (#3077)
- refactor(livekit + pipecat): Refactor for clarity (#3187)
- refactor(voice): move span attribute setters onto TranslatedSpan (#3179)

🤖 Generated with [Claude Code](https://claude.com/claude-code)