### PR TITLE
release(js): 0.8.3

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langsmith",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "Client library to connect to the LangSmith Observability and Evaluation Platform.",
   "packageManager": "pnpm@10.33.0",
   "files": [

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -50,7 +50,7 @@ export {
 } from "./_openapi_client/core/error.js";
 
 // Update using pnpm bump-version
-export const __version__ = "0.8.2";
+export const __version__ = "0.8.3";
 
 // Metadata key to hide a traced run from LangSmith's Messages View.
 export const LS_MESSAGE_VIEW_EXCLUDE = "ls_message_view_exclude" as const;


### PR DESCRIPTION
## Summary
- Bump JS SDK patch version from `0.8.2` → `0.8.3`
- Updates `js/package.json`

### Changes since 0.8.2
- chore: sync langsmith_api (#3205)

🤖 Generated with [Claude Code](https://claude.com/claude-code)