### PR TITLE
fix(sandbox): raise WebSocket open timeout to 120s

### DIFF
--- a/js/src/sandbox/ws_execute.ts
+++ b/js/src/sandbox/ws_execute.ts
@@ -12,6 +12,24 @@ import {
   LangSmithSandboxServerReloadError,
 } from "./errors.js";
 import type { WsMessage, WsRunOptions } from "./types.js";
+import { getLangSmithEnvironmentVariable } from "../utils/env.js";
+
+/** Read a WebSocket timeout override, in seconds. `<= 0` disables it. */
+function envTimeout(name: string, defaultSeconds: number): number | undefined {
+  const raw = getLangSmithEnvironmentVariable(name);
+  if (raw === undefined || raw.trim() === "") return defaultSeconds;
+  const value = Number(raw);
+  if (!Number.isFinite(value)) {
+    console.warn(
+      `Ignoring invalid LANGSMITH_${name}=${raw}, using ${defaultSeconds}`
+    );
+    return defaultSeconds;
+  }
+  return value > 0 ? value : undefined;
+}
+
+// Cold-start sandboxes can take well over a minute to accept the connection.
+export const WS_OPEN_TIMEOUT = envTimeout("SANDBOX_WS_TIMEOUT_OPEN", 120);
 
 // =============================================================================
 // Lazy ws import (optional peer dependency)
@@ -25,7 +43,7 @@ type WsWebSocket = any;
 // installed. run() reads isWsAvailable() to choose WS vs the HTTP fallback.
 const wsWebSocketPromise: Promise<WsWebSocket | null> = import("ws").then(
   (ws) => ws.default || ws.WebSocket || ws,
-  () => null,
+  () => null
 );
 
 /** Whether the optional `ws` package could be loaded (resolved once). */
@@ -41,7 +59,7 @@ async function ensureWs(): Promise<{
   if (!WebSocket) {
     throw new Error(
       "WebSocket-based execution requires the 'ws' package. " +
-        "Install it with: npm install ws",
+        "Install it with: npm install ws"
     );
   }
   return { WebSocket };
@@ -66,7 +84,7 @@ export function buildWsUrl(dataplaneUrl: string): string {
  */
 export function buildAuthHeaders(
   apiKey: string | undefined,
-  extraHeaders?: Record<string, string>,
+  extraHeaders?: Record<string, string>
 ): Record<string, string> {
   const headers: Record<string, string> = {};
   if (apiKey) {
@@ -144,21 +162,21 @@ export function raiseForWsError(msg: WsMessage, commandId = ""): never {
     throw new LangSmithSandboxOperationError(
       commandId ? `Command not found: ${commandId}` : errorMsg,
       commandId ? "reconnect" : "command",
-      errorType,
+      errorType
     );
   }
   if (errorType === "SessionExpired") {
     throw new LangSmithSandboxOperationError(
       commandId ? `Session expired: ${commandId}` : errorMsg,
       commandId ? "reconnect" : "command",
-      errorType,
+      errorType
     );
   }
 
   throw new LangSmithSandboxOperationError(
     errorMsg,
     commandId ? "reconnect" : "command",
-    errorType,
+    errorType
   );
 }
 
@@ -172,11 +190,15 @@ export function raiseForWsError(msg: WsMessage, commandId = ""): never {
  */
 async function connectWs(
   url: string,
-  headers: Record<string, string>,
+  headers: Record<string, string>
 ): Promise<WsWebSocket> {
   const { WebSocket: WS } = await ensureWs();
   return new Promise((resolve, reject) => {
-    const ws = new WS(url, { headers });
+    const ws = new WS(url, {
+      headers,
+      handshakeTimeout:
+        WS_OPEN_TIMEOUT === undefined ? undefined : WS_OPEN_TIMEOUT * 1000,
+    });
 
     ws.on("open", () => {
       ws.removeAllListeners("error");
@@ -187,8 +209,8 @@ async function connectWs(
       ws.removeAllListeners("open");
       reject(
         new LangSmithSandboxConnectionError(
-          `Failed to connect to sandbox WebSocket: ${err.message}`,
-        ),
+          `Failed to connect to sandbox WebSocket: ${err.message}`
+        )
       );
     });
   });
@@ -201,7 +223,7 @@ async function connectWs(
  * mapping them to appropriate exceptions.
  */
 async function* readWsMessages(
-  ws: WsWebSocket,
+  ws: WsWebSocket
 ): AsyncIterableIterator<WsMessage> {
   // Buffer incoming messages so the consumer can process them at its own pace
   const messageQueue: WsMessage[] = [];
@@ -224,11 +246,11 @@ async function* readWsMessages(
     done = true;
     if (code === 1001) {
       error = new LangSmithSandboxServerReloadError(
-        "Server is reloading, reconnect to resume",
+        "Server is reloading, reconnect to resume"
       );
     } else if (code !== 1000) {
       error = new LangSmithSandboxConnectionError(
-        `WebSocket connection closed unexpectedly (code: ${code}, reason: ${reason.toString()})`,
+        `WebSocket connection closed unexpectedly (code: ${code}, reason: ${reason.toString()})`
       );
     }
     if (resolve) {
@@ -242,7 +264,7 @@ async function* readWsMessages(
     done = true;
     if (!error) {
       error = new LangSmithSandboxConnectionError(
-        `WebSocket connection error: ${err.message}`,
+        `WebSocket connection error: ${err.message}`
       );
     }
     if (resolve) {
@@ -306,7 +328,7 @@ export async function runWsStream(
   dataplaneUrl: string,
   apiKey: string | undefined,
   command: string,
-  options: WsRunOptions = {},
+  options: WsRunOptions = {}
 ): Promise<[AsyncIterableIterator<WsMessage>, WSStreamControl]> {
   const {
     timeout = 60,
@@ -395,7 +417,7 @@ export async function reconnectWsStream(
     stdoutOffset?: number;
     stderrOffset?: number;
     headers?: Record<string, string>;
-  } = {},
+  } = {}
 ): Promise<[AsyncIterableIterator<WsMessage>, WSStreamControl]> {
   const { stdoutOffset = 0, stderrOffset = 0, headers: extraHeaders } = options;
 
@@ -416,7 +438,7 @@ export async function reconnectWsStream(
           command_id: commandId,
           stdout_offset: stdoutOffset,
           stderr_offset: stderrOffset,
-        }),
+        })
       );
 
       // Read messages until exit or error

--- a/js/src/sandbox/ws_execute.ts
+++ b/js/src/sandbox/ws_execute.ts
@@ -21,7 +21,7 @@ function envTimeout(name: string, defaultSeconds: number): number | undefined {
   const value = Number(raw);
   if (!Number.isFinite(value)) {
     console.warn(
-      `Ignoring invalid LANGSMITH_${name}=${raw}, using ${defaultSeconds}`
+      `Ignoring invalid LANGSMITH_${name}=${raw}, using ${defaultSeconds}`,
     );
     return defaultSeconds;
   }
@@ -43,7 +43,7 @@ type WsWebSocket = any;
 // installed. run() reads isWsAvailable() to choose WS vs the HTTP fallback.
 const wsWebSocketPromise: Promise<WsWebSocket | null> = import("ws").then(
   (ws) => ws.default || ws.WebSocket || ws,
-  () => null
+  () => null,
 );
 
 /** Whether the optional `ws` package could be loaded (resolved once). */
@@ -59,7 +59,7 @@ async function ensureWs(): Promise<{
   if (!WebSocket) {
     throw new Error(
       "WebSocket-based execution requires the 'ws' package. " +
-        "Install it with: npm install ws"
+        "Install it with: npm install ws",
     );
   }
   return { WebSocket };
@@ -84,7 +84,7 @@ export function buildWsUrl(dataplaneUrl: string): string {
  */
 export function buildAuthHeaders(
   apiKey: string | undefined,
-  extraHeaders?: Record<string, string>
+  extraHeaders?: Record<string, string>,
 ): Record<string, string> {
   const headers: Record<string, string> = {};
   if (apiKey) {
@@ -162,21 +162,21 @@ export function raiseForWsError(msg: WsMessage, commandId = ""): never {
     throw new LangSmithSandboxOperationError(
       commandId ? `Command not found: ${commandId}` : errorMsg,
       commandId ? "reconnect" : "command",
-      errorType
+      errorType,
     );
   }
   if (errorType === "SessionExpired") {
     throw new LangSmithSandboxOperationError(
       commandId ? `Session expired: ${commandId}` : errorMsg,
       commandId ? "reconnect" : "command",
-      errorType
+      errorType,
     );
   }
 
   throw new LangSmithSandboxOperationError(
     errorMsg,
     commandId ? "reconnect" : "command",
-    errorType
+    errorType,
   );
 }
 
@@ -190,7 +190,7 @@ export function raiseForWsError(msg: WsMessage, commandId = ""): never {
  */
 async function connectWs(
   url: string,
-  headers: Record<string, string>
+  headers: Record<string, string>,
 ): Promise<WsWebSocket> {
   const { WebSocket: WS } = await ensureWs();
   return new Promise((resolve, reject) => {
@@ -209,8 +209,8 @@ async function connectWs(
       ws.removeAllListeners("open");
       reject(
         new LangSmithSandboxConnectionError(
-          `Failed to connect to sandbox WebSocket: ${err.message}`
-        )
+          `Failed to connect to sandbox WebSocket: ${err.message}`,
+        ),
       );
     });
   });
@@ -223,7 +223,7 @@ async function connectWs(
  * mapping them to appropriate exceptions.
  */
 async function* readWsMessages(
-  ws: WsWebSocket
+  ws: WsWebSocket,
 ): AsyncIterableIterator<WsMessage> {
   // Buffer incoming messages so the consumer can process them at its own pace
   const messageQueue: WsMessage[] = [];
@@ -246,11 +246,11 @@ async function* readWsMessages(
     done = true;
     if (code === 1001) {
       error = new LangSmithSandboxServerReloadError(
-        "Server is reloading, reconnect to resume"
+        "Server is reloading, reconnect to resume",
       );
     } else if (code !== 1000) {
       error = new LangSmithSandboxConnectionError(
-        `WebSocket connection closed unexpectedly (code: ${code}, reason: ${reason.toString()})`
+        `WebSocket connection closed unexpectedly (code: ${code}, reason: ${reason.toString()})`,
       );
     }
     if (resolve) {
@@ -264,7 +264,7 @@ async function* readWsMessages(
     done = true;
     if (!error) {
       error = new LangSmithSandboxConnectionError(
-        `WebSocket connection error: ${err.message}`
+        `WebSocket connection error: ${err.message}`,
       );
     }
     if (resolve) {
@@ -328,7 +328,7 @@ export async function runWsStream(
   dataplaneUrl: string,
   apiKey: string | undefined,
   command: string,
-  options: WsRunOptions = {}
+  options: WsRunOptions = {},
 ): Promise<[AsyncIterableIterator<WsMessage>, WSStreamControl]> {
   const {
     timeout = 60,
@@ -417,7 +417,7 @@ export async function reconnectWsStream(
     stdoutOffset?: number;
     stderrOffset?: number;
     headers?: Record<string, string>;
-  } = {}
+  } = {},
 ): Promise<[AsyncIterableIterator<WsMessage>, WSStreamControl]> {
   const { stdoutOffset = 0, stderrOffset = 0, headers: extraHeaders } = options;
 
@@ -438,7 +438,7 @@ export async function reconnectWsStream(
           command_id: commandId,
           stdout_offset: stdoutOffset,
           stderr_offset: stderrOffset,
-        })
+        }),
       );
 
       // Read messages until exit or error

--- a/python/langsmith/sandbox/_tunnel.py
+++ b/python/langsmith/sandbox/_tunnel.py
@@ -314,7 +314,7 @@ class Tunnel:
             ws_url,
             additional_headers=headers,
             open_timeout=120,
-            close_timeout=5,
+            close_timeout=120,
             ping_interval=None,  # yamux handles keepalive
         )
 

--- a/python/langsmith/sandbox/_tunnel.py
+++ b/python/langsmith/sandbox/_tunnel.py
@@ -313,7 +313,7 @@ class Tunnel:
         self._ws = ws_connect(
             ws_url,
             additional_headers=headers,
-            open_timeout=15,
+            open_timeout=120,
             close_timeout=5,
             ping_interval=None,  # yamux handles keepalive
         )

--- a/python/langsmith/sandbox/_tunnel.py
+++ b/python/langsmith/sandbox/_tunnel.py
@@ -17,6 +17,7 @@ from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any, Optional
 
 from langsmith.sandbox._helpers import merge_headers
+from langsmith.sandbox._ws_execute import WS_OPEN_TIMEOUT
 
 if TYPE_CHECKING:
     from langsmith.sandbox._yamux import YamuxSession, YamuxStream
@@ -313,8 +314,8 @@ class Tunnel:
         self._ws = ws_connect(
             ws_url,
             additional_headers=headers,
-            open_timeout=120,
-            close_timeout=120,
+            open_timeout=WS_OPEN_TIMEOUT,
+            close_timeout=5,
             ping_interval=None,  # yamux handles keepalive
         )
 

--- a/python/langsmith/sandbox/_ws_execute.py
+++ b/python/langsmith/sandbox/_ws_execute.py
@@ -272,7 +272,7 @@ def run_ws_stream(
                 open_timeout=120,
                 close_timeout=10,
                 ping_interval=30,
-                ping_timeout=60,
+                ping_timeout=120,
             ) as ws:
                 control._bind(ws)
 
@@ -373,7 +373,7 @@ def reconnect_ws_stream(
                 open_timeout=120,
                 close_timeout=10,
                 ping_interval=30,
-                ping_timeout=60,
+                ping_timeout=120,
             ) as ws:
                 control._bind(ws)
 
@@ -462,7 +462,7 @@ async def run_ws_stream_async(
                 open_timeout=120,
                 close_timeout=10,
                 ping_interval=30,
-                ping_timeout=60,
+                ping_timeout=120,
             ) as ws:
                 control._bind(ws)
 
@@ -546,7 +546,7 @@ async def reconnect_ws_stream_async(
                 open_timeout=120,
                 close_timeout=10,
                 ping_interval=30,
-                ping_timeout=60,
+                ping_timeout=120,
             ) as ws:
                 control._bind(ws)
 

--- a/python/langsmith/sandbox/_ws_execute.py
+++ b/python/langsmith/sandbox/_ws_execute.py
@@ -30,6 +30,13 @@ except ImportError:
     WEBSOCKETS_AVAILABLE = False
 
 
+# Cold-start sandboxes can take well over a minute to accept the connection.
+WS_OPEN_TIMEOUT = 120
+WS_PING_INTERVAL = 30
+WS_PING_TIMEOUT = 120
+# Kept short: a dead peer would otherwise stall teardown for the full duration.
+WS_CLOSE_TIMEOUT = 10
+
 _MISSING_WEBSOCKETS_MSG = (
     "WebSocket-based execution requires the 'websockets' package, which ships "
     "with langsmith by default. Reinstall with: pip install --upgrade langsmith"
@@ -269,10 +276,10 @@ def run_ws_stream(
             with ws_connect(
                 ws_url,
                 additional_headers=request_headers,
-                open_timeout=120,
-                close_timeout=120,
-                ping_interval=30,
-                ping_timeout=120,
+                open_timeout=WS_OPEN_TIMEOUT,
+                close_timeout=WS_CLOSE_TIMEOUT,
+                ping_interval=WS_PING_INTERVAL,
+                ping_timeout=WS_PING_TIMEOUT,
             ) as ws:
                 control._bind(ws)
 
@@ -370,10 +377,10 @@ def reconnect_ws_stream(
             with ws_connect(
                 ws_url,
                 additional_headers=request_headers,
-                open_timeout=120,
-                close_timeout=120,
-                ping_interval=30,
-                ping_timeout=120,
+                open_timeout=WS_OPEN_TIMEOUT,
+                close_timeout=WS_CLOSE_TIMEOUT,
+                ping_interval=WS_PING_INTERVAL,
+                ping_timeout=WS_PING_TIMEOUT,
             ) as ws:
                 control._bind(ws)
 
@@ -459,10 +466,10 @@ async def run_ws_stream_async(
             async with ws_connect_async(
                 ws_url,
                 additional_headers=request_headers,
-                open_timeout=120,
-                close_timeout=120,
-                ping_interval=30,
-                ping_timeout=120,
+                open_timeout=WS_OPEN_TIMEOUT,
+                close_timeout=WS_CLOSE_TIMEOUT,
+                ping_interval=WS_PING_INTERVAL,
+                ping_timeout=WS_PING_TIMEOUT,
             ) as ws:
                 control._bind(ws)
 
@@ -543,10 +550,10 @@ async def reconnect_ws_stream_async(
             async with ws_connect_async(
                 ws_url,
                 additional_headers=request_headers,
-                open_timeout=120,
-                close_timeout=120,
-                ping_interval=30,
-                ping_timeout=120,
+                open_timeout=WS_OPEN_TIMEOUT,
+                close_timeout=WS_CLOSE_TIMEOUT,
+                ping_interval=WS_PING_INTERVAL,
+                ping_timeout=WS_PING_TIMEOUT,
             ) as ws:
                 control._bind(ws)
 

--- a/python/langsmith/sandbox/_ws_execute.py
+++ b/python/langsmith/sandbox/_ws_execute.py
@@ -270,7 +270,7 @@ def run_ws_stream(
                 ws_url,
                 additional_headers=request_headers,
                 open_timeout=120,
-                close_timeout=10,
+                close_timeout=120,
                 ping_interval=30,
                 ping_timeout=120,
             ) as ws:
@@ -371,7 +371,7 @@ def reconnect_ws_stream(
                 ws_url,
                 additional_headers=request_headers,
                 open_timeout=120,
-                close_timeout=10,
+                close_timeout=120,
                 ping_interval=30,
                 ping_timeout=120,
             ) as ws:
@@ -460,7 +460,7 @@ async def run_ws_stream_async(
                 ws_url,
                 additional_headers=request_headers,
                 open_timeout=120,
-                close_timeout=10,
+                close_timeout=120,
                 ping_interval=30,
                 ping_timeout=120,
             ) as ws:
@@ -544,7 +544,7 @@ async def reconnect_ws_stream_async(
                 ws_url,
                 additional_headers=request_headers,
                 open_timeout=120,
-                close_timeout=10,
+                close_timeout=120,
                 ping_interval=30,
                 ping_timeout=120,
             ) as ws:

--- a/python/langsmith/sandbox/_ws_execute.py
+++ b/python/langsmith/sandbox/_ws_execute.py
@@ -269,7 +269,7 @@ def run_ws_stream(
             with ws_connect(
                 ws_url,
                 additional_headers=request_headers,
-                open_timeout=30,
+                open_timeout=120,
                 close_timeout=10,
                 ping_interval=30,
                 ping_timeout=60,
@@ -370,7 +370,7 @@ def reconnect_ws_stream(
             with ws_connect(
                 ws_url,
                 additional_headers=request_headers,
-                open_timeout=30,
+                open_timeout=120,
                 close_timeout=10,
                 ping_interval=30,
                 ping_timeout=60,
@@ -459,7 +459,7 @@ async def run_ws_stream_async(
             async with ws_connect_async(
                 ws_url,
                 additional_headers=request_headers,
-                open_timeout=30,
+                open_timeout=120,
                 close_timeout=10,
                 ping_interval=30,
                 ping_timeout=60,
@@ -543,7 +543,7 @@ async def reconnect_ws_stream_async(
             async with ws_connect_async(
                 ws_url,
                 additional_headers=request_headers,
-                open_timeout=30,
+                open_timeout=120,
                 close_timeout=10,
                 ping_interval=30,
                 ping_timeout=60,

--- a/python/langsmith/sandbox/_ws_execute.py
+++ b/python/langsmith/sandbox/_ws_execute.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 import json
+import logging
 from collections.abc import AsyncIterator, Iterator, Mapping
 from typing import Any, Callable, Optional
 
+from langsmith import utils as ls_utils
 from langsmith.sandbox._exceptions import (
     CommandTimeoutError,
     SandboxConnectionError,
@@ -14,6 +16,8 @@ from langsmith.sandbox._exceptions import (
     SandboxServerReloadError,
 )
 from langsmith.sandbox._helpers import merge_headers
+
+logger = logging.getLogger(__name__)
 
 # Resolve the optional ``websockets`` dependency once, at import time, instead
 # of re-importing on every WS call. ``WEBSOCKETS_AVAILABLE`` is what run() reads
@@ -30,12 +34,25 @@ except ImportError:
     WEBSOCKETS_AVAILABLE = False
 
 
+def _env_timeout(name: str, default: float) -> Optional[float]:
+    """Read a WebSocket timeout override, in seconds. ``<= 0`` disables it."""
+    raw = ls_utils.get_env_var(name)
+    if raw is None:
+        return default
+    try:
+        value = float(raw)
+    except ValueError:
+        logger.warning("Ignoring invalid LANGSMITH_%s=%r, using %s", name, raw, default)
+        return default
+    return value if value > 0 else None
+
+
 # Cold-start sandboxes can take well over a minute to accept the connection.
-WS_OPEN_TIMEOUT = 120
-WS_PING_INTERVAL = 30
-WS_PING_TIMEOUT = 120
+WS_OPEN_TIMEOUT = _env_timeout("SANDBOX_WS_TIMEOUT_OPEN", 120)
+WS_PING_INTERVAL = _env_timeout("SANDBOX_WS_TIMEOUT_PING_INTERVAL", 30)
+WS_PING_TIMEOUT = _env_timeout("SANDBOX_WS_TIMEOUT_PING", 120)
 # Kept short: a dead peer would otherwise stall teardown for the full duration.
-WS_CLOSE_TIMEOUT = 10
+WS_CLOSE_TIMEOUT = _env_timeout("SANDBOX_WS_TIMEOUT_CLOSE", 10)
 
 _MISSING_WEBSOCKETS_MSG = (
     "WebSocket-based execution requires the 'websockets' package, which ships "


### PR DESCRIPTION
Sandbox WebSocket connects were bounded at 30s (15s for the tunnel), which a cold-start sandbox can exceed. That surfaced as `SandboxConnectionError: Failed to connect to sandbox: timed out` raised out of `socket.create_connection` — before the WebSocket handshake — and this path has no retry of its own (`_transport.py` retries only cover the httpx/REST calls).

**Python** — timeouts hoisted to module constants in `_ws_execute.py` and applied at all four call sites (sync/async × execute/reconnect); `_tunnel.py` reuses `WS_OPEN_TIMEOUT`.

| constant | env override | default |
|---|---|---|
| `WS_OPEN_TIMEOUT` | `LANGSMITH_SANDBOX_WS_TIMEOUT_OPEN` | 120s (was 30 / 15) |
| `WS_PING_INTERVAL` | `LANGSMITH_SANDBOX_WS_TIMEOUT_PING_INTERVAL` | 30s (unchanged) |
| `WS_PING_TIMEOUT` | `LANGSMITH_SANDBOX_WS_TIMEOUT_PING` | 120s (was 60) |
| `WS_CLOSE_TIMEOUT` | `LANGSMITH_SANDBOX_WS_TIMEOUT_CLOSE` | 10s (unchanged) |

`close_timeout` is deliberately left short — it only bounds the closing handshake, so raising it would stall teardown against a dead peer with no upside. A value `<= 0` disables the timeout; an unparseable value logs a warning and falls back to the default. `LANGCHAIN_`-prefixed names work too, per `get_env_var`.

**JS** — `connectWs` had no connect bound at all, so a hung connect waited for the OS TCP timeout. It now passes `handshakeTimeout`, defaulting to 120s and overridable with `LANGSMITH_SANDBOX_WS_TIMEOUT_OPEN`. `ws` exposes no client-side equivalent of `ping_interval`/`ping_timeout`/`close_timeout`, so only the open timeout is configurable there.

Go (`langsmith-go`) has the same unbounded-dial gap and is not touched here.

## Test Plan
- [x] `uv run pytest tests/unit_tests -k "sandbox or ws"` — 521 passed
- [x] Verified env overrides, `<= 0` disabling, and invalid-value fallback by import
- [x] `ruff format`/`ruff check`, `tsc --noEmit`, `oxlint`, `oxfmt`