### PR TITLE
feat(py,js): Spread OpenAI request metadata into traced metadata

### DIFF
--- a/js/src/tests/wrapped_openai.int.test.ts
+++ b/js/src/tests/wrapped_openai.int.test.ts
@@ -189,6 +189,11 @@ test("prepopulated invocation params are merged and runtime params override", as
     messages: [{ role: "user", content: "Say 'hello'" }],
     model: "gpt-4.1-nano",
     seed: 42, // Should override prepopulated seed=100
+    store: true,
+    metadata: {
+      request_key: "request_value",
+      ls_model_name: "should-not-override",
+    },
   });
 
   await new Promise((resolve) => setTimeout(resolve, 1000));
@@ -215,6 +220,11 @@ test("prepopulated invocation params are merged and runtime params override", as
   // Check that other metadata keys are preserved
   expect(metadata?.custom_key).toBe("custom_value");
   expect(metadata?.version).toBe("1.0.0");
+
+  // OpenAI request metadata is copied to LangSmith run metadata
+  expect(metadata?.request_key).toBe("request_value");
+  expect(metadata?.ls_model_name).toBe("gpt-4.1-nano");
+  expect(lsInvocationParams?.metadata).toBeUndefined();
 
   callSpy.mockClear();
 });
@@ -690,6 +700,9 @@ test("responses.create and retrieve workflow", async () => {
     reasoning: {
       effort: "low",
     },
+    metadata: {
+      request_key: "request_value",
+    },
     input: [
       {
         role: "user",
@@ -722,6 +735,7 @@ test("responses.create and retrieve workflow", async () => {
   for (const call of createCalls) {
     const body = parseRequestBody((call[1] as any).body);
     expect(body.extra.metadata).toMatchObject({
+      request_key: "request_value",
       ls_model_name: "gpt-5-nano",
       ls_model_type: "chat",
       ls_provider: "openai",

--- a/js/src/wrappers/openai.ts
+++ b/js/src/wrappers/openai.ts
@@ -360,7 +360,15 @@ const getChatModelInvocationParamsFn = (
       ls_invocation_params.use_responses_api = true;
     }
 
+    const requestMetadata =
+      typeof params.metadata === "object" &&
+      params.metadata !== null &&
+      !Array.isArray(params.metadata)
+        ? (params.metadata as Record<string, unknown>)
+        : {};
+
     return {
+      ...requestMetadata,
       ls_provider: provider,
       ls_model_type: "chat",
       ls_model_name: params.model,

--- a/python/langsmith/wrappers/_openai.py
+++ b/python/langsmith/wrappers/_openai.py
@@ -133,7 +133,12 @@ def _infer_invocation_params(
     if use_responses_api:
         invocation_params["use_responses_api"] = True
 
+    request_metadata = stripped.get("metadata")
+    if not isinstance(request_metadata, Mapping):
+        request_metadata = {}
+
     return {
+        **request_metadata,
         "ls_provider": provider,
         "ls_model_type": model_type,
         "ls_model_name": stripped.get("model"),

--- a/python/tests/unit_tests/wrappers/test_openai_processing.py
+++ b/python/tests/unit_tests/wrappers/test_openai_processing.py
@@ -1,0 +1,58 @@
+"""Unit tests for OpenAI wrapper processing functions."""
+
+import pytest
+
+from langsmith.wrappers._openai import _infer_invocation_params
+
+
+def test_infer_invocation_params_copies_request_metadata():
+    result = _infer_invocation_params(
+        "chat",
+        "openai",
+        {},
+        False,
+        {
+            "model": "gpt-4o-mini",
+            "metadata": {
+                "customer_id": "customer-123",
+                "environment": "test",
+            },
+        },
+    )
+
+    assert result["customer_id"] == "customer-123"
+    assert result["environment"] == "test"
+    assert "metadata" not in result["ls_invocation_params"]
+
+
+def test_infer_invocation_params_protects_langsmith_metadata():
+    result = _infer_invocation_params(
+        "chat",
+        "openai",
+        {},
+        False,
+        {
+            "model": "gpt-4o-mini",
+            "metadata": {
+                "ls_provider": "other",
+                "ls_model_name": "other-model",
+            },
+        },
+    )
+
+    assert result["ls_provider"] == "openai"
+    assert result["ls_model_name"] == "gpt-4o-mini"
+
+
+@pytest.mark.parametrize("metadata", [None, "invalid", ["invalid"]])
+def test_infer_invocation_params_ignores_non_mapping_metadata(metadata):
+    result = _infer_invocation_params(
+        "chat",
+        "openai",
+        {},
+        False,
+        {"model": "gpt-4o-mini", "metadata": metadata},
+    )
+
+    assert result["ls_provider"] == "openai"
+    assert result["ls_model_name"] == "gpt-4o-mini"


### PR DESCRIPTION
Most useful for setting thread id on chained responses API calls