### PR TITLE
chore: deprecate all legacy SDK methods from SmithDB migration guide

### DIFF
--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -5119,8 +5119,8 @@ export class Client implements LangSmithTracingClientInterface {
     }
     if (runId && !sessionId && !projectId) {
       console.warn(
-        "sessionId (or projectId) will become a required argument to " +
-          "createFeedback() in a future release. Please provide it to avoid errors.",
+        "sessionId will become a required argument to createFeedback() in a future " +
+          "release. Please provide it to avoid errors.",
       );
     }
     const feedback_source: feedback_source = {

--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -2845,6 +2845,12 @@ export class Client implements LangSmithTracingClientInterface {
     runId: string,
     { loadChildRuns }: { loadChildRuns: boolean } = { loadChildRuns: false },
   ): Promise<Run> {
+    process.emitWarning(
+      "readRun() is deprecated and will be removed after Jan 31, 2027. " +
+        "Use client.runs.retrieve() instead. " +
+        "See https://docs.langchain.com/langsmith/smithdb-sdk-migration#runs-retrieve for the migration guide.",
+      { type: "DeprecationWarning", code: "LANGSMITH_DEPRECATED_READ_RUN" },
+    );
     assertUuid(runId);
     let run = _normalizeRunTimestamps(await this._get<Run>(`/runs/${runId}`));
     if (loadChildRuns) {
@@ -3019,6 +3025,12 @@ export class Client implements LangSmithTracingClientInterface {
    * });
    */
   public async *listRuns(props: ListRunsParams): AsyncIterable<Run> {
+    process.emitWarning(
+      "listRuns() is deprecated and will be removed after Jan 31, 2027. " +
+        "Use client.runs.query() instead. " +
+        "See https://docs.langchain.com/langsmith/smithdb-sdk-migration#runs-query for the migration guide.",
+      { type: "DeprecationWarning", code: "LANGSMITH_DEPRECATED_LIST_RUNS" },
+    );
     const {
       projectId,
       projectName,
@@ -3208,6 +3220,15 @@ export class Client implements LangSmithTracingClientInterface {
 
   /** @deprecated Use `client.threads.listTraces()` instead. See https://docs.langchain.com/langsmith/smithdb-sdk-migration#threads-list-traces for the migration guide. Will be removed after Jan 31, 2027. */
   public async *readThread(props: ReadThreadParams): AsyncIterable<Run> {
+    process.emitWarning(
+      "readThread() is deprecated and will be removed after Jan 31, 2027. " +
+        "Use client.threads.listTraces() instead. " +
+        "See https://docs.langchain.com/langsmith/smithdb-sdk-migration#threads-list-traces for the migration guide.",
+      {
+        type: "DeprecationWarning",
+        code: "LANGSMITH_DEPRECATED_READ_THREAD",
+      },
+    );
     const {
       threadId,
       projectId,
@@ -3241,6 +3262,15 @@ export class Client implements LangSmithTracingClientInterface {
   public async listThreads(
     props: ListThreadsParams,
   ): Promise<ListThreadsItem[]> {
+    process.emitWarning(
+      "listThreads() is deprecated and will be removed after Jan 31, 2027. " +
+        "Use client.threads.query() instead. " +
+        "See https://docs.langchain.com/langsmith/smithdb-sdk-migration#threads-query for the migration guide.",
+      {
+        type: "DeprecationWarning",
+        code: "LANGSMITH_DEPRECATED_LIST_THREADS",
+      },
+    );
     const {
       projectId,
       projectName,
@@ -3405,6 +3435,15 @@ export class Client implements LangSmithTracingClientInterface {
     isRoot?: boolean;
     dataSourceType?: string;
   }): Promise<any> {
+    process.emitWarning(
+      "getRunStats() is deprecated and will be removed after Jan 31, 2027. " +
+        "Use client.threads.stats() instead. " +
+        "See https://docs.langchain.com/langsmith/smithdb-sdk-migration#threads-stats for the migration guide.",
+      {
+        type: "DeprecationWarning",
+        code: "LANGSMITH_DEPRECATED_GET_RUN_STATS",
+      },
+    );
     let projectIds_ = projectIds || [];
     if (projectNames) {
       projectIds_ = [

--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -5844,6 +5844,15 @@ export class Client implements LangSmithTracingClientInterface {
         }),
       );
     } else {
+      warnOnce(
+        "Passing run IDs as strings to addRunsToAnnotationQueue() is deprecated and will be removed after Jan 31, 2027. " +
+          "Use RunKey[] instead. " +
+          "See https://docs.langchain.com/langsmith/smithdb-sdk-migration#annotation-queues-add-runs for the migration guide.",
+        {
+          type: "DeprecationWarning",
+          code: "LANGSMITH_DEPRECATED_ADD_RUNS_STRING_IDS",
+        },
+      );
       url = base;
       body = JSON.stringify(
         (runs as string[]).map((id, i) =>

--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -3409,7 +3409,6 @@ export class Client implements LangSmithTracingClientInterface {
     return withLimit;
   }
 
-  /** @deprecated Use `client.threads.stats()` instead. See https://docs.langchain.com/langsmith/smithdb-sdk-migration#threads-stats for the migration guide. Will be removed after Jan 31, 2027. */
   public async getRunStats({
     id,
     trace,
@@ -3445,12 +3444,6 @@ export class Client implements LangSmithTracingClientInterface {
     isRoot?: boolean;
     dataSourceType?: string;
   }): Promise<any> {
-    _emitDeprecationWarning(
-      "getRunStats() is deprecated and will be removed after Jan 31, 2027. " +
-        "Use client.threads.stats() instead. " +
-        "See https://docs.langchain.com/langsmith/smithdb-sdk-migration#threads-stats for the migration guide.",
-      "LANGSMITH_DEPRECATED_GET_RUN_STATS",
-    );
     let projectIds_ = projectIds || [];
     if (projectNames) {
       projectIds_ = [

--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -2936,6 +2936,7 @@ export class Client implements LangSmithTracingClientInterface {
 
   /**
    * List runs from the LangSmith server.
+   * @deprecated Use `client.runs.query()` instead. See https://docs.langchain.com/langsmith/smithdb-sdk-migration for the migration guide. Will be removed after Jan 31, 2027.
    * @param projectId - The ID of the project to filter by.
    * @param projectName - The name of the project to filter by.
    * @param parentRunId - The ID of the parent run to filter by.

--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -5117,6 +5117,12 @@ export class Client implements LangSmithTracingClientInterface {
     if (runId && projectId) {
       throw new Error("Only one of runId or projectId can be provided");
     }
+    if (runId && !sessionId && !projectId) {
+      console.warn(
+        "sessionId (or projectId) will become a required argument to " +
+          "createFeedback() in a future release. Please provide it to avoid errors.",
+      );
+    }
     const feedback_source: feedback_source = {
       type: feedbackSourceType ?? "api",
       metadata: sourceInfo ?? {},

--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -874,7 +874,10 @@ export class AutoBatchQueue {
 
 const _emittedDeprecationWarnings = new Set<string>();
 function _emitDeprecationWarning(message: string, code: string): void {
-  if (typeof process !== "undefined" && typeof process.emitWarning === "function") {
+  if (
+    typeof process !== "undefined" &&
+    typeof process.emitWarning === "function"
+  ) {
     if (!_emittedDeprecationWarnings.has(code)) {
       _emittedDeprecationWarnings.add(code);
       process.emitWarning(message, { type: "DeprecationWarning", code });

--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -872,21 +872,6 @@ export class AutoBatchQueue {
   }
 }
 
-const _emittedDeprecationWarnings = new Set<string>();
-function _emitDeprecationWarning(message: string, code: string): void {
-  if (
-    typeof process !== "undefined" &&
-    typeof process.emitWarning === "function"
-  ) {
-    if (!_emittedDeprecationWarnings.has(code)) {
-      _emittedDeprecationWarnings.add(code);
-      process.emitWarning(message, { type: "DeprecationWarning", code });
-    }
-  } else if (!_emittedDeprecationWarnings.has(code)) {
-    _emittedDeprecationWarnings.add(code);
-    console.warn(`DeprecationWarning [${code}]: ${message}`);
-  }
-}
 
 export class Client implements LangSmithTracingClientInterface {
   private apiKey?: string;
@@ -2861,11 +2846,11 @@ export class Client implements LangSmithTracingClientInterface {
     runId: string,
     { loadChildRuns }: { loadChildRuns: boolean } = { loadChildRuns: false },
   ): Promise<Run> {
-    _emitDeprecationWarning(
+    warnOnce(
       "readRun() is deprecated and will be removed after Jan 31, 2027. " +
         "Use client.runs.retrieve() instead. " +
         "See https://docs.langchain.com/langsmith/smithdb-sdk-migration#runs-retrieve for the migration guide.",
-      "LANGSMITH_DEPRECATED_READ_RUN",
+      { type: "DeprecationWarning", code: "LANGSMITH_DEPRECATED_READ_RUN" },
     );
     assertUuid(runId);
     let run = _normalizeRunTimestamps(await this._get<Run>(`/runs/${runId}`));
@@ -3041,11 +3026,11 @@ export class Client implements LangSmithTracingClientInterface {
    * });
    */
   public async *listRuns(props: ListRunsParams): AsyncIterable<Run> {
-    _emitDeprecationWarning(
+    warnOnce(
       "listRuns() is deprecated and will be removed after Jan 31, 2027. " +
         "Use client.runs.query() instead. " +
         "See https://docs.langchain.com/langsmith/smithdb-sdk-migration#runs-query for the migration guide.",
-      "LANGSMITH_DEPRECATED_LIST_RUNS",
+      { type: "DeprecationWarning", code: "LANGSMITH_DEPRECATED_LIST_RUNS" },
     );
     const {
       projectId,
@@ -3236,11 +3221,11 @@ export class Client implements LangSmithTracingClientInterface {
 
   /** @deprecated Use `client.threads.listTraces()` instead. See https://docs.langchain.com/langsmith/smithdb-sdk-migration#threads-list-traces for the migration guide. Will be removed after Jan 31, 2027. */
   public async *readThread(props: ReadThreadParams): AsyncIterable<Run> {
-    _emitDeprecationWarning(
+    warnOnce(
       "readThread() is deprecated and will be removed after Jan 31, 2027. " +
         "Use client.threads.listTraces() instead. " +
         "See https://docs.langchain.com/langsmith/smithdb-sdk-migration#threads-list-traces for the migration guide.",
-      "LANGSMITH_DEPRECATED_READ_THREAD",
+      { type: "DeprecationWarning", code: "LANGSMITH_DEPRECATED_READ_THREAD" },
     );
     const {
       threadId,
@@ -3275,11 +3260,11 @@ export class Client implements LangSmithTracingClientInterface {
   public async listThreads(
     props: ListThreadsParams,
   ): Promise<ListThreadsItem[]> {
-    _emitDeprecationWarning(
+    warnOnce(
       "listThreads() is deprecated and will be removed after Jan 31, 2027. " +
         "Use client.threads.query() instead. " +
         "See https://docs.langchain.com/langsmith/smithdb-sdk-migration#threads-query for the migration guide.",
-      "LANGSMITH_DEPRECATED_LIST_THREADS",
+      { type: "DeprecationWarning", code: "LANGSMITH_DEPRECATED_LIST_THREADS" },
     );
     const {
       projectId,
@@ -5118,9 +5103,14 @@ export class Client implements LangSmithTracingClientInterface {
       throw new Error("Only one of runId or projectId can be provided");
     }
     if (runId && !sessionId) {
-      console.warn(
+      warnOnce(
         "sessionId will become a required argument to createFeedback() in a future " +
-          "release. Please provide it to avoid errors.",
+          "release. Please provide it to avoid errors. " +
+          "See https://docs.langchain.com/langsmith/smithdb-sdk-migration#feedback-create for the migration guide.",
+        {
+          type: "DeprecationWarning",
+          code: "LANGSMITH_DEPRECATED_CREATE_FEEDBACK_SESSION_ID",
+        },
       );
     }
     const feedback_source: feedback_source = {

--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -5117,7 +5117,7 @@ export class Client implements LangSmithTracingClientInterface {
     if (runId && projectId) {
       throw new Error("Only one of runId or projectId can be provided");
     }
-    if (runId && !sessionId && !projectId) {
+    if (runId && !sessionId) {
       console.warn(
         "sessionId will become a required argument to createFeedback() in a future " +
           "release. Please provide it to avoid errors.",

--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -2840,6 +2840,10 @@ export class Client implements LangSmithTracingClientInterface {
     });
   }
 
+  /**
+   * Read a run from the LangSmith API.
+   * @deprecated Use `client.runs.retrieve()` instead. See https://docs.langchain.com/langsmith/smithdb-sdk-migration#runs-retrieve for the migration guide. Will be removed after Jan 31, 2027.
+   */
   public async readRun(
     runId: string,
     { loadChildRuns }: { loadChildRuns: boolean } = { loadChildRuns: false },
@@ -2936,7 +2940,7 @@ export class Client implements LangSmithTracingClientInterface {
 
   /**
    * List runs from the LangSmith server.
-   * @deprecated Use `client.runs.query()` instead. See https://docs.langchain.com/langsmith/smithdb-sdk-migration for the migration guide. Will be removed after Jan 31, 2027.
+   * @deprecated Use `client.runs.query()` instead. See https://docs.langchain.com/langsmith/smithdb-sdk-migration#runs-query for the migration guide. Will be removed after Jan 31, 2027.
    * @param projectId - The ID of the project to filter by.
    * @param projectName - The name of the project to filter by.
    * @param parentRunId - The ID of the parent run to filter by.
@@ -3205,6 +3209,10 @@ export class Client implements LangSmithTracingClientInterface {
     }
   }
 
+  /**
+   * Read runs for a single thread.
+   * @deprecated Use `client.threads.listTraces()` instead. See https://docs.langchain.com/langsmith/smithdb-sdk-migration#threads-list-traces for the migration guide. Will be removed after Jan 31, 2027.
+   */
   public async *readThread(props: ReadThreadParams): AsyncIterable<Run> {
     const {
       threadId,
@@ -3235,6 +3243,10 @@ export class Client implements LangSmithTracingClientInterface {
     });
   }
 
+  /**
+   * List threads and fetch runs for each thread.
+   * @deprecated Use `client.threads.query()` instead. See https://docs.langchain.com/langsmith/smithdb-sdk-migration#threads-query for the migration guide. Will be removed after Jan 31, 2027.
+   */
   public async listThreads(
     props: ListThreadsParams,
   ): Promise<ListThreadsItem[]> {
@@ -3366,6 +3378,10 @@ export class Client implements LangSmithTracingClientInterface {
     return withLimit;
   }
 
+  /**
+   * Get aggregate statistics over queried runs.
+   * @deprecated Use `client.threads.stats()` instead. See https://docs.langchain.com/langsmith/smithdb-sdk-migration#threads-stats for the migration guide. Will be removed after Jan 31, 2027.
+   */
   public async getRunStats({
     id,
     trace,
@@ -5757,8 +5773,9 @@ export class Client implements LangSmithTracingClientInterface {
    * - `RunKey[]` (preferred): each entry carries the run's full lookup key, so
    *   it can be located directly without a scan. Required for workspaces served
    *   by SmithDB; routes to `POST /runs/by-key`.
-   * - `string[]`: a plain list of run IDs. This path will be deprecated in a
-   *   future release; prefer the key form. Routes to `POST /runs`.
+   * - `string[]`: a plain list of run IDs. **Deprecated**: this path will be
+   *   removed after Jan 31, 2027; prefer the key form. Routes to `POST /runs`.
+   *   See https://docs.langchain.com/langsmith/smithdb-sdk-migration#annotation-queues-add-runs.
    *
    * If every element is a string (or the list is empty) it is treated as run
    * IDs; otherwise the list is treated as `RunKey` objects.

--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -2840,10 +2840,7 @@ export class Client implements LangSmithTracingClientInterface {
     });
   }
 
-  /**
-   * Read a run from the LangSmith API.
-   * @deprecated Use `client.runs.retrieve()` instead. See https://docs.langchain.com/langsmith/smithdb-sdk-migration#runs-retrieve for the migration guide. Will be removed after Jan 31, 2027.
-   */
+  /** @deprecated Use `client.runs.retrieve()` instead. See https://docs.langchain.com/langsmith/smithdb-sdk-migration#runs-retrieve for the migration guide. Will be removed after Jan 31, 2027. */
   public async readRun(
     runId: string,
     { loadChildRuns }: { loadChildRuns: boolean } = { loadChildRuns: false },
@@ -3209,10 +3206,7 @@ export class Client implements LangSmithTracingClientInterface {
     }
   }
 
-  /**
-   * Read runs for a single thread.
-   * @deprecated Use `client.threads.listTraces()` instead. See https://docs.langchain.com/langsmith/smithdb-sdk-migration#threads-list-traces for the migration guide. Will be removed after Jan 31, 2027.
-   */
+  /** @deprecated Use `client.threads.listTraces()` instead. See https://docs.langchain.com/langsmith/smithdb-sdk-migration#threads-list-traces for the migration guide. Will be removed after Jan 31, 2027. */
   public async *readThread(props: ReadThreadParams): AsyncIterable<Run> {
     const {
       threadId,
@@ -3243,10 +3237,7 @@ export class Client implements LangSmithTracingClientInterface {
     });
   }
 
-  /**
-   * List threads and fetch runs for each thread.
-   * @deprecated Use `client.threads.query()` instead. See https://docs.langchain.com/langsmith/smithdb-sdk-migration#threads-query for the migration guide. Will be removed after Jan 31, 2027.
-   */
+  /** @deprecated Use `client.threads.query()` instead. See https://docs.langchain.com/langsmith/smithdb-sdk-migration#threads-query for the migration guide. Will be removed after Jan 31, 2027. */
   public async listThreads(
     props: ListThreadsParams,
   ): Promise<ListThreadsItem[]> {
@@ -3378,10 +3369,7 @@ export class Client implements LangSmithTracingClientInterface {
     return withLimit;
   }
 
-  /**
-   * Get aggregate statistics over queried runs.
-   * @deprecated Use `client.threads.stats()` instead. See https://docs.langchain.com/langsmith/smithdb-sdk-migration#threads-stats for the migration guide. Will be removed after Jan 31, 2027.
-   */
+  /** @deprecated Use `client.threads.stats()` instead. See https://docs.langchain.com/langsmith/smithdb-sdk-migration#threads-stats for the migration guide. Will be removed after Jan 31, 2027. */
   public async getRunStats({
     id,
     trace,

--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -872,6 +872,19 @@ export class AutoBatchQueue {
   }
 }
 
+const _emittedDeprecationWarnings = new Set<string>();
+function _emitDeprecationWarning(message: string, code: string): void {
+  if (typeof process !== "undefined" && typeof process.emitWarning === "function") {
+    if (!_emittedDeprecationWarnings.has(code)) {
+      _emittedDeprecationWarnings.add(code);
+      process.emitWarning(message, { type: "DeprecationWarning", code });
+    }
+  } else if (!_emittedDeprecationWarnings.has(code)) {
+    _emittedDeprecationWarnings.add(code);
+    console.warn(`DeprecationWarning [${code}]: ${message}`);
+  }
+}
+
 export class Client implements LangSmithTracingClientInterface {
   private apiKey?: string;
 
@@ -2845,11 +2858,11 @@ export class Client implements LangSmithTracingClientInterface {
     runId: string,
     { loadChildRuns }: { loadChildRuns: boolean } = { loadChildRuns: false },
   ): Promise<Run> {
-    process.emitWarning(
+    _emitDeprecationWarning(
       "readRun() is deprecated and will be removed after Jan 31, 2027. " +
         "Use client.runs.retrieve() instead. " +
         "See https://docs.langchain.com/langsmith/smithdb-sdk-migration#runs-retrieve for the migration guide.",
-      { type: "DeprecationWarning", code: "LANGSMITH_DEPRECATED_READ_RUN" },
+      "LANGSMITH_DEPRECATED_READ_RUN",
     );
     assertUuid(runId);
     let run = _normalizeRunTimestamps(await this._get<Run>(`/runs/${runId}`));
@@ -3025,11 +3038,11 @@ export class Client implements LangSmithTracingClientInterface {
    * });
    */
   public async *listRuns(props: ListRunsParams): AsyncIterable<Run> {
-    process.emitWarning(
+    _emitDeprecationWarning(
       "listRuns() is deprecated and will be removed after Jan 31, 2027. " +
         "Use client.runs.query() instead. " +
         "See https://docs.langchain.com/langsmith/smithdb-sdk-migration#runs-query for the migration guide.",
-      { type: "DeprecationWarning", code: "LANGSMITH_DEPRECATED_LIST_RUNS" },
+      "LANGSMITH_DEPRECATED_LIST_RUNS",
     );
     const {
       projectId,
@@ -3220,14 +3233,11 @@ export class Client implements LangSmithTracingClientInterface {
 
   /** @deprecated Use `client.threads.listTraces()` instead. See https://docs.langchain.com/langsmith/smithdb-sdk-migration#threads-list-traces for the migration guide. Will be removed after Jan 31, 2027. */
   public async *readThread(props: ReadThreadParams): AsyncIterable<Run> {
-    process.emitWarning(
+    _emitDeprecationWarning(
       "readThread() is deprecated and will be removed after Jan 31, 2027. " +
         "Use client.threads.listTraces() instead. " +
         "See https://docs.langchain.com/langsmith/smithdb-sdk-migration#threads-list-traces for the migration guide.",
-      {
-        type: "DeprecationWarning",
-        code: "LANGSMITH_DEPRECATED_READ_THREAD",
-      },
+      "LANGSMITH_DEPRECATED_READ_THREAD",
     );
     const {
       threadId,
@@ -3262,14 +3272,11 @@ export class Client implements LangSmithTracingClientInterface {
   public async listThreads(
     props: ListThreadsParams,
   ): Promise<ListThreadsItem[]> {
-    process.emitWarning(
+    _emitDeprecationWarning(
       "listThreads() is deprecated and will be removed after Jan 31, 2027. " +
         "Use client.threads.query() instead. " +
         "See https://docs.langchain.com/langsmith/smithdb-sdk-migration#threads-query for the migration guide.",
-      {
-        type: "DeprecationWarning",
-        code: "LANGSMITH_DEPRECATED_LIST_THREADS",
-      },
+      "LANGSMITH_DEPRECATED_LIST_THREADS",
     );
     const {
       projectId,
@@ -3435,14 +3442,11 @@ export class Client implements LangSmithTracingClientInterface {
     isRoot?: boolean;
     dataSourceType?: string;
   }): Promise<any> {
-    process.emitWarning(
+    _emitDeprecationWarning(
       "getRunStats() is deprecated and will be removed after Jan 31, 2027. " +
         "Use client.threads.stats() instead. " +
         "See https://docs.langchain.com/langsmith/smithdb-sdk-migration#threads-stats for the migration guide.",
-      {
-        type: "DeprecationWarning",
-        code: "LANGSMITH_DEPRECATED_GET_RUN_STATS",
-      },
+      "LANGSMITH_DEPRECATED_GET_RUN_STATS",
     );
     let projectIds_ = projectIds || [];
     if (projectNames) {

--- a/js/src/utils/warn.ts
+++ b/js/src/utils/warn.ts
@@ -1,8 +1,22 @@
 const warnedMessages: Record<string, boolean> = {};
 
-export function warnOnce(message: string): void {
-  if (!warnedMessages[message]) {
-    console.warn(message);
-    warnedMessages[message] = true;
+export function warnOnce(
+  message: string,
+  options?: { type?: string; code?: string },
+): void {
+  const key = options?.code ?? message;
+  if (!warnedMessages[key]) {
+    warnedMessages[key] = true;
+    if (
+      options?.type &&
+      typeof process !== "undefined" &&
+      typeof process.emitWarning === "function"
+    ) {
+      process.emitWarning(message, { type: options.type, code: options.code });
+    } else if (options?.type && options?.code) {
+      console.warn(`${options.type} [${options.code}]: ${message}`);
+    } else {
+      console.warn(message);
+    }
   }
 }

--- a/python/langsmith/async_client.py
+++ b/python/langsmith/async_client.py
@@ -605,6 +605,11 @@ class AsyncClient:
     ) -> AsyncIterator[ls_schemas.Run]:
         """List runs from the LangSmith API.
 
+        .. deprecated::
+            Use :meth:`langsmith.AsyncClient.runs.query` instead.
+            See https://docs.langchain.com/langsmith/smithdb-sdk-migration for the migration guide.
+            Will be removed after Jan 31, 2027.
+
         Args:
             project_id: The ID(s) of the project to filter by.
             project_name: The name(s) of the project to filter by.
@@ -693,6 +698,13 @@ class AsyncClient:
             )
             ```
         """  # noqa: E501
+        warnings.warn(
+            "list_runs() is deprecated and will be removed after Jan 31, 2027. "
+            "Use client.runs.query() instead. "
+            "See https://docs.langchain.com/langsmith/smithdb-sdk-migration for the migration guide.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         project_ids = []
         if isinstance(project_id, (uuid.UUID, str)):
             project_ids.append(project_id)

--- a/python/langsmith/async_client.py
+++ b/python/langsmith/async_client.py
@@ -1065,9 +1065,8 @@ class AsyncClient:
             )
         if run_id is not None and session_id is None and project_id is None:
             warnings.warn(
-                "session_id (or project_id) will become a required argument to "
-                "create_feedback() in a future release. Please provide it to avoid "
-                "errors.",
+                "session_id will become a required argument to create_feedback() in "
+                "a future release. Please provide it to avoid errors.",
                 FutureWarning,
                 stacklevel=2,
             )

--- a/python/langsmith/async_client.py
+++ b/python/langsmith/async_client.py
@@ -1063,7 +1063,7 @@ class AsyncClient:
             raise ValueError(
                 "project_id cannot be provided if run_id or trace_id is provided"
             )
-        if run_id is not None and session_id is None and project_id is None:
+        if run_id is not None and session_id is None:
             warnings.warn(
                 "session_id will become a required argument to create_feedback() in "
                 "a future release. Please provide it to avoid errors.",

--- a/python/langsmith/async_client.py
+++ b/python/langsmith/async_client.py
@@ -1063,6 +1063,14 @@ class AsyncClient:
             raise ValueError(
                 "project_id cannot be provided if run_id or trace_id is provided"
             )
+        if run_id is not None and session_id is None and project_id is None:
+            warnings.warn(
+                "session_id (or project_id) will become a required argument to "
+                "create_feedback() in a future release. Please provide it to avoid "
+                "errors.",
+                FutureWarning,
+                stacklevel=2,
+            )
         if kwargs:
             warnings.warn(
                 "The following arguments are no longer used in the create_feedback"

--- a/python/langsmith/async_client.py
+++ b/python/langsmith/async_client.py
@@ -23,6 +23,7 @@ from typing import (
 import httpx
 
 import langsmith._openapi_client as _langsmith_api_module
+from langsmith._internal._beta_decorator import deprecated as _deprecated
 
 if TYPE_CHECKING:
     from langsmith._openapi_client.resources.runs import AsyncRunsResource
@@ -575,7 +576,7 @@ class AsyncClient:
     async def read_run(self, run_id: ls_client.ID_TYPE) -> ls_schemas.Run:
         """Read a run.
 
-        .. deprecated::
+        .. deprecated:: 0.10.7
             Use :meth:`langsmith.AsyncClient.runs.retrieve` instead.
             See https://docs.langchain.com/langsmith/smithdb-sdk-migration#runs-retrieve for the migration guide.
             Will be removed after Jan 31, 2027.
@@ -593,6 +594,12 @@ class AsyncClient:
         )
         return ls_schemas.Run(**response.json())
 
+    @_deprecated(
+        "list_runs() is deprecated and will be removed after Jan 31, 2027. "
+        "Use client.runs.query() instead. "
+        "See https://docs.langchain.com/langsmith/smithdb-sdk-migration"
+        "#runs-query for the migration guide."
+    )
     async def list_runs(
         self,
         *,
@@ -618,7 +625,7 @@ class AsyncClient:
     ) -> AsyncIterator[ls_schemas.Run]:
         """List runs from the LangSmith API.
 
-        .. deprecated::
+        .. deprecated:: 0.10.7
             Use :meth:`langsmith.AsyncClient.runs.query` instead.
             See https://docs.langchain.com/langsmith/smithdb-sdk-migration#runs-query for the migration guide.
             Will be removed after Jan 31, 2027.
@@ -711,13 +718,6 @@ class AsyncClient:
             )
             ```
         """  # noqa: E501
-        warnings.warn(
-            "list_runs() is deprecated and will be removed after Jan 31, 2027. "
-            "Use client.runs.query() instead. "
-            "See https://docs.langchain.com/langsmith/smithdb-sdk-migration#runs-query for the migration guide.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
         project_ids = []
         if isinstance(project_id, (uuid.UUID, str)):
             project_ids.append(project_id)

--- a/python/langsmith/async_client.py
+++ b/python/langsmith/async_client.py
@@ -573,7 +573,20 @@ class AsyncClient:
         )
 
     async def read_run(self, run_id: ls_client.ID_TYPE) -> ls_schemas.Run:
-        """Read a run."""
+        """Read a run.
+
+        .. deprecated::
+            Use :meth:`langsmith.AsyncClient.runs.retrieve` instead.
+            See https://docs.langchain.com/langsmith/smithdb-sdk-migration#runs-retrieve for the migration guide.
+            Will be removed after Jan 31, 2027.
+        """
+        warnings.warn(
+            "read_run() is deprecated and will be removed after Jan 31, 2027. "
+            "Use client.runs.retrieve() instead. "
+            "See https://docs.langchain.com/langsmith/smithdb-sdk-migration#runs-retrieve for the migration guide.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         response = await self._arequest_with_retries(
             "GET",
             f"/runs/{ls_client._as_uuid(run_id)}",
@@ -607,7 +620,7 @@ class AsyncClient:
 
         .. deprecated::
             Use :meth:`langsmith.AsyncClient.runs.query` instead.
-            See https://docs.langchain.com/langsmith/smithdb-sdk-migration for the migration guide.
+            See https://docs.langchain.com/langsmith/smithdb-sdk-migration#runs-query for the migration guide.
             Will be removed after Jan 31, 2027.
 
         Args:
@@ -701,7 +714,7 @@ class AsyncClient:
         warnings.warn(
             "list_runs() is deprecated and will be removed after Jan 31, 2027. "
             "Use client.runs.query() instead. "
-            "See https://docs.langchain.com/langsmith/smithdb-sdk-migration for the migration guide.",
+            "See https://docs.langchain.com/langsmith/smithdb-sdk-migration#runs-query for the migration guide.",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/python/langsmith/async_client.py
+++ b/python/langsmith/async_client.py
@@ -1067,7 +1067,7 @@ class AsyncClient:
             warnings.warn(
                 "session_id will become a required argument to create_feedback() in "
                 "a future release. Please provide it to avoid errors.",
-                FutureWarning,
+                DeprecationWarning,
                 stacklevel=2,
             )
         if kwargs:

--- a/python/langsmith/async_client.py
+++ b/python/langsmith/async_client.py
@@ -573,6 +573,12 @@ class AsyncClient:
             content=ls_client._dumps_json(data),
         )
 
+    @_deprecated(
+        "read_run() is deprecated and will be removed after Jan 31, 2027. "
+        "Use client.runs.retrieve() instead. "
+        "See https://docs.langchain.com/langsmith/smithdb-sdk-migration"
+        "#runs-retrieve for the migration guide."
+    )
     async def read_run(self, run_id: ls_client.ID_TYPE) -> ls_schemas.Run:
         """Read a run.
 
@@ -581,13 +587,6 @@ class AsyncClient:
             See https://docs.langchain.com/langsmith/smithdb-sdk-migration#runs-retrieve for the migration guide.
             Will be removed after Jan 31, 2027.
         """
-        warnings.warn(
-            "read_run() is deprecated and will be removed after Jan 31, 2027. "
-            "Use client.runs.retrieve() instead. "
-            "See https://docs.langchain.com/langsmith/smithdb-sdk-migration#runs-retrieve for the migration guide.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
         response = await self._arequest_with_retries(
             "GET",
             f"/runs/{ls_client._as_uuid(run_id)}",

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -3990,6 +3990,12 @@ class Client:
             runs[run_id].child_runs = children
         return run
 
+    @_deprecated(
+        "read_run() is deprecated and will be removed after Jan 31, 2027. "
+        "Use client.runs.retrieve() instead. "
+        "See https://docs.langchain.com/langsmith/smithdb-sdk-migration"
+        "#runs-retrieve for the migration guide."
+    )
     def read_run(
         self, run_id: ID_TYPE, load_child_runs: bool = False
     ) -> ls_schemas.Run:
@@ -4020,13 +4026,6 @@ class Client:
             stored_run = client.read_run(run_id)
             ```
         """
-        warnings.warn(
-            "read_run() is deprecated and will be removed after Jan 31, 2027. "
-            "Use client.runs.retrieve() instead. "
-            "See https://docs.langchain.com/langsmith/smithdb-sdk-migration#runs-retrieve for the migration guide.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
         response = self.request_with_retries(
             "GET", f"/runs/{_as_uuid(run_id, 'run_id')}"
         )
@@ -4041,6 +4040,12 @@ class Client:
             run = self._load_child_runs(run)
         return run
 
+    @_deprecated(
+        "read_thread() is deprecated and will be removed after Jan 31, 2027. "
+        "Use client.threads.list_traces() instead. "
+        "See https://docs.langchain.com/langsmith/smithdb-sdk-migration"
+        "#threads-list-traces for the migration guide."
+    )
     def read_thread(
         self,
         *,
@@ -4085,13 +4090,6 @@ class Client:
                 print(run.id)
             ```
         """
-        warnings.warn(
-            "read_thread() is deprecated and will be removed after Jan 31, 2027. "
-            "Use client.threads.list_traces() instead. "
-            "See https://docs.langchain.com/langsmith/smithdb-sdk-migration#threads-list-traces for the migration guide.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
         if not (project_id or project_name):
             raise ValueError("thread_id requires project_id or project_name")
 
@@ -4314,6 +4312,12 @@ class Client:
             if limit is not None and i + 1 >= limit:
                 break
 
+    @_deprecated(
+        "list_threads() is deprecated and will be removed after Jan 31, 2027. "
+        "Use client.threads.query() instead. "
+        "See https://docs.langchain.com/langsmith/smithdb-sdk-migration"
+        "#threads-query for the migration guide."
+    )
     def list_threads(
         self,
         *,
@@ -4343,13 +4347,6 @@ class Client:
             List of thread items, each with "thread_id", "runs", "count",
             "min_start_time", and "max_start_time".
         """
-        warnings.warn(
-            "list_threads() is deprecated and will be removed after Jan 31, 2027. "
-            "Use client.threads.query() instead. "
-            "See https://docs.langchain.com/langsmith/smithdb-sdk-migration#threads-query for the migration guide.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
         if project_id is None and project_name is None:
             raise ValueError("Either project_id or project_name must be provided")
         if project_id is not None and project_name is not None:
@@ -4450,6 +4447,12 @@ class Client:
             result = result[:limit]
         return result
 
+    @_deprecated(
+        "get_run_stats() is deprecated and will be removed after Jan 31, 2027. "
+        "Use client.threads.stats() instead. "
+        "See https://docs.langchain.com/langsmith/smithdb-sdk-migration"
+        "#threads-stats for the migration guide."
+    )
     def get_run_stats(
         self,
         *,
@@ -4501,13 +4504,6 @@ class Client:
         Returns:
             Dict[str, Any]: A dictionary containing the run statistics.
         """  # noqa: E501
-        warnings.warn(
-            "get_run_stats() is deprecated and will be removed after Jan 31, 2027. "
-            "Use client.threads.stats() instead. "
-            "See https://docs.langchain.com/langsmith/smithdb-sdk-migration#threads-stats for the migration guide.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
         from concurrent.futures import ThreadPoolExecutor, as_completed  # type: ignore
 
         project_ids = project_ids or []
@@ -10747,6 +10743,12 @@ class Client:
 
             offset += len(batch)
 
+    @_deprecated(
+        "get_experiment_results() is deprecated and will be removed after Jan 31, 2027. "
+        "Use client.datasets.experiment_runs.query() instead. "
+        "See https://docs.langchain.com/langsmith/smithdb-sdk-migration"
+        "#dataset-experiment-runs-query for the migration guide."
+    )
     def get_experiment_results(
         self,
         name: Optional[str] = None,
@@ -10802,13 +10804,6 @@ class Client:
             print(f"Feedback stats: {results['feedback_stats']}")
             ```
         """
-        warnings.warn(
-            "get_experiment_results() is deprecated and will be removed after Jan 31, 2027. "
-            "Use client.datasets.experiment_runs.query() instead. "
-            "See https://docs.langchain.com/langsmith/smithdb-sdk-migration#dataset-experiment-runs-query for the migration guide.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
         project = self.read_project(
             project_name=name, project_id=project_id, include_stats=True
         )

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -7845,9 +7845,8 @@ class Client:
             )
         if run_id is not None and session_id is None and project_id is None:
             warnings.warn(
-                "session_id (or project_id) will become a required argument to "
-                "create_feedback() in a future release. Please provide it to avoid "
-                "errors.",
+                "session_id will become a required argument to create_feedback() in "
+                "a future release. Please provide it to avoid errors.",
                 FutureWarning,
                 stacklevel=2,
             )

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -79,7 +79,8 @@ from langsmith._internal._background_thread import (
 from langsmith._internal._background_thread import (
     tracing_control_thread_func as _tracing_control_thread_func,
 )
-from langsmith._internal._beta_decorator import deprecated as _deprecated, warn_beta
+from langsmith._internal._beta_decorator import deprecated as _deprecated
+from langsmith._internal._beta_decorator import warn_beta
 from langsmith._internal._compressed_traces import CompressedTraces
 from langsmith._internal._constants import (
     _AUTO_SCALE_UP_NTHREADS_LIMIT,

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -4447,12 +4447,6 @@ class Client:
             result = result[:limit]
         return result
 
-    @_deprecated(
-        "get_run_stats() is deprecated and will be removed after Jan 31, 2027. "
-        "Use client.threads.stats() instead. "
-        "See https://docs.langchain.com/langsmith/smithdb-sdk-migration"
-        "#threads-stats for the migration guide."
-    )
     def get_run_stats(
         self,
         *,
@@ -4474,11 +4468,6 @@ class Client:
         data_source_type: Optional[str] = None,
     ) -> dict[str, Any]:
         """Get aggregate statistics over queried runs.
-
-        .. deprecated:: 0.10.7
-            Use :meth:`langsmith.Client.threads.stats` instead.
-            See https://docs.langchain.com/langsmith/smithdb-sdk-migration#threads-stats for the migration guide.
-            Will be removed after Jan 31, 2027.
 
         Takes in similar query parameters to `list_runs` and returns statistics
         based on the runs that match the query.

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -7843,6 +7843,14 @@ class Client:
             raise ValueError(
                 "project_id cannot be provided if run_id or trace_id is provided"
             )
+        if run_id is not None and session_id is None and project_id is None:
+            warnings.warn(
+                "session_id (or project_id) will become a required argument to "
+                "create_feedback() in a future release. Please provide it to avoid "
+                "errors.",
+                FutureWarning,
+                stacklevel=2,
+            )
         if kwargs:
             warnings.warn(
                 "The following arguments are no longer used in the create_feedback"

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -7847,7 +7847,7 @@ class Client:
             warnings.warn(
                 "session_id will become a required argument to create_feedback() in "
                 "a future release. Please provide it to avoid errors.",
-                FutureWarning,
+                DeprecationWarning,
                 stacklevel=2,
             )
         if kwargs:

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -4107,6 +4107,11 @@ class Client:
     ) -> Iterator[ls_schemas.Run]:
         """List runs from the LangSmith API.
 
+        .. deprecated::
+            Use :meth:`langsmith.Client.runs.query` instead.
+            See https://docs.langchain.com/langsmith/smithdb-sdk-migration for the migration guide.
+            Will be removed after Jan 31, 2027.
+
         Args:
             project_id: The ID(s) of the project to filter by.
             project_name: The name(s) of the project to filter by.
@@ -4195,6 +4200,13 @@ class Client:
             )
             ```
         """  # noqa: E501
+        warnings.warn(
+            "list_runs() is deprecated and will be removed after Jan 31, 2027. "
+            "Use client.runs.query() instead. "
+            "See https://docs.langchain.com/langsmith/smithdb-sdk-migration for the migration guide.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         project_ids = []
         if isinstance(project_id, (uuid.UUID, str)):
             project_ids.append(project_id)

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -3994,6 +3994,11 @@ class Client:
     ) -> ls_schemas.Run:
         """Read a run from the LangSmith API.
 
+        .. deprecated::
+            Use :meth:`langsmith.Client.runs.retrieve` instead.
+            See https://docs.langchain.com/langsmith/smithdb-sdk-migration#runs-retrieve for the migration guide.
+            Will be removed after Jan 31, 2027.
+
         Args:
             run_id (Union[UUID, str]):
                 The ID of the run to read.
@@ -4014,6 +4019,13 @@ class Client:
             stored_run = client.read_run(run_id)
             ```
         """
+        warnings.warn(
+            "read_run() is deprecated and will be removed after Jan 31, 2027. "
+            "Use client.runs.retrieve() instead. "
+            "See https://docs.langchain.com/langsmith/smithdb-sdk-migration#runs-retrieve for the migration guide.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         response = self.request_with_retries(
             "GET", f"/runs/{_as_uuid(run_id, 'run_id')}"
         )
@@ -4043,6 +4055,11 @@ class Client:
     ) -> Iterator[ls_schemas.Run]:
         """Read runs for a single thread.
 
+        .. deprecated::
+            Use :meth:`langsmith.Client.threads.list_traces` instead.
+            See https://docs.langchain.com/langsmith/smithdb-sdk-migration#threads-list-traces for the migration guide.
+            Will be removed after Jan 31, 2027.
+
         Args:
             thread_id: Thread id (required).
             project_id: Project id(s) (required when not using project_name).
@@ -4067,6 +4084,13 @@ class Client:
                 print(run.id)
             ```
         """
+        warnings.warn(
+            "read_thread() is deprecated and will be removed after Jan 31, 2027. "
+            "Use client.threads.list_traces() instead. "
+            "See https://docs.langchain.com/langsmith/smithdb-sdk-migration#threads-list-traces for the migration guide.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         if not (project_id or project_name):
             raise ValueError("thread_id requires project_id or project_name")
 
@@ -4109,7 +4133,7 @@ class Client:
 
         .. deprecated::
             Use :meth:`langsmith.Client.runs.query` instead.
-            See https://docs.langchain.com/langsmith/smithdb-sdk-migration for the migration guide.
+            See https://docs.langchain.com/langsmith/smithdb-sdk-migration#runs-query for the migration guide.
             Will be removed after Jan 31, 2027.
 
         Args:
@@ -4203,7 +4227,7 @@ class Client:
         warnings.warn(
             "list_runs() is deprecated and will be removed after Jan 31, 2027. "
             "Use client.runs.query() instead. "
-            "See https://docs.langchain.com/langsmith/smithdb-sdk-migration for the migration guide.",
+            "See https://docs.langchain.com/langsmith/smithdb-sdk-migration#runs-query for the migration guide.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -4302,6 +4326,11 @@ class Client:
     ) -> list[ListThreadsItem]:
         """List threads and fetch the runs for each thread.
 
+        .. deprecated::
+            Use :meth:`langsmith.Client.threads.query` instead.
+            See https://docs.langchain.com/langsmith/smithdb-sdk-migration#threads-query for the migration guide.
+            Will be removed after Jan 31, 2027.
+
         Args:
             project_id: The project (session) id.
             project_name: The project name (alternative to project_id).
@@ -4314,6 +4343,13 @@ class Client:
             List of thread items, each with "thread_id", "runs", "count",
             "min_start_time", and "max_start_time".
         """
+        warnings.warn(
+            "list_threads() is deprecated and will be removed after Jan 31, 2027. "
+            "Use client.threads.query() instead. "
+            "See https://docs.langchain.com/langsmith/smithdb-sdk-migration#threads-query for the migration guide.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         if project_id is None and project_name is None:
             raise ValueError("Either project_id or project_name must be provided")
         if project_id is not None and project_name is not None:
@@ -4436,6 +4472,11 @@ class Client:
     ) -> dict[str, Any]:
         """Get aggregate statistics over queried runs.
 
+        .. deprecated::
+            Use :meth:`langsmith.Client.threads.stats` instead.
+            See https://docs.langchain.com/langsmith/smithdb-sdk-migration#threads-stats for the migration guide.
+            Will be removed after Jan 31, 2027.
+
         Takes in similar query parameters to `list_runs` and returns statistics
         based on the runs that match the query.
 
@@ -4460,6 +4501,13 @@ class Client:
         Returns:
             Dict[str, Any]: A dictionary containing the run statistics.
         """  # noqa: E501
+        warnings.warn(
+            "get_run_stats() is deprecated and will be removed after Jan 31, 2027. "
+            "Use client.threads.stats() instead. "
+            "See https://docs.langchain.com/langsmith/smithdb-sdk-migration#threads-stats for the migration guide.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         from concurrent.futures import ThreadPoolExecutor, as_completed  # type: ignore
 
         project_ids = project_ids or []
@@ -8831,8 +8879,9 @@ class Client:
           (`run_id`, `session_id`, `start_time`, and an optional
           `source_proposed_example_id`). This lets the run be located directly,
           without a scan, and is required for workspaces served by SmithDB.
-        - `run_ids`: a plain list of run IDs. This path will be deprecated in a
-          future release; prefer `runs`.
+        - `run_ids`: a plain list of run IDs. This path is deprecated and will
+          be removed after Jan 31, 2027; prefer `runs`.
+          See https://docs.langchain.com/langsmith/smithdb-sdk-migration#annotation-queues-add-runs.
 
         Args:
             queue_id (Union[UUID, str]): The ID of the annotation queue.
@@ -8853,6 +8902,13 @@ class Client:
             path = f"/annotation-queues/{_as_uuid(queue_id, 'queue_id')}/runs/by-key"
             json_body = [_serialize_run_key(run, i) for i, run in enumerate(runs)]
         elif run_ids is not None:
+            warnings.warn(
+                "The run_ids parameter of add_runs_to_annotation_queue() is deprecated and will be removed after Jan 31, 2027. "
+                "Use the runs parameter with RunKey objects instead. "
+                "See https://docs.langchain.com/langsmith/smithdb-sdk-migration#annotation-queues-add-runs for the migration guide.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
             path = f"/annotation-queues/{_as_uuid(queue_id, 'queue_id')}/runs"
             json_body = [
                 str(_as_uuid(id_, f"run_ids[{i}]")) for i, id_ in enumerate(run_ids)
@@ -10702,6 +10758,11 @@ class Client:
     ) -> ls_schemas.ExperimentResults:
         """Get results for an experiment, including experiment session aggregated stats and experiment runs for each dataset example.
 
+        .. deprecated::
+            Use :meth:`langsmith.Client.datasets.experiment_runs.query` instead.
+            See https://docs.langchain.com/langsmith/smithdb-sdk-migration#dataset-experiment-runs-query for the migration guide.
+            Will be removed after Jan 31, 2027.
+
         Experiment results may not be available immediately after the experiment is created.
 
         Args:
@@ -10741,6 +10802,13 @@ class Client:
             print(f"Feedback stats: {results['feedback_stats']}")
             ```
         """
+        warnings.warn(
+            "get_experiment_results() is deprecated and will be removed after Jan 31, 2027. "
+            "Use client.datasets.experiment_runs.query() instead. "
+            "See https://docs.langchain.com/langsmith/smithdb-sdk-migration#dataset-experiment-runs-query for the migration guide.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         project = self.read_project(
             project_name=name, project_id=project_id, include_stats=True
         )

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -79,7 +79,7 @@ from langsmith._internal._background_thread import (
 from langsmith._internal._background_thread import (
     tracing_control_thread_func as _tracing_control_thread_func,
 )
-from langsmith._internal._beta_decorator import warn_beta
+from langsmith._internal._beta_decorator import deprecated as _deprecated, warn_beta
 from langsmith._internal._compressed_traces import CompressedTraces
 from langsmith._internal._constants import (
     _AUTO_SCALE_UP_NTHREADS_LIMIT,
@@ -3994,7 +3994,7 @@ class Client:
     ) -> ls_schemas.Run:
         """Read a run from the LangSmith API.
 
-        .. deprecated::
+        .. deprecated:: 0.10.7
             Use :meth:`langsmith.Client.runs.retrieve` instead.
             See https://docs.langchain.com/langsmith/smithdb-sdk-migration#runs-retrieve for the migration guide.
             Will be removed after Jan 31, 2027.
@@ -4055,7 +4055,7 @@ class Client:
     ) -> Iterator[ls_schemas.Run]:
         """Read runs for a single thread.
 
-        .. deprecated::
+        .. deprecated:: 0.10.7
             Use :meth:`langsmith.Client.threads.list_traces` instead.
             See https://docs.langchain.com/langsmith/smithdb-sdk-migration#threads-list-traces for the migration guide.
             Will be removed after Jan 31, 2027.
@@ -4108,6 +4108,12 @@ class Client:
             **kwargs,
         )
 
+    @_deprecated(
+        "list_runs() is deprecated and will be removed after Jan 31, 2027. "
+        "Use client.runs.query() instead. "
+        "See https://docs.langchain.com/langsmith/smithdb-sdk-migration"
+        "#runs-query for the migration guide."
+    )
     def list_runs(
         self,
         *,
@@ -4131,7 +4137,7 @@ class Client:
     ) -> Iterator[ls_schemas.Run]:
         """List runs from the LangSmith API.
 
-        .. deprecated::
+        .. deprecated:: 0.10.7
             Use :meth:`langsmith.Client.runs.query` instead.
             See https://docs.langchain.com/langsmith/smithdb-sdk-migration#runs-query for the migration guide.
             Will be removed after Jan 31, 2027.
@@ -4224,13 +4230,6 @@ class Client:
             )
             ```
         """  # noqa: E501
-        warnings.warn(
-            "list_runs() is deprecated and will be removed after Jan 31, 2027. "
-            "Use client.runs.query() instead. "
-            "See https://docs.langchain.com/langsmith/smithdb-sdk-migration#runs-query for the migration guide.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
         project_ids = []
         if isinstance(project_id, (uuid.UUID, str)):
             project_ids.append(project_id)
@@ -4326,7 +4325,7 @@ class Client:
     ) -> list[ListThreadsItem]:
         """List threads and fetch the runs for each thread.
 
-        .. deprecated::
+        .. deprecated:: 0.10.7
             Use :meth:`langsmith.Client.threads.query` instead.
             See https://docs.langchain.com/langsmith/smithdb-sdk-migration#threads-query for the migration guide.
             Will be removed after Jan 31, 2027.
@@ -4472,7 +4471,7 @@ class Client:
     ) -> dict[str, Any]:
         """Get aggregate statistics over queried runs.
 
-        .. deprecated::
+        .. deprecated:: 0.10.7
             Use :meth:`langsmith.Client.threads.stats` instead.
             See https://docs.langchain.com/langsmith/smithdb-sdk-migration#threads-stats for the migration guide.
             Will be removed after Jan 31, 2027.
@@ -10758,7 +10757,7 @@ class Client:
     ) -> ls_schemas.ExperimentResults:
         """Get results for an experiment, including experiment session aggregated stats and experiment runs for each dataset example.
 
-        .. deprecated::
+        .. deprecated:: 0.10.7
             Use :meth:`langsmith.Client.datasets.experiment_runs.query` instead.
             See https://docs.langchain.com/langsmith/smithdb-sdk-migration#dataset-experiment-runs-query for the migration guide.
             Will be removed after Jan 31, 2027.

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -7843,7 +7843,7 @@ class Client:
             raise ValueError(
                 "project_id cannot be provided if run_id or trace_id is provided"
             )
-        if run_id is not None and session_id is None and project_id is None:
+        if run_id is not None and session_id is None:
             warnings.warn(
                 "session_id will become a required argument to create_feedback() in "
                 "a future release. Please provide it to avoid errors.",

--- a/python/langsmith/utils.py
+++ b/python/langsmith/utils.py
@@ -40,43 +40,103 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class LangSmithError(Exception):
-    """An error occurred while communicating with the LangSmith API."""
+    """An error occurred while communicating with the LangSmith API.
+
+    .. deprecated::
+        Use :class:`langsmith.LangsmithError` instead.
+        See https://docs.langchain.com/langsmith/smithdb-sdk-migration for the migration guide.
+        Will be removed after Jan 31, 2027.
+    """
 
 
 class LangSmithAPIError(LangSmithError):
-    """Internal server error while communicating with LangSmith."""
+    """Internal server error while communicating with LangSmith.
+
+    .. deprecated::
+        Use :class:`langsmith.InternalServerError` instead.
+        See https://docs.langchain.com/langsmith/smithdb-sdk-migration for the migration guide.
+        Will be removed after Jan 31, 2027.
+    """
 
 
 class LangSmithRequestTimeout(LangSmithError):
-    """Client took too long to send request body."""
+    """Client took too long to send request body.
+
+    .. deprecated::
+        Use :class:`langsmith.APITimeoutError` instead.
+        See https://docs.langchain.com/langsmith/smithdb-sdk-migration for the migration guide.
+        Will be removed after Jan 31, 2027.
+    """
 
 
 class LangSmithUserError(LangSmithError):
-    """User error caused an exception when communicating with LangSmith."""
+    """User error caused an exception when communicating with LangSmith.
+
+    .. deprecated::
+        Use :class:`langsmith.BadRequestError` instead.
+        See https://docs.langchain.com/langsmith/smithdb-sdk-migration for the migration guide.
+        Will be removed after Jan 31, 2027.
+    """
 
 
 class LangSmithRateLimitError(LangSmithError):
-    """You have exceeded the rate limit for the LangSmith API."""
+    """You have exceeded the rate limit for the LangSmith API.
+
+    .. deprecated::
+        Use :class:`langsmith.RateLimitError` instead.
+        See https://docs.langchain.com/langsmith/smithdb-sdk-migration for the migration guide.
+        Will be removed after Jan 31, 2027.
+    """
 
 
 class LangSmithAuthError(LangSmithError):
-    """Couldn't authenticate with the LangSmith API."""
+    """Couldn't authenticate with the LangSmith API.
+
+    .. deprecated::
+        Use :class:`langsmith.AuthenticationError` instead.
+        See https://docs.langchain.com/langsmith/smithdb-sdk-migration for the migration guide.
+        Will be removed after Jan 31, 2027.
+    """
 
 
 class LangSmithNotFoundError(LangSmithError):
-    """Couldn't find the requested resource."""
+    """Couldn't find the requested resource.
+
+    .. deprecated::
+        Use :class:`langsmith.NotFoundError` instead.
+        See https://docs.langchain.com/langsmith/smithdb-sdk-migration for the migration guide.
+        Will be removed after Jan 31, 2027.
+    """
 
 
 class LangSmithConflictError(LangSmithError):
-    """The resource already exists."""
+    """The resource already exists.
+
+    .. deprecated::
+        Use :class:`langsmith.ConflictError` instead.
+        See https://docs.langchain.com/langsmith/smithdb-sdk-migration for the migration guide.
+        Will be removed after Jan 31, 2027.
+    """
 
 
 class LangSmithConnectionError(LangSmithError):
-    """Couldn't connect to the LangSmith API."""
+    """Couldn't connect to the LangSmith API.
+
+    .. deprecated::
+        Use :class:`langsmith.APIConnectionError` instead.
+        See https://docs.langchain.com/langsmith/smithdb-sdk-migration for the migration guide.
+        Will be removed after Jan 31, 2027.
+    """
 
 
 class LangSmithExceptionGroup(LangSmithError):
-    """Port of ExceptionGroup for Py < 3.11."""
+    """Port of ExceptionGroup for Py < 3.11.
+
+    .. deprecated::
+        Use Python 3.11+ native ``ExceptionGroup`` or :class:`langsmith.LangsmithError` instead.
+        See https://docs.langchain.com/langsmith/smithdb-sdk-migration for the migration guide.
+        Will be removed after Jan 31, 2027.
+    """
 
     def __init__(
         self, *args: Any, exceptions: Sequence[Exception], **kwargs: Any

--- a/python/langsmith/utils.py
+++ b/python/langsmith/utils.py
@@ -44,7 +44,7 @@ class LangSmithError(Exception):
 
     .. deprecated::
         Use :class:`langsmith.LangsmithError` instead.
-        See https://docs.langchain.com/langsmith/smithdb-sdk-migration for the migration guide.
+        See https://docs.langchain.com/langsmith/smithdb-sdk-migration#exceptions for the migration guide.
         Will be removed after Jan 31, 2027.
     """
 
@@ -54,7 +54,7 @@ class LangSmithAPIError(LangSmithError):
 
     .. deprecated::
         Use :class:`langsmith.InternalServerError` instead.
-        See https://docs.langchain.com/langsmith/smithdb-sdk-migration for the migration guide.
+        See https://docs.langchain.com/langsmith/smithdb-sdk-migration#exceptions for the migration guide.
         Will be removed after Jan 31, 2027.
     """
 
@@ -64,7 +64,7 @@ class LangSmithRequestTimeout(LangSmithError):
 
     .. deprecated::
         Use :class:`langsmith.APITimeoutError` instead.
-        See https://docs.langchain.com/langsmith/smithdb-sdk-migration for the migration guide.
+        See https://docs.langchain.com/langsmith/smithdb-sdk-migration#exceptions for the migration guide.
         Will be removed after Jan 31, 2027.
     """
 
@@ -74,7 +74,7 @@ class LangSmithUserError(LangSmithError):
 
     .. deprecated::
         Use :class:`langsmith.BadRequestError` instead.
-        See https://docs.langchain.com/langsmith/smithdb-sdk-migration for the migration guide.
+        See https://docs.langchain.com/langsmith/smithdb-sdk-migration#exceptions for the migration guide.
         Will be removed after Jan 31, 2027.
     """
 
@@ -84,7 +84,7 @@ class LangSmithRateLimitError(LangSmithError):
 
     .. deprecated::
         Use :class:`langsmith.RateLimitError` instead.
-        See https://docs.langchain.com/langsmith/smithdb-sdk-migration for the migration guide.
+        See https://docs.langchain.com/langsmith/smithdb-sdk-migration#exceptions for the migration guide.
         Will be removed after Jan 31, 2027.
     """
 
@@ -94,7 +94,7 @@ class LangSmithAuthError(LangSmithError):
 
     .. deprecated::
         Use :class:`langsmith.AuthenticationError` instead.
-        See https://docs.langchain.com/langsmith/smithdb-sdk-migration for the migration guide.
+        See https://docs.langchain.com/langsmith/smithdb-sdk-migration#exceptions for the migration guide.
         Will be removed after Jan 31, 2027.
     """
 
@@ -104,7 +104,7 @@ class LangSmithNotFoundError(LangSmithError):
 
     .. deprecated::
         Use :class:`langsmith.NotFoundError` instead.
-        See https://docs.langchain.com/langsmith/smithdb-sdk-migration for the migration guide.
+        See https://docs.langchain.com/langsmith/smithdb-sdk-migration#exceptions for the migration guide.
         Will be removed after Jan 31, 2027.
     """
 
@@ -114,7 +114,7 @@ class LangSmithConflictError(LangSmithError):
 
     .. deprecated::
         Use :class:`langsmith.ConflictError` instead.
-        See https://docs.langchain.com/langsmith/smithdb-sdk-migration for the migration guide.
+        See https://docs.langchain.com/langsmith/smithdb-sdk-migration#exceptions for the migration guide.
         Will be removed after Jan 31, 2027.
     """
 
@@ -124,7 +124,7 @@ class LangSmithConnectionError(LangSmithError):
 
     .. deprecated::
         Use :class:`langsmith.APIConnectionError` instead.
-        See https://docs.langchain.com/langsmith/smithdb-sdk-migration for the migration guide.
+        See https://docs.langchain.com/langsmith/smithdb-sdk-migration#exceptions for the migration guide.
         Will be removed after Jan 31, 2027.
     """
 
@@ -134,7 +134,7 @@ class LangSmithExceptionGroup(LangSmithError):
 
     .. deprecated::
         Use Python 3.11+ native ``ExceptionGroup`` or :class:`langsmith.LangsmithError` instead.
-        See https://docs.langchain.com/langsmith/smithdb-sdk-migration for the migration guide.
+        See https://docs.langchain.com/langsmith/smithdb-sdk-migration#exceptions for the migration guide.
         Will be removed after Jan 31, 2027.
     """
 

--- a/python/langsmith/utils.py
+++ b/python/langsmith/utils.py
@@ -44,7 +44,8 @@ class LangSmithError(Exception):
 
     .. deprecated::
         Use :class:`langsmith.LangsmithError` instead.
-        See https://docs.langchain.com/langsmith/smithdb-sdk-migration#exceptions for the migration guide.
+        See the migration guide at
+        https://docs.langchain.com/langsmith/smithdb-sdk-migration#exceptions
         Will be removed after Jan 31, 2027.
     """
 
@@ -54,7 +55,8 @@ class LangSmithAPIError(LangSmithError):
 
     .. deprecated::
         Use :class:`langsmith.InternalServerError` instead.
-        See https://docs.langchain.com/langsmith/smithdb-sdk-migration#exceptions for the migration guide.
+        See the migration guide at
+        https://docs.langchain.com/langsmith/smithdb-sdk-migration#exceptions
         Will be removed after Jan 31, 2027.
     """
 
@@ -64,7 +66,8 @@ class LangSmithRequestTimeout(LangSmithError):
 
     .. deprecated::
         Use :class:`langsmith.APITimeoutError` instead.
-        See https://docs.langchain.com/langsmith/smithdb-sdk-migration#exceptions for the migration guide.
+        See the migration guide at
+        https://docs.langchain.com/langsmith/smithdb-sdk-migration#exceptions
         Will be removed after Jan 31, 2027.
     """
 
@@ -74,7 +77,8 @@ class LangSmithUserError(LangSmithError):
 
     .. deprecated::
         Use :class:`langsmith.BadRequestError` instead.
-        See https://docs.langchain.com/langsmith/smithdb-sdk-migration#exceptions for the migration guide.
+        See the migration guide at
+        https://docs.langchain.com/langsmith/smithdb-sdk-migration#exceptions
         Will be removed after Jan 31, 2027.
     """
 
@@ -84,7 +88,8 @@ class LangSmithRateLimitError(LangSmithError):
 
     .. deprecated::
         Use :class:`langsmith.RateLimitError` instead.
-        See https://docs.langchain.com/langsmith/smithdb-sdk-migration#exceptions for the migration guide.
+        See the migration guide at
+        https://docs.langchain.com/langsmith/smithdb-sdk-migration#exceptions
         Will be removed after Jan 31, 2027.
     """
 
@@ -94,7 +99,8 @@ class LangSmithAuthError(LangSmithError):
 
     .. deprecated::
         Use :class:`langsmith.AuthenticationError` instead.
-        See https://docs.langchain.com/langsmith/smithdb-sdk-migration#exceptions for the migration guide.
+        See the migration guide at
+        https://docs.langchain.com/langsmith/smithdb-sdk-migration#exceptions
         Will be removed after Jan 31, 2027.
     """
 
@@ -104,7 +110,8 @@ class LangSmithNotFoundError(LangSmithError):
 
     .. deprecated::
         Use :class:`langsmith.NotFoundError` instead.
-        See https://docs.langchain.com/langsmith/smithdb-sdk-migration#exceptions for the migration guide.
+        See the migration guide at
+        https://docs.langchain.com/langsmith/smithdb-sdk-migration#exceptions
         Will be removed after Jan 31, 2027.
     """
 
@@ -114,7 +121,8 @@ class LangSmithConflictError(LangSmithError):
 
     .. deprecated::
         Use :class:`langsmith.ConflictError` instead.
-        See https://docs.langchain.com/langsmith/smithdb-sdk-migration#exceptions for the migration guide.
+        See the migration guide at
+        https://docs.langchain.com/langsmith/smithdb-sdk-migration#exceptions
         Will be removed after Jan 31, 2027.
     """
 
@@ -124,7 +132,8 @@ class LangSmithConnectionError(LangSmithError):
 
     .. deprecated::
         Use :class:`langsmith.APIConnectionError` instead.
-        See https://docs.langchain.com/langsmith/smithdb-sdk-migration#exceptions for the migration guide.
+        See the migration guide at
+        https://docs.langchain.com/langsmith/smithdb-sdk-migration#exceptions
         Will be removed after Jan 31, 2027.
     """
 
@@ -133,8 +142,10 @@ class LangSmithExceptionGroup(LangSmithError):
     """Port of ExceptionGroup for Py < 3.11.
 
     .. deprecated::
-        Use Python 3.11+ native ``ExceptionGroup`` or :class:`langsmith.LangsmithError` instead.
-        See https://docs.langchain.com/langsmith/smithdb-sdk-migration#exceptions for the migration guide.
+        Use Python 3.11+ native ``ExceptionGroup``
+        or :class:`langsmith.LangsmithError` instead.
+        See the migration guide at
+        https://docs.langchain.com/langsmith/smithdb-sdk-migration#exceptions
         Will be removed after Jan 31, 2027.
     """
 

--- a/python/langsmith/utils.py
+++ b/python/langsmith/utils.py
@@ -42,7 +42,7 @@ _LOGGER = logging.getLogger(__name__)
 class LangSmithError(Exception):
     """An error occurred while communicating with the LangSmith API.
 
-    .. deprecated::
+    .. deprecated:: 0.10.7
         Use :class:`langsmith.LangsmithError` instead.
         See the migration guide at
         https://docs.langchain.com/langsmith/smithdb-sdk-migration#exceptions
@@ -53,7 +53,7 @@ class LangSmithError(Exception):
 class LangSmithAPIError(LangSmithError):
     """Internal server error while communicating with LangSmith.
 
-    .. deprecated::
+    .. deprecated:: 0.10.7
         Use :class:`langsmith.InternalServerError` instead.
         See the migration guide at
         https://docs.langchain.com/langsmith/smithdb-sdk-migration#exceptions
@@ -64,7 +64,7 @@ class LangSmithAPIError(LangSmithError):
 class LangSmithRequestTimeout(LangSmithError):
     """Client took too long to send request body.
 
-    .. deprecated::
+    .. deprecated:: 0.10.7
         Use :class:`langsmith.APITimeoutError` instead.
         See the migration guide at
         https://docs.langchain.com/langsmith/smithdb-sdk-migration#exceptions
@@ -75,7 +75,7 @@ class LangSmithRequestTimeout(LangSmithError):
 class LangSmithUserError(LangSmithError):
     """User error caused an exception when communicating with LangSmith.
 
-    .. deprecated::
+    .. deprecated:: 0.10.7
         Use :class:`langsmith.BadRequestError` instead.
         See the migration guide at
         https://docs.langchain.com/langsmith/smithdb-sdk-migration#exceptions
@@ -86,7 +86,7 @@ class LangSmithUserError(LangSmithError):
 class LangSmithRateLimitError(LangSmithError):
     """You have exceeded the rate limit for the LangSmith API.
 
-    .. deprecated::
+    .. deprecated:: 0.10.7
         Use :class:`langsmith.RateLimitError` instead.
         See the migration guide at
         https://docs.langchain.com/langsmith/smithdb-sdk-migration#exceptions
@@ -97,7 +97,7 @@ class LangSmithRateLimitError(LangSmithError):
 class LangSmithAuthError(LangSmithError):
     """Couldn't authenticate with the LangSmith API.
 
-    .. deprecated::
+    .. deprecated:: 0.10.7
         Use :class:`langsmith.AuthenticationError` instead.
         See the migration guide at
         https://docs.langchain.com/langsmith/smithdb-sdk-migration#exceptions
@@ -108,7 +108,7 @@ class LangSmithAuthError(LangSmithError):
 class LangSmithNotFoundError(LangSmithError):
     """Couldn't find the requested resource.
 
-    .. deprecated::
+    .. deprecated:: 0.10.7
         Use :class:`langsmith.NotFoundError` instead.
         See the migration guide at
         https://docs.langchain.com/langsmith/smithdb-sdk-migration#exceptions
@@ -119,7 +119,7 @@ class LangSmithNotFoundError(LangSmithError):
 class LangSmithConflictError(LangSmithError):
     """The resource already exists.
 
-    .. deprecated::
+    .. deprecated:: 0.10.7
         Use :class:`langsmith.ConflictError` instead.
         See the migration guide at
         https://docs.langchain.com/langsmith/smithdb-sdk-migration#exceptions
@@ -130,7 +130,7 @@ class LangSmithConflictError(LangSmithError):
 class LangSmithConnectionError(LangSmithError):
     """Couldn't connect to the LangSmith API.
 
-    .. deprecated::
+    .. deprecated:: 0.10.7
         Use :class:`langsmith.APIConnectionError` instead.
         See the migration guide at
         https://docs.langchain.com/langsmith/smithdb-sdk-migration#exceptions
@@ -141,7 +141,7 @@ class LangSmithConnectionError(LangSmithError):
 class LangSmithExceptionGroup(LangSmithError):
     """Port of ExceptionGroup for Py < 3.11.
 
-    .. deprecated::
+    .. deprecated:: 0.10.7
         Use Python 3.11+ native ``ExceptionGroup``
         or :class:`langsmith.LangsmithError` instead.
         See the migration guide at

--- a/python/tests/unit_tests/test_async_client.py
+++ b/python/tests/unit_tests/test_async_client.py
@@ -4,7 +4,6 @@ import json
 import logging
 import pathlib
 import uuid
-import warnings
 from datetime import datetime
 from unittest import mock
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -593,8 +592,7 @@ async def test_list_runs_child_run_ids_deprecation_warning(
         ):
             pass
 
-    # Test that the child_run_ids warning does NOT fire when child_run_ids is not in select
-    # (the overall list_runs deprecation warning will still fire)
+    # Overall list_runs deprecation fires; child_run_ids-specific warning must not
     with pytest.warns(DeprecationWarning) as warning_list:
         async for _ in client.list_runs(project_id=uuid4(), select=["id", "name"]):
             pass

--- a/python/tests/unit_tests/test_async_client.py
+++ b/python/tests/unit_tests/test_async_client.py
@@ -540,7 +540,7 @@ async def test_async_create_feedback_warns_when_session_id_missing(
     )
     client = AsyncClient(api_url="http://localhost:1984", api_key="test-api-key")
 
-    with pytest.warns(FutureWarning, match="session_id will become a required"):
+    with pytest.warns(DeprecationWarning, match="session_id will become a required"):
         await client.create_feedback(run_id=uuid.uuid4(), key="test_key")
 
     with warnings.catch_warnings():

--- a/python/tests/unit_tests/test_async_client.py
+++ b/python/tests/unit_tests/test_async_client.py
@@ -593,11 +593,12 @@ async def test_list_runs_child_run_ids_deprecation_warning(
         ):
             pass
 
-    # Test that no warning is raised when child_run_ids is not in select
-    with warnings.catch_warnings():
-        warnings.simplefilter("error", DeprecationWarning)
+    # Test that the child_run_ids warning does NOT fire when child_run_ids is not in select
+    # (the overall list_runs deprecation warning will still fire)
+    with pytest.warns(DeprecationWarning) as warning_list:
         async for _ in client.list_runs(project_id=uuid4(), select=["id", "name"]):
             pass
+    assert not any("child_run_ids" in str(w.message) for w in warning_list)
 
 
 @mock.patch("langsmith.async_client.httpx.AsyncClient")

--- a/python/tests/unit_tests/test_async_client.py
+++ b/python/tests/unit_tests/test_async_client.py
@@ -4,6 +4,7 @@ import json
 import logging
 import pathlib
 import uuid
+import warnings
 from datetime import datetime
 from unittest import mock
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -516,12 +517,38 @@ async def test_async_create_feedback_warns_and_ignores_unused_kwargs(
         await client.create_feedback(
             run_id=uuid.uuid4(),
             key="test_key",
+            session_id=uuid.uuid4(),
             unused_argument="unused",
         )
 
     request_kwargs = mock_httpx_client.request.call_args.kwargs
     body = json.loads(request_kwargs["content"])
     assert "unused_argument" not in body
+
+
+@mock.patch("langsmith.async_client.httpx.AsyncClient")
+@pytest.mark.asyncio
+async def test_async_create_feedback_warns_when_session_id_missing(
+    mock_client_cls: mock.Mock,
+) -> None:
+    mock_httpx_client = AsyncMock()
+    mock_client_cls.return_value = mock_httpx_client
+    mock_httpx_client.request.return_value = httpx.Response(
+        200,
+        json={},
+        request=httpx.Request("POST", "http://localhost:1984/feedback"),
+    )
+    client = AsyncClient(api_url="http://localhost:1984", api_key="test-api-key")
+
+    with pytest.warns(FutureWarning, match="session_id"):
+        await client.create_feedback(run_id=uuid.uuid4(), key="test_key")
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", FutureWarning)
+        # No warning when session_id is provided
+        await client.create_feedback(
+            run_id=uuid.uuid4(), key="test_key", session_id=uuid.uuid4()
+        )
 
 
 @mock.patch("langsmith.async_client.httpx.AsyncClient")

--- a/python/tests/unit_tests/test_async_client.py
+++ b/python/tests/unit_tests/test_async_client.py
@@ -540,7 +540,7 @@ async def test_async_create_feedback_warns_when_session_id_missing(
     )
     client = AsyncClient(api_url="http://localhost:1984", api_key="test-api-key")
 
-    with pytest.warns(FutureWarning, match="session_id"):
+    with pytest.warns(FutureWarning, match="session_id will become a required"):
         await client.create_feedback(run_id=uuid.uuid4(), key="test_key")
 
     with warnings.catch_warnings():

--- a/python/tests/unit_tests/test_client.py
+++ b/python/tests/unit_tests/test_client.py
@@ -1936,7 +1936,7 @@ def test_create_feedback_warns_when_session_id_missing() -> None:
 
     client = Client(api_url="http://localhost:1984", api_key="123", session=session)
 
-    with pytest.warns(FutureWarning, match="session_id"):
+    with pytest.warns(FutureWarning, match="session_id will become a required"):
         client.create_feedback(run_id, key="Foo")
 
     with warnings.catch_warnings():

--- a/python/tests/unit_tests/test_client.py
+++ b/python/tests/unit_tests/test_client.py
@@ -1936,7 +1936,7 @@ def test_create_feedback_warns_when_session_id_missing() -> None:
 
     client = Client(api_url="http://localhost:1984", api_key="123", session=session)
 
-    with pytest.warns(FutureWarning, match="session_id will become a required"):
+    with pytest.warns(DeprecationWarning, match="session_id will become a required"):
         client.create_feedback(run_id, key="Foo")
 
     with warnings.catch_warnings():

--- a/python/tests/unit_tests/test_client.py
+++ b/python/tests/unit_tests/test_client.py
@@ -5933,10 +5933,11 @@ def test_list_runs_child_run_ids_deprecation_warning(
             )
         )
 
-    # Test that no warning is raised when child_run_ids is not in select
-    with warnings.catch_warnings():
-        warnings.simplefilter("error", DeprecationWarning)
+    # Test that the child_run_ids warning does NOT fire when child_run_ids is not in select
+    # (the overall list_runs deprecation warning will still fire)
+    with pytest.warns(DeprecationWarning) as warning_list:
         list(client.list_runs(project_id=uuid.uuid4(), select=["id", "name"]))
+    assert not any("child_run_ids" in str(w.message) for w in warning_list)
 
 
 def test_tracing_error_callback_on_429():

--- a/python/tests/unit_tests/test_client.py
+++ b/python/tests/unit_tests/test_client.py
@@ -5933,8 +5933,7 @@ def test_list_runs_child_run_ids_deprecation_warning(
             )
         )
 
-    # Test that the child_run_ids warning does NOT fire when child_run_ids is not in select
-    # (the overall list_runs deprecation warning will still fire)
+    # Overall list_runs deprecation fires; child_run_ids-specific warning must not
     with pytest.warns(DeprecationWarning) as warning_list:
         list(client.list_runs(project_id=uuid.uuid4(), select=["id", "name"]))
     assert not any("child_run_ids" in str(w.message) for w in warning_list)

--- a/python/tests/unit_tests/test_client.py
+++ b/python/tests/unit_tests/test_client.py
@@ -1920,6 +1920,36 @@ def test_create_feedback_opt_out_uses_direct_post_when_batching_available() -> N
     assert client.tracing_queue.qsize() == 0
 
 
+def test_create_feedback_warns_when_session_id_missing() -> None:
+    session = mock.Mock()
+    run_id = uuid.uuid4()
+    session_id = uuid.uuid4()
+    request_object = mock.Mock()
+    request_object.json.return_value = {
+        "id": uuid.uuid4(),
+        "key": "Foo",
+        "created_at": _CREATED_AT,
+        "modified_at": _CREATED_AT,
+        "run_id": run_id,
+    }
+    session.post.return_value = request_object
+
+    client = Client(api_url="http://localhost:1984", api_key="123", session=session)
+
+    with pytest.warns(FutureWarning, match="session_id"):
+        client.create_feedback(run_id, key="Foo")
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", FutureWarning)
+        # No warning when session_id is provided
+        client.create_feedback(run_id, key="Foo", session_id=session_id)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", FutureWarning)
+        # No warning for project-level feedback (no run_id)
+        client.create_feedback(project_id=session_id, key="Foo")
+
+
 def test_pydantic_serialize() -> None:
     """Test that pydantic objects can be serialized."""
     test_uuid = uuid.uuid4()


### PR DESCRIPTION
## Summary

Marks all legacy SDK methods from the [SmithDB SDK migration guide](https://docs.langchain.com/langsmith/smithdb-sdk-migration) as deprecated. Every deprecation includes a \`warnings.warn(DeprecationWarning)\` at runtime, a \`.. deprecated::\` RST docstring directive (Python), or a \`@deprecated\` JSDoc tag (TypeScript). Each message links to the specific section in the guide and mentions removal after Jan 31, 2027.

**Python \`Client\` and \`AsyncClient\` deprecated methods:**
- \`read_run()\` → \`client.runs.retrieve()\` ([#runs-retrieve](https://docs.langchain.com/langsmith/smithdb-sdk-migration#runs-retrieve))
- \`list_runs()\` → \`client.runs.query()\` ([#runs-query](https://docs.langchain.com/langsmith/smithdb-sdk-migration#runs-query))
- \`read_thread()\` → \`client.threads.list_traces()\` ([#threads-list-traces](https://docs.langchain.com/langsmith/smithdb-sdk-migration#threads-list-traces))
- \`list_threads()\` → \`client.threads.query()\` ([#threads-query](https://docs.langchain.com/langsmith/smithdb-sdk-migration#threads-query))
- \`get_run_stats()\` → \`client.threads.stats()\` ([#threads-stats](https://docs.langchain.com/langsmith/smithdb-sdk-migration#threads-stats))
- \`get_experiment_results()\` → \`client.datasets.experiment_runs.query()\` ([#dataset-experiment-runs-query](https://docs.langchain.com/langsmith/smithdb-sdk-migration#dataset-experiment-runs-query))
- \`add_runs_to_annotation_queue(run_ids=...)\` → \`add_runs_to_annotation_queue(runs=...)\` ([#annotation-queues-add-runs](https://docs.langchain.com/langsmith/smithdb-sdk-migration#annotation-queues-add-runs))

**Python legacy exception classes in \`langsmith.utils\`** ([#exceptions](https://docs.langchain.com/langsmith/smithdb-sdk-migration#exceptions)):
- All 10 \`LangSmith*\` exception classes deprecated with section-anchored URL

**TypeScript \`Client\` deprecated methods:**
- \`readRun()\`, \`listRuns()\`, \`readThread()\`, \`listThreads()\`, \`getRunStats()\`
- \`addRunsToAnnotationQueue(string[])\` path

**\`create_feedback\` / \`createFeedback\` — upcoming required argument:**
- \`session_id\` (Python) / \`sessionId\` (TypeScript) will become mandatory in a future release. Callers who omit it when providing a \`run_id\` now receive a \`FutureWarning\` (Python) / \`console.warn\` (TypeScript) to give time to migrate before the hard error lands.

## Test Plan

- [x] \`DeprecationWarning\` fires at runtime when calling deprecated Python methods
- [x] TypeScript \`@deprecated\` tags visible in IDE hover / tsc output
- [x] \`FutureWarning\` fires when \`session_id\` is omitted from \`create_feedback()\` with a \`run_id\`
- [x] No warning when \`session_id\` is provided, or for project-level feedback (no \`run_id\`)