### PR TITLE
fix(sandbox): retry WebSocket connect failures in JS run()

### DIFF
--- a/js/src/sandbox/command_handle.ts
+++ b/js/src/sandbox/command_handle.ts
@@ -10,6 +10,7 @@ import type { WSStreamControl } from "./ws_execute.js";
 import type { Sandbox } from "./sandbox.js";
 import {
   LangSmithSandboxConnectionError,
+  LangSmithSandboxServerReloadError,
   LangSmithSandboxOperationError,
   LangSmithStreamEndedBeforeStartedError,
 } from "./errors.js";
@@ -213,12 +214,9 @@ export class CommandHandle {
         }
         return; // Stream ended normally (exit message received)
       } catch (e) {
-        const eName =
-          e != null && typeof e === "object" ? (e as Error).name : "";
-        if (
-          eName !== "LangSmithSandboxConnectionError" &&
-          eName !== "LangSmithSandboxServerReloadError"
-        ) {
+        // instanceof, not a name check: subclasses (connect timeout, server
+        // reload) must stay retryable here.
+        if (!(e instanceof LangSmithSandboxConnectionError)) {
           throw e;
         }
 
@@ -233,7 +231,7 @@ export class CommandHandle {
           );
         }
 
-        const isHotReload = eName === "LangSmithSandboxServerReloadError";
+        const isHotReload = e instanceof LangSmithSandboxServerReloadError;
         if (!isHotReload) {
           const delay = Math.min(
             CommandHandle.BACKOFF_BASE * 2 ** (reconnectAttempts - 1),

--- a/js/src/sandbox/errors.ts
+++ b/js/src/sandbox/errors.ts
@@ -316,6 +316,21 @@ export class LangSmithStreamEndedBeforeStartedError extends LangSmithSandboxOper
 }
 
 /**
+ * Thrown when the socket fails or times out before the WebSocket handshake.
+ *
+ * Distinct from its parent because it is safely retryable: the execute frame
+ * was never sent, so re-issuing the same command_id cannot double-run a
+ * command. run() retries this with backoff; a plain connection error (a
+ * rejected handshake) is permanent and propagates immediately.
+ */
+export class LangSmithSandboxConnectTimeoutError extends LangSmithSandboxConnectionError {
+  constructor(message: string) {
+    super(message);
+    this.name = "LangSmithSandboxConnectTimeoutError";
+  }
+}
+
+/**
  * Raised when the sandbox server is reloading (close code 1001).
  *
  * Subclass of connection error that signals immediate reconnect (no backoff).

--- a/js/src/sandbox/index.ts
+++ b/js/src/sandbox/index.ts
@@ -90,6 +90,7 @@ export {
   LangSmithSandboxAPIError,
   LangSmithSandboxAuthenticationError,
   LangSmithSandboxConnectionError,
+  LangSmithSandboxConnectTimeoutError,
   LangSmithSandboxServerReloadError,
   // Resource errors (type-based with resourceType attribute)
   LangSmithResourceNotFoundError,

--- a/js/src/sandbox/sandbox.ts
+++ b/js/src/sandbox/sandbox.ts
@@ -14,11 +14,19 @@ import type {
 import { uuid7 } from "../uuid.js";
 import {
   LangSmithDataplaneNotConfiguredError,
+  LangSmithSandboxConnectTimeoutError,
   LangSmithStreamEndedBeforeStartedError,
 } from "./errors.js";
 import { handleSandboxHttpError } from "./helpers.js";
 import { CommandHandle } from "./command_handle.js";
-import { isWsAvailable, reconnectWsStream, runWsStream } from "./ws_execute.js";
+import {
+  connectDeadline,
+  isWsAvailable,
+  openTimeoutFor,
+  reconnectWsStream,
+  remainingBudget,
+  runWsStream,
+} from "./ws_execute.js";
 
 /**
  * Represents an active sandbox for running commands and file operations.
@@ -257,6 +265,7 @@ export class Sandbox {
     const execCommandId = commandId ?? uuid7();
 
     let attempt = 0;
+    const deadline = connectDeadline();
     // eslint-disable-next-line no-constant-condition
     while (true) {
       const [stream, control] = await runWsStream(
@@ -273,6 +282,7 @@ export class Sandbox {
           killOnDisconnect,
           ttlSeconds,
           pty,
+          openTimeout: openTimeoutFor(deadline),
           ...(Object.keys(clientHeaders).length > 0
             ? { headers: clientHeaders }
             : {}),
@@ -287,18 +297,29 @@ export class Sandbox {
         await handle._ensureStarted();
         return handle;
       } catch (e) {
-        // Idempotent re-issue (same command_id) after an early close.
-        if (!(e instanceof LangSmithStreamEndedBeforeStartedError)) {
+        // Idempotent re-issue (same command_id): neither an early close nor a
+        // failed connect can have started a second command.
+        if (
+          !(e instanceof LangSmithStreamEndedBeforeStartedError) &&
+          !(e instanceof LangSmithSandboxConnectTimeoutError)
+        ) {
           throw e;
         }
         attempt++;
         if (attempt > CommandHandle.MAX_AUTO_RECONNECTS) {
           throw e;
         }
-        const delay = Math.min(
+        let delay = Math.min(
           CommandHandle.BACKOFF_BASE * 2 ** (attempt - 1),
           CommandHandle.BACKOFF_MAX,
         );
+        const remaining = remainingBudget(deadline);
+        if (remaining !== undefined) {
+          if (remaining <= 0) {
+            throw e;
+          }
+          delay = Math.min(delay, remaining);
+        }
         await new Promise((r) => setTimeout(r, delay * 1000));
       }
     }

--- a/js/src/sandbox/sandbox.ts
+++ b/js/src/sandbox/sandbox.ts
@@ -321,6 +321,12 @@ export class Sandbox {
           delay = Math.min(delay, remaining);
         }
         await new Promise((r) => setTimeout(r, delay * 1000));
+        // Never start an attempt with no budget left: openTimeoutFor would
+        // return 0, which ws forwards to Node as "no timeout at all".
+        const left = remainingBudget(deadline);
+        if (left !== undefined && left <= 0) {
+          throw e;
+        }
       }
     }
   }

--- a/js/src/sandbox/types.ts
+++ b/js/src/sandbox/types.ts
@@ -148,6 +148,11 @@ export interface WsMessage {
 export interface WsRunOptions {
   /** Command timeout in seconds. Default: 60. */
   timeout?: number;
+  /**
+   * WebSocket connect timeout in seconds, overriding the module default.
+   * run() passes the remainder of its overall connect budget. @internal
+   */
+  openTimeout?: number;
   /** Environment variables to set for the command. */
   env?: Record<string, string>;
   /** Working directory for command execution. */

--- a/js/src/sandbox/ws_execute.ts
+++ b/js/src/sandbox/ws_execute.ts
@@ -8,6 +8,7 @@
 import {
   LangSmithCommandTimeoutError,
   LangSmithSandboxConnectionError,
+  LangSmithSandboxConnectTimeoutError,
   LangSmithSandboxOperationError,
   LangSmithSandboxServerReloadError,
 } from "./errors.js";
@@ -28,8 +29,43 @@ function envTimeout(name: string, defaultSeconds: number): number | undefined {
   return value > 0 ? value : undefined;
 }
 
-// Cold-start sandboxes can take well over a minute to accept the connection.
-export const WS_OPEN_TIMEOUT = envTimeout("SANDBOX_WS_TIMEOUT_OPEN", 120);
+// A slow cold start is recovered by the retry loop in run(), not by waiting here.
+export const WS_OPEN_TIMEOUT = envTimeout("SANDBOX_WS_TIMEOUT_OPEN", 30);
+// Ceiling on the whole connect phase. Without it, retrying a blackholed
+// handshake costs MAX_AUTO_RECONNECTS + 1 full open timeouts plus backoff.
+export const WS_CONNECT_BUDGET = envTimeout(
+  "SANDBOX_WS_TIMEOUT_CONNECT_BUDGET",
+  120,
+);
+
+function nowSeconds(): number {
+  return performance.now() / 1000;
+}
+
+/** Instant after which connect attempts must stop, if bounded. */
+export function connectDeadline(): number | undefined {
+  return WS_CONNECT_BUDGET === undefined
+    ? undefined
+    : nowSeconds() + WS_CONNECT_BUDGET;
+}
+
+/** Seconds left in the connect budget, or undefined when unbounded. */
+export function remainingBudget(
+  deadline: number | undefined,
+): number | undefined {
+  return deadline === undefined ? undefined : deadline - nowSeconds();
+}
+
+/** Per-attempt open timeout, clamped so it cannot outlive `deadline`. */
+export function openTimeoutFor(
+  deadline: number | undefined,
+): number | undefined {
+  if (deadline === undefined) return WS_OPEN_TIMEOUT;
+  const remaining = Math.max(deadline - nowSeconds(), 0);
+  return WS_OPEN_TIMEOUT === undefined
+    ? remaining
+    : Math.min(WS_OPEN_TIMEOUT, remaining);
+}
 
 // =============================================================================
 // Lazy ws import (optional peer dependency)
@@ -187,28 +223,58 @@ export function raiseForWsError(msg: WsMessage, commandId = ""): never {
 /**
  * Create a ws WebSocket connection and return a promise that resolves when open
  * or rejects on error.
+ *
+ * A socket-level failure rejects with the retryable connect-timeout error; a
+ * non-101 response rejects with the permanent connection error.
  */
 async function connectWs(
   url: string,
   headers: Record<string, string>,
+  openTimeout: number | undefined = WS_OPEN_TIMEOUT,
 ): Promise<WsWebSocket> {
   const { WebSocket: WS } = await ensureWs();
   return new Promise((resolve, reject) => {
     const ws = new WS(url, {
       headers,
       handshakeTimeout:
-        WS_OPEN_TIMEOUT === undefined ? undefined : WS_OPEN_TIMEOUT * 1000,
+        openTimeout === undefined ? undefined : openTimeout * 1000,
     });
+    let settled = false;
 
     ws.on("open", () => {
-      ws.removeAllListeners("error");
+      if (settled) return;
+      settled = true;
       resolve(ws);
     });
 
+    // Attaching this suppresses ws's own "error" for a non-101 response, so the
+    // rejected upgrade cannot be misreported as a retryable socket failure. ws
+    // leaves cleanup to the handler once a listener is present.
+    ws.on(
+      "unexpected-response",
+      (
+        req: { destroy?: () => void },
+        res: { statusCode?: number; resume?: () => void },
+      ) => {
+        res.resume?.();
+        req.destroy?.();
+        if (settled) return;
+        settled = true;
+        reject(
+          new LangSmithSandboxConnectionError(
+            `WebSocket upgrade to ${url} rejected by server (HTTP ${res.statusCode})`,
+          ),
+        );
+      },
+    );
+
+    // Stays attached after settling so a late error has a listener and cannot
+    // become an unhandled 'error' event.
     ws.on("error", (err: Error) => {
-      ws.removeAllListeners("open");
+      if (settled) return;
+      settled = true;
       reject(
-        new LangSmithSandboxConnectionError(
+        new LangSmithSandboxConnectTimeoutError(
           `Failed to connect to sandbox WebSocket: ${err.message}`,
         ),
       );
@@ -343,6 +409,7 @@ export async function runWsStream(
     ttlSeconds = 600,
     pty,
     headers: extraHeaders,
+    openTimeout = WS_OPEN_TIMEOUT,
   } = options;
 
   const wsUrl = buildWsUrl(dataplaneUrl);
@@ -352,7 +419,7 @@ export async function runWsStream(
   async function* stream(): AsyncIterableIterator<WsMessage> {
     let ws: WsWebSocket | undefined;
     try {
-      ws = await connectWs(wsUrl, headers);
+      ws = await connectWs(wsUrl, headers, openTimeout);
       control._bind(ws);
 
       // Send execute request

--- a/js/src/tests/sandbox_command_id_retry.test.ts
+++ b/js/src/tests/sandbox_command_id_retry.test.ts
@@ -175,6 +175,74 @@ describe("run() early-close retry", () => {
     expect(total).toBeLessThanOrEqual(120);
   });
 
+  it("never starts an attempt once the budget is spent", async () => {
+    const sandbox = makeSandbox();
+    const opens: (number | undefined)[] = [];
+
+    runWsStream.mockImplementation((...args: unknown[]) => {
+      const opts = args[3] as { openTimeout?: number };
+      opens.push(opts.openTimeout);
+      // Land just short of the deadline so the clamped backoff spends the rest.
+      clock.now = 119.9;
+      return [
+        failingStream(new LangSmithSandboxConnectTimeoutError("timed out")),
+        null,
+      ];
+    });
+
+    await expect(sandbox.run("echo hi")).rejects.toThrow(
+      LangSmithSandboxConnectTimeoutError,
+    );
+
+    // A 0 openTimeout would disable ws's handshakeTimeout entirely.
+    expect(opens).not.toContain(0);
+  });
+
+  it("retries a connect timeout while reconnecting a live command", async () => {
+    const sandbox = makeSandbox();
+
+    // Stream dies mid-command; the handle must reconnect to finish it.
+    runWsStream.mockImplementationOnce((...args: unknown[]) => {
+      const opts = args[3] as { commandId: string };
+      return [
+        (function () {
+          const msgs: WsMessage[] = [
+            { type: "started", command_id: opts.commandId, pid: 1 },
+          ];
+          let i = 0;
+          return {
+            next: async () => {
+              if (i < msgs.length) return { value: msgs[i++], done: false };
+              throw new LangSmithSandboxConnectionError("connection lost");
+            },
+            [Symbol.asyncIterator]() {
+              return this;
+            },
+          } as AsyncIterableIterator<WsMessage>;
+        })(),
+        null,
+      ];
+    });
+
+    // First reconnect attempt fails at the socket level (the subclass that a
+    // name-based check would have let escape), the second succeeds.
+    reconnectWsStream
+      .mockImplementationOnce(() => [
+        failingStream(new LangSmithSandboxConnectTimeoutError("timed out")),
+        null,
+      ])
+      .mockImplementationOnce(() => [
+        makeStream([{ type: "exit", exit_code: 0 }]),
+        null,
+      ]);
+
+    const handle = await sandbox.run("echo hi", { wait: false });
+    const result = await handle.result;
+
+    expect(result.exit_code).toBe(0);
+    expect(reconnectWsStream).toHaveBeenCalledTimes(2);
+  });
+
   it("does not retry a non-early-close error (e.g. wrong first frame)", async () => {
     const sandbox = makeSandbox();
     runWsStream.mockImplementation((..._args: unknown[]) => [

--- a/js/src/tests/sandbox_command_id_retry.test.ts
+++ b/js/src/tests/sandbox_command_id_retry.test.ts
@@ -1,12 +1,20 @@
 /**
- * Idempotent retry when a command WebSocket closes before 'started'.
+ * Idempotent retry when a command WebSocket fails before 'started'.
  *
  * run() sends a client-generated command_id and the server does get-or-create
- * keyed on it, so re-issuing a command whose tunnel closed before 'started'
- * reattaches to the same session instead of spawning a second one.
+ * keyed on it, so re-issuing a command whose tunnel closed before 'started' —
+ * or whose connect never completed — reattaches to the same session instead of
+ * spawning a second one. A rejected handshake is permanent and must not retry.
  */
 import { jest, describe, it, expect, beforeEach } from "@jest/globals";
 import type { WsMessage } from "../sandbox/types.js";
+import {
+  LangSmithSandboxConnectionError,
+  LangSmithSandboxConnectTimeoutError,
+} from "../sandbox/errors.js";
+
+// Virtual clock so budget assertions do not depend on real elapsed time.
+const clock = { now: 0 };
 
 const runWsStream = jest.fn<any>();
 const reconnectWsStream = jest.fn<any>();
@@ -16,6 +24,15 @@ jest.unstable_mockModule("../sandbox/ws_execute.js", () => ({
   reconnectWsStream,
   WSStreamControl: class {},
   isWsAvailable: () => Promise.resolve(true),
+  WS_OPEN_TIMEOUT: 30,
+  WS_CONNECT_BUDGET: 120,
+  connectDeadline: () => clock.now + 120,
+  remainingBudget: (deadline?: number) =>
+    deadline === undefined ? undefined : deadline - clock.now,
+  openTimeoutFor: (deadline?: number) =>
+    deadline === undefined
+      ? 30
+      : Math.min(30, Math.max(deadline - clock.now, 0)),
 }));
 
 const { Sandbox } = await import("../sandbox/sandbox.js");
@@ -31,6 +48,17 @@ function makeStream(messages: WsMessage[]): AsyncIterableIterator<WsMessage> {
       return this;
     },
   };
+}
+
+function failingStream(err: Error): AsyncIterableIterator<WsMessage> {
+  return {
+    next: async () => {
+      throw err;
+    },
+    [Symbol.asyncIterator]() {
+      return this;
+    },
+  } as AsyncIterableIterator<WsMessage>;
 }
 
 function makeSandbox() {
@@ -51,6 +79,7 @@ function makeSandbox() {
 describe("run() early-close retry", () => {
   beforeEach(() => {
     runWsStream.mockReset();
+    clock.now = 0;
   });
 
   it("retries with the same command_id after a close before 'started'", async () => {
@@ -76,6 +105,74 @@ describe("run() early-close retry", () => {
     const first = runWsStream.mock.calls[0][3] as { commandId: string };
     const second = runWsStream.mock.calls[1][3] as { commandId: string };
     expect(first.commandId).toBe(second.commandId);
+  });
+
+  it("retries with the same command_id after a failed connect", async () => {
+    const sandbox = makeSandbox();
+
+    runWsStream
+      .mockImplementationOnce((..._args: unknown[]) => [
+        failingStream(new LangSmithSandboxConnectTimeoutError("timed out")),
+        null,
+      ])
+      .mockImplementationOnce((...args: unknown[]) => {
+        const opts = args[3] as { commandId: string };
+        return [
+          makeStream([
+            { type: "started", command_id: opts.commandId, pid: 1 },
+            { type: "exit", exit_code: 0 },
+          ]),
+          null,
+        ];
+      });
+
+    const result = await sandbox.run("echo hi");
+
+    expect(result.exit_code).toBe(0);
+    expect(runWsStream).toHaveBeenCalledTimes(2);
+    const first = runWsStream.mock.calls[0][3] as { commandId: string };
+    const second = runWsStream.mock.calls[1][3] as { commandId: string };
+    expect(first.commandId).toBe(second.commandId);
+  });
+
+  it("does not retry a rejected handshake", async () => {
+    const sandbox = makeSandbox();
+    runWsStream.mockImplementation((..._args: unknown[]) => [
+      failingStream(
+        new LangSmithSandboxConnectionError(
+          "WebSocket upgrade rejected by server (HTTP 404)",
+        ),
+      ),
+      null,
+    ]);
+
+    await expect(sandbox.run("echo hi")).rejects.toThrow("HTTP 404");
+    expect(runWsStream).toHaveBeenCalledTimes(1);
+  });
+
+  it("caps total connect wall clock at the budget", async () => {
+    const sandbox = makeSandbox();
+    const opens: (number | undefined)[] = [];
+
+    runWsStream.mockImplementation((...args: unknown[]) => {
+      const opts = args[3] as { openTimeout?: number };
+      opens.push(opts.openTimeout);
+      // Each attempt burns its full open timeout.
+      clock.now += opts.openTimeout ?? 0;
+      return [
+        failingStream(new LangSmithSandboxConnectTimeoutError("timed out")),
+        null,
+      ];
+    });
+
+    await expect(sandbox.run("echo hi")).rejects.toThrow(
+      LangSmithSandboxConnectTimeoutError,
+    );
+
+    expect(clock.now).toBeLessThanOrEqual(120);
+    expect(opens[0]).toBe(30);
+    const total = opens.reduce((a, b) => (a ?? 0) + (b ?? 0), 0) ?? 0;
+    expect(total).toBeLessThanOrEqual(120);
   });
 
   it("does not retry a non-early-close error (e.g. wrong first frame)", async () => {


### PR DESCRIPTION
JS counterpart of #3282. Same defect, plus one the Python side didn't have: `connectWs` had no connect bound at all.

### The gaps

1. **No connect timeout.** `new WS(url, { headers })` passed no `handshakeTimeout`, so a hung connect waited for the OS TCP timeout (~2min+ on Linux) with nothing the SDK could tune.
2. **No retry.** `run()` retries at [`sandbox.ts:259`](https://github.com/langchain-ai/langsmith-sdk/blob/main/js/src/sandbox/sandbox.ts#L259), and the connect is lazy — it happens inside the `stream()` async generator, so it surfaces from `await handle._ensureStarted()`, already inside the `try`. But the catch only matched `LangSmithStreamEndedBeforeStartedError`.
3. **No way to classify.** Every failure — socket timeout *and* a rejected upgrade — became the same `LangSmithSandboxConnectionError`, so the loop couldn't retry one without also retrying the other.

### Changes

- `LangSmithSandboxConnectTimeoutError extends LangSmithSandboxConnectionError` for socket-level, pre-handshake failures. Retryable: the execute frame was never sent, and `commandId` makes the daemon's execute get-or-create idempotent, so a re-issue reattaches rather than double-running.
- `connectWs` now attaches an `unexpected-response` listener. A non-101 response rejects with the permanent `LangSmithSandboxConnectionError` (including the status code), while socket failures reject with the retryable subclass. Attaching that listener also suppresses `ws`'s own `error` for the non-101 case, which is what makes the two distinguishable; the handler drains and destroys the request since `ws` leaves cleanup to the listener. The `error` listener stays attached after settling so a late error can't become an unhandled `'error'` event.
- `handshakeTimeout` is now set from `WS_OPEN_TIMEOUT` (30s, `LANGSMITH_SANDBOX_WS_TIMEOUT_OPEN`).
- `WS_CONNECT_BUDGET` (120s, `LANGSMITH_SANDBOX_WS_TIMEOUT_CONNECT_BUDGET`) bounds the whole connect phase: the deadline is captured once before the loop, each attempt gets `openTimeout = min(WS_OPEN_TIMEOUT, remaining)`, retries stop when the budget is spent, and backoff is clamped to what remains. Without it, retrying would multiply the per-attempt timeout — the problem caught in review on #3282.
- `run()` retries `LangSmithSandboxConnectTimeoutError` alongside the early-close marker.

`ws` exposes no client-side equivalent of `ping_interval`/`ping_timeout`/`close_timeout`, so those Python knobs still have no JS counterpart.

### Review follow-ups

- `openTimeoutFor` could return `0` once the deadline elapsed, and `ws` forwards `handshakeTimeout: 0` to Node as *no* timeout — the loop now refuses to start an attempt with no budget left instead of converting exhaustion to zero.
- `CommandHandle`'s reconnect loop classified errors by `e.name`, so the new subclass escaped it and an active command would abandon its remaining reconnect attempts on the first transient socket failure. Now `instanceof`, which also keeps future subclasses retryable.

## Test Plan
- [x] `jest src/tests/sandbox` — 143 passed
- [x] New: a failed connect retries and reuses the same `commandId`
- [x] New: a rejected handshake (HTTP 404) propagates on the first attempt, no retry
- [x] New: budget test drives a virtual clock where each attempt burns its full open timeout, asserting elapsed time and the sum of per-attempt timeouts stay within the budget
- [x] New: budget exhaustion never yields a `0` open timeout
- [x] New: a connect timeout during reconnect of a live command is retried (fails against the previous name-based check)
- [x] `tsc --noEmit`, `oxlint`, `oxfmt` (no new warnings)
