### PR TITLE
release(python): bump py version to 0.10.4

### DIFF
--- a/python/.bumpversion.cfg
+++ b/python/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.10.3
+current_version = 0.10.4
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
 serialize = {major}.{minor}.{patch}
 search = {current_version}

--- a/python/langsmith/__init__.py
+++ b/python/langsmith/__init__.py
@@ -45,7 +45,7 @@ if TYPE_CHECKING:
 
 # Avoid calling into importlib on every call to __version__
 
-__version__ = "0.10.3"
+__version__ = "0.10.4"
 version = __version__  # for backwards compatibility
 
 # Metadata key to hide a traced run from LangSmith's Messages View.


### PR DESCRIPTION
## Description
Bumps the Python `langsmith` SDK version by the smallest possible increment (patch): `0.10.3` → `0.10.4`. Generated via the documented `uv run bump2version patch` flow, touching only the two version files.

## Release Note
Release langsmith Python SDK 0.10.4.

## Test Plan
- [x] N/A.

Made by [Open SWE](https://openswe.vercel.app/agents/019f625d-88bc-767a-b332-422eaeecbacd)