### PR TITLE
feat(py/strands): improved tracing of thinking and tool result blocks from Strands [closes #3226]

### DIFF
--- a/python/langsmith/integrations/strands_agents/exporter.py
+++ b/python/langsmith/integrations/strands_agents/exporter.py
@@ -395,12 +395,14 @@ class LangSmithSpanExporter(SpanExporter):
         Bedrock uses implicit typing (the key name *is* the type)::
 
             {"text": "hello"}
+            {"reasoningContent": {"reasoningText": {"text": "...", "signature": "..."}}}
             {"toolUse": {"toolUseId": "x", "name": "f", "input": {...}}}
             {"toolResult": {"toolUseId": "x", "status": "success", "content": [...]}}
 
         LangSmith expects explicit ``type`` fields::
 
             {"type": "text", "text": "hello"}
+            {"type": "thinking", "thinking": "...", "signature": "..."}
             {"type": "tool_use", "id": "x", "name": "f", "input": {...}}
             {
                 "type": "tool_result",
@@ -416,6 +418,15 @@ class LangSmithSpanExporter(SpanExporter):
 
         if "text" in block and len(block) == 1:
             return {"type": "text", "text": block["text"]}
+
+        if "reasoningContent" in block:
+            rc = block["reasoningContent"]
+            reasoning_text = rc.get("reasoningText", {})
+            return {
+                "type": "thinking",
+                "thinking": reasoning_text.get("text", ""),
+                "signature": reasoning_text.get("signature", ""),
+            }
 
         if "toolUse" in block:
             tu = block["toolUse"]

--- a/python/langsmith/integrations/strands_agents/exporter.py
+++ b/python/langsmith/integrations/strands_agents/exporter.py
@@ -166,6 +166,7 @@ class LangSmithSpanExporter(SpanExporter):
 
         input_messages: list[dict[str, Any]] = []
         output_messages: list[dict[str, Any]] = []
+        tool_output_completion: str | None = None
         remaining_events: list[Any] = []
 
         for event in span.events:
@@ -173,13 +174,29 @@ class LangSmithSpanExporter(SpanExporter):
             attrs = dict(event.attributes) if event.attributes else {}
 
             if name == "gen_ai.choice":
-                # The final model response is the only true output
-                msg = self._event_to_message(
-                    name, attrs, tool_id_to_name=tool_id_to_name
-                )
-                if tool_call_id:
-                    msg["tool_call_id"] = tool_call_id
-                output_messages.append(msg)
+                if operation == "execute_tool":
+                    # In an 'execute_tool' span, Strands adds tool results
+                    # in a gen_ai.choice event. We convert it to expected
+                    # tool result block.
+                    raw = attrs.get("message", "[]")
+                    try:
+                        content = json.loads(raw) if isinstance(raw, str) else raw
+                    except (json.JSONDecodeError, TypeError):
+                        content = raw
+                    tool_output_completion = json.dumps({
+                        "role": "tool",
+                        "content": self._extract_tool_output(content),
+                        "name": tool_name,
+                        "tool_call_id": tool_call_id,
+                    })
+                else:
+                    # The final model response is the only true output
+                    msg = self._event_to_message(
+                        name, attrs, tool_id_to_name=tool_id_to_name
+                    )
+                    if tool_call_id:
+                        msg["tool_call_id"] = tool_call_id
+                    output_messages.append(msg)
             elif name in self._MESSAGE_EVENTS:
                 msg = self._event_to_message(
                     name, attrs, tool_id_to_name=tool_id_to_name
@@ -198,7 +215,9 @@ class LangSmithSpanExporter(SpanExporter):
         new_attrs: dict[str, Any] = dict(span_attrs)
         if input_messages:
             new_attrs["gen_ai.prompt"] = json.dumps({"messages": input_messages})
-        if output_messages:
+        if tool_output_completion is not None:
+            new_attrs["gen_ai.completion"] = tool_output_completion
+        elif output_messages:
             new_attrs["gen_ai.completion"] = json.dumps(output_messages[-1])
 
         # Map gen_ai.operation.name to langsmith.span.kind (run type).
@@ -370,6 +389,35 @@ class LangSmithSpanExporter(SpanExporter):
         if tool_call_id:
             msg["tool_call_id"] = tool_call_id
         return msg
+
+    @staticmethod
+    def _extract_tool_output(content: Any) -> str:
+        """Extract plain-text output from tool result content blocks.
+
+        Strands tool spans emit their output as a list of content blocks
+        (e.g. ``[{"text": "Hippopotamus"}]``). This extracts the text and
+        returns it as a plain string for ``gen_ai.completion`` on tool spans.
+        """
+        if isinstance(content, str):
+            return content
+
+        if isinstance(content, list):
+            text_parts: list[str] = []
+            for block in content:
+                if isinstance(block, dict) and "text" in block and len(block) == 1:
+                    text_parts.append(block["text"])
+                else:
+                    try:
+                        text_parts.append(json.dumps(block, ensure_ascii=False))
+                    except (TypeError, ValueError):
+                        text_parts.append(str(block))
+            if text_parts:
+                return "\n".join(text_parts) if len(text_parts) > 1 else text_parts[0]
+
+        try:
+            return json.dumps(content, ensure_ascii=False)
+        except (TypeError, ValueError):
+            return str(content)
 
     @staticmethod
     def _stringify_tool_content(content: Any) -> str:

--- a/python/tests/integration_tests/wrappers/test_strands_agents.py
+++ b/python/tests/integration_tests/wrappers/test_strands_agents.py
@@ -185,6 +185,19 @@ def test_exporter_transforms_live_strands_agent_spans(tmp_path, monkeypatch):
     assert "user" in roles
     assert "system" in roles
 
+    tool_spans = [
+        span for span in recorder.spans if span.name.startswith("execute_tool")
+    ]
+    assert tool_spans, [span.name for span in recorder.spans]
+    for tool_span in tool_spans:
+        assert tool_span.attributes["langsmith.span.kind"] == "tool"
+        assert _span_has_completion(tool_span)
+        completion = json.loads(tool_span.attributes["gen_ai.completion"])
+        assert completion["role"] == "tool"
+        assert "content" in completion
+        assert "name" in completion
+        assert "tool_call_id" in completion
+
 
 @pytest.mark.skipif(
     not (

--- a/python/tests/integration_tests/wrappers/test_strands_agents.py
+++ b/python/tests/integration_tests/wrappers/test_strands_agents.py
@@ -19,6 +19,7 @@ from opentelemetry.sdk.trace.export import (
     SpanExportResult,
 )
 from strands import Agent
+from strands.models.bedrock import BedrockModel
 from strands_tools import file_read, file_write, journal, python_repl, shell
 
 from langsmith.integrations.otel.processor import OtelExporter
@@ -183,3 +184,91 @@ def test_exporter_transforms_live_strands_agent_spans(tmp_path, monkeypatch):
     roles = [message["role"] for message in prompt["messages"]]
     assert "user" in roles
     assert "system" in roles
+
+
+@pytest.mark.skipif(
+    not (
+        os.getenv("AWS_ACCESS_KEY_ID")
+        or os.getenv("AWS_PROFILE")
+        or os.getenv("AWS_WEB_IDENTITY_TOKEN_FILE")
+    ),
+    reason="Live Strands/Bedrock integration test requires AWS credentials.",
+)
+@pytest.mark.skipif(
+    not os.getenv("LANGSMITH_API_KEY"),
+    reason="Live Strands/LangSmith integration test requires LANGSMITH_API_KEY.",
+)
+def test_exporter_transforms_thinking_blocks(tmp_path, monkeypatch):
+    """Invoke a Strands Agent with extended thinking and verify thinking blocks."""
+    (tmp_path / "otel_strands_share.py").write_text(
+        "def setup_langsmith_telemetry():\n"
+        "    return 'sets up Strands OTEL tracing for LangSmith'\n",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+
+    recorder = RecordingSpanExporter()
+    langsmith_exporter = OtelExporter()
+    delegate = TeeSpanExporter(recorder, langsmith_exporter)
+    provider = TracerProvider()
+    provider.add_span_processor(
+        SimpleSpanProcessor(LangSmithSpanExporter(delegate=delegate))
+    )
+
+    import strands.telemetry.tracer as strands_tracer
+
+    previous_tracer = _install_strands_tracer(provider)
+    try:
+        model = BedrockModel(
+            model_id=MODEL_ID,
+            additional_request_fields={
+                "thinking": {"type": "enabled", "budget_tokens": 5000}
+            },
+            max_tokens=16000,
+        )
+        agent = Agent(
+            model=model,
+            tools=[file_read],
+            system_prompt=SYSTEM_PROMPT,
+        )
+
+        response = agent(INPUT)
+        provider.force_flush()
+    finally:
+        provider.shutdown()
+        strands_tracer._tracer_instance = previous_tracer
+
+    assert response is not None
+
+    llm_spans = [span for span in recorder.spans if span.name == "chat"]
+    assert llm_spans, [span.name for span in recorder.spans]
+    assert any(_span_has_prompt_text(span, INPUT) for span in llm_spans)
+    assert any(_span_has_completion(span) for span in llm_spans)
+
+    for llm_span in llm_spans:
+        assert llm_span.attributes["langsmith.span.kind"] == "llm"
+        assert llm_span.attributes["gen_ai.request.model"] == MODEL_ID
+        assert llm_span.attributes["langsmith.metadata.ls_provider"] == "amazon_bedrock"
+        assert llm_span.attributes["langsmith.metadata.ls_model_type"] == "chat"
+        assert not any(event.name.startswith("gen_ai.") for event in llm_span.events)
+
+    found_thinking = False
+    for span in llm_spans:
+        completion_str = span.attributes.get("gen_ai.completion")
+        if not isinstance(completion_str, str):
+            continue
+        completion = json.loads(completion_str)
+        messages = completion if isinstance(completion, list) else [completion]
+        for msg in messages:
+            content = msg.get("content", [])
+            if isinstance(content, list):
+                for block in content:
+                    if isinstance(block, dict) and block.get("type") == "thinking":
+                        found_thinking = True
+                        assert isinstance(block["thinking"], str)
+                        assert len(block["thinking"]) > 0
+
+    assert found_thinking, (
+        "Expected at least one thinking block in LLM completions. "
+        f"Spans checked: {len(llm_spans)}"
+    )

--- a/python/tests/unit_tests/wrappers/test_strands_agents.py
+++ b/python/tests/unit_tests/wrappers/test_strands_agents.py
@@ -313,6 +313,118 @@ class TestLangSmithSpanExporter:
             "signature": "",
         }
 
+    def test_transform_tool_span_choice_outputs_tool_envelope(self):
+        """Test that execute_tool span choice events produce tool output envelope."""
+        delegate = MagicMock()
+        delegate.export.return_value = 0
+
+        exporter = LangSmithSpanExporter(delegate=delegate)
+
+        choice_event = self._make_event(
+            "gen_ai.choice",
+            {
+                "message": json.dumps([{"text": "Hippopotamus"}]),
+                "id": "tooluse_5lnW6BJJLFew8zk9eFpVUt",
+            },
+        )
+        span = self._make_span(
+            name="execute_tool get_magic_word",
+            attributes={
+                "gen_ai.operation.name": "execute_tool",
+                "gen_ai.tool.name": "get_magic_word",
+                "gen_ai.tool.call.id": "tooluse_5lnW6BJJLFew8zk9eFpVUt",
+            },
+            events=[choice_event],
+        )
+
+        exporter.export([span])
+        transformed = delegate.export.call_args[0][0][0]
+
+        completion = json.loads(transformed.attributes["gen_ai.completion"])
+        assert completion == {
+            "role": "tool",
+            "content": "Hippopotamus",
+            "name": "get_magic_word",
+            "tool_call_id": "tooluse_5lnW6BJJLFew8zk9eFpVUt",
+        }
+
+    def test_transform_tool_span_choice_multiple_text_blocks(self):
+        """Test that multi-block tool outputs are joined with newlines."""
+        delegate = MagicMock()
+        delegate.export.return_value = 0
+
+        exporter = LangSmithSpanExporter(delegate=delegate)
+
+        choice_event = self._make_event(
+            "gen_ai.choice",
+            {
+                "message": json.dumps([
+                    {"text": "Line one"},
+                    {"text": "Line two"},
+                ]),
+                "id": "tooluse_abc123",
+            },
+        )
+        span = self._make_span(
+            name="execute_tool my_tool",
+            attributes={
+                "gen_ai.operation.name": "execute_tool",
+                "gen_ai.tool.name": "my_tool",
+                "gen_ai.tool.call.id": "tooluse_abc123",
+            },
+            events=[choice_event],
+        )
+
+        exporter.export([span])
+        transformed = delegate.export.call_args[0][0][0]
+
+        completion = json.loads(transformed.attributes["gen_ai.completion"])
+        assert completion["role"] == "tool"
+        assert completion["content"] == "Line one\nLine two"
+        assert completion["name"] == "my_tool"
+        assert completion["tool_call_id"] == "tooluse_abc123"
+
+    def test_transform_chat_span_choice_still_uses_message_format(self):
+        """Test that chat span choice events still produce
+        message-format completions."""
+        delegate = MagicMock()
+        delegate.export.return_value = 0
+
+        exporter = LangSmithSpanExporter(delegate=delegate)
+
+        choice_event = self._make_event(
+            "gen_ai.choice",
+            {"message": json.dumps([{"text": "Final response"}])},
+        )
+        span = self._make_span(
+            name="chat",
+            attributes={"gen_ai.operation.name": "chat"},
+            events=[choice_event],
+        )
+
+        exporter.export([span])
+        transformed = delegate.export.call_args[0][0][0]
+
+        completion_data = json.loads(transformed.attributes["gen_ai.completion"])
+        assert completion_data["role"] == "assistant"
+        assert "content" in completion_data
+
+    def test_extract_tool_output_single_text_block(self):
+        """Test extraction from a single text block."""
+        result = LangSmithSpanExporter._extract_tool_output([{"text": "Hello world"}])
+        assert result == "Hello world"
+
+    def test_extract_tool_output_string_passthrough(self):
+        """Test that strings pass through unchanged."""
+        result = LangSmithSpanExporter._extract_tool_output("already a string")
+        assert result == "already a string"
+
+    def test_extract_tool_output_non_text_block(self):
+        """Test that non-text blocks are JSON serialized."""
+        content = [{"image": "base64data", "format": "png"}]
+        result = LangSmithSpanExporter._extract_tool_output(content)
+        assert json.loads(result) == {"image": "base64data", "format": "png"}
+
     def test_flatten_tool_result_message(self):
         """Test flattening of Bedrock tool result messages."""
         content_blocks = [

--- a/python/tests/unit_tests/wrappers/test_strands_agents.py
+++ b/python/tests/unit_tests/wrappers/test_strands_agents.py
@@ -267,6 +267,52 @@ class TestLangSmithSpanExporter:
         assert result["status"] == "success"
         assert result["content"] == [{"type": "text", "text": "result"}]
 
+    def test_convert_content_block_reasoning(self):
+        """Test conversion of reasoningContent content blocks."""
+        block = {
+            "reasoningContent": {
+                "reasoningText": {
+                    "text": "Let me break down the problem step by step.",
+                    "signature": "Ev4Q_signature_data",
+                }
+            }
+        }
+        result = LangSmithSpanExporter._convert_content_block(block)
+
+        assert result == {
+            "type": "thinking",
+            "thinking": "Let me break down the problem step by step.",
+            "signature": "Ev4Q_signature_data",
+        }
+
+    def test_convert_content_block_reasoning_missing_signature(self):
+        """Test conversion of reasoningContent blocks without signature."""
+        block = {
+            "reasoningContent": {
+                "reasoningText": {
+                    "text": "Thinking about this...",
+                }
+            }
+        }
+        result = LangSmithSpanExporter._convert_content_block(block)
+
+        assert result == {
+            "type": "thinking",
+            "thinking": "Thinking about this...",
+            "signature": "",
+        }
+
+    def test_convert_content_block_reasoning_empty(self):
+        """Test conversion of reasoningContent blocks with missing reasoningText."""
+        block = {"reasoningContent": {}}
+        result = LangSmithSpanExporter._convert_content_block(block)
+
+        assert result == {
+            "type": "thinking",
+            "thinking": "",
+            "signature": "",
+        }
+
     def test_flatten_tool_result_message(self):
         """Test flattening of Bedrock tool result messages."""
         content_blocks = [


### PR DESCRIPTION
## Summary

  Fixes #3226 improving the Strands Agents OTEL exporter in these 2 cases:

  ### 1. Reasoning/thinking blocks rendered as raw JSON

  Bedrock's `reasoningContent` blocks were not converted, causing thinking content to appear as raw JSON in LangSmith.

  This PR adds a conversion of:
  ```json
  {"reasoningContent": {"reasoningText": {"text": "...", "signature": "..."}}}
  ```
  into:
  ```json
  {"type": "thinking", "thinking": "...", "signature": "..."}
  ```

 ###  2. Tool outputs incorrectly displayed as AI messages

  `execute_tool` spans had their gen_ai.choice event wrapped in {"role": "assistant", ...}, causing LangSmith to classify tool results as AI output. With this PR, the correct tool message format is produced:
  
```json
  {"role": "tool", "content": "...", "name": "tool_name", "tool_call_id": "..."}
```

  Changes

  - `python/langsmith/integrations/strands_agents/exporter.py`: added reasoningContent handling in `_convert_content_block`; added   `_extract_tool_output` and tool-specific `gen_ai.completion` formatting for `execute_tool` spans
  - `python/tests/unit_tests/wrappers/test_strands_agents.py`: new tests for thinking blocks and tool output envelope
  - `python/tests/integration_tests/wrappers/test_strands_agents.py`: new integration test with extended thinking; added tool span output assertions

  Test plan

  - [x] Unit tests pass (make tests)
  - [x] Integration test verified locally with a Bedrock inference profile
  - [ ] CI integration tests