### PR TITLE
feat: require sessionID for feedback when ClickHouse unavailable

### DIFF
--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -549,6 +549,56 @@ type RecordStringAny = Record<string, any>;
 
 export type FeedbackSourceType = "model" | "api" | "app";
 
+export type CreateFeedbackOptions = {
+  /** The metric name, tag, or aspect to provide feedback on. */
+  key: string;
+  score?: ScoreType;
+  value?: ValueType;
+  correction?: object;
+  comment?: string;
+  sourceInfo?: object;
+  feedbackSourceType?: FeedbackSourceType;
+  feedbackConfig?: FeedbackConfig;
+  sourceRunId?: string;
+  feedbackId?: string;
+  comparativeExperimentId?: string;
+  /**
+   * The run's start time, ISO string or epoch ms. Better performance if provided.
+   */
+  startTime?: number | string;
+  /** If false, create feedback without extending the trace's retention tier. */
+  extendTraceRetention?: boolean;
+};
+
+/** @deprecated Pass all params within an object and populate sessionId. */
+export type CreateFeedbackLegacyOptions = Omit<CreateFeedbackOptions, "key"> & {
+  /**
+   * The session (project) ID of the run. Required for run-level feedback;
+   * omitting it is deprecated. See
+   * https://docs.langchain.com/langsmith/smithdb-sdk-migration#feedback-create
+   */
+  sessionId?: string;
+  /** The project (or experiment) to provide feedback on, for session-level feedback. */
+  projectId?: string;
+};
+
+export type CreateFeedbackParams = CreateFeedbackOptions &
+  (
+    | {
+        /** The run to provide feedback on. */
+        runId: string;
+        /** The session (project) ID of the run. */
+        sessionId: string;
+        projectId?: never;
+      }
+    | {
+        runId?: null;
+        /** The project (or experiment) to provide feedback on. */
+        projectId: string;
+        sessionId?: never;
+      }
+  );
+
 export type CreateExampleOptions = {
   /** The ID of the dataset to create the example in. */
   datasetId?: string;
@@ -5083,10 +5133,21 @@ export class Client implements LangSmithTracingClientInterface {
     });
   }
 
+  public async createFeedback(params: CreateFeedbackParams): Promise<Feedback>;
+  /** @deprecated Pass all params within an object and populate sessionId. */
   public async createFeedback(
     runId: string | null,
     key: string,
-    {
+    options: CreateFeedbackLegacyOptions,
+  ): Promise<Feedback>;
+  public async createFeedback(
+    runIdOrParams: string | null | CreateFeedbackParams,
+    keyArg?: string,
+    optionsArg?: CreateFeedbackLegacyOptions,
+  ): Promise<Feedback> {
+    const {
+      runId = null,
+      key,
       score,
       value,
       correction,
@@ -5101,33 +5162,9 @@ export class Client implements LangSmithTracingClientInterface {
       sessionId,
       startTime,
       extendTraceRetention,
-    }: {
-      score?: ScoreType;
-      value?: ValueType;
-      correction?: object;
-      comment?: string;
-      sourceInfo?: object;
-      feedbackSourceType?: FeedbackSourceType;
-      feedbackConfig?: FeedbackConfig;
-      sourceRunId?: string;
-      feedbackId?: string;
-      eager?: boolean;
-      projectId?: string;
-      comparativeExperimentId?: string;
-      /**
-       * The session (project) ID of the run. Required for run-level feedback;
-       * omitting it is deprecated. See
-       * https://docs.langchain.com/langsmith/smithdb-sdk-migration#feedback-create
-       */
-      sessionId?: string;
-      /**
-       * The run's start time, ISO string or epoch ms. Better performance if provided.
-       */
-      startTime?: number | string;
-      /** If false, create feedback without extending the trace's retention tier. */
-      extendTraceRetention?: boolean;
-    },
-  ): Promise<Feedback> {
+    } = typeof runIdOrParams === "object" && runIdOrParams !== null
+      ? runIdOrParams
+      : { runId: runIdOrParams, key: keyArg as string, ...optionsArg };
     if (!runId && !projectId) {
       throw new Error("One of runId or projectId must be provided");
     }

--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -2148,6 +2148,26 @@ export class Client implements LangSmithTracingClientInterface {
     return serverInfo.instance_flags?.sdb_query_enabled === true;
   }
 
+  /**
+   * Throw on SmithDB-only deployments, warn elsewhere. Call only when run-level
+   * feedback has no sessionId.
+   */
+  private async _checkFeedbackSessionId(): Promise<void> {
+    const docs =
+      "https://docs.langchain.com/langsmith/smithdb-sdk-migration#feedback-create";
+    const serverInfo = await this._ensureServerInfo();
+    if (serverInfo.instance_flags?.ch_query_enabled === false) {
+      throw new Error(
+        `sessionId must be provided when creating feedback for a run: this ` +
+          `deployment cannot locate the run without it. See ${docs}`,
+      );
+    }
+    warnOnce(
+      `Creating feedback for a run without sessionId is deprecated and will ` +
+        `stop working in a future release. See ${docs}`,
+    );
+  }
+
   protected async _getSettings() {
     if (!this.settings) {
       this.settings = this._get("/settings");
@@ -5094,9 +5114,16 @@ export class Client implements LangSmithTracingClientInterface {
       eager?: boolean;
       projectId?: string;
       comparativeExperimentId?: string;
-      /** The session (project) ID of the run this feedback is for. */
+      /**
+       * The session (project) ID of the run. Required for run-level feedback;
+       * omitting it is deprecated. See
+       * https://docs.langchain.com/langsmith/smithdb-sdk-migration#feedback-create
+       */
       sessionId?: string;
-      /** The start time of the run this feedback is for. Accepts ISO string or epoch ms. */
+      /**
+       * The run's start time, ISO string or epoch ms. With sessionId and traceId,
+       * skips the server-side run lookup.
+       */
       startTime?: number | string;
       /** If false, create feedback without extending the trace's retention tier. */
       extendTraceRetention?: boolean;
@@ -5107,6 +5134,9 @@ export class Client implements LangSmithTracingClientInterface {
     }
     if (runId && projectId) {
       throw new Error("Only one of runId or projectId can be provided");
+    }
+    if (runId && sessionId === undefined) {
+      await this._checkFeedbackSessionId();
     }
     const feedback_source: feedback_source = {
       type: feedbackSourceType ?? "api",

--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -5121,8 +5121,7 @@ export class Client implements LangSmithTracingClientInterface {
        */
       sessionId?: string;
       /**
-       * The run's start time, ISO string or epoch ms. With sessionId and traceId,
-       * skips the server-side run lookup.
+       * The run's start time, ISO string or epoch ms. Better performance if provided.
        */
       startTime?: number | string;
       /** If false, create feedback without extending the trace's retention tier. */

--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -572,6 +572,8 @@ export type CreateFeedbackOptions = {
 
 /** @deprecated Pass all params within an object and populate sessionId. */
 export type CreateFeedbackLegacyOptions = Omit<CreateFeedbackOptions, "key"> & {
+  /** @deprecated This option is no longer used. */
+  eager?: boolean;
   /**
    * The session (project) ID of the run. Required for run-level feedback;
    * omitting it is deprecated. See

--- a/js/src/tests/client.test.ts
+++ b/js/src/tests/client.test.ts
@@ -128,6 +128,28 @@ describe("Client", () => {
       });
     });
 
+    it("accepts the params-object overload, which requires sessionId", async () => {
+      const { client, paths } = infoClient(false);
+
+      await client.createFeedback({
+        runId: "550e8400-e29b-41d4-a716-446655440000",
+        key: "Foo",
+        score: 1,
+        sessionId: "550e8400-e29b-41d4-a716-446655440001",
+      });
+      // sessionId came from the params, so /info was never consulted.
+      expect(paths()).toEqual(["/feedback"]);
+
+      await client.createFeedback({
+        key: "Foo",
+        score: 1,
+        projectId: "550e8400-e29b-41d4-a716-446655440001",
+      });
+
+      // @ts-expect-error sessionId is required alongside runId.
+      await client.createFeedback({ runId: "x", key: "Foo" }).catch(() => {});
+    });
+
     it("warns without a sessionId on other deployments", async () => {
       const { client, paths } = infoClient(true);
       // warnOnce dedupes per process, so this must be the only test that warns.

--- a/js/src/tests/client.test.ts
+++ b/js/src/tests/client.test.ts
@@ -37,6 +37,7 @@ describe("Client", () => {
         {
           score: 1,
           extendTraceRetention: false,
+          sessionId: "550e8400-e29b-41d4-a716-446655440001",
         },
       );
 
@@ -76,6 +77,75 @@ describe("Client", () => {
           startTime,
         }),
       );
+    });
+
+    const infoClient = (chQueryEnabled: boolean) => {
+      const mockFetch = jest.fn<typeof fetch>().mockImplementation(
+        async () =>
+          new Response(
+            JSON.stringify({
+              instance_flags: { ch_query_enabled: chQueryEnabled },
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          ),
+      );
+      const client = new Client({
+        apiUrl: "http://localhost:1984",
+        apiKey: "test-api-key",
+        fetchImplementation: mockFetch,
+      });
+      const paths = () =>
+        mockFetch.mock.calls.map(([url]) => new URL(String(url)).pathname);
+      return { client, paths };
+    };
+
+    it("throws without a sessionId on a SmithDB-only deployment", async () => {
+      const { client, paths } = infoClient(false);
+
+      await expect(
+        client.createFeedback("550e8400-e29b-41d4-a716-446655440000", "Foo", {
+          score: 1,
+        }),
+      ).rejects.toThrow(/sessionId must be provided/);
+      // Only GET /info was called: the feedback was never sent.
+      expect(paths()).toEqual(["/info"]);
+
+      // startTime stays optional, matching the server.
+      await client.createFeedback(
+        "550e8400-e29b-41d4-a716-446655440000",
+        "Foo",
+        {
+          score: 1,
+          sessionId: "550e8400-e29b-41d4-a716-446655440001",
+        },
+      );
+      expect(paths()).toContain("/feedback");
+
+      // Session-level feedback has no run to locate.
+      await client.createFeedback(null, "Foo", {
+        score: 1,
+        projectId: "550e8400-e29b-41d4-a716-446655440001",
+      });
+    });
+
+    it("warns without a sessionId on other deployments", async () => {
+      const { client, paths } = infoClient(true);
+      // warnOnce dedupes per process, so this must be the only test that warns.
+      const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
+
+      await client.createFeedback(
+        "550e8400-e29b-41d4-a716-446655440000",
+        "Foo",
+        {
+          score: 1,
+        },
+      );
+
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining("smithdb-sdk-migration#feedback-create"),
+      );
+      expect(paths()).toContain("/feedback");
+      warn.mockRestore();
     });
   });
 

--- a/python/langsmith/async_client.py
+++ b/python/langsmith/async_client.py
@@ -1030,8 +1030,7 @@ class AsyncClient:
             session_id: The project ID of the run. Required for run-level feedback;
                 omitting it is deprecated. See
                 https://docs.langchain.com/langsmith/smithdb-sdk-migration#feedback-create
-            start_time: The start time of the run. With `session_id` and `trace_id`,
-                skips the server-side run lookup.
+            start_time: The start time of the run. Better performance if provided.
             comment: A comment about this feedback.
             extend_trace_retention: If false, create the feedback without
                 extending the trace's retention tier.

--- a/python/langsmith/async_client.py
+++ b/python/langsmith/async_client.py
@@ -1027,8 +1027,11 @@ class AsyncClient:
                 feedback.
             extra: Metadata for the feedback.
             error: Whether the feedback represents an error.
-            session_id: The project ID of the run this feedback is for.
-            start_time: The start time of the run this feedback is for.
+            session_id: The project ID of the run. Required for run-level feedback;
+                omitting it is deprecated. See
+                https://docs.langchain.com/langsmith/smithdb-sdk-migration#feedback-create
+            start_time: The start time of the run. With `session_id` and `trace_id`,
+                skips the server-side run lookup.
             comment: A comment about this feedback.
             extend_trace_retention: If false, create the feedback without
                 extending the trace's retention tier.
@@ -1047,6 +1050,8 @@ class AsyncClient:
             raise ValueError(
                 "project_id cannot be provided if run_id or trace_id is provided"
             )
+        if run_id is not None and session_id is None:
+            ls_client._check_feedback_session_id(await self.info())
         if kwargs:
             warnings.warn(
                 "The following arguments are no longer used in the create_feedback"

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -678,6 +678,25 @@ def _format_feedback_score(score: Union[float, int, bool, None]):
     return score
 
 
+def _check_feedback_session_id(info: ls_schemas.LangSmithInfo) -> None:
+    """Raise on SmithDB-only deployments, warn elsewhere.
+
+    Call only when run-level feedback has no ``session_id``.
+    """
+    docs = "https://docs.langchain.com/langsmith/smithdb-sdk-migration#feedback-create"
+    if (info.instance_flags or {}).get("ch_query_enabled") is False:
+        raise ValueError(
+            "session_id must be provided when creating feedback for a run:"
+            f" this deployment cannot locate the run without it. See {docs}"
+        )
+    warnings.warn(
+        "Creating feedback for a run without session_id is deprecated and will"
+        f" stop working in a future release. See {docs}",
+        ls_utils.LangSmithWarning,
+        stacklevel=3,
+    )
+
+
 def _get_tracing_sampling_rate(
     tracing_sampling_rate: Optional[float] = None,
 ) -> float | None:
@@ -7765,11 +7784,12 @@ class Client:
             extra (Optional[Dict]):
                 Metadata for the feedback.
             session_id (Optional[Union[UUID, str]]):
-                The session (project) ID of the run this feedback is for. Used to
-                optimize feedback ingestion by avoiding server-side lookups.
+                The session (project) ID of the run. Required for run-level
+                feedback; omitting it is deprecated. See
+                https://docs.langchain.com/langsmith/smithdb-sdk-migration#feedback-create
             start_time (Optional[datetime]):
-                The start time of the run this feedback is for. Used to optimize
-                feedback ingestion by avoiding server-side lookups.
+                The start time of the run. With `session_id` and `trace_id`, skips
+                the server-side run lookup.
             extend_trace_retention (bool, default=True):
                 If false, create the feedback without extending the trace's retention
                 tier.
@@ -7830,6 +7850,8 @@ class Client:
             raise ValueError(
                 "project_id cannot be provided if run_id or trace_id is provided"
             )
+        if run_id is not None and session_id is None:
+            _check_feedback_session_id(self.info)
         if kwargs:
             warnings.warn(
                 "The following arguments are no longer used in the create_feedback"

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -7788,8 +7788,7 @@ class Client:
                 feedback; omitting it is deprecated. See
                 https://docs.langchain.com/langsmith/smithdb-sdk-migration#feedback-create
             start_time (Optional[datetime]):
-                The start time of the run. With `session_id` and `trace_id`, skips
-                the server-side run lookup.
+                The start time of the run. Better performance if provided.
             extend_trace_retention (bool, default=True):
                 If false, create the feedback without extending the trace's retention
                 tier.

--- a/python/tests/unit_tests/test_async_client.py
+++ b/python/tests/unit_tests/test_async_client.py
@@ -283,7 +283,9 @@ async def test_create_feedback_forwards_trace_id(
     mock_httpx_client.request.return_value = response
 
     client = AsyncClient(api_url="http://localhost:1984", api_key="test")
-    await client.create_feedback(run_id, key="quality", score=1, trace_id=trace_id)
+    await client.create_feedback(
+        run_id, key="quality", score=1, trace_id=trace_id, session_id=uuid4()
+    )
 
     call = mock_httpx_client.request.call_args
     assert call.args[0] == "POST"
@@ -339,7 +341,9 @@ async def test_create_feedback_retries_on_not_found(
         api_key="test",
         retry_config={"max_retries": 2},
     )
-    feedback = await client.create_feedback(run_id, key="quality", trace_id=trace_id)
+    feedback = await client.create_feedback(
+        run_id, key="quality", trace_id=trace_id, session_id=uuid4()
+    )
 
     # A 404 (run not yet ingested) is retried, unlike other 4xx.
     assert mock_httpx_client.request.call_count == 2
@@ -397,6 +401,36 @@ async def test_async_create_feedback_includes_trace_id_and_feedback_id(
     assert body["value"] == "test_value"
     assert body["comment"] == "test_comment"
     assert body["feedback_source"]["type"] == "api"
+
+
+@mock.patch("langsmith.async_client.httpx.AsyncClient")
+@pytest.mark.asyncio
+async def test_async_create_feedback_requires_session_id_on_smithdb(
+    mock_client_cls: mock.Mock,
+) -> None:
+    """SmithDB-only backends cannot locate the run without session_id."""
+    mock_httpx_client = AsyncMock()
+    mock_client_cls.return_value = mock_httpx_client
+    client = AsyncClient(api_url="http://localhost:1984", api_key="test-api-key")
+    client._info = ls_schemas.LangSmithInfo(instance_flags={"ch_query_enabled": False})
+
+    with pytest.raises(ValueError, match="session_id must be provided"):
+        await client.create_feedback(uuid4(), key="quality")
+    mock_httpx_client.request.assert_not_called()
+
+    mock_httpx_client.request.return_value = httpx.Response(
+        200,
+        json={
+            "id": str(uuid4()),
+            "key": "quality",
+            "created_at": datetime.now().isoformat(),
+            "modified_at": datetime.now().isoformat(),
+        },
+        request=httpx.Request("POST", "http://localhost:1984/feedback"),
+    )
+    client._info = ls_schemas.LangSmithInfo(instance_flags={"ch_query_enabled": True})
+    with pytest.warns(ls_utils.LangSmithWarning, match="smithdb-sdk-migration"):
+        await client.create_feedback(uuid4(), key="quality")
 
 
 @mock.patch("langsmith.async_client.httpx.AsyncClient")
@@ -560,6 +594,7 @@ async def test_async_create_feedback_retries_on_not_found(
         trace_id=trace_id,
         feedback_id=feedback_id,
         key="test_key",
+        session_id=uuid.uuid4(),
         stop_after_attempt=2,
     )
 

--- a/python/tests/unit_tests/test_client.py
+++ b/python/tests/unit_tests/test_client.py
@@ -1920,6 +1920,43 @@ def test_create_feedback_opt_out_uses_direct_post_when_batching_available() -> N
     assert client.tracing_queue.qsize() == 0
 
 
+def _feedback_client(session: mock.Mock, **flags: bool) -> Client:
+    return Client(
+        api_url="http://localhost:1984",
+        api_key="123",
+        session=session,
+        info=ls_schemas.LangSmithInfo(version="0.8.11", instance_flags=flags),
+    )
+
+
+def test_create_feedback_requires_session_id_when_ch_query_disabled() -> None:
+    """SmithDB-only backends cannot locate the run without session_id."""
+    session = mock.Mock()
+    client = _feedback_client(session, ch_query_enabled=False)
+
+    with pytest.raises(ValueError, match="session_id must be provided"):
+        client.create_feedback(uuid.uuid4(), key="Foo")
+
+    session.request.assert_not_called()
+
+    # start_time stays optional, matching the server.
+    client.create_feedback(uuid.uuid4(), key="Foo", session_id=uuid.uuid4())
+    session.request.assert_called_once()
+
+    # Session-level feedback has no run to locate.
+    client.create_feedback(None, key="Foo", project_id=uuid.uuid4())
+
+
+def test_create_feedback_warns_without_session_id() -> None:
+    """Backends that can still look the run up get a deprecation warning."""
+    session = mock.Mock()
+    client = _feedback_client(session, ch_query_enabled=True)
+
+    with pytest.warns(ls_utils.LangSmithWarning, match="smithdb-sdk-migration"):
+        client.create_feedback(uuid.uuid4(), key="Foo")
+    session.request.assert_called_once()
+
+
 def test_pydantic_serialize() -> None:
     """Test that pydantic objects can be serialized."""
     test_uuid = uuid.uuid4()


### PR DESCRIPTION
## Summary

On SmithDB-only deployments (ClickHouse queries disabled), the server cannot associate
run-level feedback with its run unless the client supplies `session_id` — `POST /feedback`
returns **HTTP 501** pointing at the migration guide. Both SDKs let `session_id` default to
`None`, so callers only discover this at runtime, on the deployment that lacks ClickHouse.

This adds a client-side check to `create_feedback` / `createFeedback`: a hard error when the
backend advertises SmithDB-only, and a deprecation warning everywhere else, so the requirement
surfaces before the request is sent and ahead of the future removal.

## Changes

- **Capability-gated check.** When feedback has a `run_id` but no `session_id`, the SDKs read
  the `/info` flag `instance_flags["ch_query_enabled"]`. When explicitly `false`, they raise
  (`ValueError` / `Error`) without sending the request; otherwise they emit a one-time
  deprecation warning (`LangSmithWarning` / `warnOnce`) linking to
  [the migration guide](https://docs.langchain.com/langsmith/smithdb-sdk-migration#feedback-create).
  `/info` is only consulted when `session_id` is actually missing, so the common path adds no
  request. `/info` failures degrade to the warning, never the error.
- **Session-level feedback is exempt.** Feedback created with `project_id` and no run has no run
  to locate, and is unaffected.
- **JS params-object overload.** `createFeedback(params)` now accepts a single object in which
  `sessionId` is **required** by the type, so the constraint is enforced at compile time rather
  than only at runtime. The positional `createFeedback(runId, key, options)` signature is kept
  and marked `@deprecated`, following the existing `logEvaluationFeedback` convention. The params
  type is a discriminated union — `{ runId, sessionId, … }` or `{ projectId, … }` — so
  session-level feedback is still expressible.
- **Docs.** `session_id` / `sessionId` is documented as required for run-level feedback with the
  migration link; `start_time` is described as a lookup-skipping optimization.

## Compatibility

- No behavior change on ClickHouse-enabled backends beyond a one-time deprecation warning.
- Matches the server's own gate exactly: only `session_id` is required. `start_time` stays
  optional.
- The deprecated JS positional signature still compiles unchanged, including the no-op `eager`
  option, which is retained on the legacy options type for source compatibility.
- Internal SDK callers (per-run, comparative, and summary evaluators; the pytest integration)
  already pass a session and are unaffected.

## Testing

- Python unit tests, sync and async: raises without `session_id` when `ch_query_enabled: false`
  and sends nothing; accepts `session_id` without `start_time`; warns on other backends;
  session-level feedback exempt.
- JS unit tests for the same matrix, plus a `@ts-expect-error` assertion that a run-level
  params-object call without `sessionId` fails to compile (`tsconfig` covers `src/tests`, so CI's
  `tsc` enforces it).
