### PR TITLE
release(py): 0.10.11

### DIFF
--- a/python/.bumpversion.cfg
+++ b/python/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.10.10
+current_version = 0.10.11
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
 serialize = {major}.{minor}.{patch}
 search = {current_version}

--- a/python/langsmith/__init__.py
+++ b/python/langsmith/__init__.py
@@ -49,7 +49,7 @@ if TYPE_CHECKING:
 
 # Avoid calling into importlib on every call to __version__
 
-__version__ = "0.10.10"
+__version__ = "0.10.11"
 version = __version__  # for backwards compatibility
 
 # Metadata key to hide a traced run from LangSmith's Messages View.


### PR DESCRIPTION
## Description
Bumps the Python SDK to 0.10.11 using the documented `bump2version` release flow. After merge, the release workflow will tag and publish the new PyPI package.

## Test Plan
- [x] `uv run ruff format --check langsmith/__init__.py`
- [x] `uv run ruff check langsmith/__init__.py`

Made by [Open SWE](https://openswe.vercel.app/agents/c602f6cf-6e8e-0396-faf9-19bb40abf553)