### PR TITLE
fix(python): preserve `feedback_config` dict keys

### DIFF
--- a/python/langsmith/evaluation/evaluator.py
+++ b/python/langsmith/evaluation/evaluator.py
@@ -85,7 +85,7 @@ class EvaluationResult(BaseModel):
     """What the correct value should be, if applicable."""
     evaluator_info: dict = Field(default_factory=dict)
     """Additional information about the evaluator."""
-    feedback_config: Optional[Union[FeedbackConfig, dict]] = None
+    feedback_config: Optional[Union[dict, FeedbackConfig]] = None
     """The configuration used to generate this feedback."""
     source_run_id: Optional[Union[uuid.UUID, str]] = None
     """The ID of the trace of the evaluator itself."""

--- a/python/tests/unit_tests/evaluation/test_evaluator.py
+++ b/python/tests/unit_tests/evaluation/test_evaluator.py
@@ -49,6 +49,24 @@ def test_run_evaluator_decorator(run_1: Run, example_1: Example):
     assert result.score == 1.0
 
 
+@pytest.mark.parametrize(
+    "feedback_config",
+    [
+        {"threshold": 1.0},
+        {"type": "continuous", "min": 0, "max": 1},
+        {"type": "continuous", "threshold": 1.0},
+        None,
+    ],
+)
+def test_evaluation_result_preserves_feedback_config_dict(
+    feedback_config: Optional[dict],
+):
+    result = EvaluationResult(key="test", feedback_config=feedback_config)
+
+    assert result.feedback_config == feedback_config
+    assert result.model_dump()["feedback_config"] == feedback_config
+
+
 async def test_dynamic_comparison_run_evaluator():
     def foo(runs: list, example):
         return ComparisonEvaluationResult(key="bar", scores={uuid.uuid4(): 3.1})


### PR DESCRIPTION
Fixes langchain-ai/langchain#31802

---

`EvaluationResult.feedback_config` is publicly typed as accepting arbitrary dictionaries, but plain dict configs with custom keys could be parsed through the narrower `FeedbackConfig` branch first. That caused unknown keys like `threshold` to be silently dropped.

This changes the union order so regular dictionaries are preserved before attempting the narrower `FeedbackConfig` shape. Existing standard feedback configs such as continuous configs continue to work, while arbitrary config keys are no longer filtered out.

Added regression coverage for:

- arbitrary feedback config keys
- standard continuous config
- mixed standard and custom config keys
- `None`
- serialized output through `model_dump()`

AI assistance was used to prepare this contribution.