### PR TITLE
release(js): 0.8.7

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langsmith",
-  "version": "0.8.6",
+  "version": "0.8.7",
   "description": "Client library to connect to the LangSmith Observability and Evaluation Platform.",
   "packageManager": "pnpm@10.33.0",
   "files": [

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -54,7 +54,7 @@ export {
 } from "./_openapi_client/core/error.js";
 
 // Update using pnpm bump-version
-export const __version__ = "0.8.6";
+export const __version__ = "0.8.7";
 
 // Metadata key to hide a traced run from LangSmith's Messages View.
 export const LS_MESSAGE_VIEW_EXCLUDE = "ls_message_view_exclude" as const;


### PR DESCRIPTION
## Description
Bumps the JavaScript SDK to 0.8.7 using the documented `pnpm run bump-version` release flow. After merge, the release workflow will publish the new npm package.

## Test Plan
- [x] `pnpm run check-version`
- [x] `npm view langsmith version`

Made by [Open SWE](https://openswe.vercel.app/agents/c602f6cf-6e8e-0396-faf9-19bb40abf553)