### PR TITLE
chore: deprecate all legacy SDK methods from SmithDB migration guide

### DIFF
--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -2936,6 +2936,7 @@ export class Client implements LangSmithTracingClientInterface {
 
   /**
    * List runs from the LangSmith server.
+   * @deprecated Use `client.runs.query()` instead. See https://docs.langchain.com/langsmith/smithdb-sdk-migration for the migration guide. Will be removed after Jan 31, 2027.
    * @param projectId - The ID of the project to filter by.
    * @param projectName - The name of the project to filter by.
    * @param parentRunId - The ID of the parent run to filter by.

--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -2840,6 +2840,10 @@ export class Client implements LangSmithTracingClientInterface {
     });
   }
 
+  /**
+   * Read a run from the LangSmith API.
+   * @deprecated Use `client.runs.retrieve()` instead. See https://docs.langchain.com/langsmith/smithdb-sdk-migration#runs-retrieve for the migration guide. Will be removed after Jan 31, 2027.
+   */
   public async readRun(
     runId: string,
     { loadChildRuns }: { loadChildRuns: boolean } = { loadChildRuns: false },
@@ -2936,7 +2940,7 @@ export class Client implements LangSmithTracingClientInterface {
 
   /**
    * List runs from the LangSmith server.
-   * @deprecated Use `client.runs.query()` instead. See https://docs.langchain.com/langsmith/smithdb-sdk-migration for the migration guide. Will be removed after Jan 31, 2027.
+   * @deprecated Use `client.runs.query()` instead. See https://docs.langchain.com/langsmith/smithdb-sdk-migration#runs-query for the migration guide. Will be removed after Jan 31, 2027.
    * @param projectId - The ID of the project to filter by.
    * @param projectName - The name of the project to filter by.
    * @param parentRunId - The ID of the parent run to filter by.
@@ -3205,6 +3209,10 @@ export class Client implements LangSmithTracingClientInterface {
     }
   }
 
+  /**
+   * Read runs for a single thread.
+   * @deprecated Use `client.threads.listTraces()` instead. See https://docs.langchain.com/langsmith/smithdb-sdk-migration#threads-list-traces for the migration guide. Will be removed after Jan 31, 2027.
+   */
   public async *readThread(props: ReadThreadParams): AsyncIterable<Run> {
     const {
       threadId,
@@ -3235,6 +3243,10 @@ export class Client implements LangSmithTracingClientInterface {
     });
   }
 
+  /**
+   * List threads and fetch runs for each thread.
+   * @deprecated Use `client.threads.query()` instead. See https://docs.langchain.com/langsmith/smithdb-sdk-migration#threads-query for the migration guide. Will be removed after Jan 31, 2027.
+   */
   public async listThreads(
     props: ListThreadsParams,
   ): Promise<ListThreadsItem[]> {
@@ -3366,6 +3378,10 @@ export class Client implements LangSmithTracingClientInterface {
     return withLimit;
   }
 
+  /**
+   * Get aggregate statistics over queried runs.
+   * @deprecated Use `client.threads.stats()` instead. See https://docs.langchain.com/langsmith/smithdb-sdk-migration#threads-stats for the migration guide. Will be removed after Jan 31, 2027.
+   */
   public async getRunStats({
     id,
     trace,
@@ -5757,8 +5773,9 @@ export class Client implements LangSmithTracingClientInterface {
    * - `RunKey[]` (preferred): each entry carries the run's full lookup key, so
    *   it can be located directly without a scan. Required for workspaces served
    *   by SmithDB; routes to `POST /runs/by-key`.
-   * - `string[]`: a plain list of run IDs. This path will be deprecated in a
-   *   future release; prefer the key form. Routes to `POST /runs`.
+   * - `string[]`: a plain list of run IDs. **Deprecated**: this path will be
+   *   removed after Jan 31, 2027; prefer the key form. Routes to `POST /runs`.
+   *   See https://docs.langchain.com/langsmith/smithdb-sdk-migration#annotation-queues-add-runs.
    *
    * If every element is a string (or the list is empty) it is treated as run
    * IDs; otherwise the list is treated as `RunKey` objects.

--- a/python/langsmith/async_client.py
+++ b/python/langsmith/async_client.py
@@ -605,6 +605,11 @@ class AsyncClient:
     ) -> AsyncIterator[ls_schemas.Run]:
         """List runs from the LangSmith API.
 
+        .. deprecated::
+            Use :meth:`langsmith.AsyncClient.runs.query` instead.
+            See https://docs.langchain.com/langsmith/smithdb-sdk-migration for the migration guide.
+            Will be removed after Jan 31, 2027.
+
         Args:
             project_id: The ID(s) of the project to filter by.
             project_name: The name(s) of the project to filter by.
@@ -693,6 +698,13 @@ class AsyncClient:
             )
             ```
         """  # noqa: E501
+        warnings.warn(
+            "list_runs() is deprecated and will be removed after Jan 31, 2027. "
+            "Use client.runs.query() instead. "
+            "See https://docs.langchain.com/langsmith/smithdb-sdk-migration for the migration guide.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         project_ids = []
         if isinstance(project_id, (uuid.UUID, str)):
             project_ids.append(project_id)

--- a/python/langsmith/async_client.py
+++ b/python/langsmith/async_client.py
@@ -573,7 +573,20 @@ class AsyncClient:
         )
 
     async def read_run(self, run_id: ls_client.ID_TYPE) -> ls_schemas.Run:
-        """Read a run."""
+        """Read a run.
+
+        .. deprecated::
+            Use :meth:`langsmith.AsyncClient.runs.retrieve` instead.
+            See https://docs.langchain.com/langsmith/smithdb-sdk-migration#runs-retrieve for the migration guide.
+            Will be removed after Jan 31, 2027.
+        """
+        warnings.warn(
+            "read_run() is deprecated and will be removed after Jan 31, 2027. "
+            "Use client.runs.retrieve() instead. "
+            "See https://docs.langchain.com/langsmith/smithdb-sdk-migration#runs-retrieve for the migration guide.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         response = await self._arequest_with_retries(
             "GET",
             f"/runs/{ls_client._as_uuid(run_id)}",
@@ -607,7 +620,7 @@ class AsyncClient:
 
         .. deprecated::
             Use :meth:`langsmith.AsyncClient.runs.query` instead.
-            See https://docs.langchain.com/langsmith/smithdb-sdk-migration for the migration guide.
+            See https://docs.langchain.com/langsmith/smithdb-sdk-migration#runs-query for the migration guide.
             Will be removed after Jan 31, 2027.
 
         Args:
@@ -701,7 +714,7 @@ class AsyncClient:
         warnings.warn(
             "list_runs() is deprecated and will be removed after Jan 31, 2027. "
             "Use client.runs.query() instead. "
-            "See https://docs.langchain.com/langsmith/smithdb-sdk-migration for the migration guide.",
+            "See https://docs.langchain.com/langsmith/smithdb-sdk-migration#runs-query for the migration guide.",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -4107,6 +4107,11 @@ class Client:
     ) -> Iterator[ls_schemas.Run]:
         """List runs from the LangSmith API.
 
+        .. deprecated::
+            Use :meth:`langsmith.Client.runs.query` instead.
+            See https://docs.langchain.com/langsmith/smithdb-sdk-migration for the migration guide.
+            Will be removed after Jan 31, 2027.
+
         Args:
             project_id: The ID(s) of the project to filter by.
             project_name: The name(s) of the project to filter by.
@@ -4195,6 +4200,13 @@ class Client:
             )
             ```
         """  # noqa: E501
+        warnings.warn(
+            "list_runs() is deprecated and will be removed after Jan 31, 2027. "
+            "Use client.runs.query() instead. "
+            "See https://docs.langchain.com/langsmith/smithdb-sdk-migration for the migration guide.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         project_ids = []
         if isinstance(project_id, (uuid.UUID, str)):
             project_ids.append(project_id)

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -3994,6 +3994,11 @@ class Client:
     ) -> ls_schemas.Run:
         """Read a run from the LangSmith API.
 
+        .. deprecated::
+            Use :meth:`langsmith.Client.runs.retrieve` instead.
+            See https://docs.langchain.com/langsmith/smithdb-sdk-migration#runs-retrieve for the migration guide.
+            Will be removed after Jan 31, 2027.
+
         Args:
             run_id (Union[UUID, str]):
                 The ID of the run to read.
@@ -4014,6 +4019,13 @@ class Client:
             stored_run = client.read_run(run_id)
             ```
         """
+        warnings.warn(
+            "read_run() is deprecated and will be removed after Jan 31, 2027. "
+            "Use client.runs.retrieve() instead. "
+            "See https://docs.langchain.com/langsmith/smithdb-sdk-migration#runs-retrieve for the migration guide.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         response = self.request_with_retries(
             "GET", f"/runs/{_as_uuid(run_id, 'run_id')}"
         )
@@ -4043,6 +4055,11 @@ class Client:
     ) -> Iterator[ls_schemas.Run]:
         """Read runs for a single thread.
 
+        .. deprecated::
+            Use :meth:`langsmith.Client.threads.list_traces` instead.
+            See https://docs.langchain.com/langsmith/smithdb-sdk-migration#threads-list-traces for the migration guide.
+            Will be removed after Jan 31, 2027.
+
         Args:
             thread_id: Thread id (required).
             project_id: Project id(s) (required when not using project_name).
@@ -4067,6 +4084,13 @@ class Client:
                 print(run.id)
             ```
         """
+        warnings.warn(
+            "read_thread() is deprecated and will be removed after Jan 31, 2027. "
+            "Use client.threads.list_traces() instead. "
+            "See https://docs.langchain.com/langsmith/smithdb-sdk-migration#threads-list-traces for the migration guide.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         if not (project_id or project_name):
             raise ValueError("thread_id requires project_id or project_name")
 
@@ -4109,7 +4133,7 @@ class Client:
 
         .. deprecated::
             Use :meth:`langsmith.Client.runs.query` instead.
-            See https://docs.langchain.com/langsmith/smithdb-sdk-migration for the migration guide.
+            See https://docs.langchain.com/langsmith/smithdb-sdk-migration#runs-query for the migration guide.
             Will be removed after Jan 31, 2027.
 
         Args:
@@ -4203,7 +4227,7 @@ class Client:
         warnings.warn(
             "list_runs() is deprecated and will be removed after Jan 31, 2027. "
             "Use client.runs.query() instead. "
-            "See https://docs.langchain.com/langsmith/smithdb-sdk-migration for the migration guide.",
+            "See https://docs.langchain.com/langsmith/smithdb-sdk-migration#runs-query for the migration guide.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -4302,6 +4326,11 @@ class Client:
     ) -> list[ListThreadsItem]:
         """List threads and fetch the runs for each thread.
 
+        .. deprecated::
+            Use :meth:`langsmith.Client.threads.query` instead.
+            See https://docs.langchain.com/langsmith/smithdb-sdk-migration#threads-query for the migration guide.
+            Will be removed after Jan 31, 2027.
+
         Args:
             project_id: The project (session) id.
             project_name: The project name (alternative to project_id).
@@ -4314,6 +4343,13 @@ class Client:
             List of thread items, each with "thread_id", "runs", "count",
             "min_start_time", and "max_start_time".
         """
+        warnings.warn(
+            "list_threads() is deprecated and will be removed after Jan 31, 2027. "
+            "Use client.threads.query() instead. "
+            "See https://docs.langchain.com/langsmith/smithdb-sdk-migration#threads-query for the migration guide.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         if project_id is None and project_name is None:
             raise ValueError("Either project_id or project_name must be provided")
         if project_id is not None and project_name is not None:
@@ -4436,6 +4472,11 @@ class Client:
     ) -> dict[str, Any]:
         """Get aggregate statistics over queried runs.
 
+        .. deprecated::
+            Use :meth:`langsmith.Client.threads.stats` instead.
+            See https://docs.langchain.com/langsmith/smithdb-sdk-migration#threads-stats for the migration guide.
+            Will be removed after Jan 31, 2027.
+
         Takes in similar query parameters to `list_runs` and returns statistics
         based on the runs that match the query.
 
@@ -4460,6 +4501,13 @@ class Client:
         Returns:
             Dict[str, Any]: A dictionary containing the run statistics.
         """  # noqa: E501
+        warnings.warn(
+            "get_run_stats() is deprecated and will be removed after Jan 31, 2027. "
+            "Use client.threads.stats() instead. "
+            "See https://docs.langchain.com/langsmith/smithdb-sdk-migration#threads-stats for the migration guide.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         from concurrent.futures import ThreadPoolExecutor, as_completed  # type: ignore
 
         project_ids = project_ids or []
@@ -8831,8 +8879,9 @@ class Client:
           (`run_id`, `session_id`, `start_time`, and an optional
           `source_proposed_example_id`). This lets the run be located directly,
           without a scan, and is required for workspaces served by SmithDB.
-        - `run_ids`: a plain list of run IDs. This path will be deprecated in a
-          future release; prefer `runs`.
+        - `run_ids`: a plain list of run IDs. This path is deprecated and will
+          be removed after Jan 31, 2027; prefer `runs`.
+          See https://docs.langchain.com/langsmith/smithdb-sdk-migration#annotation-queues-add-runs.
 
         Args:
             queue_id (Union[UUID, str]): The ID of the annotation queue.
@@ -8853,6 +8902,13 @@ class Client:
             path = f"/annotation-queues/{_as_uuid(queue_id, 'queue_id')}/runs/by-key"
             json_body = [_serialize_run_key(run, i) for i, run in enumerate(runs)]
         elif run_ids is not None:
+            warnings.warn(
+                "The run_ids parameter of add_runs_to_annotation_queue() is deprecated and will be removed after Jan 31, 2027. "
+                "Use the runs parameter with RunKey objects instead. "
+                "See https://docs.langchain.com/langsmith/smithdb-sdk-migration#annotation-queues-add-runs for the migration guide.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
             path = f"/annotation-queues/{_as_uuid(queue_id, 'queue_id')}/runs"
             json_body = [
                 str(_as_uuid(id_, f"run_ids[{i}]")) for i, id_ in enumerate(run_ids)
@@ -10702,6 +10758,11 @@ class Client:
     ) -> ls_schemas.ExperimentResults:
         """Get results for an experiment, including experiment session aggregated stats and experiment runs for each dataset example.
 
+        .. deprecated::
+            Use :meth:`langsmith.Client.datasets.experiment_runs.query` instead.
+            See https://docs.langchain.com/langsmith/smithdb-sdk-migration#dataset-experiment-runs-query for the migration guide.
+            Will be removed after Jan 31, 2027.
+
         Experiment results may not be available immediately after the experiment is created.
 
         Args:
@@ -10741,6 +10802,13 @@ class Client:
             print(f"Feedback stats: {results['feedback_stats']}")
             ```
         """
+        warnings.warn(
+            "get_experiment_results() is deprecated and will be removed after Jan 31, 2027. "
+            "Use client.datasets.experiment_runs.query() instead. "
+            "See https://docs.langchain.com/langsmith/smithdb-sdk-migration#dataset-experiment-runs-query for the migration guide.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         project = self.read_project(
             project_name=name, project_id=project_id, include_stats=True
         )

--- a/python/langsmith/utils.py
+++ b/python/langsmith/utils.py
@@ -40,43 +40,103 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class LangSmithError(Exception):
-    """An error occurred while communicating with the LangSmith API."""
+    """An error occurred while communicating with the LangSmith API.
+
+    .. deprecated::
+        Use :class:`langsmith.LangsmithError` instead.
+        See https://docs.langchain.com/langsmith/smithdb-sdk-migration for the migration guide.
+        Will be removed after Jan 31, 2027.
+    """
 
 
 class LangSmithAPIError(LangSmithError):
-    """Internal server error while communicating with LangSmith."""
+    """Internal server error while communicating with LangSmith.
+
+    .. deprecated::
+        Use :class:`langsmith.InternalServerError` instead.
+        See https://docs.langchain.com/langsmith/smithdb-sdk-migration for the migration guide.
+        Will be removed after Jan 31, 2027.
+    """
 
 
 class LangSmithRequestTimeout(LangSmithError):
-    """Client took too long to send request body."""
+    """Client took too long to send request body.
+
+    .. deprecated::
+        Use :class:`langsmith.APITimeoutError` instead.
+        See https://docs.langchain.com/langsmith/smithdb-sdk-migration for the migration guide.
+        Will be removed after Jan 31, 2027.
+    """
 
 
 class LangSmithUserError(LangSmithError):
-    """User error caused an exception when communicating with LangSmith."""
+    """User error caused an exception when communicating with LangSmith.
+
+    .. deprecated::
+        Use :class:`langsmith.BadRequestError` instead.
+        See https://docs.langchain.com/langsmith/smithdb-sdk-migration for the migration guide.
+        Will be removed after Jan 31, 2027.
+    """
 
 
 class LangSmithRateLimitError(LangSmithError):
-    """You have exceeded the rate limit for the LangSmith API."""
+    """You have exceeded the rate limit for the LangSmith API.
+
+    .. deprecated::
+        Use :class:`langsmith.RateLimitError` instead.
+        See https://docs.langchain.com/langsmith/smithdb-sdk-migration for the migration guide.
+        Will be removed after Jan 31, 2027.
+    """
 
 
 class LangSmithAuthError(LangSmithError):
-    """Couldn't authenticate with the LangSmith API."""
+    """Couldn't authenticate with the LangSmith API.
+
+    .. deprecated::
+        Use :class:`langsmith.AuthenticationError` instead.
+        See https://docs.langchain.com/langsmith/smithdb-sdk-migration for the migration guide.
+        Will be removed after Jan 31, 2027.
+    """
 
 
 class LangSmithNotFoundError(LangSmithError):
-    """Couldn't find the requested resource."""
+    """Couldn't find the requested resource.
+
+    .. deprecated::
+        Use :class:`langsmith.NotFoundError` instead.
+        See https://docs.langchain.com/langsmith/smithdb-sdk-migration for the migration guide.
+        Will be removed after Jan 31, 2027.
+    """
 
 
 class LangSmithConflictError(LangSmithError):
-    """The resource already exists."""
+    """The resource already exists.
+
+    .. deprecated::
+        Use :class:`langsmith.ConflictError` instead.
+        See https://docs.langchain.com/langsmith/smithdb-sdk-migration for the migration guide.
+        Will be removed after Jan 31, 2027.
+    """
 
 
 class LangSmithConnectionError(LangSmithError):
-    """Couldn't connect to the LangSmith API."""
+    """Couldn't connect to the LangSmith API.
+
+    .. deprecated::
+        Use :class:`langsmith.APIConnectionError` instead.
+        See https://docs.langchain.com/langsmith/smithdb-sdk-migration for the migration guide.
+        Will be removed after Jan 31, 2027.
+    """
 
 
 class LangSmithExceptionGroup(LangSmithError):
-    """Port of ExceptionGroup for Py < 3.11."""
+    """Port of ExceptionGroup for Py < 3.11.
+
+    .. deprecated::
+        Use Python 3.11+ native ``ExceptionGroup`` or :class:`langsmith.LangsmithError` instead.
+        See https://docs.langchain.com/langsmith/smithdb-sdk-migration for the migration guide.
+        Will be removed after Jan 31, 2027.
+    """
 
     def __init__(
         self, *args: Any, exceptions: Sequence[Exception], **kwargs: Any

--- a/python/langsmith/utils.py
+++ b/python/langsmith/utils.py
@@ -44,7 +44,7 @@ class LangSmithError(Exception):
 
     .. deprecated::
         Use :class:`langsmith.LangsmithError` instead.
-        See https://docs.langchain.com/langsmith/smithdb-sdk-migration for the migration guide.
+        See https://docs.langchain.com/langsmith/smithdb-sdk-migration#exceptions for the migration guide.
         Will be removed after Jan 31, 2027.
     """
 
@@ -54,7 +54,7 @@ class LangSmithAPIError(LangSmithError):
 
     .. deprecated::
         Use :class:`langsmith.InternalServerError` instead.
-        See https://docs.langchain.com/langsmith/smithdb-sdk-migration for the migration guide.
+        See https://docs.langchain.com/langsmith/smithdb-sdk-migration#exceptions for the migration guide.
         Will be removed after Jan 31, 2027.
     """
 
@@ -64,7 +64,7 @@ class LangSmithRequestTimeout(LangSmithError):
 
     .. deprecated::
         Use :class:`langsmith.APITimeoutError` instead.
-        See https://docs.langchain.com/langsmith/smithdb-sdk-migration for the migration guide.
+        See https://docs.langchain.com/langsmith/smithdb-sdk-migration#exceptions for the migration guide.
         Will be removed after Jan 31, 2027.
     """
 
@@ -74,7 +74,7 @@ class LangSmithUserError(LangSmithError):
 
     .. deprecated::
         Use :class:`langsmith.BadRequestError` instead.
-        See https://docs.langchain.com/langsmith/smithdb-sdk-migration for the migration guide.
+        See https://docs.langchain.com/langsmith/smithdb-sdk-migration#exceptions for the migration guide.
         Will be removed after Jan 31, 2027.
     """
 
@@ -84,7 +84,7 @@ class LangSmithRateLimitError(LangSmithError):
 
     .. deprecated::
         Use :class:`langsmith.RateLimitError` instead.
-        See https://docs.langchain.com/langsmith/smithdb-sdk-migration for the migration guide.
+        See https://docs.langchain.com/langsmith/smithdb-sdk-migration#exceptions for the migration guide.
         Will be removed after Jan 31, 2027.
     """
 
@@ -94,7 +94,7 @@ class LangSmithAuthError(LangSmithError):
 
     .. deprecated::
         Use :class:`langsmith.AuthenticationError` instead.
-        See https://docs.langchain.com/langsmith/smithdb-sdk-migration for the migration guide.
+        See https://docs.langchain.com/langsmith/smithdb-sdk-migration#exceptions for the migration guide.
         Will be removed after Jan 31, 2027.
     """
 
@@ -104,7 +104,7 @@ class LangSmithNotFoundError(LangSmithError):
 
     .. deprecated::
         Use :class:`langsmith.NotFoundError` instead.
-        See https://docs.langchain.com/langsmith/smithdb-sdk-migration for the migration guide.
+        See https://docs.langchain.com/langsmith/smithdb-sdk-migration#exceptions for the migration guide.
         Will be removed after Jan 31, 2027.
     """
 
@@ -114,7 +114,7 @@ class LangSmithConflictError(LangSmithError):
 
     .. deprecated::
         Use :class:`langsmith.ConflictError` instead.
-        See https://docs.langchain.com/langsmith/smithdb-sdk-migration for the migration guide.
+        See https://docs.langchain.com/langsmith/smithdb-sdk-migration#exceptions for the migration guide.
         Will be removed after Jan 31, 2027.
     """
 
@@ -124,7 +124,7 @@ class LangSmithConnectionError(LangSmithError):
 
     .. deprecated::
         Use :class:`langsmith.APIConnectionError` instead.
-        See https://docs.langchain.com/langsmith/smithdb-sdk-migration for the migration guide.
+        See https://docs.langchain.com/langsmith/smithdb-sdk-migration#exceptions for the migration guide.
         Will be removed after Jan 31, 2027.
     """
 
@@ -134,7 +134,7 @@ class LangSmithExceptionGroup(LangSmithError):
 
     .. deprecated::
         Use Python 3.11+ native ``ExceptionGroup`` or :class:`langsmith.LangsmithError` instead.
-        See https://docs.langchain.com/langsmith/smithdb-sdk-migration for the migration guide.
+        See https://docs.langchain.com/langsmith/smithdb-sdk-migration#exceptions for the migration guide.
         Will be removed after Jan 31, 2027.
     """
 


### PR DESCRIPTION
## Summary

Marks all legacy SDK methods from the [SmithDB SDK migration guide](https://docs.langchain.com/langsmith/smithdb-sdk-migration) as deprecated. Every deprecation includes a `warnings.warn(DeprecationWarning)` at runtime, a `.. deprecated::` RST docstring directive (Python), or a `@deprecated` JSDoc tag (TypeScript). Each message links to the specific section in the guide and mentions removal after Jan 31, 2027.

**Python `Client` and `AsyncClient` deprecated methods:**
- `read_run()` → `client.runs.retrieve()` ([#runs-retrieve](https://docs.langchain.com/langsmith/smithdb-sdk-migration#runs-retrieve))
- `list_runs()` → `client.runs.query()` ([#runs-query](https://docs.langchain.com/langsmith/smithdb-sdk-migration#runs-query))
- `read_thread()` → `client.threads.list_traces()` ([#threads-list-traces](https://docs.langchain.com/langsmith/smithdb-sdk-migration#threads-list-traces))
- `list_threads()` → `client.threads.query()` ([#threads-query](https://docs.langchain.com/langsmith/smithdb-sdk-migration#threads-query))
- `get_run_stats()` → `client.threads.stats()` ([#threads-stats](https://docs.langchain.com/langsmith/smithdb-sdk-migration#threads-stats))
- `get_experiment_results()` → `client.datasets.experiment_runs.query()` ([#dataset-experiment-runs-query](https://docs.langchain.com/langsmith/smithdb-sdk-migration#dataset-experiment-runs-query))
- `add_runs_to_annotation_queue(run_ids=...)` → `add_runs_to_annotation_queue(runs=...)` ([#annotation-queues-add-runs](https://docs.langchain.com/langsmith/smithdb-sdk-migration#annotation-queues-add-runs))

**Python legacy exception classes in `langsmith.utils`** ([#exceptions](https://docs.langchain.com/langsmith/smithdb-sdk-migration#exceptions)):
- All 10 `LangSmith*` exception classes deprecated with section-anchored URL

**TypeScript `Client` deprecated methods:**
- `readRun()`, `listRuns()`, `readThread()`, `listThreads()`, `getRunStats()`
- `addRunsToAnnotationQueue(string[])` path

## Test Plan

- [x] `DeprecationWarning` fires at runtime when calling deprecated Python methods
- [x] TypeScript `@deprecated` tags visible in IDE hover / tsc output