### PR TITLE
release(python): bump py version to 0.10.3

### DIFF
--- a/python/.bumpversion.cfg
+++ b/python/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.10.2
+current_version = 0.10.3
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
 serialize = {major}.{minor}.{patch}
 search = {current_version}

--- a/python/langsmith/__init__.py
+++ b/python/langsmith/__init__.py
@@ -45,7 +45,7 @@ if TYPE_CHECKING:
 
 # Avoid calling into importlib on every call to __version__
 
-__version__ = "0.10.2"
+__version__ = "0.10.3"
 version = __version__  # for backwards compatibility
 
 # Metadata key to hide a traced run from LangSmith's Messages View.


### PR DESCRIPTION
## Summary
- Bump Python SDK patch version from \`0.10.2\` → \`0.10.3\`
- Updates \`python/.bumpversion.cfg\` and \`python/langsmith/__init__.py\`

### Changes since 0.10.2
- chore: sync langsmith_api (#3165)
- feat(voice): capture LiveKit realtime model costs (#3191)
- feat(voice): capture Pipecat TTS/realtime model costs (#3192)
- chore(deps): bump nltk from 3.9.4 to 3.10.0 in /python (#3186)
- chore(deps): bump soupsieve from 2.8.3 to 2.8.4 in /python (#3200)

🤖 Generated with [Claude Code](https://claude.com/claude-code)