### PR TITLE
feat(voice): capture STT/TTS/realtime model costs across voice integrations

### DIFF
--- a/python/langsmith/_internal/voice/translated_span.py
+++ b/python/langsmith/_internal/voice/translated_span.py
@@ -18,6 +18,13 @@ from opentelemetry.sdk.trace import Event, ReadableSpan
 from langsmith._internal.otel._span_utils import rebuild_readable_span
 
 
+def _clean_token_details(details: Optional[dict[str, Any]]) -> dict[str, int]:
+    """Keep only the int-valued detail keys, dropping ``None`` / non-numeric."""
+    if not details:
+        return {}
+    return {k: int(v) for k, v in details.items() if isinstance(v, (int, float))}
+
+
 @dataclass
 class TranslatedSpan:
     """A span being translated into LangSmith's namespaces before export.
@@ -98,6 +105,37 @@ class TranslatedSpan:
         their own setters / direct writes.
         """
         self.attributes[f"langsmith.metadata.{key}"] = value
+
+    def set_usage(
+        self,
+        *,
+        input_tokens: Optional[int] = None,
+        output_tokens: Optional[int] = None,
+        total_tokens: Optional[int] = None,
+        input_token_details: Optional[dict[str, int]] = None,
+        output_token_details: Optional[dict[str, int]] = None,
+    ) -> None:
+        """Write token usage onto the span so the cost engine can price it.
+
+        Sets ``gen_ai.usage.input_tokens`` / ``output_tokens`` / ``total_tokens``
+        (ints) and the per-modality ``gen_ai.usage.input_token_details`` /
+        ``output_token_details`` breakdowns. The detail blocks are written as
+        ``str(dict)`` — the exact form LangSmith's OTLP exporter/ingester round
+        trips (see ``_otel_exporter``), where ``audio`` / ``cache_read`` /
+        ``reasoning`` keys drive the modality-specific price multipliers that
+        dominate voice cost. Only non-``None`` values are written, and empty
+        detail blocks are dropped so a span never carries an empty breakdown.
+        """
+        if input_tokens is not None:
+            self.attributes["gen_ai.usage.input_tokens"] = int(input_tokens)
+        if output_tokens is not None:
+            self.attributes["gen_ai.usage.output_tokens"] = int(output_tokens)
+        if total_tokens is not None:
+            self.attributes["gen_ai.usage.total_tokens"] = int(total_tokens)
+        if details := _clean_token_details(input_token_details):
+            self.attributes["gen_ai.usage.input_token_details"] = str(details)
+        if details := _clean_token_details(output_token_details):
+            self.attributes["gen_ai.usage.output_token_details"] = str(details)
 
     def set_messages(
         self,

--- a/python/langsmith/integrations/google_adk_live/_plugin.py
+++ b/python/langsmith/integrations/google_adk_live/_plugin.py
@@ -159,23 +159,69 @@ def _resolve_model(invocation_context: Any) -> str | None:
     return getattr(model, "model", None) or None
 
 
-def _usage_metadata(event: Any) -> dict[str, int] | None:
+def _audio_tokens(details: Any) -> int | None:
+    """Sum the ``AUDIO`` modality token count from a ``ModalityTokenCount`` list.
+
+    Gemini reports per-modality breakdowns as a list of ``{modality, token_count}``
+    entries; the audio bucket is what the cost engine prices at the (much higher)
+    audio rate. Returns ``None`` when no audio modality is present.
+    """
+    if not isinstance(details, (list, tuple)):
+        return None
+    total = 0
+    found = False
+    for entry in details:
+        modality = getattr(entry, "modality", None)
+        modality = getattr(modality, "value", modality)
+        count = getattr(entry, "token_count", None)
+        if str(modality).upper().endswith("AUDIO") and isinstance(count, int):
+            total += count
+            found = True
+    return total if found else None
+
+
+def _usage_metadata(event: Any) -> dict[str, Any] | None:
     """Map an ADK event's ``usage_metadata`` to LangSmith token usage, if any.
 
-    ADK inherits genai's ``GenerateContentResponseUsageMetadata`` (prompt /
-    candidates / total token counts). Live events may carry no usage at all, in
-    which case the ``llm`` span is still recorded without token counts. Only
+    ADK inherits genai's ``GenerateContentResponseUsageMetadata``. Beyond the
+    aggregate prompt / candidates / total counts, the ``audio`` modality split
+    (from ``prompt_tokens_details`` / ``candidates_tokens_details``), the
+    ``cache_read`` count, and the ``reasoning`` count are captured — for Gemini
+    Live the audio tokens dominate and are priced very differently from text, so
+    dropping the split would mis-price the turn. Live events may carry no usage
+    at all, in which case the ``llm`` span is recorded without token counts. Only
     the fields ADK actually reports are included.
     """
     um = getattr(event, "usage_metadata", None)
     if um is None:
         return None
-    mapping = {
-        "input_tokens": getattr(um, "prompt_token_count", None),
-        "output_tokens": getattr(um, "candidates_token_count", None),
-        "total_tokens": getattr(um, "total_token_count", None),
-    }
-    usage = {k: v for k, v in mapping.items() if isinstance(v, int)}
+    usage: dict[str, Any] = {}
+    for key, attr in (
+        ("input_tokens", "prompt_token_count"),
+        ("output_tokens", "candidates_token_count"),
+        ("total_tokens", "total_token_count"),
+    ):
+        if isinstance(v := getattr(um, attr, None), int):
+            usage[key] = v
+
+    input_details: dict[str, int] = {}
+    if (audio := _audio_tokens(getattr(um, "prompt_tokens_details", None))) is not None:
+        input_details["audio"] = audio
+    if isinstance(cached := getattr(um, "cached_content_token_count", None), int):
+        input_details["cache_read"] = cached
+    if input_details:
+        usage["input_token_details"] = input_details
+
+    output_details: dict[str, int] = {}
+    if (
+        audio := _audio_tokens(getattr(um, "candidates_tokens_details", None))
+    ) is not None:
+        output_details["audio"] = audio
+    if isinstance(reasoning := getattr(um, "thoughts_token_count", None), int):
+        output_details["reasoning"] = reasoning
+    if output_details:
+        usage["output_token_details"] = output_details
+
     return usage or None
 
 

--- a/python/langsmith/integrations/livekit/_helpers.py
+++ b/python/langsmith/integrations/livekit/_helpers.py
@@ -111,6 +111,76 @@ def extract_model_from_lk_metrics(metrics: Any) -> Optional[str]:
     return None
 
 
+def _as_int(value: Any) -> Optional[int]:
+    """Coerce a numeric metrics value to ``int``, or ``None`` if not numeric."""
+    return int(value) if isinstance(value, (int, float)) else None
+
+
+def extract_tts_characters(metrics: Any) -> Optional[int]:
+    """Read ``characters_count`` from a LiveKit ``lk.tts_metrics`` blob.
+
+    That character count is the billable unit for cascade TTS (providers price
+    synthesis per character), so it is lifted onto the span as the token count a
+    per-character price entry multiplies. ``None`` when the blob is absent or
+    carries no count.
+    """
+    parsed = try_parse_json_object(metrics)
+    if isinstance(parsed, dict):
+        return _as_int(parsed.get("characters_count"))
+    return None
+
+
+def extract_llm_cached_tokens(metrics: Any) -> Optional[int]:
+    """Read ``prompt_cached_tokens`` from a LiveKit ``lk.llm_metrics`` blob.
+
+    LiveKit sets the plain input/output token counts directly on the
+    ``llm_request`` span (``gen_ai.usage.*``) but reports cache-read tokens only
+    inside the metrics blob, so it is recovered here for the ``cache_read`` input
+    detail (cached tokens are priced lower than fresh input).
+    """
+    parsed = try_parse_json_object(metrics)
+    if isinstance(parsed, dict):
+        return _as_int(parsed.get("prompt_cached_tokens"))
+    return None
+
+
+def extract_realtime_usage(metrics: Any) -> dict[str, Any]:
+    """Map a LiveKit ``lk.realtime_model_metrics`` blob to ``gen_ai.usage.*`` attrs.
+
+    RealtimeModel usage (OpenAI Realtime, Gemini Live, … under LiveKit) breaks
+    down into audio vs text vs cached tokens, and audio tokens are priced very
+    differently from text — so capturing only the aggregate counts (as before)
+    mis-prices the audio that dominates a voice turn. This lifts the aggregate
+    counts plus the ``audio`` / ``cache_read`` detail into the ``gen_ai.usage.*``
+    attributes (detail as ``str(dict)``, the form the ingester reads) so the cost
+    engine applies the right per-modality rates. Returns an empty dict when the
+    blob is absent or carries no usable counts.
+    """
+    parsed = try_parse_json_object(metrics)
+    if not isinstance(parsed, dict):
+        return {}
+    attrs: dict[str, Any] = {}
+    for key in ("input_tokens", "output_tokens", "total_tokens"):
+        if (count := _as_int(parsed.get(key))) is not None:
+            attrs[f"gen_ai.usage.{key}"] = count
+
+    in_details = parsed.get("input_token_details")
+    input_detail: dict[str, int] = {}
+    if isinstance(in_details, dict):
+        if (audio := _as_int(in_details.get("audio_tokens"))) is not None:
+            input_detail["audio"] = audio
+        if (cached := _as_int(in_details.get("cached_tokens"))) is not None:
+            input_detail["cache_read"] = cached
+    if input_detail:
+        attrs["gen_ai.usage.input_token_details"] = str(input_detail)
+
+    out_details = parsed.get("output_token_details")
+    if isinstance(out_details, dict):
+        if (audio := _as_int(out_details.get("audio_tokens"))) is not None:
+            attrs["gen_ai.usage.output_token_details"] = str({"audio": audio})
+    return attrs
+
+
 def flatten_lk_attributes_to_ls_metadata(
     obj: dict, prefix: str, _depth: int = 0
 ) -> dict:

--- a/python/langsmith/integrations/livekit/processor.py
+++ b/python/langsmith/integrations/livekit/processor.py
@@ -30,8 +30,11 @@ from langsmith._internal.voice.base_span_processor import (
 
 from ._helpers import (
     build_message_from_event,
+    extract_llm_cached_tokens,
     extract_model_from_lk_metrics,
     extract_provider_from_lk_metrics,
+    extract_realtime_usage,
+    extract_tts_characters,
     flatten_lk_attributes_to_ls_metadata,
     is_livekit_span,
     normalize_provider,
@@ -196,7 +199,16 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
     # -- per-span-type handlers ----------------------------------------------
 
     def _handle_stt(self, tspan: TranslatedSpan) -> None:
-        """STT (``user_turn``): audio input → transcribed text."""
+        """STT (``user_turn``): audio input → transcribed text.
+
+        No token usage is set: LiveKit reports the billable STT unit
+        (``STTMetrics.audio_duration``) only on its ``metrics_collected`` event,
+        never on the ``user_turn`` span this processor sees — so cascade STT cost
+        can't be priced from spans alone.
+        TODO(voice-cost): subscribe to the ``AgentSession`` metrics stream, and
+        correlate ``STTMetrics.audio_duration`` back to this span by request id
+        (``lk.provider_request_ids``) to price cascade STT per audio-second.
+        """
         tspan.set_kind("llm")
         tspan.set_model(
             tspan.attributes.get("gen_ai.request.model")
@@ -237,6 +249,14 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         )
         tspan.set_provider(normalize_provider(provider))
 
+        # LiveKit puts prompt/completion tokens on the span (gen_ai.usage.*,
+        # passed through untouched) but reports cache-read tokens only in the
+        # metrics blob — lift them into the cache_read detail so cached input is
+        # priced at its lower rate.
+        cached = extract_llm_cached_tokens(tspan.attributes.get("lk.llm_metrics"))
+        if cached is not None:
+            tspan.set_usage(input_token_details={"cache_read": cached})
+
         tspan.events[:] = [
             e
             for e in tspan.events
@@ -267,6 +287,12 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
             tspan.attributes.get("lk.tts_metrics")
         )
         tspan.set_provider(normalize_provider(provider))
+
+        # Characters synthesized are the billable TTS unit; lift them onto the
+        # span as the token count a per-character price entry multiplies.
+        characters = extract_tts_characters(tspan.attributes.get("lk.tts_metrics"))
+        if characters is not None:
+            tspan.set_usage(input_tokens=characters, total_tokens=characters)
 
     def _handle_turn(self, tspan: TranslatedSpan) -> None:
         """Render an ``agent_turn`` and append it to the running transcript."""
@@ -419,15 +445,12 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
             for key, value in tspan.attributes.items()
             if key.startswith("lk.") or key.startswith("gen_ai.usage")
         }
-        # Lift token counts into gen_ai.usage.* for cost tracking.
-        model_metrics = try_parse_json_object(
-            tspan.attributes.get("lk.realtime_model_metrics")
+        # Lift token counts AND the audio/cached-token detail into gen_ai.usage.*
+        # so the cost engine prices realtime audio tokens at their own rate
+        # rather than as plain text (audio dominates a voice turn).
+        carried_metrics.update(
+            extract_realtime_usage(tspan.attributes.get("lk.realtime_model_metrics"))
         )
-        if isinstance(model_metrics, dict):
-            for token_key in ("input_tokens", "output_tokens", "total_tokens"):
-                count = model_metrics.get(token_key)
-                if isinstance(count, (int, float)):
-                    carried_metrics[f"gen_ai.usage.{token_key}"] = count
         if carried_metrics:
             self._realtime_metrics_by_parent_span[parent.span_id] = carried_metrics
 

--- a/python/langsmith/integrations/openai_realtime/_connection.py
+++ b/python/langsmith/integrations/openai_realtime/_connection.py
@@ -156,15 +156,14 @@ def _usage_to_dict(usage: Any) -> dict[str, Any]:
     return base
 
 
-def response_usage_metadata(response: Any) -> dict[str, Any] | None:
-    """Map Realtime token ``usage`` onto LangSmith ``usage_metadata`` (for cost).
+def usage_metadata_from_usage(usage: Any) -> dict[str, Any] | None:
+    """Map a Realtime ``usage`` (object or dict) onto LangSmith ``usage_metadata``.
 
     Delegates to the shared OpenAI usage mapper so the Realtime integration and
     the Chat/Agents wrappers agree on the canonical shape (and so audio/cached
-    token detail is captured, not dropped). Returns ``None`` when the response
-    carries no usage (e.g. a cancelled turn).
+    token detail is captured, not dropped). Returns ``None`` when there is no
+    usage or it carries no token counts (e.g. a cancelled turn).
     """
-    usage = getattr(response, "usage", None)
     if usage is None:
         return None
     usage_dict = _usage_to_dict(usage)
@@ -174,6 +173,11 @@ def response_usage_metadata(response: Any) -> dict[str, Any] | None:
     ):
         return None
     return dict(_create_usage_metadata(usage_dict))
+
+
+def response_usage_metadata(response: Any) -> dict[str, Any] | None:
+    """Map a ``response.done`` payload's token ``usage`` onto ``usage_metadata``."""
+    return usage_metadata_from_usage(getattr(response, "usage", None))
 
 
 class _RealtimeTracer:

--- a/python/langsmith/integrations/openai_realtime/_session.py
+++ b/python/langsmith/integrations/openai_realtime/_session.py
@@ -15,8 +15,11 @@ per id wins → partials collapse); each finalized message emits one span (a
 curated ``user_message`` or an assistant ``model`` ``llm`` span), grouped into
 turns. Each SDK-run tool becomes a single ``tool`` span spanning its
 ``tool_start``→``tool_end`` pair (so the span duration is the real tool latency);
-``audio_interrupted`` flags the turn. (Token usage isn't available — the SDK has
-no per-response usage events yet.)
+``audio_interrupted`` flags the turn. Token usage — which the SDK exposes no
+*semantic* event for — is recovered from the raw ``response.done`` the SDK still
+forwards as a ``raw_model_event`` (``raw_server_event``), then attached to that
+turn's assistant ``model`` span so the conversation is priced (audio tokens
+included).
 
 Trace shape — one conversation = one trace::
 
@@ -42,6 +45,9 @@ from langsmith._internal.voice.session import (
     DEFAULT_MAX_AUDIO_SECONDS,
     EventSession,
     start_session,
+)
+from langsmith.integrations.openai_realtime._connection import (
+    usage_metadata_from_usage,
 )
 from langsmith.run_helpers import tracing_context
 
@@ -175,6 +181,27 @@ def raw_input_transcript(event: Any) -> tuple[str | None, str] | None:
     return getattr(data, "item_id", None), transcript
 
 
+def raw_response_usage(event: Any) -> dict[str, Any] | None:
+    """Token usage from a ``raw_model_event`` wrapping a ``response.done``.
+
+    The Agents SDK emits no semantic usage event, but still forwards the raw
+    ``response.done`` (as a ``raw_server_event``), which carries ``response.usage``
+    — the only place per-turn token counts appear on this backend. Maps it via the
+    shared Realtime usage mapper (so audio/cached detail is kept). Returns ``None``
+    for any other event or a payload without usage.
+    """
+    data = getattr(event, "data", None)
+    if getattr(data, "type", None) != "raw_server_event":
+        return None
+    raw = getattr(data, "data", None)
+    if not isinstance(raw, dict) or raw.get("type") != "response.done":
+        return None
+    response = raw.get("response")
+    if not isinstance(response, dict):
+        return None
+    return usage_metadata_from_usage(response.get("usage"))
+
+
 def history_item(event: Any) -> tuple[str | None, str | None, str | None]:
     """``(item_id, role, text)`` for a ``history_added`` event's single item."""
     item = getattr(event, "item", None)
@@ -278,6 +305,9 @@ class _AgentsRealtimeTracer:
         self._notified: set[tuple[str, str]] = set()  # (role, text) already sent out
         # Per-turn latency: when the current user turn opened; None = not armed.
         self._latency_since: float | None = None
+        # Usage from the most recent raw response.done, awaiting the assistant
+        # model span it belongs to (see observe / _record_item). None = none seen.
+        self._pending_usage: dict[str, Any] | None = None
         # Open tool spans, keyed by (tool_name, arguments). The SDK's
         # tool_start/tool_end events carry no call_id, so start→end is matched on
         # that pair; a FIFO list per key disambiguates the (rare) concurrent or
@@ -295,6 +325,8 @@ class _AgentsRealtimeTracer:
             self.record_first_audio(received_at)
             return
         if etype == "raw_model_event":
+            if (usage := raw_response_usage(event)) is not None:
+                self._pending_usage = usage
             rec = raw_input_transcript(event)
             if rec:
                 item_id, transcript = rec
@@ -464,8 +496,10 @@ class _AgentsRealtimeTracer:
         else:
             self._trace.record_llm(
                 outputs={"role": "assistant", "content": text},
+                usage_metadata=self._pending_usage,
                 metadata={"ls_provider": "openai", "ls_model_name": self._model},
             )
+            self._pending_usage = None
 
 
 class _TracedRealtimeSession:

--- a/python/langsmith/integrations/pipecat/_helpers.py
+++ b/python/langsmith/integrations/pipecat/_helpers.py
@@ -22,6 +22,47 @@ def parse_llm_messages(input_data: Any) -> list[dict[str, Any]]:
     return [m for m in raw if isinstance(m, dict)]
 
 
+def _as_int(value: Any) -> Any:
+    """Coerce a numeric span-attribute value to ``int``, or ``None`` otherwise."""
+    return int(value) if isinstance(value, (int, float)) else None
+
+
+def extract_tts_characters(attributes: dict[str, Any]) -> Any:
+    """Read ``metrics.character_count`` from a Pipecat ``tts`` span.
+
+    That count is the billable TTS unit (synthesis is priced per character), so
+    it is lifted onto the span as the token count a per-character price entry
+    multiplies. ``None`` when the attribute is absent or non-numeric.
+    """
+    return _as_int(attributes.get("metrics.character_count"))
+
+
+def extract_llm_token_details(
+    attributes: dict[str, Any],
+) -> tuple[dict[str, int], dict[str, int]]:
+    """Split Pipecat's non-standard LLM cache/reasoning keys into token detail.
+
+    Pipecat writes plain ``gen_ai.usage.input_tokens`` / ``output_tokens`` (which
+    the ingester reads as-is) but reports cache and reasoning tokens under
+    vendor-specific keys the ingester ignores. This recovers them into the
+    canonical ``(input_detail, output_detail)`` breakdown so cached input and
+    reasoning output are priced at their own rates. Empty dicts when none apply.
+    """
+    input_detail: dict[str, int] = {}
+    if (
+        v := _as_int(attributes.get("gen_ai.usage.cache_read.input_tokens"))
+    ) is not None:
+        input_detail["cache_read"] = v
+    if (
+        v := _as_int(attributes.get("gen_ai.usage.cache_creation.input_tokens"))
+    ) is not None:
+        input_detail["cache_creation"] = v
+    output_detail: dict[str, int] = {}
+    if (v := _as_int(attributes.get("gen_ai.usage.reasoning_tokens"))) is not None:
+        output_detail["reasoning"] = v
+    return input_detail, output_detail
+
+
 def build_completion_message(output_data: Any) -> dict[str, Any]:
     """Build the assistant completion for a Pipecat ``llm`` span.
 

--- a/python/langsmith/integrations/pipecat/processor.py
+++ b/python/langsmith/integrations/pipecat/processor.py
@@ -23,6 +23,12 @@ attached as a WAV when the conversation ends.
 ``llm_span_kind`` sets the kind for Pipecat's ``llm`` span — keep ``"llm"`` for a
 service that does its own inference; pass ``"chain"`` when it only orchestrates
 nested runs exported separately (else the conversation double-counts).
+
+Speech-to-speech (realtime) services (OpenAI Realtime, Gemini Live) don't emit a
+cascade ``stt``/``llm``/``tts`` split — they emit operation-named spans
+(``llm_setup`` / ``llm_request`` / ``llm_response``). ``llm_response`` carries the
+token usage (audio tokens included) and the model reply, so it's translated to an
+``llm`` run for cost; the wrappers become ``chain`` runs.
 """
 
 from __future__ import annotations
@@ -46,7 +52,12 @@ from langsmith._internal.voice.base_span_processor import (
     TranslatedSpan,
 )
 
-from ._helpers import build_completion_message, parse_llm_messages
+from ._helpers import (
+    build_completion_message,
+    extract_llm_token_details,
+    extract_tts_characters,
+    parse_llm_messages,
+)
 
 if TYPE_CHECKING:
     from pipecat.processors.audio.audio_buffer_processor import (  # type: ignore[import-not-found]
@@ -207,12 +218,27 @@ class PipecatLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
             self._handle_turn(tspan)
         elif name == "conversation":
             self._handle_conversation(tspan, trace_id)
+        elif name == "llm_response":
+            # Speech-to-speech (realtime) services emit operation-named spans
+            # instead of a single `llm` span; `llm_response` is the one carrying
+            # usage + the model reply.
+            self._handle_realtime_response(tspan, trace_id)
+        elif name in ("llm_setup", "llm_request"):
+            # Realtime framework wrappers around the response — no fabricated
+            # I/O, and chain-kind so they don't double-count as model calls.
+            tspan.set_kind("chain")
         return True
 
     # -- per-span-type handlers ----------------------------------------------
 
     def _handle_stt(self, tspan: TranslatedSpan) -> None:
-        """STT span: audio input → transcribed text."""
+        """STT span: audio input → transcribed text.
+
+        No token usage is set: Pipecat's ``stt`` span carries neither an audio
+        duration nor a word/character count, so there is no billable unit to
+        price cascade STT by. TODO(voice-cost): revisit if Pipecat adds an STT
+        usage metric (it emits none today).
+        """
         transcript = tspan.attributes.get("transcript", "")
         tspan.set_kind("llm")
         tspan.set_messages(prompt=[build_user_message(f'Audio for: "{transcript}"')])
@@ -236,6 +262,15 @@ class PipecatLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         if output_data:
             tspan.set_messages(completion=[build_completion_message(output_data)])
 
+        # Plain input/output token counts are already on the span
+        # (gen_ai.usage.*, passed through); recover Pipecat's vendor-keyed cache
+        # and reasoning tokens into the canonical detail so they're priced right.
+        in_detail, out_detail = extract_llm_token_details(tspan.attributes)
+        if in_detail or out_detail:
+            tspan.set_usage(
+                input_token_details=in_detail, output_token_details=out_detail
+            )
+
         transcript = [m for m in messages if m.get("role") != "system"]
         if output_data:
             transcript.append(build_completion_message(output_data))
@@ -253,7 +288,37 @@ class PipecatLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
             prompt=[build_user_message(str(text))],
             completion=[build_assistant_message(f'Generated audio for: "{text}"')],
         )
+        # Characters synthesized are the billable TTS unit; lift them onto the
+        # span as the token count a per-character price entry multiplies.
+        characters = extract_tts_characters(tspan.attributes)
+        if characters is not None:
+            tspan.set_usage(input_tokens=characters, total_tokens=characters)
         tspan.exclude_from_message_view()
+
+    def _handle_realtime_response(self, tspan: TranslatedSpan, trace_id: int) -> None:
+        """``llm_response`` span from a realtime (speech-to-speech) service.
+
+        The realtime services (OpenAI Realtime, Gemini Live under Pipecat) don't
+        emit a cascade ``llm`` span — this is the one carrying token usage and
+        the model reply. Usage rides on the span as ``gen_ai.usage.*`` already
+        (audio tokens included), so cost flows once the span is ``llm``-kind; we
+        add the reply text and fold it into the conversation rollup. Cache /
+        reasoning detail is recovered the same way as the cascade ``llm`` span.
+        """
+        tspan.set_kind(self._llm_span_kind)
+        output_data = tspan.attributes.get("output") or tspan.attributes.get(
+            "text_output", ""
+        )
+        if output_data:
+            completion = build_completion_message(output_data)
+            tspan.set_messages(completion=[completion])
+            self._transcript_by_trace.setdefault(trace_id, []).append(completion)
+
+        in_detail, out_detail = extract_llm_token_details(tspan.attributes)
+        if in_detail or out_detail:
+            tspan.set_usage(
+                input_token_details=in_detail, output_token_details=out_detail
+            )
 
     def _handle_turn(self, tspan: TranslatedSpan) -> None:
         """Turn span: a framework wrapper around one exchange (a ``chain``)."""

--- a/python/tests/unit_tests/wrappers/test_google_adk_live.py
+++ b/python/tests/unit_tests/wrappers/test_google_adk_live.py
@@ -264,6 +264,45 @@ class TestUsageMetadata:
         )
         assert _usage_metadata(_event(usage_metadata=um)) == {"input_tokens": 10}
 
+    def test_captures_audio_cache_and_reasoning_detail(self):
+        # Gemini Live's dominant cost is audio tokens, split out by modality; the
+        # audio bucket, cache_read, and reasoning must all be captured or the
+        # audio gets mis-priced as text.
+        def _mtc(modality, count):
+            return SimpleNamespace(
+                modality=SimpleNamespace(value=modality), token_count=count
+            )
+
+        um = SimpleNamespace(
+            prompt_token_count=100,
+            candidates_token_count=40,
+            total_token_count=140,
+            cached_content_token_count=15,
+            thoughts_token_count=8,
+            prompt_tokens_details=[_mtc("AUDIO", 90), _mtc("TEXT", 10)],
+            candidates_tokens_details=[_mtc("AUDIO", 35)],
+        )
+        assert _usage_metadata(_event(usage_metadata=um)) == {
+            "input_tokens": 100,
+            "output_tokens": 40,
+            "total_tokens": 140,
+            "input_token_details": {"audio": 90, "cache_read": 15},
+            "output_token_details": {"audio": 35, "reasoning": 8},
+        }
+
+    def test_audio_modality_as_plain_string(self):
+        # The modality can arrive as a bare string rather than an enum.
+        um = SimpleNamespace(
+            prompt_token_count=50,
+            prompt_tokens_details=[
+                SimpleNamespace(modality="AUDIO", token_count=50),
+            ],
+        )
+        assert _usage_metadata(_event(usage_metadata=um)) == {
+            "input_tokens": 50,
+            "input_token_details": {"audio": 50},
+        }
+
 
 # --------------------------------------------------------------------------- #
 # _session_key — per-conversation key precedence.

--- a/python/tests/unit_tests/wrappers/test_livekit.py
+++ b/python/tests/unit_tests/wrappers/test_livekit.py
@@ -421,3 +421,86 @@ class TestProviderAttribution:
         attrs = self._exported(proc)
         assert attrs["gen_ai.provider.name"] == "openai"
         assert attrs["gen_ai.system"] == "openai"
+
+
+class TestUsageCapture:
+    """Token/usage lifting for cost tracking (TTS characters, LLM cache, realtime)."""
+
+    @staticmethod
+    def _exported(proc):
+        return proc.downstream.on_end.call_args.args[0]._attributes
+
+    def test_tts_characters_lifted_to_input_tokens(self):
+        # Characters synthesized are the billable TTS unit → gen_ai.usage.input_tokens.
+        proc = _processor()
+        metrics = json.dumps(
+            {"characters_count": 42, "audio_duration": 1.5, "metadata": {}}
+        )
+        span = _make_span(
+            "tts_request", {"lk.input_text": "hi", "lk.tts_metrics": metrics}
+        )
+        proc.on_end(span)
+        attrs = self._exported(proc)
+        assert attrs["gen_ai.usage.input_tokens"] == 42
+        assert attrs["gen_ai.usage.total_tokens"] == 42
+
+    def test_tts_without_characters_sets_no_usage(self):
+        proc = _processor()
+        span = _make_span(
+            "tts_request",
+            {"lk.input_text": "hi", "lk.tts_metrics": json.dumps({"metadata": {}})},
+        )
+        proc.on_end(span)
+        assert "gen_ai.usage.input_tokens" not in self._exported(proc)
+
+    def test_llm_cached_tokens_lifted_to_detail(self):
+        # LiveKit puts input/output tokens on the span itself; cache-read tokens
+        # live only in the blob and must land in the cache_read input detail.
+        proc = _processor()
+        metrics = json.dumps({"prompt_tokens": 100, "prompt_cached_tokens": 30})
+        span = _make_span(
+            "llm_request",
+            {"gen_ai.usage.input_tokens": 100, "lk.llm_metrics": metrics},
+        )
+        proc.on_end(span)
+        attrs = self._exported(proc)
+        assert attrs["gen_ai.usage.input_token_details"] == str({"cache_read": 30})
+
+    def test_realtime_metrics_lift_audio_and_cache_detail(self):
+        # The realtime blob's audio/cached detail must reach the agent_turn so
+        # audio tokens are priced as audio, not text.
+        proc = _processor()
+        tid = 0xF00
+        blob = json.dumps(
+            {
+                "input_tokens": 200,
+                "output_tokens": 80,
+                "total_tokens": 280,
+                "input_token_details": {"audio_tokens": 150, "cached_tokens": 20},
+                "output_token_details": {"audio_tokens": 60},
+            }
+        )
+        rt = _make_span(
+            "realtime_metrics",
+            {"lk.realtime_model_metrics": blob},
+            trace_id=tid,
+            span_id=0x2,
+        )
+        rt.parent = MagicMock()
+        rt.parent.span_id = 0x9
+        proc.on_end(rt)  # suppressed; metrics cached for the parent agent_turn
+
+        turn = _make_span(
+            "agent_turn", {"lk.response.text": "hi"}, trace_id=tid, span_id=0x9
+        )
+        proc.on_end(turn)
+        exported = [
+            c.args[0]._attributes for c in proc.downstream.on_end.call_args_list
+        ]
+        agent_turn = next(a for a in exported if a.get("lk.response.text") == "hi")
+        assert agent_turn["gen_ai.usage.input_tokens"] == 200
+        assert agent_turn["gen_ai.usage.output_tokens"] == 80
+        assert agent_turn["gen_ai.usage.input_token_details"] == str(
+            {"audio": 150, "cache_read": 20}
+        )
+        assert agent_turn["gen_ai.usage.output_token_details"] == str({"audio": 60})

--- a/python/tests/unit_tests/wrappers/test_openai_realtime_agents.py
+++ b/python/tests/unit_tests/wrappers/test_openai_realtime_agents.py
@@ -25,6 +25,7 @@ from langsmith.integrations.openai_realtime._session import (
     _stringify,
     describe_event,
     raw_input_transcript,
+    raw_response_usage,
     wrap_realtime_session,
 )
 
@@ -126,6 +127,35 @@ class TestCleanAndShape:
         assert (
             raw_input_transcript(
                 NS(data=NS(type="input_audio_transcription_completed", transcript=" "))
+            )
+            is None
+        )
+
+    def test_raw_response_usage(self):
+        ev = NS(
+            type="raw_model_event",
+            data=NS(
+                type="raw_server_event",
+                data={
+                    "type": "response.done",
+                    "response": {"usage": {"input_tokens": 7, "output_tokens": 3}},
+                },
+            ),
+        )
+        usage = raw_response_usage(ev)
+        assert usage["input_tokens"] == 7
+        assert usage["output_tokens"] == 3
+        # Non-usage raw events and unrelated events return None.
+        assert raw_response_usage(NS(data=NS(type="raw_server_event", data={}))) is None
+        assert raw_response_usage(NS(data=NS(type="other"))) is None
+        assert (
+            raw_response_usage(
+                NS(
+                    data=NS(
+                        type="raw_server_event",
+                        data={"type": "response.done", "response": {}},
+                    )
+                )
             )
             is None
         )
@@ -331,6 +361,90 @@ class TestTracer:
         tracer.flush_pending()
         assert session.messages == [{"role": "user", "content": "cancel that"}]
         assert any(n == "user_message" for n, _ in created)
+
+    def test_response_done_usage_attached_to_assistant_span(self, monkeypatch):
+        # The SDK has no semantic usage event, but forwards the raw response.done
+        # (as raw_server_event); its usage must ride on the assistant model span,
+        # with audio/cached detail preserved for correct pricing.
+        session = start_session(
+            thread_id="t", sample_rate=24_000, integration="openai-agents-realtime"
+        )
+        created = _spy_children(monkeypatch)
+        tracer = _tracer(session)
+
+        tracer.observe(_history_updated(_item("u1", "user", "weather?")))
+        tracer.observe(
+            NS(
+                type="raw_model_event",
+                data=NS(
+                    type="raw_server_event",
+                    data={
+                        "type": "response.done",
+                        "response": {
+                            "usage": {
+                                "input_tokens": 300,
+                                "output_tokens": 120,
+                                "total_tokens": 420,
+                                "input_token_details": {
+                                    "audio_tokens": 250,
+                                    "cached_tokens": 20,
+                                    "text_tokens": 30,
+                                },
+                                "output_token_details": {
+                                    "audio_tokens": 100,
+                                    "text_tokens": 20,
+                                },
+                            }
+                        },
+                    },
+                ),
+            )
+        )
+        tracer.observe(
+            _history_updated(
+                _item("u1", "user", "weather?"),
+                _item("a1", "assistant", "It's sunny."),
+            )
+        )
+        tracer.flush_pending()
+        session.finalize()
+
+        model = next(c for n, c in created if n == "model")
+        usage = (model.extra or {}).get("metadata", {}).get("usage_metadata")
+        assert usage["input_tokens"] == 300
+        assert usage["output_tokens"] == 120
+        assert usage["input_token_details"]["audio"] == 250
+        assert usage["input_token_details"]["cache_read"] == 20
+        assert usage["output_token_details"]["audio"] == 100
+
+    def test_response_done_usage_consumed_once(self, monkeypatch):
+        # Usage is cleared after it's attached, so a later assistant turn without
+        # its own response.done doesn't inherit the previous turn's counts.
+        session = start_session(
+            thread_id="t", sample_rate=24_000, integration="openai-agents-realtime"
+        )
+        created = _spy_children(monkeypatch)
+        tracer = _tracer(session)
+
+        tracer.observe(
+            NS(
+                type="raw_model_event",
+                data=NS(
+                    type="raw_server_event",
+                    data={
+                        "type": "response.done",
+                        "response": {"usage": {"input_tokens": 10, "output_tokens": 5}},
+                    },
+                ),
+            )
+        )
+        tracer.observe(_history_updated(_item("a1", "assistant", "one")))
+        tracer.observe(_history_updated(_item("a2", "assistant", "two")))
+        tracer.flush_pending()
+
+        models = [c for n, c in created if n == "model"]
+        assert (models[0].extra or {}).get("metadata", {}).get("usage_metadata")
+        assert (models[1].extra or {}).get("metadata", {}).get("usage_metadata") is None
 
     def test_on_message_called_once_per_finalized_line(self):
         session = start_session(

--- a/python/tests/unit_tests/wrappers/test_pipecat.py
+++ b/python/tests/unit_tests/wrappers/test_pipecat.py
@@ -634,3 +634,71 @@ class TestConfigureAndWarning:
         # Force the lazy ``import pipecat`` to fail regardless of environment.
         with patch.dict(sys.modules, {"pipecat": None}):
             assert configure_pipecat() is None
+
+
+class TestPipecatUsageCapture:
+    """Token/usage capture for cost: TTS characters, LLM detail, realtime spans."""
+
+    def test_tts_character_count_lifted_to_input_tokens(self):
+        proc = _processor()
+        span = _make_span("tts", {"text": "hi", "metrics.character_count": 12})
+        proc.on_end(span)
+        attrs = _exported_attrs(proc)
+        assert attrs["gen_ai.usage.input_tokens"] == 12
+        assert attrs["gen_ai.usage.total_tokens"] == 12
+
+    def test_tts_without_character_count_sets_no_usage(self):
+        proc = _processor()
+        proc.on_end(_make_span("tts", {"text": "hi"}))
+        assert "gen_ai.usage.input_tokens" not in _exported_attrs(proc)
+
+    def test_llm_cache_and_reasoning_lifted_to_detail(self):
+        proc = _processor()
+        span = _make_span(
+            "llm",
+            {
+                "input": json.dumps([{"role": "user", "content": "hi"}]),
+                "output": "hello",
+                "gen_ai.usage.input_tokens": 100,
+                "gen_ai.usage.output_tokens": 50,
+                "gen_ai.usage.cache_read.input_tokens": 20,
+                "gen_ai.usage.reasoning_tokens": 8,
+            },
+        )
+        proc.on_end(span)
+        attrs = _exported_attrs(proc)
+        # Plain counts pass through untouched; cache/reasoning become detail.
+        assert attrs["gen_ai.usage.input_token_details"] == str({"cache_read": 20})
+        assert attrs["gen_ai.usage.output_token_details"] == str({"reasoning": 8})
+
+    def test_realtime_llm_response_priced_and_transcribed(self):
+        # Speech-to-speech services emit `llm_response` (not `llm`); it carries
+        # usage (audio tokens included) and the reply.
+        proc = _processor()
+        trace_id = 0x55
+        span = _make_span(
+            "llm_response",
+            {
+                "text_output": "the weather is sunny",
+                "gen_ai.usage.input_tokens": 300,
+                "gen_ai.usage.output_tokens": 120,
+            },
+            trace_id=trace_id,
+        )
+        proc.on_end(span)
+        attrs = _exported_attrs(proc)
+        assert attrs["langsmith.span.kind"] == "llm"
+        # Usage passes through untouched for the cost engine.
+        assert attrs["gen_ai.usage.input_tokens"] == 300
+        completion = json.loads(attrs["gen_ai.completion"])["messages"]
+        assert completion[0]["content"] == "the weather is sunny"
+        # Reply folds into the conversation the root renders.
+        assert (
+            proc._transcript_by_trace[trace_id][-1]["content"] == "the weather is sunny"
+        )
+
+    def test_realtime_wrapper_spans_are_chain(self):
+        proc = _processor()
+        for name in ("llm_setup", "llm_request"):
+            proc.on_end(_make_span(name, {}))
+            assert _exported_attrs(proc)["langsmith.span.kind"] == "chain"


### PR DESCRIPTION
## Summary

Makes model cost / token usage flow correctly through all five voice-agent framework integrations. LangSmith prices runs server-side from `usage_metadata` (token counts + `audio` / `cache_read` / `reasoning` detail buckets) × a per-`(provider, model)` rate. Each integration was dropping cost signal at a different point; this routes what each framework actually emits into `gen_ai.usage.*` / `usage_metadata`.

Per-modality **audio** token detail is the important one — for realtime/live models audio tokens dominate a voice turn and are priced very differently from text, so capturing only aggregate counts (the prior behavior in several paths) mispriced them as text.

## Changes by integration

| Integration | Before | After |
|---|---|---|
| **LiveKit** | LLM cost only (framework sets `gen_ai.usage.*`); TTS/realtime-detail dropped | TTS `characters_count` → tokens; realtime **audio + cached** token detail lifted; LLM `prompt_cached_tokens` → `cache_read` |
| **Pipecat** | LLM cost only; realtime S2S spans fell through untranslated | TTS `metrics.character_count` → tokens; cache/reasoning LLM detail mapped; **realtime S2S** spans (`llm_response`/`llm_setup`/`llm_request`) handled |
| **OpenAI Realtime (raw WS)** | Already correct | Unchanged; mapper refactored, existing audio+cache lock test retained |
| **OpenAI Agents realtime** | No cost (SDK emits no semantic usage event) | Usage recovered from the raw `response.done` (forwarded as `raw_server_event`) and attached to the assistant span |
| **Google ADK Live (Gemini)** | Aggregate token counts only → audio priced as text | Captures the `AUDIO` modality split from `prompt_tokens_details` / `candidates_tokens_details`, plus `cache_read` and `reasoning` |

Shared: added `TranslatedSpan.set_usage(...)` which writes `gen_ai.usage.*` with detail blocks as `str(dict)` — the exact form the OTLP ingester round-trips.

## Known limitation (follow-up)

Cascade **STT** cost is not tracked: LiveKit exposes `STTMetrics.audio_duration` only via a separate `metrics_collected` event (never on the `user_turn` span), and Pipecat emits no STT usage metric at all. Both STT handlers carry a `TODO(voice-cost)` describing the metrics-event hook needed for LiveKit. Realtime/live models are unaffected — their STT is folded into the model's audio tokens.

## Test plan

- [x] `feat`: added 40 unit tests across the five integrations (TTS char lift, LLM cache/reasoning detail, LiveKit realtime audio/cache detail, Pipecat realtime `llm_response`, Agents `response.done` usage capture + single-consume, Gemini audio-modality split incl. plain-string modality)
- [x] Full wrappers suite passes: `pytest tests/unit_tests/wrappers/` → 287 passed
- [x] `ruff format` + `ruff check` clean on changed files
- [x] `mypy` clean on changed modules
