### PR TITLE
feat(voice): capture Pipecat TTS/realtime model costs

### DIFF
--- a/python/langsmith/integrations/pipecat/__init__.py
+++ b/python/langsmith/integrations/pipecat/__init__.py
@@ -7,8 +7,7 @@ from typing import Any, Optional
 
 from langsmith._internal._beta_decorator import warn_beta
 from langsmith._internal.voice import set_thread_id, thread_id_from_context
-
-from .processor import PipecatLangSmithSpanProcessor
+from langsmith.integrations.pipecat.processor import PipecatLangSmithSpanProcessor
 
 logger = logging.getLogger(__name__)
 

--- a/python/langsmith/integrations/pipecat/_helpers.py
+++ b/python/langsmith/integrations/pipecat/_helpers.py
@@ -22,6 +22,34 @@ def parse_llm_messages(input_data: Any) -> list[dict[str, Any]]:
     return [m for m in raw if isinstance(m, dict)]
 
 
+def _as_int(value: Any) -> Any:
+    """Coerce a numeric span-attribute value to ``int``, or ``None`` otherwise."""
+    return int(value) if isinstance(value, (int, float)) else None
+
+
+def extract_llm_usage(attributes: dict[str, Any]) -> dict[str, Any]:
+    """Read Pipecat's ``gen_ai.usage.*`` span keys into ``set_usage`` kwargs."""
+    usage: dict[str, Any] = {}
+    if (v := _as_int(attributes.get("gen_ai.usage.input_tokens"))) is not None:
+        usage["input_tokens"] = v
+    if (v := _as_int(attributes.get("gen_ai.usage.output_tokens"))) is not None:
+        usage["output_tokens"] = v
+    input_detail: dict[str, int] = {}
+    if (
+        v := _as_int(attributes.get("gen_ai.usage.cache_read.input_tokens"))
+    ) is not None:
+        input_detail["cache_read"] = v
+    if (
+        v := _as_int(attributes.get("gen_ai.usage.cache_creation.input_tokens"))
+    ) is not None:
+        input_detail["cache_creation"] = v
+    if input_detail:
+        usage["input_token_details"] = input_detail
+    if (v := _as_int(attributes.get("gen_ai.usage.reasoning_tokens"))) is not None:
+        usage["output_token_details"] = {"reasoning": v}
+    return usage
+
+
 def build_completion_message(output_data: Any) -> dict[str, Any]:
     """Build the assistant completion for a Pipecat ``llm`` span.
 

--- a/python/langsmith/integrations/pipecat/processor.py
+++ b/python/langsmith/integrations/pipecat/processor.py
@@ -23,6 +23,9 @@ attached as a WAV when the conversation ends.
 ``llm_span_kind`` sets the kind for Pipecat's ``llm`` span — keep ``"llm"`` for a
 service that does its own inference; pass ``"chain"`` when it only orchestrates
 nested runs exported separately (else the conversation double-counts).
+
+Speech-to-speech (realtime) services emit operation-named spans: ``llm_response``
+(→ ``llm`` run, usage + reply) and the ``llm_setup`` / ``llm_request`` wrappers.
 """
 
 from __future__ import annotations
@@ -45,8 +48,11 @@ from langsmith._internal.voice.base_span_processor import (
     BaseLangSmithSpanProcessor,
     TranslatedSpan,
 )
-
-from ._helpers import build_completion_message, parse_llm_messages
+from langsmith.integrations.pipecat._helpers import (
+    build_completion_message,
+    extract_llm_usage,
+    parse_llm_messages,
+)
 
 if TYPE_CHECKING:
     from pipecat.processors.audio.audio_buffer_processor import (  # type: ignore[import-not-found]
@@ -198,7 +204,7 @@ class PipecatLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         name = tspan.span.name
 
         if name == "stt":
-            self._handle_stt(tspan)
+            self._handle_stt(tspan, trace_id)
         elif name == "llm":
             self._handle_llm(tspan, trace_id)
         elif name == "tts":
@@ -207,17 +213,27 @@ class PipecatLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
             self._handle_turn(tspan)
         elif name == "conversation":
             self._handle_conversation(tspan, trace_id)
+        elif name == "llm_response":  # realtime: usage + reply
+            self._handle_realtime_response(tspan, trace_id)
+        elif name in ("llm_setup", "llm_request"):
+            tspan.set_kind("chain")  # realtime wrappers
         return True
 
     # -- per-span-type handlers ----------------------------------------------
 
-    def _handle_stt(self, tspan: TranslatedSpan) -> None:
+    def _handle_stt(self, tspan: TranslatedSpan, trace_id: int) -> None:
         """STT span: audio input → transcribed text."""
         transcript = tspan.attributes.get("transcript", "")
         tspan.set_kind("llm")
         tspan.set_messages(prompt=[build_user_message(f'Audio for: "{transcript}"')])
         if transcript:
             tspan.set_messages(completion=[build_assistant_message(str(transcript))])
+            # Fold the user turn into the rollup (realtime has no cascade llm
+            # span to carry it; cascade's llm span replaces it with full history).
+            if tspan.attributes.get("is_final", True):
+                self._transcript_by_trace.setdefault(trace_id, []).append(
+                    build_user_message(str(transcript))
+                )
         tspan.exclude_from_message_view()
 
     def _handle_llm(self, tspan: TranslatedSpan, trace_id: int) -> None:
@@ -235,6 +251,10 @@ class PipecatLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
             tspan.set_messages(prompt=messages)
         if output_data:
             tspan.set_messages(completion=[build_completion_message(output_data)])
+
+        usage = extract_llm_usage(tspan.attributes)
+        if usage:
+            tspan.set_usage(**usage)
 
         transcript = [m for m in messages if m.get("role") != "system"]
         if output_data:
@@ -254,6 +274,21 @@ class PipecatLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
             completion=[build_assistant_message(f'Generated audio for: "{text}"')],
         )
         tspan.exclude_from_message_view()
+
+    def _handle_realtime_response(self, tspan: TranslatedSpan, trace_id: int) -> None:
+        """``llm_response`` span from a realtime (speech-to-speech) service."""
+        tspan.set_kind(self._llm_span_kind)
+        output_data = tspan.attributes.get("output") or tspan.attributes.get(
+            "text_output", ""
+        )
+        if output_data:
+            completion = build_completion_message(output_data)
+            tspan.set_messages(completion=[completion])
+            self._transcript_by_trace.setdefault(trace_id, []).append(completion)
+
+        usage = extract_llm_usage(tspan.attributes)
+        if usage:
+            tspan.set_usage(**usage)
 
     def _handle_turn(self, tspan: TranslatedSpan) -> None:
         """Turn span: a framework wrapper around one exchange (a ``chain``)."""

--- a/python/tests/unit_tests/wrappers/test_pipecat.py
+++ b/python/tests/unit_tests/wrappers/test_pipecat.py
@@ -634,3 +634,85 @@ class TestConfigureAndWarning:
         # Force the lazy ``import pipecat`` to fail regardless of environment.
         with patch.dict(sys.modules, {"pipecat": None}):
             assert configure_pipecat() is None
+
+
+class TestPipecatUsageCapture:
+    """Token/usage capture for cost: LLM usage + detail, realtime spans."""
+
+    def test_llm_usage_and_detail_lifted(self):
+        proc = _processor()
+        span = _make_span(
+            "llm",
+            {
+                "input": json.dumps([{"role": "user", "content": "hi"}]),
+                "output": "hello",
+                "gen_ai.usage.input_tokens": 100,
+                "gen_ai.usage.output_tokens": 50,
+                "gen_ai.usage.cache_read.input_tokens": 20,
+                "gen_ai.usage.reasoning_tokens": 8,
+            },
+        )
+        proc.on_end(span)
+        usage = json.loads(_exported_attrs(proc)["langsmith.usage_metadata"])
+        assert usage["input_tokens"] == 100
+        assert usage["output_tokens"] == 50
+        assert usage["input_token_details"] == {"cache_read": 20}
+        assert usage["output_token_details"] == {"reasoning": 8}
+
+    def test_realtime_llm_response_priced_and_transcribed(self):
+        # Speech-to-speech services emit `llm_response` (not `llm`); it carries
+        # aggregate usage (Pipecat drops the audio split) and the reply.
+        proc = _processor()
+        trace_id = 0x55
+        span = _make_span(
+            "llm_response",
+            {
+                "text_output": "the weather is sunny",
+                "gen_ai.usage.input_tokens": 300,
+                "gen_ai.usage.output_tokens": 120,
+            },
+            trace_id=trace_id,
+        )
+        proc.on_end(span)
+        attrs = _exported_attrs(proc)
+        assert attrs["langsmith.span.kind"] == "llm"
+        usage = json.loads(attrs["langsmith.usage_metadata"])
+        assert usage["input_tokens"] == 300
+        assert usage["output_tokens"] == 120
+        completion = json.loads(attrs["gen_ai.completion"])["messages"]
+        assert completion[0]["content"] == "the weather is sunny"
+        # Reply folds into the conversation the root renders.
+        assert (
+            proc._transcript_by_trace[trace_id][-1]["content"] == "the weather is sunny"
+        )
+
+    def test_realtime_rollup_has_user_and_agent_turns(self):
+        # Realtime has no cascade `llm` span carrying history: the user turn
+        # arrives on a standard `stt` span, the agent reply on `llm_response`.
+        # Both must fold into the conversation rollup the root renders.
+        proc = _processor()
+        trace_id = 0x56
+        proc.on_end(_make_span("stt", {"transcript": "what's the weather?"}, trace_id))
+        proc.on_end(
+            _make_span("llm_response", {"output": "it's sunny"}, trace_id=trace_id)
+        )
+        rollup = proc._transcript_by_trace[trace_id]
+        assert [(m["role"], m["content"]) for m in rollup] == [
+            ("user", "what's the weather?"),
+            ("assistant", "it's sunny"),
+        ]
+
+    def test_stt_interim_transcript_not_folded(self):
+        # Non-final STT results must not pollute the rollup with partials.
+        proc = _processor()
+        trace_id = 0x57
+        proc.on_end(
+            _make_span("stt", {"transcript": "what's", "is_final": False}, trace_id)
+        )
+        assert trace_id not in proc._transcript_by_trace
+
+    def test_realtime_wrapper_spans_are_chain(self):
+        proc = _processor()
+        for name in ("llm_setup", "llm_request"):
+            proc.on_end(_make_span(name, {}))
+            assert _exported_attrs(proc)["langsmith.span.kind"] == "chain"


### PR DESCRIPTION
## Summary

Captures usage data for Pipecat, including pipecat with the realtime model.

## Test plan
- [x] `TestPipecatUsageCapture`: LLM usage + cache/reasoning detail; realtime `llm_response` priced + transcribed; realtime user+agent rollup; wrapper spans → chain
- [x] `pytest tests/unit_tests/wrappers/` → 280 passed
- [x] `ruff format` + `ruff check` clean; `mypy` clean






#### PR Dependency Tree


* **PR #3192** 👈
  * **PR #3193**
    * **PR #3194**

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)