### PR TITLE
release(py): 0.10.12

### DIFF
--- a/python/.bumpversion.cfg
+++ b/python/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.10.11
+current_version = 0.10.12
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
 serialize = {major}.{minor}.{patch}
 search = {current_version}

--- a/python/langsmith/__init__.py
+++ b/python/langsmith/__init__.py
@@ -49,7 +49,7 @@ if TYPE_CHECKING:
 
 # Avoid calling into importlib on every call to __version__
 
-__version__ = "0.10.11"
+__version__ = "0.10.12"
 version = __version__  # for backwards compatibility
 
 # Metadata key to hide a traced run from LangSmith's Messages View.


### PR DESCRIPTION
## Description

Bumps the Python SDK to 0.10.12 via the documented `uv run bump2version patch` flow. On merge, `.github/workflows/release.yml` tags `v0.10.12` and publishes to PyPI.

Ships three changes since 0.10.11:

- #3282 — sandbox WebSocket connect failures are now retried by `run()`'s existing idempotent re-issue loop instead of failing the call, with a 120s ceiling on the whole connect phase. Fixes `SandboxConnectionError: Failed to connect to sandbox: timed out` against a cold-starting sandbox.
- #3280 — `LANGSMITH_SANDBOX_WS_TIMEOUT_{OPEN,CLOSE,PING,PING_INTERVAL}` overrides for the sandbox WebSocket timeouts.
- #3262 — internal `list_runs`/`read_run` usages migrated to the SmithDB v2 API.

Replaces #3281, which was closed before merge.

## Test Plan
- [x] `uv run bump2version patch` (no hand-edits to `__init__.py` / `.bumpversion.cfg`)
- [x] `uv run ruff format --check langsmith/__init__.py`
- [x] `uv run ruff check langsmith/__init__.py`
- [x] Local tag `v0.10.12` not pushed — verified absent on the remote, so the release workflow creates the authoritative tag on merge