### PR TITLE
fix(py/openai,gemini): handle OTel-style sync wrappers around async methods

### DIFF
--- a/python/langsmith/wrappers/_gemini.py
+++ b/python/langsmith/wrappers/_gemini.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import base64
 import functools
+import inspect
 import logging
 from collections.abc import Mapping
 from typing import (
@@ -26,6 +27,27 @@ if TYPE_CHECKING:
 
 C = TypeVar("C", bound=Union["genai.Client", Any])
 logger = logging.getLogger(__name__)
+
+
+def _is_async_or_wraps_async(func: Callable) -> bool:
+    """Walk the __wrapped__ chain to detect if func or any ancestor is async.
+
+    Needed for OTel compatibility: opentelemetry-instrumentation-google-genai may
+    replace async SDK methods with a sync closure (via wrapt.wrap_function_wrapper)
+    that internally returns a coroutine. inspect.iscoroutinefunction returns False
+    for the outer closure, so a single-level check misclassifies it as sync. Walking
+    the full __wrapped__ chain catches this pattern.
+    """
+    seen: set[int] = set()
+    current: Optional[Callable] = func
+    while current is not None:
+        if id(current) in seen:
+            break
+        seen.add(id(current))
+        if inspect.iscoroutinefunction(current):
+            return True
+        current = getattr(current, "__wrapped__", None)
+    return False
 
 
 def _strip_none(d: dict) -> dict:
@@ -505,9 +527,16 @@ def _get_wrapper(
             **textra,
         )
 
-        return await decorator(original_generate)(*args, **kwargs)
+        if run_helpers.is_async(original_generate):
+            return await decorator(original_generate)(*args, **kwargs)
+        # OTel-style sync wrapper that returns a coroutine: wrap in a true async
+        # function so traceable selects its async path and awaits the result.
+        async def _async_proxy(*a: Any, **kw: Any) -> Any:
+            return await original_generate(*a, **kw)
 
-    return agenerate if run_helpers.is_async(original_generate) else generate
+        return await decorator(_async_proxy)(*args, **kwargs)
+
+    return agenerate if _is_async_or_wraps_async(original_generate) else generate
 
 
 class TracingExtra(TypedDict, total=False):

--- a/python/langsmith/wrappers/_openai.py
+++ b/python/langsmith/wrappers/_openai.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import functools
+import inspect
 import logging
 from collections import defaultdict
 from collections.abc import Mapping
@@ -36,6 +37,27 @@ if TYPE_CHECKING:
 # Any is used since it may work with Azure or other providers
 C = TypeVar("C", bound=Union["OpenAI", "AsyncOpenAI", Any])
 logger = logging.getLogger(__name__)
+
+
+def _is_async_or_wraps_async(func: Callable) -> bool:
+    """Walk the __wrapped__ chain to detect if func or any ancestor is async.
+
+    Needed for OTel compatibility: opentelemetry-instrumentation-openai replaces
+    async SDK methods with a sync closure (via wrapt.wrap_function_wrapper) that
+    internally returns a coroutine. inspect.iscoroutinefunction returns False for
+    the outer closure, so a single-level check misclassifies it as sync. Walking
+    the full __wrapped__ chain catches this pattern.
+    """
+    seen: set[int] = set()
+    current: Optional[Callable] = func
+    while current is not None:
+        if id(current) in seen:
+            break
+        seen.add(id(current))
+        if inspect.iscoroutinefunction(current):
+            return True
+        current = getattr(current, "__wrapped__", None)
+    return False
 
 
 @functools.lru_cache
@@ -313,9 +335,16 @@ def _get_wrapper(
             process_outputs=process_outputs,
             **textra,
         )
-        return await decorator(original_create)(*args, **kwargs)
+        if run_helpers.is_async(original_create):
+            return await decorator(original_create)(*args, **kwargs)
+        # OTel-style sync wrapper that returns a coroutine: wrap in a true async
+        # function so traceable selects its async path and awaits the result.
+        async def _async_proxy(*a: Any, **kw: Any) -> Any:
+            return await original_create(*a, **kw)
 
-    return acreate if run_helpers.is_async(original_create) else create
+        return await decorator(_async_proxy)(*args, **kwargs)
+
+    return acreate if _is_async_or_wraps_async(original_create) else create
 
 
 def _get_parse_wrapper(
@@ -351,9 +380,14 @@ def _get_parse_wrapper(
             process_outputs=process_outputs,
             **textra,
         )
-        return await decorator(original_parse)(*args, **kwargs)
+        if run_helpers.is_async(original_parse):
+            return await decorator(original_parse)(*args, **kwargs)
+        async def _async_proxy(*a: Any, **kw: Any) -> Any:
+            return await original_parse(*a, **kw)
 
-    return aparse if run_helpers.is_async(original_parse) else parse
+        return await decorator(_async_proxy)(*args, **kwargs)
+
+    return aparse if _is_async_or_wraps_async(original_parse) else parse
 
 
 def _reduce_response_events(events: list[ResponseStreamEvent]) -> dict:

--- a/python/tests/unit_tests/wrappers/test_gemini_processing.py
+++ b/python/tests/unit_tests/wrappers/test_gemini_processing.py
@@ -1,8 +1,13 @@
 """Unit tests for Gemini wrapper processing functions."""
 
+import asyncio
+import functools
+
 from langsmith.wrappers._gemini import (
     _create_usage_metadata,
+    _get_wrapper,
     _infer_invocation_params,
+    _is_async_or_wraps_async,
     _process_gemini_inputs,
     _process_generate_content_response,
     _reduce_generate_content_chunks,
@@ -735,3 +740,109 @@ class TestProcessGeminiInputsWithObjects:
         result = _process_gemini_inputs(inputs)
 
         assert result["messages"][0]["content"] == "from part object"
+
+
+class TestIsAsyncOrWrapsAsync:
+    """Verify _is_async_or_wraps_async walks the __wrapped__ chain correctly."""
+
+    def test_direct_async_function(self):
+        async def fn():
+            pass
+
+        assert _is_async_or_wraps_async(fn) is True
+
+    def test_direct_sync_function(self):
+        def fn():
+            pass
+
+        assert _is_async_or_wraps_async(fn) is False
+
+    def test_sync_wrapper_over_async_via_functools_wraps(self):
+        """functools.wraps sets __wrapped__; chain-walk should detect the async ancestor."""
+
+        async def original():
+            pass
+
+        @functools.wraps(original)
+        def sync_wrapper(*args, **kwargs):
+            return original(*args, **kwargs)
+
+        assert _is_async_or_wraps_async(sync_wrapper) is True
+
+    def test_sync_wrapper_over_sync_function(self):
+        def original():
+            pass
+
+        @functools.wraps(original)
+        def sync_wrapper(*args, **kwargs):
+            return original(*args, **kwargs)
+
+        assert _is_async_or_wraps_async(sync_wrapper) is False
+
+    def test_deep_chain_finds_async_ancestor(self):
+        async def base():
+            pass
+
+        @functools.wraps(base)
+        def mid(*args, **kwargs):
+            return base(*args, **kwargs)
+
+        @functools.wraps(mid)
+        def outer(*args, **kwargs):
+            return mid(*args, **kwargs)
+
+        assert _is_async_or_wraps_async(outer) is True
+
+    def test_cycle_guard(self):
+        """A __wrapped__ cycle should not infinite-loop."""
+
+        def fn():
+            pass
+
+        fn.__wrapped__ = fn  # type: ignore[attr-defined]
+        assert _is_async_or_wraps_async(fn) is False
+
+
+class TestGetWrapperOtelInterop:
+    """Verify _get_wrapper selects the async path when OTel hides async behind a sync closure."""
+
+    def test_returns_async_wrapper_for_otel_style_sync_over_async(self):
+        async def original_async():
+            return {"candidates": []}
+
+        @functools.wraps(original_async)
+        def otel_sync_wrapper(*args, **kwargs):
+            return original_async(*args, **kwargs)
+
+        wrapper = _get_wrapper(otel_sync_wrapper, "ChatGoogleGenerativeAI", {})
+        assert asyncio.iscoroutinefunction(wrapper), (
+            "_get_wrapper must return an async callable when the chain contains an async ancestor"
+        )
+
+    def test_otel_style_wrapper_returns_real_result_not_coroutine(self):
+        """End-to-end: the async wrapper should await the coroutine, not return it raw."""
+
+        async def original_async():
+            return {"candidates": [{"text": "hi"}]}
+
+        @functools.wraps(original_async)
+        def otel_sync_wrapper(*args, **kwargs):
+            return original_async(*args, **kwargs)
+
+        wrapper = _get_wrapper(otel_sync_wrapper, "ChatGoogleGenerativeAI", {})
+
+        import unittest.mock as mock
+
+        with mock.patch("langsmith.utils.tracing_is_enabled", return_value=False):
+            result = asyncio.run(wrapper())
+
+        assert result == {"candidates": [{"text": "hi"}]}, (
+            "async wrapper must return the awaited result, not a coroutine object"
+        )
+
+    def test_returns_sync_wrapper_for_plain_sync_function(self):
+        def original_sync():
+            return {"candidates": []}
+
+        wrapper = _get_wrapper(original_sync, "ChatGoogleGenerativeAI", {})
+        assert not asyncio.iscoroutinefunction(wrapper)

--- a/python/tests/unit_tests/wrappers/test_openai_processing.py
+++ b/python/tests/unit_tests/wrappers/test_openai_processing.py
@@ -1,8 +1,16 @@
 """Unit tests for OpenAI wrapper processing functions."""
 
+import asyncio
+import functools
+
 import pytest
 
-from langsmith.wrappers._openai import _infer_invocation_params
+from langsmith.wrappers._openai import (
+    _get_wrapper,
+    _infer_invocation_params,
+    _is_async_or_wraps_async,
+    _reduce_chat,
+)
 
 
 def test_infer_invocation_params_copies_request_metadata():
@@ -56,3 +64,109 @@ def test_infer_invocation_params_ignores_non_mapping_metadata(metadata):
 
     assert result["ls_provider"] == "openai"
     assert result["ls_model_name"] == "gpt-4o-mini"
+
+
+class TestIsAsyncOrWrapsAsync:
+    """Verify _is_async_or_wraps_async walks the __wrapped__ chain correctly."""
+
+    def test_direct_async_function(self):
+        async def fn():
+            pass
+
+        assert _is_async_or_wraps_async(fn) is True
+
+    def test_direct_sync_function(self):
+        def fn():
+            pass
+
+        assert _is_async_or_wraps_async(fn) is False
+
+    def test_sync_wrapper_over_async_via_functools_wraps(self):
+        """functools.wraps sets __wrapped__; chain-walk should detect the async ancestor."""
+
+        async def original():
+            pass
+
+        @functools.wraps(original)
+        def sync_wrapper(*args, **kwargs):
+            return original(*args, **kwargs)
+
+        assert _is_async_or_wraps_async(sync_wrapper) is True
+
+    def test_sync_wrapper_over_sync_function(self):
+        def original():
+            pass
+
+        @functools.wraps(original)
+        def sync_wrapper(*args, **kwargs):
+            return original(*args, **kwargs)
+
+        assert _is_async_or_wraps_async(sync_wrapper) is False
+
+    def test_deep_chain_finds_async_ancestor(self):
+        async def base():
+            pass
+
+        @functools.wraps(base)
+        def mid(*args, **kwargs):
+            return base(*args, **kwargs)
+
+        @functools.wraps(mid)
+        def outer(*args, **kwargs):
+            return mid(*args, **kwargs)
+
+        assert _is_async_or_wraps_async(outer) is True
+
+    def test_cycle_guard(self):
+        """A __wrapped__ cycle should not infinite-loop."""
+
+        def fn():
+            pass
+
+        fn.__wrapped__ = fn  # type: ignore[attr-defined]
+        assert _is_async_or_wraps_async(fn) is False
+
+
+class TestGetWrapperOtelInterop:
+    """Verify _get_wrapper selects the async path when OTel hides async behind a sync closure."""
+
+    def test_returns_async_wrapper_for_otel_style_sync_over_async(self):
+        async def original_async():
+            return {"output": "hello"}
+
+        @functools.wraps(original_async)
+        def otel_sync_wrapper(*args, **kwargs):
+            return original_async(*args, **kwargs)
+
+        wrapper = _get_wrapper(otel_sync_wrapper, "ChatOpenAI", _reduce_chat)
+        assert asyncio.iscoroutinefunction(wrapper), (
+            "_get_wrapper must return an async callable when the chain contains an async ancestor"
+        )
+
+    def test_otel_style_wrapper_returns_real_result_not_coroutine(self):
+        """End-to-end: the async wrapper should await the coroutine, not return it raw."""
+
+        async def original_async():
+            return {"output": "awaited"}
+
+        @functools.wraps(original_async)
+        def otel_sync_wrapper(*args, **kwargs):
+            return original_async(*args, **kwargs)
+
+        wrapper = _get_wrapper(otel_sync_wrapper, "ChatOpenAI", _reduce_chat)
+
+        import unittest.mock as mock
+
+        with mock.patch("langsmith.utils.tracing_is_enabled", return_value=False):
+            result = asyncio.run(wrapper())
+
+        assert result == {"output": "awaited"}, (
+            "async wrapper must return the awaited result, not a coroutine object"
+        )
+
+    def test_returns_sync_wrapper_for_plain_sync_function(self):
+        def original_sync():
+            return {"output": "sync"}
+
+        wrapper = _get_wrapper(original_sync, "ChatOpenAI", _reduce_chat)
+        assert not asyncio.iscoroutinefunction(wrapper)


### PR DESCRIPTION
## Summary

Extends the OTel interop fix from #3211 (which covered `_anthropic.py`) to the OpenAI and Gemini wrappers. When `opentelemetry-instrumentation-openai` or `opentelemetry-instrumentation-google-genai` instruments **before** LangSmith wraps the client, it replaces async SDK methods at the class level via `wrapt.wrap_function_wrapper` with a sync closure that returns a coroutine internally. `run_helpers.is_async` returns `False` for the outer closure, so `_get_wrapper` picks the sync path and records the raw `<coroutine object>` as the trace output instead of the actual API response.

The root cause and fix are identical to #2122 / #3211 — only the affected wrappers differ.

## Root Cause / Motivation

`_get_wrapper` in `_openai.py` and `_gemini.py` both dispatch on:

```python
return acreate if run_helpers.is_async(original_create) else create
```

`run_helpers.is_async` checks `inspect.iscoroutinefunction` on the immediate callable and one level of `__wrapped__`. OTel's sync closure passes neither check, so the sync `create` path is chosen — it calls `decorator(original_create)(*args, **kwargs)` and returns whatever that produces. Since `original_create` (the OTel wrapper) returns a coroutine when called, the trace records that coroutine object rather than awaiting it.

The Anthropic wrapper hit the same bug (#2122, fixed in #3211). The fix was not yet applied to the OpenAI and Gemini wrappers.

## Design Decisions

- **Local helper per file** (`_is_async_or_wraps_async`) mirrors the structure of the Anthropic fix and keeps each module self-contained. If/when the Anthropic fix lands, a follow-up can consolidate into `run_helpers.py`.
- **Async proxy in `acreate`/`agenerate`** (only used in the OTel case): wraps the sync OTel closure in a true `async def` so `run_helpers.traceable` selects its async code path and awaits the result before recording the trace.
- Existing sync clients and direct-async clients are unaffected: the dispatch and proxy logic is guarded by `run_helpers.is_async(original_create)`.

## Changes

| File | What changed |
|------|-------------|
| `python/langsmith/wrappers/_openai.py` | Add `_is_async_or_wraps_async`; update `_get_wrapper` and `_get_parse_wrapper` to use chain-walk + async proxy |
| `python/langsmith/wrappers/_gemini.py` | Add `_is_async_or_wraps_async`; update `_get_wrapper` to use chain-walk + async proxy |
| `python/tests/unit_tests/wrappers/test_openai_processing.py` | Add `TestIsAsyncOrWrapsAsync` and `TestGetWrapperOtelInterop` (9 new tests) |
| `python/tests/unit_tests/wrappers/test_gemini_processing.py` | Add `TestIsAsyncOrWrapsAsync` and `TestGetWrapperOtelInterop` (9 new tests) |

## Testing

- [x] All existing tests pass
- [x] `TestIsAsyncOrWrapsAsync` — 6 tests: direct async/sync, `functools.wraps` chain, deep multi-level chain, cycle guard
- [x] `TestGetWrapperOtelInterop` — 3 tests each: dispatch selection for OTel-style wrapper, end-to-end awaited result (not coroutine object), sync fallback unchanged

```
python -m pytest python/tests/unit_tests/wrappers/test_openai_processing.py \
                 python/tests/unit_tests/wrappers/test_gemini_processing.py -v
# 64 passed
```

## Impact

Users who use `opentelemetry-instrumentation-openai` or `opentelemetry-instrumentation-google-genai` alongside `wrap_openai` / `wrap_gemini` (OTel instruments first) will now see the actual API response in their LangSmith traces instead of `<coroutine object ...>`.