### PR TITLE
feat(pipecat): capture realtime user transcript via instrument_user_aggregator

### DIFF
--- a/python/langsmith/integrations/pipecat/__init__.py
+++ b/python/langsmith/integrations/pipecat/__init__.py
@@ -47,6 +47,11 @@ def configure_pipecat(
     and applies it to every span in the trace — so it holds even for spans
     finished on a background task, and concurrent conversations stay separated.
 
+    For a realtime (speech-to-speech) service, also call
+    :meth:`PipecatLangSmithSpanProcessor.instrument_user_aggregator` on the
+    returned processor: the user transcript arrives on a session event rather
+    than on a span, so without it the trace shows only the agent's turns.
+
     Args:
         llm_span_kind: LangSmith run kind for Pipecat's ``llm`` span; see the
             :mod:`~langsmith.integrations.pipecat.processor` module docstring.

--- a/python/langsmith/integrations/pipecat/processor.py
+++ b/python/langsmith/integrations/pipecat/processor.py
@@ -26,6 +26,9 @@ nested runs exported separately (else the conversation double-counts).
 
 Speech-to-speech (realtime) services emit operation-named spans: ``llm_response``
 (→ ``llm`` run, usage + reply) and the ``llm_setup`` / ``llm_request`` wrappers.
+They carry only the agent's turns — the user transcript arrives on a session
+event instead — so wire it in with
+:meth:`PipecatLangSmithSpanProcessor.instrument_user_aggregator`.
 """
 
 from __future__ import annotations
@@ -144,6 +147,76 @@ class PipecatLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         self._audio_by_conversation: MutableMapping[str, _AudioRecord] = TTLCache(
             maxsize=DEFAULT_STATE_MAXSIZE, ttl=state_ttl_seconds
         )
+        # thread id -> trace_id, so a realtime user transcript (delivered via a
+        # session event, not a span) can find the trace whose rollup it belongs to.
+        self._trace_by_thread: MutableMapping[str, int] = TTLCache(
+            maxsize=DEFAULT_STATE_MAXSIZE, ttl=state_ttl_seconds
+        )
+        # thread id -> user messages that arrived before their trace was known.
+        self._pending_user_transcripts: MutableMapping[str, list[dict[str, Any]]] = (
+            TTLCache(maxsize=DEFAULT_STATE_MAXSIZE, ttl=state_ttl_seconds)
+        )
+
+    def _remember_thread_id(self, trace_id: int, thread_id: str) -> None:
+        """Also index thread→trace, draining any user transcript buffered early."""
+        super()._remember_thread_id(trace_id, thread_id)
+        self._trace_by_thread[thread_id] = trace_id
+        pending = self._pending_user_transcripts.pop(thread_id, None)
+        if pending:
+            conversation = self._transcript_by_trace.get(trace_id) or []
+            conversation[:0] = pending  # earliest turns sort first
+            self._transcript_by_trace[trace_id] = conversation
+
+    # -- realtime user transcript (speech-to-speech) -------------------------
+
+    def instrument_user_aggregator(self, aggregator: Any, thread_id: str) -> None:
+        """Fold a realtime session's user transcript into the trace.
+
+        A realtime (speech-to-speech) service — OpenAI Realtime, Gemini Live —
+        emits no ``stt`` span, so the user's words never reach the processor from
+        spans; only the assistant turns do. Instead the finalized user transcript
+        arrives on the user context aggregator's ``on_user_turn_message_added``
+        event. Call this once after building the aggregator to wire it in::
+
+            processor = configure_pipecat(...)
+            aggregators = LLMContextAggregatorPair(context)
+            set_thread_id(conversation_id)
+            processor.instrument_user_aggregator(aggregators, conversation_id)
+
+        No-op benefit for the cascade pipeline, where the user turn already rides
+        the ``stt`` span — but harmless to call there too.
+
+        Args:
+            aggregator: the ``LLMContextAggregatorPair`` or its user aggregator.
+            thread_id: the conversation id, matching :func:`set_thread_id`.
+        """
+        if callable(getattr(aggregator, "user", None)):
+            aggregator = aggregator.user()
+        tid = str(thread_id)
+
+        @aggregator.event_handler("on_user_turn_message_added")
+        async def _on_user_turn_message_added(_aggregator: Any, message: Any) -> None:
+            content = getattr(message, "content", "") or ""
+            if content:
+                self._record_user_transcript(tid, str(content))
+
+    def _record_user_transcript(self, thread_id: str, text: str) -> None:
+        """Append a realtime user turn to the conversation rollup.
+
+        Rendered onto the root ``conversation`` span alongside the agent turns.
+        Buffered by thread id if the trace isn't known yet (drained once its first
+        span starts); re-assigns the cache entry so each turn refreshes the TTL.
+        """
+        message = build_user_message(text)
+        trace_id = self._trace_by_thread.get(thread_id)
+        if trace_id is None:
+            pending = self._pending_user_transcripts.get(thread_id) or []
+            pending.append(message)
+            self._pending_user_transcripts[thread_id] = pending
+            return
+        conversation = self._transcript_by_trace.get(trace_id) or []
+        conversation.append(message)
+        self._transcript_by_trace[trace_id] = conversation
 
     # -- audio buffer registration -------------------------------------------
 
@@ -359,6 +432,10 @@ class PipecatLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         )
 
     def _cleanup_conversation(self, trace_id: int, conversation_id: str) -> None:
+        thread_id = self._thread_id_by_trace.get(trace_id)
         self._transcript_by_trace.pop(trace_id, None)
         self._audio_by_conversation.pop(conversation_id, None)
+        if thread_id is not None:
+            self._trace_by_thread.pop(thread_id, None)
+            self._pending_user_transcripts.pop(thread_id, None)
         self._forget_thread_id(trace_id)

--- a/python/tests/unit_tests/wrappers/test_pipecat.py
+++ b/python/tests/unit_tests/wrappers/test_pipecat.py
@@ -7,11 +7,13 @@ span rewriting, the shared ``BaseLangSmithSpanProcessor`` helpers, and the
 required (only ``opentelemetry-sdk``, a dev dependency).
 """
 
+import asyncio
 import base64
 import io
 import json
 import sys
 import wave
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -716,3 +718,120 @@ class TestPipecatUsageCapture:
         for name in ("llm_setup", "llm_request"):
             proc.on_end(_make_span(name, {}))
             assert _exported_attrs(proc)["langsmith.span.kind"] == "chain"
+
+
+class _FakeAggregator:
+    """Minimal stand-in for a Pipecat user context aggregator.
+
+    Records the handler registered via ``event_handler`` so tests can fire the
+    event, mirroring Pipecat's ``(aggregator, message)`` call convention.
+    """
+
+    def __init__(self):
+        self._handlers = {}
+
+    def event_handler(self, event_name):
+        def decorator(handler):
+            self._handlers[event_name] = handler
+            return handler
+
+        return decorator
+
+    def emit(self, event_name, content):
+        message = SimpleNamespace(content=content, timestamp="t0")
+        asyncio.run(self._handlers[event_name](self, message))
+
+
+class TestRealtimeUserTranscript:
+    """Realtime user transcript folded in via ``instrument_user_aggregator``."""
+
+    def test_user_turn_folds_into_rollup(self):
+        proc = _processor()
+        trace_id = 0x71
+        proc._remember_thread_id(trace_id, "conv-1")
+        agg = _FakeAggregator()
+        proc.instrument_user_aggregator(agg, "conv-1")
+
+        agg.emit("on_user_turn_message_added", "what's the weather?")
+
+        rollup = proc._transcript_by_trace[trace_id]
+        assert [(m["role"], m["content"]) for m in rollup] == [
+            ("user", "what's the weather?"),
+        ]
+
+    def test_user_turn_precedes_agent_reply_on_root(self):
+        # The realtime user turn (event) and agent reply (`llm_response` span)
+        # both land on the root, user first.
+        proc = _processor()
+        trace_id = 0x72
+        proc._remember_thread_id(trace_id, "conv-2")
+        agg = _FakeAggregator()
+        proc.instrument_user_aggregator(agg, "conv-2")
+
+        agg.emit("on_user_turn_message_added", "hi there")
+        proc.on_end(_make_span("llm_response", {"output": "hello!"}, trace_id=trace_id))
+        proc.on_end(
+            _make_span("conversation", {"conversation.id": "c2"}, trace_id=trace_id)
+        )
+
+        prompt = json.loads(_exported_attrs(proc)["gen_ai.prompt"])
+        assert [(m["role"], m["content"]) for m in prompt["messages"]] == [
+            ("user", "hi there"),
+            ("assistant", "hello!"),
+        ]
+
+    def test_transcript_before_trace_is_buffered_then_drained(self):
+        # A transcript that races ahead of the trace's first span is buffered by
+        # thread id, then drained (earliest-first) once the trace is known.
+        proc = _processor()
+        agg = _FakeAggregator()
+        proc.instrument_user_aggregator(agg, "conv-3")
+
+        agg.emit("on_user_turn_message_added", "early words")
+        assert "conv-3" in proc._pending_user_transcripts
+
+        trace_id = 0x73
+        proc._remember_thread_id(trace_id, "conv-3")
+        assert "conv-3" not in proc._pending_user_transcripts
+        assert proc._transcript_by_trace[trace_id][0]["content"] == "early words"
+
+    def test_accepts_aggregator_pair(self):
+        # A LLMContextAggregatorPair (exposing `.user()`) is unwrapped.
+        proc = _processor()
+        trace_id = 0x74
+        proc._remember_thread_id(trace_id, "conv-4")
+        user_agg = _FakeAggregator()
+        pair = SimpleNamespace(user=lambda: user_agg)
+        proc.instrument_user_aggregator(pair, "conv-4")
+
+        user_agg.emit("on_user_turn_message_added", "via the pair")
+
+        assert proc._transcript_by_trace[trace_id][0]["content"] == "via the pair"
+
+    def test_empty_transcript_ignored(self):
+        proc = _processor()
+        trace_id = 0x75
+        proc._remember_thread_id(trace_id, "conv-5")
+        agg = _FakeAggregator()
+        proc.instrument_user_aggregator(agg, "conv-5")
+
+        agg.emit("on_user_turn_message_added", "")
+
+        assert trace_id not in proc._transcript_by_trace
+        assert "conv-5" not in proc._pending_user_transcripts
+
+    def test_cleanup_frees_thread_state(self):
+        proc = _processor()
+        trace_id = 0x76
+        proc._remember_thread_id(trace_id, "conv-6")
+        agg = _FakeAggregator()
+        proc.instrument_user_aggregator(agg, "conv-6")
+        agg.emit("on_user_turn_message_added", "some words")
+
+        proc.on_end(
+            _make_span("conversation", {"conversation.id": "c6"}, trace_id=trace_id)
+        )
+
+        assert "conv-6" not in proc._trace_by_thread
+        assert "conv-6" not in proc._pending_user_transcripts
+        assert trace_id not in proc._transcript_by_trace


### PR DESCRIPTION
## Description
Pipecat realtime (speech-to-speech) services — OpenAI Realtime, Gemini Live — emit only `llm_setup`/`llm_request`/`llm_response` OTel spans, all carrying the **agent's** turns. There is no `stt` span, so the user's spoken words never reach the processor from a span and LangSmith traces show only agent-generated content.

Mirroring the LiveKit fix (#3201), this adds `PipecatLangSmithSpanProcessor.instrument_user_aggregator(aggregator, thread_id)`. It subscribes to the user context aggregator's `on_user_turn_message_added` event (the finalized user transcript, delivered out-of-band in realtime mode) and folds each user turn into the conversation rollup rendered on the root `conversation` span, alongside the agent turns.

- Accepts either the `LLMContextAggregatorPair` (unwrapped via `.user()`) or the user aggregator directly.
- Transcripts that race ahead of their trace are buffered by thread id and drained (earliest-first) once the trace's first span starts.
- New `_trace_by_thread` / `_pending_user_transcripts` state is size- and TTL-bounded (existing `DEFAULT_STATE_MAXSIZE` / `state_ttl_seconds`) and freed in `_cleanup_conversation`.
- No-op benefit for the cascade pipeline (the user turn already rides the `stt` span), but harmless to call there.

## Release Note
Pipecat realtime (speech-to-speech) user transcripts are now captured in traces via `processor.instrument_user_aggregator(aggregators, conversation_id)`.

## Test Plan
- [x] `TEST=tests/unit_tests/wrappers/test_pipecat.py make tests` (added realtime user-turn rollup, user-before-agent root ordering, buffer-then-drain, aggregator-pair unwrapping, empty-transcript, and cleanup cases)
- [x] `make format` / `make lint` clean
