### PR TITLE
fix(python): exclude internal signing env vars from trace metadata

### DIFF
--- a/python/langsmith/env/_runtime_env.py
+++ b/python/langsmith/env/_runtime_env.py
@@ -177,6 +177,9 @@ def get_langchain_env_var_metadata() -> dict:
         "LANGCHAIN_PROJECT",
         "LANGCHAIN_SESSION",
         "LANGSMITH_RUNS_ENDPOINTS",
+        # Control-plane signing secrets the substring filter misses; excluded here.
+        "LANGSMITH_SIGNING_JWKS",
+        "LANGSMITH_SANDBOX_CALLBACK_SIGNING_JWK",
     }
     langchain_metadata = {
         k: v

--- a/python/tests/unit_tests/test_env.py
+++ b/python/tests/unit_tests/test_env.py
@@ -1,7 +1,7 @@
 import pytest
 
 from langsmith.env import __all__ as env_all
-from langsmith.env import get_git_info
+from langsmith.env import get_git_info, get_langchain_env_var_metadata
 
 _EXPECTED = [
     "get_docker_compose_command",
@@ -32,3 +32,20 @@ def test_git_info() -> None:
         assert "langsmith-sdk" in git_info["remote_url"]
     except AssertionError:
         pytest.skip("Git information is not available, skipping test.")
+
+
+@pytest.mark.parametrize(
+    "secret_var",
+    ["LANGSMITH_SIGNING_JWKS", "LANGSMITH_SANDBOX_CALLBACK_SIGNING_JWK"],
+)
+def test_env_var_metadata_excludes_signing_secrets(
+    monkeypatch: pytest.MonkeyPatch, secret_var: str
+) -> None:
+    monkeypatch.setenv(secret_var, "super-secret-value")
+    monkeypatch.setenv("LANGSMITH_LANGGRAPH_API_VARIANT", "local")
+    monkeypatch.setenv("LANGCHAIN_REVISION_ID", "abc123")
+    get_langchain_env_var_metadata.cache_clear()
+    metadata = get_langchain_env_var_metadata()
+    assert secret_var not in metadata
+    assert metadata["LANGSMITH_LANGGRAPH_API_VARIANT"] == "local"
+    assert metadata["revision_id"] == "abc123"


### PR DESCRIPTION
Internal signing secrets injected by the LangGraph Platform control plane — `LANGSMITH_SIGNING_JWKS` and `LANGSMITH_SANDBOX_CALLBACK_SIGNING_JWK` — were being forwarded into LangSmith trace run metadata on self-hosted and BYOC deployments. `get_langchain_env_var_metadata()` collects every `LANGCHAIN_`/`LANGSMITH_`-prefixed env var except a small `excluded` set and names containing `key`/`secret`/`token`; these two contain none of those substrings, so they attached to every traced run via `Client._insert_runtime_env`.

## Changes
- Add `LANGSMITH_SIGNING_JWKS` and `LANGSMITH_SANDBOX_CALLBACK_SIGNING_JWK` to the `excluded` set in `get_langchain_env_var_metadata()`, keeping them out of run metadata. Chose explicit names over broadening the substring filter to avoid false positives on legitimate vars (e.g. public JWKS URLs, signing-algorithm names).

## Testing
- Parameterized unit test over both names asserting each is absent from the returned metadata, while a benign var (`LANGSMITH_LANGGRAPH_API_VARIANT`) and the `revision_id` mapping still pass through. Clears the function's `lru_cache` before the call and on teardown. Fails on `main`, passes with the fix.
