### PR TITLE
feat(livekit): capture realtime user transcript via instrument_session

### DIFF
--- a/python/langsmith/integrations/livekit/__init__.py
+++ b/python/langsmith/integrations/livekit/__init__.py
@@ -48,6 +48,11 @@ def configure_livekit(
     and applies it to every span in the trace — so it holds even for spans
     finished on a background task, and concurrent conversations stay separated.
 
+    For a realtime (speech-to-speech) model, also call
+    :meth:`LiveKitLangSmithSpanProcessor.instrument_session` on the returned
+    processor: the user transcript arrives as a session event rather than on a
+    span, so without it the trace shows only the agent's turns.
+
     Args:
         audio_path_provider: zero-arg callable returning a local recording path
             whose bytes are embedded in the root span (console/dev only). For

--- a/python/langsmith/integrations/livekit/processor.py
+++ b/python/langsmith/integrations/livekit/processor.py
@@ -53,9 +53,6 @@ _TURN_SPAN = "agent_turn"
 _SESSION_SPAN = "agent_session"
 _TOOL_SPAN = "function_tool"
 _REALTIME_METRICS_SPAN = "realtime_metrics"
-# Realtime (speech-to-speech) user turn. Unlike the cascade STT ``user_turn``, it
-# carries no transcript on the span — the words arrive out of band on the
-# session's ``user_input_transcribed`` event (see :meth:`instrument_session`).
 _USER_SPEAKING_SPAN = "user_speaking"
 
 # ``llm_request`` emits one ``gen_ai.<role>.message`` event per chat item, plus a
@@ -107,9 +104,6 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
             return TTLCache(maxsize=DEFAULT_STATE_MAXSIZE, ttl=state_ttl_seconds)
 
         # trace_id -> running transcript, rolled up onto the root at session end.
-        # Each entry is ``(sort_key, message)``; the root renders them ordered by
-        # ``sort_key`` (the source span's start_time) so a realtime user turn —
-        # fed late, after its reply is already recorded — lands in its place.
         self._transcript_by_trace: MutableMapping[int, list[tuple[Any, dict]]] = (
             _cache()
         )
@@ -123,10 +117,6 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         self._pending_audio_by_thread: MutableMapping[str, dict] = _cache()
         # thread id -> trace_id, so ``complete_recording`` can find the trace.
         self._trace_by_thread: MutableMapping[str, int] = _cache()
-        # Realtime user transcripts paired FIFO with their ``user_speaking`` spans,
-        # keyed by thread id. ``_deferred_user_speaking`` holds ended spans awaiting
-        # a transcript; ``_pending_user_transcripts`` buffers transcripts that
-        # arrived before their span ended.
         self._deferred_user_speaking: MutableMapping[str, list[TranslatedSpan]] = (
             _cache()
         )
@@ -165,8 +155,6 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
 
         @session.on("user_input_transcribed")
         def _on_user_input_transcribed(ev: Any) -> None:
-            # Feed every *final* transcript (including empty ones) so the FIFO
-            # pairing with user_speaking spans stays aligned; skip interim results.
             if getattr(ev, "is_final", False):
                 self._record_user_transcript(
                     str(thread_id), getattr(ev, "transcript", "") or ""
@@ -336,8 +324,6 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         response = tspan.attributes.get("lk.response.text")
         trace_id = tspan.span.context.trace_id
         start = tspan.span.start_time
-        # Cascade turns carry the user input; realtime turns don't (it rides the
-        # user_speaking span, appended by _apply_user_transcript).
         if user_input:
             msg = build_user_message(str(user_input))
             tspan.set_messages(prompt=[msg])
@@ -366,13 +352,12 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         tspan.set_kind("chain")
         thread = tspan.attributes.get("langsmith.metadata.thread_id")
         if thread is None:
-            return True  # no conversation id to pair a transcript against
+            return True
         thread = str(thread)
 
         pending = self._pending_user_transcripts.get(thread)
         if pending:
             transcript = pending.pop(0)
-            # pop(0) mutates in place: refresh the TTL if any remain, else drop it.
             if pending:
                 self._pending_user_transcripts[thread] = pending
             else:
@@ -383,7 +368,7 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
 
         held = self._deferred_user_speaking.get(thread) or []
         held.append(tspan)
-        self._deferred_user_speaking[thread] = held  # re-assign to refresh TTL
+        self._deferred_user_speaking[thread] = held
         return False
 
     def _record_user_transcript(self, thread_id: str, transcript: str) -> None:
@@ -396,7 +381,6 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         held = self._deferred_user_speaking.get(tid)
         if held:
             tspan = held.pop(0)
-            # pop(0) mutates in place: refresh the TTL if any remain, else drop it.
             if held:
                 self._deferred_user_speaking[tid] = held
             else:
@@ -404,10 +388,9 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
             self._apply_user_transcript(tspan, transcript)
             self._export(tspan)
             return
-        # The span hasn't ended yet — buffer until _handle_user_speaking sees it.
         pending = self._pending_user_transcripts.get(tid) or []
         pending.append(transcript)
-        self._pending_user_transcripts[tid] = pending  # re-assign to refresh TTL
+        self._pending_user_transcripts[tid] = pending
 
     def _apply_user_transcript(self, tspan: TranslatedSpan, transcript: str) -> None:
         """Render a fed transcript onto a ``user_speaking`` span as the user's turn.
@@ -421,7 +404,6 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
             tspan.attributes["lk.user_transcript"] = transcript
             msg = build_user_message(transcript)
             tspan.set_messages(prompt=[msg])
-            # Root rollup, keyed by start_time so it sorts before the reply.
             self._append_transcript(
                 tspan.span.context.trace_id, msg, tspan.span.start_time
             )
@@ -489,12 +471,7 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         self._cleanup_trace(trace_id)
 
     def _render_conversation(self, tspan: TranslatedSpan) -> bool:
-        """Set the whole transcript as the root's input messages; return if any.
-
-        Messages are ordered by their source span's start_time (a stable sort, so
-        same-turn ties keep insertion order) — a realtime user turn fed late, out
-        of order, still lands in its correct position.
-        """
+        """Set the whole transcript (ordered by span start_time) as the root's input."""
         entries = self._transcript_by_trace.get(tspan.span.context.trace_id, [])
         if not entries:
             return False
@@ -512,8 +489,6 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
             self._trace_by_thread.pop(thread, None)
             self._threads_awaiting_recording.pop(thread, None)
             self._pending_audio_by_thread.pop(thread, None)
-            # Backstop: normally flushed at session end, but cover a root released
-            # without an agent_session span having flushed first (e.g. egress).
             self._flush_user_speaking(thread)
 
     def shutdown(self) -> None:

--- a/python/langsmith/integrations/livekit/processor.py
+++ b/python/langsmith/integrations/livekit/processor.py
@@ -53,6 +53,10 @@ _TURN_SPAN = "agent_turn"
 _SESSION_SPAN = "agent_session"
 _TOOL_SPAN = "function_tool"
 _REALTIME_METRICS_SPAN = "realtime_metrics"
+# Realtime (speech-to-speech) user turn. Unlike the cascade STT ``user_turn``, it
+# carries no transcript on the span — the words arrive out of band on the
+# session's ``user_input_transcribed`` event (see :meth:`instrument_session`).
+_USER_SPEAKING_SPAN = "user_speaking"
 
 # ``llm_request`` emits one ``gen_ai.<role>.message`` event per chat item, plus a
 # ``gen_ai.choice`` for the reply.
@@ -103,7 +107,12 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
             return TTLCache(maxsize=DEFAULT_STATE_MAXSIZE, ttl=state_ttl_seconds)
 
         # trace_id -> running transcript, rolled up onto the root at session end.
-        self._transcript_by_trace: MutableMapping[int, list[dict]] = _cache()
+        # Each entry is ``(sort_key, message)``; the root renders them ordered by
+        # ``sort_key`` (the source span's start_time) so a realtime user turn —
+        # fed late, after its reply is already recorded — lands in its place.
+        self._transcript_by_trace: MutableMapping[int, list[tuple[Any, dict]]] = (
+            _cache()
+        )
         # trace_id -> root span held open until the session (and any egress) ends.
         self._deferred_root_by_trace: MutableMapping[int, TranslatedSpan] = _cache()
         # trace_ids whose ``agent_session`` end span has arrived (used as a set).
@@ -114,11 +123,54 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         self._pending_audio_by_thread: MutableMapping[str, dict] = _cache()
         # thread id -> trace_id, so ``complete_recording`` can find the trace.
         self._trace_by_thread: MutableMapping[str, int] = _cache()
+        # Realtime user transcripts paired FIFO with their ``user_speaking`` spans,
+        # keyed by thread id. ``_deferred_user_speaking`` holds ended spans awaiting
+        # a transcript; ``_pending_user_transcripts`` buffers transcripts that
+        # arrived before their span ended.
+        self._deferred_user_speaking: MutableMapping[str, list[TranslatedSpan]] = (
+            _cache()
+        )
+        self._pending_user_transcripts: MutableMapping[str, list[str]] = _cache()
 
     def _remember_thread_id(self, trace_id: int, thread_id: str) -> None:
         """Also index thread→trace (so ``complete_recording`` can find the trace)."""
         super()._remember_thread_id(trace_id, thread_id)
         self._trace_by_thread[thread_id] = trace_id
+
+    # -- realtime session instrumentation ------------------------------------
+
+    def instrument_session(self, session: Any, thread_id: str) -> None:
+        """Subscribe this processor to a LiveKit ``AgentSession``'s events.
+
+        A realtime (speech-to-speech) model's user transcript arrives via the
+        ``user_input_transcribed`` session event — never on a span — so the
+        processor can't see it from spans alone, and the trace ends up with only
+        the agent's turns. Call this once after creating the session to wire the
+        transcript in::
+
+            processor = configure_livekit(...)
+            session = AgentSession(llm=...)
+            set_thread_id(conversation_id)
+            processor.instrument_session(session, conversation_id)
+
+        Each final transcript is paired FIFO with the next ``user_speaking`` span
+        that has no transcript yet (we have no id to match a transcript to its
+        exact span). No-op for the cascade pipeline, where the transcript already
+        rides the STT ``user_turn`` span.
+
+        Args:
+            session: the LiveKit ``AgentSession`` to subscribe to.
+            thread_id: the conversation id, matching :func:`set_thread_id`.
+        """
+
+        @session.on("user_input_transcribed")
+        def _on_user_input_transcribed(ev: Any) -> None:
+            # Feed every *final* transcript (including empty ones) so the FIFO
+            # pairing with user_speaking spans stays aligned; skip interim results.
+            if getattr(ev, "is_final", False):
+                self._record_user_transcript(
+                    str(thread_id), getattr(ev, "transcript", "") or ""
+                )
 
     # -- production recording (egress) ---------------------------------------
 
@@ -173,10 +225,13 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
             tspan.set_kind("chain")  # wrappers: no fabricated I/O
         elif name == _TURN_SPAN:
             self._handle_turn(tspan)
+        elif name == _USER_SPEAKING_SPAN:
+            return self._handle_user_speaking(tspan)
         elif name == _SESSION_SPAN:
             # Session end: release the deferred root, then export this span.
             tspan.set_kind("chain")
             self._ended_session_traces[trace_id] = True
+            self._flush_user_speaking(self._thread_id_by_trace.get(trace_id))
             self._maybe_release(trace_id)
         elif name == "eou_detection":
             tspan.set_kind("chain")  # framework step
@@ -280,18 +335,105 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         user_input = tspan.attributes.get("lk.user_input")
         response = tspan.attributes.get("lk.response.text")
         trace_id = tspan.span.context.trace_id
-        conversation = self._transcript_by_trace.get(trace_id) or []
+        start = tspan.span.start_time
+        # Cascade turns carry the user input; realtime turns don't (it rides the
+        # user_speaking span, appended by _apply_user_transcript).
         if user_input:
             msg = build_user_message(str(user_input))
             tspan.set_messages(prompt=[msg])
-            conversation.append(msg)
+            self._append_transcript(trace_id, msg, start)
         if response:
             msg = build_assistant_message(str(response))
             tspan.set_messages(completion=[msg])
-            conversation.append(msg)
+            self._append_transcript(trace_id, msg, start)
+
+    def _append_transcript(self, trace_id: int, message: dict, sort_key: Any) -> None:
+        """Append a message to the transcript the root rolls up, keyed for ordering."""
+        conversation = self._transcript_by_trace.get(trace_id) or []
+        conversation.append((sort_key, message))
         # Re-assign (not just mutate) so each turn refreshes the cache TTL.
-        if conversation:
-            self._transcript_by_trace[trace_id] = conversation
+        self._transcript_by_trace[trace_id] = conversation
+
+    # -- realtime user transcript (speech-to-speech) --------------------------
+
+    def _handle_user_speaking(self, tspan: TranslatedSpan) -> bool:
+        """Handle a ``user_speaking`` span — the realtime user turn.
+
+        Deferred (``False``): stamp+export now if the transcript was already
+        buffered, else hold it until one is fed (or flushed untouched at session
+        end). Exported as-is (``True``) when there's no thread id to pair against.
+        """
+        tspan.set_kind("chain")
+        thread = tspan.attributes.get("langsmith.metadata.thread_id")
+        if thread is None:
+            return True  # no conversation id to pair a transcript against
+        thread = str(thread)
+
+        pending = self._pending_user_transcripts.get(thread)
+        if pending:
+            transcript = pending.pop(0)
+            # pop(0) mutates in place: refresh the TTL if any remain, else drop it.
+            if pending:
+                self._pending_user_transcripts[thread] = pending
+            else:
+                self._pending_user_transcripts.pop(thread, None)
+            self._apply_user_transcript(tspan, transcript)
+            self._export(tspan)
+            return False
+
+        held = self._deferred_user_speaking.get(thread) or []
+        held.append(tspan)
+        self._deferred_user_speaking[thread] = held  # re-assign to refresh TTL
+        return False
+
+    def _record_user_transcript(self, thread_id: str, transcript: str) -> None:
+        """Pair a realtime transcript (from ``instrument_session``) with its span.
+
+        Applies it to the oldest held ``user_speaking`` span for the thread, or
+        buffers it if that span hasn't ended yet.
+        """
+        tid = str(thread_id)
+        held = self._deferred_user_speaking.get(tid)
+        if held:
+            tspan = held.pop(0)
+            # pop(0) mutates in place: refresh the TTL if any remain, else drop it.
+            if held:
+                self._deferred_user_speaking[tid] = held
+            else:
+                self._deferred_user_speaking.pop(tid, None)
+            self._apply_user_transcript(tspan, transcript)
+            self._export(tspan)
+            return
+        # The span hasn't ended yet — buffer until _handle_user_speaking sees it.
+        pending = self._pending_user_transcripts.get(tid) or []
+        pending.append(transcript)
+        self._pending_user_transcripts[tid] = pending  # re-assign to refresh TTL
+
+    def _apply_user_transcript(self, tspan: TranslatedSpan, transcript: str) -> None:
+        """Render a fed transcript onto a ``user_speaking`` span as the user's turn.
+
+        Unlike the cascade STT ``user_turn`` (which is excluded), this is the only
+        record of the realtime user's words, so it's shown — as a plain ``user``
+        message. An empty transcript renders no fabricated I/O.
+        """
+        tspan.set_kind("llm")
+        if transcript:
+            tspan.attributes["lk.user_transcript"] = transcript
+            msg = build_user_message(transcript)
+            tspan.set_messages(prompt=[msg])
+            # Root rollup, keyed by start_time so it sorts before the reply.
+            self._append_transcript(
+                tspan.span.context.trace_id, msg, tspan.span.start_time
+            )
+
+    def _flush_user_speaking(self, thread_id: Optional[str]) -> None:
+        """Export held ``user_speaking`` spans untranscribed (no transcript arrived)."""
+        if thread_id is None:
+            return
+        tid = str(thread_id)
+        for tspan in self._deferred_user_speaking.pop(tid, None) or []:
+            self._export(tspan)
+        self._pending_user_transcripts.pop(tid, None)
 
     def _handle_tool(self, tspan: TranslatedSpan) -> None:
         """``function_tool``: render as a proper ``tool`` run with its I/O."""
@@ -347,10 +489,16 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         self._cleanup_trace(trace_id)
 
     def _render_conversation(self, tspan: TranslatedSpan) -> bool:
-        """Set the whole transcript as the root's input messages; return if any."""
-        messages = self._transcript_by_trace.get(tspan.span.context.trace_id, [])
-        if not messages:
+        """Set the whole transcript as the root's input messages; return if any.
+
+        Messages are ordered by their source span's start_time (a stable sort, so
+        same-turn ties keep insertion order) — a realtime user turn fed late, out
+        of order, still lands in its correct position.
+        """
+        entries = self._transcript_by_trace.get(tspan.span.context.trace_id, [])
+        if not entries:
             return False
+        messages = [msg for _, msg in sorted(entries, key=lambda e: e[0])]
         tspan.set_messages(prompt=messages)
         return True
 
@@ -364,15 +512,20 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
             self._trace_by_thread.pop(thread, None)
             self._threads_awaiting_recording.pop(thread, None)
             self._pending_audio_by_thread.pop(thread, None)
+            # Backstop: normally flushed at session end, but cover a root released
+            # without an agent_session span having flushed first (e.g. egress).
+            self._flush_user_speaking(thread)
 
     def shutdown(self) -> None:
-        """Force-export any still-held roots (last resort), then shut down.
+        """Force-export any still-held roots and user_speaking spans, then shut down.
 
         ``force_flush`` deliberately does not — a still-held root there is
         legitimately in progress, not a buffered export waiting to drain.
         """
         for trace_id in list(self._deferred_root_by_trace):
             self._maybe_release(trace_id, force=True)
+        for thread in list(self._deferred_user_speaking.keys()):
+            self._flush_user_speaking(thread)
         super().shutdown()
 
     def force_flush(self, timeout_millis: int = 30000) -> bool:

--- a/python/tests/unit_tests/wrappers/test_livekit.py
+++ b/python/tests/unit_tests/wrappers/test_livekit.py
@@ -27,6 +27,7 @@ def _make_span(
     span_id=0x1,
     parent=True,
     scope="livekit-agents",
+    start_time=None,
 ):
     """Build a mock LiveKit span.
 
@@ -46,6 +47,9 @@ def _make_span(
     span.context = MagicMock()
     span.context.trace_id = trace_id
     span.context.span_id = span_id
+    # start_time (ns) is the root's conversation-ordering key; default to span_id
+    # so spans sort in a stable, explicit order without every test setting it.
+    span.start_time = span_id if start_time is None else start_time
     span.parent = MagicMock() if parent else None
     span.instrumentation_scope = MagicMock()
     span.instrumentation_scope.name = scope
@@ -130,6 +134,296 @@ class TestDeferredRootRelease:
         # Per-conversation state freed after release.
         assert len(proc._deferred_root_by_trace) == 0
         assert len(proc._transcript_by_trace) == 0
+
+
+class TestRealtimeUserTranscript:
+    """Realtime (speech-to-speech) user transcripts fed via instrument_session.
+
+    In the realtime pipeline there is no STT ``user_turn`` span; LiveKit emits a
+    bare ``user_speaking`` span and delivers the transcript out of band via the
+    ``user_input_transcribed`` event. The host forwards it to the processor, which
+    holds the span until the transcript arrives, then stamps it on.
+    """
+
+    def teardown_method(self):
+        set_thread_id(None)
+
+    def _speaking(self, *, thread="call-1", trace_id=0xABC, span_id=0x2):
+        return _make_span(
+            "user_speaking",
+            {"langsmith.metadata.thread_id": thread},
+            trace_id=trace_id,
+            span_id=span_id,
+        )
+
+    def _exported(self, proc, name):
+        return [
+            c.args[0]
+            for c in proc.downstream.on_end.call_args_list
+            if c.args[0].name == name
+        ]
+
+    def test_transcript_after_span_stamps_and_exports(self):
+        # Span ends empty first (held), then the transcript arrives.
+        proc = _processor()
+        proc.on_end(self._speaking())
+        # Held — nothing exported yet.
+        assert self._exported(proc, "user_speaking") == []
+
+        proc._record_user_transcript("call-1", "what's the weather?")
+
+        exported = self._exported(proc, "user_speaking")
+        assert len(exported) == 1
+        span = exported[0]
+        assert span._attributes["lk.user_transcript"] == "what's the weather?"
+        assert span._attributes["langsmith.span.kind"] == "llm"
+        # Rendered as the user's turn (not excluded, not attributed to assistant).
+        assert "langsmith.metadata.ls_message_view_exclude" not in span._attributes
+        assert json.loads(span._attributes["gen_ai.prompt"])["messages"][0] == {
+            "role": "user",
+            "content": "what's the weather?",
+        }
+        assert "gen_ai.completion" not in span._attributes
+        # No state left behind.
+        assert len(proc._deferred_user_speaking) == 0
+        assert len(proc._pending_user_transcripts) == 0
+
+    def test_transcript_before_span_is_buffered(self):
+        # Transcript can race ahead of the span's on_end — buffer, then apply.
+        proc = _processor()
+        proc._record_user_transcript("call-1", "hello there")
+        assert self._exported(proc, "user_speaking") == []
+
+        proc.on_end(self._speaking())
+
+        exported = self._exported(proc, "user_speaking")
+        assert len(exported) == 1
+        assert exported[0]._attributes["lk.user_transcript"] == "hello there"
+        assert len(proc._pending_user_transcripts) == 0
+
+    def test_fifo_pairing_within_conversation(self):
+        # Two utterances, two transcripts — paired in order.
+        proc = _processor()
+        proc.on_end(self._speaking(span_id=0x2))
+        proc.on_end(self._speaking(span_id=0x3))
+        proc._record_user_transcript("call-1", "first")
+        proc._record_user_transcript("call-1", "second")
+
+        transcripts = [
+            s._attributes["lk.user_transcript"]
+            for s in self._exported(proc, "user_speaking")
+        ]
+        assert transcripts == ["first", "second"]
+
+    def test_no_thread_id_exports_untouched(self):
+        # Without a thread id there is nothing to pair against — export as-is.
+        proc = _processor()
+        proc.on_end(_make_span("user_speaking", trace_id=0xABC, span_id=0x2))
+        exported = self._exported(proc, "user_speaking")
+        assert len(exported) == 1
+        assert exported[0]._attributes["langsmith.span.kind"] == "chain"
+        assert "lk.user_transcript" not in exported[0]._attributes
+
+    def test_empty_transcript_consumes_slot_without_fake_io(self):
+        # A final-but-empty transcript still pairs (keeping FIFO aligned) but
+        # renders no fabricated I/O.
+        proc = _processor()
+        proc.on_end(self._speaking())
+        proc._record_user_transcript("call-1", "")
+
+        exported = self._exported(proc, "user_speaking")
+        assert len(exported) == 1
+        assert "gen_ai.completion" not in exported[0]._attributes
+        assert "lk.user_transcript" not in exported[0]._attributes
+
+    def test_session_end_flushes_untranscribed_span(self):
+        # Realtime input transcription disabled: no transcript ever arrives, so
+        # the held span must still be exported (untouched) at session end.
+        proc = _processor()
+        tid = 0xABC
+        # Production flow: set_thread_id + on_start caches the trace's thread id,
+        # so the session-end flush can resolve which held spans to release.
+        set_thread_id("call-1")
+        proc.on_start(_make_span("job_entrypoint", parent=None, trace_id=tid))
+        set_thread_id(None)
+        proc.on_end(_make_span("job_entrypoint", parent=None, trace_id=tid))
+        proc.on_end(self._speaking(trace_id=tid))
+        assert self._exported(proc, "user_speaking") == []  # held
+
+        proc.on_end(_make_span("agent_session", trace_id=tid, span_id=0x3))
+
+        assert len(self._exported(proc, "user_speaking")) == 1
+        assert len(proc._deferred_user_speaking) == 0
+
+    def test_shutdown_flushes_untranscribed_span(self):
+        proc = _processor()
+        proc.on_end(self._speaking())
+        proc.shutdown()
+        assert len(self._exported(proc, "user_speaking")) == 1
+
+
+class TestRealtimeRootRollup:
+    """A late realtime user transcript sorts into its place in the root rollup.
+
+    The transcript arrives after its turn's ``agent_turn`` reply is already
+    recorded, so ordering keys off each message's source-span start_time — the
+    ``user_speaking`` span (earlier) before the ``agent_turn`` reply (later).
+    """
+
+    def _root(self, proc):
+        return next(
+            c.args[0]
+            for c in proc.downstream.on_end.call_args_list
+            if c.args[0]._attributes.get("langsmith.root_span")
+        )
+
+    def test_user_sorts_before_reply_despite_late_arrival(self):
+        proc = _processor()
+        tid = 0xABC
+        proc.on_end(
+            _make_span(
+                "job_entrypoint",
+                {"langsmith.metadata.thread_id": "call-1"},
+                parent=None,
+                trace_id=tid,
+            )
+        )
+        # User speaks (early span), then the reply turn lands and is recorded...
+        proc.on_end(
+            _make_span(
+                "user_speaking",
+                {"langsmith.metadata.thread_id": "call-1"},
+                trace_id=tid,
+                span_id=0x2,
+                start_time=10,
+            )
+        )
+        proc.on_end(
+            _make_span(
+                "agent_turn",
+                {"lk.response.text": "sunny"},
+                trace_id=tid,
+                span_id=0x3,
+                start_time=20,
+            )
+        )
+        # ...only *then* does the transcript arrive (out of order).
+        proc._record_user_transcript("call-1", "weather?")
+        proc.on_end(_make_span("agent_session", trace_id=tid, span_id=0x4))
+
+        root = self._root(proc)
+        prompt = json.loads(root._attributes["gen_ai.prompt"])["messages"]
+        assert [m["content"] for m in prompt] == ["weather?", "sunny"]
+        assert "gen_ai.completion" not in root._attributes
+
+    def test_greeting_then_user_turn_ordered(self):
+        # Agent greets first (agent_turn, no user_speaking), then a user turn.
+        # The greeting must not steal the user's transcript, and order holds.
+        proc = _processor()
+        tid = 0xABC
+        proc.on_end(
+            _make_span(
+                "job_entrypoint",
+                {"langsmith.metadata.thread_id": "call-1"},
+                parent=None,
+                trace_id=tid,
+            )
+        )
+        proc.on_end(
+            _make_span(
+                "agent_turn",
+                {"lk.response.text": "hi there!"},
+                trace_id=tid,
+                span_id=0x2,
+                start_time=5,
+            )
+        )
+        proc.on_end(
+            _make_span(
+                "user_speaking",
+                {"langsmith.metadata.thread_id": "call-1"},
+                trace_id=tid,
+                span_id=0x3,
+                start_time=10,
+            )
+        )
+        proc.on_end(
+            _make_span(
+                "agent_turn",
+                {"lk.response.text": "sunny"},
+                trace_id=tid,
+                span_id=0x4,
+                start_time=20,
+            )
+        )
+        proc._record_user_transcript("call-1", "weather?")
+        proc.on_end(_make_span("agent_session", trace_id=tid, span_id=0x5))
+
+        root = self._root(proc)
+        contents = [
+            m["content"]
+            for m in json.loads(root._attributes["gen_ai.prompt"])["messages"]
+        ]
+        assert contents == ["hi there!", "weather?", "sunny"]
+
+
+class TestInstrumentSession:
+    """instrument_session subscribes the processor to a session's events itself."""
+
+    class _FakeSession:
+        """Minimal stand-in for a LiveKit AgentSession's event emitter."""
+
+        def __init__(self):
+            self.handlers = {}
+
+        def on(self, name):
+            def _register(fn):
+                self.handlers[name] = fn
+                return fn
+
+            return _register
+
+    @staticmethod
+    def _event(*, is_final, transcript):
+        ev = MagicMock()
+        ev.is_final = is_final
+        ev.transcript = transcript
+        return ev
+
+    def test_final_transcript_wired_to_processor(self):
+        proc = _processor()
+        session = self._FakeSession()
+        proc.instrument_session(session, "call-1")
+
+        proc.on_end(
+            _make_span(
+                "user_speaking",
+                {"langsmith.metadata.thread_id": "call-1"},
+                span_id=0x2,
+            )
+        )
+        session.handlers["user_input_transcribed"](
+            self._event(is_final=True, transcript="hello there")
+        )
+
+        exported = [
+            c.args[0]
+            for c in proc.downstream.on_end.call_args_list
+            if c.args[0].name == "user_speaking"
+        ]
+        assert len(exported) == 1
+        assert exported[0]._attributes["lk.user_transcript"] == "hello there"
+
+    def test_interim_transcript_ignored(self):
+        proc = _processor()
+        session = self._FakeSession()
+        proc.instrument_session(session, "call-1")
+
+        session.handlers["user_input_transcribed"](
+            self._event(is_final=False, transcript="partial")
+        )
+        # Interim result buffered nothing; a later span has no transcript to pair.
+        assert len(proc._pending_user_transcripts) == 0
 
 
 class TestForceFlush:
@@ -259,7 +553,8 @@ class TestStateTTL:
                 "agent_turn", {"lk.response.text": "two"}, trace_id=tid, span_id=0x3
             )
         )
-        assert [m["content"] for m in proc._transcript_by_trace[tid]] == [
+        # The store holds (sort_key, message) tuples.
+        assert [m["content"] for _, m in proc._transcript_by_trace[tid]] == [
             "one",
             "two",
         ]


### PR DESCRIPTION
## Description
Realtime (speech-to-speech) LiveKit models deliver the user transcript on the session's `user_input_transcribed` event rather than on a span, so LangSmith traces showed only the agent's turns. This adds `LiveKitLangSmithSpanProcessor.instrument_session(session, thread_id)`, which subscribes to that event and pairs each final transcript FIFO with the next `user_speaking` span that has no transcript yet (buffering transcripts that race ahead of their span). The root conversation rollup is now ordered by span `start_time` so a late-arriving user turn sorts before its reply. Builds the idea from the stale #3180 on top of current `main`.

## Release Note
LiveKit realtime (speech-to-speech) user transcripts are now captured in traces via `processor.instrument_session(session, thread_id)`.

## Test Plan
- [ ] `TEST=tests/unit_tests/wrappers/test_livekit.py make tests` (added realtime transcript, FIFO pairing, root-rollup ordering, and `instrument_session` cases)

Made by [Open SWE](https://openswe.vercel.app/agents/019f5ebb-64a2-771f-b82e-fb14106f94b7)