### PR TITLE
fix(js): Ensure dataset version for an experiment is after all examples

### DIFF
--- a/js/src/tests/jestlike/experiment_metadata.test.ts
+++ b/js/src/tests/jestlike/experiment_metadata.test.ts
@@ -1,21 +1,18 @@
 import { jest } from "@jest/globals";
 
 import { Client } from "../../client.js";
-import {
-  evaluatorLogFeedbackPromises,
-  syncExamplePromises,
-} from "../../utils/jestlike/globals.js";
+import { evaluatorLogFeedbackPromises } from "../../utils/jestlike/globals.js";
 import { generateWrapperFromJestlikeMethods } from "../../utils/jestlike/index.js";
 
-const FUTURE_MODIFIED_AT = "2099-01-01T00:00:00.000Z";
+const FIRST_MODIFIED_AT = "2099-01-01T00:00:00.000Z";
+const SECOND_MODIFIED_AT = "2099-02-01T00:00:00.000Z";
 
-test("records the final example version on the experiment", async () => {
-  syncExamplePromises.clear();
+test("scopes the final example version to each experiment", async () => {
   evaluatorLogFeedbackPromises.clear();
 
-  let beforeAllHook: (() => Promise<void>) | undefined;
-  let afterAllHook: (() => Promise<void>) | undefined;
-  let testFunction: (() => Promise<void>) | undefined;
+  const beforeAllHooks: Array<() => Promise<void>> = [];
+  const afterAllHooks: Array<() => Promise<void>> = [];
+  const testFunctions: Array<() => Promise<void>> = [];
 
   const describe = Object.assign((_name: string, fn: () => void) => fn(), {
     only: (_name: string, fn: () => void) => fn(),
@@ -24,7 +21,7 @@ test("records the final example version on the experiment", async () => {
   });
   const testMethod = Object.assign(
     (_name: string, fn: () => Promise<void>) => {
-      testFunction = fn;
+      testFunctions.push(fn);
     },
     {
       only: jest.fn(),
@@ -42,22 +39,39 @@ test("records the final example version on the experiment", async () => {
   const client = {
     readDataset: resolved({
       id: "11111111-1111-4111-8111-111111111111",
-      name: "test-dataset",
+      name: "shared-dataset",
     }),
-    createProject: resolved({
-      id: "22222222-2222-4222-8222-222222222222",
-      name: "test-project",
-    }),
+    createProject: jest
+      .fn<() => Promise<{ id: string; name: string }>>()
+      .mockResolvedValueOnce({
+        id: "22222222-2222-4222-8222-222222222222",
+        name: "first-project",
+      })
+      .mockResolvedValueOnce({
+        id: "44444444-4444-4444-8444-444444444444",
+        name: "second-project",
+      }),
     getDatasetUrl: resolved("https://example.com/datasets/1"),
-    readExample: resolved({
-      id: "33333333-3333-4333-8333-333333333333",
-      dataset_id: "11111111-1111-4111-8111-111111111111",
-      inputs: { question: "test" },
-      outputs: { answer: "test" },
-      metadata: {},
-      created_at: FUTURE_MODIFIED_AT,
-      modified_at: FUTURE_MODIFIED_AT,
-    }),
+    readExample: jest
+      .fn<() => Promise<Record<string, unknown>>>()
+      .mockResolvedValueOnce({
+        id: "33333333-3333-4333-8333-333333333333",
+        dataset_id: "11111111-1111-4111-8111-111111111111",
+        inputs: { question: "first" },
+        outputs: { answer: "first" },
+        metadata: {},
+        created_at: FIRST_MODIFIED_AT,
+        modified_at: FIRST_MODIFIED_AT,
+      })
+      .mockResolvedValueOnce({
+        id: "55555555-5555-4555-8555-555555555555",
+        dataset_id: "11111111-1111-4111-8111-111111111111",
+        inputs: { question: "second" },
+        outputs: { answer: "second" },
+        metadata: {},
+        created_at: SECOND_MODIFIED_AT,
+        modified_at: SECOND_MODIFIED_AT,
+      }),
     createRun: resolved(undefined),
     updateRun: resolved(undefined),
     logEvaluationFeedback: resolved(undefined),
@@ -71,44 +85,52 @@ test("records the final example version on the experiment", async () => {
       expect,
       test: testMethod,
       describe,
-      beforeAll: (fn: () => Promise<void>) => {
-        beforeAllHook = fn;
-      },
-      afterAll: (fn: () => Promise<void>) => {
-        afterAllHook = fn;
-      },
+      beforeAll: (fn: () => Promise<void>) => beforeAllHooks.push(fn),
+      afterAll: (fn: () => Promise<void>) => afterAllHooks.push(fn),
     },
     "jest",
   );
 
-  ls.describe(
-    "test-dataset",
-    () => {
-      ls.test(
-        "test-case",
-        {
-          inputs: { question: "test" },
-          referenceOutputs: { answer: "test" },
-        },
-        () => ({ answer: "test" }),
-      );
-    },
-    { client, enableTestTracking: true },
-  );
+  const registerSuite = (question: string) => {
+    ls.describe(
+      "shared-dataset",
+      () => {
+        ls.test(
+          `${question}-test`,
+          {
+            inputs: { question },
+            referenceOutputs: { answer: question },
+          },
+          () => ({ answer: question }),
+        );
+      },
+      { client, enableTestTracking: true },
+    );
+  };
 
-  await beforeAllHook?.();
-  await testFunction?.();
-  await afterAllHook?.();
+  registerSuite("first");
+  registerSuite("second");
+
+  for (const hook of beforeAllHooks) await hook();
+  for (const fn of testFunctions) await fn();
+  for (const hook of afterAllHooks) await hook();
 
   expect(updateProject).toHaveBeenCalledWith(
     "22222222-2222-4222-8222-222222222222",
     expect.objectContaining({
       metadata: expect.objectContaining({
-        dataset_version: FUTURE_MODIFIED_AT,
+        dataset_version: FIRST_MODIFIED_AT,
+      }),
+    }),
+  );
+  expect(updateProject).toHaveBeenCalledWith(
+    "44444444-4444-4444-8444-444444444444",
+    expect.objectContaining({
+      metadata: expect.objectContaining({
+        dataset_version: SECOND_MODIFIED_AT,
       }),
     }),
   );
 
-  syncExamplePromises.clear();
   evaluatorLogFeedbackPromises.clear();
 });

--- a/js/src/tests/jestlike/experiment_metadata.test.ts
+++ b/js/src/tests/jestlike/experiment_metadata.test.ts
@@ -1,0 +1,114 @@
+import { jest } from "@jest/globals";
+
+import { Client } from "../../client.js";
+import {
+  evaluatorLogFeedbackPromises,
+  syncExamplePromises,
+} from "../../utils/jestlike/globals.js";
+import { generateWrapperFromJestlikeMethods } from "../../utils/jestlike/index.js";
+
+const FUTURE_MODIFIED_AT = "2099-01-01T00:00:00.000Z";
+
+test("records the final example version on the experiment", async () => {
+  syncExamplePromises.clear();
+  evaluatorLogFeedbackPromises.clear();
+
+  let beforeAllHook: (() => Promise<void>) | undefined;
+  let afterAllHook: (() => Promise<void>) | undefined;
+  let testFunction: (() => Promise<void>) | undefined;
+
+  const describe = Object.assign((_name: string, fn: () => void) => fn(), {
+    only: (_name: string, fn: () => void) => fn(),
+    skip: jest.fn(),
+    concurrent: (_name: string, fn: () => void) => fn(),
+  });
+  const testMethod = Object.assign(
+    (_name: string, fn: () => Promise<void>) => {
+      testFunction = fn;
+    },
+    {
+      only: jest.fn(),
+      skip: jest.fn(),
+      concurrent: jest.fn(),
+      each: jest.fn(),
+    },
+  );
+
+  const resolved = <T>(value: T) =>
+    jest.fn<() => Promise<T>>().mockResolvedValue(value);
+  const updateProject = jest
+    .fn<(_projectId: string, _options: unknown) => Promise<void>>()
+    .mockResolvedValue(undefined);
+  const client = {
+    readDataset: resolved({
+      id: "11111111-1111-4111-8111-111111111111",
+      name: "test-dataset",
+    }),
+    createProject: resolved({
+      id: "22222222-2222-4222-8222-222222222222",
+      name: "test-project",
+    }),
+    getDatasetUrl: resolved("https://example.com/datasets/1"),
+    readExample: resolved({
+      id: "33333333-3333-4333-8333-333333333333",
+      dataset_id: "11111111-1111-4111-8111-111111111111",
+      inputs: { question: "test" },
+      outputs: { answer: "test" },
+      metadata: {},
+      created_at: FUTURE_MODIFIED_AT,
+      modified_at: FUTURE_MODIFIED_AT,
+    }),
+    createRun: resolved(undefined),
+    updateRun: resolved(undefined),
+    logEvaluationFeedback: resolved(undefined),
+    awaitPendingTraceBatches: resolved(undefined),
+    updateProject,
+    updateDatasetTag: resolved(undefined),
+  } as unknown as Client;
+
+  const ls = generateWrapperFromJestlikeMethods(
+    {
+      expect,
+      test: testMethod,
+      describe,
+      beforeAll: (fn: () => Promise<void>) => {
+        beforeAllHook = fn;
+      },
+      afterAll: (fn: () => Promise<void>) => {
+        afterAllHook = fn;
+      },
+    },
+    "jest",
+  );
+
+  ls.describe(
+    "test-dataset",
+    () => {
+      ls.test(
+        "test-case",
+        {
+          inputs: { question: "test" },
+          referenceOutputs: { answer: "test" },
+        },
+        () => ({ answer: "test" }),
+      );
+    },
+    { client, enableTestTracking: true },
+  );
+
+  await beforeAllHook?.();
+  await testFunction?.();
+  await afterAllHook?.();
+
+  expect(updateProject).toHaveBeenCalledWith(
+    "22222222-2222-4222-8222-222222222222",
+    expect.objectContaining({
+      metadata: expect.objectContaining({
+        dataset_version: FUTURE_MODIFIED_AT,
+      }),
+    }),
+  );
+
+  syncExamplePromises.clear();
+  evaluatorLogFeedbackPromises.clear();
+});

--- a/js/src/utils/jestlike/globals.ts
+++ b/js/src/utils/jestlike/globals.ts
@@ -22,6 +22,7 @@ export type TestWrapperAsyncLocalStorageData = {
   suiteName: string;
   testRootRunTree?: RunTree;
   setupPromise?: Promise<void>;
+  syncExamplePromises?: Map<string, Promise<Example>>;
 };
 
 export const testWrapperAsyncLocalStorageInstance =
@@ -38,7 +39,6 @@ export function trackingEnabled(context: TestWrapperAsyncLocalStorageData) {
 }
 
 export const evaluatorLogFeedbackPromises = new Set();
-export const syncExamplePromises = new Map();
 
 export function _logTestFeedback(params: {
   exampleId?: string;
@@ -67,7 +67,7 @@ export function _logTestFeedback(params: {
             "Could not log feedback to LangSmith: missing project information. Please contact us for help.",
           );
         }
-        await syncExamplePromises.get(exampleId);
+        await context.syncExamplePromises?.get(exampleId);
         await client?.logEvaluationFeedback({
           evaluatorResponse: feedback,
           run: runTree,

--- a/js/src/utils/jestlike/index.ts
+++ b/js/src/utils/jestlike/index.ts
@@ -434,6 +434,7 @@ export function generateWrapperFromJestlikeMethods(
             await client.updateProject(datasetInfo.project.id, {
               metadata: {
                 ...suiteMetadata,
+                dataset_version: finalModifiedAt,
                 commit,
                 branch,
                 dirty,

--- a/js/src/utils/jestlike/index.ts
+++ b/js/src/utils/jestlike/index.ts
@@ -23,7 +23,6 @@ import {
   TestWrapperAsyncLocalStorageData,
   testWrapperAsyncLocalStorageInstance,
   _logTestFeedback,
-  syncExamplePromises,
   trackingEnabled,
   DEFAULT_TEST_CLIENT,
 } from "./globals.js";
@@ -365,6 +364,7 @@ export function generateWrapperFromJestlikeMethods(
           },
           enableTestTracking: experimentConfig?.enableTestTracking,
           setupPromise,
+          syncExamplePromises: new Map(),
         };
 
         beforeAll(async () => {
@@ -374,15 +374,16 @@ export function generateWrapperFromJestlikeMethods(
         });
 
         afterAll(async () => {
+          const examples = await Promise.all(
+            context.syncExamplePromises.values(),
+          );
           await Promise.all([
             client.awaitPendingTraceBatches(),
-            ...syncExamplePromises.values(),
             ...evaluatorLogFeedbackPromises.values(),
           ]);
           if (!trackingEnabled(context)) {
             return;
           }
-          const examples = [...syncExamplePromises.values()];
           if (examples.length === 0) {
             return;
           }
@@ -673,21 +674,25 @@ export function generateWrapperFromJestlikeMethods(
                 // Currently run end time has to be after example modified time
                 // for examples to render properly, so we must modify the example
                 // first before running the test.
-                if (syncExamplePromises.get(exampleId) === undefined) {
-                  syncExamplePromises.set(
-                    exampleId,
-                    await syncExample({
-                      client,
-                      exampleId,
-                      datasetId: dataset.id,
-                      inputs,
-                      outputs: referenceOutputs ?? {},
-                      metadata,
-                      split,
-                      createdAt,
-                    }),
+                if (context.syncExamplePromises === undefined) {
+                  throw new Error(
+                    "Could not identify suite example state. Please contact us for help.",
                   );
                 }
+                if (!context.syncExamplePromises.has(exampleId)) {
+                  const syncPromise = syncExample({
+                    client,
+                    exampleId,
+                    datasetId: dataset.id,
+                    inputs,
+                    outputs: referenceOutputs ?? {},
+                    metadata,
+                    split,
+                    createdAt,
+                  });
+                  context.syncExamplePromises.set(exampleId, syncPromise);
+                }
+                await context.syncExamplePromises.get(exampleId);
 
                 const traceableOptions = {
                   reference_example_id: exampleId,

--- a/js/src/utils/jestlike/index.ts
+++ b/js/src/utils/jestlike/index.ts
@@ -676,7 +676,7 @@ export function generateWrapperFromJestlikeMethods(
                 // first before running the test.
                 if (context.syncExamplePromises === undefined) {
                   throw new Error(
-                    "Could not identify suite example state. Please contact us for help.",
+                    "Internal error: syncExamplePromises not initialized. This is a bug in the LangSmith SDK — please open an issue at https://github.com/langchain-ai/langsmith-sdk/issues.",
                   );
                 }
                 if (!context.syncExamplePromises.has(exampleId)) {


### PR DESCRIPTION
On the first execution of a test case, `/v2/datasets/{dataset_id}/experiment-runs` could return no results even though `/v2/traces/query` returned the corresponding root run.

The SmithDB experiment-runs endpoint reconstructs dataset examples as of the experiment’s `dataset_version`. When that metadata is absent, it falls back to the experiment start time. Because Jest/Vitest creates new examples after starting the experiment, those examples fall outside that snapshot, causing their runs to be omitted.

Subsequent executions generally work because the deterministic example already exists before the new experiment starts.

## Fix

Include the final example modification time as `dataset_version` when updating Jest/Vitest experiment metadata:

```ts
dataset_version: finalModifiedAt
```

This ensures the experiment-runs endpoint uses a dataset snapshot that includes examples created during the test run.