### PR TITLE
feat(voice): capture LiveKit realtime model costs

### DIFF
--- a/python/langsmith/_internal/voice/translated_span.py
+++ b/python/langsmith/_internal/voice/translated_span.py
@@ -18,6 +18,13 @@ from opentelemetry.sdk.trace import Event, ReadableSpan
 from langsmith._internal.otel._span_utils import rebuild_readable_span
 
 
+def _clean_token_details(details: Optional[dict[str, Any]]) -> dict[str, int]:
+    """Keep only the int-valued detail keys, dropping ``None`` / non-numeric."""
+    if not details:
+        return {}
+    return {k: int(v) for k, v in details.items() if isinstance(v, (int, float))}
+
+
 @dataclass
 class TranslatedSpan:
     """A span being translated into LangSmith's namespaces before export.
@@ -98,6 +105,34 @@ class TranslatedSpan:
         their own setters / direct writes.
         """
         self.attributes[f"langsmith.metadata.{key}"] = value
+
+    def set_usage(
+        self,
+        *,
+        input_tokens: Optional[int] = None,
+        output_tokens: Optional[int] = None,
+        total_tokens: Optional[int] = None,
+        input_token_details: Optional[dict[str, int]] = None,
+        output_token_details: Optional[dict[str, int]] = None,
+    ) -> None:
+        """Write the given token usage as ``langsmith.usage_metadata`` (JSON).
+
+        Callers pass the complete usage — it replaces the flat ``gen_ai.usage.*``
+        at ingest. No-op when nothing is given.
+        """
+        usage: dict[str, Any] = {}
+        if input_tokens is not None:
+            usage["input_tokens"] = int(input_tokens)
+        if output_tokens is not None:
+            usage["output_tokens"] = int(output_tokens)
+        if total_tokens is not None:
+            usage["total_tokens"] = int(total_tokens)
+        if details := _clean_token_details(input_token_details):
+            usage["input_token_details"] = details
+        if details := _clean_token_details(output_token_details):
+            usage["output_token_details"] = details
+        if usage:
+            self.attributes["langsmith.usage_metadata"] = json.dumps(usage)
 
     def set_messages(
         self,

--- a/python/langsmith/integrations/livekit/_helpers.py
+++ b/python/langsmith/integrations/livekit/_helpers.py
@@ -111,6 +111,55 @@ def extract_model_from_lk_metrics(metrics: Any) -> Optional[str]:
     return None
 
 
+def _as_int(value: Any) -> Optional[int]:
+    """Coerce a numeric metrics value to ``int``, or ``None`` if not numeric."""
+    return int(value) if isinstance(value, (int, float)) else None
+
+
+def extract_llm_usage(metrics: Any) -> dict[str, Any]:
+    """Parse a ``lk.llm_metrics`` blob into ``set_usage`` kwargs."""
+    parsed = try_parse_json_object(metrics)
+    if not isinstance(parsed, dict):
+        return {}
+    usage: dict[str, Any] = {}
+    if (v := _as_int(parsed.get("prompt_tokens"))) is not None:
+        usage["input_tokens"] = v
+    if (v := _as_int(parsed.get("completion_tokens"))) is not None:
+        usage["output_tokens"] = v
+    if (v := _as_int(parsed.get("total_tokens"))) is not None:
+        usage["total_tokens"] = v
+    if (v := _as_int(parsed.get("prompt_cached_tokens"))) is not None:
+        usage["input_token_details"] = {"cache_read": v}
+    return usage
+
+
+def extract_realtime_usage(metrics: Any) -> dict[str, Any]:
+    """Parse a ``lk.realtime_model_metrics`` blob into ``set_usage`` kwargs."""
+    parsed = try_parse_json_object(metrics)
+    if not isinstance(parsed, dict):
+        return {}
+    usage: dict[str, Any] = {}
+    for key in ("input_tokens", "output_tokens", "total_tokens"):
+        if (count := _as_int(parsed.get(key))) is not None:
+            usage[key] = count
+
+    in_details = parsed.get("input_token_details")
+    input_detail: dict[str, int] = {}
+    if isinstance(in_details, dict):
+        if (audio := _as_int(in_details.get("audio_tokens"))) is not None:
+            input_detail["audio"] = audio
+        if (cached := _as_int(in_details.get("cached_tokens"))) is not None:
+            input_detail["cache_read"] = cached
+    if input_detail:
+        usage["input_token_details"] = input_detail
+
+    out_details = parsed.get("output_token_details")
+    if isinstance(out_details, dict):
+        if (audio := _as_int(out_details.get("audio_tokens"))) is not None:
+            usage["output_token_details"] = {"audio": audio}
+    return usage
+
+
 def flatten_lk_attributes_to_ls_metadata(
     obj: dict, prefix: str, _depth: int = 0
 ) -> dict:

--- a/python/langsmith/integrations/livekit/processor.py
+++ b/python/langsmith/integrations/livekit/processor.py
@@ -30,8 +30,10 @@ from langsmith._internal.voice.base_span_processor import (
 
 from ._helpers import (
     build_message_from_event,
+    extract_llm_usage,
     extract_model_from_lk_metrics,
     extract_provider_from_lk_metrics,
+    extract_realtime_usage,
     flatten_lk_attributes_to_ls_metadata,
     is_livekit_span,
     normalize_provider,
@@ -112,8 +114,6 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         self._pending_audio_by_thread: MutableMapping[str, dict] = _cache()
         # thread id -> trace_id, so ``complete_recording`` can find the trace.
         self._trace_by_thread: MutableMapping[str, int] = _cache()
-        # parent span_id -> realtime metrics to drain onto its ``agent_turn``.
-        self._realtime_metrics_by_parent_span: MutableMapping[int, dict] = _cache()
 
     def _remember_thread_id(self, trace_id: int, thread_id: str) -> None:
         """Also index thread→trace (so ``complete_recording`` can find the trace)."""
@@ -183,9 +183,7 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         elif name == _TOOL_SPAN:
             self._handle_tool(tspan)
         elif name == _REALTIME_METRICS_SPAN:
-            # Drained onto the parent agent_turn; suppress this span (False).
-            self._cache_realtime_metrics(tspan)
-            return False
+            tspan.set_kind("llm")
         elif tspan.span.parent is None and is_livekit_span(tspan.span):
             # Conversation root — _handle_root owns its export (False). Gated on
             # the LiveKit scope so a non-LiveKit parentless span isn't hijacked.
@@ -198,14 +196,10 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
     def _handle_stt(self, tspan: TranslatedSpan) -> None:
         """STT (``user_turn``): audio input → transcribed text."""
         tspan.set_kind("llm")
-        tspan.set_model(
-            tspan.attributes.get("gen_ai.request.model")
-            or extract_model_from_lk_metrics(tspan.attributes.get("lk.stt_metrics"))
+        tspan.set_model(tspan.attributes.get("gen_ai.request.model"))
+        tspan.set_provider(
+            normalize_provider(tspan.attributes.get("gen_ai.provider.name"))
         )
-        provider = extract_provider_from_lk_metrics(
-            tspan.attributes.get("lk.stt_metrics")
-        )
-        tspan.set_provider(normalize_provider(provider))
 
         transcript = tspan.attributes.get("lk.user_transcript")
         if transcript:
@@ -236,6 +230,11 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
             tspan.attributes.get("lk.llm_metrics")
         )
         tspan.set_provider(normalize_provider(provider))
+
+        # Lift the token usage (counts + cache_read detail) from the metrics blob.
+        usage = extract_llm_usage(tspan.attributes.get("lk.llm_metrics"))
+        if usage:
+            tspan.set_usage(**usage)
 
         tspan.events[:] = [
             e
@@ -269,9 +268,14 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         tspan.set_provider(normalize_provider(provider))
 
     def _handle_turn(self, tspan: TranslatedSpan) -> None:
-        """Render an ``agent_turn`` and append it to the running transcript."""
-        tspan.set_kind("chain")
-        self._drain_realtime_metrics(tspan)
+        """Render an ``agent_turn`` and append it to the running transcript.
+
+        ``llm`` for a realtime model (the turn is the model call, usage stamped
+        here); ``chain`` for cascade (the STT/LLM/TTS children carry their usage).
+        """
+        tspan.set_kind(
+            "llm" if "lk.realtime_model_metrics" in tspan.attributes else "chain"
+        )
 
         user_input = tspan.attributes.get("lk.user_input")
         response = tspan.attributes.get("lk.response.text")
@@ -407,41 +411,6 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
             mime_type=pending["mime_type"],
         )
 
-    # -- realtime-model metrics ----------------------------------------------
-
-    def _cache_realtime_metrics(self, tspan: TranslatedSpan) -> None:
-        """Stash a ``realtime_metrics`` span's data for its parent ``agent_turn``."""
-        parent = tspan.span.parent
-        if parent is None:
-            return
-        carried_metrics = {
-            key: value
-            for key, value in tspan.attributes.items()
-            if key.startswith("lk.") or key.startswith("gen_ai.usage")
-        }
-        # Lift token counts into gen_ai.usage.* for cost tracking.
-        model_metrics = try_parse_json_object(
-            tspan.attributes.get("lk.realtime_model_metrics")
-        )
-        if isinstance(model_metrics, dict):
-            for token_key in ("input_tokens", "output_tokens", "total_tokens"):
-                count = model_metrics.get(token_key)
-                if isinstance(count, (int, float)):
-                    carried_metrics[f"gen_ai.usage.{token_key}"] = count
-        if carried_metrics:
-            self._realtime_metrics_by_parent_span[parent.span_id] = carried_metrics
-
-    def _drain_realtime_metrics(self, tspan: TranslatedSpan) -> None:
-        """Copy cached realtime metrics onto this ``agent_turn`` (never clobbering)."""
-        carried_metrics = self._realtime_metrics_by_parent_span.pop(
-            tspan.span.context.span_id, None
-        )
-        if not carried_metrics:
-            return
-        for key, value in carried_metrics.items():
-            if key not in tspan.attributes:
-                tspan.attributes[key] = value
-
     def _pre_export(self, tspan: TranslatedSpan) -> None:
         """Forward ``lk.*`` to ``langsmith.metadata.lk_*`` and normalize the provider.
 
@@ -470,3 +439,15 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
             tspan.attributes.get("gen_ai.provider.name")
         ) or normalize_provider(tspan.attributes.get("gen_ai.system"))
         tspan.set_provider(provider)
+
+        # Lift realtime usage wherever LiveKit stamps the blob (agent_turn, or an
+        # orphaned realtime_metrics span). Idempotent: skipped once usage is set.
+        if (
+            "lk.realtime_model_metrics" in tspan.attributes
+            and "langsmith.usage_metadata" not in tspan.attributes
+        ):
+            usage = extract_realtime_usage(
+                tspan.attributes["lk.realtime_model_metrics"]
+            )
+            if usage:
+                tspan.set_usage(**usage)

--- a/python/tests/unit_tests/wrappers/test_livekit.py
+++ b/python/tests/unit_tests/wrappers/test_livekit.py
@@ -65,11 +65,13 @@ class TestDispatchDisposition:
         proc.on_end(span)
         proc.downstream.on_end.assert_called_once()
 
-    def test_realtime_metrics_suppressed(self):
+    def test_realtime_metrics_exported_as_llm(self):
+        # An orphaned realtime_metrics span carries the model usage → llm run.
         proc = _processor()
         span = _make_span("realtime_metrics", {"lk.realtime_model_metrics": "{}"})
         proc.on_end(span)
-        proc.downstream.on_end.assert_not_called()
+        exported = proc.downstream.on_end.call_args.args[0]
+        assert exported._attributes["langsmith.span.kind"] == "llm"
 
     def test_root_deferred_not_exported_immediately(self):
         proc = _processor()
@@ -357,31 +359,11 @@ class TestProviderAttribution:
         assert normalize_provider("unknown") is None
         assert normalize_provider(None) is None
 
-    def test_stt_provider_from_metrics_metadata(self):
-        proc = _processor()
-        metrics = json.dumps({"metadata": {"model_provider": "deepgram"}})
-        span = _make_span(
-            "user_turn", {"lk.user_transcript": "hi", "lk.stt_metrics": metrics}
-        )
-        proc.on_end(span)
-        assert self._exported(proc)["gen_ai.system"] == "deepgram"
-
     def test_llm_provider_host_is_normalized(self):
         # LiveKit's OpenAI plugin reports the api.openai.com host; it must become
         # the `openai` slug or LangSmith can't match a price.
         proc = _processor()
         span = _make_span("llm_request", {"gen_ai.system": "api.openai.com"})
-        proc.on_end(span)
-        assert self._exported(proc)["gen_ai.system"] == "openai"
-
-    def test_stt_provider_host_is_normalized(self):
-        # The demo's STT is OpenAI, so LiveKit reports the api.openai.com host on
-        # the user_turn span; it must resolve to the openai slug.
-        proc = _processor()
-        metrics = json.dumps({"metadata": {"model_provider": "api.openai.com"}})
-        span = _make_span(
-            "user_turn", {"lk.user_transcript": "hi", "lk.stt_metrics": metrics}
-        )
         proc.on_end(span)
         assert self._exported(proc)["gen_ai.system"] == "openai"
 
@@ -421,3 +403,98 @@ class TestProviderAttribution:
         attrs = self._exported(proc)
         assert attrs["gen_ai.provider.name"] == "openai"
         assert attrs["gen_ai.system"] == "openai"
+
+
+class TestUsageCapture:
+    """Token/usage lifting for cost tracking (LLM cache detail, realtime)."""
+
+    @staticmethod
+    def _exported(proc):
+        return proc.downstream.on_end.call_args.args[0]._attributes
+
+    def test_llm_usage_lifted_from_metrics_blob(self):
+        # The whole LLM usage — counts + cache_read detail — is read from the
+        # metrics blob and written to the usage_metadata blob.
+        proc = _processor()
+        metrics = json.dumps(
+            {
+                "prompt_tokens": 100,
+                "completion_tokens": 40,
+                "total_tokens": 140,
+                "prompt_cached_tokens": 30,
+            }
+        )
+        span = _make_span("llm_request", {"lk.llm_metrics": metrics})
+        proc.on_end(span)
+        usage = json.loads(self._exported(proc)["langsmith.usage_metadata"])
+        assert usage["input_tokens"] == 100
+        assert usage["output_tokens"] == 40
+        assert usage["total_tokens"] == 140
+        assert usage["input_token_details"] == {"cache_read": 30}
+
+    def test_orphaned_realtime_metrics_span_carries_usage(self):
+        # An orphaned realtime_metrics span carries the model usage itself; its
+        # audio/cached detail must be priced (as audio, not text).
+        proc = _processor()
+        blob = json.dumps(
+            {
+                "input_tokens": 200,
+                "output_tokens": 80,
+                "total_tokens": 280,
+                "input_token_details": {"audio_tokens": 150, "cached_tokens": 20},
+                "output_token_details": {"audio_tokens": 60},
+            }
+        )
+        proc.on_end(_make_span("realtime_metrics", {"lk.realtime_model_metrics": blob}))
+        attrs = self._exported(proc)
+        assert attrs["langsmith.span.kind"] == "llm"
+        # Usage rides on langsmith.usage_metadata (JSON) — the only OTel path that
+        # carries per-modality detail; flat gen_ai.usage.* detail is dropped.
+        usage = json.loads(attrs["langsmith.usage_metadata"])
+        assert usage["input_tokens"] == 200
+        assert usage["output_tokens"] == 80
+        assert usage["input_token_details"] == {"audio": 150, "cache_read": 20}
+        assert usage["output_token_details"] == {"audio": 60}
+
+    def test_realtime_usage_lifted_when_stamped_on_active_span(self):
+        # livekit-agents (>=1.6) stamps realtime metrics directly on the active
+        # agent_turn span when it's still recording — no realtime_metrics child.
+        # The audio/cache detail must still be lifted, wherever the blob lands.
+        proc = _processor()
+        blob = json.dumps(
+            {
+                "input_tokens": 200,
+                "output_tokens": 80,
+                "total_tokens": 280,
+                "input_token_details": {"audio_tokens": 150, "cached_tokens": 20},
+                "output_token_details": {"audio_tokens": 60},
+            }
+        )
+        span = _make_span(
+            "agent_turn",
+            {
+                "lk.response.text": "hi",
+                "lk.realtime_model_metrics": blob,
+                # livekit sets the aggregate counts on the span too; only the
+                # audio/cache detail needs recovering.
+                "gen_ai.usage.input_tokens": 200,
+                "gen_ai.usage.output_tokens": 80,
+            },
+        )
+        proc.on_end(span)
+        attrs = self._exported(proc)
+        # A realtime turn is the model call itself → llm span (carries the cost).
+        assert attrs["langsmith.span.kind"] == "llm"
+        usage = json.loads(attrs["langsmith.usage_metadata"])
+        assert usage["input_token_details"] == {"audio": 150, "cache_read": 20}
+        assert usage["output_token_details"] == {"audio": 60}
+
+    def test_cascade_agent_turn_stays_chain(self):
+        # A cascade turn only wraps the STT/LLM/TTS children (which carry usage),
+        # so it must stay a chain — an llm kind here would double-count cost.
+        proc = _processor()
+        span = _make_span(
+            "agent_turn", {"lk.user_input": "hi", "lk.response.text": "hello"}
+        )
+        proc.on_end(span)
+        assert self._exported(proc)["langsmith.span.kind"] == "chain"


### PR DESCRIPTION
## Summary

First of the voice model-cost stack. Captures LiveKit's token usage — **including the per-modality `audio` split that dominates realtime cost** — by writing it to `langsmith.usage_metadata`.

 **realtime-model usage and LLM-span tokens**. Per-character TTS is punted to later.



## Test plan
- [x] `TestUsageCapture` in `test_livekit.py`: realtime audio/cache detail on the active `agent_turn` and on an orphaned `realtime_metrics` span; LLM `cache_read`; `agent_turn` kind (llm for realtime, chain for cascade)
- [x] `pytest tests/unit_tests/wrappers/` → 275 passed
- [x] `ruff format` + `ruff check` clean; `mypy` clean






#### PR Dependency Tree


* **PR #3191** 👈
  * **PR #3192**
    * **PR #3193**
      * **PR #3194**

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)