### PR TITLE
fix(deps): correct uv override-dependencies syntax for json-repair

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -191,8 +191,12 @@ langsmith_plugin = "langsmith.pytest_plugin"
 
 [tool.uv]
 exclude-newer = "P1D"
+# Force `json-repair` past the patched 0.60.1 floor everywhere. `livekit-agents`
+# pins the vulnerable `json-repair==0.59.10`; uv's `override-dependencies` takes a
+# flat list of PEP 508 requirements (not a per-package map), so a global override
+# is the supported way to force the patched version over that pin.
 override-dependencies = [
-    { package = { name = "livekit-agents" }, dependencies = ["json-repair>=0.60.1"] },
+    "json-repair>=0.60.1",
 ]
 
 [tool.hatch.version]

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -15,7 +15,7 @@ exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for 
 exclude-newer-span = "P1D"
 
 [manifest]
-overrides = [{ package = { name = "livekit-agents" }, dependencies = [{ name = "json-repair", specifier = ">=0.60.1" }] }]
+overrides = [{ name = "json-repair", specifier = ">=0.60.1" }]
 
 [[package]]
 name = "aiofiles"


### PR DESCRIPTION
## Summary

Commit `ce093c9b` ("Patch Dependabot alert dependencies #3216") added a scoped `uv` dependency override to force `json-repair` past the vulnerable `0.60.1` floor (`livekit-agents` pins `json-repair==0.59.10`), but used an **invalid per-package map form**:

```toml
override-dependencies = [
    { package = { name = "livekit-agents" }, dependencies = ["json-repair>=0.60.1"] },
]
```

`uv`'s `override-dependencies` expects a **flat list of PEP 508 requirement strings**, not a per-package map. uv 0.9.28 rejects the map form with a TOML parse error:

```
TOML parse error ... invalid type: map, expected a string containing a PEP 508 requirement
```

This broke **every uv operation** on the langsmith package (`uv run` / `uv sync` / `uv lock`). The same invalid map was also written into `uv.lock`'s `[manifest].overrides`, making the lockfile itself unparseable. This cascaded into downstream consumers that depend on the local editable langsmith checkout (e.g. the voice-demo), which could no longer resolve or sync.

Notably, the original commit message claimed validation with `uv lock --check`, but the syntax is unparseable by uv — the lock was never actually regenerated by a uv that reads this form.

## Fix

Replace the invalid map in both `python/pyproject.toml` and `python/uv.lock` (`[manifest].overrides`) with the supported flat form:

```toml
override-dependencies = [
    "json-repair>=0.60.1",
]
```

A global `override-dependencies` entry is the correct way to force a patched version over a transitive pin. Verified empirically that `["json-repair>=0.60.1"]` overrides even a direct `json-repair==0.59.10` pin and resolves to the patched `0.61.x`, preserving the original security goal.

## Validation

- `uv lock --check` passes with **no resolution change** (208 packages, `json-repair` stays at `0.61.4`).
- `uv run python -c "import langsmith"` works → `langsmith 0.10.5`.
- Pipecat integration tests: **68 passed**.

## Notes

- The root-cause commit (`ce093c9b`) is already on `main`, so this fix should also be **cherry-picked to `main`** in a follow-up (or this branch rebased onto `main`) — it is not specific to the pipecat live-transcript work. This PR targets `open-swe/pipecat-live-transcripts` only so the diff is a single commit.
- This is a pre-existing build/resolve breakage, **not** introduced by any of the recent voice-integration changes (which sit on top of the broken base).


#### PR Dependency Tree


* **PR #3221** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)