### PR TITLE
fix: strip a trailing /api (not a bare /v1) from the generated OpenAPI client base URL

### DIFF
--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -1445,7 +1445,7 @@ export class Client implements LangSmithTracingClientInterface {
 
   private _getOpenAPIBaseUrl(): string {
     const url = this.apiUrl.replace(/\/$/, "");
-    for (const suffix of ["/api/v1", "/v1", "/api"]) {
+    for (const suffix of ["/api/v1", "/api"]) {
       if (url.endsWith(suffix)) return url.slice(0, -suffix.length);
     }
     return url;

--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -1445,8 +1445,9 @@ export class Client implements LangSmithTracingClientInterface {
 
   private _getOpenAPIBaseUrl(): string {
     const url = this.apiUrl.replace(/\/$/, "");
-    if (url.endsWith("/api/v1")) return url.slice(0, -"/api/v1".length);
-    if (url.endsWith("/v1")) return url.slice(0, -3);
+    for (const suffix of ["/api/v1", "/v1", "/api"]) {
+      if (url.endsWith(suffix)) return url.slice(0, -suffix.length);
+    }
     return url;
   }
 

--- a/js/src/tests/client.test.ts
+++ b/js/src/tests/client.test.ts
@@ -600,10 +600,13 @@ describe("Client", () => {
       );
     });
 
-    it("should strip a trailing /v1", () => {
+    it("should not strip a bare trailing /v1", () => {
       expect(getOpenAPIBaseUrl("https://api.smith.langchain.com/v1")).toBe(
-        "https://api.smith.langchain.com",
+        "https://api.smith.langchain.com/v1",
       );
+      expect(
+        getOpenAPIBaseUrl("https://self-hosted.example.com/langsmith/v1"),
+      ).toBe("https://self-hosted.example.com/langsmith/v1");
     });
 
     it("should strip a trailing /api", () => {
@@ -620,14 +623,11 @@ describe("Client", () => {
         getOpenAPIBaseUrl("https://self-hosted.example.com/langsmith/api/v1"),
       ).toBe("https://self-hosted.example.com/langsmith");
       expect(
-        getOpenAPIBaseUrl("https://self-hosted.example.com/langsmith/v1"),
-      ).toBe("https://self-hosted.example.com/langsmith");
-      expect(
         getOpenAPIBaseUrl("https://self-hosted.example.com/langsmith/api"),
       ).toBe("https://self-hosted.example.com/langsmith");
     });
 
-    it("should leave a URL without a version or /api suffix unchanged", () => {
+    it("should leave a URL without an /api suffix unchanged", () => {
       expect(getOpenAPIBaseUrl("https://api.smith.langchain.com")).toBe(
         "https://api.smith.langchain.com",
       );
@@ -636,16 +636,10 @@ describe("Client", () => {
       );
     });
 
-    it("should only strip /v1 or /api when it is the trailing path segment", () => {
-      expect(getOpenAPIBaseUrl("https://api.smith.langchain.com/v1/runs")).toBe(
-        "https://api.smith.langchain.com/v1/runs",
-      );
+    it("should only strip /api when it is the trailing path segment", () => {
       expect(
         getOpenAPIBaseUrl("https://api.smith.langchain.com/api/runs"),
       ).toBe("https://api.smith.langchain.com/api/runs");
-      expect(getOpenAPIBaseUrl("https://v1.example.com")).toBe(
-        "https://v1.example.com",
-      );
       expect(getOpenAPIBaseUrl("https://api.example.com")).toBe(
         "https://api.example.com",
       );

--- a/js/src/tests/client.test.ts
+++ b/js/src/tests/client.test.ts
@@ -606,6 +606,15 @@ describe("Client", () => {
       );
     });
 
+    it("should strip a trailing /api", () => {
+      expect(getOpenAPIBaseUrl("https://api.smith.langchain.com/api")).toBe(
+        "https://api.smith.langchain.com",
+      );
+      expect(getOpenAPIBaseUrl("https://api.smith.langchain.com/api/")).toBe(
+        "https://api.smith.langchain.com",
+      );
+    });
+
     it("should preserve a self-hosted path prefix", () => {
       expect(
         getOpenAPIBaseUrl("https://self-hosted.example.com/langsmith/api/v1"),
@@ -613,26 +622,32 @@ describe("Client", () => {
       expect(
         getOpenAPIBaseUrl("https://self-hosted.example.com/langsmith/v1"),
       ).toBe("https://self-hosted.example.com/langsmith");
+      expect(
+        getOpenAPIBaseUrl("https://self-hosted.example.com/langsmith/api"),
+      ).toBe("https://self-hosted.example.com/langsmith");
     });
 
-    it("should leave a URL without a version suffix unchanged", () => {
+    it("should leave a URL without a version or /api suffix unchanged", () => {
       expect(getOpenAPIBaseUrl("https://api.smith.langchain.com")).toBe(
         "https://api.smith.langchain.com",
-      );
-      expect(getOpenAPIBaseUrl("https://self-hosted.example.com/api")).toBe(
-        "https://self-hosted.example.com/api",
       );
       expect(getOpenAPIBaseUrl("http://localhost:1984")).toBe(
         "http://localhost:1984",
       );
     });
 
-    it("should only strip /v1 when it is the trailing path segment", () => {
+    it("should only strip /v1 or /api when it is the trailing path segment", () => {
       expect(getOpenAPIBaseUrl("https://api.smith.langchain.com/v1/runs")).toBe(
         "https://api.smith.langchain.com/v1/runs",
       );
+      expect(
+        getOpenAPIBaseUrl("https://api.smith.langchain.com/api/runs"),
+      ).toBe("https://api.smith.langchain.com/api/runs");
       expect(getOpenAPIBaseUrl("https://v1.example.com")).toBe(
         "https://v1.example.com",
+      );
+      expect(getOpenAPIBaseUrl("https://api.example.com")).toBe(
+        "https://api.example.com",
       );
     });
   });

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -156,7 +156,7 @@ def _reset_tracing_drop_log() -> None:
 def _get_openapi_base_url(api_url: str) -> str:
     """Convert a handwritten client API URL to a generated OpenAPI base URL."""
     api_url = api_url.rstrip("/")
-    for suffix in ("/api/v1", "/v1", "/api"):
+    for suffix in ("/api/v1", "/api"):
         if api_url.endswith(suffix):
             return api_url[: -len(suffix)]
     return api_url

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -156,9 +156,10 @@ def _reset_tracing_drop_log() -> None:
 def _get_openapi_base_url(api_url: str) -> str:
     """Convert a handwritten client API URL to a generated OpenAPI base URL."""
     api_url = api_url.rstrip("/")
-    if api_url.endswith("/api/v1"):
-        return api_url[: -len("/api/v1")]
-    return api_url[:-3] if api_url.endswith("/v1") else api_url
+    for suffix in ("/api/v1", "/v1", "/api"):
+        if api_url.endswith(suffix):
+            return api_url[: -len(suffix)]
+    return api_url
 
 
 _TRACING_SEND_TIMEOUT = (3, 10)  # (connect, read) seconds for background sends

--- a/python/tests/unit_tests/test_client.py
+++ b/python/tests/unit_tests/test_client.py
@@ -5511,21 +5511,33 @@ def test_construct_url_errors(api_url, pathname, error_match):
             "https://self-hosted.example.com/langsmith/v1",
             "https://self-hosted.example.com/langsmith",
         ),
-        # No version suffix: left unchanged (aside from trailing slashes).
+        # Bare /api suffix (no version segment).
+        ("https://api.smith.langchain.com/api", "https://api.smith.langchain.com"),
+        ("https://api.smith.langchain.com/api/", "https://api.smith.langchain.com"),
+        (
+            "https://self-hosted.example.com/api",
+            "https://self-hosted.example.com",
+        ),
+        (
+            "https://self-hosted.example.com/langsmith/api",
+            "https://self-hosted.example.com/langsmith",
+        ),
+        # No version or /api suffix: left unchanged (aside from trailing slashes).
         ("https://api.smith.langchain.com", "https://api.smith.langchain.com"),
         ("https://api.smith.langchain.com/", "https://api.smith.langchain.com"),
-        (
-            "https://self-hosted.example.com/api",
-            "https://self-hosted.example.com/api",
-        ),
         ("http://localhost:1984", "http://localhost:1984"),
         ("http://localhost:1984/api/v1", "http://localhost:1984"),
-        # /v1 must be a trailing path segment, not a substring.
+        # /v1 and /api must be trailing path segments, not substrings.
         (
             "https://api.smith.langchain.com/v1/runs",
             "https://api.smith.langchain.com/v1/runs",
         ),
+        (
+            "https://api.smith.langchain.com/api/runs",
+            "https://api.smith.langchain.com/api/runs",
+        ),
         ("https://v1.example.com", "https://v1.example.com"),
+        ("https://api.example.com", "https://api.example.com"),
     ],
 )
 def test_get_openapi_base_url(api_url: str, expected: str) -> None:

--- a/python/tests/unit_tests/test_client.py
+++ b/python/tests/unit_tests/test_client.py
@@ -5496,19 +5496,19 @@ def test_construct_url_errors(api_url, pathname, error_match):
             "https://api.smith.langchain.com/api/v1/",
             "https://api.smith.langchain.com",
         ),
-        # Bare /v1 suffix (no /api prefix).
+        # A bare /v1 suffix (no /api prefix) is not stripped.
         (
             "https://api.smith.langchain.com/v1",
-            "https://api.smith.langchain.com",
+            "https://api.smith.langchain.com/v1",
         ),
-        ("https://api.smith.langchain.com/v1/", "https://api.smith.langchain.com"),
+        ("https://api.smith.langchain.com/v1/", "https://api.smith.langchain.com/v1"),
+        (
+            "https://self-hosted.example.com/langsmith/v1",
+            "https://self-hosted.example.com/langsmith/v1",
+        ),
         # Self-hosted deployments under a path prefix.
         (
             "https://self-hosted.example.com/langsmith/api/v1",
-            "https://self-hosted.example.com/langsmith",
-        ),
-        (
-            "https://self-hosted.example.com/langsmith/v1",
             "https://self-hosted.example.com/langsmith",
         ),
         # Bare /api suffix (no version segment).
@@ -5522,26 +5522,21 @@ def test_construct_url_errors(api_url, pathname, error_match):
             "https://self-hosted.example.com/langsmith/api",
             "https://self-hosted.example.com/langsmith",
         ),
-        # No version or /api suffix: left unchanged (aside from trailing slashes).
+        # No /api suffix: left unchanged (aside from trailing slashes).
         ("https://api.smith.langchain.com", "https://api.smith.langchain.com"),
         ("https://api.smith.langchain.com/", "https://api.smith.langchain.com"),
         ("http://localhost:1984", "http://localhost:1984"),
         ("http://localhost:1984/api/v1", "http://localhost:1984"),
-        # /v1 and /api must be trailing path segments, not substrings.
-        (
-            "https://api.smith.langchain.com/v1/runs",
-            "https://api.smith.langchain.com/v1/runs",
-        ),
+        # /api must be a trailing path segment, not a substring.
         (
             "https://api.smith.langchain.com/api/runs",
             "https://api.smith.langchain.com/api/runs",
         ),
-        ("https://v1.example.com", "https://v1.example.com"),
         ("https://api.example.com", "https://api.example.com"),
     ],
 )
 def test_get_openapi_base_url(api_url: str, expected: str) -> None:
-    """Test _get_openapi_base_url strips the handwritten client's version suffix."""
+    """Test _get_openapi_base_url strips the handwritten client's /api[/v1] suffix."""
     assert _get_openapi_base_url(api_url) == expected
 
 


### PR DESCRIPTION
## Summary

`_get_openapi_base_url` / `_getOpenAPIBaseUrl` convert the handwritten client's `api_url` into the base URL handed to the autogenerated OpenAPI client. Until now they stripped a trailing `/api/v1` or a bare `/v1`, but left a bare `/api` intact — so a URL like `https://self-hosted.example.com/api` had the generated client's own version segments appended on top of it, producing `/api/v1/...` style paths.

This PR changes the stripped suffixes to `/api/v1` and `/api`. The bare `/v1` case is dropped: `https://api.smith.langchain.com/v1` is now left unchanged.

Stripping remains restricted to trailing path segments, so `https://api.example.com` and `.../api/runs` are untouched.

## Changes

- `python/langsmith/client.py` — `_get_openapi_base_url` strips the first matching suffix among `/api/v1`, `/api`.
- `js/src/client.ts` — same change in `Client._getOpenAPIBaseUrl`.

## Tests

Updated the existing unit tests in both languages:

- cases asserting a bare `/api` was preserved now assert it is stripped, with added coverage for a self-hosted path prefix (`/langsmith/api`) and a trailing slash;
- cases asserting a bare `/v1` was stripped now assert the URL is left unchanged;
- kept the substring cases that must stay untouched (`https://api.example.com`, `.../api/runs`).

- `uv run pytest tests/unit_tests/test_client.py -k "openapi_base_url or normalized_base_url"` → 20 passed
- `pnpm test:single src/tests/client.test.ts -t "_getOpenAPIBaseUrl"` → 7 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)