### PR TITLE
js: only check min backend version on stainless resource access

### DIFF
--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -934,6 +934,8 @@ export class Client implements LangSmithTracingClientInterface {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private _getServerInfoPromise?: Promise<Record<string, any>>;
 
+  private _stainlessVersionChecked = false;
+
   private manualFlushMode = false;
 
   private _serializeWorker?: SerializeWorker | null;
@@ -1477,30 +1479,36 @@ export class Client implements LangSmithTracingClientInterface {
   }
 
   public get evaluators(): Evaluators {
+    this._checkStainlessVersion();
     return this.openAPIClient.onlineEvaluators;
   }
 
   public get runs(): OpenAPIRuns {
+    this._checkStainlessVersion();
     return this.openAPIClient.runs;
   }
 
   /** Access the v2 sandboxes resource (registries, snapshots, boxes). */
   public get sandboxes(): Sandboxes {
+    this._checkStainlessVersion();
     return this.openAPIClient.sandboxes;
   }
 
   /** Access the v2 datasets resource (experimentRuns, etc.). */
   public get datasets(): Datasets {
+    this._checkStainlessVersion();
     return this.openAPIClient.datasets;
   }
 
   /** Access the threads resource (query, stats, listTraces). */
   public get threads(): Threads {
+    this._checkStainlessVersion();
     return this.openAPIClient.threads;
   }
 
   /** Access the traces resource (query, listRuns). */
   public get traces(): Traces {
+    this._checkStainlessVersion();
     return this.openAPIClient.traces;
   }
 
@@ -2096,15 +2104,26 @@ export class Client implements LangSmithTracingClientInterface {
     return json;
   }
 
+  private _checkStainlessVersion(): void {
+    if (this._stainlessVersionChecked) return;
+    this._stainlessVersionChecked = true;
+    this._ensureServerInfo()
+      .then((serverInfo) => {
+        if (serverInfo?.version) {
+          _checkBackendVersion(serverInfo.version);
+        }
+      })
+      .catch(() => {
+        // _ensureServerInfo handles and logs its own errors
+      });
+  }
+
   protected async _ensureServerInfo() {
     if (this._getServerInfoPromise === undefined) {
       this._getServerInfoPromise = (async () => {
         if (this._serverInfo === undefined) {
           try {
             this._serverInfo = await this._getServerInfo();
-            if (this._serverInfo?.version) {
-              _checkBackendVersion(this._serverInfo.version);
-            }
           } catch (e: any) {
             console.warn(
               `[LANGSMITH]: Failed to fetch info on supported operations. Falling back to batch operations and default limits. Info: ${

--- a/js/src/tests/client.test.ts
+++ b/js/src/tests/client.test.ts
@@ -51,22 +51,33 @@ describe("Client", () => {
 
   describe("evaluators", () => {
     it("creates an evaluator through the platform endpoint", async () => {
-      const mockFetch = jest.fn<typeof fetch>().mockResolvedValue(
-        new Response(
-          JSON.stringify({
-            evaluator: {
-              id: "eval-1",
-              name: "SDK smoke test code evaluator",
-              type: "code",
-            },
-          }),
-          {
+      const mockFetch = jest
+        .fn<typeof fetch>()
+        .mockResolvedValueOnce(
+          // first call: _checkStainlessVersion triggers GET /info
+          new Response(JSON.stringify({ version: "0.16.14" }), {
             status: 200,
             statusText: "OK",
             headers: { "content-type": "application/json" },
-          },
-        ),
-      );
+          }),
+        )
+        .mockResolvedValueOnce(
+          // second call: the actual evaluator create
+          new Response(
+            JSON.stringify({
+              evaluator: {
+                id: "eval-1",
+                name: "SDK smoke test code evaluator",
+                type: "code",
+              },
+            }),
+            {
+              status: 200,
+              statusText: "OK",
+              headers: { "content-type": "application/json" },
+            },
+          ),
+        );
       const client = new Client({
         apiUrl: "http://localhost:8080",
         apiKey: "test-api-key",
@@ -84,7 +95,7 @@ describe("Client", () => {
       });
 
       expect(response.evaluator?.id).toBe("eval-1");
-      const [url, init] = mockFetch.mock.calls[0];
+      const [url, init] = mockFetch.mock.calls[1]; // call[0] is the /info prefetch
       const headers = new Headers(init?.headers);
       expect(url).toBe("http://localhost:8080/v1/platform/evaluators");
       expect(init).toEqual(


### PR DESCRIPTION
## Summary

- Moves the `_checkBackendVersion` call out of `_ensureServerInfo` (which fires on every batch operation) and into a new `_checkStainlessVersion` helper that fires only when a stainless (v2 OpenAPI) resource is first accessed.
- Adds `_checkStainlessVersion()` calls to all six stainless resource getters: `runs`, `evaluators`, `sandboxes`, `datasets`, `threads`, `traces`.
- Guards with a `_stainlessVersionChecked` flag so the warning fires at most once per client instance.

This mirrors the existing Python SDK behavior in `client.py`, where `_check_backend_version(self.info.version)` is called inside each stainless property getter rather than during batch ingestion.

**Before:** users who only use tracing/batch ops (never touching a v2 resource) would see a backend version warning.  
**After:** the warning only surfaces when a stainless resource is actually accessed — the APIs that actually require the newer backend.

## Test plan

- [ ] Existing `_checkBackendVersion` unit tests (8 cases) all pass.
- [ ] Pre-existing env-var test failures in `client.test.ts` are unrelated to this change (local `LANGSMITH_*` env vars bleeding into snapshot assertions).

🤖 Generated with [Claude Code](https://claude.ai/claude-code)