### PR TITLE
fix(claude-agent-sdk): propagate SDK stream exceptions to the caller

### DIFF
--- a/python/langsmith/integrations/claude_agent_sdk/_client.py
+++ b/python/langsmith/integrations/claude_agent_sdk/_client.py
@@ -2,50 +2,67 @@
 
 import logging
 import time
+import weakref
 from collections.abc import AsyncGenerator, AsyncIterable
 from datetime import datetime, timezone
-from functools import cache
 from typing import Any, Optional
 
+from langsmith._internal import _context
+from langsmith._internal._package_version import get_package_version
 from langsmith.run_helpers import get_current_run_tree, trace
 
+from ._config import get_tracing_config
 from ._hooks import (
+    SessionState,
+    _current_session,
+    _register_session,
+    _set_session_root,
+    _unregister_session,
     clear_active_tool_runs,
+    get_subagent_run_by_tool_id,
     post_tool_use_failure_hook,
     post_tool_use_hook,
     pre_tool_use_hook,
+    subagent_start_hook,
+    subagent_stop_hook,
 )
 from ._messages import (
     build_llm_input,
-    extract_usage_from_result_message,
     flatten_content_blocks,
+    unwrap_message_dicts,
 )
-from ._tools import clear_parent_run_tree, get_parent_run_tree, set_parent_run_tree
+from ._tools import (
+    clear_parent_run_tree,
+    get_parent_run_tree,
+    set_parent_run_tree,
+)
+from ._transcripts import LLM_RUN_NAME, reconcile_from_transcripts
+from ._usage import extract_usage_metadata
 
 logger = logging.getLogger(__name__)
 
 TRACE_CHAIN_NAME = "claude.conversation"
 
 
-@cache
-def _get_package_version(package_name: str) -> str | None:
-    try:
-        from importlib.metadata import version
-
-        return version(package_name)
-    except Exception:
-        return None
-
-
-LLM_RUN_NAME = "claude.assistant.turn"
-
-
 class TurnLifecycle:
-    """Track ongoing model runs so consecutive messages are recorded correctly."""
+    """Track ongoing model runs so consecutive messages are recorded correctly.
+
+    The Claude Agent SDK may deliver a single assistant turn as multiple
+    ``AssistantMessage`` events (e.g. one with ``ThinkingBlock``, another
+    with ``TextBlock``/``ToolUseBlock``).  Messages that share the same
+    ``message_id`` are accumulated into a single LLM run.
+    """
 
     def __init__(self, query_start_time: Optional[float] = None):
         self.current_run: Optional[Any] = None
+        self.current_message_id: Optional[str] = None
         self.next_start_time: Optional[float] = query_start_time
+        # message_id → RunTree for all LLM runs created this conversation.
+        # Used to retroactively set usage from transcripts.
+        self.llm_runs_by_message_id: dict[str, Any] = {}
+        # Runs that have been end()ed but not yet patch()ed.
+        # Deferred so transcript usage can be set before the single patch().
+        self._pending_patch: list[Any] = []
 
     def start_llm_run(
         self,
@@ -54,39 +71,91 @@ class TurnLifecycle:
         history: list[dict[str, Any]],
         parent: Optional[Any] = None,
     ) -> Optional[dict[str, Any]]:
-        """Begin a new model run, ending any existing one."""
+        """Begin or continue a model run for *message*.
+
+        If *message* has the same ``message_id`` as the current run the
+        output is appended; otherwise a new run is started (ending any
+        previous one first).
+        """
+        message_id = getattr(message, "message_id", None)
         start = self.next_start_time or time.time()
 
+        # Same turn – just accumulate the output blocks and update usage.
+        # Return None so the caller does NOT append a duplicate history
+        # entry; the original entry in ``history`` is updated in place.
+        if message_id and message_id == self.current_message_id and self.current_run:
+            content = flatten_content_blocks(getattr(message, "content", None))
+            if content and self.current_run.outputs:
+                prev = self.current_run.outputs.get("content", [])
+                if isinstance(prev, list) and isinstance(content, list):
+                    merged = prev + content
+                    self.current_run.outputs["content"] = merged
+                    # Update the existing history entry in place so
+                    # subsequent LLM runs see a single merged message.
+                    for entry in reversed(history):
+                        if entry.get("role") == "assistant":
+                            entry["content"] = merged
+                            break
+                elif isinstance(content, list):
+                    self.current_run.outputs["content"] = content
+            self._set_usage_from_message(message, self.current_run)
+            return None
+
+        # Different turn – end previous but defer patch() until
+        # transcript usage is available.
         if self.current_run:
             self.current_run.end()
-            self.current_run.patch()
+            self._pending_patch.append(self.current_run)
 
         final_output, run = begin_llm_run_from_assistant_messages(
             [message], prompt, history, start_time=start, parent=parent
         )
         self.current_run = run
+        self.current_message_id = message_id
         self.next_start_time = None
+
+        if run:
+            if message_id:
+                self.llm_runs_by_message_id[message_id] = run
+            self._set_usage_from_message(message, run)
+
         return final_output
+
+    @staticmethod
+    def _set_usage_from_message(message: Any, run: Any) -> None:
+        """Set usage metadata on a run from a live AssistantMessage.
+
+        Always overwrites — later chunks in the same turn have more
+        accurate counts.  Transcript-based usage will overwrite again
+        if available.
+        """
+        raw_usage = getattr(message, "usage", None)
+        if not raw_usage:
+            return
+        usage_meta = extract_usage_metadata(raw_usage)
+        if usage_meta:
+            meta = run.extra.setdefault("metadata", {})
+            meta["usage_metadata"] = usage_meta
 
     def mark_next_start(self) -> None:
         """Mark when the next assistant message will start."""
         self.next_start_time = time.time()
 
-    def add_usage(self, metrics: dict[str, Any]) -> None:
-        """Attach token usage details to the current run."""
-        if not (self.current_run and metrics):
-            return
-        meta = self.current_run.extra.setdefault("metadata", {}).setdefault(
-            "usage_metadata", {}
-        )
-        meta.update(metrics)
-
     def close(self) -> None:
-        """End any open run gracefully."""
+        """End any open run and add to pending patch list."""
         if self.current_run:
             self.current_run.end()
-            self.current_run.patch()
+            self._pending_patch.append(self.current_run)
             self.current_run = None
+
+    def flush(self) -> None:
+        """Patch all deferred LLM runs. Call after usage has been set."""
+        for run in self._pending_patch:
+            try:
+                run.patch()
+            except Exception as e:
+                logger.warning(f"Failed to patch LLM run: {e}")
+        self._pending_patch.clear()
 
 
 def begin_llm_run_from_assistant_messages(
@@ -114,11 +183,15 @@ def begin_llm_run_from_assistant_messages(
         if hasattr(m, "content")
     ]
 
+    llm_metadata: dict[str, Any] = {"ls_provider": "anthropic"}
+    if model:
+        llm_metadata["ls_model_name"] = model
+
     llm_run = parent.create_child(
         name=LLM_RUN_NAME,
         run_type="llm",
         inputs={"messages": inputs} if inputs else {},
-        extra={"metadata": {"ls_model_name": model}} if model else {},
+        extra={"metadata": llm_metadata},
         start_time=datetime.fromtimestamp(start_time, tz=timezone.utc)
         if start_time
         else None,
@@ -140,8 +213,29 @@ def begin_llm_run_from_assistant_messages(
     return final_content, llm_run
 
 
-def _inject_tracing_hooks(options: Any) -> None:
-    """Inject LangSmith tracing hooks into ClaudeAgentOptions."""
+def _bind_hook_to_session(hook: Any, session: Optional[SessionState]) -> Any:
+    """Return a hook callable that runs with *session* bound, if provided."""
+    if session is None:
+        return hook
+
+    async def _bound(input_data: Any, tool_use_id: Any, context: Any) -> Any:
+        token = _current_session.set(session)
+        try:
+            return await hook(input_data, tool_use_id, context)
+        finally:
+            _current_session.reset(token)
+
+    return _bound
+
+
+def _inject_tracing_hooks(options: Any, session: Optional[SessionState] = None) -> None:
+    """Inject LangSmith tracing hooks into ClaudeAgentOptions.
+
+    If *session* is provided, injected hook callables bind that session around
+    each hook invocation. This is important because the Claude SDK may execute
+    hooks in async contexts that do not inherit the ``receive_response``
+    ContextVar; binding at hook injection time keeps each client isolated.
+    """
     if not hasattr(options, "hooks"):
         return
 
@@ -149,22 +243,41 @@ def _inject_tracing_hooks(options: Any) -> None:
     if options.hooks is None:
         options.hooks = {}
 
-    for event in ("PreToolUse", "PostToolUse", "PostToolUseFailure"):
+    for event in (
+        "PreToolUse",
+        "PostToolUse",
+        "PostToolUseFailure",
+        "SubagentStart",
+        "SubagentStop",
+    ):
         if event not in options.hooks:
             options.hooks[event] = []
 
     try:
         from claude_agent_sdk import HookMatcher  # type: ignore[import-not-found]
 
-        langsmith_pre_matcher = HookMatcher(matcher=None, hooks=[pre_tool_use_hook])
-        langsmith_post_matcher = HookMatcher(matcher=None, hooks=[post_tool_use_hook])
+        langsmith_pre_matcher = HookMatcher(
+            matcher=None, hooks=[_bind_hook_to_session(pre_tool_use_hook, session)]
+        )
+        langsmith_post_matcher = HookMatcher(
+            matcher=None, hooks=[_bind_hook_to_session(post_tool_use_hook, session)]
+        )
         langsmith_failure_matcher = HookMatcher(
-            matcher=None, hooks=[post_tool_use_failure_hook]
+            matcher=None,
+            hooks=[_bind_hook_to_session(post_tool_use_failure_hook, session)],
+        )
+        langsmith_subagent_start_matcher = HookMatcher(
+            matcher=None, hooks=[_bind_hook_to_session(subagent_start_hook, session)]
+        )
+        langsmith_subagent_stop_matcher = HookMatcher(
+            matcher=None, hooks=[_bind_hook_to_session(subagent_stop_hook, session)]
         )
 
         options.hooks["PreToolUse"].insert(0, langsmith_pre_matcher)
         options.hooks["PostToolUse"].insert(0, langsmith_post_matcher)
         options.hooks["PostToolUseFailure"].insert(0, langsmith_failure_matcher)
+        options.hooks["SubagentStart"].insert(0, langsmith_subagent_start_matcher)
+        options.hooks["SubagentStop"].insert(0, langsmith_subagent_stop_matcher)
 
         logger.debug("Injected LangSmith tracing hooks into ClaudeAgentOptions")
     except ImportError:
@@ -173,325 +286,417 @@ def _inject_tracing_hooks(options: Any) -> None:
         logger.warning(f"Failed to inject tracing hooks: {e}")
 
 
-def _unwrap_streamed_messages(
-    messages: list[dict[str, Any]],
-) -> list[dict[str, Any]]:
-    """Unwrap streaming input messages for trace display."""
-    if not messages:
-        return []
+def _wrap_tool_handler(
+    original_handler: Any,
+    session: Optional[SessionState] = None,
+    tool_name: Optional[str] = None,
+) -> Any:
+    """Wrap an MCP tool handler to propagate LangSmith run context.
 
-    formatted = []
-    for msg in messages:
-        if not isinstance(msg, dict):
-            formatted.append(msg)
-            continue
+    The Claude SDK runs hooks and tool handlers in different async task
+    contexts, so contextvars set in ``PreToolUse`` are invisible to the
+    handler. This wrapper copies the active tool run into the contextvar before
+    calling the original handler, so ``@traceable`` calls inside the handler
+    nest correctly.
+    """
 
-        if "message" in msg:
-            inner = msg["message"]
-            if isinstance(inner, dict):
-                formatted.append(
-                    {
-                        "role": inner.get("role", "user"),
-                        "content": inner.get("content", ""),
-                    }
-                )
-            else:
-                formatted.append(msg)
-        else:
-            formatted.append(msg)
+    async def _wrapped(args: Any) -> Any:
+        # The most recently added active tool run is the one PreToolUse just
+        # created for this invocation. Prefer an explicitly bound client
+        # session because tool handlers may run in an async context that did
+        # not inherit _current_session.
+        tool_run = _get_last_active_tool_run(session, args=args, tool_name=tool_name)
+        if tool_run:
+            token = _context._PARENT_RUN_TREE_REF.set(weakref.ref(tool_run))
+            session_token = (
+                _current_session.set(session) if session is not None else None
+            )
+            try:
+                return await original_handler(args)
+            finally:
+                if session_token is not None:
+                    _current_session.reset(session_token)
+                _context._PARENT_RUN_TREE_REF.reset(token)
+        return await original_handler(args)
 
-    return formatted
+    _wrapped._langsmith_wrapped = True  # type: ignore[attr-defined]
+    _wrapped._langsmith_original_handler = original_handler  # type: ignore[attr-defined]
+    _wrapped._langsmith_session = session  # type: ignore[attr-defined]
+    _wrapped._langsmith_tool_name = tool_name  # type: ignore[attr-defined]
+    return _wrapped
 
 
-def instrument_claude_client(original_class: Any) -> Any:
-    """Wrap `ClaudeSDKClient` to trace both `query()` and `receive_response()`."""
+def _tool_run_matches(run: Any, args: Any, tool_name: Optional[str]) -> bool:
+    """Return whether *run* appears to be for this SDK MCP handler call.
+
+    Matching is intentionally strict: we require both the tool name and the
+    handler args to line up with what the ``PreToolUse`` hook recorded. This
+    avoids cross-attributing a handler invocation to the wrong client's active
+    tool run under concurrency.
+    """
+    if not tool_name:
+        return False
+    run_name = str(getattr(run, "name", ""))
+    # SDK MCP tools show up in hook data as e.g. ``mcp__weather__get_weather``
+    # while the handler only knows its short name ``get_weather``.
+    name_matches = (
+        tool_name == run_name or tool_name in run_name or run_name in tool_name
+    )
+    if not name_matches:
+        return False
+    inputs = getattr(run, "inputs", None)
+    if not isinstance(inputs, dict):
+        return False
+    # PreToolUse stores {} when the tool had no inputs, otherwise
+    # {"input": <tool_input>}. Normalise both sides before comparing.
+    recorded = inputs.get("input", {}) if inputs else {}
+    return recorded == (args or {})
+
+
+def _newest_matching_tool_run(
+    sessions: list[SessionState], args: Any, tool_name: Optional[str]
+) -> Any:
+    """Return the most recently created active tool run that matches."""
+    candidates: list[tuple[float, Any]] = []
+    for candidate_session in sessions:
+        for run, start_time in candidate_session.active_tool_runs.values():
+            if _tool_run_matches(run, args, tool_name):
+                candidates.append((start_time, run))
+    if not candidates:
+        return None
+    return max(candidates, key=lambda item: item[0])[1]
+
+
+def _get_last_active_tool_run(
+    session: Optional[SessionState] = None,
+    *,
+    args: Any = None,
+    tool_name: Optional[str] = None,
+) -> Any:
+    """Return the active tool run for an SDK MCP handler, or None.
+
+    Lookup order:
+
+    1. The session explicitly bound to the handler (if any).
+    2. The session bound to the current ContextVar.
+    3. The module-level default session (unit tests / unbound callers).
+    4. Any live client session — only used when the handler is unbound and the
+       SDK invoked it in a detached async context. Requires an exact tool
+       name + args match to avoid cross-attribution across clients.
+    """
+    from ._hooks import (
+        _current_session,
+        _current_session_or_default,
+        _registered_sessions,
+    )
+
+    # If we have a specific session (explicitly bound, current-context, or the
+    # test default), just return its newest active tool run. There is no
+    # cross-client ambiguity at that point.
+    def _newest_in(s: SessionState) -> Any:
+        if not s.active_tool_runs:
+            return None
+        latest_id = max(
+            s.active_tool_runs,
+            key=lambda tid: s.active_tool_runs[tid][1],
+        )
+        return s.active_tool_runs[latest_id][0]
+
+    if session is not None:
+        return _newest_in(session)
+
+    current_session = _current_session.get()
+    if current_session is not None:
+        run = _newest_in(current_session)
+        if run is not None:
+            return run
+
+    default_session = _current_session_or_default()
+    if default_session is not current_session:
+        run = _newest_in(default_session)
+        if run is not None:
+            return run
+
+    # Last resort: the SDK invoked this handler in a detached async context and
+    # the handler object wasn't bound to a session. Require strict tool-name +
+    # args match so concurrent clients can't steal each other's attribution.
+    return _newest_matching_tool_run(_registered_sessions(), args, tool_name)
+
+
+def instrument_claude_client(original_class: Any) -> None:
+    """Patch ``ClaudeSDKClient`` **in place** to trace calls.
+
+    In-place patching (rather than subclassing + reference replacement)
+    ensures that callers who imported ``ClaudeSDKClient`` *before*
+    ``configure_claude_agent_sdk()`` was called still get instrumented.
+    """
     if getattr(original_class, "_langsmith_instrumented", False):
-        return original_class  # Already wrapped, avoid double-tracing
+        return  # Already wrapped, avoid double-tracing
 
-    class TracedClaudeSDKClient(original_class):
-        _langsmith_instrumented = True
+    # ── stash originals ──────────────────────────────────────────────
+    _orig_init = original_class.__init__
+    _orig_query = original_class.query
+    _orig_receive_response = original_class.receive_response
 
-        def __init__(self, *args: Any, **kwargs: Any):
-            # Inject LangSmith tracing hooks into options before initialization
-            options = kwargs.get("options") or (args[0] if args else None)
-            if options:
-                _inject_tracing_hooks(options)
+    # ── patched __init__ ─────────────────────────────────────────────
+    def _traced_init(self: Any, *args: Any, **kwargs: Any) -> None:
+        options = kwargs.get("options") or (args[0] if args else None)
+        self._ls_session = SessionState()
+        if options:
+            _inject_tracing_hooks(options, self._ls_session)
+        _orig_init(self, *args, **kwargs)
+        self._ls_prompt = None
+        self._ls_start_time = None
+        self._ls_streamed_input = None
 
-            super().__init__(*args, **kwargs)
-            self._prompt: Optional[str] = None
-            self._start_time: Optional[float] = None
-            self._streamed_input: Optional[list[dict[str, Any]]] = None
+    # ── patched query ────────────────────────────────────────────────
+    async def _traced_query(self: Any, *args: Any, **kwargs: Any) -> Any:
+        self._ls_start_time = time.time()
+        self._ls_streamed_input = None
+        prompt = args[0] if args else kwargs.get("prompt")
 
-        async def query(self, *args: Any, **kwargs: Any) -> Any:
-            """Capture prompt and start time, wrapping generators if needed."""
-            self._start_time = time.time()
-            self._streamed_input = None
-            prompt = args[0] if args else kwargs.get("prompt")
+        if prompt is None:
+            pass
+        elif isinstance(prompt, str):
+            self._ls_prompt = prompt
+        elif isinstance(prompt, AsyncIterable):
+            collector: list[dict[str, Any]] = []
+            self._ls_streamed_input = collector
+            self._ls_prompt = None
 
-            if prompt is None:
-                pass
-            elif isinstance(prompt, str):
-                self._prompt = prompt
-            elif isinstance(prompt, AsyncIterable):
-                collector: list[dict[str, Any]] = []
-                self._streamed_input = collector
-                self._prompt = None
+            async def _gen_wrapper() -> AsyncGenerator[dict[str, Any], None]:
+                async for msg in prompt:
+                    collector.append(msg)
+                    yield msg
 
-                async def _gen_wrapper() -> AsyncGenerator[dict[str, Any], None]:
-                    async for msg in prompt:
-                        collector.append(msg)
-                        yield msg
-
-                if args:
-                    args = (_gen_wrapper(),) + args[1:]
-                else:
-                    kwargs["prompt"] = _gen_wrapper()
+            if args:
+                args = (_gen_wrapper(),) + args[1:]
             else:
-                self._prompt = str(prompt)
+                kwargs["prompt"] = _gen_wrapper()
+        else:
+            self._ls_prompt = str(prompt)
 
-            return await super().query(*args, **kwargs)
+        return await _orig_query(self, *args, **kwargs)
 
-        def _handle_assistant_tool_uses(
-            self,
-            msg: Any,
-            run: Any,
-            subagent_sessions: dict[str, Any],
-        ) -> None:
-            """Process tool uses for an assistant message."""
-            if not hasattr(msg, "content"):
-                return
+    # ── patched receive_response ─────────────────────────────────────
+    async def _traced_receive_response(self: Any) -> AsyncGenerator[Any, None]:
+        messages = _orig_receive_response(self)
 
-            from ._hooks import _client_managed_runs
+        trace_inputs: dict[str, Any] = {}
+        trace_metadata: dict[str, Any] = {
+            "ls_integration": "claude-agent-sdk",
+            "ls_integration_version": get_package_version("claude_agent_sdk"),
+        }
 
-            parent_tool_use_id = getattr(msg, "parent_tool_use_id", None)
+        awaiting_streamed_input = self._ls_streamed_input is not None
 
-            for block in msg.content:
-                if type(block).__name__ != "ToolUseBlock":
-                    continue
+        if self._ls_prompt:
+            trace_inputs["prompt"] = self._ls_prompt
 
-                try:
-                    tool_use_id = getattr(block, "id", None)
-                    tool_name = getattr(block, "name", "unknown_tool")
-                    tool_input = getattr(block, "input", {})
-
-                    if not tool_use_id:
-                        continue
-
-                    start_time = time.time()
-
-                    # Check if this is a Task tool (subagent)
-                    if tool_name == "Task" and not parent_tool_use_id:
-                        # Extract subagent name
-                        subagent_name = (
-                            tool_input.get("subagent_type")
-                            or (
-                                tool_input.get("description", "").split()[0]
-                                if tool_input.get("description")
-                                else None
-                            )
-                            or "unknown-agent"
+        if hasattr(self, "options") and self.options:
+            if hasattr(self.options, "system_prompt") and self.options.system_prompt:
+                system_prompt = self.options.system_prompt
+                if isinstance(system_prompt, str):
+                    trace_inputs["system"] = system_prompt
+                elif isinstance(system_prompt, dict):
+                    if system_prompt.get("type") == "preset":
+                        preset_text = (
+                            f"preset: {system_prompt.get('preset', 'claude_code')}"
                         )
-
-                        subagent_session = run.create_child(
-                            name=subagent_name,
-                            run_type="chain",
-                            inputs=tool_input,
-                            start_time=datetime.fromtimestamp(
-                                start_time, tz=timezone.utc
-                            ),
-                        )
-                        subagent_session.post()
-                        subagent_sessions[tool_use_id] = subagent_session
-
-                        _client_managed_runs[tool_use_id] = subagent_session
-
-                    # Check if tool use is within a subagent
-                    elif parent_tool_use_id and parent_tool_use_id in subagent_sessions:
-                        subagent_session = subagent_sessions[parent_tool_use_id]
-                        # Create tool run as child of subagent
-                        tool_run = subagent_session.create_child(
-                            name=tool_name,
-                            run_type="tool",
-                            inputs={"input": tool_input} if tool_input else {},
-                            start_time=datetime.fromtimestamp(
-                                start_time,
-                                tz=timezone.utc,
-                            ),
-                        )
-                        tool_run.post()
-                        _client_managed_runs[tool_use_id] = tool_run
-
-                except Exception as e:
-                    logger.warning(f"Failed to create client-managed tool run: {e}")
-
-        async def receive_response(self) -> AsyncGenerator[Any, None]:
-            """Intercept message stream and record chain run activity."""
-            messages = super().receive_response()
-
-            # Capture configuration in inputs and metadata
-            trace_inputs: dict[str, Any] = {}
-            trace_metadata: dict[str, Any] = {
-                "ls_integration": "claude-agent-sdk",
-                "ls_integration_version": _get_package_version("claude_agent_sdk"),
-            }
-
-            # Track if we need to update input from captured streaming messages
-            awaiting_streamed_input = self._streamed_input is not None
-
-            # Add prompt to inputs (for string prompts)
-            if self._prompt:
-                trace_inputs["prompt"] = self._prompt
-
-            # Add system_prompt to inputs if available
-            if hasattr(self, "options") and self.options:
-                if (
-                    hasattr(self.options, "system_prompt")
-                    and self.options.system_prompt
-                ):
-                    system_prompt = self.options.system_prompt
-                    if isinstance(system_prompt, str):
+                        if "append" in system_prompt:
+                            preset_text += f"\nappend: {system_prompt['append']}"
+                        trace_inputs["system"] = preset_text
+                    else:
                         trace_inputs["system"] = system_prompt
-                    elif isinstance(system_prompt, dict):
-                        # Handle SystemPromptPreset format
-                        if system_prompt.get("type") == "preset":
-                            preset_text = (
-                                f"preset: {system_prompt.get('preset', 'claude_code')}"
-                            )
-                            if "append" in system_prompt:
-                                preset_text += f"\nappend: {system_prompt['append']}"
-                            trace_inputs["system"] = preset_text
-                        else:
-                            trace_inputs["system"] = system_prompt
 
-                # Add other config to metadata
-                for attr in ["model", "permission_mode", "max_turns"]:
-                    if hasattr(self.options, attr):
-                        val = getattr(self.options, attr)
-                        if val is not None:
-                            trace_metadata[attr] = val
+            for attr in ["model", "permission_mode", "max_turns"]:
+                if hasattr(self.options, attr):
+                    val = getattr(self.options, attr)
+                    if val is not None:
+                        trace_metadata[attr] = val
 
-            async with trace(
-                name=TRACE_CHAIN_NAME,
-                run_type="chain",
-                inputs=trace_inputs,
-                metadata=trace_metadata,
-            ) as run:
-                set_parent_run_tree(run)
-                tracker = TurnLifecycle(self._start_time)
-                collected: list[dict[str, Any]] = []
+        config = get_tracing_config()
+        user_metadata = config.get("metadata") or {}
 
-                # Track subagent sessions by Task tool_use_id
-                subagent_sessions: dict[str, Any] = {}
+        trace_kwargs: dict[str, Any] = {
+            "name": config.get("name") or TRACE_CHAIN_NAME,
+            "run_type": "chain",
+            "inputs": trace_inputs,
+            "metadata": {
+                **trace_metadata,
+                **user_metadata,
+                "ls_agent_type": "root",
+            },
+        }
+        if config.get("project_name"):
+            trace_kwargs["project_name"] = config["project_name"]
+        if config.get("tags"):
+            trace_kwargs["tags"] = config["tags"]
 
-                prompt_for_llm: Any = self._prompt
+        async with trace(**trace_kwargs) as run:
+            # Bind this client's state container to the ContextVar so stream
+            # helpers on this SDK event loop pick it up (see
+            # _hooks.SessionState). This keeps concurrent ClaudeSDKClient
+            # instances — eval runs, FastAPI handlers, Celery workers,
+            # asyncio.gather — from corrupting each other's correlation state.
+            session = getattr(self, "_ls_session", None)
+            if session is None:
+                session = self._ls_session = SessionState()
+            session_token = _register_session(session)
+            _set_session_root(session, run)
+            parent_token = set_parent_run_tree(run)
+            tracker = TurnLifecycle(self._ls_start_time)
+            collected_by_ctx: dict[Optional[str], list[dict[str, Any]]] = {None: []}
 
-                try:
-                    async for msg in messages:
-                        if awaiting_streamed_input and self._streamed_input:
-                            unwrapped_messages = _unwrap_streamed_messages(
-                                self._streamed_input
-                            )
-                            if unwrapped_messages:
-                                run.inputs["messages"] = unwrapped_messages
-                                prompt_for_llm = self._streamed_input
-                            awaiting_streamed_input = False
+            prompt_for_llm: Any = self._ls_prompt
 
-                        msg_type = type(msg).__name__
-                        if msg_type == "AssistantMessage":
-                            # Check if this message belongs to a subagent
-                            parent_tool_use_id = getattr(
-                                msg, "parent_tool_use_id", None
-                            )
-                            llm_parent = (
-                                subagent_sessions.get(parent_tool_use_id)
-                                if parent_tool_use_id
-                                else None
-                            )
+            try:
+                async for msg in messages:
+                    if awaiting_streamed_input and self._ls_streamed_input:
+                        unwrapped_messages = unwrap_message_dicts(
+                            self._ls_streamed_input
+                        )
+                        if unwrapped_messages:
+                            run.inputs["messages"] = unwrapped_messages
+                            prompt_for_llm = self._ls_streamed_input
+                        awaiting_streamed_input = False
 
-                            content = tracker.start_llm_run(
-                                msg, prompt_for_llm, collected, parent=llm_parent
-                            )
-                            if content:
-                                collected.append(content)
+                    msg_type = type(msg).__name__
 
-                            # Process tool uses in this AssistantMessage
-                            self._handle_assistant_tool_uses(
-                                msg,
-                                run,
-                                subagent_sessions,
-                            )
-                        elif msg_type == "UserMessage":
-                            if hasattr(msg, "content"):
-                                # Check if this is a tool result message
-                                flattened = flatten_content_blocks(msg.content)
-                                if (
-                                    isinstance(flattened, list)
-                                    and flattened
-                                    and isinstance(flattened[0], dict)
-                                    and flattened[0].get("type") == "tool_result"
-                                ):
-                                    # Format each tool result as a separate message
-                                    for block in flattened:
-                                        collected.append(
-                                            {
-                                                "role": "tool",
-                                                "content": block.get("content", ""),
-                                                "tool_call_id": block.get(
-                                                    "tool_use_id"
-                                                ),
-                                            }
-                                        )
-                                else:
-                                    collected.append(
+                    if msg_type == "AssistantMessage":
+                        parent_tool_use_id = getattr(msg, "parent_tool_use_id", None)
+                        llm_parent = (
+                            get_subagent_run_by_tool_id(parent_tool_use_id)
+                            if parent_tool_use_id
+                            else None
+                        )
+
+                        ctx_key = parent_tool_use_id
+                        ctx_history = collected_by_ctx.setdefault(ctx_key, [])
+
+                        content = tracker.start_llm_run(
+                            msg,
+                            prompt_for_llm if parent_tool_use_id is None else None,
+                            ctx_history,
+                            parent=llm_parent,
+                        )
+                        if content:
+                            ctx_history.append(content)
+
+                    elif msg_type == "UserMessage":
+                        parent_tool_use_id = getattr(msg, "parent_tool_use_id", None)
+                        ctx_key = parent_tool_use_id
+                        ctx_history = collected_by_ctx.setdefault(ctx_key, [])
+
+                        if hasattr(msg, "content"):
+                            flattened = flatten_content_blocks(msg.content)
+                            if (
+                                isinstance(flattened, list)
+                                and flattened
+                                and isinstance(flattened[0], dict)
+                                and flattened[0].get("type") == "tool_result"
+                            ):
+                                for block in flattened:
+                                    tool_use_id = block.get("tool_use_id")
+                                    ctx_history.append(
                                         {
-                                            "content": flattened,
-                                            "role": "user",
+                                            "role": "tool",
+                                            "content": block.get("content", ""),
+                                            "tool_call_id": tool_use_id,
                                         }
                                     )
-                            tracker.mark_next_start()
-                        elif msg_type == "ResultMessage":
-                            # Add usage metrics including cost
-                            if hasattr(msg, "usage"):
-                                usage = extract_usage_from_result_message(msg)
-                                # Add total_cost to usage_metadata if available
-                                if (
-                                    hasattr(msg, "total_cost_usd")
-                                    and msg.total_cost_usd is not None
-                                ):
-                                    usage["total_cost"] = msg.total_cost_usd
-                                tracker.add_usage(usage)
+                                    if (
+                                        tool_use_id
+                                        and tool_use_id in session.active_tool_runs
+                                    ):
+                                        tool_run, _ = session.active_tool_runs.pop(
+                                            tool_use_id
+                                        )
+                                        result_content = block.get("content", "")
+                                        is_error = block.get("is_error", False)
+                                        tool_run.end(
+                                            outputs={"output": result_content},
+                                            error=str(result_content)
+                                            if is_error
+                                            else None,
+                                        )
+                                        try:
+                                            tool_run.patch()
+                                        except Exception as e:
+                                            logger.warning(
+                                                "Failed to patch"
+                                                f" orphaned tool run: {e}"
+                                            )
+                            else:
+                                ctx_history.append(
+                                    {
+                                        "content": flattened,
+                                        "role": "user",
+                                    }
+                                )
+                        tracker.mark_next_start()
+                    elif msg_type == "ResultMessage":
+                        session_id_val = getattr(msg, "session_id", None)
+                        meta = {
+                            k: v
+                            for k, v in {
+                                "num_turns": getattr(msg, "num_turns", None),
+                                "session_id": session_id_val,
+                                "thread_id": session_id_val,
+                                "duration_ms": getattr(msg, "duration_ms", None),
+                                "duration_api_ms": getattr(
+                                    msg, "duration_api_ms", None
+                                ),
+                                "is_error": getattr(msg, "is_error", None),
+                            }.items()
+                            if v is not None
+                        }
+                        if meta:
+                            run.metadata.update(meta)
 
-                            # Add conversation-level metadata
-                            meta = {
-                                k: v
-                                for k, v in {
-                                    "num_turns": getattr(msg, "num_turns", None),
-                                    "session_id": getattr(msg, "session_id", None),
-                                    "duration_ms": getattr(msg, "duration_ms", None),
-                                    "duration_api_ms": getattr(
-                                        msg, "duration_api_ms", None
-                                    ),
-                                    "is_error": getattr(msg, "is_error", None),
-                                }.items()
-                                if v is not None
-                            }
-                            if meta:
-                                run.metadata.update(meta)
-
-                        yield msg
-                    run.end(outputs=collected[-1] if collected else None)
-                except Exception:
-                    logger.exception("Error while tracing Claude Agent stream")
+                    yield msg
+                main_collected = collected_by_ctx.get(None, [])
+                run.end(outputs=main_collected[-1] if main_collected else None)
+            except Exception:
+                logger.exception("Error while tracing Claude Agent stream")
+                raise
+            finally:
+                tracker.close()
+                reconcile_from_transcripts(tracker, session=session)
+                tracker.flush()
+                clear_parent_run_tree(parent_token)
+                try:
+                    clear_active_tool_runs(session)
                 finally:
-                    tracker.close()
-                    clear_parent_run_tree()
-                    clear_active_tool_runs()
+                    _unregister_session(session, session_token)
 
-        async def __aenter__(self) -> "TracedClaudeSDKClient":
-            await super().__aenter__()
-            return self
+    # ── apply patches to the class itself ────────────────────────────
+    original_class.__init__ = _traced_init
+    original_class.query = _traced_query
+    original_class.receive_response = _traced_receive_response
+    original_class._langsmith_instrumented = True
 
-        async def __aexit__(self, *args: Any) -> None:
-            await super().__aexit__(*args)
 
-    return TracedClaudeSDKClient
+def instrument_sdk_mcp_tool(tool_class: Any) -> None:
+    """Patch ``SdkMcpTool.__init__`` to auto-wrap handlers.
+
+    Wrapping happens at construction time so that any tool created
+    *after* ``configure_claude_agent_sdk()`` automatically gets
+    run-context propagation, regardless of how ``tool`` or
+    ``create_sdk_mcp_server`` were imported.
+    """
+    if getattr(tool_class, "_langsmith_handler_patched", False):
+        return
+
+    _orig_init = tool_class.__init__
+
+    def _patched_init(self: Any, *args: Any, **kwargs: Any) -> None:
+        _orig_init(self, *args, **kwargs)
+        handler = self.handler
+        if callable(handler) and not getattr(handler, "_langsmith_wrapped", False):
+            self.handler = _wrap_tool_handler(
+                handler, tool_name=getattr(self, "name", None)
+            )
+
+    tool_class.__init__ = _patched_init
+    tool_class._langsmith_handler_patched = True

--- a/python/tests/unit_tests/wrappers/test_claude_agent_sdk_hooks.py
+++ b/python/tests/unit_tests/wrappers/test_claude_agent_sdk_hooks.py
@@ -2,16 +2,20 @@
 
 import asyncio
 import sys
-from unittest.mock import MagicMock
+from contextlib import asynccontextmanager
+from unittest.mock import MagicMock, patch
 
 import pytest
 
+from langsmith.integrations.claude_agent_sdk import _hooks as _hooks_module
 from langsmith.integrations.claude_agent_sdk._hooks import (
-    _active_tool_runs,
-    _client_managed_runs,
+    clear_active_tool_runs,
+    get_subagent_run_by_tool_id,
     post_tool_use_failure_hook,
     post_tool_use_hook,
     pre_tool_use_hook,
+    subagent_start_hook,
+    subagent_stop_hook,
 )
 from langsmith.run_trees import RunTree
 
@@ -20,12 +24,21 @@ ERROR_MSG = "Exit code 1\ncat: /nonexistent: No such file or directory"
 
 @pytest.fixture(autouse=True)
 def _clear_state():
-    """Reset global hook state between tests."""
-    _active_tool_runs.clear()
-    _client_managed_runs.clear()
+    """Reset default hook state between tests."""
+
+    def _reset():
+        _hooks_module._default_session.active_tool_runs.clear()
+        _hooks_module._default_session.subagent_runs.clear()
+        _hooks_module._default_session.pending_agent_tools.clear()
+        _hooks_module._default_session.agent_to_tool_mapping.clear()
+        _hooks_module._default_session.ended_subagent_runs.clear()
+        _hooks_module._default_session.subagent_transcript_paths.clear()
+        _hooks_module._default_session.main_transcript_path = None
+        _hooks_module._default_session.root_run = None
+
+    _reset()
     yield
-    _active_tool_runs.clear()
-    _client_managed_runs.clear()
+    _reset()
 
 
 def _make_parent_run() -> RunTree:
@@ -53,8 +66,8 @@ class TestToolUseSuccessFlow:
             )
         )
 
-        assert "tu_1" in _active_tool_runs
-        tool_run, _ = _active_tool_runs["tu_1"]
+        assert "tu_1" in _hooks_module._default_session.active_tool_runs
+        tool_run, _ = _hooks_module._default_session.active_tool_runs["tu_1"]
         assert tool_run.name == "Bash"
         assert tool_run.run_type == "tool"
         assert tool_run.inputs == {"input": {"command": "echo hi"}}
@@ -70,7 +83,7 @@ class TestToolUseSuccessFlow:
             )
         )
 
-        assert "tu_1" not in _active_tool_runs
+        assert "tu_1" not in _hooks_module._default_session.active_tool_runs
         assert tool_run.outputs == {"output": "hi", "is_error": False}
         assert tool_run.error is None
 
@@ -98,27 +111,21 @@ class TestToolUseFailureFlow:
             )
         )
 
-        tool_run, _ = _active_tool_runs["tu_2"]
+        assert "tu_2" in _hooks_module._default_session.active_tool_runs
 
         asyncio.run(
             post_tool_use_failure_hook(
-                {
-                    "tool_name": "Bash",
-                    "tool_input": {"command": "cat /nonexistent"},
-                    "error": ERROR_MSG,
-                },
+                {"tool_name": "Bash", "error": ERROR_MSG},
                 "tu_2",
                 MagicMock(),
             )
         )
 
-        assert "tu_2" not in _active_tool_runs
-        assert tool_run.error == ERROR_MSG
-        assert tool_run.outputs == {"error": ERROR_MSG}
+        assert "tu_2" not in _hooks_module._default_session.active_tool_runs
 
 
 class TestInjectTracingHooks:
-    def test_injects_all_three_hooks(self):
+    def test_injects_all_hooks(self):
         from langsmith.integrations.claude_agent_sdk._client import (
             _inject_tracing_hooks,
         )
@@ -126,13 +133,732 @@ class TestInjectTracingHooks:
         options = MagicMock()
         options.hooks = None
 
+        original_module = sys.modules.get("claude_agent_sdk")
         mock_module = MagicMock()
         sys.modules["claude_agent_sdk"] = mock_module
         try:
             _inject_tracing_hooks(options)
         finally:
-            del sys.modules["claude_agent_sdk"]
+            if original_module is not None:
+                sys.modules["claude_agent_sdk"] = original_module
+            else:
+                sys.modules.pop("claude_agent_sdk", None)
 
-        for event in ("PreToolUse", "PostToolUse", "PostToolUseFailure"):
+        for event in (
+            "PreToolUse",
+            "PostToolUse",
+            "PostToolUseFailure",
+            "SubagentStart",
+            "SubagentStop",
+        ):
             assert event in options.hooks
             assert len(options.hooks[event]) == 1
+
+
+class TestSubagentFlow:
+    """Test subagent start/stop hooks and tool nesting."""
+
+    @pytest.fixture(autouse=True)
+    def _set_parent(self):
+        from langsmith.integrations.claude_agent_sdk import _tools
+
+        _tools.set_parent_run_tree(_make_parent_run())
+        yield
+        _tools.clear_parent_run_tree()
+
+    def test_subagent_nested_under_agent_tool(self):
+        """Subagent run should be nested under the Agent tool run."""
+        # PreToolUse for the Agent tool
+        asyncio.run(
+            pre_tool_use_hook(
+                {"tool_name": "Agent", "tool_input": {"agent": "foo"}},
+                "tool_1",
+                MagicMock(),
+            )
+        )
+
+        assert "tool_1" in _hooks_module._default_session.active_tool_runs
+        agent_tool_run, _ = _hooks_module._default_session.active_tool_runs["tool_1"]
+        assert agent_tool_run.name == "Agent"
+
+        # The Agent tool_use_id should be pending
+        assert "tool_1" in _hooks_module._default_session.pending_agent_tools
+
+        # SubagentStart — note: SDK passes a different tool_use_id
+        asyncio.run(
+            subagent_start_hook(
+                {"agent_id": "agent_123", "agent_type": "foo"},
+                "sdk_internal_session_id",  # NOT tool_1
+                MagicMock(),
+            )
+        )
+
+        # Subagent run should exist and be nested under Agent tool
+        assert "agent_123" in _hooks_module._default_session.subagent_runs
+        subagent_run = _hooks_module._default_session.subagent_runs["agent_123"]
+        assert subagent_run.name == "foo"
+        assert subagent_run.run_type == "chain"
+        assert subagent_run.parent_run_id == agent_tool_run.id
+
+        # Inputs should come from the Agent tool's input
+        assert subagent_run.inputs == {"agent": "foo"}
+
+        # Mappings should be set
+        assert (
+            _hooks_module._default_session.agent_to_tool_mapping["agent_123"]
+            == "tool_1"
+        )
+        assert get_subagent_run_by_tool_id("tool_1") == subagent_run
+
+        # Pending should be consumed
+        assert "tool_1" not in _hooks_module._default_session.pending_agent_tools
+
+    def test_tool_inside_subagent_nests_under_subagent(self):
+        """Tools inside a subagent should nest under the subagent run."""
+        # Set up: Agent tool call + subagent start
+        asyncio.run(
+            pre_tool_use_hook(
+                {"tool_name": "Agent", "tool_input": {"agent": "foo"}},
+                "tool_1",
+                MagicMock(),
+            )
+        )
+        asyncio.run(
+            subagent_start_hook(
+                {"agent_id": "agent_123", "agent_type": "foo"},
+                "sdk_session_id",
+                MagicMock(),
+            )
+        )
+
+        # Tool inside subagent — agent_id identifies the subagent
+        asyncio.run(
+            pre_tool_use_hook(
+                {
+                    "tool_name": "Bash",
+                    "tool_input": {"command": "ls"},
+                    "agent_id": "agent_123",
+                },
+                "tool_2",
+                MagicMock(),
+            )
+        )
+
+        assert "tool_2" in _hooks_module._default_session.active_tool_runs
+        tool_run, _ = _hooks_module._default_session.active_tool_runs["tool_2"]
+        assert tool_run.name == "Bash"
+        assert (
+            tool_run.parent_run_id
+            == _hooks_module._default_session.subagent_runs["agent_123"].id
+        )
+
+    def test_subagent_findable_after_stop(self):
+        """Subagent run is still findable via tool_use_id after SubagentStop."""
+        asyncio.run(
+            pre_tool_use_hook(
+                {"tool_name": "Agent", "tool_input": {}},
+                "tool_1",
+                MagicMock(),
+            )
+        )
+        asyncio.run(
+            subagent_start_hook(
+                {"agent_id": "a1", "agent_type": "foo"},
+                "sdk_1",
+                MagicMock(),
+            )
+        )
+
+        run = _hooks_module._default_session.subagent_runs["a1"]
+        assert get_subagent_run_by_tool_id("tool_1") is run
+
+        # After SubagentStop, the run is stashed but still findable
+        asyncio.run(
+            subagent_stop_hook(
+                {"agent_id": "a1", "agent_type": "foo"},
+                "sdk_1",
+                MagicMock(),
+            )
+        )
+        assert "a1" not in _hooks_module._default_session.subagent_runs
+        assert get_subagent_run_by_tool_id("tool_1") is run
+
+    def test_subagent_stop_and_post_tool_use_set_outputs(self):
+        """SubagentStop + PostToolUse should set outputs on both runs."""
+        # Agent tool call
+        asyncio.run(
+            pre_tool_use_hook(
+                {"tool_name": "Agent", "tool_input": {"agent": "foo"}},
+                "tool_1",
+                MagicMock(),
+            )
+        )
+        # Subagent start
+        asyncio.run(
+            subagent_start_hook(
+                {"agent_id": "agent_123", "agent_type": "foo"},
+                "sdk_session_id",
+                MagicMock(),
+            )
+        )
+        subagent_run = _hooks_module._default_session.subagent_runs["agent_123"]
+
+        # Subagent stop — run should be stashed, not ended yet
+        asyncio.run(
+            subagent_stop_hook(
+                {"agent_id": "agent_123", "agent_type": "foo"},
+                "sdk_session_id",
+                MagicMock(),
+            )
+        )
+
+        assert "agent_123" not in _hooks_module._default_session.subagent_runs
+        assert "tool_1" in _hooks_module._default_session.ended_subagent_runs
+        assert (
+            _hooks_module._default_session.ended_subagent_runs["tool_1"] is subagent_run
+        )
+        assert subagent_run.end_time is None
+
+        # PostToolUse for Agent — sets outputs on subagent but doesn't end it
+        asyncio.run(
+            post_tool_use_hook(
+                {
+                    "tool_name": "Agent",
+                    "tool_response": {"output": "bar"},
+                },
+                "tool_1",
+                MagicMock(),
+            )
+        )
+
+        # Agent tool run should be ended
+        assert "tool_1" not in _hooks_module._default_session.active_tool_runs
+
+        # Subagent outputs should be set but run not yet ended
+        assert subagent_run.outputs == {"output": "bar"}
+        assert subagent_run.end_time is None
+
+        # Subagent can still be found for LLM nesting
+        assert get_subagent_run_by_tool_id("tool_1") is subagent_run
+
+        # clear_active_tool_runs finalises everything
+        clear_active_tool_runs()
+        assert subagent_run.end_time is not None
+        assert len(_hooks_module._default_session.ended_subagent_runs) == 0
+
+
+class TestTranscriptPathCapture:
+    """Pre-tool-use hook captures transcript_path from BaseHookInput."""
+
+    @pytest.fixture(autouse=True)
+    def _set_parent(self):
+        from langsmith.integrations.claude_agent_sdk import _tools
+
+        _tools.set_parent_run_tree(_make_parent_run())
+        yield
+        _tools.clear_parent_run_tree()
+
+    def test_captures_transcript_path_from_first_hook(self):
+        assert _hooks_module._default_session.main_transcript_path is None
+
+        asyncio.run(
+            pre_tool_use_hook(
+                {
+                    "tool_name": "Bash",
+                    "tool_input": {"command": "echo hi"},
+                    "transcript_path": "/tmp/sessions/abc.jsonl",
+                },
+                "tu_1",
+                MagicMock(),
+            )
+        )
+
+        assert (
+            _hooks_module._default_session.main_transcript_path
+            == "/tmp/sessions/abc.jsonl"
+        )
+
+    def test_does_not_overwrite_on_subsequent_hooks(self):
+        # Seed the default session's transcript path so the "first writer wins"
+        # guard in pre_tool_use_hook kicks in.
+        _hooks_module._default_session.main_transcript_path = "/first/path.jsonl"
+
+        asyncio.run(
+            pre_tool_use_hook(
+                {
+                    "tool_name": "Bash",
+                    "tool_input": {},
+                    "transcript_path": "/second/path.jsonl",
+                },
+                "tu_2",
+                MagicMock(),
+            )
+        )
+
+        assert (
+            _hooks_module._default_session.main_transcript_path == "/first/path.jsonl"
+        )
+
+    def test_clear_active_tool_runs_resets_transcript_path(self):
+        _hooks_module._default_session.main_transcript_path = "/some/path.jsonl"
+        clear_active_tool_runs()
+        assert _hooks_module._default_session.main_transcript_path is None
+
+
+class TestReadLLMTurnsFromTranscript:
+    """Unit tests for read_llm_turns_from_transcript."""
+
+    def test_extracts_final_entries_only(self, tmp_path):
+        from langsmith.integrations.claude_agent_sdk._usage import (
+            read_llm_turns_from_transcript,
+        )
+
+        transcript = tmp_path / "session.jsonl"
+        import json
+
+        lines = [
+            # Initial user prompt
+            {
+                "type": "user",
+                "message": {"content": "echo hello"},
+            },
+            # Partial (streaming) — stop_reason null
+            {
+                "type": "assistant",
+                "message": {
+                    "id": "msg_001",
+                    "model": "claude-haiku-4-5-20251001",
+                    "content": [{"type": "text", "text": "Thinking..."}],
+                    "stop_reason": None,
+                    "usage": {"input_tokens": 100, "output_tokens": 3},
+                },
+                "timestamp": "2025-01-01T00:00:00.000Z",
+            },
+            # Final — stop_reason set
+            {
+                "type": "assistant",
+                "message": {
+                    "id": "msg_001",
+                    "model": "claude-haiku-4-5-20251001",
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "id": "tu_1",
+                            "name": "Bash",
+                            "input": {"command": "echo hello"},
+                        },
+                    ],
+                    "stop_reason": "tool_use",
+                    "usage": {"input_tokens": 100, "output_tokens": 42},
+                },
+                "timestamp": "2025-01-01T00:00:01.000Z",
+            },
+            # User message (tool result)
+            {
+                "type": "user",
+                "message": {
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "tu_1",
+                            "content": "hello",
+                        },
+                    ]
+                },
+            },
+            # Second turn — partial
+            {
+                "type": "assistant",
+                "message": {
+                    "id": "msg_002",
+                    "model": "claude-haiku-4-5-20251001",
+                    "content": [{"type": "text", "text": "d"}],
+                    "stop_reason": None,
+                    "usage": {"input_tokens": 150, "output_tokens": 1},
+                },
+                "timestamp": "2025-01-01T00:00:02.000Z",
+            },
+            # Second turn — final
+            {
+                "type": "assistant",
+                "message": {
+                    "id": "msg_002",
+                    "model": "claude-haiku-4-5-20251001",
+                    "content": [{"type": "text", "text": "done"}],
+                    "stop_reason": "end_turn",
+                    "usage": {"input_tokens": 150, "output_tokens": 5},
+                },
+                "timestamp": "2025-01-01T00:00:03.000Z",
+            },
+        ]
+        transcript.write_text("\n".join(json.dumps(entry) for entry in lines))
+
+        turns = read_llm_turns_from_transcript(str(transcript))
+
+        assert len(turns) == 2
+
+        assert turns[0]["message_id"] == "msg_001"
+        assert turns[0]["stop_reason"] == "tool_use"
+        assert turns[0]["usage"]["output_tokens"] == 42
+        # First turn should see only the initial user prompt
+        assert turns[0]["input_messages"] == [
+            {"role": "user", "content": "echo hello"},
+        ]
+
+        assert turns[1]["message_id"] == "msg_002"
+        assert turns[1]["stop_reason"] == "end_turn"
+        assert turns[1]["content"] == [{"type": "text", "text": "done"}]
+        # Second turn should see full conversation history
+        assert turns[1]["input_messages"] == [
+            {"role": "user", "content": "echo hello"},
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "tu_1",
+                        "name": "Bash",
+                        "input": {"command": "echo hello"},
+                    },
+                ],
+            },
+            {"role": "tool", "content": "hello", "tool_call_id": "tu_1"},
+        ]
+
+    def test_empty_file(self, tmp_path):
+        from langsmith.integrations.claude_agent_sdk._usage import (
+            read_llm_turns_from_transcript,
+        )
+
+        transcript = tmp_path / "empty.jsonl"
+        transcript.write_text("")
+        assert read_llm_turns_from_transcript(str(transcript)) == []
+
+    def test_missing_file(self):
+        from langsmith.integrations.claude_agent_sdk._usage import (
+            read_llm_turns_from_transcript,
+        )
+
+        assert read_llm_turns_from_transcript("/nonexistent/path.jsonl") == []
+
+
+class TestMissingSubagentLLMRuns:
+    """reconcile_from_transcripts creates LLM runs for subagent turns
+    that were not seen in the live stream."""
+
+    def test_creates_missing_llm_run_from_transcript(self, tmp_path):
+        import json
+
+        from langsmith.integrations.claude_agent_sdk._client import TurnLifecycle
+        from langsmith.integrations.claude_agent_sdk._transcripts import (
+            LLM_RUN_NAME,
+            reconcile_from_transcripts,
+        )
+
+        # Create a subagent run
+        parent = _make_parent_run()
+        subagent_run = parent.create_child(
+            name="foo",
+            run_type="chain",
+        )
+
+        # Write a transcript with 2 turns
+        transcript = tmp_path / "subagent.jsonl"
+        lines = [
+            {
+                "type": "assistant",
+                "message": {
+                    "id": "msg_seen",
+                    "model": "claude-haiku-4-5-20251001",
+                    "content": [
+                        {"type": "tool_use", "id": "tu_1", "name": "Bash", "input": {}}
+                    ],
+                    "stop_reason": "tool_use",
+                    "usage": {"input_tokens": 100, "output_tokens": 20},
+                },
+                "timestamp": "2025-01-01T00:00:01.000Z",
+            },
+            {
+                "type": "assistant",
+                "message": {
+                    "id": "msg_missing",
+                    "model": "claude-haiku-4-5-20251001",
+                    "content": [{"type": "text", "text": "done"}],
+                    "stop_reason": "end_turn",
+                    "usage": {"input_tokens": 150, "output_tokens": 5},
+                },
+                "timestamp": "2025-01-01T00:00:03.000Z",
+            },
+        ]
+        transcript.write_text("\n".join(json.dumps(entry) for entry in lines))
+
+        # Set up tracker with msg_seen already created
+        tracker = TurnLifecycle()
+        existing_run = parent.create_child(
+            name=LLM_RUN_NAME,
+            run_type="llm",
+        )
+        tracker.llm_runs_by_message_id["msg_seen"] = existing_run
+
+        # Register subagent transcript
+        _hooks_module._default_session.subagent_transcript_paths.append(
+            (str(transcript), subagent_run)
+        )
+
+        reconcile_from_transcripts(tracker)
+
+        # msg_missing should now have an LLM run
+        assert "msg_missing" in tracker.llm_runs_by_message_id
+        new_run = tracker.llm_runs_by_message_id["msg_missing"]
+        assert new_run.name == LLM_RUN_NAME
+        assert new_run.run_type == "llm"
+        assert new_run.parent_run_id == subagent_run.id
+        assert new_run.outputs == {
+            "content": [{"type": "text", "text": "done"}],
+            "role": "assistant",
+        }
+
+    def test_skips_already_seen_message_ids(self, tmp_path):
+        import json
+
+        from langsmith.integrations.claude_agent_sdk._client import TurnLifecycle
+        from langsmith.integrations.claude_agent_sdk._transcripts import (
+            LLM_RUN_NAME,
+            reconcile_from_transcripts,
+        )
+
+        parent = _make_parent_run()
+        subagent_run = parent.create_child(
+            name="foo",
+            run_type="chain",
+        )
+
+        transcript = tmp_path / "subagent.jsonl"
+        lines = [
+            {
+                "type": "assistant",
+                "message": {
+                    "id": "msg_already_seen",
+                    "model": "claude-haiku-4-5-20251001",
+                    "content": [{"type": "text", "text": "hi"}],
+                    "stop_reason": "end_turn",
+                    "usage": {"input_tokens": 50, "output_tokens": 2},
+                },
+            },
+        ]
+        transcript.write_text("\n".join(json.dumps(entry) for entry in lines))
+
+        tracker = TurnLifecycle()
+        existing_run = parent.create_child(
+            name=LLM_RUN_NAME,
+            run_type="llm",
+        )
+        tracker.llm_runs_by_message_id["msg_already_seen"] = existing_run
+
+        _hooks_module._default_session.subagent_transcript_paths.append(
+            (str(transcript), subagent_run)
+        )
+
+        reconcile_from_transcripts(tracker)
+
+        # Should still be the same run, not replaced
+        assert tracker.llm_runs_by_message_id["msg_already_seen"] is existing_run
+
+
+class TestSessionBinding:
+    """Small unit guard for hooks bound to a client SessionState."""
+
+    def test_bound_hook_uses_client_session(self):
+        import asyncio
+        import contextvars
+
+        from langsmith.integrations.claude_agent_sdk._client import (
+            _bind_hook_to_session,
+        )
+        from langsmith.integrations.claude_agent_sdk._hooks import (
+            SessionState,
+            _set_session_root,
+            pre_tool_use_hook,
+        )
+
+        parent_run = _make_parent_run()
+        session = SessionState()
+        _set_session_root(session, parent_run)
+        bound_hook = _bind_hook_to_session(pre_tool_use_hook, session)
+
+        contextvars.Context().run(
+            lambda: asyncio.run(
+                bound_hook(
+                    {"tool_name": "Bash", "tool_input": {"command": "echo hi"}},
+                    "tool_bound_session",
+                    MagicMock(),
+                )
+            )
+        )
+
+        assert "tool_bound_session" in session.active_tool_runs
+        assert len(_hooks_module._default_session.active_tool_runs) == 0
+
+    def test_bound_tool_handler_uses_client_session(self):
+        from langsmith._internal import _context
+        from langsmith.integrations.claude_agent_sdk._client import _wrap_tool_handler
+        from langsmith.integrations.claude_agent_sdk._hooks import SessionState
+
+        session = SessionState()
+        tool_run = _make_parent_run().create_child(name="get_weather", run_type="tool")
+        session.active_tool_runs["tool_1"] = (tool_run, 0.0)
+        seen_parent = None
+
+        async def handler(args):
+            nonlocal seen_parent
+            parent_ref = _context._PARENT_RUN_TREE_REF.get()
+            seen_parent = parent_ref() if parent_ref else None
+            return {"ok": args["ok"]}
+
+        wrapped = _wrap_tool_handler(handler, session)
+        result = asyncio.run(wrapped({"ok": True}))
+
+        assert result == {"ok": True}
+        assert seen_parent is tool_run
+
+    def test_unbound_tool_handler_finds_registered_session_by_args(self):
+        from langsmith._internal import _context
+        from langsmith.integrations.claude_agent_sdk._client import _wrap_tool_handler
+        from langsmith.integrations.claude_agent_sdk._hooks import (
+            SessionState,
+            _register_session,
+            _unregister_session,
+        )
+
+        session = SessionState()
+        tool_run = _make_parent_run().create_child(
+            name="mcp__weather__get_weather",
+            run_type="tool",
+            inputs={"input": {"city": "SF"}},
+        )
+        session.active_tool_runs["tool_1"] = (tool_run, 0.0)
+        token = _register_session(session)
+        seen_parent = None
+
+        async def handler(args):
+            nonlocal seen_parent
+            parent_ref = _context._PARENT_RUN_TREE_REF.get()
+            seen_parent = parent_ref() if parent_ref else None
+            return {"ok": True}
+
+        try:
+            wrapped = _wrap_tool_handler(handler, tool_name="get_weather")
+            result = asyncio.run(wrapped({"city": "SF"}))
+        finally:
+            _unregister_session(session, token)
+
+        assert result == {"ok": True}
+        assert seen_parent is tool_run
+
+
+class TestStreamExceptionPropagation:
+    """Exceptions from the SDK generator must propagate to the caller.
+
+    Previously, ``_traced_receive_response`` swallowed all exceptions in a
+    bare ``except Exception: logger.exception(...)`` block, so SDK errors
+    (network failures, API errors, etc.) were silently dropped and the
+    caller's ``async for`` loop exited normally without any error.
+    """
+
+    @staticmethod
+    def _make_fake_sdk_client_class(stream_events, raise_after=None):
+        """Return a minimal SDK-client class whose receive_response yields
+        ``stream_events`` and then optionally raises ``raise_after``."""
+
+        class FakeSdkClient:
+            def __init__(self):
+                self.options = None
+
+            async def receive_response(self):
+                for evt in stream_events:
+                    yield evt
+                if raise_after is not None:
+                    raise raise_after
+
+            async def query(self, *args, **kwargs):
+                pass
+
+        return FakeSdkClient
+
+    @staticmethod
+    @asynccontextmanager
+    async def _no_op_trace(**kwargs):
+        """A no-op stand-in for ``langsmith.run_helpers.trace``."""
+        run = MagicMock()
+        run.inputs = {}
+        run.metadata = {}
+        run.extra = {}
+        run.end = MagicMock()
+        run.patch = MagicMock()
+        try:
+            yield run
+        except Exception:
+            run.end(error="error")
+            raise
+
+    def test_sdk_exception_propagates_to_caller(self):
+        """RuntimeError from the SDK stream must reach the caller."""
+        from langsmith.integrations.claude_agent_sdk._client import (
+            instrument_claude_client,
+        )
+
+        sdk_error = RuntimeError("SDK network failure")
+        FakeSdkClient = self._make_fake_sdk_client_class([], raise_after=sdk_error)
+
+        with patch(
+            "langsmith.integrations.claude_agent_sdk._client.trace",
+            side_effect=self._no_op_trace,
+        ):
+            instrument_claude_client(FakeSdkClient)
+            client = FakeSdkClient()
+            client._ls_prompt = "hello"
+            client._ls_start_time = None
+            client._ls_streamed_input = None
+
+            async def _run():
+                async for _ in client.receive_response():
+                    pass
+
+            with pytest.raises(RuntimeError, match="SDK network failure"):
+                asyncio.run(_run())
+
+    def test_sdk_exception_propagates_after_partial_stream(self):
+        """Caller sees the error even when some messages were already yielded."""
+        from langsmith.integrations.claude_agent_sdk._client import (
+            instrument_claude_client,
+        )
+
+        received = []
+        sdk_error = ValueError("stream cut off mid-way")
+
+        class _UserMsg:
+            parent_tool_use_id = None
+            content = []
+
+        FakeSdkClient = self._make_fake_sdk_client_class(
+            [_UserMsg(), _UserMsg()], raise_after=sdk_error
+        )
+
+        with patch(
+            "langsmith.integrations.claude_agent_sdk._client.trace",
+            side_effect=self._no_op_trace,
+        ):
+            instrument_claude_client(FakeSdkClient)
+            client = FakeSdkClient()
+            client._ls_prompt = "hi"
+            client._ls_start_time = None
+            client._ls_streamed_input = None
+
+            async def _run():
+                async for msg in client.receive_response():
+                    received.append(msg)
+
+            with pytest.raises(ValueError, match="stream cut off mid-way"):
+                asyncio.run(_run())
+
+        assert len(received) == 2


### PR DESCRIPTION
## Summary

`_traced_receive_response` wraps the SDK event loop in a bare
`except Exception: logger.exception(...)` with **no `raise`**.  Any
exception from the underlying `_orig_receive_response` generator—network
errors, API failures, rate-limit hits, `claude_agent_sdk` internal
errors—is silently swallowed, so:

- the caller's `async for` loop exits **without raising**;
- the LangSmith trace records the run as **successful** (no error state);
- retry / error-handling logic in calling code **can never trigger**.

## Change

`python/langsmith/integrations/claude_agent_sdk/_client.py`

```diff
         except Exception:
             logger.exception("Error while tracing Claude Agent stream")
+            raise
```

One line.  The `raise` lets the exception:

1. propagate through the `finally`-block cleanup (tracker, sessions), and
2. reach `trace().__aexit__`, which calls `run.end(error=tb)` and
   patches the run—so the trace is recorded as errored, not successful.

## Tests

Two new regression tests in
`python/tests/unit_tests/wrappers/test_claude_agent_sdk_hooks.py`
(`TestStreamExceptionPropagation`):

- `test_sdk_exception_propagates_to_caller` — empty stream, error on first tick
- `test_sdk_exception_propagates_after_partial_stream` — two events delivered, then error

Both confirm the exception reaches the caller and (in the partial case) that already-yielded events were still received.

## Test plan

- [x] `pytest python/tests/unit_tests/wrappers/test_claude_agent_sdk_hooks.py` — all 20 tests pass
- [x] New tests fail on the unpatched code, pass with the fix