### PR TITLE
feat: expose annotation queue clients

### DIFF
--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -80,6 +80,7 @@ import { OnlineEvaluators as Evaluators } from "./_openapi_client/resources/onli
 import { Runs as OpenAPIRuns } from "./_openapi_client/resources/runs.js";
 import { Sandboxes } from "./_openapi_client/resources/sandboxes/sandboxes.js";
 import { Datasets } from "./_openapi_client/resources/datasets/datasets.js";
+import { AnnotationQueues } from "./_openapi_client/resources/annotation-queues/annotation-queues.js";
 import { Threads } from "./_openapi_client/resources/threads.js";
 import { Traces } from "./_openapi_client/resources/traces.js";
 import { Public } from "./_openapi_client/resources/public/public.js";
@@ -1553,6 +1554,12 @@ export class Client implements LangSmithTracingClientInterface {
   public get datasets(): Datasets {
     this._checkStainlessVersion();
     return this.openAPIClient.datasets;
+  }
+
+  /** Access the annotation queues resource (runs, items). */
+  public get annotationQueues(): AnnotationQueues {
+    this._checkStainlessVersion();
+    return this.openAPIClient.annotationQueues;
   }
 
   /** Access the threads resource (query, stats, listTraces). */

--- a/js/src/tests/client.test.ts
+++ b/js/src/tests/client.test.ts
@@ -239,6 +239,49 @@ describe("Client", () => {
     });
   });
 
+  describe("annotationQueues", () => {
+    it("exposes generated annotation queue item endpoints", async () => {
+      const mockFetch = jest
+        .fn<typeof fetch>()
+        .mockResolvedValueOnce(
+          // first call: _checkStainlessVersion triggers GET /info
+          new Response(JSON.stringify({ version: "0.16.14" }), {
+            status: 200,
+            statusText: "OK",
+            headers: { "content-type": "application/json" },
+          }),
+        )
+        .mockResolvedValueOnce(
+          new Response(JSON.stringify({ count: 3 }), {
+            status: 200,
+            statusText: "OK",
+            headers: { "content-type": "application/json" },
+          }),
+        );
+      const client = new Client({
+        apiUrl: "http://localhost:8080",
+        apiKey: "test-api-key",
+        workspaceId: "test-workspace-id",
+        fetchImplementation: mockFetch,
+      });
+
+      const response = await client.annotationQueues.items.retrieveCount(
+        "queue-1",
+        { status: "all" },
+      );
+
+      expect(response.count).toBe(3);
+      const [url, init] = mockFetch.mock.calls[1]; // call[0] is the /info prefetch
+      const headers = new Headers(init?.headers);
+      expect(url).toBe(
+        "http://localhost:8080/api/v1/annotation-queues/queue-1/items/count?status=all",
+      );
+      expect(init).toEqual(expect.objectContaining({ method: "GET" }));
+      expect(headers.get("x-api-key")).toBe("test-api-key");
+      expect(headers.get("x-tenant-id")).toBe("test-workspace-id");
+    });
+  });
+
   describe("createLLMExample", () => {
     it("should create an example with the given input and generation", async () => {
       const client = new Client({ apiKey: "test-api-key" });

--- a/python/langsmith/async_client.py
+++ b/python/langsmith/async_client.py
@@ -53,6 +53,9 @@ logger = logging.getLogger(__name__)
 ID_TYPE = Union[uuid.UUID, str]
 
 if TYPE_CHECKING:
+    from langsmith._openapi_client.resources.annotation_queues.annotation_queues import (
+        AsyncAnnotationQueuesResource,
+    )
     from langsmith._openapi_client.resources.datasets.datasets import (
         AsyncDatasetsResource,
     )
@@ -338,6 +341,11 @@ class AsyncClient:
     def datasets(self) -> AsyncDatasetsResource:
         """Access the v2 datasets resource (experiment_runs, etc.)."""
         return self._langsmith_api.datasets
+
+    @property
+    def annotation_queues(self) -> AsyncAnnotationQueuesResource:
+        """Access the annotation queues resource (runs, items)."""
+        return self._langsmith_api.annotation_queues
 
     @property
     def threads(self) -> AsyncThreadsResource:

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -275,6 +275,9 @@ if TYPE_CHECKING:
     from langchain_core.runnables import Runnable
 
     from langsmith import schemas
+    from langsmith._openapi_client.resources.annotation_queues.annotation_queues import (
+        AsyncAnnotationQueuesResource,
+    )
     from langsmith._openapi_client.resources.datasets.datasets import (
         AsyncDatasetsResource,
     )
@@ -1562,6 +1565,12 @@ class Client:
         """Access the v2 datasets resource (experiment_runs, etc.)."""
         _check_backend_version(self.info.version)
         return self._get_langsmith_api().datasets
+
+    @property
+    def annotation_queues(self) -> AsyncAnnotationQueuesResource:
+        """Access the annotation queues resource (runs, items)."""
+        _check_backend_version(self.info.version)
+        return self._get_langsmith_api().annotation_queues
 
     @property
     def threads(self) -> AsyncThreadsResource:

--- a/python/tests/unit_tests/test_client.py
+++ b/python/tests/unit_tests/test_client.py
@@ -904,6 +904,31 @@ def test_evaluators_uses_generated_openapi_resource() -> None:
     assert timeout.read == 5.678
 
 
+def test_annotation_queues_uses_generated_openapi_resource() -> None:
+    resource = object()
+
+    with mock.patch("langsmith.client.LangsmithOpenAPIClient") as openapi_client:
+        openapi_client.return_value.annotation_queues = resource
+
+        client = Client(
+            api_url="http://localhost:8080",
+            api_key="test-api-key",
+            workspace_id="test-workspace-id",
+            timeout_ms=(1234, 5678),
+            info=ls_schemas.LangSmithInfo(),
+        )
+
+        assert client.annotation_queues is resource
+
+    openapi_client.assert_called_once()
+    assert openapi_client.call_args.kwargs["api_key"] == "test-api-key"
+    assert openapi_client.call_args.kwargs["tenant_id"] == "test-workspace-id"
+    assert openapi_client.call_args.kwargs["base_url"] == "http://localhost:8080"
+    timeout = openapi_client.call_args.kwargs["timeout"]
+    assert timeout.connect == 1.234
+    assert timeout.read == 5.678
+
+
 def test_async_evaluators_uses_generated_openapi_resource() -> None:
     resource = object()
 
@@ -918,6 +943,34 @@ def test_async_evaluators_uses_generated_openapi_resource() -> None:
         )
 
         assert client.evaluators is resource
+
+    openapi_client.assert_called_once()
+    assert openapi_client.call_args.kwargs["api_key"] == "test-api-key"
+    assert openapi_client.call_args.kwargs["tenant_id"] == "test-workspace-id"
+    assert openapi_client.call_args.kwargs["base_url"] == "http://localhost:8080"
+    timeout = openapi_client.call_args.kwargs["timeout"]
+    assert timeout.connect == 1.234
+    assert timeout.read == 5.678
+    assert (
+        openapi_client.call_args.kwargs["default_headers"]["X-Tenant-Id"]
+        == "test-workspace-id"
+    )
+
+
+def test_async_annotation_queues_uses_generated_openapi_resource() -> None:
+    resource = object()
+
+    with mock.patch("langsmith._openapi_client.AsyncLangsmith") as openapi_client:
+        openapi_client.return_value.annotation_queues = resource
+
+        client = AsyncClient(
+            api_url="http://localhost:8080",
+            api_key="test-api-key",
+            workspace_id="test-workspace-id",
+            timeout_ms=(1234, 5678),
+        )
+
+        assert client.annotation_queues is resource
 
     openapi_client.assert_called_once()
     assert openapi_client.call_args.kwargs["api_key"] == "test-api-key"


### PR DESCRIPTION
## Summary
- Expose the generated annotation queue OpenAPI resources through the handwritten Python and TypeScript clients.
- Add focused tests for the Python sync/async accessors and a TypeScript generated item endpoint call.

## Test Plan
- [x] Unit tests
