### PR TITLE
optionally use V2 list runs in evaluator runners

### DIFF
--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -2143,6 +2143,11 @@ export class Client implements LangSmithTracingClientInterface {
     });
   }
 
+  public async _supportsSDBQuery(): Promise<boolean> {
+    const serverInfo = await this._ensureServerInfo();
+    return serverInfo.instance_flags?.sdb_query_enabled === true;
+  }
+
   protected async _getSettings() {
     if (!this.settings) {
       this.settings = this._get("/settings");

--- a/js/src/evaluation/evaluate_comparative.ts
+++ b/js/src/evaluation/evaluate_comparative.ts
@@ -11,6 +11,7 @@ import { AsyncCaller } from "../utils/async_caller.js";
 import { evaluate } from "./index.js";
 import pRetry from "../utils/p-retry/index.js";
 import { getCurrentRunTree, traceable } from "../traceable.js";
+import { loadTraces } from "../utils/v2_migration.js";
 
 type ExperimentResults = Awaited<ReturnType<typeof evaluate>>;
 
@@ -30,44 +31,6 @@ async function loadExperiment(
   return client.readProject(
     validate(value) ? { projectId: value } : { projectName: value },
   );
-}
-
-async function loadTraces(
-  client: Client,
-  experiment: string,
-  options: { loadNested: boolean },
-) {
-  const executionOrder = options.loadNested ? undefined : 1;
-  const runs = await client.listRuns(
-    validate(experiment)
-      ? { projectId: experiment, executionOrder }
-      : { projectName: experiment, executionOrder },
-  );
-
-  const treeMap: Record<string, Run[]> = {};
-  const runIdMap: Record<string, Run> = {};
-  const results: Run[] = [];
-
-  for await (const run of runs) {
-    if (run.parent_run_id != null) {
-      treeMap[run.parent_run_id] ??= [];
-      treeMap[run.parent_run_id].push(run);
-    } else {
-      results.push(run);
-    }
-
-    runIdMap[run.id] = run;
-  }
-
-  for (const [parentRunId, childRuns] of Object.entries(treeMap)) {
-    const parentRun = runIdMap[parentRunId];
-    parentRun.child_runs = childRuns.sort((a, b) => {
-      if (a.dotted_order == null || b.dotted_order == null) return 0;
-      return a.dotted_order.localeCompare(b.dotted_order);
-    });
-  }
-
-  return results;
 }
 
 /** @deprecated Use ComparativeEvaluatorNew instead: (args: { runs, example, inputs, outputs, referenceOutputs }) => ... */
@@ -268,8 +231,8 @@ export async function evaluateComparative(
   }
 
   const experimentRuns = await Promise.all(
-    projects.map((p) =>
-      loadTraces(client, p.id, { loadNested: !!options.loadNested }),
+    projects.map((project) =>
+      loadTraces(client, project, { loadNested: !!options.loadNested }),
     ),
   );
 

--- a/js/src/evaluation/evaluate_comparative.ts
+++ b/js/src/evaluation/evaluate_comparative.ts
@@ -5,13 +5,14 @@ import {
   ComparisonEvaluationResult as ComparisonEvaluationResultRow,
   Example,
   Run,
+  TracerSession,
 } from "../schemas.js";
 import { shuffle } from "../utils/shuffle.js";
 import { AsyncCaller } from "../utils/async_caller.js";
 import { evaluate } from "./index.js";
 import pRetry from "../utils/p-retry/index.js";
 import { getCurrentRunTree, traceable } from "../traceable.js";
-import { loadTraces } from "../utils/v2_migration.js";
+import { loadTracesV2 } from "../utils/v2_migration.js";
 
 type ExperimentResults = Awaited<ReturnType<typeof evaluate>>;
 
@@ -31,6 +32,45 @@ async function loadExperiment(
   return client.readProject(
     validate(value) ? { projectId: value } : { projectName: value },
   );
+}
+
+export async function loadTracesForExperiment(
+  client: Client,
+  project: TracerSession,
+  options: { loadNested: boolean },
+): Promise<Run[]> {
+  // v1 `/runs/query` returns 501 on SmithDB-only backends; use v2 when it's available.
+  const isRoot = options.loadNested ? undefined : true;
+  const runs = (await client._supportsSDBQuery())
+    ? await loadTracesV2(client, project, { isRoot })
+    : await client.listRuns({
+        projectId: project.id,
+        executionOrder: options.loadNested ? undefined : 1,
+      });
+
+  const treeMap: Record<string, Run[]> = {};
+  const runIdMap: Record<string, Run> = {};
+  const results: Run[] = [];
+
+  for await (const run of runs) {
+    if (run.parent_run_id != null) {
+      treeMap[run.parent_run_id] ??= [];
+      treeMap[run.parent_run_id].push(run);
+    } else {
+      results.push(run);
+    }
+    runIdMap[run.id] = run;
+  }
+
+  for (const [parentRunId, childRuns] of Object.entries(treeMap)) {
+    const parentRun = runIdMap[parentRunId];
+    parentRun.child_runs = childRuns.sort((a, b) => {
+      if (a.dotted_order == null || b.dotted_order == null) return 0;
+      return a.dotted_order.localeCompare(b.dotted_order);
+    });
+  }
+
+  return results;
 }
 
 /** @deprecated Use ComparativeEvaluatorNew instead: (args: { runs, example, inputs, outputs, referenceOutputs }) => ... */
@@ -232,7 +272,9 @@ export async function evaluateComparative(
 
   const experimentRuns = await Promise.all(
     projects.map((project) =>
-      loadTraces(client, project, { loadNested: !!options.loadNested }),
+      loadTracesForExperiment(client, project, {
+        loadNested: !!options.loadNested,
+      }),
     ),
   );
 

--- a/js/src/tests/evaluate_runner.test.ts
+++ b/js/src/tests/evaluate_runner.test.ts
@@ -1,3 +1,6 @@
+import { jest } from "@jest/globals";
+import type { Run as V2Run } from "../_openapi_client/resources/runs/runs.js";
+import type { Client } from "../client.js";
 import {
   _collectEvaluatorKeys,
   _extractEvaluatorFeedbackKeys,
@@ -5,8 +8,9 @@ import {
   _reorderResultRowsByExampleIndex,
   evaluate,
 } from "../evaluation/_runner.js";
+import { loadTracesForExperiment } from "../evaluation/evaluate_comparative.js";
 import { PQueue } from "../utils/p-queue.js";
-import { Example } from "../schemas.js";
+import { Example, Run, TracerSession } from "../schemas.js";
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -744,5 +748,90 @@ describe("evaluator feedback-key extraction", () => {
       "field_completeness",
       "analysis_quality",
     ]);
+  });
+});
+
+describe("loadTracesForExperiment", () => {
+  const project: TracerSession = {
+    id: "00000000-0000-0000-0000-000000000001",
+    tenant_id: "00000000-0000-0000-0000-000000000002",
+    start_time: 0,
+    end_time: 1_000,
+  };
+
+  const v2Run: V2Run = {
+    id: "00000000-0000-0000-0000-000000000003",
+    name: "root",
+    run_type: "CHAIN",
+    start_time: "1970-01-01T00:00:00.000Z",
+    trace_id: "00000000-0000-0000-0000-000000000003",
+    project_id: project.id,
+    parent_run_ids: [],
+    reference_example_id: "00000000-0000-0000-0000-000000000004",
+    inputs: { question: "test" },
+    outputs: { answer: "test" },
+    status: "SUCCESS",
+  };
+
+  test("loads runs from v2 when SDB querying is enabled", async () => {
+    const queryV2 = jest.fn(() => fromArray([v2Run]));
+    const listRuns = jest.fn();
+    const client = {
+      _supportsSDBQuery: async () => true,
+      runs: { queryV2 },
+      listRuns,
+    } as unknown as Client;
+
+    const runs = await loadTracesForExperiment(client, project, {
+      loadNested: false,
+    });
+
+    expect(runs).toHaveLength(1);
+    expect(runs[0].session_id).toBe(project.id);
+    expect(queryV2).toHaveBeenCalledWith(
+      expect.objectContaining({
+        project_ids: [project.id],
+        min_start_time: "1970-01-01T00:00:00.000Z",
+        max_start_time: "1970-01-01T00:00:01.000Z",
+        is_root: true,
+      }),
+    );
+    expect(listRuns).not.toHaveBeenCalled();
+  });
+
+  test("loads and nests runs from v1 when SDB querying is disabled", async () => {
+    const root: Run = {
+      id: "00000000-0000-0000-0000-000000000005",
+      name: "root",
+      run_type: "chain",
+      inputs: {},
+    };
+    const child: Run = {
+      id: "00000000-0000-0000-0000-000000000006",
+      name: "child",
+      run_type: "tool",
+      inputs: {},
+      parent_run_id: root.id,
+      dotted_order: "2",
+    };
+    const listRuns = jest.fn(() => fromArray([child, root]));
+    const queryV2 = jest.fn();
+    const client = {
+      _supportsSDBQuery: async () => false,
+      runs: { queryV2 },
+      listRuns,
+    } as unknown as Client;
+
+    const runs = await loadTracesForExperiment(client, project, {
+      loadNested: true,
+    });
+
+    expect(runs).toEqual([root]);
+    expect(root.child_runs).toEqual([child]);
+    expect(listRuns).toHaveBeenCalledWith({
+      projectId: project.id,
+      executionOrder: undefined,
+    });
+    expect(queryV2).not.toHaveBeenCalled();
   });
 });

--- a/js/src/tests/v2_migration.test.ts
+++ b/js/src/tests/v2_migration.test.ts
@@ -1,12 +1,6 @@
-import { jest } from "@jest/globals";
 import type { Run as V2Run } from "../_openapi_client/resources/runs/runs.js";
-import type { Client } from "../client.js";
-import type { Run, TracerSession } from "../schemas.js";
-import { loadTraces, v2RunToRun } from "../utils/v2_migration.js";
-
-async function* fromArray<T>(items: T[]): AsyncGenerator<T> {
-  yield* items;
-}
+import type { TracerSession } from "../schemas.js";
+import { v2RunToRun } from "../utils/v2_migration.js";
 
 const project: TracerSession = {
   id: "00000000-0000-0000-0000-000000000001",
@@ -41,63 +35,5 @@ describe("v2 migration utils", () => {
         outputs: v2Run.outputs,
       }),
     );
-  });
-
-  test("loads runs from v2 when SDB querying is enabled", async () => {
-    const queryV2 = jest.fn(() => fromArray([v2Run]));
-    const listRuns = jest.fn();
-    const client = {
-      _supportsSDBQuery: async () => true,
-      runs: { queryV2 },
-      listRuns,
-    } as unknown as Client;
-
-    const runs = await loadTraces(client, project, { loadNested: false });
-
-    expect(runs).toHaveLength(1);
-    expect(runs[0].session_id).toBe(project.id);
-    expect(queryV2).toHaveBeenCalledWith(
-      expect.objectContaining({
-        project_ids: [project.id],
-        min_start_time: "1970-01-01T00:00:00.000Z",
-        max_start_time: "1970-01-01T00:00:01.000Z",
-        is_root: true,
-      }),
-    );
-    expect(listRuns).not.toHaveBeenCalled();
-  });
-
-  test("loads and nests runs from v1 when SDB querying is disabled", async () => {
-    const root: Run = {
-      id: "00000000-0000-0000-0000-000000000005",
-      name: "root",
-      run_type: "chain",
-      inputs: {},
-    };
-    const child: Run = {
-      id: "00000000-0000-0000-0000-000000000006",
-      name: "child",
-      run_type: "tool",
-      inputs: {},
-      parent_run_id: root.id,
-      dotted_order: "2",
-    };
-    const listRuns = jest.fn(() => fromArray([child, root]));
-    const queryV2 = jest.fn();
-    const client = {
-      _supportsSDBQuery: async () => false,
-      runs: { queryV2 },
-      listRuns,
-    } as unknown as Client;
-
-    const runs = await loadTraces(client, project, { loadNested: true });
-
-    expect(runs).toEqual([root]);
-    expect(root.child_runs).toEqual([child]);
-    expect(listRuns).toHaveBeenCalledWith({
-      projectId: project.id,
-      executionOrder: undefined,
-    });
-    expect(queryV2).not.toHaveBeenCalled();
   });
 });

--- a/js/src/tests/v2_migration.test.ts
+++ b/js/src/tests/v2_migration.test.ts
@@ -1,0 +1,103 @@
+import { jest } from "@jest/globals";
+import type { Run as V2Run } from "../_openapi_client/resources/runs/runs.js";
+import type { Client } from "../client.js";
+import type { Run, TracerSession } from "../schemas.js";
+import { loadTraces, v2RunToRun } from "../utils/v2_migration.js";
+
+async function* fromArray<T>(items: T[]): AsyncGenerator<T> {
+  yield* items;
+}
+
+const project: TracerSession = {
+  id: "00000000-0000-0000-0000-000000000001",
+  tenant_id: "00000000-0000-0000-0000-000000000002",
+  start_time: 0,
+  end_time: 1_000,
+};
+
+const v2Run: V2Run = {
+  id: "00000000-0000-0000-0000-000000000003",
+  name: "root",
+  run_type: "CHAIN",
+  start_time: "1970-01-01T00:00:00.000Z",
+  trace_id: "00000000-0000-0000-0000-000000000003",
+  project_id: project.id,
+  parent_run_ids: [],
+  reference_example_id: "00000000-0000-0000-0000-000000000004",
+  inputs: { question: "test" },
+  outputs: { answer: "test" },
+  status: "SUCCESS",
+};
+
+describe("v2 migration utils", () => {
+  test("maps generated v2 runs to legacy runs", () => {
+    expect(v2RunToRun(v2Run)).toEqual(
+      expect.objectContaining({
+        id: v2Run.id,
+        session_id: project.id,
+        run_type: "chain",
+        parent_run_id: undefined,
+        inputs: v2Run.inputs,
+        outputs: v2Run.outputs,
+      }),
+    );
+  });
+
+  test("loads runs from v2 when SDB querying is enabled", async () => {
+    const queryV2 = jest.fn(() => fromArray([v2Run]));
+    const listRuns = jest.fn();
+    const client = {
+      _supportsSDBQuery: async () => true,
+      runs: { queryV2 },
+      listRuns,
+    } as unknown as Client;
+
+    const runs = await loadTraces(client, project, { loadNested: false });
+
+    expect(runs).toHaveLength(1);
+    expect(runs[0].session_id).toBe(project.id);
+    expect(queryV2).toHaveBeenCalledWith(
+      expect.objectContaining({
+        project_ids: [project.id],
+        min_start_time: "1970-01-01T00:00:00.000Z",
+        max_start_time: "1970-01-01T00:00:01.000Z",
+        is_root: true,
+      }),
+    );
+    expect(listRuns).not.toHaveBeenCalled();
+  });
+
+  test("loads and nests runs from v1 when SDB querying is disabled", async () => {
+    const root: Run = {
+      id: "00000000-0000-0000-0000-000000000005",
+      name: "root",
+      run_type: "chain",
+      inputs: {},
+    };
+    const child: Run = {
+      id: "00000000-0000-0000-0000-000000000006",
+      name: "child",
+      run_type: "tool",
+      inputs: {},
+      parent_run_id: root.id,
+      dotted_order: "2",
+    };
+    const listRuns = jest.fn(() => fromArray([child, root]));
+    const queryV2 = jest.fn();
+    const client = {
+      _supportsSDBQuery: async () => false,
+      runs: { queryV2 },
+      listRuns,
+    } as unknown as Client;
+
+    const runs = await loadTraces(client, project, { loadNested: true });
+
+    expect(runs).toEqual([root]);
+    expect(root.child_runs).toEqual([child]);
+    expect(listRuns).toHaveBeenCalledWith({
+      projectId: project.id,
+      executionOrder: undefined,
+    });
+    expect(queryV2).not.toHaveBeenCalled();
+  });
+});

--- a/js/src/utils/v2_migration.ts
+++ b/js/src/utils/v2_migration.ts
@@ -1,0 +1,102 @@
+import type {
+  Run as V2Run,
+  RunSelectField,
+} from "../_openapi_client/resources/runs/runs.js";
+import type { Client } from "../client.js";
+import type { Run, TracerSession } from "../schemas.js";
+
+// Omitting selects from `/v2/runs/query` returns only the run ID.
+const V2_RUN_SELECTS: RunSelectField[] = [
+  "ID",
+  "NAME",
+  "RUN_TYPE",
+  "STATUS",
+  "START_TIME",
+  "END_TIME",
+  "INPUTS",
+  "OUTPUTS",
+  "PARENT_RUN_IDS",
+  "PROJECT_ID",
+  "TRACE_ID",
+  "DOTTED_ORDER",
+  "REFERENCE_EXAMPLE_ID",
+  "ERROR",
+];
+
+export function v2RunToRun(run: V2Run): Run {
+  if (run.id == null || run.name == null || run.run_type == null) {
+    throw new Error("V2 run response is missing required fields.");
+  }
+  return {
+    id: run.id,
+    name: run.name,
+    run_type: run.run_type.toLowerCase(),
+    start_time: run.start_time,
+    end_time: run.end_time,
+    trace_id: run.trace_id,
+    session_id: run.project_id,
+    parent_run_id: run.parent_run_ids?.at(-1),
+    dotted_order: run.dotted_order,
+    reference_example_id: run.reference_example_id,
+    inputs: run.inputs ?? {},
+    outputs: run.outputs,
+    error: run.error ?? undefined,
+    status: run.status,
+  };
+}
+
+async function loadTracesV2(
+  client: Client,
+  project: TracerSession,
+  options: { loadNested: boolean },
+): Promise<Run[]> {
+  const runs: Run[] = [];
+  const pager = client.runs.queryV2({
+    project_ids: [project.id],
+    min_start_time: new Date(project.start_time).toISOString(),
+    max_start_time: new Date(project.end_time ?? Date.now()).toISOString(),
+    is_root: options.loadNested ? undefined : true,
+    selects: V2_RUN_SELECTS,
+  });
+  for await (const run of pager) {
+    runs.push(v2RunToRun(run));
+  }
+  return runs;
+}
+
+export async function loadTraces(
+  client: Client,
+  project: TracerSession,
+  options: { loadNested: boolean },
+): Promise<Run[]> {
+  const runs = (await client._supportsSDBQuery())
+    ? await loadTracesV2(client, project, options)
+    : await client.listRuns({
+        projectId: project.id,
+        executionOrder: options.loadNested ? undefined : 1,
+      });
+
+  const treeMap: Record<string, Run[]> = {};
+  const runIdMap: Record<string, Run> = {};
+  const results: Run[] = [];
+
+  for await (const run of runs) {
+    if (run.parent_run_id != null) {
+      treeMap[run.parent_run_id] ??= [];
+      treeMap[run.parent_run_id].push(run);
+    } else {
+      results.push(run);
+    }
+    runIdMap[run.id] = run;
+  }
+
+  for (const [parentRunId, childRuns] of Object.entries(treeMap)) {
+    const parentRun = runIdMap[parentRunId];
+    parentRun.child_runs = childRuns.sort((a, b) => {
+      if (a.dotted_order == null || b.dotted_order == null) return 0;
+      return a.dotted_order.localeCompare(b.dotted_order);
+    });
+  }
+
+  return results;
+}

--- a/js/src/utils/v2_migration.ts
+++ b/js/src/utils/v2_migration.ts
@@ -45,58 +45,21 @@ export function v2RunToRun(run: V2Run): Run {
   };
 }
 
-async function loadTracesV2(
+export async function loadTracesV2(
   client: Client,
   project: TracerSession,
-  options: { loadNested: boolean },
+  options: { isRoot?: boolean },
 ): Promise<Run[]> {
   const runs: Run[] = [];
   const pager = client.runs.queryV2({
     project_ids: [project.id],
     min_start_time: new Date(project.start_time).toISOString(),
     max_start_time: new Date(project.end_time ?? Date.now()).toISOString(),
-    is_root: options.loadNested ? undefined : true,
+    is_root: options.isRoot,
     selects: V2_RUN_SELECTS,
   });
   for await (const run of pager) {
     runs.push(v2RunToRun(run));
   }
   return runs;
-}
-
-export async function loadTraces(
-  client: Client,
-  project: TracerSession,
-  options: { loadNested: boolean },
-): Promise<Run[]> {
-  const runs = (await client._supportsSDBQuery())
-    ? await loadTracesV2(client, project, options)
-    : await client.listRuns({
-        projectId: project.id,
-        executionOrder: options.loadNested ? undefined : 1,
-      });
-
-  const treeMap: Record<string, Run[]> = {};
-  const runIdMap: Record<string, Run> = {};
-  const results: Run[] = [];
-
-  for await (const run of runs) {
-    if (run.parent_run_id != null) {
-      treeMap[run.parent_run_id] ??= [];
-      treeMap[run.parent_run_id].push(run);
-    } else {
-      results.push(run);
-    }
-    runIdMap[run.id] = run;
-  }
-
-  for (const [parentRunId, childRuns] of Object.entries(treeMap)) {
-    const parentRun = runIdMap[parentRunId];
-    parentRun.child_runs = childRuns.sort((a, b) => {
-      if (a.dotted_order == null || b.dotted_order == null) return 0;
-      return a.dotted_order.localeCompare(b.dotted_order);
-    });
-  }
-
-  return results;
 }

--- a/python/langsmith/_internal/_v2_migration_utils.py
+++ b/python/langsmith/_internal/_v2_migration_utils.py
@@ -1,0 +1,82 @@
+"""Utilities for migrating functionality to the v2 LangSmith API."""
+
+from __future__ import annotations
+
+import datetime
+from typing import TYPE_CHECKING, Any, Optional
+
+from langsmith import schemas
+
+if TYPE_CHECKING:
+    from langsmith.client import Client
+
+
+# Fields for `/v2/runs/query` (RunSelectField enum); omitting selects returns only id.
+_V2_RUN_SELECTS = [
+    "ID",
+    "NAME",
+    "RUN_TYPE",
+    "STATUS",
+    "START_TIME",
+    "END_TIME",
+    "INPUTS",
+    "OUTPUTS",
+    "PARENT_RUN_IDS",
+    "PROJECT_ID",
+    "TRACE_ID",
+    "DOTTED_ORDER",
+    "REFERENCE_EXAMPLE_ID",
+    "ERROR",
+]
+
+
+def _load_traces_v2(
+    project: schemas.TracerSession,
+    client: Client,
+    *,
+    is_root: Optional[bool],
+) -> list[schemas.Run]:
+    """List an experiment's runs from v2.
+
+    `query_v2` defaults `min_start_time` to ~24h, so bound the window to the session
+    explicitly or older experiments drop.
+    """
+    now = datetime.datetime.now(datetime.timezone.utc)
+    kwargs: dict[str, Any] = {
+        "project_ids": [str(project.id)],
+        "min_start_time": project.start_time,
+        "max_start_time": project.end_time or now,
+        "selects": _V2_RUN_SELECTS,
+    }
+    if is_root is not None:
+        kwargs["is_root"] = is_root
+    pager = client._get_langsmith_api_sync().runs.query_v2(**kwargs)
+    return [_v2_run_to_schema(run) for run in pager]
+
+
+def _v2_run_to_schema(run: Any) -> schemas.Run:
+    """Map a v2 `Run` to `schemas.Run`.
+
+    `project_id`→`session_id`, `parent_run_ids[-1]`→`parent_run_id`; drop `None` so
+    schema defaults apply (e.g. `dotted_order`).
+    """
+    parent_run_ids = getattr(run, "parent_run_ids", None)
+    fields = {
+        "id": run.id,
+        "name": run.name,
+        "run_type": run.run_type,
+        "start_time": run.start_time,
+        "end_time": getattr(run, "end_time", None),
+        "trace_id": run.trace_id,
+        "session_id": getattr(run, "project_id", None),
+        "parent_run_id": parent_run_ids[-1] if parent_run_ids else None,
+        "dotted_order": getattr(run, "dotted_order", None),
+        "reference_example_id": getattr(run, "reference_example_id", None),
+        "inputs": getattr(run, "inputs", None) or {},
+        "outputs": getattr(run, "outputs", None),
+        "error": getattr(run, "error", None),
+        "status": getattr(run, "status", None),
+    }
+    return schemas.Run(
+        **{key: value for key, value in fields.items() if value is not None}
+    )

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -113,6 +113,7 @@ from langsmith._internal._operations import (
 from langsmith._internal._serde import dumps_json as _dumps_json
 from langsmith._internal._uuid import uuid7
 from langsmith._openapi_client import AsyncLangsmith as LangsmithOpenAPIClient
+from langsmith._openapi_client import Langsmith as SyncLangsmithOpenAPIClient
 from langsmith.prompt_cache import PromptCache, prompt_cache_singleton
 from langsmith.schemas import AttachmentInfo, ExampleWithRuns
 
@@ -917,6 +918,7 @@ class Client:
         "_profile_auth",
         "_profile_auth_headers",
         "_langsmith_api",
+        "_langsmith_api_sync",
     ]
 
     _api_key: Optional[str]
@@ -928,6 +930,7 @@ class Client:
     _profile_auth: Optional[_profiles.ProfileAuth]
     _profile_auth_headers: dict[str, str]
     _langsmith_api: Optional[LangsmithOpenAPIClient]
+    _langsmith_api_sync: Optional[SyncLangsmithOpenAPIClient]
 
     def __init__(
         self,
@@ -1467,6 +1470,7 @@ class Client:
             self._failed_traces_max_bytes = 100 * 1024 * 1024
 
         self._langsmith_api = None
+        self._langsmith_api_sync = None
 
     # ------------------------------------------------------------------
     # Stainless v2 resource accessors
@@ -1490,6 +1494,22 @@ class Client:
                 default_headers=self._headers or None,
             )
         return self._langsmith_api
+
+    def _get_langsmith_api_sync(self) -> SyncLangsmithOpenAPIClient:
+        if self._langsmith_api_sync is None:
+            self._langsmith_api_sync = SyncLangsmithOpenAPIClient(
+                api_key=self._api_key,
+                tenant_id=str(self._workspace_id) if self._workspace_id else None,
+                base_url=self.api_url,
+                timeout=_httpx.Timeout(
+                    connect=self._timeout[0],
+                    read=self._timeout[1],
+                    write=self._timeout[1],
+                    pool=self._timeout[0],
+                ),
+                default_headers=self._headers or None,
+            )
+        return self._langsmith_api_sync
 
     @property
     def runs(self) -> AsyncRunsResource:

--- a/python/langsmith/evaluation/_arunner.py
+++ b/python/langsmith/evaluation/_arunner.py
@@ -42,7 +42,7 @@ from langsmith.evaluation._runner import (
     _load_examples_map,
     _load_experiment,
     _load_tqdm,
-    _load_traces,
+    _load_traces_for_experiment,
     _resolve_data,
     _resolve_evaluators,
     _resolve_experiment,
@@ -447,7 +447,7 @@ async def aevaluate_existing(
     )
     runs = await aitertools.aio_to_thread(
         contextvars.copy_context(),
-        _load_traces,
+        _load_traces_for_experiment,
         project,
         client,
         load_nested=load_nested,

--- a/python/langsmith/evaluation/_arunner.py
+++ b/python/langsmith/evaluation/_arunner.py
@@ -448,7 +448,7 @@ async def aevaluate_existing(
     runs = await aitertools.aio_to_thread(
         contextvars.copy_context(),
         _load_traces,
-        experiment,
+        project,
         client,
         load_nested=load_nested,
     )

--- a/python/langsmith/evaluation/_runner.py
+++ b/python/langsmith/evaluation/_runner.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import asyncio
 import collections
 import concurrent.futures as cf
+import datetime
 import functools
 import inspect
 import io
@@ -505,7 +507,7 @@ def evaluate_existing(
     """  # noqa: E501
     client = client or rt.get_cached_client(timeout_ms=(20_000, 90_001))
     project = _load_experiment(experiment, client)
-    runs = _load_traces(experiment, client, load_nested=load_nested)
+    runs = _load_traces(project, client, load_nested=load_nested)
     data_map = _load_examples_map(client, project)
     data = [data_map[cast(uuid.UUID, run.reference_example_id)] for run in runs]
     return _evaluate(
@@ -893,8 +895,7 @@ def evaluate_comparative(
     comparison_url = _build_comparative_url(experiments_tuple, comparative_experiment)
     _print_comparative_experiment_start(comparison_url)
     runs = [
-        _load_traces(experiment, client, load_nested=load_nested)
-        for experiment in experiments
+        _load_traces(project, client, load_nested=load_nested) for project in projects
     ]
     # Only check intersections for the experiments
     examples_intersection = None
@@ -1167,7 +1168,12 @@ def _load_traces(
 ) -> list[schemas.Run]:
     """Load nested traces for a given project."""
     is_root = None if load_nested else True
-    if isinstance(project, schemas.TracerSession):
+    # v1 `/runs/query` returns 501 on SmithDB-only backends; use v2 when it's available.
+    if (client.info.instance_flags or {}).get("sdb_query_enabled"):
+        if not isinstance(project, schemas.TracerSession):
+            project = _load_experiment(project, client)
+        runs = _load_traces_v2(project, client, is_root=is_root)
+    elif isinstance(project, schemas.TracerSession):
         runs = client.list_runs(project_id=project.id, is_root=is_root)
     elif isinstance(project, uuid.UUID) or _is_uuid(project):
         runs = client.list_runs(project_id=project, is_root=is_root)
@@ -1190,6 +1196,92 @@ def _load_traces(
     for run_id, child_runs in treemap.items():
         all_runs[run_id].child_runs = sorted(child_runs, key=lambda r: r.dotted_order)
     return results
+
+
+# Fields for `/v2/runs/query` (RunSelectField enum); omitting selects returns only id.
+_V2_RUN_SELECTS = [
+    "ID",
+    "NAME",
+    "RUN_TYPE",
+    "STATUS",
+    "START_TIME",
+    "END_TIME",
+    "INPUTS",
+    "OUTPUTS",
+    "PARENT_RUN_IDS",
+    "PROJECT_ID",
+    "TRACE_ID",
+    "DOTTED_ORDER",
+    "REFERENCE_EXAMPLE_ID",
+    "ERROR",
+]
+
+
+def _load_traces_v2(
+    project: schemas.TracerSession,
+    client: langsmith.Client,
+    *,
+    is_root: Optional[bool],
+) -> list[schemas.Run]:
+    """List an experiment's runs from v2.
+
+    `query_v2` defaults `min_start_time` to ~24h, so bound the window to the session
+    explicitly or older experiments drop.
+    """
+    now = datetime.datetime.now(datetime.timezone.utc)
+    kwargs: dict[str, Any] = {
+        "project_ids": [str(project.id)],
+        "min_start_time": project.start_time,
+        "max_start_time": project.end_time or now,
+        "selects": _V2_RUN_SELECTS,
+    }
+    if is_root is not None:
+        kwargs["is_root"] = is_root
+    return [_v2_run_to_schema(r) for r in _query_v2_runs_sync(client, **kwargs)]
+
+
+def _query_v2_runs_sync(client: langsmith.Client, **kwargs: Any) -> list[Any]:
+    """Run the async `client.runs.query_v2` to completion.
+
+    Callers have no running loop (sync `evaluate`, or an `aio_to_thread` worker), so
+    `asyncio.run` works; fall back to a thread if one is running.
+    """
+
+    async def _collect() -> list[Any]:
+        return [run async for run in await client.runs.query_v2(**kwargs)]
+
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(_collect())
+    with cf.ThreadPoolExecutor(max_workers=1) as executor:
+        return executor.submit(lambda: asyncio.run(_collect())).result()
+
+
+def _v2_run_to_schema(run: Any) -> schemas.Run:
+    """Map a v2 `Run` to `ls_schemas.Run`.
+
+    `project_id`→`session_id`, `parent_run_ids[-1]`→`parent_run_id`; drop `None` so
+    schema defaults apply (e.g. `dotted_order`).
+    """
+    parent_run_ids = getattr(run, "parent_run_ids", None)
+    fields = {
+        "id": run.id,
+        "name": run.name,
+        "run_type": run.run_type,
+        "start_time": run.start_time,
+        "end_time": getattr(run, "end_time", None),
+        "trace_id": run.trace_id,
+        "session_id": getattr(run, "project_id", None),
+        "parent_run_id": parent_run_ids[-1] if parent_run_ids else None,
+        "dotted_order": getattr(run, "dotted_order", None),
+        "reference_example_id": getattr(run, "reference_example_id", None),
+        "inputs": getattr(run, "inputs", None) or {},
+        "outputs": getattr(run, "outputs", None),
+        "error": getattr(run, "error", None),
+        "status": getattr(run, "status", None),
+    }
+    return schemas.Run(**{k: v for k, v in fields.items() if v is not None})
 
 
 def _load_examples_map(

--- a/python/langsmith/evaluation/_runner.py
+++ b/python/langsmith/evaluation/_runner.py
@@ -506,7 +506,7 @@ def evaluate_existing(
     """  # noqa: E501
     client = client or rt.get_cached_client(timeout_ms=(20_000, 90_001))
     project = _load_experiment(experiment, client)
-    runs = _load_traces(project, client, load_nested=load_nested)
+    runs = _load_traces_for_experiment(project, client, load_nested=load_nested)
     data_map = _load_examples_map(client, project)
     data = [data_map[cast(uuid.UUID, run.reference_example_id)] for run in runs]
     return _evaluate(
@@ -894,7 +894,8 @@ def evaluate_comparative(
     comparison_url = _build_comparative_url(experiments_tuple, comparative_experiment)
     _print_comparative_experiment_start(comparison_url)
     runs = [
-        _load_traces(project, client, load_nested=load_nested) for project in projects
+        _load_traces_for_experiment(project, client, load_nested=load_nested)
+        for project in projects
     ]
     # Only check intersections for the experiments
     examples_intersection = None
@@ -1160,7 +1161,7 @@ def _load_experiment(
         return client.read_project(project_name=project)
 
 
-def _load_traces(
+def _load_traces_for_experiment(
     project: Union[str, uuid.UUID, schemas.TracerSession],
     client: langsmith.Client,
     load_nested: bool = False,

--- a/python/langsmith/evaluation/_runner.py
+++ b/python/langsmith/evaluation/_runner.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import collections
 import concurrent.futures as cf
-import datetime
 import functools
 import inspect
 import io
@@ -44,6 +43,7 @@ from langsmith import run_helpers as rh
 from langsmith import run_trees as rt
 from langsmith import schemas
 from langsmith import utils as ls_utils
+from langsmith._internal import _v2_migration_utils
 from langsmith._internal._beta_decorator import _warn_once
 from langsmith.evaluation.evaluator import (
     SUMMARY_EVALUATOR_T,
@@ -1167,11 +1167,12 @@ def _load_traces(
 ) -> list[schemas.Run]:
     """Load nested traces for a given project."""
     is_root = None if load_nested else True
+    runs: Iterable[schemas.Run]
     # v1 `/runs/query` returns 501 on SmithDB-only backends; use v2 when it's available.
     if (client.info.instance_flags or {}).get("sdb_query_enabled"):
         if not isinstance(project, schemas.TracerSession):
             project = _load_experiment(project, client)
-        runs = _load_traces_v2(project, client, is_root=is_root)
+        runs = _v2_migration_utils._load_traces_v2(project, client, is_root=is_root)
     elif isinstance(project, schemas.TracerSession):
         runs = client.list_runs(project_id=project.id, is_root=is_root)
     elif isinstance(project, uuid.UUID) or _is_uuid(project):
@@ -1195,75 +1196,6 @@ def _load_traces(
     for run_id, child_runs in treemap.items():
         all_runs[run_id].child_runs = sorted(child_runs, key=lambda r: r.dotted_order)
     return results
-
-
-# Fields for `/v2/runs/query` (RunSelectField enum); omitting selects returns only id.
-_V2_RUN_SELECTS = [
-    "ID",
-    "NAME",
-    "RUN_TYPE",
-    "STATUS",
-    "START_TIME",
-    "END_TIME",
-    "INPUTS",
-    "OUTPUTS",
-    "PARENT_RUN_IDS",
-    "PROJECT_ID",
-    "TRACE_ID",
-    "DOTTED_ORDER",
-    "REFERENCE_EXAMPLE_ID",
-    "ERROR",
-]
-
-
-def _load_traces_v2(
-    project: schemas.TracerSession,
-    client: langsmith.Client,
-    *,
-    is_root: Optional[bool],
-) -> list[schemas.Run]:
-    """List an experiment's runs from v2.
-
-    `query_v2` defaults `min_start_time` to ~24h, so bound the window to the session
-    explicitly or older experiments drop.
-    """
-    now = datetime.datetime.now(datetime.timezone.utc)
-    kwargs: dict[str, Any] = {
-        "project_ids": [str(project.id)],
-        "min_start_time": project.start_time,
-        "max_start_time": project.end_time or now,
-        "selects": _V2_RUN_SELECTS,
-    }
-    if is_root is not None:
-        kwargs["is_root"] = is_root
-    pager = client._get_langsmith_api_sync().runs.query_v2(**kwargs)
-    return [_v2_run_to_schema(r) for r in pager]
-
-
-def _v2_run_to_schema(run: Any) -> schemas.Run:
-    """Map a v2 `Run` to `ls_schemas.Run`.
-
-    `project_id`→`session_id`, `parent_run_ids[-1]`→`parent_run_id`; drop `None` so
-    schema defaults apply (e.g. `dotted_order`).
-    """
-    parent_run_ids = getattr(run, "parent_run_ids", None)
-    fields = {
-        "id": run.id,
-        "name": run.name,
-        "run_type": run.run_type,
-        "start_time": run.start_time,
-        "end_time": getattr(run, "end_time", None),
-        "trace_id": run.trace_id,
-        "session_id": getattr(run, "project_id", None),
-        "parent_run_id": parent_run_ids[-1] if parent_run_ids else None,
-        "dotted_order": getattr(run, "dotted_order", None),
-        "reference_example_id": getattr(run, "reference_example_id", None),
-        "inputs": getattr(run, "inputs", None) or {},
-        "outputs": getattr(run, "outputs", None),
-        "error": getattr(run, "error", None),
-        "status": getattr(run, "status", None),
-    }
-    return schemas.Run(**{k: v for k, v in fields.items() if v is not None})
 
 
 def _load_examples_map(

--- a/python/langsmith/evaluation/_runner.py
+++ b/python/langsmith/evaluation/_runner.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import collections
 import concurrent.futures as cf
 import datetime
@@ -1237,25 +1236,8 @@ def _load_traces_v2(
     }
     if is_root is not None:
         kwargs["is_root"] = is_root
-    return [_v2_run_to_schema(r) for r in _query_v2_runs_sync(client, **kwargs)]
-
-
-def _query_v2_runs_sync(client: langsmith.Client, **kwargs: Any) -> list[Any]:
-    """Run the async `client.runs.query_v2` to completion.
-
-    Callers have no running loop (sync `evaluate`, or an `aio_to_thread` worker), so
-    `asyncio.run` works; fall back to a thread if one is running.
-    """
-
-    async def _collect() -> list[Any]:
-        return [run async for run in await client.runs.query_v2(**kwargs)]
-
-    try:
-        asyncio.get_running_loop()
-    except RuntimeError:
-        return asyncio.run(_collect())
-    with cf.ThreadPoolExecutor(max_workers=1) as executor:
-        return executor.submit(lambda: asyncio.run(_collect())).result()
+    pager = client._get_langsmith_api_sync().runs.query_v2(**kwargs)
+    return [_v2_run_to_schema(r) for r in pager]
 
 
 def _v2_run_to_schema(run: Any) -> schemas.Run:

--- a/python/tests/unit_tests/evaluation/test_runner.py
+++ b/python/tests/unit_tests/evaluation/test_runner.py
@@ -28,7 +28,6 @@ from langsmith.evaluation._runner import (
     _collect_evaluator_keys,
     _get_target_args,
     _load_traces,
-    _query_v2_runs_sync,
     _v2_run_to_schema,
 )
 from langsmith.evaluation.evaluator import (
@@ -1739,26 +1738,21 @@ def _experiment_session() -> ls_schemas.TracerSession:
 
 
 def test_load_traces_uses_v2_when_sdb_query_enabled() -> None:
-    """sdb_query_enabled → /v2/runs/query (client.runs.query_v2), never v1 list_runs."""
+    """sdb_query_enabled → sync query_v2 (/v2/runs/query), never v1 list_runs."""
     project = _experiment_session()
     gen_runs = [_make_generated_run(), _make_generated_run()]
 
-    class _AsyncPage:
-        async def __aiter__(self):
-            for r in gen_runs:
-                yield r
-
-    async def _query_v2(**kwargs):
+    def _query_v2(**kwargs):
         # Verify the query is scoped to this experiment, root-only, with a window.
         assert kwargs["project_ids"] == [str(project.id)]
         assert kwargs["is_root"] is True
         assert kwargs["min_start_time"] == project.start_time
         assert "selects" in kwargs
-        return _AsyncPage()
+        return iter(gen_runs)  # sync paginator auto-iterates with a plain for-loop
 
     client = mock.Mock()
     client.info.instance_flags = {"sdb_query_enabled": True}
-    client.runs.query_v2 = _query_v2
+    client._get_langsmith_api_sync.return_value.runs.query_v2 = _query_v2
 
     runs = _load_traces(project, client, load_nested=False)
 
@@ -1777,23 +1771,5 @@ def test_load_traces_uses_v1_when_sdb_query_disabled() -> None:
     _load_traces(project, client, load_nested=False)
 
     client.list_runs.assert_called_once_with(project_id=project.id, is_root=True)
-    client.runs.query_v2.assert_not_called()
+    client._get_langsmith_api_sync.assert_not_called()
 
-
-def test_query_v2_runs_sync_collects_all_pages() -> None:
-    """The sync wrapper drives the async auto-paginator to completion."""
-    gen_runs = [_make_generated_run() for _ in range(3)]
-
-    class _AsyncPage:
-        async def __aiter__(self):
-            for r in gen_runs:
-                yield r
-
-    async def _query_v2(**kwargs):
-        return _AsyncPage()
-
-    client = mock.Mock()
-    client.runs.query_v2 = _query_v2
-
-    out = _query_v2_runs_sync(client, project_ids=["x"])
-    assert out == gen_runs

--- a/python/tests/unit_tests/evaluation/test_runner.py
+++ b/python/tests/unit_tests/evaluation/test_runner.py
@@ -28,7 +28,7 @@ from langsmith.evaluation._runner import (
     _build_comparative_url,
     _collect_evaluator_keys,
     _get_target_args,
-    _load_traces,
+    _load_traces_for_experiment,
 )
 from langsmith.evaluation.evaluator import (
     DynamicRunEvaluator,
@@ -1754,7 +1754,7 @@ def test_load_traces_uses_v2_when_sdb_query_enabled() -> None:
     client.info.instance_flags = {"sdb_query_enabled": True}
     client._get_langsmith_api_sync.return_value.runs.query_v2 = _query_v2
 
-    runs = _load_traces(project, client, load_nested=False)
+    runs = _load_traces_for_experiment(project, client, load_nested=False)
 
     assert len(runs) == 2
     assert all(isinstance(r, ls_schemas.Run) for r in runs)
@@ -1768,7 +1768,7 @@ def test_load_traces_uses_v1_when_sdb_query_disabled() -> None:
     client.info.instance_flags = {}  # sdb_query_enabled absent
     client.list_runs.return_value = iter([])
 
-    _load_traces(project, client, load_nested=False)
+    _load_traces_for_experiment(project, client, load_nested=False)
 
     client.list_runs.assert_called_once_with(project_id=project.id, is_root=True)
     client._get_langsmith_api_sync.assert_not_called()

--- a/python/tests/unit_tests/evaluation/test_runner.py
+++ b/python/tests/unit_tests/evaluation/test_runner.py
@@ -22,13 +22,13 @@ from langchain_core.runnables import chain as as_runnable
 
 from langsmith import Client, aevaluate, evaluate
 from langsmith import schemas as ls_schemas
+from langsmith._internal._v2_migration_utils import _v2_run_to_schema
 from langsmith.evaluation._runner import (
     ComparativeExperimentResults,
     _build_comparative_url,
     _collect_evaluator_keys,
     _get_target_args,
     _load_traces,
-    _v2_run_to_schema,
 )
 from langsmith.evaluation.evaluator import (
     DynamicRunEvaluator,
@@ -1772,4 +1772,3 @@ def test_load_traces_uses_v1_when_sdb_query_disabled() -> None:
 
     client.list_runs.assert_called_once_with(project_id=project.id, is_root=True)
     client._get_langsmith_api_sync.assert_not_called()
-

--- a/python/tests/unit_tests/evaluation/test_runner.py
+++ b/python/tests/unit_tests/evaluation/test_runner.py
@@ -12,6 +12,7 @@ import time
 import uuid
 from datetime import datetime, timezone
 from threading import Lock
+from types import SimpleNamespace
 from typing import Any, Callable, Dict, List, Tuple
 from unittest import mock
 from unittest.mock import MagicMock
@@ -26,6 +27,9 @@ from langsmith.evaluation._runner import (
     _build_comparative_url,
     _collect_evaluator_keys,
     _get_target_args,
+    _load_traces,
+    _query_v2_runs_sync,
+    _v2_run_to_schema,
 )
 from langsmith.evaluation.evaluator import (
     DynamicRunEvaluator,
@@ -1643,3 +1647,153 @@ def test_comparative_experiment_results_exposes_url_and_experiment() -> None:
     legacy = ComparativeExperimentResults(results={}, examples={})
     assert legacy.url is None
     assert legacy.comparative_experiment is None
+
+
+def test_v2_run_to_schema_maps_generated_fields() -> None:
+    """Generated v2 Run (project_id, parent_run_ids) → ls_schemas.Run."""
+    run_id = uuid.uuid4()
+    trace_id = uuid.uuid4()
+    project_id = uuid.uuid4()
+    parent_id = uuid.uuid4()
+    example_id = uuid.uuid4()
+    start = datetime.now(timezone.utc)
+    # SimpleNamespace, not Mock: `name` is a reserved Mock kwarg.
+    generated = SimpleNamespace(
+        id=str(run_id),
+        name="root",
+        run_type="chain",
+        start_time=start,
+        end_time=None,
+        trace_id=str(trace_id),
+        project_id=str(project_id),
+        parent_run_ids=[str(uuid.uuid4()), str(parent_id)],
+        dotted_order="20240101T000000000000Z" + str(run_id),
+        reference_example_id=str(example_id),
+        inputs={"a": 1},
+        outputs={"b": 2},
+        error=None,
+        status="SUCCESS",
+    )
+
+    run = _v2_run_to_schema(generated)
+
+    assert run.id == run_id
+    assert run.trace_id == trace_id
+    # project_id → session_id, last parent_run_ids entry → parent_run_id
+    assert run.session_id == project_id
+    assert run.parent_run_id == parent_id
+    assert run.reference_example_id == example_id
+    assert run.outputs == {"b": 2}
+
+
+def test_v2_run_to_schema_handles_root_run() -> None:
+    """A root run (no parents) maps to parent_run_id=None."""
+    generated = SimpleNamespace(
+        id=str(uuid.uuid4()),
+        name="root",
+        run_type="chain",
+        start_time=datetime.now(timezone.utc),
+        end_time=None,
+        trace_id=str(uuid.uuid4()),
+        project_id=str(uuid.uuid4()),
+        parent_run_ids=[],
+        dotted_order=None,
+        reference_example_id=None,
+        inputs=None,
+        outputs=None,
+        error=None,
+        status=None,
+    )
+    run = _v2_run_to_schema(generated)
+    assert run.parent_run_id is None
+    assert run.inputs == {}
+
+
+def _make_generated_run() -> SimpleNamespace:
+    return SimpleNamespace(
+        id=str(uuid.uuid4()),
+        name="root",
+        run_type="chain",
+        start_time=datetime.now(timezone.utc),
+        end_time=None,
+        trace_id=str(uuid.uuid4()),
+        project_id=str(uuid.uuid4()),
+        parent_run_ids=[],
+        dotted_order=None,
+        reference_example_id=str(uuid.uuid4()),
+        inputs={},
+        outputs={},
+        error=None,
+        status="SUCCESS",
+    )
+
+
+def _experiment_session() -> ls_schemas.TracerSession:
+    return ls_schemas.TracerSession(
+        id=uuid.uuid4(),
+        name="exp",
+        tenant_id=uuid.uuid4(),
+        reference_dataset_id=uuid.uuid4(),
+        start_time=datetime(2020, 1, 1, tzinfo=timezone.utc),
+    )
+
+
+def test_load_traces_uses_v2_when_sdb_query_enabled() -> None:
+    """sdb_query_enabled → /v2/runs/query (client.runs.query_v2), never v1 list_runs."""
+    project = _experiment_session()
+    gen_runs = [_make_generated_run(), _make_generated_run()]
+
+    class _AsyncPage:
+        async def __aiter__(self):
+            for r in gen_runs:
+                yield r
+
+    async def _query_v2(**kwargs):
+        # Verify the query is scoped to this experiment, root-only, with a window.
+        assert kwargs["project_ids"] == [str(project.id)]
+        assert kwargs["is_root"] is True
+        assert kwargs["min_start_time"] == project.start_time
+        assert "selects" in kwargs
+        return _AsyncPage()
+
+    client = mock.Mock()
+    client.info.instance_flags = {"sdb_query_enabled": True}
+    client.runs.query_v2 = _query_v2
+
+    runs = _load_traces(project, client, load_nested=False)
+
+    assert len(runs) == 2
+    assert all(isinstance(r, ls_schemas.Run) for r in runs)
+    client.list_runs.assert_not_called()
+
+
+def test_load_traces_uses_v1_when_sdb_query_disabled() -> None:
+    """Without the flag, keep the existing v1 client.list_runs path unchanged."""
+    project = _experiment_session()
+    client = mock.Mock()
+    client.info.instance_flags = {}  # sdb_query_enabled absent
+    client.list_runs.return_value = iter([])
+
+    _load_traces(project, client, load_nested=False)
+
+    client.list_runs.assert_called_once_with(project_id=project.id, is_root=True)
+    client.runs.query_v2.assert_not_called()
+
+
+def test_query_v2_runs_sync_collects_all_pages() -> None:
+    """The sync wrapper drives the async auto-paginator to completion."""
+    gen_runs = [_make_generated_run() for _ in range(3)]
+
+    class _AsyncPage:
+        async def __aiter__(self):
+            for r in gen_runs:
+                yield r
+
+    async def _query_v2(**kwargs):
+        return _AsyncPage()
+
+    client = mock.Mock()
+    client.runs.query_v2 = _query_v2
+
+    out = _query_v2_runs_sync(client, project_ids=["x"])
+    assert out == gen_runs


### PR DESCRIPTION
## Summary

`evaluate_existing`, `evaluate_comparative`, and `aevaluate_existing` load an experiment's existing runs through `client.list_runs` → `POST /runs/query`, which is ClickHouse-gated and returns **HTTP 501** on SmithDB-only deployments. This routes that run-loading to the SmithDB-backed v2 endpoint when the backend advertises support, so the evaluator runners work on all environments (including SmithDB-only) with no change on ClickHouse backends.

## Changes

- **Capability-gated v2 run-loading.** `_load_traces` now checks the `/info` flag `instance_flags["sdb_query_enabled"]`. When set, it lists runs via the generated `client.runs.query_v2` (`POST /v2/runs/query`); otherwise it keeps the existing v1 `client.list_runs` path unchanged.
- **Result mapping.** v2 runs are mapped back onto `schemas.Run` (`project_id` → `session_id`, `parent_run_ids[-1]` → `parent_run_id`), so downstream evaluator/feedback code is unaffected.
- **Explicit time window.** The v2 query is bounded to the experiment session's own start/end — `query_v2` (otherwise defaults to ~24h and would silently drop older experiments).
- **Sync client.** Uses a new synchronous generated-client accessor (`_get_langsmith_api_sync()`) added alongside the existing async one. `aevaluate_existing` keeps offloading `_load_traces` via `aio_to_thread`, so no event loop is spun up for run-loading.

## Compatibility

- No behavior change on non-SmithDB-enabled backends: the flag is absent/false → v1 `list_runs`.
- Scope limited to evaluator run-loading.

## Testing

- Unit tests covering v2/v1 branch selection and the v2 → `schemas.Run` mapping (root and nested runs).
- Verified end-to-end against a SmithDB-only backend: `evaluate_comparative` and `evaluate_existing` (sync) and `aevaluate_existing` (async) load runs and persist feedback, where they previously failed with 501. 

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)