### PR TITLE
fix: preserve env replica project names

### DIFF
--- a/js/src/run_trees.ts
+++ b/js/src/run_trees.ts
@@ -1171,9 +1171,22 @@ function _getWriteReplicasFromEnv(): WriteReplica[] {
           continue;
         }
 
+        if (
+          item.project_name !== undefined &&
+          item.project_name !== null &&
+          typeof item.project_name !== "string"
+        ) {
+          console.warn(
+            `Invalid project_name type in LANGSMITH_RUNS_ENDPOINTS: ` +
+              `expected string, got ${typeof item.project_name}`,
+          );
+          continue;
+        }
+
         replicas.push({
           apiUrl: item.api_url.replace(/\/$/, ""),
           apiKey: item.api_key,
+          projectName: item.project_name ?? undefined,
         });
       }
       return replicas;

--- a/js/src/tests/replica_endpoints.test.ts
+++ b/js/src/tests/replica_endpoints.test.ts
@@ -333,6 +333,44 @@ describe("LANGSMITH_RUNS_ENDPOINTS Replica Testing", () => {
       expect(callSpy).toHaveBeenCalled();
     });
 
+    it("should preserve project names from array format", async () => {
+      const endpointsConfig = [
+        {
+          api_url: "https://workspace1.example.com",
+          api_key: "workspace1-key",
+          project_name: "project-prod",
+        },
+        {
+          api_url: "https://workspace2.example.com",
+          api_key: "workspace2-key",
+          project_name: "project-staging",
+        },
+      ];
+
+      process.env.LANGSMITH_RUNS_ENDPOINTS = JSON.stringify(endpointsConfig);
+
+      const client = new Client({ autoBatchTracing: false });
+
+      const createRunSpy = jest
+        .spyOn(client, "createRun")
+        .mockResolvedValue(undefined);
+
+      const runTree = new RunTree({
+        name: "test-run",
+        inputs: { input: "test" },
+        client,
+        project_name: "fallback-project",
+      });
+
+      await runTree.postRun();
+
+      const sessionNames = createRunSpy.mock.calls.map(
+        ([runCreate]: any) => runCreate.session_name,
+      );
+
+      expect(sessionNames.sort()).toEqual(["project-prod", "project-staging"]);
+    });
+
     it("should handle object format", async () => {
       const endpointsConfig = {
         "https://workspace1.example.com": "workspace1-key",

--- a/python/langsmith/run_trees.py
+++ b/python/langsmith/run_trees.py
@@ -1187,6 +1187,7 @@ def _parse_write_replicas_from_env_var(env_var: Optional[str]) -> list[WriteRepl
 
                 api_url = item.get("api_url")
                 api_key = item.get("api_key")
+                project_name = item.get("project_name")
 
                 if not isinstance(api_url, str):
                     logger.warning(
@@ -1202,11 +1203,18 @@ def _parse_write_replicas_from_env_var(env_var: Optional[str]) -> list[WriteRepl
                     )
                     continue
 
+                if project_name is not None and not isinstance(project_name, str):
+                    logger.warning(
+                        f"Invalid project_name type in LANGSMITH_RUNS_ENDPOINTS: "
+                        f"expected string, got {type(project_name).__name__}"
+                    )
+                    continue
+
                 replicas.append(
                     WriteReplica(
                         api_url=api_url.rstrip("/"),
                         auth=AuthHeaders(api_key=api_key),
-                        project_name=None,
+                        project_name=project_name,
                         updates=None,
                     )
                 )

--- a/python/tests/unit_tests/test_replica_endpoints.py
+++ b/python/tests/unit_tests/test_replica_endpoints.py
@@ -353,8 +353,16 @@ class TestParseWriteReplicasFromEnvVar:
         """Test parsing new array format."""
         env_var = json.dumps(
             [
-                {"api_url": "https://api.example.com", "api_key": "key1"},
-                {"api_url": "https://api.example.com", "api_key": "key2"},
+                {
+                    "api_url": "https://api.example.com",
+                    "api_key": "key1",
+                    "project_name": "project-prod",
+                },
+                {
+                    "api_url": "https://api.example.com",
+                    "api_key": "key2",
+                    "project_name": "project-staging",
+                },
                 {"api_url": "https://api.example.com", "api_key": "key3"},
             ]
         )
@@ -372,8 +380,11 @@ class TestParseWriteReplicasFromEnvVar:
         assert "key2" in keys
         assert "key3" in keys
 
-        # All should have None for project_name and updates
-        assert all(r["project_name"] is None for r in result)
+        assert [r["project_name"] for r in result] == [
+            "project-prod",
+            "project-staging",
+            None,
+        ]
         assert all(r["updates"] is None for r in result)
 
     def test_parse_object_format(self):
@@ -814,6 +825,38 @@ class TestRunTreeReplicas:
         call_args = client.update_run.call_args
         assert call_args[1]["api_key"] == "replica-key"
         assert call_args[1]["api_url"] == "https://replica.example.com"
+
+    def test_run_tree_preserves_env_replica_project_names(self):
+        client = Mock()
+        env_var = json.dumps(
+            [
+                {
+                    "api_url": "https://replica1.example.com",
+                    "api_key": "replica1-key",
+                    "project_name": "project-prod",
+                },
+                {
+                    "api_url": "https://replica2.example.com",
+                    "api_key": "replica2-key",
+                    "project_name": "project-staging",
+                },
+            ]
+        )
+
+        with patch.dict(os.environ, {"LANGSMITH_RUNS_ENDPOINTS": env_var}, clear=True):
+            _parse_write_replicas_from_env_var.cache_clear()
+            run_tree = RunTree(
+                name="test_run",
+                inputs={"input": "test"},
+                client=client,
+                project_name="fallback-project",
+            )
+            run_tree.post()
+
+        session_names = [
+            call.kwargs["session_name"] for call in client.create_run.call_args_list
+        ]
+        assert session_names == ["project-prod", "project-staging"]
 
 
 class TestBaggageReplicaParsing:


### PR DESCRIPTION
## Description
Preserve documented per-replica project names when parsing `LANGSMITH_RUNS_ENDPOINTS` array entries in both Python and JS. The change only reads local env config and leaves distributed-tracing header credential filtering unchanged.

## Test Plan
- [x] `cd python && TEST='tests/unit_tests/test_replica_endpoints.py' make tests`
- [x] `cd js && NODE_OPTIONS=--experimental-vm-modules pnpm exec jest src/tests/replica_endpoints.test.ts --runInBand --no-colors`

Made by [Open SWE](https://openswe.vercel.app/agents/a93e94fa-fcbf-19a0-dd9f-3295cdf93992)