### PR TITLE
fix(sandbox): keep dataplane_url after stop()

### DIFF
--- a/js/src/sandbox/sandbox.ts
+++ b/js/src/sandbox/sandbox.ts
@@ -496,8 +496,9 @@ export class Sandbox {
    */
   async stop(): Promise<void> {
     await this._client.stopSandbox(this.name);
+    // dataplane_url stays set: it is stable across stop/start and a request on
+    // it resumes the sandbox.
     this.status = "stopped";
-    this.dataplane_url = undefined;
   }
 
   /**

--- a/js/src/tests/sandbox.test.ts
+++ b/js/src/tests/sandbox.test.ts
@@ -2437,7 +2437,7 @@ describe("Sandbox - start/stop/captureSnapshot", () => {
     expect(sandbox.dataplane_url).toBe("https://dp.example.com/my-vm");
   });
 
-  it("stop should set status to stopped and clear dataplane_url", async () => {
+  it("stop should set status to stopped and keep dataplane_url", async () => {
     const mockClient = createMockClient({
       stopSandbox: jest
         .fn<(name: string) => Promise<void>>()
@@ -2456,7 +2456,7 @@ describe("Sandbox - start/stop/captureSnapshot", () => {
     await sandbox.stop();
 
     expect(sandbox.status).toBe("stopped");
-    expect(sandbox.dataplane_url).toBeUndefined();
+    expect(sandbox.dataplane_url).toBe("https://dp.example.com/my-vm");
   });
 
   it("captureSnapshot should delegate to client", async () => {

--- a/python/langsmith/sandbox/_async_sandbox.py
+++ b/python/langsmith/sandbox/_async_sandbox.py
@@ -752,8 +752,9 @@ class AsyncSandbox:
             SandboxClientError: For other errors.
         """
         await self._client.stop_sandbox(self.name, headers=headers)
+        # dataplane_url stays set: it is stable across stop/start and a request
+        # on it resumes the sandbox.
         self.status = "stopped"
-        self.dataplane_url = None
 
     async def delete(self, *, headers: RequestHeaders = None) -> None:
         """Delete this sandbox.

--- a/python/langsmith/sandbox/_sandbox.py
+++ b/python/langsmith/sandbox/_sandbox.py
@@ -754,8 +754,9 @@ class Sandbox:
             SandboxClientError: For other errors.
         """
         self._client.stop_sandbox(self.name, headers=headers)
+        # dataplane_url stays set: it is stable across stop/start and a request
+        # on it resumes the sandbox.
         self.status = "stopped"
-        self.dataplane_url = None
 
     def delete(self, *, headers: RequestHeaders = None) -> None:
         """Delete this sandbox.

--- a/python/tests/unit_tests/sandbox/test_async_sandbox.py
+++ b/python/tests/unit_tests/sandbox/test_async_sandbox.py
@@ -189,6 +189,27 @@ class TestAsyncSandboxStatusFields:
         with pytest.raises(DataplaneNotConfiguredError):
             await sb.read("/tmp/test.txt")
 
+    async def test_stop_preserves_dataplane_url(self, client, httpx_mock: HTTPXMock):
+        """stop() must not clear dataplane_url: it stays valid across
+        stop/start and a request on it resumes the sandbox."""
+        httpx_mock.add_response(
+            method="POST",
+            url="http://test-server:8080/boxes/test-sandbox/stop",
+            json={},
+        )
+        sb = AsyncSandbox.from_dict(
+            data={
+                "name": "test-sandbox",
+                "status": "ready",
+                "dataplane_url": "https://sandbox-router.example.com/sb-123",
+            },
+            client=client,
+            auto_delete=False,
+        )
+        await sb.stop()
+        assert sb.status == "stopped"
+        assert sb.dataplane_url == "https://sandbox-router.example.com/sb-123"
+
 
 class TestAsyncSandboxRun:
     """AsyncSandbox.run() over the HTTP fallback path.

--- a/python/tests/unit_tests/sandbox/test_sandbox.py
+++ b/python/tests/unit_tests/sandbox/test_sandbox.py
@@ -198,6 +198,27 @@ class TestSandboxStatusFields:
         with pytest.raises(DataplaneNotConfiguredError):
             sb.read("/tmp/test.txt")
 
+    def test_stop_preserves_dataplane_url(self, client, httpx_mock: HTTPXMock):
+        """stop() must not clear dataplane_url: it stays valid across
+        stop/start and a request on it resumes the sandbox."""
+        httpx_mock.add_response(
+            method="POST",
+            url="http://test-server:8080/boxes/test-sandbox/stop",
+            json={},
+        )
+        sb = Sandbox.from_dict(
+            data={
+                "name": "test-sandbox",
+                "status": "ready",
+                "dataplane_url": "https://sandbox-router.example.com/sb-123",
+            },
+            client=client,
+            auto_delete=False,
+        )
+        sb.stop()
+        assert sb.status == "stopped"
+        assert sb.dataplane_url == "https://sandbox-router.example.com/sb-123"
+
 
 class TestSandboxRun:
     """Sandbox.run() over the HTTP fallback path.


### PR DESCRIPTION
`Sandbox.stop()` / `AsyncSandbox.stop()` (Python) and `Sandbox.stop()` (JS) cleared `dataplane_url`, so a subsequent `run` / `read` / `write` raised `DataplaneNotConfiguredError` client-side — a lifecycle-state gate, which these SDKs otherwise deliberately avoid.

The platform resumes a stopped sandbox when a dataplane request arrives, and the server derives `dataplane_url` from the claim ID (+ cluster), so the URL stays valid across stop/start. `status` is still updated to `stopped`; only the URL clearing is dropped.

The Go SDK had the same bug plus a hard `status != "ready"` check; that half is fixed in langchain-ai/langsmith-go-staging#85.

## Test Plan

- [x] 507 Python sandbox unit tests pass; `ruff` and `mypy` clean
- [x] 133 JS sandbox tests pass; no new `tsc` errors under `src/sandbox`
- [x] New `test_stop_preserves_dataplane_url` in both `test_sandbox.py` and `test_async_sandbox.py`
- [x] JS `stop should set status to stopped and keep dataplane_url` updated to assert the URL survives