### PR TITLE
fix: include experiment metadata in eval feedback

### DIFF
--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -7570,6 +7570,7 @@ class Client:
         source_info: Optional[dict[str, Any]] = None,
         project_id: Optional[ID_TYPE] = None,
         *,
+        session_id: Optional[ID_TYPE] = None,
         _executor: Optional[cf.ThreadPoolExecutor] = None,
     ) -> list[ls_evaluator.EvaluationResult]:
         results = self._select_eval_results(evaluator_response)
@@ -7607,7 +7608,7 @@ class Client:
                 project_id=project_id,
                 extra=res.extra,
                 trace_id=run.trace_id if run else None,
-                session_id=run.session_id if run else None,
+                session_id=run.session_id if run and run.session_id else session_id,
                 start_time=run.start_time if run else None,
                 error=error,
             )

--- a/python/langsmith/evaluation/_arunner.py
+++ b/python/langsmith/evaluation/_arunner.py
@@ -1021,7 +1021,10 @@ class _AsyncExperimentManager(_ExperimentManagerMixin):
 
                     if self._upload_results:
                         self.client._log_evaluation_feedback(
-                            evaluator_response, run=run, _executor=feedback_executor
+                            evaluator_response,
+                            run=run,
+                            session_id=self._get_experiment().id,
+                            _executor=feedback_executor,
                         )
                     return selected_results
                 except Exception as e:
@@ -1044,7 +1047,10 @@ class _AsyncExperimentManager(_ExperimentManagerMixin):
                         )
                         if self._upload_results:
                             self.client._log_evaluation_feedback(
-                                error_response, run=run, _executor=feedback_executor
+                                error_response,
+                                run=run,
+                                session_id=self._get_experiment().id,
+                                _executor=feedback_executor,
                             )
                         return selected_results
                     except Exception as e2:

--- a/python/langsmith/evaluation/_runner.py
+++ b/python/langsmith/evaluation/_runner.py
@@ -1681,7 +1681,10 @@ class _ExperimentManager(_ExperimentManagerMixin):
                     if self._upload_results:
                         # TODO: This is a hack
                         self.client._log_evaluation_feedback(
-                            evaluator_response, run=run, _executor=executor
+                            evaluator_response,
+                            run=run,
+                            session_id=self._get_experiment().id,
+                            _executor=executor,
                         )
                 except Exception as e:
                     try:
@@ -1704,7 +1707,10 @@ class _ExperimentManager(_ExperimentManagerMixin):
                         if self._upload_results:
                             # TODO: This is a hack
                             self.client._log_evaluation_feedback(
-                                error_response, run=run, _executor=executor
+                                error_response,
+                                run=run,
+                                session_id=self._get_experiment().id,
+                                _executor=executor,
                             )
                     except Exception as e2:
                         logger.debug(f"Error parsing feedback keys: {e2}")

--- a/python/tests/unit_tests/evaluation/test_runner.py
+++ b/python/tests/unit_tests/evaluation/test_runner.py
@@ -44,6 +44,7 @@ class FakeRequest:
     def __init__(self, ds_id, ds_name, ds_examples, tenant_id):
         self.created_session = None
         self.runs = {}
+        self.feedbacks = []
         self.should_fail = False
         self.ds_id = ds_id
         self.ds_name = ds_name
@@ -116,6 +117,7 @@ class FakeRequest:
                 }
                 return res
             elif endpoint == "http://localhost:1984/feedback":
+                self.feedbacks.append(json.loads(kwargs["data"]))
                 response = MagicMock()
                 response.json.return_value = {}
                 return response
@@ -176,6 +178,79 @@ def _create_example(idx: int) -> Tuple[ls_schemas.Example, Dict[str, Any]]:
         "metadata": {"meta": idx},
         "attachment_urls": None,
     }
+
+
+def _fake_client_for_examples(
+    examples: list[dict[str, Any]], ds_id: str, ds_name: str
+) -> tuple[Client, FakeRequest]:
+    tenant_id = str(uuid.uuid4())
+    session = mock.Mock()
+    fake_request = FakeRequest(ds_id, ds_name, examples, tenant_id)
+    session.request = fake_request.request
+    client = Client(api_url="http://localhost:1984", api_key="123", session=session)
+    client._tenant_id = uuid.UUID(tenant_id)
+    return client, fake_request
+
+
+def test_evaluate_feedback_includes_experiment_session_id_and_run_start_time() -> None:
+    example, example_payload = _create_example(0)
+    client, fake_request = _fake_client_for_examples(
+        [example_payload], str(example.dataset_id), "my-dataset"
+    )
+
+    def predict(inputs: dict) -> dict:
+        return {"output": inputs["in"] + 1}
+
+    def score(run, example):
+        return {"key": "quality", "score": 1}
+
+    results = evaluate(
+        predict,
+        data=[example],
+        evaluators=[score],
+        client=client,
+        blocking=True,
+        max_concurrency=0,
+    )
+    assert len(list(results)) == 1
+    _wait_until(lambda: len(fake_request.feedbacks) == 1)
+
+    feedback = fake_request.feedbacks[0]
+    _wait_until(lambda: feedback["run_id"] in fake_request.runs)
+    run = fake_request.runs[feedback["run_id"]]
+    assert feedback["session_id"] == fake_request.created_session["id"]
+    assert feedback["start_time"] == run["start_time"]
+
+
+@pytest.mark.asyncio
+async def test_aevaluate_feedback_includes_experiment_id_and_start_time() -> None:
+    example, example_payload = _create_example(0)
+    client, fake_request = _fake_client_for_examples(
+        [example_payload], str(example.dataset_id), "my-dataset"
+    )
+
+    async def predict(inputs: dict) -> dict:
+        return {"output": inputs["in"] + 1}
+
+    async def score(run, example):
+        return {"key": "quality", "score": 1}
+
+    results = await aevaluate(
+        predict,
+        data=[example],
+        evaluators=[score],
+        client=client,
+        blocking=True,
+        max_concurrency=0,
+    )
+    assert len([row async for row in results]) == 1
+    _wait_until(lambda: len(fake_request.feedbacks) == 1)
+
+    feedback = fake_request.feedbacks[0]
+    _wait_until(lambda: feedback["run_id"] in fake_request.runs)
+    run = fake_request.runs[feedback["run_id"]]
+    assert feedback["session_id"] == fake_request.created_session["id"]
+    assert feedback["start_time"] == run["start_time"]
 
 
 @pytest.mark.skipif(sys.version_info < (3, 9), reason="requires python3.9 or higher")


### PR DESCRIPTION
## Description
Evaluator feedback created by `evaluate`/`aevaluate` now includes the experiment session id when the traced run has not been hydrated with one, while preserving the evaluated run's `start_time`. This avoids backend lookups for row-level evaluation feedback from new experiments.

## Test Plan
- [x] Added sync and async evaluation unit coverage asserting feedback includes the experiment session id and run start time.
- [x] `UV_PYTHON=/usr/bin/python3.13 make -C /workspace/langsmith-sdk/python lint`
- [x] `UV_PYTHON=/usr/bin/python3.13 make -C /workspace/langsmith-sdk/python tests TEST='tests/unit_tests/evaluation/test_runner.py'`

Made by [Open SWE](https://openswe.vercel.app/agents/be5e6335-9ec5-813b-9071-68f0da6f43dc)