### PR TITLE
feat(py): add explicit workspace validation [closes LSDK-315]

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -278,6 +278,32 @@ os.environ["LANGSMITH_API_KEY"] = "<YOUR-LANGSMITH-API-KEY>"
 
 > **Tip:** Projects are groups of traces. All runs are logged to a project. If not specified, the project is set to `default`.
 
+> [!IMPORTANT]
+> The SDK reads the endpoint and workspace when each client is created. It does not
+> load `.env` files itself, and defaults to the US endpoint when no endpoint is set.
+> Load your `.env` file before creating the client, or pass `api_url` directly.
+> For a fail-loud region and workspace guard, also set `LANGSMITH_WORKSPACE_ID` or
+> pass `workspace_id`; a request to an endpoint that cannot serve that workspace
+> will fail instead of selecting another accessible workspace.
+
+You can verify the resolved endpoint and workspace before reading data:
+
+```python
+from langsmith import Client
+
+expected_workspace_id = "<YOUR-WORKSPACE-ID>"
+client = Client(
+    api_url="https://eu.api.smith.langchain.com",
+    workspace_id=expected_workspace_id,
+)
+workspace = client.get_current_workspace()
+if workspace.id != expected_workspace_id:
+    raise RuntimeError(
+        f"LangSmith workspace mismatch: expected {expected_workspace_id}, "
+        f"connected to {workspace.id} via {client.api_url}"
+    )
+```
+
 2. **Run an Agent, Chain, or Language Model in LangChain**
 
 If the environment variables are correctly set, your application will automatically connect to the LangSmith platform.

--- a/python/langsmith/async_client.py
+++ b/python/langsmith/async_client.py
@@ -1668,18 +1668,18 @@ class AsyncClient:
         )
         ls_utils.raise_for_status_with_text(response)
 
-    async def _get_settings(self) -> ls_schemas.LangSmithSettings:
-        """Get the settings for the current tenant.
-
-        Returns:
-            dict: The settings for the current tenant.
-        """
+    async def get_current_workspace(self) -> ls_schemas.LangSmithSettings:
+        """Get the workspace selected by the client's endpoint and credentials."""
         if self._settings is None:
             response = await self._arequest_with_retries("GET", "/settings")
             ls_utils.raise_for_status_with_text(response)
             self._settings = ls_schemas.LangSmithSettings(**response.json())
 
         return self._settings
+
+    async def _get_settings(self) -> ls_schemas.LangSmithSettings:
+        """Get the settings for the current tenant."""
+        return await self.get_current_workspace()
 
     async def _current_tenant_is_owner(self, owner: str) -> bool:
         """Check if the current workspace has the same handle as owner.

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -1751,18 +1751,18 @@ class Client:
 
         return self._info
 
-    def _get_settings(self) -> ls_schemas.LangSmithSettings:
-        """Get the settings for the current tenant.
-
-        Returns:
-            The settings for the current tenant.
-        """
+    def get_current_workspace(self) -> ls_schemas.LangSmithSettings:
+        """Get the workspace selected by the client's endpoint and credentials."""
         if self._settings is None:
             response = self.request_with_retries("GET", "/settings")
             ls_utils.raise_for_status_with_text(response)
             self._settings = ls_schemas.LangSmithSettings(**response.json())
 
         return self._settings
+
+    def _get_settings(self) -> ls_schemas.LangSmithSettings:
+        """Get the settings for the current tenant."""
+        return self.get_current_workspace()
 
     def _content_above_size(self, content_length: Optional[int]) -> Optional[str]:
         if content_length is None or self._info is None:

--- a/python/tests/unit_tests/test_async_client.py
+++ b/python/tests/unit_tests/test_async_client.py
@@ -31,6 +31,33 @@ def _clear_profile_env(monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv(key, raising=False)
 
 
+@pytest.mark.asyncio
+async def test_get_current_workspace() -> None:
+    client = AsyncClient(
+        api_url="https://eu.api.smith.langchain.com",
+        api_key="test-key",
+        workspace_id="expected-workspace",
+    )
+    response = mock.Mock()
+    response.json.return_value = {
+        "id": "expected-workspace",
+        "display_name": "Expected Workspace",
+        "created_at": "2026-07-11T00:00:00Z",
+    }
+
+    with mock.patch.object(
+        AsyncClient, "_arequest_with_retries", new_callable=AsyncMock
+    ) as request:
+        request.return_value = response
+        workspace = await client.get_current_workspace()
+        cached_workspace = await client.get_current_workspace()
+
+    assert workspace.id == "expected-workspace"
+    assert cached_workspace is workspace
+    request.assert_awaited_once_with("GET", "/settings")
+    await client.aclose()
+
+
 @mock.patch("langsmith.async_client.httpx.AsyncClient")
 def test_async_client_custom_headers(mock_client_cls: mock.Mock) -> None:
     mock_httpx_client = mock.Mock()

--- a/python/tests/unit_tests/test_client.py
+++ b/python/tests/unit_tests/test_client.py
@@ -164,6 +164,31 @@ def test_validate_api_url(monkeypatch: pytest.MonkeyPatch) -> None:
     assert client.api_url == "https://api.smith.langsmith-endpoint.com"
 
 
+def test_get_current_workspace() -> None:
+    client = Client(
+        api_url="https://eu.api.smith.langchain.com",
+        api_key="test-key",
+        workspace_id="expected-workspace",
+        auto_batch_tracing=False,
+    )
+    response = mock.Mock()
+    response.json.return_value = {
+        "id": "expected-workspace",
+        "display_name": "Expected Workspace",
+        "created_at": "2026-07-11T00:00:00Z",
+    }
+
+    with mock.patch.object(
+        Client, "request_with_retries", return_value=response
+    ) as request:
+        workspace = client.get_current_workspace()
+        cached_workspace = client.get_current_workspace()
+
+    assert workspace.id == "expected-workspace"
+    assert cached_workspace is workspace
+    request.assert_called_once_with("GET", "/settings")
+
+
 def test_client_init_does_not_eagerly_initialize_openapi_client(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Description
Expose sync and async workspace identity checks so applications can verify the endpoint resolved to the expected tenant. Document client-construction timing, `.env` loading, and the `workspace_id` fail-loud guard.

## Release Note
Python clients can now call `get_current_workspace()` to validate their resolved LangSmith workspace.

## Test Plan
- [x] Focused sync and async workspace tests; Ruff passes. Full mypy is blocked by pre-existing Python 3.14 typing failures.

Linear: https://linear.app/langchain/issue/LSDK-315/sdk-silently-falls-back-to-default-us-tenant

Made by [Open SWE](https://openswe.vercel.app/agents/862ff660-3abd-f4fa-fe68-a05ef23c31a1)