### PR TITLE
feat(py,js): Expose method for calculating replica ids and add concept of a primary replica

### DIFF
--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -20,7 +20,11 @@ export { overrideFetchImplementation } from "./singletons/fetch.js";
 
 export { getDefaultProjectName } from "./utils/project.js";
 
-export { computeRunIdForReplica, uuid7, uuid7FromTime } from "./uuid.js";
+export {
+  computeRunIdForSecondaryReplica,
+  uuid7,
+  uuid7FromTime,
+} from "./uuid.js";
 
 export { isTracingEnabled } from "./utils/guard.js";
 

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -14,7 +14,7 @@ export type {
   RetrieverOutput,
 } from "./schemas.js";
 
-export { RunTree, type RunTreeConfig } from "./run_trees.js";
+export { RunTree, type RunTreeConfig, type WriteReplica } from "./run_trees.js";
 
 export { overrideFetchImplementation } from "./singletons/fetch.js";
 

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -20,7 +20,7 @@ export { overrideFetchImplementation } from "./singletons/fetch.js";
 
 export { getDefaultProjectName } from "./utils/project.js";
 
-export { uuid7, uuid7FromTime } from "./uuid.js";
+export { computeRunIdForReplica, uuid7, uuid7FromTime } from "./uuid.js";
 
 export { isTracingEnabled } from "./utils/guard.js";
 

--- a/js/src/run_trees.ts
+++ b/js/src/run_trees.ts
@@ -24,10 +24,8 @@ import {
 import { getDefaultProjectName } from "./utils/project.js";
 import { getLangSmithEnvironmentVariable } from "./utils/env.js";
 import { warnOnce } from "./utils/warn.js";
-import {
-  uuid7FromTime,
-  nonCryptographicUuid7Deterministic,
-} from "./utils/_uuid.js";
+import { uuid7FromTime } from "./utils/_uuid.js";
+import { computeRunIdForReplica } from "./uuid.js";
 import { v5 as uuidv5 } from "./utils/uuid/src/index.js";
 
 const TIMESTAMP_LENGTH = 36;
@@ -729,19 +727,16 @@ export class RunTree implements BaseRun {
       }
     }
 
-    // Remap IDs for the replica using nonCryptographicUuid7Deterministic
+    // Remap IDs for the replica using the public replica ID helper
     // This ensures consistency across runs in the same replica while
     // preserving UUID7 properties (time-ordering, monotonicity)
     const oldId = baseRun.id;
-    const newId = nonCryptographicUuid7Deterministic(oldId, projectName);
+    const newId = computeRunIdForReplica(oldId, projectName);
 
     // Remap trace_id
     let newTraceId: string;
     if (baseRun.trace_id) {
-      newTraceId = nonCryptographicUuid7Deterministic(
-        baseRun.trace_id,
-        projectName,
-      );
+      newTraceId = computeRunIdForReplica(baseRun.trace_id, projectName);
     } else {
       newTraceId = newId;
     }
@@ -749,10 +744,7 @@ export class RunTree implements BaseRun {
     // Remap parent_run_id
     let newParentId: string | undefined;
     if (baseRun.parent_run_id) {
-      newParentId = nonCryptographicUuid7Deterministic(
-        baseRun.parent_run_id,
-        projectName,
-      );
+      newParentId = computeRunIdForReplica(baseRun.parent_run_id, projectName);
     }
 
     // Remap dotted_order segments
@@ -762,10 +754,7 @@ export class RunTree implements BaseRun {
       const remappedSegs = segs.map((seg) => {
         // Extract the UUID from the segment (last TIMESTAMP_LENGTH characters)
         const segId = seg.slice(-TIMESTAMP_LENGTH);
-        const remappedId = nonCryptographicUuid7Deterministic(
-          segId,
-          projectName,
-        );
+        const remappedId = computeRunIdForReplica(segId, projectName);
         // Replace the UUID part while keeping the timestamp prefix
         return seg.slice(0, -TIMESTAMP_LENGTH) + remappedId;
       });

--- a/js/src/run_trees.ts
+++ b/js/src/run_trees.ts
@@ -24,8 +24,10 @@ import {
 import { getDefaultProjectName } from "./utils/project.js";
 import { getLangSmithEnvironmentVariable } from "./utils/env.js";
 import { warnOnce } from "./utils/warn.js";
-import { uuid7FromTime } from "./utils/_uuid.js";
-import { computeRunIdForReplica } from "./uuid.js";
+import {
+  uuid7FromTime,
+  nonCryptographicUuid7Deterministic,
+} from "./utils/_uuid.js";
 import { v5 as uuidv5 } from "./utils/uuid/src/index.js";
 
 const TIMESTAMP_LENGTH = 36;
@@ -155,11 +157,13 @@ interface HeadersLike {
 }
 
 type ProjectReplica = [string, KVMap | undefined];
-type WriteReplica = {
+export type WriteReplica = {
   apiUrl?: string;
   apiKey?: string;
   workspaceId?: string;
   projectName?: string;
+  /** Whether this replica keeps the original run IDs. */
+  primary?: boolean;
   updates?: KVMap | undefined;
   fromEnv?: boolean;
   reroot?: boolean;
@@ -622,6 +626,7 @@ export class RunTree implements BaseRun {
 
   private _remapForProject(params: {
     projectName: string;
+    primary?: boolean;
     runtimeEnv?: RuntimeEnvironment;
     excludeChildRuns?: boolean;
     reroot?: boolean;
@@ -632,6 +637,7 @@ export class RunTree implements BaseRun {
   }): RunCreate & { id: string } {
     const {
       projectName,
+      primary,
       runtimeEnv,
       excludeChildRuns = true,
       reroot = false,
@@ -642,8 +648,8 @@ export class RunTree implements BaseRun {
     } = params;
     const baseRun = this._convertToCreate(this, runtimeEnv, excludeChildRuns);
 
-    // Skip remapping if project name is the same
-    if (projectName === this.project_name) {
+    // Preserve legacy behavior when `primary` is omitted.
+    if (primary === undefined && projectName === this.project_name) {
       return {
         ...baseRun,
         session_name: projectName,
@@ -727,16 +733,26 @@ export class RunTree implements BaseRun {
       }
     }
 
-    // Remap IDs for the replica using the public replica ID helper
+    if (primary) {
+      return {
+        ...baseRun,
+        session_name: projectName,
+      };
+    }
+
+    // Remap IDs for the replica using nonCryptographicUuid7Deterministic
     // This ensures consistency across runs in the same replica while
     // preserving UUID7 properties (time-ordering, monotonicity)
     const oldId = baseRun.id;
-    const newId = computeRunIdForReplica(oldId, projectName);
+    const newId = nonCryptographicUuid7Deterministic(oldId, projectName);
 
     // Remap trace_id
     let newTraceId: string;
     if (baseRun.trace_id) {
-      newTraceId = computeRunIdForReplica(baseRun.trace_id, projectName);
+      newTraceId = nonCryptographicUuid7Deterministic(
+        baseRun.trace_id,
+        projectName,
+      );
     } else {
       newTraceId = newId;
     }
@@ -744,7 +760,10 @@ export class RunTree implements BaseRun {
     // Remap parent_run_id
     let newParentId: string | undefined;
     if (baseRun.parent_run_id) {
-      newParentId = computeRunIdForReplica(baseRun.parent_run_id, projectName);
+      newParentId = nonCryptographicUuid7Deterministic(
+        baseRun.parent_run_id,
+        projectName,
+      );
     }
 
     // Remap dotted_order segments
@@ -754,7 +773,10 @@ export class RunTree implements BaseRun {
       const remappedSegs = segs.map((seg) => {
         // Extract the UUID from the segment (last TIMESTAMP_LENGTH characters)
         const segId = seg.slice(-TIMESTAMP_LENGTH);
-        const remappedId = computeRunIdForReplica(segId, projectName);
+        const remappedId = nonCryptographicUuid7Deterministic(
+          segId,
+          projectName,
+        );
         // Replace the UUID part while keeping the timestamp prefix
         return seg.slice(0, -TIMESTAMP_LENGTH) + remappedId;
       });
@@ -781,6 +803,7 @@ export class RunTree implements BaseRun {
       if (this.replicas && this.replicas.length > 0) {
         for (const {
           projectName,
+          primary,
           apiKey,
           apiUrl,
           workspaceId,
@@ -789,6 +812,7 @@ export class RunTree implements BaseRun {
         } of this.replicas) {
           const runCreate = this._remapForProject({
             projectName: projectName ?? this.project_name,
+            primary,
             runtimeEnv,
             excludeChildRuns: true,
             reroot,
@@ -832,6 +856,7 @@ export class RunTree implements BaseRun {
     if (this.replicas && this.replicas.length > 0) {
       for (const {
         projectName,
+        primary,
         apiKey,
         apiUrl,
         workspaceId,
@@ -841,6 +866,7 @@ export class RunTree implements BaseRun {
       } of this.replicas) {
         const runData = this._remapForProject({
           projectName: projectName ?? this.project_name,
+          primary,
           runtimeEnv: undefined,
           excludeChildRuns: true,
           reroot,
@@ -1172,10 +1198,19 @@ function _getWriteReplicasFromEnv(): WriteReplica[] {
           continue;
         }
 
+        if (item.primary !== undefined && typeof item.primary !== "boolean") {
+          console.warn(
+            `Invalid primary type in LANGSMITH_RUNS_ENDPOINTS: ` +
+              `expected boolean, got ${typeof item.primary}`,
+          );
+          continue;
+        }
+
         replicas.push({
           apiUrl: item.api_url.replace(/\/$/, ""),
           apiKey: item.api_key,
           projectName: item.project_name ?? undefined,
+          primary: item.primary ?? undefined,
         });
       }
       return replicas;
@@ -1220,19 +1255,21 @@ function _getWriteReplicasFromEnv(): WriteReplica[] {
 }
 
 function _ensureWriteReplicas(replicas?: Replica[]): WriteReplica[] {
-  // If null -> fetch from env
-  if (replicas) {
-    return replicas.map((replica) => {
-      if (Array.isArray(replica)) {
-        return {
-          projectName: replica[0],
-          updates: replica[1],
-        };
-      }
-      return replica;
-    });
+  const ensured = replicas
+    ? replicas.map((replica) => {
+        if (Array.isArray(replica)) {
+          return {
+            projectName: replica[0],
+            updates: replica[1],
+          };
+        }
+        return replica;
+      })
+    : _getWriteReplicasFromEnv();
+  if (ensured.filter((replica) => replica.primary === true).length > 1) {
+    throw new Error("Only one replica can be marked as primary.");
   }
-  return _getWriteReplicasFromEnv();
+  return ensured;
 }
 
 function _checkEndpointEnvUnset(parsed: Record<string, unknown>) {

--- a/js/src/run_trees.ts
+++ b/js/src/run_trees.ts
@@ -187,6 +187,9 @@ const HEADER_SAFE_REPLICA_FIELDS = new Set([
 function filterReplicaForHeaders(replica: WriteReplica): WriteReplica {
   const filtered: WriteReplica = {};
   for (const key of Object.keys(replica) as (keyof WriteReplica)[]) {
+    if (key === "primary" && typeof replica[key] !== "boolean") {
+      continue;
+    }
     if (HEADER_SAFE_REPLICA_FIELDS.has(key)) {
       (filtered as Record<string, unknown>)[key] = replica[key];
     }

--- a/js/src/run_trees.ts
+++ b/js/src/run_trees.ts
@@ -179,6 +179,7 @@ type Replica = ProjectReplica | WriteReplica;
 
 const HEADER_SAFE_REPLICA_FIELDS = new Set([
   "projectName",
+  "primary",
   "updates",
   "reroot",
 ]);

--- a/js/src/tests/replica_endpoints.test.ts
+++ b/js/src/tests/replica_endpoints.test.ts
@@ -236,6 +236,20 @@ describe("LANGSMITH_RUNS_ENDPOINTS Replica Testing", () => {
   });
 
   describe("RunTree Replicas", () => {
+    it("should reject multiple primary replicas", () => {
+      expect(
+        () =>
+          new RunTree({
+            name: "test-run",
+            inputs: {},
+            replicas: [
+              { projectName: "primary-1", primary: true },
+              { projectName: "primary-2", primary: true },
+            ],
+          }),
+      ).toThrow("Only one replica");
+    });
+
     it("should send traces to multiple replicas via RunTree", async () => {
       const endpointsConfig = {
         "https://primary.example.com": "primary-key",
@@ -339,11 +353,19 @@ describe("LANGSMITH_RUNS_ENDPOINTS Replica Testing", () => {
           api_url: "https://workspace1.example.com",
           api_key: "workspace1-key",
           project_name: "project-prod",
+          primary: true,
         },
         {
           api_url: "https://workspace2.example.com",
           api_key: "workspace2-key",
           project_name: "project-staging",
+          primary: false,
+        },
+        {
+          api_url: "https://invalid.example.com",
+          api_key: "invalid-key",
+          project_name: "invalid-project",
+          primary: "true",
         },
       ];
 
@@ -361,6 +383,11 @@ describe("LANGSMITH_RUNS_ENDPOINTS Replica Testing", () => {
         client,
         project_name: "fallback-project",
       });
+
+      expect(runTree.replicas?.map((replica) => replica.primary)).toEqual([
+        true,
+        false,
+      ]);
 
       await runTree.postRun();
 

--- a/js/src/tests/run_trees.test.ts
+++ b/js/src/tests/run_trees.test.ts
@@ -5,7 +5,7 @@ import { Client } from "../client.js";
 import { RunTree } from "../run_trees.js";
 import { getCurrentRunTree, withRunTree } from "../singletons/traceable.js";
 import { traceable } from "../traceable.js";
-import { computeRunIdForReplica } from "../uuid.js";
+import { computeRunIdForSecondaryReplica } from "../uuid.js";
 import { mockClient } from "./utils/mock_client.js";
 import { getAssumedTreeFromCalls } from "./utils/tree.js";
 
@@ -340,11 +340,11 @@ test("_remapForProject honors replica primary semantics", () => {
 
   expect(remap("different-project", true).id).toBe(run.id);
   expect(remap("original-project", false).id).toBe(
-    computeRunIdForReplica(run.id, "original-project"),
+    computeRunIdForSecondaryReplica(run.id, "original-project"),
   );
   expect(remap("original-project").id).toBe(run.id);
   expect(remap("different-project").id).toBe(
-    computeRunIdForReplica(run.id, "different-project"),
+    computeRunIdForSecondaryReplica(run.id, "different-project"),
   );
 });
 

--- a/js/src/tests/run_trees.test.ts
+++ b/js/src/tests/run_trees.test.ts
@@ -5,6 +5,7 @@ import { Client } from "../client.js";
 import { RunTree } from "../run_trees.js";
 import { getCurrentRunTree, withRunTree } from "../singletons/traceable.js";
 import { traceable } from "../traceable.js";
+import { computeRunIdForReplica } from "../uuid.js";
 import { mockClient } from "./utils/mock_client.js";
 import { getAssumedTreeFromCalls } from "./utils/tree.js";
 
@@ -324,6 +325,27 @@ test("distributed tracing: _remapForProject with reroot", () => {
   });
 
   expect(remappedNoParam.parent_run_id).toBeTruthy();
+});
+
+test("_remapForProject honors replica primary semantics", () => {
+  const { client } = mockClient();
+  const run = new RunTree({
+    name: "run",
+    inputs: {},
+    client,
+    project_name: "original-project",
+  });
+  const remap = (projectName: string, primary?: boolean) =>
+    (run as any)._remapForProject({ projectName, primary });
+
+  expect(remap("different-project", true).id).toBe(run.id);
+  expect(remap("original-project", false).id).toBe(
+    computeRunIdForReplica(run.id, "original-project"),
+  );
+  expect(remap("original-project").id).toBe(run.id);
+  expect(remap("different-project").id).toBe(
+    computeRunIdForReplica(run.id, "different-project"),
+  );
 });
 
 test("distributed tracing: fromHeaders sets distributedParentId correctly", () => {

--- a/js/src/tests/run_trees.test.ts
+++ b/js/src/tests/run_trees.test.ts
@@ -607,6 +607,7 @@ test("fromHeaders filters replica credentials", () => {
       apiKey: "injected-key",
       apiUrl: "https://evil.com/exfil",
       projectName: "legit-project",
+      primary: true,
       updates: { reroot: true },
     },
   ];
@@ -629,5 +630,6 @@ test("fromHeaders filters replica credentials", () => {
   expect(replica.apiKey).toBeUndefined();
   expect(replica.apiUrl).toBeUndefined();
   expect(replica.projectName).toBe("legit-project");
+  expect(replica.primary).toBe(true);
   expect(replica.updates).toEqual({ reroot: true });
 });

--- a/js/src/tests/run_trees.test.ts
+++ b/js/src/tests/run_trees.test.ts
@@ -633,3 +633,20 @@ test("fromHeaders filters replica credentials", () => {
   expect(replica.primary).toBe(true);
   expect(replica.updates).toEqual({ reroot: true });
 });
+
+test("fromHeaders drops a non-boolean replica primary value", () => {
+  const baggage = `langsmith-replicas=${encodeURIComponent(
+    JSON.stringify([{ projectName: "replica-project", primary: "false" }]),
+  )}`;
+  const parsed = RunTree.fromHeaders({
+    "langsmith-trace":
+      "20240101T000000000000Z00000000-0000-0000-0000-000000000001",
+    baggage,
+  });
+
+  expect(parsed).toBeDefined();
+  const replica = parsed!.replicas![0];
+  expect(replica.primary).toBeUndefined();
+  const remapped = (parsed as any)._remapForProject(replica);
+  expect(remapped.id).not.toBe(parsed!.id);
+});

--- a/js/src/tests/run_trees.uuid.test.ts
+++ b/js/src/tests/run_trees.uuid.test.ts
@@ -1,6 +1,6 @@
 import { jest } from "@jest/globals";
 import { v4 as uuidv4, v7 as uuidv7 } from "../utils/uuid/src/index.js";
-import { computeRunIdForReplica } from "../index.js";
+import { computeRunIdForSecondaryReplica } from "../index.js";
 import { RunTree } from "../run_trees.js";
 import { traceable } from "../traceable.js";
 import {
@@ -123,19 +123,21 @@ test("nonCryptographicUuid7Deterministic timestamp handling", async () => {
   expect(uuidV7Ms(derivedV4)).toBeLessThanOrEqual(afterMs);
 });
 
-test("computeRunIdForReplica returns the replica run ID", () => {
+test("computeRunIdForSecondaryReplica returns the replica run ID", () => {
   const original = "019c0711-e1aa-7223-bf21-12119afe80f7";
 
-  const remapped = computeRunIdForReplica(original, "replica-project");
+  const remapped = computeRunIdForSecondaryReplica(original, "replica-project");
 
   expect(remapped).toBe("019c0711-e1aa-7817-8301-943c0df9a3cd");
   expect(
-    computeRunIdForReplica(original.toUpperCase(), "replica-project"),
+    computeRunIdForSecondaryReplica(original.toUpperCase(), "replica-project"),
   ).toBe(remapped);
-  expect(() => computeRunIdForReplica(original, "")).toThrow("projectName");
-  expect(() => computeRunIdForReplica(uuidv4(), "replica-project")).toThrow(
-    "UUID v7",
+  expect(() => computeRunIdForSecondaryReplica(original, "")).toThrow(
+    "projectName",
   );
+  expect(() =>
+    computeRunIdForSecondaryReplica(uuidv4(), "replica-project"),
+  ).toThrow("UUID v7");
 });
 
 test("internal replica remapping accepts non-UUIDv7 run IDs", () => {

--- a/js/src/tests/run_trees.uuid.test.ts
+++ b/js/src/tests/run_trees.uuid.test.ts
@@ -1,5 +1,6 @@
 import { jest } from "@jest/globals";
 import { v4 as uuidv4, v7 as uuidv7 } from "../utils/uuid/src/index.js";
+import { computeRunIdForReplica } from "../index.js";
 import { RunTree } from "../run_trees.js";
 import { traceable } from "../traceable.js";
 import {
@@ -120,6 +121,15 @@ test("nonCryptographicUuid7Deterministic timestamp handling", async () => {
   expect(getUuidVersion(derivedV4)).toBe(7);
   expect(uuidV7Ms(derivedV4)).toBeGreaterThanOrEqual(beforeMs);
   expect(uuidV7Ms(derivedV4)).toBeLessThanOrEqual(afterMs);
+});
+
+test("computeRunIdForReplica returns the replica run ID", () => {
+  const remapped = computeRunIdForReplica(
+    "019c0711-e1aa-7223-bf21-12119afe80f7",
+    "replica-project",
+  );
+
+  expect(remapped).toBe("019c0711-e1aa-7817-8301-943c0df9a3cd");
 });
 
 test("nonCryptographicUuid7Deterministic produces expected values", () => {

--- a/js/src/tests/run_trees.uuid.test.ts
+++ b/js/src/tests/run_trees.uuid.test.ts
@@ -124,12 +124,36 @@ test("nonCryptographicUuid7Deterministic timestamp handling", async () => {
 });
 
 test("computeRunIdForReplica returns the replica run ID", () => {
-  const remapped = computeRunIdForReplica(
-    "019c0711-e1aa-7223-bf21-12119afe80f7",
-    "replica-project",
-  );
+  const original = "019c0711-e1aa-7223-bf21-12119afe80f7";
+
+  const remapped = computeRunIdForReplica(original, "replica-project");
 
   expect(remapped).toBe("019c0711-e1aa-7817-8301-943c0df9a3cd");
+  expect(
+    computeRunIdForReplica(original.toUpperCase(), "replica-project"),
+  ).toBe(remapped);
+  expect(() => computeRunIdForReplica(original, "")).toThrow("projectName");
+  expect(() => computeRunIdForReplica(uuidv4(), "replica-project")).toThrow(
+    "UUID v7",
+  );
+});
+
+test("internal replica remapping accepts non-UUIDv7 run IDs", () => {
+  const { client } = mockClient();
+  const run = new RunTree({
+    id: uuidv4(),
+    name: "test",
+    inputs: {},
+    client,
+    project_name: "original-project",
+  });
+
+  const remapped = (run as any)._remapForProject({
+    projectName: "replica-project",
+    primary: false,
+  });
+
+  expect(getUuidVersion(remapped.id)).toBe(7);
 });
 
 test("nonCryptographicUuid7Deterministic produces expected values", () => {

--- a/js/src/uuid.ts
+++ b/js/src/uuid.ts
@@ -15,13 +15,13 @@ export function uuid7(): string {
 }
 
 /**
- * Compute the run ID used for a tracing replica project.
+ * Compute the run ID used for a secondary tracing replica.
  *
  * @param runId - The original UUID v7 run ID.
- * @param projectName - The destination replica project name.
- * @returns The run ID used in the replica destination.
+ * @param projectName - The secondary replica's destination project name.
+ * @returns The run ID used in the secondary replica destination.
  */
-export function computeRunIdForReplica(
+export function computeRunIdForSecondaryReplica(
   runId: string,
   projectName: string,
 ): string {

--- a/js/src/uuid.ts
+++ b/js/src/uuid.ts
@@ -1,4 +1,6 @@
 import { v7 as uuidv7 } from "./utils/uuid/src/index.js";
+import { nonCryptographicUuid7Deterministic } from "./utils/_uuid.js";
+
 export { uuid7FromTime } from "./utils/_uuid.js";
 
 /**
@@ -6,4 +8,23 @@ export { uuid7FromTime } from "./utils/_uuid.js";
  */
 export function uuid7(): string {
   return uuidv7();
+}
+
+/**
+ * Generate the run ID used for a tracing replica.
+ *
+ * Use this ID when creating feedback for a run in a replica project. The
+ * result matches the deterministic ID remapping performed when LangSmith
+ * sends a UUID v7 run to a replica whose project differs from the run's
+ * original project.
+ *
+ * @param runId - The original run ID.
+ * @param projectName - The destination replica project name.
+ * @returns The run ID used in the replica project.
+ */
+export function computeRunIdForReplica(
+  runId: string,
+  projectName: string,
+): string {
+  return nonCryptographicUuid7Deterministic(runId, projectName);
 }

--- a/js/src/uuid.ts
+++ b/js/src/uuid.ts
@@ -1,5 +1,9 @@
 import { v7 as uuidv7 } from "./utils/uuid/src/index.js";
-import { nonCryptographicUuid7Deterministic } from "./utils/_uuid.js";
+import {
+  assertUuid,
+  getUuidVersion,
+  nonCryptographicUuid7Deterministic,
+} from "./utils/_uuid.js";
 
 export { uuid7FromTime } from "./utils/_uuid.js";
 
@@ -11,20 +15,24 @@ export function uuid7(): string {
 }
 
 /**
- * Generate the run ID used for a tracing replica.
+ * Compute the run ID used for a tracing replica project.
  *
- * Use this ID when creating feedback for a run in a replica project. The
- * result matches the deterministic ID remapping performed when LangSmith
- * sends a UUID v7 run to a replica whose project differs from the run's
- * original project.
- *
- * @param runId - The original run ID.
+ * @param runId - The original UUID v7 run ID.
  * @param projectName - The destination replica project name.
- * @returns The run ID used in the replica project.
+ * @returns The run ID used in the replica destination.
  */
 export function computeRunIdForReplica(
   runId: string,
   projectName: string,
 ): string {
-  return nonCryptographicUuid7Deterministic(runId, projectName);
+  if (typeof projectName !== "string" || projectName.length === 0) {
+    throw new Error("projectName must be a non-empty string");
+  }
+
+  assertUuid(runId, "runId");
+  const normalizedRunId = runId.toLowerCase();
+  if (getUuidVersion(normalizedRunId) !== 7) {
+    throw new Error("runId must be a UUID v7");
+  }
+  return nonCryptographicUuid7Deterministic(normalizedRunId, projectName);
 }

--- a/python/langsmith/__init__.py
+++ b/python/langsmith/__init__.py
@@ -41,7 +41,11 @@ if TYPE_CHECKING:
     from langsmith.run_trees import RunTree, configure
     from langsmith.testing._internal import test, unit
     from langsmith.utils import ContextThreadPoolExecutor
-    from langsmith.uuid import uuid7, uuid7_from_datetime
+    from langsmith.uuid import (
+        compute_run_id_for_replica,
+        uuid7,
+        uuid7_from_datetime,
+    )
 
 # Avoid calling into importlib on every call to __version__
 
@@ -144,6 +148,10 @@ def __getattr__(name: str) -> Any:
         from langsmith.run_trees import configure
 
         return configure
+    elif name == "compute_run_id_for_replica":
+        from langsmith.uuid import compute_run_id_for_replica
+
+        return compute_run_id_for_replica
     elif name == "uuid7":
         from langsmith.uuid import uuid7
 
@@ -238,6 +246,7 @@ __all__ = [
     "get_current_run_tree",
     "set_run_metadata",
     "ContextThreadPoolExecutor",
+    "compute_run_id_for_replica",
     "uuid7",
     "uuid7_from_datetime",
     "set_runtime_overrides",

--- a/python/langsmith/__init__.py
+++ b/python/langsmith/__init__.py
@@ -42,7 +42,7 @@ if TYPE_CHECKING:
     from langsmith.testing._internal import test, unit
     from langsmith.utils import ContextThreadPoolExecutor
     from langsmith.uuid import (
-        compute_run_id_for_replica,
+        compute_run_id_for_secondary_replica,
         uuid7,
         uuid7_from_datetime,
     )
@@ -148,10 +148,10 @@ def __getattr__(name: str) -> Any:
         from langsmith.run_trees import configure
 
         return configure
-    elif name == "compute_run_id_for_replica":
-        from langsmith.uuid import compute_run_id_for_replica
+    elif name == "compute_run_id_for_secondary_replica":
+        from langsmith.uuid import compute_run_id_for_secondary_replica
 
-        return compute_run_id_for_replica
+        return compute_run_id_for_secondary_replica
     elif name == "uuid7":
         from langsmith.uuid import uuid7
 
@@ -246,7 +246,7 @@ __all__ = [
     "get_current_run_tree",
     "set_run_metadata",
     "ContextThreadPoolExecutor",
-    "compute_run_id_for_replica",
+    "compute_run_id_for_secondary_replica",
     "uuid7",
     "uuid7_from_datetime",
     "set_runtime_overrides",

--- a/python/langsmith/run_trees.py
+++ b/python/langsmith/run_trees.py
@@ -77,7 +77,9 @@ class WriteReplica(TypedDict, total=False):
     """
 
 
-_HEADER_SAFE_REPLICA_FIELDS: frozenset[str] = frozenset({"project_name", "updates"})
+_HEADER_SAFE_REPLICA_FIELDS: frozenset[str] = frozenset(
+    {"project_name", "primary", "updates"}
+)
 
 # Untrusted header-supplied replica `updates` is merged into the run, so restrict it
 # to a fail-closed allow-list. `reroot` (re-parenting control) is always kept;

--- a/python/langsmith/run_trees.py
+++ b/python/langsmith/run_trees.py
@@ -20,9 +20,9 @@ from typing_extensions import NotRequired, TypedDict
 import langsmith._internal._context as _context
 from langsmith import schemas as ls_schemas
 from langsmith import utils
-from langsmith._internal._uuid import uuid7
+from langsmith._internal._uuid import uuid7, uuid7_deterministic
 from langsmith.client import ID_TYPE, RUN_TYPE_T, Client, _dumps_json, _ensure_uuid
-from langsmith.uuid import compute_run_id_for_replica, uuid7_from_datetime
+from langsmith.uuid import uuid7_from_datetime
 
 logger = logging.getLogger(__name__)
 
@@ -57,6 +57,11 @@ class WriteReplica(TypedDict, total=False):
     api_key: NotRequired[str]
     auth: AuthHeaders
     project_name: Optional[str]
+    primary: bool
+    """Whether this replica keeps the original run IDs.
+
+    When omitted, legacy project-based remapping behavior is preserved.
+    """
     updates: Optional[dict]
     client: Optional[Client]
     """Optional dedicated :class:`~langsmith.Client` for this replica.
@@ -702,11 +707,15 @@ class RunTree(ls_schemas.RunBase):
             run_dict.pop("parent_run_id", None)
 
     def _remap_for_project(
-        self, project_name: str, updates: Optional[dict] = None
+        self,
+        project_name: str,
+        updates: Optional[dict] = None,
+        *,
+        primary: Optional[bool] = None,
     ) -> dict:
         """Rewrites ids/dotted_order for a given project with optional updates."""
         run_dict = self._get_dicts_safe()
-        if project_name == self.session_name:
+        if primary is None and project_name == self.session_name:
             return run_dict
 
         if updates and updates.get("reroot", False):
@@ -714,18 +723,25 @@ class RunTree(ls_schemas.RunBase):
             if distributed_parent_id:
                 self._slice_parent_id(distributed_parent_id, run_dict)
 
+        if primary:
+            dup = utils.deepish_copy(run_dict)
+            dup["session_name"] = project_name
+            if updates:
+                dup.update(updates)
+            return dup
+
         old_id = run_dict["id"]
-        new_id = compute_run_id_for_replica(UUID(str(old_id)), project_name)
+        new_id = uuid7_deterministic(UUID(str(old_id)), project_name)
         # trace id
         old_trace = run_dict.get("trace_id")
         if old_trace:
-            new_trace = compute_run_id_for_replica(UUID(str(old_trace)), project_name)
+            new_trace = uuid7_deterministic(UUID(str(old_trace)), project_name)
         else:
             new_trace = None
         # parent id
         parent = run_dict.get("parent_run_id")
         if parent:
-            new_parent = compute_run_id_for_replica(UUID(str(parent)), project_name)
+            new_parent = uuid7_deterministic(UUID(str(parent)), project_name)
         else:
             new_parent = None
         # dotted order
@@ -734,7 +750,7 @@ class RunTree(ls_schemas.RunBase):
             rebuilt = []
             for part in segs[:-1]:
                 seg_id = UUID(part[-TIMESTAMP_LENGTH:])
-                repl = compute_run_id_for_replica(seg_id, project_name)
+                repl = uuid7_deterministic(seg_id, project_name)
                 rebuilt.append(part[:-TIMESTAMP_LENGTH] + str(repl))
             rebuilt.append(segs[-1][:-TIMESTAMP_LENGTH] + str(new_id))
             dotted = ".".join(rebuilt)
@@ -760,7 +776,9 @@ class RunTree(ls_schemas.RunBase):
             for replica in self.replicas:
                 project_name = replica.get("project_name") or self.session_name
                 updates = replica.get("updates")
-                run_dict = self._remap_for_project(project_name, updates)
+                run_dict = self._remap_for_project(
+                    project_name, updates, primary=replica.get("primary")
+                )
                 api_url, api_key, service_key, tenant_id, authorization, cookie = (
                     _extract_replica_auth(replica)
                 )
@@ -829,7 +847,9 @@ class RunTree(ls_schemas.RunBase):
             for replica in self.replicas:
                 project_name = replica.get("project_name") or self.session_name
                 updates = replica.get("updates")
-                run_dict = self._remap_for_project(project_name, updates)
+                run_dict = self._remap_for_project(
+                    project_name, updates, primary=replica.get("primary")
+                )
                 api_url, api_key, service_key, tenant_id, authorization, cookie = (
                     _extract_replica_auth(replica)
                 )
@@ -1188,6 +1208,8 @@ def _parse_write_replicas_from_env_var(env_var: Optional[str]) -> list[WriteRepl
                 api_url = item.get("api_url")
                 api_key = item.get("api_key")
                 project_name = item.get("project_name")
+                primary = item.get("primary")
+                has_primary = "primary" in item
 
                 if not isinstance(api_url, str):
                     logger.warning(
@@ -1210,14 +1232,22 @@ def _parse_write_replicas_from_env_var(env_var: Optional[str]) -> list[WriteRepl
                     )
                     continue
 
-                replicas.append(
-                    WriteReplica(
-                        api_url=api_url.rstrip("/"),
-                        auth=AuthHeaders(api_key=api_key),
-                        project_name=project_name,
-                        updates=None,
+                if has_primary and not isinstance(primary, bool):
+                    logger.warning(
+                        f"Invalid primary type in LANGSMITH_RUNS_ENDPOINTS: "
+                        f"expected boolean, got {type(primary).__name__}"
                     )
+                    continue
+
+                replica = WriteReplica(
+                    api_url=api_url.rstrip("/"),
+                    auth=AuthHeaders(api_key=api_key),
+                    project_name=project_name,
+                    updates=None,
                 )
+                if has_primary:
+                    replica["primary"] = cast(bool, primary)
+                replicas.append(replica)
             return replicas
         elif isinstance(parsed, dict):
             _check_endpoint_env_unset(parsed)
@@ -1283,11 +1313,10 @@ def _ensure_write_replicas(
     replicas: Optional[Sequence[WriteReplica]],
 ) -> list[WriteReplica]:
     """Convert replicas to WriteReplica format."""
-    if replicas is None:
-        return _get_write_replicas_from_env()
-
-    # All replicas should now be WriteReplica dicts
-    return list(replicas)
+    ensured = _get_write_replicas_from_env() if replicas is None else list(replicas)
+    if sum(replica.get("primary") is True for replica in ensured) > 1:
+        raise ValueError("Only one replica can be marked as primary.")
+    return ensured
 
 
 def _parse_dotted_order(dotted_order: str) -> list[tuple[datetime, UUID]]:

--- a/python/langsmith/run_trees.py
+++ b/python/langsmith/run_trees.py
@@ -133,6 +133,8 @@ def _filter_replica_for_headers(replica: WriteReplica) -> WriteReplica:
         for key, value in replica.items()
         if key in _HEADER_SAFE_REPLICA_FIELDS
     }
+    if "primary" in filtered and not isinstance(filtered["primary"], bool):
+        filtered.pop("primary")
     if "updates" in filtered:
         filtered["updates"] = _sanitize_header_updates(filtered.get("updates"))
     return cast(WriteReplica, filtered)

--- a/python/langsmith/run_trees.py
+++ b/python/langsmith/run_trees.py
@@ -20,9 +20,9 @@ from typing_extensions import NotRequired, TypedDict
 import langsmith._internal._context as _context
 from langsmith import schemas as ls_schemas
 from langsmith import utils
-from langsmith._internal._uuid import uuid7, uuid7_deterministic
+from langsmith._internal._uuid import uuid7
 from langsmith.client import ID_TYPE, RUN_TYPE_T, Client, _dumps_json, _ensure_uuid
-from langsmith.uuid import uuid7_from_datetime
+from langsmith.uuid import compute_run_id_for_replica, uuid7_from_datetime
 
 logger = logging.getLogger(__name__)
 
@@ -715,17 +715,17 @@ class RunTree(ls_schemas.RunBase):
                 self._slice_parent_id(distributed_parent_id, run_dict)
 
         old_id = run_dict["id"]
-        new_id = uuid7_deterministic(UUID(str(old_id)), project_name)
+        new_id = compute_run_id_for_replica(UUID(str(old_id)), project_name)
         # trace id
         old_trace = run_dict.get("trace_id")
         if old_trace:
-            new_trace = uuid7_deterministic(UUID(str(old_trace)), project_name)
+            new_trace = compute_run_id_for_replica(UUID(str(old_trace)), project_name)
         else:
             new_trace = None
         # parent id
         parent = run_dict.get("parent_run_id")
         if parent:
-            new_parent = uuid7_deterministic(UUID(str(parent)), project_name)
+            new_parent = compute_run_id_for_replica(UUID(str(parent)), project_name)
         else:
             new_parent = None
         # dotted order
@@ -734,7 +734,7 @@ class RunTree(ls_schemas.RunBase):
             rebuilt = []
             for part in segs[:-1]:
                 seg_id = UUID(part[-TIMESTAMP_LENGTH:])
-                repl = uuid7_deterministic(seg_id, project_name)
+                repl = compute_run_id_for_replica(seg_id, project_name)
                 rebuilt.append(part[:-TIMESTAMP_LENGTH] + str(repl))
             rebuilt.append(segs[-1][:-TIMESTAMP_LENGTH] + str(new_id))
             dotted = ".".join(rebuilt)

--- a/python/langsmith/uuid.py
+++ b/python/langsmith/uuid.py
@@ -39,21 +39,26 @@ def uuid7_from_datetime(dt: _dt.datetime) -> _uuid.UUID:
 def compute_run_id_for_replica(
     run_id: _uuid.UUID | str, project_name: str
 ) -> _uuid.UUID:
-    """Generate the run ID used for a tracing replica.
-
-    Use this ID when creating feedback for a run in a replica project. The
-    result matches the deterministic ID remapping performed when LangSmith
-    sends a UUID v7 run to a replica whose project differs from the run's
-    original project.
+    """Compute the run ID used for a tracing replica project.
 
     Args:
-        run_id: The original run ID.
+        run_id: The original UUID v7 run ID.
         project_name: The destination replica project name.
 
     Returns:
-        uuid.UUID: The run ID used in the replica project.
+        uuid.UUID: The run ID used in the replica destination.
+
+    Raises:
+        ValueError: If ``run_id`` is not UUID v7, or if ``project_name`` is
+            empty or invalid.
     """
-    return _uuid7_deterministic(_uuid.UUID(str(run_id)), project_name)
+    if not isinstance(project_name, str) or not project_name:
+        raise ValueError("project_name must be a non-empty string")
+
+    parsed_run_id = _uuid.UUID(str(run_id))
+    if parsed_run_id.version != 7:
+        raise ValueError("run_id must be a UUID v7")
+    return _uuid7_deterministic(parsed_run_id, project_name)
 
 
 __all__ = ["compute_run_id_for_replica", "uuid7", "uuid7_from_datetime"]

--- a/python/langsmith/uuid.py
+++ b/python/langsmith/uuid.py
@@ -36,17 +36,17 @@ def uuid7_from_datetime(dt: _dt.datetime) -> _uuid.UUID:
     return _uuid7(nanoseconds)
 
 
-def compute_run_id_for_replica(
+def compute_run_id_for_secondary_replica(
     run_id: _uuid.UUID | str, project_name: str
 ) -> _uuid.UUID:
-    """Compute the run ID used for a tracing replica project.
+    """Compute the run ID used for a secondary tracing replica.
 
     Args:
         run_id: The original UUID v7 run ID.
-        project_name: The destination replica project name.
+        project_name: The secondary replica's destination project name.
 
     Returns:
-        uuid.UUID: The run ID used in the replica destination.
+        uuid.UUID: The run ID used in the secondary replica destination.
 
     Raises:
         ValueError: If ``run_id`` is not UUID v7, or if ``project_name`` is
@@ -61,4 +61,4 @@ def compute_run_id_for_replica(
     return _uuid7_deterministic(parsed_run_id, project_name)
 
 
-__all__ = ["compute_run_id_for_replica", "uuid7", "uuid7_from_datetime"]
+__all__ = ["compute_run_id_for_secondary_replica", "uuid7", "uuid7_from_datetime"]

--- a/python/langsmith/uuid.py
+++ b/python/langsmith/uuid.py
@@ -9,6 +9,7 @@ import datetime as _dt
 import uuid as _uuid
 
 from ._internal._uuid import uuid7 as _uuid7
+from ._internal._uuid import uuid7_deterministic as _uuid7_deterministic
 
 
 def uuid7() -> _uuid.UUID:
@@ -35,4 +36,24 @@ def uuid7_from_datetime(dt: _dt.datetime) -> _uuid.UUID:
     return _uuid7(nanoseconds)
 
 
-__all__ = ["uuid7", "uuid7_from_datetime"]
+def compute_run_id_for_replica(
+    run_id: _uuid.UUID | str, project_name: str
+) -> _uuid.UUID:
+    """Generate the run ID used for a tracing replica.
+
+    Use this ID when creating feedback for a run in a replica project. The
+    result matches the deterministic ID remapping performed when LangSmith
+    sends a UUID v7 run to a replica whose project differs from the run's
+    original project.
+
+    Args:
+        run_id: The original run ID.
+        project_name: The destination replica project name.
+
+    Returns:
+        uuid.UUID: The run ID used in the replica project.
+    """
+    return _uuid7_deterministic(_uuid.UUID(str(run_id)), project_name)
+
+
+__all__ = ["compute_run_id_for_replica", "uuid7", "uuid7_from_datetime"]

--- a/python/tests/unit_tests/test_replica_endpoints.py
+++ b/python/tests/unit_tests/test_replica_endpoints.py
@@ -8,7 +8,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from langsmith import Client, compute_run_id_for_replica
+from langsmith import Client, compute_run_id_for_secondary_replica
 from langsmith import utils as ls_utils
 from langsmith.run_trees import (
     ApiKeyAuth,
@@ -803,7 +803,7 @@ class TestRunTreeReplicas:
         assert calls[1][1]["api_key"] == "replica2-key"
         assert calls[1][1]["api_url"] == "https://replica2.example.com"
         assert calls[0][1]["id"] == run_tree.id
-        assert calls[1][1]["id"] == compute_run_id_for_replica(
+        assert calls[1][1]["id"] == compute_run_id_for_secondary_replica(
             run_tree.id, "replica2-project"
         )
 
@@ -865,7 +865,7 @@ class TestRunTreeReplicas:
         call_args = client.update_run.call_args
         assert call_args[1]["api_key"] == "replica-key"
         assert call_args[1]["api_url"] == "https://replica.example.com"
-        assert call_args[1]["run_id"] == compute_run_id_for_replica(
+        assert call_args[1]["run_id"] == compute_run_id_for_secondary_replica(
             run_tree.id, "replica-project"
         )
 

--- a/python/tests/unit_tests/test_replica_endpoints.py
+++ b/python/tests/unit_tests/test_replica_endpoints.py
@@ -8,7 +8,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from langsmith import Client
+from langsmith import Client, compute_run_id_for_replica
 from langsmith import utils as ls_utils
 from langsmith.run_trees import (
     ApiKeyAuth,
@@ -76,6 +76,15 @@ class TestWriteReplicaTypes:
         assert result[1]["api_url"] == "https://replica2.example.com"
         assert result[1]["auth"]["api_key"] == "key2"
         assert result[1].get("project_name") is None
+
+    def test_ensure_write_replicas_rejects_multiple_primary_replicas(self):
+        replicas = [
+            WriteReplica(project_name="primary-1", primary=True),
+            WriteReplica(project_name="primary-2", primary=True),
+        ]
+
+        with pytest.raises(ValueError, match="Only one replica"):
+            _ensure_write_replicas(replicas)
 
 
 class TestEnvironmentVariableParsing:
@@ -357,11 +366,13 @@ class TestParseWriteReplicasFromEnvVar:
                     "api_url": "https://api.example.com",
                     "api_key": "key1",
                     "project_name": "project-prod",
+                    "primary": True,
                 },
                 {
                     "api_url": "https://api.example.com",
                     "api_key": "key2",
                     "project_name": "project-staging",
+                    "primary": False,
                 },
                 {"api_url": "https://api.example.com", "api_key": "key3"},
             ]
@@ -386,6 +397,30 @@ class TestParseWriteReplicasFromEnvVar:
             None,
         ]
         assert all(r["updates"] is None for r in result)
+        assert [r.get("primary") for r in result] == [True, False, None]
+
+    @pytest.mark.parametrize("primary", ["true", 1, None])
+    def test_parse_new_array_format_rejects_invalid_primary(self, primary):
+        env_var = json.dumps(
+            [
+                {
+                    "api_url": "https://invalid.example.com",
+                    "api_key": "invalid-key",
+                    "primary": primary,
+                },
+                {
+                    "api_url": "https://valid.example.com",
+                    "api_key": "valid-key",
+                    "primary": False,
+                },
+            ]
+        )
+
+        result = _parse_write_replicas_from_env_var(env_var)
+
+        assert len(result) == 1
+        assert result[0]["api_url"] == "https://valid.example.com"
+        assert result[0]["primary"] is False
 
     def test_parse_object_format(self):
         """Test parsing object format."""
@@ -740,6 +775,7 @@ class TestRunTreeReplicas:
                 api_url="https://replica1.example.com",
                 auth=ApiKeyAuth(api_key="replica1-key"),
                 project_name="replica1-project",
+                primary=True,
             ),
             WriteReplica(
                 api_url="https://replica2.example.com",
@@ -766,6 +802,10 @@ class TestRunTreeReplicas:
         assert calls[0][1]["api_url"] == "https://replica1.example.com"
         assert calls[1][1]["api_key"] == "replica2-key"
         assert calls[1][1]["api_url"] == "https://replica2.example.com"
+        assert calls[0][1]["id"] == run_tree.id
+        assert calls[1][1]["id"] == compute_run_id_for_replica(
+            run_tree.id, "replica2-project"
+        )
 
     def test_run_tree_with_service_auth_replicas(self):
         """Test RunTree with ServiceAuth replicas."""
@@ -825,6 +865,9 @@ class TestRunTreeReplicas:
         call_args = client.update_run.call_args
         assert call_args[1]["api_key"] == "replica-key"
         assert call_args[1]["api_url"] == "https://replica.example.com"
+        assert call_args[1]["run_id"] == compute_run_id_for_replica(
+            run_tree.id, "replica-project"
+        )
 
     def test_run_tree_preserves_env_replica_project_names(self):
         client = Mock()

--- a/python/tests/unit_tests/test_run_trees.py
+++ b/python/tests/unit_tests/test_run_trees.py
@@ -343,9 +343,17 @@ def test_remap_for_project():
     root = RunTree(name="Root", inputs={}, client=mock_client, session_name="original")
     child = root.create_child(name="Child")
 
-    # Same project: no remapping
+    # Omitted primary preserves legacy same-project behavior.
     same = child._remap_for_project("original")
     assert same["id"] == child.id
+
+    # Explicit primary preserves IDs regardless of project.
+    primary = child._remap_for_project("replica", primary=True)
+    assert primary["id"] == child.id
+
+    # Explicit non-primary remaps even within the same project.
+    non_primary = child._remap_for_project("original", primary=False)
+    assert non_primary["id"] == uuid7_deterministic(child.id, "original")
 
     # Different project: IDs remapped deterministically
     r1 = child._remap_for_project("replica")

--- a/python/tests/unit_tests/test_run_trees.py
+++ b/python/tests/unit_tests/test_run_trees.py
@@ -563,6 +563,26 @@ def test_from_headers_filters_replica_credentials():
     assert replica.get("updates") == {"reroot": True}
 
 
+def test_from_headers_drops_non_boolean_replica_primary():
+    replicas_json = json.dumps(
+        [{"project_name": "replica-project", "primary": "false"}]
+    )
+    baggage = f"langsmith-replicas={urllib.parse.quote(replicas_json)}"
+    headers = {
+        "langsmith-trace": "20240101T000000000000Z00000000-0000-0000-0000-000000000001",
+        "baggage": baggage,
+    }
+
+    parsed = RunTree.from_headers(headers)
+
+    assert parsed is not None
+    assert parsed.replicas is not None
+    replica = parsed.replicas[0]
+    assert replica.get("primary") is None
+    remapped = parsed._remap_for_project(replica["project_name"])
+    assert remapped["id"] != parsed.id
+
+
 def test_from_headers_allowlists_update_fields():
     """Only allow-listed fields survive in an untrusted baggage replica's `updates`."""
     replicas_json = json.dumps(

--- a/python/tests/unit_tests/test_run_trees.py
+++ b/python/tests/unit_tests/test_run_trees.py
@@ -539,6 +539,7 @@ def test_from_headers_filters_replica_credentials():
                 "api_key": "injected-key",
                 "api_url": "https://evil.com/exfil",
                 "project_name": "legit-project",
+                "primary": True,
                 "updates": {"reroot": True},
             }
         ]
@@ -558,6 +559,7 @@ def test_from_headers_filters_replica_credentials():
     assert "api_key" not in replica
     assert "api_url" not in replica
     assert replica.get("project_name") == "legit-project"
+    assert replica.get("primary") is True
     assert replica.get("updates") == {"reroot": True}
 
 

--- a/python/tests/unit_tests/test_uuid_v7.py
+++ b/python/tests/unit_tests/test_uuid_v7.py
@@ -2,6 +2,7 @@ import datetime
 from typing import Any
 from unittest.mock import MagicMock
 
+from langsmith import compute_run_id_for_replica
 from langsmith._internal._uuid import uuid7, uuid7_deterministic
 from langsmith.client import Client
 from langsmith.run_helpers import traceable
@@ -92,6 +93,14 @@ def test_post_and_patch_include_run_type_and_start_time() -> None:
     _, update_kwargs = client.update_run.call_args
     assert update_kwargs["run_type"] == "llm"
     assert update_kwargs["start_time"] == fixed_start
+
+
+def test_compute_run_id_for_replica() -> None:
+    original = "019c0711-e1aa-7223-bf21-12119afe80f7"
+
+    remapped = compute_run_id_for_replica(original, "replica-project")
+
+    assert str(remapped) == "019c0711-e1aa-7817-8301-943c0df9a3cd"
 
 
 def test_uuid7_deterministic_produces_expected_values() -> None:

--- a/python/tests/unit_tests/test_uuid_v7.py
+++ b/python/tests/unit_tests/test_uuid_v7.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from langsmith import compute_run_id_for_replica
+from langsmith import compute_run_id_for_secondary_replica
 from langsmith._internal._uuid import uuid7, uuid7_deterministic
 from langsmith.client import Client
 from langsmith.run_helpers import traceable
@@ -97,17 +97,17 @@ def test_post_and_patch_include_run_type_and_start_time() -> None:
     assert update_kwargs["start_time"] == fixed_start
 
 
-def test_compute_run_id_for_replica() -> None:
+def test_compute_run_id_for_secondary_replica() -> None:
     original = "019c0711-e1aa-7223-bf21-12119afe80f7"
 
-    remapped = compute_run_id_for_replica(original, "replica-project")
+    remapped = compute_run_id_for_secondary_replica(original, "replica-project")
 
     assert str(remapped) == "019c0711-e1aa-7817-8301-943c0df9a3cd"
 
     with pytest.raises(ValueError, match="project_name"):
-        compute_run_id_for_replica(original, "")
+        compute_run_id_for_secondary_replica(original, "")
     with pytest.raises(ValueError, match="UUID v7"):
-        compute_run_id_for_replica(
+        compute_run_id_for_secondary_replica(
             "12345678-1234-4234-8234-123456789abc", "replica-project"
         )
 

--- a/python/tests/unit_tests/test_uuid_v7.py
+++ b/python/tests/unit_tests/test_uuid_v7.py
@@ -2,6 +2,8 @@ import datetime
 from typing import Any
 from unittest.mock import MagicMock
 
+import pytest
+
 from langsmith import compute_run_id_for_replica
 from langsmith._internal._uuid import uuid7, uuid7_deterministic
 from langsmith.client import Client
@@ -101,6 +103,27 @@ def test_compute_run_id_for_replica() -> None:
     remapped = compute_run_id_for_replica(original, "replica-project")
 
     assert str(remapped) == "019c0711-e1aa-7817-8301-943c0df9a3cd"
+
+    with pytest.raises(ValueError, match="project_name"):
+        compute_run_id_for_replica(original, "")
+    with pytest.raises(ValueError, match="UUID v7"):
+        compute_run_id_for_replica(
+            "12345678-1234-4234-8234-123456789abc", "replica-project"
+        )
+
+
+def test_internal_replica_remapping_accepts_non_uuid7() -> None:
+    original = "12345678-1234-4234-8234-123456789abc"
+    run_tree = RunTree(
+        id=original,
+        name="test",
+        inputs={},
+        project_name="original-project",
+    )
+
+    remapped = run_tree._remap_for_project("replica-project", primary=False)
+
+    assert remapped["id"].version == 7
 
 
 def test_uuid7_deterministic_produces_expected_values() -> None:


### PR DESCRIPTION
Allows users to predictably calculate what a run id be remapped to when sent to different replicas

Useful for e.g. leaving feedback on all replica runs going to different destinations