### PR TITLE
feat: capture Pipecat realtime transcripts

### DIFF
--- a/python/langsmith/integrations/pipecat/__init__.py
+++ b/python/langsmith/integrations/pipecat/__init__.py
@@ -47,6 +47,11 @@ def configure_pipecat(
     and applies it to every span in the trace — so it holds even for spans
     finished on a background task, and concurrent conversations stay separated.
 
+    For a realtime (speech-to-speech) service, also call
+    :meth:`PipecatLangSmithSpanProcessor.instrument_user_aggregator` on the
+    returned processor. Pipecat delivers finalized user text through the user
+    context aggregator rather than an OTel span.
+
     Args:
         llm_span_kind: LangSmith run kind for Pipecat's ``llm`` span; see the
             :mod:`~langsmith.integrations.pipecat.processor` module docstring.

--- a/python/langsmith/integrations/pipecat/_helpers.py
+++ b/python/langsmith/integrations/pipecat/_helpers.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import json
-from typing import Any
+from datetime import datetime
+from typing import Any, Optional
 
 from langsmith._internal.voice._helpers import (
     build_assistant_message,
@@ -61,3 +62,26 @@ def build_completion_message(output_data: Any) -> dict[str, Any]:
         return {"role": "assistant", **parsed}
     content = output_data if isinstance(output_data, str) else str(output_data)
     return build_assistant_message(content)
+
+
+def iso_to_ns(timestamp: str) -> int:
+    """Parse an ISO 8601 timestamp to epoch nanoseconds (0 if unparseable)."""
+    try:
+        return int(datetime.fromisoformat(timestamp).timestamp() * 1e9)
+    except (ValueError, TypeError):
+        return 0
+
+
+def tool_message_key(message: dict[str, Any]) -> Optional[tuple]:
+    """Dedup identity for a tool-round-trip message, or ``None`` otherwise.
+
+    Only assistant tool-call messages and tool-result messages carry one;
+    user turns and plain assistant replies (owned by other sources) return
+    ``None`` so they are ignored here.
+    """
+    tool_calls = message.get("tool_calls")
+    if tool_calls:
+        return ("assistant_tool_call", tuple(str(c.get("id")) for c in tool_calls))
+    if message.get("role") == "tool":
+        return ("tool_result", str(message.get("tool_call_id")))
+    return None

--- a/python/langsmith/integrations/pipecat/processor.py
+++ b/python/langsmith/integrations/pipecat/processor.py
@@ -27,7 +27,9 @@ nested runs exported separately (else the conversation double-counts).
 
 Speech-to-speech (realtime) services emit operation-named spans: ``llm_response``
 (→ ``llm`` run, usage + reply) and the ``llm_setup`` / ``llm_request`` wrappers.
-A realtime tool call arrives as two sibling spans, ``llm_tool_call`` (args) then
+Call :meth:`PipecatLangSmithSpanProcessor.instrument_user_aggregator` to supply
+finalized user transcripts emitted outside those spans. A realtime tool call
+arrives as two sibling spans, ``llm_tool_call`` (args) then
 ``llm_tool_result`` (output); the processor defers the call and merges the result
 onto it, so each call renders as one ``tool`` run spanning call → result.
 """
@@ -55,10 +57,24 @@ from langsmith._internal.voice.base_span_processor import (
 from langsmith.integrations.pipecat._helpers import (
     build_completion_message,
     extract_llm_usage,
+    iso_to_ns,
     parse_llm_messages,
+    tool_message_key,
 )
 
+# Sort key for transcript entries: (epoch nanoseconds, sequence). Ordering the
+# rollup by when each message actually occurred — rather than by the order spans
+# arrive — keeps realtime user turns (whose transcripts land late, after the
+# model has already replied) in their spoken position. ``seq`` breaks ties within
+# one source (e.g. tool call before its result from the same snapshot).
+_SortKey = tuple[int, int]
+
 if TYPE_CHECKING:
+    from pipecat.processors.aggregators.llm_response_universal import (  # type: ignore[import-not-found]
+        LLMContextAggregatorPair,
+        LLMUserAggregator,
+        UserTurnMessageAddedMessage,
+    )
     from pipecat.processors.audio.audio_buffer_processor import (  # type: ignore[import-not-found]
         AudioBufferProcessor,
     )
@@ -139,11 +155,11 @@ class PipecatLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         )
         self._llm_span_kind = llm_span_kind
         self._audio_mime_type = audio_mime_type
-        # trace_id -> latest llm context (the full history == the conversation),
-        # rendered onto the root ``conversation`` span, which ends last.
-        self._transcript_by_trace: MutableMapping[int, list[dict[str, Any]]] = TTLCache(
-            maxsize=DEFAULT_STATE_MAXSIZE, ttl=state_ttl_seconds
-        )
+        # trace_id -> the conversation the root renders, as ``(sort_key, message)``
+        # entries ordered by when each message occurred (see ``_SortKey``).
+        self._transcript_by_trace: MutableMapping[
+            int, list[tuple[_SortKey, dict[str, Any]]]
+        ] = TTLCache(maxsize=DEFAULT_STATE_MAXSIZE, ttl=state_ttl_seconds)
         # conversation id -> merged PCM from an AudioBufferProcessor.
         self._audio_by_conversation: MutableMapping[str, _AudioRecord] = TTLCache(
             maxsize=DEFAULT_STATE_MAXSIZE, ttl=state_ttl_seconds
@@ -153,6 +169,83 @@ class PipecatLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         self._tool_calls_by_trace: MutableMapping[int, list[TranslatedSpan]] = TTLCache(
             maxsize=DEFAULT_STATE_MAXSIZE, ttl=state_ttl_seconds
         )
+        # thread id -> trace_id, so realtime user transcripts delivered outside
+        # spans can find the conversation rollup they belong to.
+        self._trace_by_thread: MutableMapping[str, int] = TTLCache(
+            maxsize=DEFAULT_STATE_MAXSIZE, ttl=state_ttl_seconds
+        )
+        # thread id -> user turns (as ``(sort_key, message)``) that arrived before
+        # their trace was known.
+        self._pending_user_transcripts: MutableMapping[
+            str, list[tuple[_SortKey, dict[str, Any]]]
+        ] = TTLCache(maxsize=DEFAULT_STATE_MAXSIZE, ttl=state_ttl_seconds)
+
+    def _remember_thread_id(self, trace_id: int, thread_id: str) -> None:
+        """Also index thread→trace, draining user turns buffered before the map."""
+        super()._remember_thread_id(trace_id, thread_id)
+        self._trace_by_thread[thread_id] = trace_id
+        pending = self._pending_user_transcripts.pop(thread_id, None)
+        for sort_key, message in pending or []:
+            self._append_transcript(trace_id, message, sort_key)
+
+    # -- realtime user transcript --------------------------------------------
+
+    def instrument_user_aggregator(
+        self, aggregator: LLMContextAggregatorPair, thread_id: str
+    ) -> None:
+        """Fold a realtime session's finalized user transcripts into its trace.
+
+        Pipecat realtime services emit the user's finalized text through the user
+        context aggregator's ``on_user_turn_message_added`` event rather than on
+        an OTel span. Call this once after building the context aggregators::
+
+            processor = configure_pipecat(...)
+            aggregators = LLMContextAggregatorPair(context)
+            set_thread_id(conversation_id)
+            processor.instrument_user_aggregator(aggregators, conversation_id)
+
+        The aggregator is the authoritative source of user turns: a realtime
+        service transcribes the user's audio asynchronously, so the text lands
+        (via this event, carrying the turn-start timestamp) after the model has
+        already replied. The transcript is ordered by that timestamp, not arrival.
+
+        Args:
+            aggregator: the ``LLMContextAggregatorPair`` for the conversation.
+            thread_id: the conversation id, matching :func:`set_thread_id`.
+        """
+        user_aggregator = aggregator.user()
+        tid = str(thread_id)
+
+        @user_aggregator.event_handler("on_user_turn_message_added")
+        async def _on_user_turn_message_added(
+            _aggregator: LLMUserAggregator, message: UserTurnMessageAddedMessage
+        ) -> None:
+            self._record_user_transcript(tid, message.content, message.timestamp)
+
+    def _record_user_transcript(
+        self, thread_id: str, text: str, timestamp: str
+    ) -> None:
+        """Append or buffer a finalized user turn, keyed by when it was spoken."""
+        if not text:
+            return
+        message = build_user_message(text)
+        sort_key = (iso_to_ns(timestamp), 0)
+        trace_id = self._trace_by_thread.get(thread_id)
+        if trace_id is None:
+            pending = self._pending_user_transcripts.get(thread_id) or []
+            pending.append((sort_key, message))
+            self._pending_user_transcripts[thread_id] = pending
+            return
+        self._append_transcript(trace_id, message, sort_key)
+
+    def _append_transcript(
+        self, trace_id: int, message: dict[str, Any], sort_key: _SortKey
+    ) -> None:
+        """Add a message to the transcript the root renders, keyed for ordering."""
+        conversation = self._transcript_by_trace.get(trace_id) or []
+        conversation.append((sort_key, message))
+        # Re-assign (not just mutate) so each turn refreshes the cache TTL.
+        self._transcript_by_trace[trace_id] = conversation
 
     # -- audio buffer registration -------------------------------------------
 
@@ -224,14 +317,14 @@ class PipecatLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
             self._handle_conversation(tspan, trace_id)
         elif name == "llm_response":  # realtime: usage + reply
             self._handle_realtime_response(tspan, trace_id)
+        elif name == "llm_request":  # OpenAI realtime: history snapshot
+            self._handle_llm_request(tspan, trace_id)
+        elif name == "llm_setup":
+            tspan.set_kind("chain")  # realtime wrapper
         elif name == "llm_tool_call":  # realtime: defer, merge with its result
             return self._handle_tool_call(tspan, trace_id)
         elif name == "llm_tool_result":
             return self._handle_tool_result(tspan, trace_id)
-        elif name == "llm_request":  # OpenAI realtime: history snapshot
-            self._handle_llm_request(tspan, trace_id)
-        elif name == "llm_setup":
-            tspan.set_kind("chain")
         return True
 
     # -- per-span-type handlers ----------------------------------------------
@@ -239,15 +332,20 @@ class PipecatLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
     def _handle_stt(self, tspan: TranslatedSpan, trace_id: int) -> None:
         """STT span: audio input → transcribed text."""
         transcript = tspan.attributes.get("transcript", "")
+        is_final = tspan.attributes.get("is_final", True)
         tspan.set_kind("llm")
         tspan.set_messages(prompt=[build_user_message(f'Audio for: "{transcript}"')])
         if transcript:
             tspan.set_messages(completion=[build_assistant_message(str(transcript))])
-            # Fold the user turn into the rollup (realtime has no cascade llm
-            # span to carry it; cascade's llm span replaces it with full history).
-            if tspan.attributes.get("is_final", True):
-                self._transcript_by_trace.setdefault(trace_id, []).append(
-                    build_user_message(str(transcript))
+            # Fold the finalized user turn into the rollup, keyed by when it was
+            # transcribed. Realtime services emit only interim (is_final=False)
+            # stt spans, so their user turns come from the aggregator instead;
+            # this fold is the cascade path (STT→LLM→TTS, no aggregator).
+            if is_final:
+                self._append_transcript(
+                    trace_id,
+                    build_user_message(str(transcript)),
+                    (tspan.span.start_time or 0, 0),
                 )
         tspan.exclude_from_message_view()
 
@@ -271,11 +369,17 @@ class PipecatLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         if usage:
             tspan.set_usage(**usage)
 
+        # Cascade: the ``llm`` input already carries the whole ordered history, so
+        # replace the transcript with this snapshot, keyed so the messages keep
+        # their order and sort after earlier turns.
         transcript = [m for m in messages if m.get("role") != "system"]
         if output_data:
             transcript.append(build_completion_message(output_data))
         if transcript:
-            self._transcript_by_trace[trace_id] = transcript
+            base = tspan.span.start_time or 0
+            self._transcript_by_trace[trace_id] = [
+                ((base, i), message) for i, message in enumerate(transcript)
+            ]
 
     def _handle_tts(self, tspan: TranslatedSpan) -> None:
         """TTS span: text → audio. The voice is metadata, not content."""
@@ -291,32 +395,56 @@ class PipecatLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         tspan.exclude_from_message_view()
 
     def _handle_realtime_response(self, tspan: TranslatedSpan, trace_id: int) -> None:
-        """``llm_response`` span from a realtime (speech-to-speech) service."""
+        """``llm_response`` span: conversation so far → realtime reply."""
         tspan.set_kind(self._llm_span_kind)
+        conversation = self._render_messages(trace_id)
+        if conversation:
+            tspan.set_messages(prompt=conversation)
+
         output_data = tspan.attributes.get("output") or tspan.attributes.get(
             "text_output", ""
         )
         if output_data:
             completion = build_completion_message(output_data)
             tspan.set_messages(completion=[completion])
-            self._transcript_by_trace.setdefault(trace_id, []).append(completion)
+            self._append_transcript(
+                trace_id, completion, (tspan.span.start_time or 0, 0)
+            )
 
         usage = extract_llm_usage(tspan.attributes)
         if usage:
             tspan.set_usage(**usage)
 
     def _handle_llm_request(self, tspan: TranslatedSpan, trace_id: int) -> None:
-        """``llm_request`` span (OpenAI realtime): snapshot the full history.
+        """``llm_request`` span (OpenAI realtime): capture the tool round-trip.
 
-        Realtime emits no cascade ``llm`` span, but OpenAI realtime puts the whole
-        context (tool calls and results included) on this wrapper's ``input``. The
-        reply arrives on ``llm_response`` and is appended there.
+        For OpenAI realtime, tool calls and results have no spans of their own —
+        they exist only in this context snapshot. User turns come from the
+        aggregator and assistant replies from ``llm_response``, so take *only* the
+        tool-call / tool-result messages here, deduped by their id, keyed by this
+        span's time so they sort after the user turn that triggered them.
         """
         tspan.set_kind("chain")
         messages = parse_llm_messages(tspan.attributes.get("input", ""))
-        transcript = [m for m in messages if m.get("role") != "system"]
-        if transcript:
-            self._transcript_by_trace[trace_id] = transcript
+        seen = {
+            key
+            for message in self._render_messages(trace_id)
+            if (key := tool_message_key(message)) is not None
+        }
+        base = tspan.span.start_time or 0
+        added = 0
+        for message in messages:
+            key = tool_message_key(message)
+            if key is None or key in seen:
+                continue
+            seen.add(key)
+            self._append_transcript(trace_id, message, (base, added))
+            added += 1
+
+    def _render_messages(self, trace_id: int) -> list[dict[str, Any]]:
+        """Return the transcript as plain messages, ordered by sort key."""
+        entries = self._transcript_by_trace.get(trace_id, [])
+        return [message for _, message in sorted(entries, key=lambda e: e[0])]
 
     def _handle_tool_call(self, tspan: TranslatedSpan, trace_id: int) -> bool:
         """``llm_tool_call`` span: defer the call (args) until its result arrives."""
@@ -389,7 +517,7 @@ class PipecatLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
             "ls_integration_version", get_package_version("pipecat-ai") or ""
         )
 
-        messages = self._transcript_by_trace.get(trace_id, [])
+        messages = self._render_messages(trace_id)
         if messages:
             tspan.set_messages(prompt=messages)
 
@@ -435,8 +563,12 @@ class PipecatLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         )
 
     def _cleanup_conversation(self, trace_id: int, conversation_id: str) -> None:
+        thread_id = self._thread_id_by_trace.get(trace_id)
         self._transcript_by_trace.pop(trace_id, None)
         self._audio_by_conversation.pop(conversation_id, None)
+        if thread_id is not None:
+            self._trace_by_thread.pop(thread_id, None)
+            self._pending_user_transcripts.pop(thread_id, None)
         self._forget_thread_id(trace_id)
         self._flush_tool_calls(trace_id)
 

--- a/python/tests/unit_tests/wrappers/test_pipecat.py
+++ b/python/tests/unit_tests/wrappers/test_pipecat.py
@@ -7,11 +7,14 @@ span rewriting, the shared ``BaseLangSmithSpanProcessor`` helpers, and the
 required (only ``opentelemetry-sdk``, a dev dependency).
 """
 
+import asyncio
 import base64
 import io
 import json
 import sys
 import wave
+from datetime import datetime
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -30,12 +33,24 @@ from langsmith.integrations.pipecat.processor import (
 )
 
 
-def _make_span(name: str, attributes: dict | None = None, trace_id: int = 0x1):
+def _ns(iso: str) -> int:
+    """Epoch nanoseconds for an ISO 8601 timestamp (the transcript sort scale)."""
+    return int(datetime.fromisoformat(iso).timestamp() * 1e9)
+
+
+def _make_span(
+    name: str,
+    attributes: dict | None = None,
+    trace_id: int = 0x1,
+    start_time: int = 0,
+):
     """Build a mock span for the processor.
 
     The processor copies the span into a ``TranslatedSpan`` draft and builds a
     fresh span for export, leaving this input unchanged. The remaining
     ``ReadableSpan`` fields are auto-mocked, which is all ``finalize`` needs.
+    ``start_time`` (epoch ns) is the transcript sort key for span-sourced
+    messages; pass it (e.g. via :func:`_ns`) when a test asserts ordering.
     """
     span = MagicMock()
     span.name = name
@@ -46,8 +61,10 @@ def _make_span(name: str, attributes: dict | None = None, trace_id: int = 0x1):
     span.events = []
     span.end_time = None
     span._end_time = None
+    span._start_time = start_time
     type(span).name = property(lambda value: value._name)
     type(span).end_time = property(lambda value: value._end_time)
+    type(span).start_time = property(lambda value: value._start_time)
     return span
 
 
@@ -244,12 +261,14 @@ class TestPipecatDispatch:
 
 
 class TestPipecatRealtimeHistory:
-    """OpenAI realtime ``llm_request`` carries the authoritative history snapshot."""
+    """OpenAI realtime ``llm_request`` contributes only the tool round-trip."""
 
-    def test_llm_request_snapshots_history_including_tools(self):
-        # The llm_request span's `input` is the full context — including the
-        # assistant tool call and the tool result — so the conversation root
-        # renders them. The spoken reply arrives on llm_response and is appended.
+    def test_llm_request_contributes_tool_structure_only(self):
+        # OpenAI realtime emits no per-tool spans, so the assistant tool call and
+        # its result are taken from the llm_request context snapshot. The user and
+        # plain-assistant messages in that snapshot are ignored (they come from
+        # the aggregator and llm_response); the spoken reply arrives on
+        # llm_response. Ordering is by span time: request (t=1) then response (t=2).
         proc = _processor()
         trace_id = 0xDEF
         history = [
@@ -272,43 +291,72 @@ class TestPipecatRealtimeHistory:
             {"role": "tool", "tool_call_id": "c1", "content": '{"temp": 68}'},
         ]
         req = _make_span(
-            "llm_request", {"input": json.dumps(history)}, trace_id=trace_id
+            "llm_request",
+            {"input": json.dumps(history)},
+            trace_id=trace_id,
+            start_time=_ns("2026-01-01T00:00:01+00:00"),
         )
         proc.on_end(req)
         # The llm_request span itself stays a chain wrapper (usage is on response).
         assert _exported_attrs(proc)["langsmith.span.kind"] == "chain"
 
-        resp = _make_span("llm_response", {"output": "it's 68"}, trace_id=trace_id)
+        resp = _make_span(
+            "llm_response",
+            {"output": "it's 68"},
+            trace_id=trace_id,
+            start_time=_ns("2026-01-01T00:00:02+00:00"),
+        )
         proc.on_end(resp)
 
         convo = _make_span("conversation", {"conversation.id": "c"}, trace_id=trace_id)
         proc.on_end(convo)
 
         prompt = json.loads(_exported_attrs(proc)["gen_ai.prompt"])["messages"]
-        assert [m["role"] for m in prompt] == ["user", "assistant", "tool", "assistant"]
-        assert prompt[1]["tool_calls"][0]["function"]["name"] == "get_weather"
-        assert prompt[2]["content"] == '{"temp": 68}'  # tool result rendered
-        assert prompt[3]["content"] == "it's 68"  # spoken reply appended
+        # No user turn (that needs the aggregator); tool call + result + reply.
+        assert [m["role"] for m in prompt] == ["assistant", "tool", "assistant"]
+        assert prompt[0]["tool_calls"][0]["function"]["name"] == "get_weather"
+        assert prompt[1]["content"] == '{"temp": 68}'  # tool result rendered
+        assert prompt[2]["content"] == "it's 68"  # spoken reply appended
 
-    def test_llm_request_replaces_accumulated_transcript(self):
-        # A stray STT-fold is overwritten by the authoritative snapshot — no
-        # duplicated user turn.
+    def test_llm_request_dedupes_tool_round_trip_across_snapshots(self):
+        # Each snapshot is the full history, so the same tool call recurs. Dedup by
+        # tool_call_id keeps one assistant-call + one result, not one per snapshot.
         proc = _processor()
         tid = 0x1
-        proc.on_end(
-            _make_span("stt", {"transcript": "hi", "is_final": True}, trace_id=tid)
-        )
-        snapshot = [
-            {"role": "user", "content": "hi"},
-            {"role": "assistant", "content": "hello"},
+        first = [
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "c1",
+                        "type": "function",
+                        "function": {"name": "weather", "arguments": "{}"},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "c1", "content": "sunny"},
         ]
         proc.on_end(
-            _make_span("llm_request", {"input": json.dumps(snapshot)}, trace_id=tid)
+            _make_span(
+                "llm_request",
+                {"input": json.dumps(first)},
+                tid,
+                _ns("2026-01-01T00:00:01+00:00"),
+            )
+        )
+        proc.on_end(
+            _make_span(
+                "llm_request",
+                {"input": json.dumps(first)},
+                tid,
+                _ns("2026-01-01T00:00:02+00:00"),
+            )
         )
         proc.on_end(_make_span("conversation", {"conversation.id": "c"}, trace_id=tid))
 
         prompt = json.loads(_exported_attrs(proc)["gen_ai.prompt"])["messages"]
-        assert [m["content"] for m in prompt] == ["hi", "hello"]
+        assert [m["role"] for m in prompt] == ["assistant", "tool"]
 
     def test_cascade_llm_handling_unchanged(self):
         # Cascade emits `llm`, never `llm_request`; its snapshot+append behavior
@@ -845,6 +893,301 @@ class TestConfigureAndWarning:
             assert configure_pipecat() is None
 
 
+class _FakeUserAggregator:
+    """Minimal Pipecat user aggregator event emitter."""
+
+    def __init__(self):
+        self.handlers = {}
+
+    def event_handler(self, event_name):
+        def decorator(handler):
+            self.handlers[event_name] = handler
+            return handler
+
+        return decorator
+
+    def emit(self, content, timestamp="2026-01-01T00:00:00+00:00"):
+        message = SimpleNamespace(content=content, timestamp=timestamp)
+        asyncio.run(self.handlers["on_user_turn_message_added"](self, message))
+
+
+class _FakeAggregatorPair:
+    """Minimal Pipecat context aggregator pair."""
+
+    def __init__(self):
+        self.user_aggregator = _FakeUserAggregator()
+
+    def user(self):
+        return self.user_aggregator
+
+
+class TestPipecatRealtimeTranscript:
+    """Realtime user events populate response inputs and the root transcript."""
+
+    def test_aggregator_pair_records_user_turn(self):
+        proc = _processor()
+        trace_id = 0x71
+        proc._remember_thread_id(trace_id, "conv-1")
+        aggregators = _FakeAggregatorPair()
+        proc.instrument_user_aggregator(aggregators, "conv-1")
+
+        aggregators.user().emit("what's the weather?")
+
+        assert proc._render_messages(trace_id) == [
+            {"role": "user", "content": "what's the weather?"}
+        ]
+
+    def test_invalid_aggregator_raises(self):
+        proc = _processor()
+        with pytest.raises(AttributeError):
+            proc.instrument_user_aggregator(object(), "conv-2")
+
+    def test_repeated_finalized_events_are_distinct_turns(self):
+        # Identical utterances are kept as separate turns (no dedup).
+        proc = _processor()
+        trace_id = 0x72
+        proc._remember_thread_id(trace_id, "conv-2")
+        aggregators = _FakeAggregatorPair()
+        proc.instrument_user_aggregator(aggregators, "conv-2")
+
+        aggregators.user().emit("yes", "2026-01-01T00:00:01+00:00")
+        aggregators.user().emit("yes", "2026-01-01T00:00:02+00:00")
+
+        assert proc._render_messages(trace_id) == [
+            {"role": "user", "content": "yes"},
+            {"role": "user", "content": "yes"},
+        ]
+
+    def test_transcript_before_trace_is_buffered_and_cleaned_up(self):
+        proc = _processor()
+        aggregators = _FakeAggregatorPair()
+        proc.instrument_user_aggregator(aggregators, "conv-3")
+        aggregators.user().emit("early words")
+        # Pending entries are (sort_key, message) tuples.
+        assert (
+            proc._pending_user_transcripts["conv-3"][0][1]["content"] == "early words"
+        )
+
+        trace_id = 0x73
+        proc._remember_thread_id(trace_id, "conv-3")
+        assert proc._render_messages(trace_id)[0]["content"] == "early words"
+        assert "conv-3" not in proc._pending_user_transcripts
+
+        proc.on_end(_make_span("conversation", {"conversation.id": "conv-3"}, trace_id))
+        assert "conv-3" not in proc._trace_by_thread
+        assert trace_id not in proc._transcript_by_trace
+
+    def test_gemini_response_has_history_and_root_has_both_roles(self):
+        proc = _processor()
+        trace_id = 0x74
+        proc._remember_thread_id(trace_id, "conv-4")
+        aggregators = _FakeAggregatorPair()
+        proc.instrument_user_aggregator(aggregators, "conv-4")
+        aggregators.user().emit("hi there", "2026-01-01T00:00:01+00:00")
+
+        proc.on_end(
+            _make_span(
+                "llm_response",
+                {"output": "hello!"},
+                trace_id,
+                _ns("2026-01-01T00:00:02+00:00"),
+            )
+        )
+        response_attrs = _exported_attrs(proc)
+        assert json.loads(response_attrs["gen_ai.prompt"])["messages"] == [
+            {"role": "user", "content": "hi there"}
+        ]
+
+        proc.on_end(_make_span("conversation", {"conversation.id": "conv-4"}, trace_id))
+        root = json.loads(_exported_attrs(proc)["gen_ai.prompt"])["messages"]
+        assert [(message["role"], message["content"]) for message in root] == [
+            ("user", "hi there"),
+            ("assistant", "hello!"),
+        ]
+
+    def test_user_from_aggregator_tools_from_snapshot_reply_from_response(self):
+        # The three sources compose into one ordered transcript: user (aggregator),
+        # tool call + result (llm_request snapshot), spoken reply (llm_response).
+        proc = _processor()
+        trace_id = 0x75
+        proc._remember_thread_id(trace_id, "conv-5")
+        aggregators = _FakeAggregatorPair()
+        proc.instrument_user_aggregator(aggregators, "conv-5")
+        aggregators.user().emit("weather?", "2026-01-01T00:00:01+00:00")
+        history = [
+            {"role": "system", "content": "be brief"},
+            {"role": "user", "content": "weather?"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "c1",
+                        "type": "function",
+                        "function": {"name": "weather", "arguments": "{}"},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "c1", "content": "sunny"},
+        ]
+        proc.on_end(
+            _make_span(
+                "llm_request",
+                {"input": json.dumps(history)},
+                trace_id,
+                _ns("2026-01-01T00:00:02+00:00"),
+            )
+        )
+        proc.on_end(
+            _make_span(
+                "llm_response",
+                {"output": "It is sunny."},
+                trace_id,
+                _ns("2026-01-01T00:00:03+00:00"),
+            )
+        )
+        proc.on_end(_make_span("conversation", {"conversation.id": "conv-5"}, trace_id))
+
+        prompt = json.loads(_exported_attrs(proc)["gen_ai.prompt"])["messages"]
+        assert [m["role"] for m in prompt] == [
+            "user",
+            "assistant",
+            "tool",
+            "assistant",
+        ]
+        assert prompt[0]["content"] == "weather?"  # once, from the aggregator
+        assert prompt[1]["tool_calls"][0]["function"]["name"] == "weather"
+        assert prompt[3]["content"] == "It is sunny."
+
+    def test_snapshot_without_tools_contributes_nothing(self):
+        # A snapshot with only user / plain-assistant messages adds nothing: those
+        # roles come from the aggregator and llm_response, not llm_request.
+        proc = _processor()
+        trace_id = 0x76
+        proc._remember_thread_id(trace_id, "conv-6")
+        aggregators = _FakeAggregatorPair()
+        proc.instrument_user_aggregator(aggregators, "conv-6")
+        aggregators.user().emit("new question", "2026-01-01T00:00:01+00:00")
+
+        proc.on_end(
+            _make_span(
+                "llm_request",
+                {"input": json.dumps([{"role": "assistant", "content": "hello"}])},
+                trace_id,
+                _ns("2026-01-01T00:00:02+00:00"),
+            )
+        )
+        proc.on_end(
+            _make_span(
+                "llm_response",
+                {"output": "answer"},
+                trace_id,
+                _ns("2026-01-01T00:00:03+00:00"),
+            )
+        )
+
+        # The snapshot's "hello" is absent; only the aggregator user turn and the
+        # llm_response reply make up the transcript.
+        assert [(m["role"], m["content"]) for m in proc._render_messages(trace_id)] == [
+            ("user", "new question"),
+            ("assistant", "answer"),
+        ]
+
+    def test_async_user_turn_sorts_by_speech_time_not_arrival(self):
+        # The regression: OpenAI transcribes late, so the tool round-trip
+        # (llm_request) is processed BEFORE the user transcript arrives — but the
+        # user spoke first. Keying the user turn by its turn-start timestamp puts
+        # it ahead of the tool block, regardless of arrival order.
+        proc = _processor()
+        trace_id = 0x7A
+        proc._remember_thread_id(trace_id, "conv-async")
+        aggregators = _FakeAggregatorPair()
+        proc.instrument_user_aggregator(aggregators, "conv-async")
+
+        history = [
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "c1",
+                        "type": "function",
+                        "function": {"name": "weather", "arguments": "{}"},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "c1", "content": "sunny"},
+        ]
+        # Tool round-trip arrives first (t=3)...
+        proc.on_end(
+            _make_span(
+                "llm_request",
+                {"input": json.dumps(history)},
+                trace_id,
+                _ns("2026-01-01T00:00:03+00:00"),
+            )
+        )
+        # ...then the late user transcript, stamped when the user started (t=1).
+        aggregators.user().emit("weather?", "2026-01-01T00:00:01+00:00")
+        proc.on_end(
+            _make_span(
+                "llm_response",
+                {"output": "It is sunny."},
+                trace_id,
+                _ns("2026-01-01T00:00:04+00:00"),
+            )
+        )
+        proc.on_end(
+            _make_span("conversation", {"conversation.id": "conv-async"}, trace_id)
+        )
+
+        root = json.loads(_exported_attrs(proc)["gen_ai.prompt"])["messages"]
+        assert [m["role"] for m in root] == ["user", "assistant", "tool", "assistant"]
+        assert root[0]["content"] == "weather?"  # ahead of the tool call it triggered
+
+    def test_multi_turn_order_and_empty_transcript(self):
+        proc = _processor()
+        trace_id = 0x77
+        proc._remember_thread_id(trace_id, "conv-7")
+        aggregators = _FakeAggregatorPair()
+        proc.instrument_user_aggregator(aggregators, "conv-7")
+        user = aggregators.user()
+
+        user.emit("")  # empty content is ignored
+        user.emit("first", "2026-01-01T00:00:01+00:00")
+        proc.on_end(
+            _make_span(
+                "llm_response",
+                {"output": "one"},
+                trace_id,
+                _ns("2026-01-01T00:00:02+00:00"),
+            )
+        )
+        user.emit("second", "2026-01-01T00:00:03+00:00")
+        proc.on_end(
+            _make_span(
+                "llm_response",
+                {"output": "two"},
+                trace_id,
+                _ns("2026-01-01T00:00:04+00:00"),
+            )
+        )
+
+        rollup = proc._render_messages(trace_id)
+        assert [(message["role"], message["content"]) for message in rollup] == [
+            ("user", "first"),
+            ("assistant", "one"),
+            ("user", "second"),
+            ("assistant", "two"),
+        ]
+        second_prompt = json.loads(_exported_attrs(proc)["gen_ai.prompt"])["messages"]
+        assert [(message["role"], message["content"]) for message in second_prompt] == [
+            ("user", "first"),
+            ("assistant", "one"),
+            ("user", "second"),
+        ]
+
+
 class TestPipecatUsageCapture:
     """Token/usage capture for cost: LLM usage + detail, realtime spans."""
 
@@ -891,21 +1234,30 @@ class TestPipecatUsageCapture:
         completion = json.loads(attrs["gen_ai.completion"])["messages"]
         assert completion[0]["content"] == "the weather is sunny"
         # Reply folds into the conversation the root renders.
-        assert (
-            proc._transcript_by_trace[trace_id][-1]["content"] == "the weather is sunny"
-        )
+        assert proc._render_messages(trace_id)[-1]["content"] == "the weather is sunny"
 
     def test_realtime_rollup_has_user_and_agent_turns(self):
-        # Realtime has no cascade `llm` span carrying history: the user turn
-        # arrives on a standard `stt` span, the agent reply on `llm_response`.
-        # Both must fold into the conversation rollup the root renders.
+        # Without an instrumented aggregator, a finalized `stt` span folds the user
+        # turn and `llm_response` folds the agent reply; both roll up on the root.
         proc = _processor()
         trace_id = 0x56
-        proc.on_end(_make_span("stt", {"transcript": "what's the weather?"}, trace_id))
         proc.on_end(
-            _make_span("llm_response", {"output": "it's sunny"}, trace_id=trace_id)
+            _make_span(
+                "stt",
+                {"transcript": "what's the weather?"},
+                trace_id,
+                _ns("2026-01-01T00:00:01+00:00"),
+            )
         )
-        rollup = proc._transcript_by_trace[trace_id]
+        proc.on_end(
+            _make_span(
+                "llm_response",
+                {"output": "it's sunny"},
+                trace_id,
+                _ns("2026-01-01T00:00:02+00:00"),
+            )
+        )
+        rollup = proc._render_messages(trace_id)
         assert [(m["role"], m["content"]) for m in rollup] == [
             ("user", "what's the weather?"),
             ("assistant", "it's sunny"),


### PR DESCRIPTION
## Description
Capture finalized Pipecat realtime user turns from context-aggregator events and combine them with agent output for complete OpenAI Realtime and Gemini Live traces. Each `llm_response` now receives conversation-so-far input while OpenAI context snapshots retain structured tool history.

## Release Note
Pipecat OpenAI Realtime and Gemini Live traces now capture complete user and agent transcripts.

## Test Plan
- [x] Verify Gemini and OpenAI realtime response histories, tools, buffering, ordering, and cleanup in focused unit tests.

Made by [Open SWE](https://openswe.vercel.app/agents/019f68c7-f7c7-72a1-b1bd-a51a2cae716c)

## References
- Plan: https://openswe.vercel.app/agents/019f68c7-f7c7-72a1-b1bd-a51a2cae716c/plan





#### PR Dependency Tree


* **PR #3219** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)