### PR TITLE
fix(sandbox): retry exec on graceful close before 'started'

### DIFF
--- a/js/src/sandbox/command_handle.ts
+++ b/js/src/sandbox/command_handle.ts
@@ -55,7 +55,6 @@ export class CommandHandle {
   private _lastStdoutOffset: number;
   private _lastStderrOffset: number;
   private _started: boolean;
-  private _sentCommandId?: string;
   private _onStdout?: (data: string) => void;
   private _onStderr?: (data: string) => void;
 
@@ -66,7 +65,6 @@ export class CommandHandle {
     sandbox: Sandbox,
     options?: {
       commandId?: string;
-      sentCommandId?: string;
       stdoutOffset?: number;
       stderrOffset?: number;
       onStdout?: (data: string) => void;
@@ -76,7 +74,6 @@ export class CommandHandle {
     this._stream = messageStream;
     this._control = control;
     this._sandbox = sandbox;
-    this._sentCommandId = options?.sentCommandId;
     this._lastStdoutOffset = options?.stdoutOffset ?? 0;
     this._lastStderrOffset = options?.stderrOffset ?? 0;
     this._onStdout = options?.onStdout;
@@ -117,10 +114,6 @@ export class CommandHandle {
     this._commandId = (firstMsg.command_id as string) ?? null;
     this._pid = (firstMsg.pid as number) ?? null;
     this._started = true;
-    if (this._sentCommandId) {
-      this._sandbox._clientCommandIdHonored =
-        this._commandId === this._sentCommandId;
-    }
   }
 
   /** The server-assigned command ID. Available after _ensureStarted(). */

--- a/js/src/sandbox/command_handle.ts
+++ b/js/src/sandbox/command_handle.ts
@@ -11,6 +11,7 @@ import type { Sandbox } from "./sandbox.js";
 import {
   LangSmithSandboxConnectionError,
   LangSmithSandboxOperationError,
+  LangSmithStreamEndedBeforeStartedError,
 } from "./errors.js";
 
 /**
@@ -54,6 +55,7 @@ export class CommandHandle {
   private _lastStdoutOffset: number;
   private _lastStderrOffset: number;
   private _started: boolean;
+  private _sentCommandId?: string;
   private _onStdout?: (data: string) => void;
   private _onStderr?: (data: string) => void;
 
@@ -64,6 +66,7 @@ export class CommandHandle {
     sandbox: Sandbox,
     options?: {
       commandId?: string;
+      sentCommandId?: string;
       stdoutOffset?: number;
       stderrOffset?: number;
       onStdout?: (data: string) => void;
@@ -73,6 +76,7 @@ export class CommandHandle {
     this._stream = messageStream;
     this._control = control;
     this._sandbox = sandbox;
+    this._sentCommandId = options?.sentCommandId;
     this._lastStdoutOffset = options?.stdoutOffset ?? 0;
     this._lastStderrOffset = options?.stderrOffset ?? 0;
     this._onStdout = options?.onStdout;
@@ -99,9 +103,8 @@ export class CommandHandle {
 
     const firstResult = await this._stream.next();
     if (firstResult.done) {
-      throw new LangSmithSandboxOperationError(
+      throw new LangSmithStreamEndedBeforeStartedError(
         "Command stream ended before 'started' message",
-        "command",
       );
     }
     const firstMsg = firstResult.value;
@@ -114,6 +117,10 @@ export class CommandHandle {
     this._commandId = (firstMsg.command_id as string) ?? null;
     this._pid = (firstMsg.pid as number) ?? null;
     this._started = true;
+    if (this._sentCommandId) {
+      this._sandbox._clientCommandIdHonored =
+        this._commandId === this._sentCommandId;
+    }
   }
 
   /** The server-assigned command ID. Available after _ensureStarted(). */

--- a/js/src/sandbox/errors.ts
+++ b/js/src/sandbox/errors.ts
@@ -301,6 +301,21 @@ export class LangSmithCommandTimeoutError extends LangSmithSandboxOperationError
 }
 
 /**
+ * Internal: a command WebSocket closed before the guest sent its 'started'
+ * frame (the proxied tunnel was torn down gracefully mid-handshake).
+ *
+ * Marks the idempotently-retryable early close, as distinct from a
+ * command-level failure. Subclasses the operation error so callers that catch
+ * the public type are unaffected.
+ */
+export class LangSmithStreamEndedBeforeStartedError extends LangSmithSandboxOperationError {
+  constructor(message: string) {
+    super(message, "command");
+    this.name = "LangSmithStreamEndedBeforeStartedError";
+  }
+}
+
+/**
  * Raised when the sandbox server is reloading (close code 1001).
  *
  * Subclass of connection error that signals immediate reconnect (no backoff).

--- a/js/src/sandbox/sandbox.ts
+++ b/js/src/sandbox/sandbox.ts
@@ -82,14 +82,6 @@ export class Sandbox {
 
   private _client: SandboxClient;
 
-  /**
-   * Learned once per sandbox: true after a "started" frame echoes back the
-   * client-supplied commandId, proving the daemon honors it (get-or-create).
-   * Only then is an early-close retry idempotency-safe. undefined = unknown.
-   * @internal
-   */
-  _clientCommandIdHonored?: boolean;
-
   /** @internal */
   constructor(data: SandboxData, client: SandboxClient) {
     this.name = data.name;
@@ -260,11 +252,11 @@ export class Sandbox {
 
     const clientHeaders = this._client.getDefaultHeaders();
 
-    // Client-supplied command_id makes execute idempotent (server does
-    // get-or-create keyed on it), so a tunnel that closes before "started"
-    // can be safely re-issued: the daemon reattaches to the existing command
-    // rather than spawning a second one.
-    const sentCommandId = commandId ?? uuidv4();
+    // A client-supplied command_id makes execute idempotent: the daemon does
+    // get-or-create keyed on it, so if the tunnel closes before "started" we
+    // can re-issue the same id and reattach to the existing command instead of
+    // spawning a second one.
+    const execCommandId = commandId ?? uuidv4();
 
     let attempt = 0;
     // eslint-disable-next-line no-constant-condition
@@ -278,7 +270,7 @@ export class Sandbox {
           env,
           cwd,
           shell,
-          commandId: sentCommandId,
+          commandId: execCommandId,
           idleTimeout,
           killOnDisconnect,
           ttlSeconds,
@@ -290,7 +282,6 @@ export class Sandbox {
       );
 
       const handle = new CommandHandle(stream, control, this, {
-        sentCommandId,
         onStdout,
         onStderr,
       });
@@ -298,13 +289,8 @@ export class Sandbox {
         await handle._ensureStarted();
         return handle;
       } catch (e) {
-        // Only retry when the daemon has proven it honors our command_id;
-        // otherwise a re-issue could double-run the command. Unknown/
-        // unsupported → surface the original error.
-        if (
-          !(e instanceof LangSmithStreamEndedBeforeStartedError) ||
-          this._clientCommandIdHonored !== true
-        ) {
+        // Idempotent re-issue (same command_id) after an early close.
+        if (!(e instanceof LangSmithStreamEndedBeforeStartedError)) {
           throw e;
         }
         attempt++;

--- a/js/src/sandbox/sandbox.ts
+++ b/js/src/sandbox/sandbox.ts
@@ -11,7 +11,7 @@ import type {
   Snapshot,
   StartSandboxOptions,
 } from "./types.js";
-import { v4 as uuidv4 } from "../utils/uuid/src/index.js";
+import { uuid7 } from "../uuid.js";
 import {
   LangSmithDataplaneNotConfiguredError,
   LangSmithStreamEndedBeforeStartedError,
@@ -256,7 +256,7 @@ export class Sandbox {
     // get-or-create keyed on it, so if the tunnel closes before "started" we
     // can re-issue the same id and reattach to the existing command instead of
     // spawning a second one.
-    const execCommandId = commandId ?? uuidv4();
+    const execCommandId = commandId ?? uuid7();
 
     let attempt = 0;
     // eslint-disable-next-line no-constant-condition

--- a/js/src/sandbox/sandbox.ts
+++ b/js/src/sandbox/sandbox.ts
@@ -11,7 +11,11 @@ import type {
   Snapshot,
   StartSandboxOptions,
 } from "./types.js";
-import { LangSmithDataplaneNotConfiguredError } from "./errors.js";
+import { v4 as uuidv4 } from "../utils/uuid/src/index.js";
+import {
+  LangSmithDataplaneNotConfiguredError,
+  LangSmithStreamEndedBeforeStartedError,
+} from "./errors.js";
 import { handleSandboxHttpError } from "./helpers.js";
 import { CommandHandle } from "./command_handle.js";
 import { reconnectWsStream, runWsStream } from "./ws_execute.js";
@@ -77,6 +81,14 @@ export class Sandbox {
   readonly fs_capacity_bytes?: number;
 
   private _client: SandboxClient;
+
+  /**
+   * Learned once per sandbox: true after a "started" frame echoes back the
+   * client-supplied commandId, proving the daemon honors it (get-or-create).
+   * Only then is an early-close retry idempotency-safe. undefined = unknown.
+   * @internal
+   */
+  _clientCommandIdHonored?: boolean;
 
   /** @internal */
   constructor(data: SandboxData, client: SandboxClient) {
@@ -247,32 +259,65 @@ export class Sandbox {
     const dataplaneUrl = this.requireDataplaneUrl();
 
     const clientHeaders = this._client.getDefaultHeaders();
-    const [stream, control] = await runWsStream(
-      dataplaneUrl,
-      this._client.getApiKey(),
-      command,
-      {
-        timeout,
-        env,
-        cwd,
-        shell,
-        commandId,
-        idleTimeout,
-        killOnDisconnect,
-        ttlSeconds,
-        pty,
-        ...(Object.keys(clientHeaders).length > 0
-          ? { headers: clientHeaders }
-          : {}),
-      },
-    );
 
-    const handle = new CommandHandle(stream, control, this, {
-      onStdout,
-      onStderr,
-    });
-    await handle._ensureStarted();
-    return handle;
+    // Client-supplied command_id makes execute idempotent (server does
+    // get-or-create keyed on it), so a tunnel that closes before "started"
+    // can be safely re-issued: the daemon reattaches to the existing command
+    // rather than spawning a second one.
+    const sentCommandId = commandId ?? uuidv4();
+
+    let attempt = 0;
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      const [stream, control] = await runWsStream(
+        dataplaneUrl,
+        this._client.getApiKey(),
+        command,
+        {
+          timeout,
+          env,
+          cwd,
+          shell,
+          commandId: sentCommandId,
+          idleTimeout,
+          killOnDisconnect,
+          ttlSeconds,
+          pty,
+          ...(Object.keys(clientHeaders).length > 0
+            ? { headers: clientHeaders }
+            : {}),
+        },
+      );
+
+      const handle = new CommandHandle(stream, control, this, {
+        sentCommandId,
+        onStdout,
+        onStderr,
+      });
+      try {
+        await handle._ensureStarted();
+        return handle;
+      } catch (e) {
+        // Only retry when the daemon has proven it honors our command_id;
+        // otherwise a re-issue could double-run the command. Unknown/
+        // unsupported → surface the original error.
+        if (
+          !(e instanceof LangSmithStreamEndedBeforeStartedError) ||
+          this._clientCommandIdHonored !== true
+        ) {
+          throw e;
+        }
+        attempt++;
+        if (attempt > CommandHandle.MAX_AUTO_RECONNECTS) {
+          throw e;
+        }
+        const delay = Math.min(
+          CommandHandle.BACKOFF_BASE * 2 ** (attempt - 1),
+          CommandHandle.BACKOFF_MAX,
+        );
+        await new Promise((r) => setTimeout(r, delay * 1000));
+      }
+    }
   }
 
   /**

--- a/js/src/tests/sandbox.test.ts
+++ b/js/src/tests/sandbox.test.ts
@@ -35,6 +35,7 @@ import {
   LangSmithSandboxOperationError,
   LangSmithCommandTimeoutError,
   LangSmithSandboxServerReloadError,
+  LangSmithStreamEndedBeforeStartedError,
 } from "../sandbox/errors.js";
 import type {
   WsMessage,
@@ -1600,6 +1601,42 @@ describe("CommandHandle", () => {
       });
       // Should already be started
       expect(handle.commandId).toBe("cmd-123");
+    });
+
+    it("marks the daemon as honoring the client command_id when echoed", async () => {
+      const stream = createMockStream([
+        { type: "started", command_id: "cid-1", pid: 42 },
+        { type: "exit", exit_code: 0 },
+      ]);
+      const sandbox = createMockSandbox();
+      const handle = new CommandHandle(stream, null, sandbox, {
+        sentCommandId: "cid-1",
+      });
+      await handle._ensureStarted();
+      expect(sandbox._clientCommandIdHonored).toBe(true);
+    });
+
+    it("marks the daemon as not honoring the id on a mismatched echo", async () => {
+      const stream = createMockStream([
+        { type: "started", command_id: "server-assigned", pid: 42 },
+        { type: "exit", exit_code: 0 },
+      ]);
+      const sandbox = createMockSandbox();
+      const handle = new CommandHandle(stream, null, sandbox, {
+        sentCommandId: "cid-1",
+      });
+      await handle._ensureStarted();
+      expect(sandbox._clientCommandIdHonored).toBe(false);
+    });
+
+    it("throws the early-close marker when the stream ends before started", async () => {
+      const stream = createMockStream([]);
+      const handle = new CommandHandle(stream, null, createMockSandbox(), {
+        sentCommandId: "cid-1",
+      });
+      await expect(handle._ensureStarted()).rejects.toThrow(
+        LangSmithStreamEndedBeforeStartedError,
+      );
     });
   });
 

--- a/js/src/tests/sandbox.test.ts
+++ b/js/src/tests/sandbox.test.ts
@@ -1603,37 +1603,9 @@ describe("CommandHandle", () => {
       expect(handle.commandId).toBe("cmd-123");
     });
 
-    it("marks the daemon as honoring the client command_id when echoed", async () => {
-      const stream = createMockStream([
-        { type: "started", command_id: "cid-1", pid: 42 },
-        { type: "exit", exit_code: 0 },
-      ]);
-      const sandbox = createMockSandbox();
-      const handle = new CommandHandle(stream, null, sandbox, {
-        sentCommandId: "cid-1",
-      });
-      await handle._ensureStarted();
-      expect(sandbox._clientCommandIdHonored).toBe(true);
-    });
-
-    it("marks the daemon as not honoring the id on a mismatched echo", async () => {
-      const stream = createMockStream([
-        { type: "started", command_id: "server-assigned", pid: 42 },
-        { type: "exit", exit_code: 0 },
-      ]);
-      const sandbox = createMockSandbox();
-      const handle = new CommandHandle(stream, null, sandbox, {
-        sentCommandId: "cid-1",
-      });
-      await handle._ensureStarted();
-      expect(sandbox._clientCommandIdHonored).toBe(false);
-    });
-
     it("throws the early-close marker when the stream ends before started", async () => {
       const stream = createMockStream([]);
-      const handle = new CommandHandle(stream, null, createMockSandbox(), {
-        sentCommandId: "cid-1",
-      });
+      const handle = new CommandHandle(stream, null, createMockSandbox());
       await expect(handle._ensureStarted()).rejects.toThrow(
         LangSmithStreamEndedBeforeStartedError,
       );

--- a/js/src/tests/sandbox_command_id_retry.test.ts
+++ b/js/src/tests/sandbox_command_id_retry.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Idempotent retry when a command WebSocket closes before 'started'.
+ *
+ * run() sends a client-generated command_id and the server does get-or-create
+ * keyed on it, so re-issuing a command whose tunnel closed before 'started'
+ * reattaches to the same session instead of spawning a second one -- but only
+ * once the daemon has proven it honors the id (echoed it back in a 'started').
+ */
+import { jest, describe, it, expect, beforeEach } from "@jest/globals";
+import type { WsMessage } from "../sandbox/types.js";
+
+const runWsStream = jest.fn<any>();
+const reconnectWsStream = jest.fn<any>();
+
+jest.unstable_mockModule("../sandbox/ws_execute.js", () => ({
+  runWsStream,
+  reconnectWsStream,
+  WSStreamControl: class {},
+}));
+
+const { Sandbox } = await import("../sandbox/sandbox.js");
+
+function makeStream(messages: WsMessage[]): AsyncIterableIterator<WsMessage> {
+  let i = 0;
+  return {
+    next: async () =>
+      i < messages.length
+        ? { value: messages[i++], done: false }
+        : { value: undefined as never, done: true },
+    [Symbol.asyncIterator]() {
+      return this;
+    },
+  };
+}
+
+function makeSandbox() {
+  const client = {
+    getApiKey: () => "test-key",
+    getDefaultHeaders: () => ({}),
+  };
+  return new Sandbox(
+    {
+      name: "sb",
+      dataplane_url: "https://dp.example.com/sb-123",
+      status: "ready",
+    } as never,
+    client as never,
+  );
+}
+
+describe("run() early-close retry", () => {
+  beforeEach(() => {
+    runWsStream.mockReset();
+  });
+
+  it("retries with the same command_id once the daemon is known to honor it", async () => {
+    const sandbox = makeSandbox();
+    sandbox._clientCommandIdHonored = true; // proven by a prior command
+
+    runWsStream
+      .mockImplementationOnce((..._args: unknown[]) => [makeStream([]), null])
+      .mockImplementationOnce((...args: unknown[]) => {
+        const opts = args[3] as { commandId: string };
+        return [
+          makeStream([
+            { type: "started", command_id: opts.commandId, pid: 1 },
+            { type: "exit", exit_code: 0 },
+          ]),
+          null,
+        ];
+      });
+
+    const result = await sandbox.run("echo hi");
+
+    expect(result.exit_code).toBe(0);
+    expect(runWsStream).toHaveBeenCalledTimes(2);
+    const first = runWsStream.mock.calls[0][3] as { commandId: string };
+    const second = runWsStream.mock.calls[1][3] as { commandId: string };
+    expect(first.commandId).toBe(second.commandId);
+  });
+
+  it("does not retry when the capability is unknown", async () => {
+    const sandbox = makeSandbox(); // _clientCommandIdHonored undefined
+    runWsStream.mockImplementation((..._args: unknown[]) => [
+      makeStream([]),
+      null,
+    ]);
+
+    await expect(sandbox.run("echo hi", { wait: false })).rejects.toThrow(
+      "Command stream ended before 'started'",
+    );
+    expect(runWsStream).toHaveBeenCalledTimes(1);
+  });
+});

--- a/js/src/tests/sandbox_command_id_retry.test.ts
+++ b/js/src/tests/sandbox_command_id_retry.test.ts
@@ -3,8 +3,7 @@
  *
  * run() sends a client-generated command_id and the server does get-or-create
  * keyed on it, so re-issuing a command whose tunnel closed before 'started'
- * reattaches to the same session instead of spawning a second one -- but only
- * once the daemon has proven it honors the id (echoed it back in a 'started').
+ * reattaches to the same session instead of spawning a second one.
  */
 import { jest, describe, it, expect, beforeEach } from "@jest/globals";
 import type { WsMessage } from "../sandbox/types.js";
@@ -53,9 +52,8 @@ describe("run() early-close retry", () => {
     runWsStream.mockReset();
   });
 
-  it("retries with the same command_id once the daemon is known to honor it", async () => {
+  it("retries with the same command_id after a close before 'started'", async () => {
     const sandbox = makeSandbox();
-    sandbox._clientCommandIdHonored = true; // proven by a prior command
 
     runWsStream
       .mockImplementationOnce((..._args: unknown[]) => [makeStream([]), null])
@@ -79,15 +77,15 @@ describe("run() early-close retry", () => {
     expect(first.commandId).toBe(second.commandId);
   });
 
-  it("does not retry when the capability is unknown", async () => {
-    const sandbox = makeSandbox(); // _clientCommandIdHonored undefined
+  it("does not retry a non-early-close error (e.g. wrong first frame)", async () => {
+    const sandbox = makeSandbox();
     runWsStream.mockImplementation((..._args: unknown[]) => [
-      makeStream([]),
+      makeStream([{ type: "stdout", data: "oops", offset: 0 }]),
       null,
     ]);
 
     await expect(sandbox.run("echo hi", { wait: false })).rejects.toThrow(
-      "Command stream ended before 'started'",
+      "Expected 'started'",
     );
     expect(runWsStream).toHaveBeenCalledTimes(1);
   });

--- a/python/langsmith/sandbox/_async_sandbox.py
+++ b/python/langsmith/sandbox/_async_sandbox.py
@@ -383,9 +383,9 @@ class AsyncSandbox:
     ) -> Union[ExecutionResult, AsyncCommandHandle]:
         """Execute via WebSocket /execute/ws."""
         import asyncio
-        import uuid
 
         from langsmith.sandbox._ws_execute import run_ws_stream_async
+        from langsmith.uuid import uuid7
 
         dataplane_url = self._require_dataplane_url()
         api_key = self._client._api_key
@@ -394,7 +394,7 @@ class AsyncSandbox:
         # get-or-create keyed on it, so if the tunnel closes before "started" we
         # can re-issue the same id and reattach to the existing command instead
         # of spawning a second one.
-        command_id = uuid.uuid4().hex
+        command_id = uuid7().hex
 
         ws_kwargs: dict[str, Any] = {
             "command_id": command_id,

--- a/python/langsmith/sandbox/_async_sandbox.py
+++ b/python/langsmith/sandbox/_async_sandbox.py
@@ -96,10 +96,6 @@ class AsyncSandbox:
     # Internal fields (not from API)
     _client: AsyncSandboxClient = field(repr=False, default=None)  # type: ignore
     _auto_delete: bool = field(repr=False, default=True)
-    # Learned once per sandbox: True after a "started" frame echoes back the
-    # client-supplied command_id, proving the daemon honors it (get-or-create).
-    # Only then is an early-close retry idempotency-safe. None = unknown.
-    _client_command_id_honored: Optional[bool] = field(repr=False, default=None)
 
     @classmethod
     def from_dict(
@@ -394,10 +390,10 @@ class AsyncSandbox:
         dataplane_url = self._require_dataplane_url()
         api_key = self._client._api_key
 
-        # Client-supplied command_id makes execute idempotent (server does
-        # get-or-create keyed on it), so a tunnel that closes before "started"
-        # can be safely re-issued: the daemon reattaches to the existing command
-        # rather than spawning a second one.
+        # A client-supplied command_id makes execute idempotent: the daemon does
+        # get-or-create keyed on it, so if the tunnel closes before "started" we
+        # can re-issue the same id and reattach to the existing command instead
+        # of spawning a second one.
         command_id = uuid.uuid4().hex
 
         ws_kwargs: dict[str, Any] = {
@@ -427,7 +423,6 @@ class AsyncSandbox:
                 msg_stream,
                 control,
                 self,
-                sent_command_id=command_id,
                 on_stdout=on_stdout,
                 on_stderr=on_stderr,
             )
@@ -435,11 +430,7 @@ class AsyncSandbox:
                 await handle._ensure_started()
                 break
             except _StreamEndedBeforeStarted:
-                # Only retry when the daemon has proven it honors our
-                # command_id; otherwise a re-issue could double-run the
-                # command. Unknown/unsupported → surface the original error.
-                if self._client_command_id_honored is not True:
-                    raise
+                # Idempotent re-issue (same command_id) after an early close.
                 attempt += 1
                 if attempt > AsyncCommandHandle.MAX_AUTO_RECONNECTS:
                     raise

--- a/python/langsmith/sandbox/_async_sandbox.py
+++ b/python/langsmith/sandbox/_async_sandbox.py
@@ -20,6 +20,7 @@ from langsmith.sandbox._models import (
     AsyncServiceURL,
     ExecutionResult,
     Snapshot,
+    _StreamEndedBeforeStarted,
 )
 from langsmith.sandbox._tunnel import AsyncTunnel
 
@@ -95,6 +96,10 @@ class AsyncSandbox:
     # Internal fields (not from API)
     _client: AsyncSandboxClient = field(repr=False, default=None)  # type: ignore
     _auto_delete: bool = field(repr=False, default=True)
+    # Learned once per sandbox: True after a "started" frame echoes back the
+    # client-supplied command_id, proving the daemon honors it (get-or-create).
+    # Only then is an early-close retry idempotency-safe. None = unknown.
+    _client_command_id_honored: Optional[bool] = field(repr=False, default=None)
 
     @classmethod
     def from_dict(
@@ -381,12 +386,22 @@ class AsyncSandbox:
         headers: RequestHeaders = None,
     ) -> Union[ExecutionResult, AsyncCommandHandle]:
         """Execute via WebSocket /execute/ws."""
+        import asyncio
+        import uuid
+
         from langsmith.sandbox._ws_execute import run_ws_stream_async
 
         dataplane_url = self._require_dataplane_url()
         api_key = self._client._api_key
 
+        # Client-supplied command_id makes execute idempotent (server does
+        # get-or-create keyed on it), so a tunnel that closes before "started"
+        # can be safely re-issued: the daemon reattaches to the existing command
+        # rather than spawning a second one.
+        command_id = uuid.uuid4().hex
+
         ws_kwargs: dict[str, Any] = {
+            "command_id": command_id,
             "timeout": timeout,
             "env": env,
             "cwd": cwd,
@@ -400,21 +415,40 @@ class AsyncSandbox:
         if merged:
             ws_kwargs["headers"] = merged
 
-        msg_stream, control = await run_ws_stream_async(
-            dataplane_url,
-            api_key,
-            command,
-            **ws_kwargs,
-        )
-
-        handle = AsyncCommandHandle(
-            msg_stream,
-            control,
-            self,
-            on_stdout=on_stdout,
-            on_stderr=on_stderr,
-        )
-        await handle._ensure_started()
+        attempt = 0
+        while True:
+            msg_stream, control = await run_ws_stream_async(
+                dataplane_url,
+                api_key,
+                command,
+                **ws_kwargs,
+            )
+            handle = AsyncCommandHandle(
+                msg_stream,
+                control,
+                self,
+                sent_command_id=command_id,
+                on_stdout=on_stdout,
+                on_stderr=on_stderr,
+            )
+            try:
+                await handle._ensure_started()
+                break
+            except _StreamEndedBeforeStarted:
+                # Only retry when the daemon has proven it honors our
+                # command_id; otherwise a re-issue could double-run the
+                # command. Unknown/unsupported → surface the original error.
+                if self._client_command_id_honored is not True:
+                    raise
+                attempt += 1
+                if attempt > AsyncCommandHandle.MAX_AUTO_RECONNECTS:
+                    raise
+                await asyncio.sleep(
+                    min(
+                        AsyncCommandHandle._BACKOFF_BASE * (2 ** (attempt - 1)),
+                        AsyncCommandHandle._BACKOFF_MAX,
+                    )
+                )
 
         if not wait:
             return handle

--- a/python/langsmith/sandbox/_models.py
+++ b/python/langsmith/sandbox/_models.py
@@ -502,7 +502,6 @@ class CommandHandle:
         sandbox: Sandbox,
         *,
         command_id: str = "",
-        sent_command_id: str = "",
         stdout_offset: int = 0,
         stderr_offset: int = 0,
         on_stdout: Optional[Callable[[str], Any]] = None,
@@ -511,7 +510,6 @@ class CommandHandle:
         self._stream = message_stream
         self._control = control
         self._sandbox = sandbox
-        self._sent_command_id = sent_command_id
         self._on_stdout = on_stdout
         self._on_stderr = on_stderr
         self._command_id: Optional[str] = None
@@ -553,10 +551,6 @@ class CommandHandle:
             )
         self._command_id = first_msg.get("command_id")
         self._pid = first_msg.get("pid")
-        if self._sent_command_id:
-            self._sandbox._client_command_id_honored = (
-                self._command_id == self._sent_command_id
-            )
 
     @property
     def command_id(self) -> Optional[str]:
@@ -768,7 +762,6 @@ class AsyncCommandHandle:
         sandbox: AsyncSandbox,
         *,
         command_id: str = "",
-        sent_command_id: str = "",
         stdout_offset: int = 0,
         stderr_offset: int = 0,
         on_stdout: Optional[Callable[[str], Any]] = None,
@@ -777,7 +770,6 @@ class AsyncCommandHandle:
         self._stream = message_stream
         self._control = control
         self._sandbox = sandbox
-        self._sent_command_id = sent_command_id
         self._on_stdout = on_stdout
         self._on_stderr = on_stderr
         self._command_id: Optional[str] = None
@@ -817,10 +809,6 @@ class AsyncCommandHandle:
         self._command_id = first_msg.get("command_id")
         self._pid = first_msg.get("pid")
         self._started = True
-        if self._sent_command_id:
-            self._sandbox._client_command_id_honored = (
-                self._command_id == self._sent_command_id
-            )
 
     @property
     def command_id(self) -> Optional[str]:

--- a/python/langsmith/sandbox/_models.py
+++ b/python/langsmith/sandbox/_models.py
@@ -24,6 +24,16 @@ if TYPE_CHECKING:
     )
 
 
+class _StreamEndedBeforeStarted(SandboxOperationError):
+    """A command WebSocket closed before the guest sent its 'started' frame.
+
+    Internal marker for the idempotently-retryable early close (the proxied
+    tunnel was torn down gracefully mid-handshake), as distinct from a
+    command-level failure. Subclasses SandboxOperationError so callers that
+    catch the public type are unaffected.
+    """
+
+
 @dataclass
 class ExecutionResult:
     """Result of executing a command in a sandbox."""
@@ -492,6 +502,7 @@ class CommandHandle:
         sandbox: Sandbox,
         *,
         command_id: str = "",
+        sent_command_id: str = "",
         stdout_offset: int = 0,
         stderr_offset: int = 0,
         on_stdout: Optional[Callable[[str], Any]] = None,
@@ -500,6 +511,7 @@ class CommandHandle:
         self._stream = message_stream
         self._control = control
         self._sandbox = sandbox
+        self._sent_command_id = sent_command_id
         self._on_stdout = on_stdout
         self._on_stderr = on_stderr
         self._command_id: Optional[str] = None
@@ -530,7 +542,7 @@ class CommandHandle:
         try:
             first_msg = next(self._stream)
         except StopIteration:
-            raise SandboxOperationError(
+            raise _StreamEndedBeforeStarted(
                 "Command stream ended before 'started' message",
                 operation="command",
             )
@@ -541,6 +553,10 @@ class CommandHandle:
             )
         self._command_id = first_msg.get("command_id")
         self._pid = first_msg.get("pid")
+        if self._sent_command_id:
+            self._sandbox._client_command_id_honored = (
+                self._command_id == self._sent_command_id
+            )
 
     @property
     def command_id(self) -> Optional[str]:
@@ -752,6 +768,7 @@ class AsyncCommandHandle:
         sandbox: AsyncSandbox,
         *,
         command_id: str = "",
+        sent_command_id: str = "",
         stdout_offset: int = 0,
         stderr_offset: int = 0,
         on_stdout: Optional[Callable[[str], Any]] = None,
@@ -760,6 +777,7 @@ class AsyncCommandHandle:
         self._stream = message_stream
         self._control = control
         self._sandbox = sandbox
+        self._sent_command_id = sent_command_id
         self._on_stdout = on_stdout
         self._on_stderr = on_stderr
         self._command_id: Optional[str] = None
@@ -787,7 +805,7 @@ class AsyncCommandHandle:
         try:
             first_msg = await self._stream.__anext__()
         except StopAsyncIteration:
-            raise SandboxOperationError(
+            raise _StreamEndedBeforeStarted(
                 "Command stream ended before 'started' message",
                 operation="command",
             )
@@ -799,6 +817,10 @@ class AsyncCommandHandle:
         self._command_id = first_msg.get("command_id")
         self._pid = first_msg.get("pid")
         self._started = True
+        if self._sent_command_id:
+            self._sandbox._client_command_id_honored = (
+                self._command_id == self._sent_command_id
+            )
 
     @property
     def command_id(self) -> Optional[str]:

--- a/python/langsmith/sandbox/_sandbox.py
+++ b/python/langsmith/sandbox/_sandbox.py
@@ -19,6 +19,7 @@ from langsmith.sandbox._models import (
     ExecutionResult,
     ServiceURL,
     Snapshot,
+    _StreamEndedBeforeStarted,
 )
 from langsmith.sandbox._tunnel import Tunnel
 
@@ -92,6 +93,10 @@ class Sandbox:
     # Internal fields (not from API)
     _client: SandboxClient = field(repr=False, default=None)  # type: ignore
     _auto_delete: bool = field(repr=False, default=True)
+    # Learned once per sandbox: True after a "started" frame echoes back the
+    # client-supplied command_id, proving the daemon honors it (get-or-create).
+    # Only then is an early-close retry idempotency-safe. None = unknown.
+    _client_command_id_honored: Optional[bool] = field(repr=False, default=None)
 
     @classmethod
     def from_dict(
@@ -380,12 +385,22 @@ class Sandbox:
         headers: RequestHeaders = None,
     ) -> Union[ExecutionResult, CommandHandle]:
         """Execute via WebSocket /execute/ws."""
+        import time
+        import uuid
+
         from langsmith.sandbox._ws_execute import run_ws_stream
 
         dataplane_url = self._require_dataplane_url()
         api_key = self._client._api_key
 
+        # Client-supplied command_id makes execute idempotent (server does
+        # get-or-create keyed on it), so a tunnel that closes before "started"
+        # can be safely re-issued: the daemon reattaches to the existing command
+        # rather than spawning a second one.
+        command_id = uuid.uuid4().hex
+
         ws_kwargs: dict[str, Any] = {
+            "command_id": command_id,
             "timeout": timeout,
             "env": env,
             "cwd": cwd,
@@ -399,20 +414,39 @@ class Sandbox:
         if merged:
             ws_kwargs["headers"] = merged
 
-        msg_stream, control = run_ws_stream(
-            dataplane_url,
-            api_key,
-            command,
-            **ws_kwargs,
-        )
-
-        handle = CommandHandle(
-            msg_stream,
-            control,
-            self,
-            on_stdout=on_stdout,
-            on_stderr=on_stderr,
-        )
+        attempt = 0
+        while True:
+            msg_stream, control = run_ws_stream(
+                dataplane_url,
+                api_key,
+                command,
+                **ws_kwargs,
+            )
+            try:
+                handle = CommandHandle(
+                    msg_stream,
+                    control,
+                    self,
+                    sent_command_id=command_id,
+                    on_stdout=on_stdout,
+                    on_stderr=on_stderr,
+                )
+                break
+            except _StreamEndedBeforeStarted:
+                # Only retry when the daemon has proven it honors our
+                # command_id; otherwise a re-issue could double-run the
+                # command. Unknown/unsupported → surface the original error.
+                if self._client_command_id_honored is not True:
+                    raise
+                attempt += 1
+                if attempt > CommandHandle.MAX_AUTO_RECONNECTS:
+                    raise
+                time.sleep(
+                    min(
+                        CommandHandle._BACKOFF_BASE * (2 ** (attempt - 1)),
+                        CommandHandle._BACKOFF_MAX,
+                    )
+                )
 
         if not wait:
             return handle

--- a/python/langsmith/sandbox/_sandbox.py
+++ b/python/langsmith/sandbox/_sandbox.py
@@ -93,10 +93,6 @@ class Sandbox:
     # Internal fields (not from API)
     _client: SandboxClient = field(repr=False, default=None)  # type: ignore
     _auto_delete: bool = field(repr=False, default=True)
-    # Learned once per sandbox: True after a "started" frame echoes back the
-    # client-supplied command_id, proving the daemon honors it (get-or-create).
-    # Only then is an early-close retry idempotency-safe. None = unknown.
-    _client_command_id_honored: Optional[bool] = field(repr=False, default=None)
 
     @classmethod
     def from_dict(
@@ -393,10 +389,10 @@ class Sandbox:
         dataplane_url = self._require_dataplane_url()
         api_key = self._client._api_key
 
-        # Client-supplied command_id makes execute idempotent (server does
-        # get-or-create keyed on it), so a tunnel that closes before "started"
-        # can be safely re-issued: the daemon reattaches to the existing command
-        # rather than spawning a second one.
+        # A client-supplied command_id makes execute idempotent: the daemon does
+        # get-or-create keyed on it, so if the tunnel closes before "started" we
+        # can re-issue the same id and reattach to the existing command instead
+        # of spawning a second one.
         command_id = uuid.uuid4().hex
 
         ws_kwargs: dict[str, Any] = {
@@ -427,17 +423,12 @@ class Sandbox:
                     msg_stream,
                     control,
                     self,
-                    sent_command_id=command_id,
                     on_stdout=on_stdout,
                     on_stderr=on_stderr,
                 )
                 break
             except _StreamEndedBeforeStarted:
-                # Only retry when the daemon has proven it honors our
-                # command_id; otherwise a re-issue could double-run the
-                # command. Unknown/unsupported → surface the original error.
-                if self._client_command_id_honored is not True:
-                    raise
+                # Idempotent re-issue (same command_id) after an early close.
                 attempt += 1
                 if attempt > CommandHandle.MAX_AUTO_RECONNECTS:
                     raise

--- a/python/langsmith/sandbox/_sandbox.py
+++ b/python/langsmith/sandbox/_sandbox.py
@@ -382,9 +382,9 @@ class Sandbox:
     ) -> Union[ExecutionResult, CommandHandle]:
         """Execute via WebSocket /execute/ws."""
         import time
-        import uuid
 
         from langsmith.sandbox._ws_execute import run_ws_stream
+        from langsmith.uuid import uuid7
 
         dataplane_url = self._require_dataplane_url()
         api_key = self._client._api_key
@@ -393,7 +393,7 @@ class Sandbox:
         # get-or-create keyed on it, so if the tunnel closes before "started" we
         # can re-issue the same id and reattach to the existing command instead
         # of spawning a second one.
-        command_id = uuid.uuid4().hex
+        command_id = uuid7().hex
 
         ws_kwargs: dict[str, Any] = {
             "command_id": command_id,

--- a/python/langsmith/sandbox/_ws_execute.py
+++ b/python/langsmith/sandbox/_ws_execute.py
@@ -228,6 +228,7 @@ def run_ws_stream(
     api_key: Optional[str],
     command: str,
     *,
+    command_id: str = "",
     timeout: int = 60,
     env: Optional[dict[str, str]] = None,
     cwd: Optional[str] = None,
@@ -281,6 +282,8 @@ def run_ws_stream(
                     "kill_on_disconnect": kill_on_disconnect,
                     "ttl_seconds": ttl_seconds,
                 }
+                if command_id:
+                    payload["command_id"] = command_id
                 if env:
                     payload["env"] = env
                 if cwd:
@@ -425,6 +428,7 @@ async def run_ws_stream_async(
     api_key: Optional[str],
     command: str,
     *,
+    command_id: str = "",
     timeout: int = 60,
     env: Optional[dict[str, str]] = None,
     cwd: Optional[str] = None,
@@ -467,6 +471,8 @@ async def run_ws_stream_async(
                     "kill_on_disconnect": kill_on_disconnect,
                     "ttl_seconds": ttl_seconds,
                 }
+                if command_id:
+                    payload["command_id"] = command_id
                 if env:
                     payload["env"] = env
                 if cwd:

--- a/python/tests/unit_tests/sandbox/test_async_ws_execute.py
+++ b/python/tests/unit_tests/sandbox/test_async_ws_execute.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from collections.abc import AsyncIterator
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -734,6 +734,7 @@ class TestAsyncSandboxRunWs:
             "https://router.example.com/sb-123",
             "test-key",
             "echo hello",
+            command_id=ANY,
             timeout=60,
             env=None,
             cwd=None,

--- a/python/tests/unit_tests/sandbox/test_command_id_retry.py
+++ b/python/tests/unit_tests/sandbox/test_command_id_retry.py
@@ -1,0 +1,198 @@
+"""Idempotent retry when a command WebSocket closes before 'started'.
+
+A proxied exec tunnel can be torn down gracefully before the guest emits its
+'started' frame. Because run() sends a client-generated command_id and the
+server does get-or-create keyed on it, re-issuing the command reattaches to the
+same session instead of spawning a second one -- but only once the daemon has
+proven it honors the id (by echoing it back in a prior 'started').
+"""
+
+from unittest import mock
+
+import pytest
+
+from langsmith.sandbox import (
+    AsyncSandboxClient,
+    SandboxClient,
+    SandboxOperationError,
+)
+from langsmith.sandbox._async_sandbox import AsyncSandbox
+from langsmith.sandbox._models import (
+    CommandHandle,
+    _StreamEndedBeforeStarted,
+)
+from langsmith.sandbox._sandbox import Sandbox
+
+
+@pytest.fixture(autouse=True)
+def _no_sleep(monkeypatch):
+    monkeypatch.setattr("time.sleep", lambda _s: None)
+
+
+def _client():
+    return SandboxClient(api_endpoint="http://test-server:8080", max_retries=0)
+
+
+def _sandbox():
+    return Sandbox.from_dict(
+        data={
+            "name": "sb",
+            "dataplane_url": "https://sandbox-router.example.com/sb-123",
+        },
+        client=_client(),
+        auto_delete=False,
+    )
+
+
+def _empty():
+    return iter(())
+
+
+def _started_then_exit(command_id):
+    return iter(
+        [
+            {"type": "started", "command_id": command_id, "pid": 1},
+            {"type": "exit", "exit_code": 0},
+        ]
+    )
+
+
+class TestStartedEcho:
+    def test_matching_echo_marks_supported(self):
+        sandbox = _sandbox()
+        CommandHandle(
+            _started_then_exit("cid-1"),
+            None,
+            sandbox,
+            sent_command_id="cid-1",
+        )
+        assert sandbox._client_command_id_honored is True
+
+    def test_mismatched_echo_marks_unsupported(self):
+        sandbox = _sandbox()
+        CommandHandle(
+            _started_then_exit("server-assigned"),
+            None,
+            sandbox,
+            sent_command_id="cid-1",
+        )
+        assert sandbox._client_command_id_honored is False
+
+    def test_empty_stream_raises_marker(self):
+        with pytest.raises(_StreamEndedBeforeStarted):
+            CommandHandle(_empty(), None, _sandbox(), sent_command_id="cid-1")
+
+
+class TestSyncRetry:
+    def test_retries_with_same_command_id_when_supported(self, monkeypatch):
+        sandbox = _sandbox()
+        sandbox._client_command_id_honored = True  # proven by a prior command
+        calls: list[dict] = []
+
+        def fake_run_ws_stream(dataplane_url, api_key, command, **kwargs):
+            calls.append(kwargs)
+            if len(calls) == 1:
+                return _empty(), None
+            return _started_then_exit(kwargs["command_id"]), None
+
+        monkeypatch.setattr(
+            "langsmith.sandbox._ws_execute.run_ws_stream", fake_run_ws_stream
+        )
+
+        result = sandbox.run("echo hi")
+
+        assert result.exit_code == 0
+        assert len(calls) == 2
+        # Same id across the retry -> server dedupes, no double-run.
+        assert calls[0]["command_id"] == calls[1]["command_id"]
+
+    def test_no_retry_when_capability_unknown(self, monkeypatch):
+        sandbox = _sandbox()  # _client_command_id_honored is None
+        calls: list[dict] = []
+
+        def fake_run_ws_stream(dataplane_url, api_key, command, **kwargs):
+            calls.append(kwargs)
+            return _empty(), None
+
+        monkeypatch.setattr(
+            "langsmith.sandbox._ws_execute.run_ws_stream", fake_run_ws_stream
+        )
+
+        with pytest.raises(SandboxOperationError):
+            sandbox.run("echo hi", wait=False)
+        assert len(calls) == 1
+
+    def test_gives_up_after_max_attempts(self, monkeypatch):
+        sandbox = _sandbox()
+        sandbox._client_command_id_honored = True
+        calls: list[dict] = []
+
+        def fake_run_ws_stream(dataplane_url, api_key, command, **kwargs):
+            calls.append(kwargs)
+            return _empty(), None
+
+        monkeypatch.setattr(
+            "langsmith.sandbox._ws_execute.run_ws_stream", fake_run_ws_stream
+        )
+
+        with pytest.raises(_StreamEndedBeforeStarted):
+            sandbox.run("echo hi", wait=False)
+        assert len(calls) == CommandHandle.MAX_AUTO_RECONNECTS + 1
+
+
+def _async_sandbox():
+    client = AsyncSandboxClient(api_endpoint="http://test-server:8080", max_retries=0)
+    return AsyncSandbox.from_dict(
+        data={
+            "name": "sb",
+            "dataplane_url": "https://sandbox-router.example.com/sb-123",
+        },
+        client=client,
+        auto_delete=False,
+    )
+
+
+async def _aempty():
+    return
+    yield  # make it an async generator
+
+
+async def _astarted_then_exit(command_id):
+    yield {"type": "started", "command_id": command_id, "pid": 1}
+    yield {"type": "exit", "exit_code": 0}
+
+
+class TestAsyncRetry:
+    async def test_retries_with_same_command_id_when_supported(self, monkeypatch):
+        sandbox = _async_sandbox()
+        sandbox._client_command_id_honored = True
+        calls: list[dict] = []
+
+        async def fake(dataplane_url, api_key, command, **kwargs):
+            calls.append(kwargs)
+            if len(calls) == 1:
+                return _aempty(), None
+            return _astarted_then_exit(kwargs["command_id"]), None
+
+        monkeypatch.setattr("asyncio.sleep", mock.AsyncMock())
+        monkeypatch.setattr("langsmith.sandbox._ws_execute.run_ws_stream_async", fake)
+
+        result = await sandbox.run("echo hi")
+
+        assert result.exit_code == 0
+        assert len(calls) == 2
+        assert calls[0]["command_id"] == calls[1]["command_id"]
+
+    async def test_no_retry_when_capability_unknown(self, monkeypatch):
+        sandbox = _async_sandbox()
+        calls: list[dict] = []
+
+        async def fake(dataplane_url, api_key, command, **kwargs):
+            calls.append(kwargs)
+            return _aempty(), None
+
+        monkeypatch.setattr("langsmith.sandbox._ws_execute.run_ws_stream_async", fake)
+
+        with pytest.raises(SandboxOperationError):
+            await sandbox.run("echo hi", wait=False)
+        assert len(calls) == 1

--- a/python/tests/unit_tests/sandbox/test_command_id_retry.py
+++ b/python/tests/unit_tests/sandbox/test_command_id_retry.py
@@ -1,20 +1,16 @@
 """Idempotent retry when a command WebSocket closes before 'started'.
 
 A proxied exec tunnel can be torn down gracefully before the guest emits its
-'started' frame. Because run() sends a client-generated command_id and the
-server does get-or-create keyed on it, re-issuing the command reattaches to the
-same session instead of spawning a second one -- but only once the daemon has
-proven it honors the id (by echoing it back in a prior 'started').
+'started' frame. run() sends a client-generated command_id and the server does
+get-or-create keyed on it, so re-issuing the same command reattaches to the
+existing session instead of spawning a second one.
 """
-
-from unittest import mock
 
 import pytest
 
 from langsmith.sandbox import (
     AsyncSandboxClient,
     SandboxClient,
-    SandboxOperationError,
 )
 from langsmith.sandbox._async_sandbox import AsyncSandbox
 from langsmith.sandbox._models import (
@@ -29,17 +25,13 @@ def _no_sleep(monkeypatch):
     monkeypatch.setattr("time.sleep", lambda _s: None)
 
 
-def _client():
-    return SandboxClient(api_endpoint="http://test-server:8080", max_retries=0)
-
-
 def _sandbox():
     return Sandbox.from_dict(
         data={
             "name": "sb",
             "dataplane_url": "https://sandbox-router.example.com/sb-123",
         },
-        client=_client(),
+        client=SandboxClient(api_endpoint="http://test-server:8080", max_retries=0),
         auto_delete=False,
     )
 
@@ -57,36 +49,15 @@ def _started_then_exit(command_id):
     )
 
 
-class TestStartedEcho:
-    def test_matching_echo_marks_supported(self):
-        sandbox = _sandbox()
-        CommandHandle(
-            _started_then_exit("cid-1"),
-            None,
-            sandbox,
-            sent_command_id="cid-1",
-        )
-        assert sandbox._client_command_id_honored is True
-
-    def test_mismatched_echo_marks_unsupported(self):
-        sandbox = _sandbox()
-        CommandHandle(
-            _started_then_exit("server-assigned"),
-            None,
-            sandbox,
-            sent_command_id="cid-1",
-        )
-        assert sandbox._client_command_id_honored is False
-
+class TestCommandHandle:
     def test_empty_stream_raises_marker(self):
         with pytest.raises(_StreamEndedBeforeStarted):
-            CommandHandle(_empty(), None, _sandbox(), sent_command_id="cid-1")
+            CommandHandle(_empty(), None, _sandbox())
 
 
 class TestSyncRetry:
-    def test_retries_with_same_command_id_when_supported(self, monkeypatch):
+    def test_retries_with_same_command_id(self, monkeypatch):
         sandbox = _sandbox()
-        sandbox._client_command_id_honored = True  # proven by a prior command
         calls: list[dict] = []
 
         def fake_run_ws_stream(dataplane_url, api_key, command, **kwargs):
@@ -106,25 +77,8 @@ class TestSyncRetry:
         # Same id across the retry -> server dedupes, no double-run.
         assert calls[0]["command_id"] == calls[1]["command_id"]
 
-    def test_no_retry_when_capability_unknown(self, monkeypatch):
-        sandbox = _sandbox()  # _client_command_id_honored is None
-        calls: list[dict] = []
-
-        def fake_run_ws_stream(dataplane_url, api_key, command, **kwargs):
-            calls.append(kwargs)
-            return _empty(), None
-
-        monkeypatch.setattr(
-            "langsmith.sandbox._ws_execute.run_ws_stream", fake_run_ws_stream
-        )
-
-        with pytest.raises(SandboxOperationError):
-            sandbox.run("echo hi", wait=False)
-        assert len(calls) == 1
-
     def test_gives_up_after_max_attempts(self, monkeypatch):
         sandbox = _sandbox()
-        sandbox._client_command_id_honored = True
         calls: list[dict] = []
 
         def fake_run_ws_stream(dataplane_url, api_key, command, **kwargs):
@@ -163,9 +117,8 @@ async def _astarted_then_exit(command_id):
 
 
 class TestAsyncRetry:
-    async def test_retries_with_same_command_id_when_supported(self, monkeypatch):
+    async def test_retries_with_same_command_id(self, monkeypatch):
         sandbox = _async_sandbox()
-        sandbox._client_command_id_honored = True
         calls: list[dict] = []
 
         async def fake(dataplane_url, api_key, command, **kwargs):
@@ -174,7 +127,10 @@ class TestAsyncRetry:
                 return _aempty(), None
             return _astarted_then_exit(kwargs["command_id"]), None
 
-        monkeypatch.setattr("asyncio.sleep", mock.AsyncMock())
+        async def _no_sleep(_s):
+            return None
+
+        monkeypatch.setattr("asyncio.sleep", _no_sleep)
         monkeypatch.setattr("langsmith.sandbox._ws_execute.run_ws_stream_async", fake)
 
         result = await sandbox.run("echo hi")
@@ -182,17 +138,3 @@ class TestAsyncRetry:
         assert result.exit_code == 0
         assert len(calls) == 2
         assert calls[0]["command_id"] == calls[1]["command_id"]
-
-    async def test_no_retry_when_capability_unknown(self, monkeypatch):
-        sandbox = _async_sandbox()
-        calls: list[dict] = []
-
-        async def fake(dataplane_url, api_key, command, **kwargs):
-            calls.append(kwargs)
-            return _aempty(), None
-
-        monkeypatch.setattr("langsmith.sandbox._ws_execute.run_ws_stream_async", fake)
-
-        with pytest.raises(SandboxOperationError):
-            await sandbox.run("echo hi", wait=False)
-        assert len(calls) == 1

--- a/python/tests/unit_tests/sandbox/test_ws_execute.py
+++ b/python/tests/unit_tests/sandbox/test_ws_execute.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 from typing import Any, Iterator
-from unittest.mock import MagicMock, patch
+from unittest.mock import ANY, MagicMock, patch
 
 import pytest
 
@@ -692,6 +692,7 @@ class TestSandboxRunWs:
             "https://router.example.com/sb-123",
             "test-key",
             "echo hello",
+            command_id=ANY,
             timeout=60,
             env=None,
             cwd=None,


### PR DESCRIPTION
## Problem

A command exec runs over a proxied WebSocket tunnel (`SDK → LB → platform-backend → sandbox-host → guestd`). guestd sends a `started` frame first, carrying `command_id`/`pid`. If the tunnel is torn down **gracefully** (a normal/OK WS close) *before* that frame arrives — e.g. a proxy hop draining, or an upstream leg racing during connect — the SDK's `next(stream)` hits `StopIteration`/`done` and raises:

```
SandboxOperationError: Command stream ended before 'started' message
```

This is **unrecoverable today**: the started-frame read runs in the handle constructor, *before* the auto-reconnect loop, so there is no retry. Because a graceful close produces no server-side 5xx/error, it's invisible to server logs. We saw it fail an Engine (Issues Agent) run in prod, twice in a row.

A naive re-execute is unsafe: a lost `started` means we don't know whether the process already spawned, so re-running could double-run a side-effecting command (`pip install`, `git push`, …).

## Fix

`run()` now generates a client-side `command_id` and sends it on `execute`. The daemon does **get-or-create** keyed on that id (`exec_ws_handler.go` / `session.go`): re-issuing the *same* id after an early close reattaches to the existing command and streams from offset 0 instead of spawning a second one — exactly-once, and correct under both the v1 (disk) and v2 (acked, back-pressured mem) buffers. Retries are capped at `MAX_AUTO_RECONNECTS` with the existing exponential backoff.

Implemented symmetrically in **Python** (sync + async) and **JS**.

> Note: the sandbox exec feature is SaaS-only, so the daemon is always current (get-or-create by client id has shipped since early 2026). No backward-compat gating needed.

## Test Plan

- [x] Python: empty stream raises the early-close marker; `run()` retries with the *same* command_id; gives up after `MAX_AUTO_RECONNECTS` (`test_command_id_retry.py`, sync + async)
- [x] JS: handle raises the marker; `run()` retries with the same command_id; a non-early-close error (wrong first frame) is *not* retried (`sandbox.test.ts` + `sandbox_command_id_retry.test.ts`)
- [x] Full existing sandbox suites pass (Python 503, JS 134); updated two `forwards_headers` expectations for the new `command_id` kwarg
- [x] `ruff` + `mypy` clean; `tsc` clean on changed files
