### PR TITLE
feat(client): shared-run accessor +  runs.share and public.runs itg tests

### DIFF
--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -82,6 +82,7 @@ import { Sandboxes } from "./_openapi_client/resources/sandboxes/sandboxes.js";
 import { Datasets } from "./_openapi_client/resources/datasets/datasets.js";
 import { Threads } from "./_openapi_client/resources/threads.js";
 import { Traces } from "./_openapi_client/resources/traces.js";
+import { Public } from "./_openapi_client/resources/public/public.js";
 import { assertUuid } from "./utils/_uuid.js";
 import { warnOnce } from "./utils/warn.js";
 import { _MIN_BACKEND_VERSION } from "./utils/constants.js";
@@ -1501,6 +1502,11 @@ export class Client implements LangSmithTracingClientInterface {
   /** Access the traces resource (query, listRuns). */
   public get traces(): Traces {
     return this.openAPIClient.traces;
+  }
+
+  /** Access the public shared-run resource (runs.retrieve, runs.query). */
+  public get public(): Public {
+    return this.openAPIClient.public;
   }
 
   private async processInputs(inputs: KVMap): Promise<KVMap> {

--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -1504,7 +1504,7 @@ export class Client implements LangSmithTracingClientInterface {
     return this.openAPIClient.traces;
   }
 
-  /** Access the public shared-run resource (runs.retrieve, runs.query). */
+  /** Access the public shared-run resource. */
   public get public(): Public {
     return this.openAPIClient.public;
   }

--- a/js/src/tests/public_runs.int.test.ts
+++ b/js/src/tests/public_runs.int.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Smoke integration tests for the v2 public.runs resource.
+ *
+ * Covers `Client.public.runs` (retrieve, query) against a live backend. Public
+ * shared-run reads are authenticated by the share token in the path; the
+ * client's API key is used only to mint that token via runs.share.create.
+ */
+import { Client } from "../client.js";
+import { v4 as uuidv4 } from "../utils/uuid/src/index.js";
+import { deleteProject, pollRunsUntilCount, waitUntil } from "./utils.js";
+
+// Public run fields to request; START_TIME is needed as the retrieve coordinate.
+const SELECTS: Array<"ID" | "NAME" | "RUN_TYPE" | "STATUS" | "START_TIME"> = [
+  "ID",
+  "NAME",
+  "RUN_TYPE",
+  "STATUS",
+  "START_TIME",
+];
+
+async function setUpSharedRun(client: Client) {
+  const projectName = `__test_v2_public_runs_${uuidv4().slice(0, 12)}`;
+  if (await client.hasProject({ projectName })) {
+    await deleteProject(client, projectName);
+  }
+
+  const runId = uuidv4();
+  const now = new Date();
+  await client.createRun({
+    id: runId,
+    name: "run_1",
+    inputs: { i: 1 },
+    run_type: "llm",
+    project_name: projectName,
+    start_time: now.getTime(),
+  });
+  await pollRunsUntilCount(client, projectName, 1, 30_000);
+
+  const run = await client.readRun(runId);
+  const project = await client.readProject({ projectName });
+  const traceId = run.trace_id ?? runId;
+
+  let shareToken: string | undefined;
+  // share.create resolves the trace root from SmithDB, which may lag indexing.
+  await waitUntil(
+    async () => {
+      const resp = await client.runs.share.create(runId, {
+        session_id: project.id,
+        trace_id: traceId,
+      });
+      shareToken = resp.share_token;
+      return !!shareToken;
+    },
+    90_000,
+    3_000,
+  );
+  if (!shareToken) throw new Error("share.create did not return a share_token");
+
+  return { projectName, runId, projectId: project.id, shareToken };
+}
+
+test("public.runs.query returns the shared trace's runs by share token", async () => {
+  const client = new Client({
+    autoBatchTracing: false,
+    callerOptions: { maxRetries: 6 },
+  });
+  const { projectName, runId, shareToken } = await setUpSharedRun(client);
+  try {
+    let found = false;
+    await waitUntil(
+      async () => {
+        const page = await client.public.runs.query(shareToken, {
+          selects: SELECTS,
+        });
+        found = (page.items ?? []).some((i) => i.id === runId);
+        return found;
+      },
+      90_000,
+      3_000,
+    );
+    expect(found).toBe(true);
+  } finally {
+    await deleteProject(client, projectName);
+  }
+});
+
+test("public.runs.retrieve returns a single run by share token, id, start_time", async () => {
+  const client = new Client({
+    autoBatchTracing: false,
+    callerOptions: { maxRetries: 6 },
+  });
+  const { projectName, runId, shareToken } = await setUpSharedRun(client);
+  try {
+    let retrievedId: string | undefined;
+    await waitUntil(
+      async () => {
+        // Derive the exact start_time coordinate from the public read path
+        // itself, so it matches what the backend stored (retrieve is a point
+        // lookup).
+        const page = await client.public.runs.query(shareToken, {
+          selects: SELECTS,
+        });
+        const item = (page.items ?? []).find((i) => i.id === runId);
+        if (!item?.start_time) return false;
+        const run = await client.public.runs.retrieve(runId, {
+          share_token: shareToken,
+          selects: SELECTS,
+          start_time: item.start_time,
+        });
+        retrievedId = run.id;
+        return retrievedId === runId;
+      },
+      90_000,
+      3_000,
+    );
+    expect(retrievedId).toBe(runId);
+  } finally {
+    await deleteProject(client, projectName);
+  }
+});

--- a/js/src/tests/runs_share.int.test.ts
+++ b/js/src/tests/runs_share.int.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Smoke integration tests for the v2 runs.share resource.
+ *
+ * Covers `Client.runs.share` (create, delete) against a live backend.
+ */
+import { Client } from "../client.js";
+import { v4 as uuidv4 } from "../utils/uuid/src/index.js";
+import { deleteProject, pollRunsUntilCount, waitUntil } from "./utils.js";
+
+async function setUpProjectWithRun(client: Client) {
+  const projectName = `__test_v2_runs_share_${uuidv4().slice(0, 12)}`;
+  if (await client.hasProject({ projectName })) {
+    await deleteProject(client, projectName);
+  }
+
+  const runId = uuidv4();
+  const now = new Date();
+  await client.createRun({
+    id: runId,
+    name: "run_1",
+    inputs: { i: 1 },
+    run_type: "llm",
+    project_name: projectName,
+    start_time: now.getTime(),
+  });
+  await pollRunsUntilCount(client, projectName, 1, 30_000);
+
+  const run = await client.readRun(runId);
+  const project = await client.readProject({ projectName });
+  return {
+    projectName,
+    runId,
+    traceId: run.trace_id ?? runId,
+    projectId: project.id,
+  };
+}
+
+test("runs.share.create mints a share token for a run's trace root", async () => {
+  const client = new Client({
+    autoBatchTracing: false,
+    callerOptions: { maxRetries: 6 },
+  });
+  const { projectName, runId, traceId, projectId } =
+    await setUpProjectWithRun(client);
+  try {
+    let shareToken: string | undefined;
+    // share.create resolves the trace root from SmithDB, which may lag indexing.
+    await waitUntil(
+      async () => {
+        const resp = await client.runs.share.create(runId, {
+          session_id: projectId,
+          trace_id: traceId,
+        });
+        shareToken = resp.share_token;
+        return !!shareToken;
+      },
+      90_000,
+      3_000,
+    );
+    expect(shareToken).toBeDefined();
+    expect(typeof shareToken).toBe("string");
+  } finally {
+    await deleteProject(client, projectName);
+  }
+});
+
+test("runs.share.delete removes the share token and is idempotent", async () => {
+  const client = new Client({
+    autoBatchTracing: false,
+    callerOptions: { maxRetries: 6 },
+  });
+  const { projectName, runId, traceId, projectId } =
+    await setUpProjectWithRun(client);
+  try {
+    await waitUntil(
+      async () => {
+        const resp = await client.runs.share.create(runId, {
+          session_id: projectId,
+          trace_id: traceId,
+        });
+        return !!resp.share_token;
+      },
+      90_000,
+      3_000,
+    );
+
+    // Delete resolves (204) and is idempotent: a second delete also succeeds.
+    // Success is "does not reject".
+    await client.runs.share.delete(traceId, { session_id: projectId });
+    await client.runs.share.delete(traceId, { session_id: projectId });
+  } finally {
+    await deleteProject(client, projectName);
+  }
+});

--- a/python/langsmith/async_client.py
+++ b/python/langsmith/async_client.py
@@ -344,7 +344,7 @@ class AsyncClient:
 
     @property
     def public(self) -> AsyncPublicResource:
-        """Access the public shared-run resource (runs.retrieve, runs.query)."""
+        """Access the public shared-run resource."""
         return self._langsmith_api.public
 
     async def __aenter__(self) -> AsyncClient:

--- a/python/langsmith/async_client.py
+++ b/python/langsmith/async_client.py
@@ -52,6 +52,9 @@ if TYPE_CHECKING:
     from langsmith._openapi_client.resources.online_evaluators import (
         AsyncOnlineEvaluatorsResource as AsyncEvaluatorsResource,
     )
+    from langsmith._openapi_client.resources.public.public import (
+        AsyncPublicResource,
+    )
     from langsmith._openapi_client.resources.sandboxes.sandboxes import (
         AsyncSandboxesResource,
     )
@@ -338,6 +341,11 @@ class AsyncClient:
     def traces(self) -> AsyncTracesResource:
         """Access the traces resource (query, list_runs)."""
         return self._langsmith_api.traces
+
+    @property
+    def public(self) -> AsyncPublicResource:
+        """Access the public shared-run resource (runs.retrieve, runs.query)."""
+        return self._langsmith_api.public
 
     async def __aenter__(self) -> AsyncClient:
         """Enter the async client."""

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -1529,7 +1529,7 @@ class Client:
 
     @property
     def public(self) -> AsyncPublicResource:
-        """Access the public shared-run resource (runs.retrieve, runs.query)."""
+        """Access the public shared-run resource."""
         _check_backend_version(self.info.version)
         return self._get_langsmith_api().public
 

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -272,6 +272,9 @@ if TYPE_CHECKING:
     from langsmith._openapi_client.resources.online_evaluators import (
         AsyncOnlineEvaluatorsResource as AsyncEvaluatorsResource,
     )
+    from langsmith._openapi_client.resources.public.public import (
+        AsyncPublicResource,
+    )
     from langsmith._openapi_client.resources.runs import AsyncRunsResource
     from langsmith._openapi_client.resources.sandboxes.sandboxes import (
         AsyncSandboxesResource,
@@ -1523,6 +1526,12 @@ class Client:
         """Access the traces resource (query, list_runs)."""
         _check_backend_version(self.info.version)
         return self._get_langsmith_api().traces
+
+    @property
+    def public(self) -> AsyncPublicResource:
+        """Access the public shared-run resource (runs.retrieve, runs.query)."""
+        _check_backend_version(self.info.version)
+        return self._get_langsmith_api().public
 
     def _dump_failed_trace(
         self,

--- a/python/tests/integration_tests/test_v2_public_runs.py
+++ b/python/tests/integration_tests/test_v2_public_runs.py
@@ -1,0 +1,151 @@
+"""Smoke integration tests for the v2 public.runs resource.
+
+Covers ``Client.public.runs`` (retrieve, query) against a live backend. Public
+shared-run reads are authenticated by the share token in the path; the client's
+API key is created only to mint that token via ``runs.share.create``.
+"""
+
+import datetime
+import logging
+import time
+from typing import Any, Callable
+
+import pytest
+
+from langsmith import uuid7
+from langsmith.client import Client
+from langsmith.utils import get_env_var
+
+logger = logging.getLogger(__name__)
+
+# Public run fields to request; START_TIME is needed as the retrieve coordinate.
+_SELECTS = ["ID", "NAME", "RUN_TYPE", "STATUS", "START_TIME"]
+
+
+def _wait_for_sync(
+    condition: Callable[[], bool],
+    max_sleep_time: int = 60,
+    sleep_time: int = 3,
+) -> None:
+    start = time.time()
+    while time.time() - start < max_sleep_time:
+        try:
+            if condition():
+                return
+        except Exception:
+            logger.debug("Error checking sync condition", exc_info=True)
+        time.sleep(sleep_time)
+    raise ValueError(f"Condition not met within {max_sleep_time}s")
+
+
+async def _wait_for_async(
+    condition: Callable[[], Any],
+    max_sleep_time: int = 60,
+    sleep_time: int = 3,
+) -> Any:
+    """Poll `condition` until it returns a truthy value, then return it."""
+    start = time.time()
+    while time.time() - start < max_sleep_time:
+        try:
+            result = await condition()
+            if result:
+                return result
+        except Exception:
+            logger.debug("Error checking async condition", exc_info=True)
+        time.sleep(sleep_time)
+    raise ValueError(f"Condition not met within {max_sleep_time}s")
+
+
+@pytest.fixture
+def langchain_client() -> Client:
+    get_env_var.cache_clear()
+    return Client()
+
+
+@pytest.fixture
+async def shared_run(langchain_client: Client):
+    """Create a project with one root run and share it.
+
+    Yields a dict with run_id, project_id, and share_token.
+    """
+    project_name = f"__test_v2_public_runs_{uuid7().hex[:12]}"
+    if langchain_client.has_project(project_name=project_name):
+        langchain_client.delete_project(project_name=project_name)
+
+    run_id = str(uuid7())
+    now = datetime.datetime.now(datetime.timezone.utc)
+    langchain_client.create_run(
+        id=run_id,
+        name="run_1",
+        inputs={"i": 1},
+        run_type="llm",
+        project_name=project_name,
+        start_time=now,
+    )
+
+    def _run_indexed() -> bool:
+        return (
+            next(langchain_client.list_runs(project_name=project_name, limit=1), None)
+            is not None
+        )
+
+    _wait_for_sync(_run_indexed, max_sleep_time=90, sleep_time=2)
+
+    run = langchain_client.read_run(run_id)
+    project = langchain_client.read_project(project_name=project_name)
+    project_id = str(project.id)
+    trace_id = str(run.trace_id) if run.trace_id else run_id
+
+    async def _create_share():
+        return await langchain_client.runs.share.create(
+            run_id, session_id=project_id, trace_id=trace_id
+        )
+
+    # share.create resolves the trace root from SmithDB, which may lag indexing.
+    resp = await _wait_for_async(_create_share, max_sleep_time=90)
+
+    try:
+        yield {
+            "run_id": run_id,
+            "project_id": project_id,
+            "share_token": resp.share_token,
+        }
+    finally:
+        if langchain_client.has_project(project_name=project_name):
+            langchain_client.delete_project(project_name=project_name)
+
+
+async def test_public_runs_query(langchain_client: Client, shared_run) -> None:
+    """public.runs.query() returns the shared trace's runs by share token."""
+    share_token = shared_run["share_token"]
+    run_id = shared_run["run_id"]
+
+    async def _ready():
+        page = await langchain_client.public.runs.query(share_token, selects=_SELECTS)
+        return page if any(str(i.id) == run_id for i in page.items) else None
+
+    page = await _wait_for_async(_ready, max_sleep_time=90)
+    assert run_id in {str(i.id) for i in page.items}
+
+
+async def test_public_runs_retrieve(langchain_client: Client, shared_run) -> None:
+    """public.runs.retrieve() returns a single run by (share token, id, start_time)."""
+    share_token = shared_run["share_token"]
+    run_id = shared_run["run_id"]
+
+    async def _retrieve():
+        # Derive the exact start_time coordinate from the public read path itself,
+        # so it matches whatever the backend stored (retrieve is a point lookup).
+        page = await langchain_client.public.runs.query(share_token, selects=_SELECTS)
+        item = next((i for i in page.items if str(i.id) == run_id), None)
+        if item is None or item.start_time is None:
+            return None
+        return await langchain_client.public.runs.retrieve(
+            run_id,
+            share_token=share_token,
+            selects=_SELECTS,
+            start_time=item.start_time,
+        )
+
+    run = await _wait_for_async(_retrieve, max_sleep_time=90)
+    assert str(run.id) == run_id

--- a/python/tests/integration_tests/test_v2_runs_share.py
+++ b/python/tests/integration_tests/test_v2_runs_share.py
@@ -1,0 +1,141 @@
+"""Smoke integration tests for the v2 runs.share resource.
+
+Covers ``Client.runs.share`` (create, delete) against a live backend.
+"""
+
+import datetime
+import logging
+import time
+import uuid
+from typing import Any, Callable
+
+import pytest
+
+from langsmith import uuid7
+from langsmith.client import Client
+from langsmith.utils import get_env_var
+
+logger = logging.getLogger(__name__)
+
+
+def _wait_for_sync(
+    condition: Callable[[], bool],
+    max_sleep_time: int = 60,
+    sleep_time: int = 3,
+) -> None:
+    start = time.time()
+    while time.time() - start < max_sleep_time:
+        try:
+            if condition():
+                return
+        except Exception:
+            logger.debug("Error checking sync condition", exc_info=True)
+        time.sleep(sleep_time)
+    raise ValueError(f"Condition not met within {max_sleep_time}s")
+
+
+async def _wait_for_async(
+    condition: Callable[[], Any],
+    max_sleep_time: int = 60,
+    sleep_time: int = 3,
+) -> Any:
+    """Poll `condition` until it returns a truthy value, then return it."""
+    start = time.time()
+    while time.time() - start < max_sleep_time:
+        try:
+            result = await condition()
+            if result:
+                return result
+        except Exception:
+            logger.debug("Error checking async condition", exc_info=True)
+        time.sleep(sleep_time)
+    raise ValueError(f"Condition not met within {max_sleep_time}s")
+
+
+@pytest.fixture
+def langchain_client() -> Client:
+    get_env_var.cache_clear()
+    return Client()
+
+
+@pytest.fixture
+def project_with_run(langchain_client: Client):
+    """Create a project with one root run.
+
+    Yields a dict with run_id, trace_id, and project_id (== session_id).
+    """
+    project_name = f"__test_v2_runs_share_{uuid7().hex[:12]}"
+    if langchain_client.has_project(project_name=project_name):
+        langchain_client.delete_project(project_name=project_name)
+
+    run_id = str(uuid7())
+    now = datetime.datetime.now(datetime.timezone.utc)
+    langchain_client.create_run(
+        id=run_id,
+        name="run_1",
+        inputs={"i": 1},
+        run_type="llm",
+        project_name=project_name,
+        start_time=now,
+    )
+
+    def _run_indexed() -> bool:
+        return (
+            next(langchain_client.list_runs(project_name=project_name, limit=1), None)
+            is not None
+        )
+
+    _wait_for_sync(_run_indexed, max_sleep_time=90, sleep_time=2)
+
+    run = langchain_client.read_run(run_id)
+    project = langchain_client.read_project(project_name=project_name)
+    trace_id = str(run.trace_id) if run.trace_id else run_id
+    try:
+        yield {
+            "run_id": run_id,
+            "trace_id": trace_id,
+            "project_id": str(project.id),
+        }
+    finally:
+        if langchain_client.has_project(project_name=project_name):
+            langchain_client.delete_project(project_name=project_name)
+
+
+async def test_runs_share_create(langchain_client: Client, project_with_run) -> None:
+    """runs.share.create() mints a valid share token for a run's trace root."""
+    run = project_with_run
+
+    async def _create():
+        return await langchain_client.runs.share.create(
+            run["run_id"],
+            session_id=run["project_id"],
+            trace_id=run["trace_id"],
+        )
+
+    # share.create resolves the trace root from SmithDB, which may lag indexing.
+    resp = await _wait_for_async(_create, max_sleep_time=90)
+    # Raises ValueError if the token is not a valid UUID.
+    assert uuid.UUID(resp.share_token)
+
+
+async def test_runs_share_delete(langchain_client: Client, project_with_run) -> None:
+    """runs.share.delete() removes the share token and is idempotent."""
+    run = project_with_run
+
+    async def _create():
+        return await langchain_client.runs.share.create(
+            run["run_id"],
+            session_id=run["project_id"],
+            trace_id=run["trace_id"],
+        )
+
+    await _wait_for_async(_create, max_sleep_time=90)
+
+    # Delete returns None (204) and is idempotent: a second delete also
+    # succeeds. Success is "does not raise".
+    await langchain_client.runs.share.delete(
+        run["trace_id"], session_id=run["project_id"]
+    )
+    await langchain_client.runs.share.delete(
+        run["trace_id"], session_id=run["project_id"]
+    )


### PR DESCRIPTION
## Description

Exposes the generated OpenAPI v2 `public` resource on the langsmith clients and
adds live-backend integration tests for the v2 `runs.share` and `public.runs`
resources.

The `public.runs` (retrieve/query) and `runs.share` (create/delete) resources
already existed in the vendored `_openapi_client`; `runs.share` was already
reachable via `client.runs.share`, but `public` had no top-level accessor. This
PR adds only the thin `public` wrapper accessor and the tests - no generated
`_openapi_client` code is modified.

### Accessor

- **Python `Client`** (`client.py`): adds `public -> AsyncPublicResource`, with
  the standard `_check_backend_version` check, consistent with the existing
  `runs`/`threads`/`traces` accessors.
- **Python `AsyncClient`** (`async_client.py`): adds `public -> AsyncPublicResource`
  (no per-call version check, matching the other async accessors + the imports).
- **JS `Client`** (`client.ts`): adds `get public(): Public`.

### Integration tests

- **Python**: `test_v2_runs_share.py` (`runs.share.create`, `runs.share.delete`)
  and `test_v2_public_runs.py` (`public.runs.query`, `public.runs.retrieve`).
- **JS**: `runs_share.int.test.ts` and `public_runs.int.test.ts` covering the
  same four methods.

Each test creates a throwaway `__test_v2_*` project + root run, mints a share
token via `runs.share.create`, reads it back through the share-token-scoped
`public.runs` endpoints, and deletes the project in cleanup — mirroring the
existing `test_v2_*` conventions (self-contained `langchain_client` fixture,
`_wait_for_*` / `waitUntil` retry wrappers for eventual consistency.

**Note**
Public sharing must be enabled for the org for the tests to pass