### PR TITLE
fix(py/anthropic): handle OTel-style sync wrappers around async methods

### DIFF
--- a/python/langsmith/wrappers/_anthropic.py
+++ b/python/langsmith/wrappers/_anthropic.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import functools
+import inspect
 import logging
 import warnings
 from collections.abc import AsyncIterator, Mapping, Sequence
@@ -240,6 +241,28 @@ def _process_chat_completion(outputs: Any):
         return {"output": outputs}
 
 
+def _is_async_or_wraps_async(func: Callable) -> bool:
+    """Check whether *func* or any function in its ``__wrapped__`` chain is async.
+
+    Some instrumentation libraries (e.g. OpenTelemetry via *wrapt*) replace an
+    async method with a synchronous closure that calls the original coroutine
+    function internally and returns the resulting coroutine object.  The sync
+    wrapper hides the async nature from ``inspect.iscoroutinefunction``, but
+    ``wrapt.FunctionWrapper`` (and ``BoundFunctionWrapper``) still expose the
+    original function through the ``__wrapped__`` attribute.  Walking that chain
+    lets ``_get_wrapper`` pick the correct ``acreate`` path even when the outer
+    callable doesn't look async.
+    """
+    seen: set[int] = set()
+    f: Any = func
+    while f is not None and id(f) not in seen:
+        seen.add(id(f))
+        if run_helpers.is_async(f):
+            return True
+        f = getattr(f, "__wrapped__", None)
+    return False
+
+
 def _get_wrapper(
     original_create: Callable,
     name: str,
@@ -279,10 +302,28 @@ def _get_wrapper(
             ),
             **tracing_extra,
         )
-        result = await decorator(original_create)(*args, **kwargs)
+        # When a third-party library (e.g. OpenTelemetry) has already wrapped
+        # original_create with a sync closure that returns a coroutine,
+        # run_helpers.traceable would detect a sync function and record the raw
+        # coroutine object as the trace output instead of the real response.
+        # Normalise to an explicit async function so traceable always takes the
+        # async code path and awaits the result before logging it.
+        if run_helpers.is_async(original_create):
+            traced_fn: Callable = original_create
+        else:
+            @functools.wraps(original_create)
+            async def _async_proxy(*a: Any, **kw: Any) -> Any:
+                result = original_create(*a, **kw)
+                if inspect.iscoroutine(result):
+                    return await result
+                return result
+
+            traced_fn = _async_proxy
+
+        result = await decorator(traced_fn)(*args, **kwargs)
         return result
 
-    return acreate if run_helpers.is_async(original_create) else create
+    return acreate if _is_async_or_wraps_async(original_create) else create
 
 
 def _get_stream_wrapper(

--- a/python/tests/unit_tests/wrappers/test_anthropic_processing.py
+++ b/python/tests/unit_tests/wrappers/test_anthropic_processing.py
@@ -1,10 +1,18 @@
 """Unit tests for Anthropic wrapper processing functions."""
 
+import asyncio
+import functools
+import inspect
 import warnings
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from langsmith._internal._orjson import loads as _loads
-from langsmith.wrappers._anthropic import _create_usage_metadata, _message_to_outputs
+from langsmith.wrappers._anthropic import (
+    _create_usage_metadata,
+    _get_wrapper,
+    _is_async_or_wraps_async,
+    _message_to_outputs,
+)
 
 
 class TestCreateUsageMetadata:
@@ -247,3 +255,107 @@ class TestMessageToOutputsParsedMessage:
 
         assert len(caught) == 1
         assert "some other warning" in str(caught[0].message)
+
+
+class TestOtelInterop:
+    """Tests for correct behaviour when OpenTelemetry instruments before LangSmith.
+
+    OpenTelemetry's ``AnthropicInstrumentor`` uses *wrapt* to patch
+    ``AsyncMessages.create`` at the *class* level with a sync wrapper that
+    internally calls the original coroutine function and returns the resulting
+    coroutine object.  LangSmith then patches at the *instance* level.  The
+    sync wrapper hides the async nature from a naive ``iscoroutinefunction``
+    check, which causes LangSmith to select the sync code path and record the
+    raw coroutine object as the trace output.
+
+    The fix: ``_is_async_or_wraps_async`` walks the ``__wrapped__`` chain, and
+    ``acreate`` creates an async proxy when the detected callable is sync but
+    its wrapped original is async.
+    """
+
+    def test_is_async_or_wraps_async_direct_async(self):
+        async def afunc():
+            return 42
+
+        assert _is_async_or_wraps_async(afunc) is True
+
+    def test_is_async_or_wraps_async_plain_sync(self):
+        def func():
+            return 42
+
+        assert _is_async_or_wraps_async(func) is False
+
+    def test_is_async_or_wraps_async_sync_wrapping_async(self):
+        """Sync wrapper whose __wrapped__ points to an async function is detected."""
+        async def original_async():
+            return 42
+
+        @functools.wraps(original_async)
+        def sync_wrapper(*args, **kwargs):
+            return original_async(*args, **kwargs)
+
+        assert _is_async_or_wraps_async(sync_wrapper) is True
+
+    def test_is_async_or_wraps_async_multi_level_chain(self):
+        """Async function nested two __wrapped__ levels deep is still detected."""
+        async def original_async():
+            return 42
+
+        @functools.wraps(original_async)
+        def inner_wrapper(*args, **kwargs):
+            return original_async(*args, **kwargs)
+
+        @functools.wraps(inner_wrapper)
+        def outer_wrapper(*args, **kwargs):
+            return inner_wrapper(*args, **kwargs)
+
+        assert _is_async_or_wraps_async(outer_wrapper) is True
+
+    def test_get_wrapper_returns_async_for_otel_style_sync_wrapper(self):
+        """_get_wrapper must select acreate when the original has __wrapped__ async."""
+        async def real_create(**kwargs):
+            return {"id": "msg_123"}
+
+        @functools.wraps(real_create)
+        def otel_sync_wrapper(**kwargs):
+            # OTel pattern: sync closure that returns a coroutine object
+            return real_create(**kwargs)
+
+        wrapper = _get_wrapper(
+            otel_sync_wrapper,
+            name="test",
+            reduce_fn=lambda x: x,
+            prepopulated_invocation_params={},
+            tracing_extra={},
+        )
+
+        assert inspect.iscoroutinefunction(wrapper), (
+            "_get_wrapper should return an async wrapper when the original function "
+            "wraps an async method (OTel instrumentation pattern)"
+        )
+
+    def test_acreate_returns_real_result_not_coroutine(self):
+        """acreate must return the awaited result, not a coroutine object."""
+        expected = {"id": "msg_123", "content": "hi"}
+
+        async def real_create(**kwargs):
+            return expected
+
+        @functools.wraps(real_create)
+        def otel_sync_wrapper(**kwargs):
+            return real_create(**kwargs)
+
+        with patch("langsmith.utils.tracing_is_enabled", return_value=False):
+            wrapper = _get_wrapper(
+                otel_sync_wrapper,
+                name="test",
+                reduce_fn=lambda x: x,
+                prepopulated_invocation_params={},
+                tracing_extra={},
+            )
+            result = asyncio.run(wrapper(model="claude-3-5-haiku", max_tokens=10, messages=[]))
+
+        assert not inspect.iscoroutine(result), (
+            "Result must be the awaited message dict, not a coroutine object"
+        )
+        assert result == expected


### PR DESCRIPTION
## Summary

Fixes #2122

When `opentelemetry-instrumentation-anthropic` instruments before LangSmith, it replaces `AsyncMessages.create` at the **class level** using `wrapt.wrap_function_wrapper`. The resulting wrapper is a sync closure (from `_with_chat_telemetry_wrapper`) that internally calls the original `async def _awrap` and returns the resulting coroutine object.

LangSmith then reads that wrapped method via instance attribute access. `run_helpers.is_async` checks `inspect.iscoroutinefunction` on the outer closure — which is **sync** — and falls back to the sync `create` path. The sync path records the raw coroutine object as the traced output instead of the actual response, producing the `<coroutine object _awrap at 0x...>` shown in the LangSmith UI.

**Root cause**: `_get_wrapper` only checked the immediate callable for async-ness. When third-party instrumentation hides the async nature behind a sync closure, the `__wrapped__` chain still points to the original async function.

## Changes

- **`_is_async_or_wraps_async(func)`** — new helper that walks the `__wrapped__` chain so a sync wrapper whose ancestor is async is correctly classified as "effectively async".
- **`_get_wrapper`** — uses `_is_async_or_wraps_async` instead of `run_helpers.is_async` for the `acreate` / `create` dispatch.
- **`acreate`** — when `run_helpers.is_async(original_create)` is False but we reached `acreate` via the chain check, a thin async proxy is created so `run_helpers.traceable` also selects its async code path and awaits the result before recording the trace output.

## Test plan

New `TestOtelInterop` class in `test_anthropic_processing.py`:
- `test_is_async_or_wraps_async_*` — unit-tests the chain-walking helper
- `test_get_wrapper_returns_async_for_otel_style_sync_wrapper` — verifies dispatch selects `acreate`
- `test_acreate_returns_real_result_not_coroutine` — end-to-end: result is the awaited dict, not a coroutine object

```
python -m pytest python/tests/unit_tests/wrappers/test_anthropic_processing.py -v
# 18 passed
```

The fix is backward-compatible: existing sync clients continue to use `create`, existing direct-async clients continue to use `acreate` with no proxy.