### PR TITLE
fix(python): promote usage_metadata from run.extra to OTEL span attributes

### DIFF
--- a/python/langsmith/_internal/otel/_otel_exporter.py
+++ b/python/langsmith/_internal/otel/_otel_exporter.py
@@ -612,7 +612,7 @@ class OTELExporter:
                 span.set_attribute(GEN_AI_SERIALIZED_DOC, serialized["doc"])
 
         # Set inputs/outputs if available
-        self._set_io_attributes(span, op)
+        self._set_io_attributes(span, op, run_info)
 
     def _set_gen_ai_system(self, span: Span, run_info: dict) -> None:
         """Set the gen_ai.system attribute on the span based on the model provider.
@@ -702,12 +702,18 @@ class OTELExporter:
                 GEN_AI_REQUEST_PRESENCE_PENALTY, invocation_params["presence_penalty"]
             )
 
-    def _set_io_attributes(self, span: Span, op: SerializedRunOperation) -> None:
+    def _set_io_attributes(
+        self, span: Span, op: SerializedRunOperation, run_info: dict
+    ) -> None:
         """Set input/output attributes on the span.
 
         Args:
             span: The span to set attributes on.
             op: The serialized run operation.
+            run_info: The deserialized run info. Used to fall back to token
+                usage recorded under ``extra.metadata.usage_metadata`` (e.g.
+                by the claude_agent_sdk integration) when neither the
+                top-level run token fields nor the outputs carry usage.
         """
         if op.inputs:
             try:
@@ -755,6 +761,21 @@ class OTELExporter:
 
                 # Extract token usage from outputs (for LLM runs)
                 token_usage = self.get_unified_run_tokens(outputs)
+                if not token_usage and not self._has_run_info_token_usage(run_info):
+                    # Some integrations (e.g. claude_agent_sdk) record real
+                    # per-turn usage only under extra.metadata.usage_metadata,
+                    # never in outputs or the top-level run token fields.
+                    # Fall back to it as a last resort so usage still
+                    # reaches OTEL. Lowest precedence: only used when
+                    # neither run_info nor outputs already supplied usage.
+                    extra = run_info.get("extra")
+                    metadata = (
+                        extra.get("metadata") if isinstance(extra, dict) else None
+                    )
+                    if isinstance(metadata, dict):
+                        token_usage = self._extract_unified_run_tokens(
+                            metadata.get("usage_metadata")
+                        )
                 if token_usage:
                     span.set_attribute(GEN_AI_USAGE_INPUT_TOKENS, token_usage[0])
                     span.set_attribute(GEN_AI_USAGE_OUTPUT_TOKENS, token_usage[1])
@@ -837,6 +858,15 @@ class OTELExporter:
         except ValueError:
             logger.exception(f"Failed to parse timestamp {timestamp}")
             return None
+
+    @staticmethod
+    def _has_run_info_token_usage(run_info: dict) -> bool:
+        """Whether run_info's top-level token fields already carry usage."""
+        return (
+            run_info.get("prompt_tokens") is not None
+            or run_info.get("completion_tokens") is not None
+            or run_info.get("total_tokens") is not None
+        )
 
     def get_unified_run_tokens(
         self, outputs: Optional[dict]

--- a/python/langsmith/_internal/otel/_otel_exporter.py
+++ b/python/langsmith/_internal/otel/_otel_exporter.py
@@ -755,36 +755,15 @@ class OTELExporter:
                     "Failed to process inputs for run %s", op.id, exc_info=True
                 )
 
+        outputs: Optional[dict] = None
+        token_usage: Optional[tuple[int, int]] = None
+
         if op.outputs:
             try:
                 outputs = _orjson.loads(op.outputs)
 
                 # Extract token usage from outputs (for LLM runs)
                 token_usage = self.get_unified_run_tokens(outputs)
-                if not token_usage and not self._has_run_info_token_usage(run_info):
-                    # Some integrations (e.g. claude_agent_sdk) record real
-                    # per-turn usage only under extra.metadata.usage_metadata,
-                    # never in outputs or the top-level run token fields.
-                    # Fall back to it as a last resort so usage still
-                    # reaches OTEL. Lowest precedence: only used when
-                    # neither run_info nor outputs already supplied usage.
-                    extra = run_info.get("extra")
-                    metadata = (
-                        extra.get("metadata") if isinstance(extra, dict) else None
-                    )
-                    if isinstance(metadata, dict):
-                        token_usage = self._extract_unified_run_tokens(
-                            metadata.get("usage_metadata")
-                        )
-                if token_usage:
-                    span.set_attribute(GEN_AI_USAGE_INPUT_TOKENS, token_usage[0])
-                    span.set_attribute(GEN_AI_USAGE_OUTPUT_TOKENS, token_usage[1])
-                    span.set_attribute(
-                        GEN_AI_USAGE_TOTAL_TOKENS, token_usage[0] + token_usage[1]
-                    )
-
-                    if "model" in outputs:
-                        span.set_attribute(GEN_AI_RESPONSE_MODEL, str(outputs["model"]))
                 # Extract additional response attributes.
                 if isinstance(outputs, dict):
                     if "id" in outputs and outputs["id"] is not None:
@@ -848,6 +827,31 @@ class OTELExporter:
                 logger.debug(
                     "Failed to process outputs for run %s", op.id, exc_info=True
                 )
+
+        if not token_usage and not self._has_run_info_token_usage(run_info):
+            # Some integrations (e.g. claude_agent_sdk) record real per-turn
+            # usage only under extra.metadata.usage_metadata -- never in
+            # outputs or the top-level run token fields, and sometimes on a
+            # patch operation that carries no outputs at all. Fall back to
+            # it as a last resort so usage still reaches OTEL. Lowest
+            # precedence: only used when neither run_info nor outputs
+            # already supplied usage.
+            extra = run_info.get("extra")
+            metadata = extra.get("metadata") if isinstance(extra, dict) else None
+            if isinstance(metadata, dict):
+                token_usage = self._extract_unified_run_tokens(
+                    metadata.get("usage_metadata")
+                )
+
+        if token_usage:
+            span.set_attribute(GEN_AI_USAGE_INPUT_TOKENS, token_usage[0])
+            span.set_attribute(GEN_AI_USAGE_OUTPUT_TOKENS, token_usage[1])
+            span.set_attribute(
+                GEN_AI_USAGE_TOTAL_TOKENS, token_usage[0] + token_usage[1]
+            )
+
+            if outputs is not None and "model" in outputs:
+                span.set_attribute(GEN_AI_RESPONSE_MODEL, str(outputs["model"]))
 
     def _as_utc_nano(self, timestamp: Optional[str]) -> Optional[int]:
         if not timestamp:

--- a/python/tests/unit_tests/test_otel_exporter.py
+++ b/python/tests/unit_tests/test_otel_exporter.py
@@ -6,6 +6,13 @@ import time
 import uuid
 from unittest.mock import MagicMock, patch
 
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+    InMemorySpanExporter,
+)
+
+from langsmith._internal._operations import serialize_run_dict
 from langsmith._internal.otel._otel_exporter import OTELExporter
 from langsmith.integrations.otel import (
     otel_safe_attribute_value,
@@ -297,3 +304,124 @@ def test_get_otlp_tracer_provider_no_project(mock_utils, mock_import):
         endpoint="https://api.smith.langchain.com/otel",
         headers={"x-api-key": "lsv2_pt_test123"},
     )
+
+
+# --- Tests for token usage promotion (extra.metadata.usage_metadata fallback) ---
+
+
+def _export_single_run(run_data: dict) -> "list":
+    """Serialize ``run_data`` as a 'post' op and export it through a real
+    OTELExporter backed by a real OTEL SDK TracerProvider, returning the
+    finished spans recorded by an in-memory span exporter.
+    """
+    in_memory_exporter = InMemorySpanExporter()
+    tracer_provider = TracerProvider()
+    tracer_provider.add_span_processor(SimpleSpanProcessor(in_memory_exporter))
+
+    exporter = OTELExporter(tracer_provider=tracer_provider)
+    op = serialize_run_dict("post", dict(run_data))
+    exporter.export_batch([op], {})
+
+    return in_memory_exporter.get_finished_spans()
+
+
+def _base_llm_run(run_id: uuid.UUID, trace_id: uuid.UUID) -> dict:
+    return {
+        "id": run_id,
+        "trace_id": trace_id,
+        "dotted_order": f"20240101T000000000000Z{trace_id}.{run_id}",
+        "name": "example-turn",
+        "run_type": "llm",
+        "start_time": "2024-01-01T00:00:00+00:00",
+        "end_time": "2024-01-01T00:00:01+00:00",
+        "inputs": {"messages": [{"role": "user", "content": "hi"}]},
+    }
+
+
+def test_export_batch_promotes_usage_from_extra_metadata():
+    """Usage recorded only under extra.metadata.usage_metadata (the shape
+    written by integrations such as claude_agent_sdk, which capture real
+    per-turn usage there rather than in outputs) is still promoted to the
+    gen_ai.usage.* span attributes.
+    """
+    run_id = uuid.uuid4()
+    trace_id = uuid.uuid4()
+    run_data = _base_llm_run(run_id, trace_id)
+    run_data.update(
+        # A turn's real output content -- no usage anywhere inside it.
+        outputs={
+            "content": [{"type": "text", "text": "hello"}],
+            "role": "assistant",
+        },
+        # Usage is captured only here.
+        extra={
+            "metadata": {
+                "usage_metadata": {
+                    "input_tokens": 21400,
+                    "output_tokens": 7,
+                    "total_tokens": 21407,
+                }
+            }
+        },
+    )
+
+    spans = _export_single_run(run_data)
+
+    assert len(spans) == 1
+    attributes = spans[0].attributes
+    assert attributes["gen_ai.usage.input_tokens"] == 21400
+    assert attributes["gen_ai.usage.output_tokens"] == 7
+    assert attributes["gen_ai.usage.total_tokens"] == 21407
+
+
+def test_export_batch_outputs_usage_takes_precedence_over_extra_metadata():
+    """The extra.metadata.usage_metadata fallback must never override real
+    usage already present on run.outputs -- it is a last resort only.
+    """
+    run_id = uuid.uuid4()
+    trace_id = uuid.uuid4()
+    run_data = _base_llm_run(run_id, trace_id)
+    run_data.update(
+        outputs={
+            "usage_metadata": {
+                "input_tokens": 100,
+                "output_tokens": 20,
+                "total_tokens": 120,
+            }
+        },
+        extra={
+            "metadata": {
+                "usage_metadata": {
+                    "input_tokens": 999,
+                    "output_tokens": 999,
+                    "total_tokens": 1998,
+                }
+            }
+        },
+    )
+
+    spans = _export_single_run(run_data)
+
+    assert len(spans) == 1
+    attributes = spans[0].attributes
+    assert attributes["gen_ai.usage.input_tokens"] == 100
+    assert attributes["gen_ai.usage.output_tokens"] == 20
+    assert attributes["gen_ai.usage.total_tokens"] == 120
+
+
+def test_export_batch_no_usage_anywhere_sets_no_usage_attributes():
+    """No usage source present -- no gen_ai.usage.* attributes are set."""
+    run_id = uuid.uuid4()
+    trace_id = uuid.uuid4()
+    run_data = _base_llm_run(run_id, trace_id)
+    run_data.update(
+        outputs={"content": [{"type": "text", "text": "hi"}], "role": "assistant"},
+    )
+
+    spans = _export_single_run(run_data)
+
+    assert len(spans) == 1
+    attributes = spans[0].attributes
+    assert "gen_ai.usage.input_tokens" not in attributes
+    assert "gen_ai.usage.output_tokens" not in attributes
+    assert "gen_ai.usage.total_tokens" not in attributes

--- a/python/tests/unit_tests/test_otel_exporter.py
+++ b/python/tests/unit_tests/test_otel_exporter.py
@@ -374,6 +374,36 @@ def test_export_batch_promotes_usage_from_extra_metadata():
     assert attributes["gen_ai.usage.total_tokens"] == 21407
 
 
+def test_export_batch_promotes_usage_from_extra_metadata_without_outputs():
+    """The extra.metadata.usage_metadata fallback must not depend on
+    outputs being present -- a run/patch operation can carry usage there
+    while having no outputs at all (e.g. a patch that only updates usage).
+    """
+    run_id = uuid.uuid4()
+    trace_id = uuid.uuid4()
+    run_data = _base_llm_run(run_id, trace_id)
+    run_data.update(
+        extra={
+            "metadata": {
+                "usage_metadata": {
+                    "input_tokens": 21400,
+                    "output_tokens": 7,
+                    "total_tokens": 21407,
+                }
+            }
+        },
+    )
+    assert "outputs" not in run_data
+
+    spans = _export_single_run(run_data)
+
+    assert len(spans) == 1
+    attributes = spans[0].attributes
+    assert attributes["gen_ai.usage.input_tokens"] == 21400
+    assert attributes["gen_ai.usage.output_tokens"] == 7
+    assert attributes["gen_ai.usage.total_tokens"] == 21407
+
+
 def test_export_batch_outputs_usage_takes_precedence_over_extra_metadata():
     """The extra.metadata.usage_metadata fallback must never override real
     usage already present on run.outputs -- it is a last resort only.


### PR DESCRIPTION
## Problem

The `claude_agent_sdk` integration (`langsmith/integrations/claude_agent_sdk/_client.py::TurnLifecycle._set_usage_from_message` and `_transcripts.py::_patch_usage_on_llm_runs`) captures real per-turn token usage from the Claude Agent SDK and stores it in `run.extra["metadata"]["usage_metadata"]`.

The OTEL exporter (`langsmith/_internal/otel/_otel_exporter.py`) only promotes token usage into the `gen_ai.usage.input_tokens` / `gen_ai.usage.output_tokens` / `gen_ai.usage.total_tokens` span attributes from two places:
- the top-level run token fields (`prompt_tokens` / `completion_tokens` / `total_tokens`), or
- `run.outputs[...]["usage_metadata"]`, via `get_unified_run_tokens`.

It never looks at `run.extra["metadata"]["usage_metadata"]`. As a result, any run whose usage was only captured there -- as is the case for every LLM turn produced by the `claude_agent_sdk` integration, and for any other integration that follows the same pattern -- is exported to OTEL with **no usage attributes at all**, so any OTEL backend consuming these spans sees `usage=0` even though LangSmith itself has the correct token counts.

## Repro

1. Trace a Claude Agent SDK session with LangSmith's `claude_agent_sdk` integration and `LANGSMITH_OTEL_ENABLED=true` (or otherwise wire an OTEL exporter/backend).
2. Inspect the exported spans for the LLM turns: `gen_ai.usage.input_tokens` / `gen_ai.usage.output_tokens` / `gen_ai.usage.total_tokens` are absent, even though the corresponding LangSmith run has `extra["metadata"]["usage_metadata"]` populated with real counts.

## Fix

In `_otel_exporter.py`, `_set_io_attributes` now falls back to `run_info["extra"]["metadata"]["usage_metadata"]` when neither the run's top-level token fields nor `run.outputs` already supplied usage. The fallback:
- reuses the existing `_extract_unified_run_tokens` key-extraction helper, so it accepts the same `input_tokens`/`output_tokens` shape as every other source;
- is strictly lowest precedence -- it never overrides usage already found via `run.outputs` or the run token fields;
- does not depend on `run.outputs` being present at all, since usage can arrive on an operation (e.g. a patch) that carries no outputs.

## Tests

Added to `tests/unit_tests/test_otel_exporter.py`, driving `OTELExporter.export_batch` end-to-end against a real `opentelemetry.sdk.trace.TracerProvider` + `InMemorySpanExporter` (no mocking of the exporter logic under test):
- `test_export_batch_promotes_usage_from_extra_metadata` -- usage present only in `extra.metadata.usage_metadata` is promoted to the span.
- `test_export_batch_promotes_usage_from_extra_metadata_without_outputs` -- same, when the operation has no outputs at all.
- `test_export_batch_outputs_usage_takes_precedence_over_extra_metadata` -- usage in `run.outputs` still wins when both sources are present.
- `test_export_batch_no_usage_anywhere_sets_no_usage_attributes` -- no usage source means no usage attributes are set (no false positives).

`make format`, `make lint` (ruff + mypy), and `make tests` (full `tests/unit_tests`, **2134 passed / 6 skipped / 1 xfailed**) are all green at exact head `67f53026592f84252b9375e10f72e7da629aec37`, based on current `main` at `4ddfa249823d102183054c750fc4ba4a9a356899`.
