### PR TITLE
fix(sandbox): retry WebSocket connect failures instead of waiting longer

### DIFF
--- a/python/langsmith/sandbox/__init__.py
+++ b/python/langsmith/sandbox/__init__.py
@@ -45,6 +45,7 @@ from langsmith.sandbox._exceptions import (
     SandboxAuthenticationError,
     SandboxClientError,
     SandboxConnectionError,
+    SandboxConnectTimeoutError,
     SandboxNotReadyError,
     SandboxOperationError,
     SandboxServerReloadError,
@@ -144,6 +145,7 @@ __all__ = [
     "SandboxAPIError",
     "SandboxAuthenticationError",
     "SandboxConnectionError",
+    "SandboxConnectTimeoutError",
     "SandboxServerReloadError",
     # Resource errors (type-based with resource_type attribute)
     "ResourceCreationError",

--- a/python/langsmith/sandbox/_async_sandbox.py
+++ b/python/langsmith/sandbox/_async_sandbox.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import time
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Callable, Literal, Optional, Union, overload
@@ -23,7 +24,11 @@ from langsmith.sandbox._models import (
     _StreamEndedBeforeStarted,
 )
 from langsmith.sandbox._tunnel import AsyncTunnel
-from langsmith.sandbox._ws_execute import WEBSOCKETS_AVAILABLE
+from langsmith.sandbox._ws_execute import (
+    WEBSOCKETS_AVAILABLE,
+    connect_deadline,
+    open_timeout_for,
+)
 
 if TYPE_CHECKING:
     from langsmith.sandbox._async_client import AsyncSandboxClient
@@ -412,7 +417,9 @@ class AsyncSandbox:
             ws_kwargs["headers"] = merged
 
         attempt = 0
+        deadline = connect_deadline()
         while True:
+            ws_kwargs["open_timeout"] = open_timeout_for(deadline)
             msg_stream, control = await run_ws_stream_async(
                 dataplane_url,
                 api_key,
@@ -435,12 +442,16 @@ class AsyncSandbox:
                 attempt += 1
                 if attempt > AsyncCommandHandle.MAX_AUTO_RECONNECTS:
                     raise
-                await asyncio.sleep(
-                    min(
-                        AsyncCommandHandle._BACKOFF_BASE * (2 ** (attempt - 1)),
-                        AsyncCommandHandle._BACKOFF_MAX,
-                    )
+                backoff = min(
+                    AsyncCommandHandle._BACKOFF_BASE * (2 ** (attempt - 1)),
+                    AsyncCommandHandle._BACKOFF_MAX,
                 )
+                if deadline is not None:
+                    remaining = deadline - time.monotonic()
+                    if remaining <= 0:
+                        raise
+                    backoff = min(backoff, remaining)
+                await asyncio.sleep(backoff)
 
         if not wait:
             return handle

--- a/python/langsmith/sandbox/_async_sandbox.py
+++ b/python/langsmith/sandbox/_async_sandbox.py
@@ -12,6 +12,7 @@ import httpx
 from langsmith.sandbox._exceptions import (
     DataplaneNotConfiguredError,
     ResourceNotFoundError,
+    SandboxConnectTimeoutError,
 )
 from langsmith.sandbox._helpers import handle_sandbox_http_error
 from langsmith.sandbox._models import (
@@ -428,8 +429,9 @@ class AsyncSandbox:
             try:
                 await handle._ensure_started()
                 break
-            except _StreamEndedBeforeStarted:
-                # Idempotent re-issue (same command_id) after an early close.
+            except (_StreamEndedBeforeStarted, SandboxConnectTimeoutError):
+                # Idempotent re-issue (same command_id): neither an early close
+                # nor a failed connect can have started a second command.
                 attempt += 1
                 if attempt > AsyncCommandHandle.MAX_AUTO_RECONNECTS:
                     raise

--- a/python/langsmith/sandbox/_exceptions.py
+++ b/python/langsmith/sandbox/_exceptions.py
@@ -44,6 +44,18 @@ class SandboxConnectionError(SandboxClientError):
     pass
 
 
+class SandboxConnectTimeoutError(SandboxConnectionError):
+    """Raised when the socket fails or times out before the WebSocket handshake.
+
+    Distinct from its parent because it is safely retryable: the execute frame
+    was never sent, so re-issuing the same command_id cannot double-run a
+    command. run() retries this with backoff; a plain SandboxConnectionError
+    (a rejected handshake) is permanent and propagates immediately.
+    """
+
+    pass
+
+
 class SandboxServerReloadError(SandboxConnectionError):
     """Raised when the server sends a 1001 Going Away close frame.
 

--- a/python/langsmith/sandbox/_sandbox.py
+++ b/python/langsmith/sandbox/_sandbox.py
@@ -22,7 +22,11 @@ from langsmith.sandbox._models import (
     _StreamEndedBeforeStarted,
 )
 from langsmith.sandbox._tunnel import Tunnel
-from langsmith.sandbox._ws_execute import WEBSOCKETS_AVAILABLE
+from langsmith.sandbox._ws_execute import (
+    WEBSOCKETS_AVAILABLE,
+    connect_deadline,
+    open_timeout_for,
+)
 
 if TYPE_CHECKING:
     from langsmith.sandbox._async_client import AsyncSandboxClient
@@ -410,7 +414,9 @@ class Sandbox:
             ws_kwargs["headers"] = merged
 
         attempt = 0
+        deadline = connect_deadline()
         while True:
+            ws_kwargs["open_timeout"] = open_timeout_for(deadline)
             msg_stream, control = run_ws_stream(
                 dataplane_url,
                 api_key,
@@ -432,12 +438,16 @@ class Sandbox:
                 attempt += 1
                 if attempt > CommandHandle.MAX_AUTO_RECONNECTS:
                     raise
-                time.sleep(
-                    min(
-                        CommandHandle._BACKOFF_BASE * (2 ** (attempt - 1)),
-                        CommandHandle._BACKOFF_MAX,
-                    )
+                backoff = min(
+                    CommandHandle._BACKOFF_BASE * (2 ** (attempt - 1)),
+                    CommandHandle._BACKOFF_MAX,
                 )
+                if deadline is not None:
+                    remaining = deadline - time.monotonic()
+                    if remaining <= 0:
+                        raise
+                    backoff = min(backoff, remaining)
+                time.sleep(backoff)
 
         if not wait:
             return handle

--- a/python/langsmith/sandbox/_sandbox.py
+++ b/python/langsmith/sandbox/_sandbox.py
@@ -11,6 +11,7 @@ import httpx
 from langsmith.sandbox._exceptions import (
     DataplaneNotConfiguredError,
     ResourceNotFoundError,
+    SandboxConnectTimeoutError,
 )
 from langsmith.sandbox._helpers import handle_sandbox_http_error
 from langsmith.sandbox._models import (
@@ -425,8 +426,9 @@ class Sandbox:
                     on_stderr=on_stderr,
                 )
                 break
-            except _StreamEndedBeforeStarted:
-                # Idempotent re-issue (same command_id) after an early close.
+            except (_StreamEndedBeforeStarted, SandboxConnectTimeoutError):
+                # Idempotent re-issue (same command_id): neither an early close
+                # nor a failed connect can have started a second command.
                 attempt += 1
                 if attempt > CommandHandle.MAX_AUTO_RECONNECTS:
                     raise

--- a/python/langsmith/sandbox/_ws_execute.py
+++ b/python/langsmith/sandbox/_ws_execute.py
@@ -11,6 +11,7 @@ from langsmith import utils as ls_utils
 from langsmith.sandbox._exceptions import (
     CommandTimeoutError,
     SandboxConnectionError,
+    SandboxConnectTimeoutError,
     SandboxNotReadyError,
     SandboxOperationError,
     SandboxServerReloadError,
@@ -47,10 +48,10 @@ def _env_timeout(name: str, default: float) -> Optional[float]:
     return value if value > 0 else None
 
 
-# Cold-start sandboxes can take well over a minute to accept the connection.
-WS_OPEN_TIMEOUT = _env_timeout("SANDBOX_WS_TIMEOUT_OPEN", 120)
+# A slow cold start is recovered by the retry loop in run(), not by waiting here.
+WS_OPEN_TIMEOUT = _env_timeout("SANDBOX_WS_TIMEOUT_OPEN", 30)
 WS_PING_INTERVAL = _env_timeout("SANDBOX_WS_TIMEOUT_PING_INTERVAL", 30)
-WS_PING_TIMEOUT = _env_timeout("SANDBOX_WS_TIMEOUT_PING", 120)
+WS_PING_TIMEOUT = _env_timeout("SANDBOX_WS_TIMEOUT_PING", 60)
 # Kept short: a dead peer would otherwise stall teardown for the full duration.
 WS_CLOSE_TIMEOUT = _env_timeout("SANDBOX_WS_TIMEOUT_CLOSE", 10)
 
@@ -356,7 +357,9 @@ def run_ws_stream(
                 f"WebSocket connection closed unexpectedly: {e}"
             ) from e
         except (OSError, RuntimeError) as e:
-            raise SandboxConnectionError(f"Failed to connect to sandbox: {e}") from e
+            raise SandboxConnectTimeoutError(
+                f"Failed to connect to sandbox: {e}"
+            ) from e
         finally:
             control._unbind()
 
@@ -439,7 +442,9 @@ def reconnect_ws_stream(
                 f"WebSocket connection closed unexpectedly: {e}"
             ) from e
         except (OSError, RuntimeError) as e:
-            raise SandboxConnectionError(f"Failed to connect to sandbox: {e}") from e
+            raise SandboxConnectTimeoutError(
+                f"Failed to connect to sandbox: {e}"
+            ) from e
         finally:
             control._unbind()
 
@@ -540,7 +545,9 @@ async def run_ws_stream_async(
                 f"WebSocket connection closed unexpectedly: {e}"
             ) from e
         except (OSError, RuntimeError) as e:
-            raise SandboxConnectionError(f"Failed to connect to sandbox: {e}") from e
+            raise SandboxConnectTimeoutError(
+                f"Failed to connect to sandbox: {e}"
+            ) from e
         finally:
             control._unbind()
 
@@ -608,7 +615,9 @@ async def reconnect_ws_stream_async(
                 f"WebSocket connection closed unexpectedly: {e}"
             ) from e
         except (OSError, RuntimeError) as e:
-            raise SandboxConnectionError(f"Failed to connect to sandbox: {e}") from e
+            raise SandboxConnectTimeoutError(
+                f"Failed to connect to sandbox: {e}"
+            ) from e
         finally:
             control._unbind()
 

--- a/python/langsmith/sandbox/_ws_execute.py
+++ b/python/langsmith/sandbox/_ws_execute.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+import time
 from collections.abc import AsyncIterator, Iterator, Mapping
 from typing import Any, Callable, Optional
 
@@ -54,6 +55,27 @@ WS_PING_INTERVAL = _env_timeout("SANDBOX_WS_TIMEOUT_PING_INTERVAL", 30)
 WS_PING_TIMEOUT = _env_timeout("SANDBOX_WS_TIMEOUT_PING", 60)
 # Kept short: a dead peer would otherwise stall teardown for the full duration.
 WS_CLOSE_TIMEOUT = _env_timeout("SANDBOX_WS_TIMEOUT_CLOSE", 10)
+# Ceiling on the whole connect phase. Without it, retrying a blackholed handshake
+# costs MAX_AUTO_RECONNECTS + 1 full open timeouts plus backoff.
+WS_CONNECT_BUDGET = _env_timeout("SANDBOX_WS_TIMEOUT_CONNECT_BUDGET", 120)
+
+
+def connect_deadline() -> Optional[float]:
+    """Monotonic instant after which connect attempts must stop, if bounded."""
+    if WS_CONNECT_BUDGET is None:
+        return None
+    return time.monotonic() + WS_CONNECT_BUDGET
+
+
+def open_timeout_for(deadline: Optional[float]) -> Optional[float]:
+    """Per-attempt open timeout, clamped so it cannot outlive ``deadline``."""
+    if deadline is None:
+        return WS_OPEN_TIMEOUT
+    remaining = max(deadline - time.monotonic(), 0.0)
+    if WS_OPEN_TIMEOUT is None:
+        return remaining
+    return min(WS_OPEN_TIMEOUT, remaining)
+
 
 _MISSING_WEBSOCKETS_MSG = (
     "WebSocket-based execution requires the 'websockets' package, which ships "
@@ -269,6 +291,7 @@ def run_ws_stream(
     ttl_seconds: int = 600,
     pty: bool = False,
     headers: Optional[Mapping[str, str]] = None,
+    open_timeout: Optional[float] = WS_OPEN_TIMEOUT,
 ) -> tuple[Iterator[dict], _WSStreamControl]:
     """Execute a command over WebSocket, yielding raw message dicts.
 
@@ -294,7 +317,7 @@ def run_ws_stream(
             with ws_connect(
                 ws_url,
                 additional_headers=request_headers,
-                open_timeout=WS_OPEN_TIMEOUT,
+                open_timeout=open_timeout,
                 close_timeout=WS_CLOSE_TIMEOUT,
                 ping_interval=WS_PING_INTERVAL,
                 ping_timeout=WS_PING_TIMEOUT,
@@ -473,6 +496,7 @@ async def run_ws_stream_async(
     ttl_seconds: int = 600,
     pty: bool = False,
     headers: Optional[Mapping[str, str]] = None,
+    open_timeout: Optional[float] = WS_OPEN_TIMEOUT,
 ) -> tuple[AsyncIterator[dict], _AsyncWSStreamControl]:
     """Async equivalent of run_ws_stream.
 
@@ -488,7 +512,7 @@ async def run_ws_stream_async(
             async with ws_connect_async(
                 ws_url,
                 additional_headers=request_headers,
-                open_timeout=WS_OPEN_TIMEOUT,
+                open_timeout=open_timeout,
                 close_timeout=WS_CLOSE_TIMEOUT,
                 ping_interval=WS_PING_INTERVAL,
                 ping_timeout=WS_PING_TIMEOUT,

--- a/python/tests/unit_tests/sandbox/test_async_ws_execute.py
+++ b/python/tests/unit_tests/sandbox/test_async_ws_execute.py
@@ -744,6 +744,7 @@ class TestAsyncSandboxRunWs:
             kill_on_disconnect=False,
             ttl_seconds=600,
             pty=False,
+            open_timeout=ANY,
         )
 
     @pytest.mark.asyncio

--- a/python/tests/unit_tests/sandbox/test_command_id_retry.py
+++ b/python/tests/unit_tests/sandbox/test_command_id_retry.py
@@ -13,6 +13,7 @@ import pytest
 from langsmith.sandbox import (
     AsyncSandboxClient,
     SandboxClient,
+    _ws_execute,
 )
 from langsmith.sandbox._async_sandbox import AsyncSandbox
 from langsmith.sandbox._exceptions import (
@@ -126,6 +127,33 @@ class TestSyncRetry:
         with pytest.raises(SandboxConnectionError):
             sandbox.run("echo hi")
         assert len(calls) == 1
+
+    def test_connect_budget_caps_total_wall_clock(self, monkeypatch):
+        """A blackholed handshake must not cost attempts x open_timeout."""
+        sandbox = _sandbox()
+        clock = {"now": 0.0}
+        opens: list[float] = []
+
+        def fake_run_ws_stream(dataplane_url, api_key, command, **kwargs):
+            opens.append(kwargs["open_timeout"])
+            clock["now"] += kwargs["open_timeout"]  # attempt burns its timeout
+            return _raises(SandboxConnectTimeoutError("timed out")), None
+
+        monkeypatch.setattr("time.monotonic", lambda: clock["now"])
+        monkeypatch.setattr(
+            "time.sleep", lambda s: clock.__setitem__("now", clock["now"] + s)
+        )
+        monkeypatch.setattr(
+            "langsmith.sandbox._ws_execute.run_ws_stream", fake_run_ws_stream
+        )
+
+        with pytest.raises(SandboxConnectTimeoutError):
+            sandbox.run("echo hi")
+
+        assert clock["now"] <= _ws_execute.WS_CONNECT_BUDGET
+        # Later attempts get clamped so none can outlive the budget.
+        assert opens[0] == _ws_execute.WS_OPEN_TIMEOUT
+        assert sum(opens) <= _ws_execute.WS_CONNECT_BUDGET
 
     def test_gives_up_after_max_attempts(self, monkeypatch):
         sandbox = _sandbox()

--- a/python/tests/unit_tests/sandbox/test_command_id_retry.py
+++ b/python/tests/unit_tests/sandbox/test_command_id_retry.py
@@ -1,9 +1,11 @@
-"""Idempotent retry when a command WebSocket closes before 'started'.
+"""Idempotent retry when a command WebSocket fails before 'started'.
 
 A proxied exec tunnel can be torn down gracefully before the guest emits its
-'started' frame. run() sends a client-generated command_id and the server does
-get-or-create keyed on it, so re-issuing the same command reattaches to the
-existing session instead of spawning a second one.
+'started' frame, and a cold-starting sandbox can refuse the connection outright.
+run() sends a client-generated command_id and the server does get-or-create
+keyed on it, so re-issuing the same command reattaches to the existing session
+instead of spawning a second one. A rejected handshake is permanent and must
+not be retried.
 """
 
 import pytest
@@ -13,6 +15,10 @@ from langsmith.sandbox import (
     SandboxClient,
 )
 from langsmith.sandbox._async_sandbox import AsyncSandbox
+from langsmith.sandbox._exceptions import (
+    SandboxConnectionError,
+    SandboxConnectTimeoutError,
+)
 from langsmith.sandbox._models import (
     CommandHandle,
     _StreamEndedBeforeStarted,
@@ -38,6 +44,14 @@ def _sandbox():
 
 def _empty():
     return iter(())
+
+
+def _raises(exc):
+    def _gen():
+        raise exc
+        yield  # make it a generator
+
+    return _gen()
 
 
 def _started_then_exit(command_id):
@@ -76,6 +90,42 @@ class TestSyncRetry:
         assert len(calls) == 2
         # Same id across the retry -> server dedupes, no double-run.
         assert calls[0]["command_id"] == calls[1]["command_id"]
+
+    def test_retries_connect_timeout(self, monkeypatch):
+        sandbox = _sandbox()
+        calls: list[dict] = []
+
+        def fake_run_ws_stream(dataplane_url, api_key, command, **kwargs):
+            calls.append(kwargs)
+            if len(calls) == 1:
+                return _raises(SandboxConnectTimeoutError("timed out")), None
+            return _started_then_exit(kwargs["command_id"]), None
+
+        monkeypatch.setattr(
+            "langsmith.sandbox._ws_execute.run_ws_stream", fake_run_ws_stream
+        )
+
+        result = sandbox.run("echo hi")
+
+        assert result.exit_code == 0
+        assert len(calls) == 2
+        assert calls[0]["command_id"] == calls[1]["command_id"]
+
+    def test_does_not_retry_rejected_handshake(self, monkeypatch):
+        sandbox = _sandbox()
+        calls: list[dict] = []
+
+        def fake_run_ws_stream(dataplane_url, api_key, command, **kwargs):
+            calls.append(kwargs)
+            return _raises(SandboxConnectionError("upgrade rejected (HTTP 404)")), None
+
+        monkeypatch.setattr(
+            "langsmith.sandbox._ws_execute.run_ws_stream", fake_run_ws_stream
+        )
+
+        with pytest.raises(SandboxConnectionError):
+            sandbox.run("echo hi")
+        assert len(calls) == 1
 
     def test_gives_up_after_max_attempts(self, monkeypatch):
         sandbox = _sandbox()
@@ -116,6 +166,11 @@ async def _astarted_then_exit(command_id):
     yield {"type": "exit", "exit_code": 0}
 
 
+async def _araises(exc):
+    raise exc
+    yield  # make it an async generator
+
+
 class TestAsyncRetry:
     async def test_retries_with_same_command_id(self, monkeypatch):
         sandbox = _async_sandbox()
@@ -125,6 +180,28 @@ class TestAsyncRetry:
             calls.append(kwargs)
             if len(calls) == 1:
                 return _aempty(), None
+            return _astarted_then_exit(kwargs["command_id"]), None
+
+        async def _no_sleep(_s):
+            return None
+
+        monkeypatch.setattr("asyncio.sleep", _no_sleep)
+        monkeypatch.setattr("langsmith.sandbox._ws_execute.run_ws_stream_async", fake)
+
+        result = await sandbox.run("echo hi")
+
+        assert result.exit_code == 0
+        assert len(calls) == 2
+        assert calls[0]["command_id"] == calls[1]["command_id"]
+
+    async def test_retries_connect_timeout(self, monkeypatch):
+        sandbox = _async_sandbox()
+        calls: list[dict] = []
+
+        async def fake(dataplane_url, api_key, command, **kwargs):
+            calls.append(kwargs)
+            if len(calls) == 1:
+                return _araises(SandboxConnectTimeoutError("timed out")), None
             return _astarted_then_exit(kwargs["command_id"]), None
 
         async def _no_sleep(_s):

--- a/python/tests/unit_tests/sandbox/test_ws_execute.py
+++ b/python/tests/unit_tests/sandbox/test_ws_execute.py
@@ -702,6 +702,7 @@ class TestSandboxRunWs:
             kill_on_disconnect=False,
             ttl_seconds=600,
             pty=False,
+            open_timeout=ANY,
         )
 
     @patch("langsmith.sandbox._ws_execute.run_ws_stream")


### PR DESCRIPTION
Follow-up to #3280, which raised the WebSocket connect timeout to 120s. Waiting longer was the wrong lever — `run()` already has an idempotent retry loop that wraps the connect, it just didn't catch this error. This moves recovery into that loop and restores the shorter timeouts.

### The gap

`run()` retries at [`_sandbox.py:412`](https://github.com/langchain-ai/langsmith-sdk/blob/main/python/langsmith/sandbox/_sandbox.py#L412) (5 retries, 0.5s backoff doubling to 8s). The connect is lazy — `run_ws_stream` only builds the generator, and the socket is opened inside `CommandHandle.__init__` → `_consume_started()` → `next(stream)`, which is already inside the `try`. But the loop caught only `_StreamEndedBeforeStarted`, so a connect timeout raised `SandboxConnectionError` and escaped:

```
langsmith.sandbox._exceptions.SandboxConnectionError: Failed to connect to sandbox: timed out
```

Re-issuing is safe by construction: `ws_kwargs` carries a client-generated `command_id` and the daemon does get-or-create keyed on it, so a retry reattaches instead of spawning a second command. A failed connect never sent the execute frame at all.

### Changes

- New `SandboxConnectTimeoutError(SandboxConnectionError)`, raised at the four `except (OSError, RuntimeError)` connect sites (sync/async × execute/reconnect).
- The retry loops in `_sandbox.py` and `_async_sandbox.py` catch it alongside `_StreamEndedBeforeStarted`.
- `_raise_for_invalid_handshake` deliberately keeps raising plain `SandboxConnectionError`. A 404 (server has no `/execute/ws`) or a non-HTTP response is permanent — retrying it only delays the error.
- New `WS_CONNECT_BUDGET` (120s, `LANGSMITH_SANDBOX_WS_TIMEOUT_CONNECT_BUDGET`) bounds the **whole** connect phase, since retrying otherwise multiplies the per-attempt timeout. The deadline is captured once before the loop; each attempt gets `open_timeout = min(WS_OPEN_TIMEOUT, remaining)`, the loop stops retrying once the budget is spent, and the backoff is clamped to what remains. Without this, 6 attempts × 30s + 15.5s backoff ≈ 195.5s — worse than the 120s it replaces. Thanks to the Open SWE review for catching that.
- Defaults restored: `WS_OPEN_TIMEOUT` 120 → 30, `WS_PING_TIMEOUT` 120 → 60. The `LANGSMITH_SANDBOX_WS_TIMEOUT_*` env overrides from #3280 stay.

Net effect: the connect phase is bounded at ~120s as before, but a sandbox that becomes reachable at t=20s now succeeds on the second attempt instead of waiting out one long timeout.

JS has the same structure ([`sandbox.ts:259`](https://github.com/langchain-ai/langsmith-sdk/blob/main/js/src/sandbox/sandbox.ts#L259) catches only `LangSmithStreamEndedBeforeStartedError`) and follows in a separate PR.

## Test Plan
- [x] `uv run pytest tests/unit_tests/sandbox` — 511 passed
- [x] New: connect timeout retries and reuses the same `command_id` (sync + async)
- [x] New: a rejected handshake propagates on the first attempt, no retry
- [x] New: `test_connect_budget_caps_total_wall_clock` drives a fake monotonic clock where every attempt burns its full open timeout, asserting total elapsed and the sum of per-attempt timeouts both stay within the budget
- [x] `uv run ruff format` / `ruff check`