### PR TITLE
feat(voice): capture OpenAI Agents realtime model costs

### DIFF
--- a/python/langsmith/integrations/openai_realtime/_connection.py
+++ b/python/langsmith/integrations/openai_realtime/_connection.py
@@ -156,15 +156,14 @@ def _usage_to_dict(usage: Any) -> dict[str, Any]:
     return base
 
 
-def response_usage_metadata(response: Any) -> dict[str, Any] | None:
-    """Map Realtime token ``usage`` onto LangSmith ``usage_metadata`` (for cost).
+def usage_metadata_from_usage(usage: Any) -> dict[str, Any] | None:
+    """Map a Realtime ``usage`` (object or dict) onto LangSmith ``usage_metadata``.
 
     Delegates to the shared OpenAI usage mapper so the Realtime integration and
     the Chat/Agents wrappers agree on the canonical shape (and so audio/cached
-    token detail is captured, not dropped). Returns ``None`` when the response
-    carries no usage (e.g. a cancelled turn).
+    token detail is captured, not dropped). Returns ``None`` when there is no
+    usage or it carries no token counts (e.g. a cancelled turn).
     """
-    usage = getattr(response, "usage", None)
     if usage is None:
         return None
     usage_dict = _usage_to_dict(usage)
@@ -174,6 +173,11 @@ def response_usage_metadata(response: Any) -> dict[str, Any] | None:
     ):
         return None
     return dict(_create_usage_metadata(usage_dict))
+
+
+def response_usage_metadata(response: Any) -> dict[str, Any] | None:
+    """Map a ``response.done`` payload's token ``usage`` onto ``usage_metadata``."""
+    return usage_metadata_from_usage(getattr(response, "usage", None))
 
 
 class _RealtimeTracer:

--- a/python/langsmith/integrations/openai_realtime/_session.py
+++ b/python/langsmith/integrations/openai_realtime/_session.py
@@ -15,8 +15,11 @@ per id wins → partials collapse); each finalized message emits one span (a
 curated ``user_message`` or an assistant ``model`` ``llm`` span), grouped into
 turns. Each SDK-run tool becomes a single ``tool`` span spanning its
 ``tool_start``→``tool_end`` pair (so the span duration is the real tool latency);
-``audio_interrupted`` flags the turn. (Token usage isn't available — the SDK has
-no per-response usage events yet.)
+``audio_interrupted`` flags the turn. Token usage — which the SDK exposes no
+*semantic* event for — is recovered from the raw ``response.done`` the SDK still
+forwards as a ``raw_model_event`` (``raw_server_event``), then attached to that
+turn's assistant ``model`` span so the conversation is priced (audio tokens
+included).
 
 Trace shape — one conversation = one trace::
 
@@ -42,6 +45,9 @@ from langsmith._internal.voice.session import (
     DEFAULT_MAX_AUDIO_SECONDS,
     EventSession,
     start_session,
+)
+from langsmith.integrations.openai_realtime._connection import (
+    usage_metadata_from_usage,
 )
 from langsmith.run_helpers import tracing_context
 
@@ -175,6 +181,25 @@ def raw_input_transcript(event: Any) -> tuple[str | None, str] | None:
     return getattr(data, "item_id", None), transcript
 
 
+def raw_response_usage(event: Any) -> dict[str, Any] | None:
+    """Token usage from a ``raw_model_event`` wrapping a ``response.done``.
+
+    The Agents SDK emits no semantic usage event, but still forwards the raw
+    ``response.done`` (as a ``raw_server_event``), which carries ``response.usage``
+    — the only place per-turn token counts appear on this backend. Maps it via the
+    shared Realtime usage mapper (so audio/cached detail is kept). Returns ``None``
+    for any other event or a payload without usage.
+    """
+    data = getattr(event, "data", None)
+    raw = getattr(data, "data", None)
+    if not isinstance(raw, dict) or raw.get("type") != "response.done":
+        return None
+    response = raw.get("response")
+    if not isinstance(response, dict):
+        return None
+    return usage_metadata_from_usage(response.get("usage"))
+
+
 def history_item(event: Any) -> tuple[str | None, str | None, str | None]:
     """``(item_id, role, text)`` for a ``history_added`` event's single item."""
     item = getattr(event, "item", None)
@@ -278,6 +303,9 @@ class _AgentsRealtimeTracer:
         self._notified: set[tuple[str, str]] = set()  # (role, text) already sent out
         # Per-turn latency: when the current user turn opened; None = not armed.
         self._latency_since: float | None = None
+        # Usage from the most recent raw response.done, awaiting the assistant
+        # model span it belongs to (see observe / _record_item). None = none seen.
+        self._pending_usage: dict[str, Any] | None = None
         # Open tool spans, keyed by (tool_name, arguments). The SDK's
         # tool_start/tool_end events carry no call_id, so start→end is matched on
         # that pair; a FIFO list per key disambiguates the (rare) concurrent or
@@ -295,6 +323,8 @@ class _AgentsRealtimeTracer:
             self.record_first_audio(received_at)
             return
         if etype == "raw_model_event":
+            if (usage := raw_response_usage(event)) is not None:
+                self._pending_usage = usage
             rec = raw_input_transcript(event)
             if rec:
                 item_id, transcript = rec
@@ -464,8 +494,10 @@ class _AgentsRealtimeTracer:
         else:
             self._trace.record_llm(
                 outputs={"role": "assistant", "content": text},
+                usage_metadata=self._pending_usage,
                 metadata={"ls_provider": "openai", "ls_model_name": self._model},
             )
+            self._pending_usage = None
 
 
 class _TracedRealtimeSession:

--- a/python/tests/unit_tests/wrappers/test_openai_realtime_agents.py
+++ b/python/tests/unit_tests/wrappers/test_openai_realtime_agents.py
@@ -25,6 +25,7 @@ from langsmith.integrations.openai_realtime._session import (
     _stringify,
     describe_event,
     raw_input_transcript,
+    raw_response_usage,
     wrap_realtime_session,
 )
 
@@ -126,6 +127,35 @@ class TestCleanAndShape:
         assert (
             raw_input_transcript(
                 NS(data=NS(type="input_audio_transcription_completed", transcript=" "))
+            )
+            is None
+        )
+
+    def test_raw_response_usage(self):
+        ev = NS(
+            type="raw_model_event",
+            data=NS(
+                type="raw_server_event",
+                data={
+                    "type": "response.done",
+                    "response": {"usage": {"input_tokens": 7, "output_tokens": 3}},
+                },
+            ),
+        )
+        usage = raw_response_usage(ev)
+        assert usage["input_tokens"] == 7
+        assert usage["output_tokens"] == 3
+        # Non-usage raw events and unrelated events return None.
+        assert raw_response_usage(NS(data=NS(type="raw_server_event", data={}))) is None
+        assert raw_response_usage(NS(data=NS(type="other"))) is None
+        assert (
+            raw_response_usage(
+                NS(
+                    data=NS(
+                        type="raw_server_event",
+                        data={"type": "response.done", "response": {}},
+                    )
+                )
             )
             is None
         )
@@ -331,6 +361,90 @@ class TestTracer:
         tracer.flush_pending()
         assert session.messages == [{"role": "user", "content": "cancel that"}]
         assert any(n == "user_message" for n, _ in created)
+
+    def test_response_done_usage_attached_to_assistant_span(self, monkeypatch):
+        # The SDK has no semantic usage event, but forwards the raw response.done
+        # (as raw_server_event); its usage must ride on the assistant model span,
+        # with audio/cached detail preserved for correct pricing.
+        session = start_session(
+            thread_id="t", sample_rate=24_000, integration="openai-agents-realtime"
+        )
+        created = _spy_children(monkeypatch)
+        tracer = _tracer(session)
+
+        tracer.observe(_history_updated(_item("u1", "user", "weather?")))
+        tracer.observe(
+            NS(
+                type="raw_model_event",
+                data=NS(
+                    type="raw_server_event",
+                    data={
+                        "type": "response.done",
+                        "response": {
+                            "usage": {
+                                "input_tokens": 300,
+                                "output_tokens": 120,
+                                "total_tokens": 420,
+                                "input_token_details": {
+                                    "audio_tokens": 250,
+                                    "cached_tokens": 20,
+                                    "text_tokens": 30,
+                                },
+                                "output_token_details": {
+                                    "audio_tokens": 100,
+                                    "text_tokens": 20,
+                                },
+                            }
+                        },
+                    },
+                ),
+            )
+        )
+        tracer.observe(
+            _history_updated(
+                _item("u1", "user", "weather?"),
+                _item("a1", "assistant", "It's sunny."),
+            )
+        )
+        tracer.flush_pending()
+        session.finalize()
+
+        model = next(c for n, c in created if n == "model")
+        usage = (model.extra or {}).get("metadata", {}).get("usage_metadata")
+        assert usage["input_tokens"] == 300
+        assert usage["output_tokens"] == 120
+        assert usage["input_token_details"]["audio"] == 250
+        assert usage["input_token_details"]["cache_read"] == 20
+        assert usage["output_token_details"]["audio"] == 100
+
+    def test_response_done_usage_consumed_once(self, monkeypatch):
+        # Usage is cleared after it's attached, so a later assistant turn without
+        # its own response.done doesn't inherit the previous turn's counts.
+        session = start_session(
+            thread_id="t", sample_rate=24_000, integration="openai-agents-realtime"
+        )
+        created = _spy_children(monkeypatch)
+        tracer = _tracer(session)
+
+        tracer.observe(
+            NS(
+                type="raw_model_event",
+                data=NS(
+                    type="raw_server_event",
+                    data={
+                        "type": "response.done",
+                        "response": {"usage": {"input_tokens": 10, "output_tokens": 5}},
+                    },
+                ),
+            )
+        )
+        tracer.observe(_history_updated(_item("a1", "assistant", "one")))
+        tracer.observe(_history_updated(_item("a2", "assistant", "two")))
+        tracer.flush_pending()
+
+        models = [c for n, c in created if n == "model"]
+        assert (models[0].extra or {}).get("metadata", {}).get("usage_metadata")
+        assert (models[1].extra or {}).get("metadata", {}).get("usage_metadata") is None
 
     def test_on_message_called_once_per_finalized_line(self):
         session = start_session(


### PR DESCRIPTION
## Summary

Part of a 4-PR stack on voice model-cost capture. Stacked on #3192 (Pipecat).

This PR covers **`integrations/openai_realtime`** (both the raw-WebSocket and Agents SDK realtime flavors).

The raw-WS integration already captures audio + cached token detail (unchanged, still covered by its existing test). The gap was the **Agents SDK realtime backend**, which emits no *semantic* usage event:

- Recover token usage from the raw `response.done` the SDK still forwards as a `raw_model_event` (`raw_server_event`), and attach it to that turn's assistant `model` span — so the conversation is priced (audio tokens included) where before it had none.
- Refactor the shared mapper into `usage_metadata_from_usage` so both realtime flavors map through the same canonical shape.

## Test plan

- [x] Added to `test_openai_realtime_agents.py`: `raw_response_usage` helper (extraction + None cases), usage attached to the assistant span with audio/cache detail, and usage consumed once (not inherited by a later turn)
- [x] Existing raw-WS audio/cache detail test retained
- [x] `pytest tests/unit_tests/wrappers/` → 287 passed
- [x] `ruff format` + `ruff check` clean; `mypy` clean on changed modules









#### PR Dependency Tree


* **PR #3193** 👈
  * **PR #3194**

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)