### PR TITLE
fix(py): merge sandbox request headers case-insensitively

### DIFF
--- a/python/langsmith/sandbox/_helpers.py
+++ b/python/langsmith/sandbox/_helpers.py
@@ -34,9 +34,21 @@ def merge_headers(
     base_headers: Optional[Mapping[str, str]] = None,
     override_headers: Optional[Mapping[str, str]] = None,
 ) -> dict[str, str]:
-    """Merge request headers, giving precedence to overrides."""
+    """Merge request headers, giving precedence to overrides.
+
+    Matching is case-insensitive: an override replaces a base header that
+    differs only in casing, rather than both being sent. HTTP treats header
+    names case-insensitively, so emitting both is ambiguous — a server that
+    reads the first value would see the base header instead of the override.
+    """
     merged: dict[str, str] = dict(base_headers or {})
     if override_headers:
+        overridden = {name.lower() for name in override_headers}
+        merged = {
+            name: value
+            for name, value in merged.items()
+            if name.lower() not in overridden
+        }
         merged.update(override_headers)
     return merged
 

--- a/python/langsmith/sandbox/_helpers.py
+++ b/python/langsmith/sandbox/_helpers.py
@@ -36,20 +36,15 @@ def merge_headers(
 ) -> dict[str, str]:
     """Merge request headers, giving precedence to overrides.
 
-    Matching is case-insensitive: an override replaces a base header that
-    differs only in casing, rather than both being sent. HTTP treats header
-    names case-insensitively, so emitting both is ambiguous — a server that
-    reads the first value would see the base header instead of the override.
+    Names are normalized to lowercase so an override replaces a base header that
+    differs only in casing. HTTP header names are case-insensitive, so keeping
+    both would be ambiguous — a server reading the first value would see the
+    base header instead of the override.
     """
-    merged: dict[str, str] = dict(base_headers or {})
-    if override_headers:
-        overridden = {name.lower() for name in override_headers}
-        merged = {
-            name: value
-            for name, value in merged.items()
-            if name.lower() not in overridden
-        }
-        merged.update(override_headers)
+    merged: dict[str, str] = {}
+    for headers in (base_headers, override_headers):
+        for name, value in (headers or {}).items():
+            merged[name.lower()] = value
     return merged
 
 

--- a/python/tests/unit_tests/sandbox/test_async_client.py
+++ b/python/tests/unit_tests/sandbox/test_async_client.py
@@ -116,7 +116,8 @@ class TestAsyncSandboxClientInit:
             assert client._http.headers.get("X-Service-Key") == "svc-jwt"
             assert client._http.headers.get("X-Api-Key") == "api-key"
             assert client._default_headers == {"X-Service-Key": "svc-jwt"}
-            assert client._ws_default_headers(None) == {"X-Service-Key": "svc-jwt"}
+            # merge_headers normalizes names to lowercase.
+            assert client._ws_default_headers(None) == {"x-service-key": "svc-jwt"}
             await client.aclose()
 
     async def test_max_retries_default(self):

--- a/python/tests/unit_tests/sandbox/test_client.py
+++ b/python/tests/unit_tests/sandbox/test_client.py
@@ -133,13 +133,14 @@ class TestSandboxClientInit:
             api_key="api-key",
             headers={"X-Service-Key": "svc-jwt"},
         )
-        assert client._ws_default_headers(None) == {"X-Service-Key": "svc-jwt"}
+        # merge_headers normalizes names to lowercase.
+        assert client._ws_default_headers(None) == {"x-service-key": "svc-jwt"}
         assert client._ws_default_headers({"X-Test": "v"}) == {
-            "X-Service-Key": "svc-jwt",
-            "X-Test": "v",
+            "x-service-key": "svc-jwt",
+            "x-test": "v",
         }
         assert client._ws_default_headers({"X-Service-Key": "override"}) == {
-            "X-Service-Key": "override"
+            "x-service-key": "override"
         }
         client.close()
 

--- a/python/tests/unit_tests/sandbox/test_helpers.py
+++ b/python/tests/unit_tests/sandbox/test_helpers.py
@@ -6,8 +6,9 @@ from langsmith.sandbox._helpers import merge_headers
 
 
 def test_merge_headers_override_wins() -> None:
+    # Names are normalized to lowercase and the override wins.
     merged = merge_headers({"X-Service-Key": "base"}, {"X-Service-Key": "override"})
-    assert merged == {"X-Service-Key": "override"}
+    assert merged == {"x-service-key": "override"}
 
 
 def test_merge_headers_preserves_non_overridden_base() -> None:

--- a/python/tests/unit_tests/sandbox/test_helpers.py
+++ b/python/tests/unit_tests/sandbox/test_helpers.py
@@ -1,0 +1,36 @@
+"""Unit tests for langsmith.sandbox._helpers."""
+
+import httpx
+
+from langsmith.sandbox._helpers import merge_headers
+
+
+def test_merge_headers_override_wins() -> None:
+    merged = merge_headers({"X-Service-Key": "base"}, {"X-Service-Key": "override"})
+    assert merged == {"X-Service-Key": "override"}
+
+
+def test_merge_headers_preserves_non_overridden_base() -> None:
+    merged = merge_headers({"a": "1", "b": "2"}, {"b": "3"})
+    assert merged == {"a": "1", "b": "3"}
+
+
+def test_merge_headers_none_inputs() -> None:
+    assert merge_headers(None, None) == {}
+    assert merge_headers({"a": "1"}, None) == {"a": "1"}
+    assert merge_headers(None, {"a": "1"}) == {"a": "1"}
+
+
+def test_merge_headers_override_replaces_across_casing() -> None:
+    # httpx.Headers normalizes names to lowercase; a Title-Case override must
+    # still replace the base rather than produce a second, duplicate header.
+    base = httpx.Headers({"X-Service-Key": "base", "X-Api-Key": ""})
+    merged = merge_headers(base, {"X-Service-Key": "override"})
+
+    assert [v for k, v in merged.items() if k.lower() == "x-service-key"] == [
+        "override"
+    ]
+    # And only one X-Service-Key actually goes on the wire.
+    request = httpx.Request("GET", "https://example.com", headers=merged)
+    on_wire = [v.decode() for k, v in request.headers.raw if k.lower() == b"x-service-key"]
+    assert on_wire == ["override"]

--- a/python/tests/unit_tests/sandbox/test_helpers.py
+++ b/python/tests/unit_tests/sandbox/test_helpers.py
@@ -32,5 +32,7 @@ def test_merge_headers_override_replaces_across_casing() -> None:
     ]
     # And only one X-Service-Key actually goes on the wire.
     request = httpx.Request("GET", "https://example.com", headers=merged)
-    on_wire = [v.decode() for k, v in request.headers.raw if k.lower() == b"x-service-key"]
+    on_wire = [
+        v.decode() for k, v in request.headers.raw if k.lower() == b"x-service-key"
+    ]
     assert on_wire == ["override"]

--- a/python/tests/unit_tests/sandbox/test_ws_execute.py
+++ b/python/tests/unit_tests/sandbox/test_ws_execute.py
@@ -74,8 +74,9 @@ class TestBuildWsUrl:
 
 class TestBuildAuthHeaders:
     def test_builds_header(self):
+        # Header names are normalized to lowercase.
         headers = _build_auth_headers("my-key")
-        assert headers == {"X-Api-Key": "my-key"}
+        assert headers == {"x-api-key": "my-key"}
 
     def test_none_key_returns_empty(self):
         headers = _build_auth_headers(None)
@@ -87,8 +88,8 @@ class TestBuildAuthHeaders:
             {"X-Api-Key": "override-key", "X-Test-Header": "ws-value"},
         )
         assert headers == {
-            "X-Api-Key": "override-key",
-            "X-Test-Header": "ws-value",
+            "x-api-key": "override-key",
+            "x-test-header": "ws-value",
         }
 
 


### PR DESCRIPTION
Merge sandbox request headers case-insensitively so a per-request override replaces a base header that differs only in casing, instead of emitting both.

## Problem

`merge_headers` merges per-request overrides onto the client’s default headers with a plain `dict.update`. The client stores its defaults as `httpx.Headers`, which normalizes names to **lowercase**, so the base dict has e.g. `x-service-key`. When a caller passes a per-request override using a different casing (e.g. Title-Case `X-Service-Key`), `dict.update` treats it as a distinct key and **both** headers are sent:

```
x-service-key: <client default>     # sent first
X-Service-Key: <override>           # sent second
```

HTTP header names are case-insensitive, so this is ambiguous. A server that reads the first value (Go’s `http.Header.Get`, for one) sees the **client default**, not the override — so a caller that overrides an auth header per-request silently gets the wrong one, e.g. an auth rejection.

## Fix

`merge_headers` now drops any base header whose name matches an override name case-insensitively before applying the override, so exactly one header (the override’s) is emitted.

## Test Plan

- [x] `uv run pytest tests/unit_tests/sandbox/test_helpers.py` — new `merge_headers` tests, including a regression that a Title-Case override replaces an `httpx.Headers` (lowercased) base and only one header reaches the wire
- [x] `uv run pytest tests/unit_tests/sandbox/` — full sandbox unit suite (499 passed)