### PR TITLE
release(js): 0.8.2

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langsmith",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Client library to connect to the LangSmith Observability and Evaluation Platform.",
   "packageManager": "pnpm@10.33.0",
   "files": [

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -50,7 +50,7 @@ export {
 } from "./_openapi_client/core/error.js";
 
 // Update using pnpm bump-version
-export const __version__ = "0.8.1";
+export const __version__ = "0.8.2";
 
 // Metadata key to hide a traced run from LangSmith's Messages View.
 export const LS_MESSAGE_VIEW_EXCLUDE = "ls_message_view_exclude" as const;


### PR DESCRIPTION
## Summary
- Bump JS SDK patch version from \`0.8.1\` → \`0.8.2\`
- Updates \`js/package.json\`

### Changes since 0.8.1
- feat: add SmithDB by-key path to add_runs_to_annotation_queue (runs= param) [LSDK-287] (#3077)
- fix: Auto-Batch Processing Drops Workspace Override Leading to Cross-Tenant Data Leakage (#3174)
- chore(deps): bump esbuild from 0.17.19 to 0.28.1 in /js/internal/environment_tests/test-exports-cf (#3172)
- chore: sync langsmith_api (#3165)

🤖 Generated with [Claude Code](https://claude.com/claude-code)