### PR TITLE
feat(python): trace raw Gemini Live sessions

### DIFF
--- a/python/langsmith/integrations/_gemini_usage.py
+++ b/python/langsmith/integrations/_gemini_usage.py
@@ -1,0 +1,67 @@
+"""Shared token-usage normalization for Gemini integrations."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def _audio_tokens(details: Any) -> int | None:
+    """Sum the audio token count from a Gemini modality-details sequence."""
+    if not isinstance(details, (list, tuple)):
+        return None
+    total = 0
+    found = False
+    for entry in details:
+        modality = getattr(entry, "modality", None)
+        modality = getattr(modality, "value", modality)
+        count = getattr(entry, "token_count", None)
+        if str(modality).upper() == "AUDIO" and isinstance(count, int):
+            total += count
+            found = True
+    return total if found else None
+
+
+def normalize_gemini_usage_metadata(usage: Any) -> dict[str, Any] | None:
+    """Map a Gemini usage object onto LangSmith's canonical token metadata.
+
+    Gemini's direct Live API uses ``response_*`` output fields, while ADK and
+    older generated response types use ``candidates_*``. Only the known token
+    fields below are read so provider objects cannot add arbitrary metadata.
+    """
+    if usage is None:
+        return None
+
+    result: dict[str, Any] = {}
+    for key, attrs in (
+        ("input_tokens", ("prompt_token_count",)),
+        ("output_tokens", ("response_token_count", "candidates_token_count")),
+        ("total_tokens", ("total_token_count",)),
+    ):
+        for attr in attrs:
+            value = getattr(usage, attr, None)
+            if isinstance(value, int):
+                result[key] = value
+                break
+
+    input_details: dict[str, int] = {}
+    if (
+        audio := _audio_tokens(getattr(usage, "prompt_tokens_details", None))
+    ) is not None:
+        input_details["audio"] = audio
+    if isinstance(cached := getattr(usage, "cached_content_token_count", None), int):
+        input_details["cache_read"] = cached
+    if input_details:
+        result["input_token_details"] = input_details
+
+    output_details: dict[str, int] = {}
+    response_details = getattr(usage, "response_tokens_details", None)
+    if response_details is None:
+        response_details = getattr(usage, "candidates_tokens_details", None)
+    if (audio := _audio_tokens(response_details)) is not None:
+        output_details["audio"] = audio
+    if isinstance(reasoning := getattr(usage, "thoughts_token_count", None), int):
+        output_details["reasoning"] = reasoning
+    if output_details:
+        result["output_token_details"] = output_details
+
+    return result or None

--- a/python/langsmith/integrations/gemini_live/__init__.py
+++ b/python/langsmith/integrations/gemini_live/__init__.py
@@ -1,0 +1,19 @@
+"""LangSmith integration for the Gemini Live API.
+
+Use :func:`wrap_gemini_live` with the ``AsyncSession`` yielded by
+``google.genai.Client().aio.live.connect(...)``. The wrapper observes the
+session's WebSocket event stream without changing the application's receive,
+audio, or tool-handling loop.
+
+The implementation intentionally imports no ``google-genai`` types at runtime,
+so importing this module does not require the optional provider dependency.
+"""
+
+from __future__ import annotations
+
+from langsmith._internal._beta_decorator import warn_beta
+from langsmith.integrations.gemini_live._session import wrap_gemini_live
+
+wrap_gemini_live = warn_beta(wrap_gemini_live)
+
+__all__ = ["wrap_gemini_live"]

--- a/python/langsmith/integrations/gemini_live/_session.py
+++ b/python/langsmith/integrations/gemini_live/_session.py
@@ -1,0 +1,453 @@
+"""LangSmith tracing for a raw Gemini Live WebSocket session.
+
+Gemini Live is exposed by ``google-genai`` as an ``AsyncSession`` over a
+bidirectional WebSocket. :func:`wrap_gemini_live` returns a transparent proxy
+whose :meth:`receive` generator observes each ``LiveServerMessage`` while
+leaving the application's own audio playback and tool loop untouched.
+
+Trace shape -- one live session = one trace::
+
+    realtime_session                         (root; transcript + stereo WAV)
+    ├── input_transcription                  (curated user message)
+    ├── lookup_weather                       (caller's @traceable tool)
+    ├── turn_complete                        (llm; assistant text + usage)
+    ├── interrupted                          (barge-in marker)
+    └── turn_complete                        (turn marker)
+
+Provider events are always passed through the shared ``scrub`` helper before
+they become span metadata, replacing raw audio bytes and truncating long text.
+Tracing is fail-open: observation and teardown failures are logged but never
+break the provider session.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from typing import TYPE_CHECKING, Any, Callable, Optional
+
+from langsmith._internal._package_version import get_package_version
+from langsmith._internal.voice.helpers import dump_event, observe_safely, scrub
+from langsmith._internal.voice.session import (
+    DEFAULT_MAX_AUDIO_SECONDS,
+    EventSession,
+    start_session,
+)
+from langsmith.run_helpers import tracing_context
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator, Sequence
+
+    from langsmith import Client
+    from langsmith.run_trees import WriteReplica
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_SAMPLE_RATE = 24_000
+MAX_TRANSCRIPT_CHARS = 2_000
+
+
+class _LiveMessageView:
+    """Readable, dependency-free view over a ``LiveServerMessage``."""
+
+    def __init__(self, raw: Any) -> None:
+        self.raw = raw
+
+    @property
+    def server_content(self) -> Any:
+        return getattr(self.raw, "server_content", None)
+
+    def _transcript(self, attr: str) -> str | None:
+        content = self.server_content
+        tx = getattr(content, attr, None) if content is not None else None
+        text = getattr(tx, "text", None) if tx is not None else None
+        return str(text) if text else None
+
+    @property
+    def user_transcript(self) -> str | None:
+        return self._transcript("input_transcription")
+
+    @property
+    def user_transcript_finished(self) -> bool:
+        content = self.server_content
+        tx = getattr(content, "input_transcription", None) if content else None
+        return bool(tx is not None and getattr(tx, "finished", False))
+
+    @property
+    def agent_transcript(self) -> str | None:
+        return self._transcript("output_transcription")
+
+    @property
+    def function_calls(self) -> list[Any]:
+        tool_call = getattr(self.raw, "tool_call", None)
+        return list(getattr(tool_call, "function_calls", None) or [])
+
+    @property
+    def cancelled_tool_call_ids(self) -> list[str]:
+        cancellation = getattr(self.raw, "tool_call_cancellation", None)
+        return [str(value) for value in getattr(cancellation, "ids", None) or []]
+
+    @property
+    def interrupted(self) -> bool:
+        content = self.server_content
+        return bool(content is not None and getattr(content, "interrupted", False))
+
+    @property
+    def turn_complete(self) -> bool:
+        content = self.server_content
+        return bool(content is not None and getattr(content, "turn_complete", False))
+
+
+def _audio_tokens(details: Any) -> int | None:
+    """Sum the AUDIO token count from a Gemini modality-details sequence."""
+    if not isinstance(details, (list, tuple)):
+        return None
+    total = 0
+    found = False
+    for entry in details:
+        modality = getattr(entry, "modality", None)
+        modality = getattr(modality, "value", modality)
+        count = getattr(entry, "token_count", None)
+        if str(modality).upper() == "AUDIO" and isinstance(count, int):
+            total += count
+            found = True
+    return total if found else None
+
+
+def usage_metadata_from_message(message: Any) -> dict[str, Any] | None:
+    """Map Gemini Live usage onto LangSmith's canonical token metadata."""
+    usage = getattr(message, "usage_metadata", None)
+    if usage is None:
+        return None
+
+    result: dict[str, Any] = {}
+    for key, attrs in (
+        ("input_tokens", ("prompt_token_count",)),
+        # Direct Gemini Live uses ``response_*``. ``candidates_*`` keeps the
+        # mapper compatible with older/generated response shapes.
+        ("output_tokens", ("response_token_count", "candidates_token_count")),
+        ("total_tokens", ("total_token_count",)),
+    ):
+        for attr in attrs:
+            value = getattr(usage, attr, None)
+            if isinstance(value, int):
+                result[key] = value
+                break
+
+    input_details: dict[str, int] = {}
+    prompt_details = getattr(usage, "prompt_tokens_details", None)
+    if (audio := _audio_tokens(prompt_details)) is not None:
+        input_details["audio"] = audio
+    if isinstance(cached := getattr(usage, "cached_content_token_count", None), int):
+        input_details["cache_read"] = cached
+    if input_details:
+        result["input_token_details"] = input_details
+
+    output_details: dict[str, int] = {}
+    response_details = getattr(usage, "response_tokens_details", None)
+    if response_details is None:
+        response_details = getattr(usage, "candidates_tokens_details", None)
+    if (audio := _audio_tokens(response_details)) is not None:
+        output_details["audio"] = audio
+    if isinstance(reasoning := getattr(usage, "thoughts_token_count", None), int):
+        output_details["reasoning"] = reasoning
+    if output_details:
+        result["output_token_details"] = output_details
+
+    return result or None
+
+
+def _merge_transcript(current: str, fragment: str) -> str:
+    """Merge delta-style or cumulative transcription fragments, with a cap."""
+    fragment = fragment[:MAX_TRANSCRIPT_CHARS]
+    if not current:
+        merged = fragment
+    elif fragment.startswith(current):
+        # Some Gemini versions send the full transcript-so-far each time.
+        merged = fragment
+    elif current.startswith(fragment) or current.endswith(fragment):
+        # Ignore an older cumulative snapshot or a repeated final fragment.
+        merged = current
+    else:
+        # Other versions stream true deltas (including their own whitespace).
+        merged = current + fragment
+    return merged[:MAX_TRANSCRIPT_CHARS]
+
+
+class _GeminiLiveTracer:
+    """Turn raw Gemini Live server messages into a conversation trace."""
+
+    def __init__(
+        self,
+        session: EventSession,
+        *,
+        model: str | None,
+        is_agent_speaking: Optional[Callable[[], bool]] = None,
+    ) -> None:
+        self._session = session
+        self._model = model
+        self._is_agent_speaking = is_agent_speaking
+        self._user_text = ""
+        self._agent_text = ""
+        self._turn_usage: dict[str, Any] | None = None
+        self._last_message: Any = None
+
+    def observe(self, message: Any) -> None:
+        self._last_message = message
+        view = _LiveMessageView(message)
+        now = self._session.now()
+
+        if user_fragment := view.user_transcript:
+            self._user_text = _merge_transcript(self._user_text, user_fragment)
+        if view.user_transcript_finished:
+            self._flush_user(message, now)
+
+        if agent_fragment := view.agent_transcript:
+            self._agent_text = _merge_transcript(self._agent_text, agent_fragment)
+        usage = usage_metadata_from_message(message)
+        if usage is not None:
+            self._turn_usage = usage
+
+        if view.interrupted:
+            if self._is_agent_speaking is not None and self._is_agent_speaking():
+                interruption_metadata = {"was_audible": True}
+            else:
+                interruption_metadata = None
+            with self._session.event_span(
+                message,
+                now,
+                name="interrupted",
+                inbound=False,
+                outputs={},
+                metadata=interruption_metadata,
+            ):
+                pass
+
+        if view.turn_complete:
+            self._flush_user(message, now)
+            agent_text = self._take_agent_text()
+            if agent_text:
+                self._session.add_message("assistant", agent_text)
+            with self._session.event_span(
+                message,
+                now,
+                name="turn_complete",
+                inbound=False,
+                run_type="llm",
+                outputs=(
+                    {"role": "assistant", "content": agent_text} if agent_text else {}
+                ),
+                usage_metadata=self._turn_usage,
+                metadata={
+                    "ls_provider": "google",
+                    "ls_model_name": self._model,
+                },
+            ):
+                pass
+            self._turn_usage = None
+
+        cancelled_ids = view.cancelled_tool_call_ids
+        if cancelled_ids:
+            with self._session.event_span(
+                message,
+                now,
+                name="tool_call_cancellation",
+                inbound=False,
+                outputs={"call_ids": cancelled_ids},
+            ):
+                pass
+
+        # Function-call messages deliberately create no synthetic wrapper span.
+        # The application's @traceable function is the single, correctly typed
+        # tool run and inherits the live session root as its parent.
+
+    def _flush_user(self, message: Any, now: float) -> None:
+        text = self._user_text.strip()
+        self._user_text = ""
+        if not text:
+            return
+        self._session.add_message("user", text)
+        self._session.set_title(text)
+        with self._session.event_span(
+            message,
+            now,
+            name="input_transcription",
+            inbound=True,
+            inputs={"role": "user", "content": text},
+        ):
+            pass
+
+    def _take_agent_text(self) -> str:
+        text = self._agent_text.strip()
+        self._agent_text = ""
+        return text
+
+    def _flush_incomplete_agent(self) -> None:
+        text = self._take_agent_text()
+        if not text:
+            return
+        self._session.add_message("assistant", text)
+        self._session.record_llm(
+            name="output_transcription",
+            outputs={"role": "assistant", "content": text},
+            usage_metadata=self._turn_usage,
+            metadata={
+                "raw_event": scrub(dump_event(self._last_message)),
+                "ls_provider": "google",
+                "ls_model_name": self._model,
+            },
+        )
+        self._turn_usage = None
+
+    def finalize(self) -> None:
+        if self._last_message is not None:
+            self._flush_user(self._last_message, self._session.now())
+        self._flush_incomplete_agent()
+
+
+class _TracedGeminiLiveSession:
+    """Transparent proxy over ``google.genai.live.AsyncSession``."""
+
+    def __init__(
+        self, session: Any, tracer: _GeminiLiveTracer, trace: EventSession
+    ) -> None:
+        self._wrapped_session = session
+        self._tracer = tracer
+        self._trace = trace
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(object.__getattribute__(self, "_wrapped_session"), name)
+
+    async def receive(self) -> AsyncIterator[Any]:
+        async for message in self._wrapped_session.receive():
+            observe_safely(self._tracer.observe, message)
+            yield message
+
+    def record_user_audio(self, pcm: bytes) -> None:
+        """Record user PCM16 for the bounded stereo conversation WAV."""
+        self._trace.record_user(self._trace.now(), pcm)
+
+    def record_agent_audio(self, pcm: bytes) -> None:
+        """Record actually-played agent PCM16 for the conversation WAV."""
+        self._trace.record_agent(self._trace.now(), pcm)
+
+
+class _GeminiLiveTracingSession:
+    """Async context manager that owns one Gemini Live conversation trace."""
+
+    def __init__(
+        self,
+        session: Any,
+        *,
+        model: str | None,
+        thread_id: Optional[str],
+        sample_rate: int,
+        project_name: Optional[str],
+        tags: Optional[list[str]],
+        metadata: Optional[dict[str, Any]],
+        is_agent_speaking: Optional[Callable[[], bool]],
+        max_audio_seconds: Optional[float],
+        client: Optional[Client],
+        replicas: Optional[Sequence[WriteReplica]],
+    ) -> None:
+        self._wrapped_session = session
+        self._model = model
+        self._thread_id = thread_id or str(uuid.uuid4())
+        self._sample_rate = sample_rate
+        self._project_name = project_name
+        self._tags = tags
+        self._metadata = metadata
+        self._is_agent_speaking = is_agent_speaking
+        self._max_audio_seconds = max_audio_seconds
+        self._client = client
+        self._replicas = replicas
+        self._trace: EventSession | None = None
+        self._tracer: _GeminiLiveTracer | None = None
+        self._context: Any = None
+
+    async def __aenter__(self) -> _TracedGeminiLiveSession:
+        self._trace = start_session(
+            thread_id=self._thread_id,
+            sample_rate=self._sample_rate,
+            project_name=self._project_name,
+            tags=self._tags,
+            metadata=self._metadata,
+            max_audio_seconds=self._max_audio_seconds,
+            client=self._client,
+            replicas=self._replicas,
+            integration="gemini-live",
+            integration_version=get_package_version("google-genai"),
+        )
+        self._context = tracing_context(
+            parent=self._trace.run,
+            metadata={"thread_id": self._thread_id},
+            tags=self._tags,
+            project_name=self._project_name,
+            replicas=self._replicas,
+        )
+        self._context.__enter__()
+        self._tracer = _GeminiLiveTracer(
+            self._trace,
+            model=self._model,
+            is_agent_speaking=self._is_agent_speaking,
+        )
+        return _TracedGeminiLiveSession(
+            self._wrapped_session, self._tracer, self._trace
+        )
+
+    async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> bool:
+        try:
+            if self._tracer is not None:
+                self._tracer.finalize()
+            if self._trace is not None:
+                if exc is not None:
+                    self._trace.run.error = f"{exc_type.__name__}: {exc}"
+                self._trace.finalize()
+        except Exception:
+            logger.warning("Gemini Live tracing: failed to finalize", exc_info=True)
+        finally:
+            if self._context is not None:
+                self._context.__exit__(None, None, None)
+        return False
+
+
+def wrap_gemini_live(
+    session: Any,
+    *,
+    model: str | None = None,
+    thread_id: Optional[str] = None,
+    sample_rate: int = DEFAULT_SAMPLE_RATE,
+    project_name: Optional[str] = None,
+    tags: Optional[list[str]] = None,
+    metadata: Optional[dict[str, Any]] = None,
+    is_agent_speaking: Optional[Callable[[], bool]] = None,
+    max_audio_seconds: Optional[float] = DEFAULT_MAX_AUDIO_SECONDS,
+    client: Optional[Client] = None,
+    replicas: Optional[Sequence[WriteReplica]] = None,
+) -> _GeminiLiveTracingSession:
+    """Trace a Gemini Live ``AsyncSession`` into LangSmith.
+
+    Use the returned async context manager alongside the provider connection::
+
+        async with client.aio.live.connect(model=model, config=config) as raw, \
+                   wrap_gemini_live(raw, model=model) as session:
+            async for message in session.receive():
+                ...
+
+    The yielded object proxies every provider-session method. Feed PCM16 to
+    ``record_user_audio`` and ``record_agent_audio`` to attach a bounded stereo
+    WAV, and optionally provide ``is_agent_speaking`` to annotate interruptions.
+    """
+    return _GeminiLiveTracingSession(
+        session,
+        model=model,
+        thread_id=thread_id,
+        sample_rate=sample_rate,
+        project_name=project_name,
+        tags=tags,
+        metadata=metadata,
+        is_agent_speaking=is_agent_speaking,
+        max_audio_seconds=max_audio_seconds,
+        client=client,
+        replicas=replicas,
+    )

--- a/python/langsmith/integrations/gemini_live/_session.py
+++ b/python/langsmith/integrations/gemini_live/_session.py
@@ -25,7 +25,9 @@ from __future__ import annotations
 import logging
 import uuid
 from collections.abc import Mapping, Sequence
-from typing import TYPE_CHECKING, Any, Callable, Optional
+from contextlib import AbstractContextManager
+from types import TracebackType
+from typing import TYPE_CHECKING, Any, Callable, Optional, cast
 
 from langsmith._internal._package_version import get_package_version
 from langsmith._internal.voice.helpers import dump_event, observe_safely, scrub
@@ -40,6 +42,14 @@ from langsmith.run_helpers import tracing_context
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
 
+    from google.genai.live import AsyncSession
+    from google.genai.types import (
+        FunctionCall,
+        FunctionResponseOrDict,
+        LiveServerContent,
+        LiveServerMessage,
+    )
+
     from langsmith import Client
     from langsmith.run_trees import RunTree, WriteReplica
 
@@ -52,12 +62,12 @@ MAX_TRANSCRIPT_CHARS = 2_000
 class _LiveMessageView:
     """Readable, dependency-free view over a ``LiveServerMessage``."""
 
-    def __init__(self, raw: Any) -> None:
+    def __init__(self, raw: LiveServerMessage) -> None:
         self.raw = raw
 
     @property
-    def server_content(self) -> Any:
-        return getattr(self.raw, "server_content", None)
+    def server_content(self) -> LiveServerContent | None:
+        return self.raw.server_content
 
     def _transcript(self, attr: str) -> str | None:
         content = self.server_content
@@ -80,14 +90,14 @@ class _LiveMessageView:
         return self._transcript("output_transcription")
 
     @property
-    def function_calls(self) -> list[Any]:
-        tool_call = getattr(self.raw, "tool_call", None)
-        return list(getattr(tool_call, "function_calls", None) or [])
+    def function_calls(self) -> list[FunctionCall]:
+        tool_call = self.raw.tool_call
+        return list(tool_call.function_calls or []) if tool_call is not None else []
 
     @property
     def cancelled_tool_call_ids(self) -> list[str]:
-        cancellation = getattr(self.raw, "tool_call_cancellation", None)
-        return [str(value) for value in getattr(cancellation, "ids", None) or []]
+        cancellation = self.raw.tool_call_cancellation
+        return [str(value) for value in cancellation.ids or []] if cancellation else []
 
     @property
     def interrupted(self) -> bool:
@@ -100,9 +110,11 @@ class _LiveMessageView:
         return bool(content is not None and getattr(content, "turn_complete", False))
 
 
-def usage_metadata_from_message(message: Any) -> dict[str, Any] | None:
+def usage_metadata_from_message(
+    message: LiveServerMessage,
+) -> dict[str, Any] | None:
     """Map Gemini Live usage onto LangSmith's canonical token metadata."""
-    return normalize_gemini_usage_metadata(getattr(message, "usage_metadata", None))
+    return normalize_gemini_usage_metadata(message.usage_metadata)
 
 
 def _append_transcript(current: str, fragment: str) -> str:
@@ -127,10 +139,10 @@ class _GeminiLiveTracer:
         self._user_text = ""
         self._agent_text = ""
         self._turn_usage: dict[str, Any] | None = None
-        self._last_message: Any = None
+        self._last_message: LiveServerMessage | None = None
         self._open_tools: dict[str, list[RunTree]] = {}
 
-    def observe(self, message: Any) -> None:
+    def observe(self, message: LiveServerMessage) -> None:
         self._last_message = message
         view = _LiveMessageView(message)
         now = self._session.now()
@@ -203,48 +215,57 @@ class _GeminiLiveTracer:
             self._start_tool(call, message)
 
     @staticmethod
-    def _field(value: Any, name: str) -> Any:
+    def _field(value: object, name: str) -> object:
         if isinstance(value, Mapping):
-            return value.get(name)
+            return next((item for key, item in value.items() if key == name), None)
         return getattr(value, name, None)
 
     @classmethod
-    def _tool_key(cls, value: Any) -> str:
+    def _tool_id(cls, value: FunctionCall | FunctionResponseOrDict) -> str | None:
         call_id = cls._field(value, "id")
-        if call_id:
-            return str(call_id)
-        return str(cls._field(value, "name") or "tool")
+        return call_id if isinstance(call_id, str) else None
 
-    def _start_tool(self, call: Any, message: Any) -> None:
-        name = self._field(call, "name") or "tool"
+    @classmethod
+    def _tool_name(cls, value: FunctionCall | FunctionResponseOrDict) -> str | None:
+        name = cls._field(value, "name")
+        return name if isinstance(name, str) else None
+
+    @classmethod
+    def _tool_key(cls, value: FunctionCall | FunctionResponseOrDict) -> str:
+        return cls._tool_id(value) or cls._tool_name(value) or "tool"
+
+    def _start_tool(self, call: FunctionCall, message: LiveServerMessage) -> None:
+        name = call.name or "tool"
         run = self._session.open_span(
-            name=str(name),
+            name=name,
             run_type="tool",
-            inputs={"args": self._field(call, "args")},
+            inputs={"args": call.args},
             metadata={
-                "function_call_id": self._field(call, "id"),
+                "function_call_id": call.id,
                 "raw_event": scrub(dump_event(message)),
             },
         )
         self._open_tools.setdefault(self._tool_key(call), []).append(run)
 
-    def observe_tool_responses(self, responses: Any) -> None:
+    def observe_tool_responses(
+        self,
+        responses: FunctionResponseOrDict | Sequence[FunctionResponseOrDict],
+    ) -> None:
         """Close tool spans after responses are sent to Gemini."""
-        if isinstance(responses, Sequence) and not isinstance(
-            responses, (str, bytes, bytearray, Mapping)
-        ):
-            items = responses
+        if isinstance(responses, Sequence) and not isinstance(responses, Mapping):
+            items = cast("Sequence[FunctionResponseOrDict]", responses)
         else:
-            items = [responses]
+            items = (cast("FunctionResponseOrDict", responses),)
         for response in items:
             self._end_tool(response)
 
-    def _end_tool(self, response: Any) -> None:
-        name = self._field(response, "name") or "tool"
-        outputs = {"response": self._field(response, "response")}
+    def _end_tool(self, response: FunctionResponseOrDict) -> None:
+        name = self._tool_name(response) or "tool"
+        response_value = self._field(response, "response")
+        outputs = {"response": response_value}
         queue = self._open_tools.get(self._tool_key(response))
-        if not queue and self._field(response, "id"):
-            queue = self._open_tools.get(str(name))
+        if not queue and self._tool_id(response):
+            queue = self._open_tools.get(name)
         if queue:
             run = queue.pop(0)
             self._prune_empty_tools()
@@ -283,7 +304,7 @@ class _GeminiLiveTracer:
                 self._session.close_span(run)
         self._open_tools.clear()
 
-    def _flush_user(self, message: Any, now: float) -> None:
+    def _flush_user(self, message: LiveServerMessage, now: float) -> None:
         text = self._user_text.strip()
         self._user_text = ""
         if not text:
@@ -332,7 +353,7 @@ class _TracedGeminiLiveSession:
     """Transparent proxy over ``google.genai.live.AsyncSession``."""
 
     def __init__(
-        self, session: Any, tracer: _GeminiLiveTracer, trace: EventSession
+        self, session: AsyncSession, tracer: _GeminiLiveTracer, trace: EventSession
     ) -> None:
         self._wrapped_session = session
         self._tracer = tracer
@@ -341,20 +362,21 @@ class _TracedGeminiLiveSession:
     def __getattr__(self, name: str) -> Any:
         return getattr(object.__getattribute__(self, "_wrapped_session"), name)
 
-    async def receive(self) -> AsyncIterator[Any]:
+    async def receive(self) -> AsyncIterator[LiveServerMessage]:
         async for message in self._wrapped_session.receive():
             observe_safely(self._tracer.observe, message)
             yield message
 
-    async def send_tool_response(self, *args: Any, **kwargs: Any) -> Any:
+    async def send_tool_response(
+        self,
+        *,
+        function_responses: FunctionResponseOrDict | Sequence[FunctionResponseOrDict],
+    ) -> None:
         """Forward tool responses and use them to finish inferred tool spans."""
-        result = await self._wrapped_session.send_tool_response(*args, **kwargs)
-        responses = kwargs.get("function_responses")
-        if responses is None and args:
-            responses = args[0]
-        if responses is not None:
-            observe_safely(self._tracer.observe_tool_responses, responses)
-        return result
+        await self._wrapped_session.send_tool_response(
+            function_responses=function_responses
+        )
+        observe_safely(self._tracer.observe_tool_responses, function_responses)
 
     def record_user_audio(self, pcm: bytes) -> None:
         """Record user PCM16 for the bounded stereo conversation WAV."""
@@ -370,7 +392,7 @@ class _GeminiLiveTracingSession:
 
     def __init__(
         self,
-        session: Any,
+        session: AsyncSession,
         *,
         model: str | None,
         thread_id: Optional[str],
@@ -396,7 +418,7 @@ class _GeminiLiveTracingSession:
         self._replicas = replicas
         self._trace: EventSession | None = None
         self._tracer: _GeminiLiveTracer | None = None
-        self._context: Any = None
+        self._context: AbstractContextManager[None] | None = None
 
     async def __aenter__(self) -> _TracedGeminiLiveSession:
         self._trace = start_session(
@@ -428,13 +450,18 @@ class _GeminiLiveTracingSession:
             self._wrapped_session, self._tracer, self._trace
         )
 
-    async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> bool:
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> bool:
         try:
             if self._tracer is not None:
                 self._tracer.finalize()
             if self._trace is not None:
                 if exc is not None:
-                    self._trace.run.error = f"{exc_type.__name__}: {exc}"
+                    self._trace.run.error = f"{type(exc).__name__}: {exc}"
                 self._trace.finalize()
         except Exception:
             logger.warning("Gemini Live tracing: failed to finalize", exc_info=True)
@@ -445,7 +472,7 @@ class _GeminiLiveTracingSession:
 
 
 def wrap_gemini_live(
-    session: Any,
+    session: AsyncSession,
     *,
     model: str | None = None,
     thread_id: Optional[str] = None,

--- a/python/langsmith/integrations/gemini_live/_session.py
+++ b/python/langsmith/integrations/gemini_live/_session.py
@@ -104,21 +104,10 @@ def usage_metadata_from_message(message: Any) -> dict[str, Any] | None:
     return normalize_gemini_usage_metadata(getattr(message, "usage_metadata", None))
 
 
-def _merge_transcript(current: str, fragment: str) -> str:
-    """Merge delta-style or cumulative transcription fragments, with a cap."""
-    fragment = fragment[:MAX_TRANSCRIPT_CHARS]
-    if not current:
-        merged = fragment
-    elif fragment.startswith(current):
-        # Some Gemini versions send the full transcript-so-far each time.
-        merged = fragment
-    elif current.startswith(fragment) or current.endswith(fragment):
-        # Ignore an older cumulative snapshot or a repeated final fragment.
-        merged = current
-    else:
-        # Other versions stream true deltas (including their own whitespace).
-        merged = current + fragment
-    return merged[:MAX_TRANSCRIPT_CHARS]
+def _append_transcript(current: str, fragment: str) -> str:
+    """Append one Gemini transcription delta, retaining the per-turn cap."""
+    remaining = MAX_TRANSCRIPT_CHARS - len(current)
+    return current if remaining <= 0 else current + fragment[:remaining]
 
 
 class _GeminiLiveTracer:
@@ -145,12 +134,12 @@ class _GeminiLiveTracer:
         now = self._session.now()
 
         if user_fragment := view.user_transcript:
-            self._user_text = _merge_transcript(self._user_text, user_fragment)
+            self._user_text = _append_transcript(self._user_text, user_fragment)
         if view.user_transcript_finished:
             self._flush_user(message, now)
 
         if agent_fragment := view.agent_transcript:
-            self._agent_text = _merge_transcript(self._agent_text, agent_fragment)
+            self._agent_text = _append_transcript(self._agent_text, agent_fragment)
         usage = usage_metadata_from_message(message)
         if usage is not None:
             self._turn_usage = usage

--- a/python/langsmith/integrations/gemini_live/_session.py
+++ b/python/langsmith/integrations/gemini_live/_session.py
@@ -33,6 +33,7 @@ from langsmith._internal.voice.session import (
     EventSession,
     start_session,
 )
+from langsmith.integrations._gemini_usage import normalize_gemini_usage_metadata
 from langsmith.run_helpers import tracing_context
 
 if TYPE_CHECKING:
@@ -98,63 +99,9 @@ class _LiveMessageView:
         return bool(content is not None and getattr(content, "turn_complete", False))
 
 
-def _audio_tokens(details: Any) -> int | None:
-    """Sum the AUDIO token count from a Gemini modality-details sequence."""
-    if not isinstance(details, (list, tuple)):
-        return None
-    total = 0
-    found = False
-    for entry in details:
-        modality = getattr(entry, "modality", None)
-        modality = getattr(modality, "value", modality)
-        count = getattr(entry, "token_count", None)
-        if str(modality).upper() == "AUDIO" and isinstance(count, int):
-            total += count
-            found = True
-    return total if found else None
-
-
 def usage_metadata_from_message(message: Any) -> dict[str, Any] | None:
     """Map Gemini Live usage onto LangSmith's canonical token metadata."""
-    usage = getattr(message, "usage_metadata", None)
-    if usage is None:
-        return None
-
-    result: dict[str, Any] = {}
-    for key, attrs in (
-        ("input_tokens", ("prompt_token_count",)),
-        # Direct Gemini Live uses ``response_*``. ``candidates_*`` keeps the
-        # mapper compatible with older/generated response shapes.
-        ("output_tokens", ("response_token_count", "candidates_token_count")),
-        ("total_tokens", ("total_token_count",)),
-    ):
-        for attr in attrs:
-            value = getattr(usage, attr, None)
-            if isinstance(value, int):
-                result[key] = value
-                break
-
-    input_details: dict[str, int] = {}
-    prompt_details = getattr(usage, "prompt_tokens_details", None)
-    if (audio := _audio_tokens(prompt_details)) is not None:
-        input_details["audio"] = audio
-    if isinstance(cached := getattr(usage, "cached_content_token_count", None), int):
-        input_details["cache_read"] = cached
-    if input_details:
-        result["input_token_details"] = input_details
-
-    output_details: dict[str, int] = {}
-    response_details = getattr(usage, "response_tokens_details", None)
-    if response_details is None:
-        response_details = getattr(usage, "candidates_tokens_details", None)
-    if (audio := _audio_tokens(response_details)) is not None:
-        output_details["audio"] = audio
-    if isinstance(reasoning := getattr(usage, "thoughts_token_count", None), int):
-        output_details["reasoning"] = reasoning
-    if output_details:
-        result["output_token_details"] = output_details
-
-    return result or None
+    return normalize_gemini_usage_metadata(getattr(message, "usage_metadata", None))
 
 
 def _merge_transcript(current: str, fragment: str) -> str:

--- a/python/langsmith/integrations/gemini_live/_session.py
+++ b/python/langsmith/integrations/gemini_live/_session.py
@@ -9,7 +9,7 @@ Trace shape -- one live session = one trace::
 
     realtime_session                         (root; transcript + stereo WAV)
     ├── input_transcription                  (curated user message)
-    ├── lookup_weather                       (caller's @traceable tool)
+    ├── lookup_weather                       (tool; args in / response out)
     ├── turn_complete                        (llm; assistant text + usage)
     ├── interrupted                          (barge-in marker)
     └── turn_complete                        (turn marker)
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import logging
 import uuid
+from collections.abc import Mapping, Sequence
 from typing import TYPE_CHECKING, Any, Callable, Optional
 
 from langsmith._internal._package_version import get_package_version
@@ -37,10 +38,10 @@ from langsmith.integrations._gemini_usage import normalize_gemini_usage_metadata
 from langsmith.run_helpers import tracing_context
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator, Sequence
+    from collections.abc import AsyncIterator
 
     from langsmith import Client
-    from langsmith.run_trees import WriteReplica
+    from langsmith.run_trees import RunTree, WriteReplica
 
 logger = logging.getLogger(__name__)
 
@@ -127,6 +128,7 @@ class _GeminiLiveTracer:
         self._agent_text = ""
         self._turn_usage: dict[str, Any] | None = None
         self._last_message: Any = None
+        self._open_tools: dict[str, list[RunTree]] = {}
 
     def observe(self, message: Any) -> None:
         self._last_message = message
@@ -192,10 +194,94 @@ class _GeminiLiveTracer:
                 outputs={"call_ids": cancelled_ids},
             ):
                 pass
+            for call_id in cancelled_ids:
+                self._cancel_tool(call_id)
 
-        # Function-call messages deliberately create no synthetic wrapper span.
-        # The application's @traceable function is the single, correctly typed
-        # tool run and inherits the live session root as its parent.
+        # One held-open tool span per function call. ``send_tool_response`` on
+        # the session proxy closes it after the application executes the tool.
+        for call in view.function_calls:
+            self._start_tool(call, message)
+
+    @staticmethod
+    def _field(value: Any, name: str) -> Any:
+        if isinstance(value, Mapping):
+            return value.get(name)
+        return getattr(value, name, None)
+
+    @classmethod
+    def _tool_key(cls, value: Any) -> str:
+        call_id = cls._field(value, "id")
+        if call_id:
+            return str(call_id)
+        return str(cls._field(value, "name") or "tool")
+
+    def _start_tool(self, call: Any, message: Any) -> None:
+        name = self._field(call, "name") or "tool"
+        run = self._session.open_span(
+            name=str(name),
+            run_type="tool",
+            inputs={"args": self._field(call, "args")},
+            metadata={
+                "function_call_id": self._field(call, "id"),
+                "raw_event": scrub(dump_event(message)),
+            },
+        )
+        self._open_tools.setdefault(self._tool_key(call), []).append(run)
+
+    def observe_tool_responses(self, responses: Any) -> None:
+        """Close tool spans after responses are sent to Gemini."""
+        if isinstance(responses, Sequence) and not isinstance(
+            responses, (str, bytes, bytearray, Mapping)
+        ):
+            items = responses
+        else:
+            items = [responses]
+        for response in items:
+            self._end_tool(response)
+
+    def _end_tool(self, response: Any) -> None:
+        name = self._field(response, "name") or "tool"
+        outputs = {"response": self._field(response, "response")}
+        queue = self._open_tools.get(self._tool_key(response))
+        if not queue and self._field(response, "id"):
+            queue = self._open_tools.get(str(name))
+        if queue:
+            run = queue.pop(0)
+            self._prune_empty_tools()
+            self._session.close_span(
+                run,
+                outputs=outputs,
+                metadata={"raw_response": dump_event(response)},
+            )
+            return
+        with self._session.event_span(
+            response,
+            self._session.now(),
+            name=str(name),
+            run_type="tool",
+            inbound=False,
+            inputs={},
+            outputs=outputs,
+        ):
+            pass
+
+    def _cancel_tool(self, call_id: str) -> None:
+        queue = self._open_tools.pop(str(call_id), [])
+        for run in queue:
+            run.error = "tool call cancelled by Gemini"
+            self._session.close_span(run)
+
+    def _prune_empty_tools(self) -> None:
+        self._open_tools = {
+            key: queue for key, queue in self._open_tools.items() if queue
+        }
+
+    def _flush_open_tools(self) -> None:
+        for queue in self._open_tools.values():
+            for run in queue:
+                run.error = "tool did not complete before the session ended"
+                self._session.close_span(run)
+        self._open_tools.clear()
 
     def _flush_user(self, message: Any, now: float) -> None:
         text = self._user_text.strip()
@@ -239,6 +325,7 @@ class _GeminiLiveTracer:
         if self._last_message is not None:
             self._flush_user(self._last_message, self._session.now())
         self._flush_incomplete_agent()
+        self._flush_open_tools()
 
 
 class _TracedGeminiLiveSession:
@@ -258,6 +345,16 @@ class _TracedGeminiLiveSession:
         async for message in self._wrapped_session.receive():
             observe_safely(self._tracer.observe, message)
             yield message
+
+    async def send_tool_response(self, *args: Any, **kwargs: Any) -> Any:
+        """Forward tool responses and use them to finish inferred tool spans."""
+        result = await self._wrapped_session.send_tool_response(*args, **kwargs)
+        responses = kwargs.get("function_responses")
+        if responses is None and args:
+            responses = args[0]
+        if responses is not None:
+            observe_safely(self._tracer.observe_tool_responses, responses)
+        return result
 
     def record_user_audio(self, pcm: bytes) -> None:
         """Record user PCM16 for the bounded stereo conversation WAV."""

--- a/python/langsmith/integrations/google_adk_live/_plugin.py
+++ b/python/langsmith/integrations/google_adk_live/_plugin.py
@@ -59,6 +59,7 @@ from langsmith._internal.voice.session import (
     EventSession,
     start_session,
 )
+from langsmith.integrations._gemini_usage import normalize_gemini_usage_metadata
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -159,28 +160,6 @@ def _resolve_model(invocation_context: Any) -> str | None:
     return getattr(model, "model", None) or None
 
 
-def _audio_tokens(details: Any) -> int | None:
-    """Sum the ``AUDIO`` modality token count from a ``ModalityTokenCount`` list.
-
-    Gemini reports per-modality breakdowns as a list of ``{modality, token_count}``
-    entries; the audio bucket is what the cost engine prices at the (much higher)
-    audio rate. ``MediaModality`` has a single audio member (``AUDIO``), so an
-    exact match is enough. Returns ``None`` when no audio modality is present.
-    """
-    if not isinstance(details, (list, tuple)):
-        return None
-    total = 0
-    found = False
-    for entry in details:
-        modality = getattr(entry, "modality", None)
-        modality = getattr(modality, "value", modality)
-        count = getattr(entry, "token_count", None)
-        if str(modality).upper() == "AUDIO" and isinstance(count, int):
-            total += count
-            found = True
-    return total if found else None
-
-
 def _usage_metadata(event: Any) -> dict[str, Any] | None:
     """Map an ADK event's ``usage_metadata`` to LangSmith token usage, if any.
 
@@ -193,37 +172,7 @@ def _usage_metadata(event: Any) -> dict[str, Any] | None:
     at all, in which case the ``llm`` span is recorded without token counts. Only
     the fields ADK actually reports are included.
     """
-    um = getattr(event, "usage_metadata", None)
-    if um is None:
-        return None
-    usage: dict[str, Any] = {}
-    for key, attr in (
-        ("input_tokens", "prompt_token_count"),
-        ("output_tokens", "candidates_token_count"),
-        ("total_tokens", "total_token_count"),
-    ):
-        if isinstance(v := getattr(um, attr, None), int):
-            usage[key] = v
-
-    input_details: dict[str, int] = {}
-    if (audio := _audio_tokens(getattr(um, "prompt_tokens_details", None))) is not None:
-        input_details["audio"] = audio
-    if isinstance(cached := getattr(um, "cached_content_token_count", None), int):
-        input_details["cache_read"] = cached
-    if input_details:
-        usage["input_token_details"] = input_details
-
-    output_details: dict[str, int] = {}
-    if (
-        audio := _audio_tokens(getattr(um, "candidates_tokens_details", None))
-    ) is not None:
-        output_details["audio"] = audio
-    if isinstance(reasoning := getattr(um, "thoughts_token_count", None), int):
-        output_details["reasoning"] = reasoning
-    if output_details:
-        usage["output_token_details"] = output_details
-
-    return usage or None
+    return normalize_gemini_usage_metadata(getattr(event, "usage_metadata", None))
 
 
 class _AdkLiveTracer:

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -86,6 +86,10 @@ openai-realtime = [
     "openai-agents>=0.0.3",
 ]
 
+# Enabled via `pip install langsmith[gemini-live]`
+# Raw Gemini Live WebSocket tracing via ``wrap_gemini_live``.
+gemini-live = ["google-genai>=1.75"]
+
 # Enabled via `pip install langsmith[openai-agents]`
 openai-agents = ["openai-agents>=0.0.3"]
 

--- a/python/tests/unit_tests/wrappers/test_gemini_live.py
+++ b/python/tests/unit_tests/wrappers/test_gemini_live.py
@@ -11,8 +11,8 @@ from langsmith import Client, traceable
 from langsmith._internal.voice import session as session_mod
 from langsmith.integrations.gemini_live import _session as live_mod
 from langsmith.integrations.gemini_live._session import (
+    _append_transcript,
     _LiveMessageView,
-    _merge_transcript,
     usage_metadata_from_message,
     wrap_gemini_live,
 )
@@ -123,11 +123,10 @@ class TestHelpers:
         assert _LiveMessageView(message).user_transcript == "partial"
         assert _LiveMessageView(message).user_transcript_finished is False
 
-    def test_merge_transcript_supports_deltas_cumulative_and_cap(self):
-        assert _merge_transcript("Hello ", "world") == "Hello world"
-        assert _merge_transcript("Hello", "Hello world") == "Hello world"
-        assert _merge_transcript("Hello world", "Hello") == "Hello world"
-        assert len(_merge_transcript("", "x" * 3_000)) == 2_000
+    def test_append_transcript_supports_deltas_repetition_and_cap(self):
+        assert _append_transcript("Hello ", "world") == "Hello world"
+        assert _append_transcript("ha", "ha") == "haha"
+        assert len(_append_transcript("", "x" * 3_000)) == 2_000
 
     def test_usage_maps_direct_live_fields_and_audio(self):
         usage = NS(
@@ -211,7 +210,7 @@ class TestWrapper:
         )
         messages = [
             _message(user="what is ", user_finished=False),
-            _message(user="what is the weather?", user_finished=False),
+            _message(user="the weather?", user_finished=False),
             _message(agent="It is ", agent_finished=False),
             _message(agent="sunny.", agent_finished=False),
             _message(turn_complete=True, usage=usage),

--- a/python/tests/unit_tests/wrappers/test_gemini_live.py
+++ b/python/tests/unit_tests/wrappers/test_gemini_live.py
@@ -1,0 +1,311 @@
+"""Unit tests for raw Gemini Live session tracing."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace as NS
+from unittest import mock
+
+import pytest
+
+from langsmith import Client, traceable
+from langsmith._internal.voice import session as session_mod
+from langsmith.integrations.gemini_live import _session as live_mod
+from langsmith.integrations.gemini_live._session import (
+    _LiveMessageView,
+    _merge_transcript,
+    usage_metadata_from_message,
+    wrap_gemini_live,
+)
+from langsmith.run_helpers import get_current_run_tree
+
+LS_TEST_CLIENT_INFO = {
+    "batch_ingest_config": {
+        "use_multipart_endpoint": False,
+        "scale_up_qsize_trigger": 1000,
+        "scale_up_nthreads_limit": 16,
+        "scale_down_nempty_trigger": 4,
+        "size_limit": 100,
+        "size_limit_bytes": 20971520,
+    },
+}
+
+
+@pytest.fixture
+def mock_client() -> Client:
+    return Client(session=mock.MagicMock(), info=LS_TEST_CLIENT_INFO, api_key="test")
+
+
+@pytest.fixture(autouse=True)
+def _patch_cached_client(mock_client, monkeypatch):
+    monkeypatch.setattr(
+        "langsmith.run_trees.get_cached_client", lambda **_: mock_client
+    )
+
+
+class FakeSession:
+    """Small stand-in for ``google.genai.live.AsyncSession``."""
+
+    def __init__(self, messages):
+        self._messages = list(messages)
+        self.session_id = "provider-session"
+
+    async def receive(self):
+        for message in self._messages:
+            yield message
+
+    async def send_tool_response(self, **kwargs):
+        return kwargs
+
+
+def _message(
+    *,
+    user=None,
+    user_finished=True,
+    agent=None,
+    agent_finished=True,
+    calls=None,
+    interrupted=False,
+    turn_complete=False,
+    usage=None,
+):
+    content = None
+    if user is not None or agent is not None or interrupted or turn_complete:
+        content = NS(
+            input_transcription=(
+                NS(text=user, finished=user_finished) if user is not None else None
+            ),
+            output_transcription=(
+                NS(text=agent, finished=agent_finished) if agent is not None else None
+            ),
+            interrupted=interrupted,
+            turn_complete=turn_complete,
+        )
+    tool_call = NS(function_calls=calls) if calls is not None else None
+    return NS(
+        server_content=content,
+        tool_call=tool_call,
+        tool_call_cancellation=None,
+        usage_metadata=usage,
+        model_dump=lambda: {
+            "server_content": {"audio": b"\x00\x01"} if content else None
+        },
+    )
+
+
+class TestHelpers:
+    def test_message_view(self):
+        call = NS(id="call-1", name="lookup_weather", args={"city": "Paris"})
+        message = _message(
+            user="weather?",
+            agent="Sunny.",
+            calls=[call],
+            interrupted=True,
+            turn_complete=True,
+        )
+        view = _LiveMessageView(message)
+        assert view.user_transcript == "weather?"
+        assert view.user_transcript_finished is True
+        assert view.agent_transcript == "Sunny."
+        assert view.function_calls == [call]
+        assert view.interrupted is True
+        assert view.turn_complete is True
+
+    def test_tool_call_cancellation_view(self):
+        message = _message()
+        message.tool_call_cancellation = NS(ids=["call-1", "call-2"])
+        assert _LiveMessageView(message).cancelled_tool_call_ids == [
+            "call-1",
+            "call-2",
+        ]
+
+    def test_unfinished_transcription_is_ignored(self):
+        message = _message(user="partial", user_finished=False)
+        assert _LiveMessageView(message).user_transcript == "partial"
+        assert _LiveMessageView(message).user_transcript_finished is False
+
+    def test_merge_transcript_supports_deltas_cumulative_and_cap(self):
+        assert _merge_transcript("Hello ", "world") == "Hello world"
+        assert _merge_transcript("Hello", "Hello world") == "Hello world"
+        assert _merge_transcript("Hello world", "Hello") == "Hello world"
+        assert len(_merge_transcript("", "x" * 3_000)) == 2_000
+
+    def test_usage_maps_direct_live_fields_and_audio(self):
+        usage = NS(
+            prompt_token_count=100,
+            response_token_count=40,
+            total_token_count=140,
+            prompt_tokens_details=[NS(modality="AUDIO", token_count=80)],
+            response_tokens_details=[NS(modality=NS(value="AUDIO"), token_count=30)],
+            cached_content_token_count=10,
+            thoughts_token_count=4,
+        )
+        assert usage_metadata_from_message(_message(usage=usage)) == {
+            "input_tokens": 100,
+            "output_tokens": 40,
+            "total_tokens": 140,
+            "input_token_details": {"audio": 80, "cache_read": 10},
+            "output_token_details": {"audio": 30, "reasoning": 4},
+        }
+
+    def test_usage_falls_back_to_candidates_fields(self):
+        usage = NS(
+            prompt_token_count=3,
+            response_token_count=None,
+            candidates_token_count=2,
+            total_token_count=5,
+            prompt_tokens_details=None,
+            response_tokens_details=None,
+            candidates_tokens_details=None,
+            cached_content_token_count=None,
+            thoughts_token_count=None,
+        )
+        assert usage_metadata_from_message(_message(usage=usage)) == {
+            "input_tokens": 3,
+            "output_tokens": 2,
+            "total_tokens": 5,
+        }
+
+    def test_no_usage(self):
+        assert usage_metadata_from_message(_message()) is None
+
+
+def _spy_children(monkeypatch):
+    created = []
+    real = session_mod.RunTree.create_child
+
+    def spy(self, **kwargs):
+        child = real(self, **kwargs)
+        created.append((kwargs.get("name"), child))
+        return child
+
+    monkeypatch.setattr(session_mod.RunTree, "create_child", spy)
+    return created
+
+
+class TestWrapper:
+    async def test_proxy_is_transparent_and_tracing_is_fail_open(self, monkeypatch):
+        messages = [_message(user="hello"), _message(turn_complete=True)]
+        monkeypatch.setattr(
+            live_mod._GeminiLiveTracer,
+            "observe",
+            mock.Mock(side_effect=RuntimeError("broken tracer")),
+        )
+        seen = []
+        async with wrap_gemini_live(FakeSession(messages)) as session:
+            assert session.session_id == "provider-session"
+            assert await session.send_tool_response(answer=42) == {"answer": 42}
+            async for message in session.receive():
+                seen.append(message)
+        assert seen == messages
+
+    async def test_transcript_usage_llm_and_markers(self, monkeypatch):
+        created = _spy_children(monkeypatch)
+        usage = NS(
+            prompt_token_count=8,
+            response_token_count=5,
+            total_token_count=13,
+            prompt_tokens_details=None,
+            response_tokens_details=None,
+            cached_content_token_count=None,
+            thoughts_token_count=None,
+        )
+        messages = [
+            _message(user="what is ", user_finished=False),
+            _message(user="what is the weather?", user_finished=False),
+            _message(agent="It is ", agent_finished=False),
+            _message(agent="sunny.", agent_finished=False),
+            _message(turn_complete=True, usage=usage),
+        ]
+        async with wrap_gemini_live(
+            FakeSession(messages), model="gemini-live", thread_id="thread-1"
+        ) as session:
+            async for _ in session.receive():
+                pass
+            trace = session._trace
+
+        assert trace.messages == [
+            {"role": "user", "content": "what is the weather?"},
+            {"role": "assistant", "content": "It is sunny."},
+        ]
+        assert trace.run.name == "what is the weather?"
+        assert trace.run.outputs == {"messages": trace.messages}
+        root_metadata = (trace.run.extra or {}).get("metadata") or {}
+        assert root_metadata["ls_integration"] == "gemini-live"
+
+        llms = [child for name, child in created if name == "turn_complete"]
+        assert len(llms) == 1
+        assert llms[0].run_type == "llm"
+        assert llms[0].outputs == {"role": "assistant", "content": "It is sunny."}
+        assert "usage_metadata" not in llms[0].outputs
+        llm_metadata = (llms[0].extra or {}).get("metadata") or {}
+        assert llm_metadata["usage_metadata"] == {
+            "input_tokens": 8,
+            "output_tokens": 5,
+            "total_tokens": 13,
+        }
+        assert llm_metadata["ls_provider"] == "google"
+        assert llm_metadata["ls_model_name"] == "gemini-live"
+        assert [name for name, _ in created].count("output_transcription") == 0
+
+    async def test_function_call_span_and_interruption(self, monkeypatch):
+        created = _spy_children(monkeypatch)
+        call = NS(id="call-1", name="lookup_weather", args={"city": "Tokyo"})
+        tool_runs = []
+
+        @traceable(run_type="tool", name="lookup_weather")
+        async def lookup_weather(city: str) -> dict:
+            tool_runs.append(get_current_run_tree())
+            return {"city": city, "condition": "sunny"}
+
+        messages = [
+            _message(calls=[call]),
+            _message(interrupted=True),
+        ]
+        async with wrap_gemini_live(
+            FakeSession(messages), is_agent_speaking=lambda: True
+        ) as session:
+            async for message in session.receive():
+                if message.tool_call:
+                    await lookup_weather("Tokyo")
+            trace = session._trace
+
+        # The integration emits no synthetic function-call chain. The demo's
+        # @traceable lookup_weather function is therefore the only tool run.
+        assert not [name for name, _ in created if name.startswith("function_call")]
+        assert len(tool_runs) == 1
+        assert tool_runs[0].run_type == "tool"
+        assert tool_runs[0].parent_run_id == trace.run.id
+        interrupted = [child for name, child in created if name == "interrupted"]
+        assert len(interrupted) == 1
+        metadata = (interrupted[0].extra or {}).get("metadata") or {}
+        assert metadata["was_audible"] is True
+
+    async def test_audio_is_bounded_and_replicas_propagate(self, monkeypatch):
+        created = _spy_children(monkeypatch)
+        replicas = [{"project_name": "replica"}]
+        async with wrap_gemini_live(
+            FakeSession([_message(user="hi")]),
+            sample_rate=10,
+            max_audio_seconds=1.0,
+            replicas=replicas,
+        ) as session:
+            session.record_user_audio(b"\x00" * 16)
+            session.record_user_audio(b"\x00" * 16)
+            async for _ in session.receive():
+                pass
+            trace = session._trace
+
+        assert trace.max_audio_bytes == 20
+        assert sum(len(chunk) for _, chunk in trace.user_chunks) == 20
+        assert trace._audio_truncated is True
+        assert trace.run.replicas == replicas
+        input_runs = [child for name, child in created if name == "input_transcription"]
+        assert input_runs and input_runs[0].replicas == replicas
+
+    async def test_body_error_is_recorded_and_propagated(self):
+        context = wrap_gemini_live(FakeSession([]))
+        with pytest.raises(RuntimeError, match="application failed"):
+            async with context as session:
+                trace = session._trace
+                raise RuntimeError("application failed")
+        assert trace.run.error == "RuntimeError: application failed"

--- a/python/tests/unit_tests/wrappers/test_gemini_live.py
+++ b/python/tests/unit_tests/wrappers/test_gemini_live.py
@@ -7,7 +7,7 @@ from unittest import mock
 
 import pytest
 
-from langsmith import Client, traceable
+from langsmith import Client
 from langsmith._internal.voice import session as session_mod
 from langsmith.integrations.gemini_live import _session as live_mod
 from langsmith.integrations.gemini_live._session import (
@@ -16,7 +16,6 @@ from langsmith.integrations.gemini_live._session import (
     usage_metadata_from_message,
     wrap_gemini_live,
 )
-from langsmith.run_helpers import get_current_run_tree
 
 LS_TEST_CLIENT_INFO = {
     "batch_ingest_config": {
@@ -249,12 +248,11 @@ class TestWrapper:
     async def test_function_call_span_and_interruption(self, monkeypatch):
         created = _spy_children(monkeypatch)
         call = NS(id="call-1", name="lookup_weather", args={"city": "Tokyo"})
-        tool_runs = []
-
-        @traceable(run_type="tool", name="lookup_weather")
-        async def lookup_weather(city: str) -> dict:
-            tool_runs.append(get_current_run_tree())
-            return {"city": city, "condition": "sunny"}
+        response = NS(
+            id="call-1",
+            name="lookup_weather",
+            response={"city": "Tokyo", "condition": "sunny"},
+        )
 
         messages = [
             _message(calls=[call]),
@@ -265,19 +263,55 @@ class TestWrapper:
         ) as session:
             async for message in session.receive():
                 if message.tool_call:
-                    await lookup_weather("Tokyo")
+                    await session.send_tool_response(function_responses=response)
             trace = session._trace
 
-        # The integration emits no synthetic function-call chain. The demo's
-        # @traceable lookup_weather function is therefore the only tool run.
-        assert not [name for name, _ in created if name.startswith("function_call")]
+        tool_runs = [child for name, child in created if name == "lookup_weather"]
         assert len(tool_runs) == 1
         assert tool_runs[0].run_type == "tool"
         assert tool_runs[0].parent_run_id == trace.run.id
+        assert tool_runs[0].inputs == {"args": {"city": "Tokyo"}}
+        assert tool_runs[0].outputs == {
+            "response": {"city": "Tokyo", "condition": "sunny"}
+        }
+        tool_metadata = (tool_runs[0].extra or {}).get("metadata") or {}
+        assert tool_metadata["function_call_id"] == "call-1"
         interrupted = [child for name, child in created if name == "interrupted"]
         assert len(interrupted) == 1
         metadata = (interrupted[0].extra or {}).get("metadata") or {}
         assert metadata["was_audible"] is True
+
+    async def test_parallel_tool_calls_are_matched_by_id(self, monkeypatch):
+        created = _spy_children(monkeypatch)
+        calls = [
+            NS(id="call-1", name="first", args={"value": 1}),
+            NS(id="call-2", name="second", args={"value": 2}),
+        ]
+        responses = [
+            {"id": "call-2", "name": "second", "response": {"result": 2}},
+            {"id": "call-1", "name": "first", "response": {"result": 1}},
+        ]
+
+        async with wrap_gemini_live(FakeSession([_message(calls=calls)])) as session:
+            async for _ in session.receive():
+                pass
+            await session.send_tool_response(function_responses=responses)
+
+        tools = {name: child for name, child in created if name in {"first", "second"}}
+        assert tools["first"].outputs == {"response": {"result": 1}}
+        assert tools["second"].outputs == {"response": {"result": 2}}
+
+    async def test_incomplete_tool_call_is_closed_with_error(self, monkeypatch):
+        created = _spy_children(monkeypatch)
+        call = NS(id="call-1", name="lookup_weather", args={"city": "Tokyo"})
+
+        async with wrap_gemini_live(FakeSession([_message(calls=[call])])) as session:
+            async for _ in session.receive():
+                pass
+
+        tool_runs = [child for name, child in created if name == "lookup_weather"]
+        assert len(tool_runs) == 1
+        assert tool_runs[0].error == "tool did not complete before the session ended"
 
     async def test_audio_is_bounded_and_replicas_propagate(self, monkeypatch):
         created = _spy_children(monkeypatch)

--- a/python/tests/unit_tests/wrappers/test_gemini_live.py
+++ b/python/tests/unit_tests/wrappers/test_gemini_live.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import subprocess
+import sys
 from types import SimpleNamespace as NS
 from unittest import mock
 
@@ -47,13 +49,14 @@ class FakeSession:
     def __init__(self, messages):
         self._messages = list(messages)
         self.session_id = "provider-session"
+        self.sent_tool_responses = []
 
     async def receive(self):
         for message in self._messages:
             yield message
 
-    async def send_tool_response(self, **kwargs):
-        return kwargs
+    async def send_tool_response(self, *, function_responses):
+        self.sent_tool_responses.append(function_responses)
 
 
 def _message(
@@ -181,20 +184,41 @@ def _spy_children(monkeypatch):
 
 
 class TestWrapper:
+    def test_import_does_not_load_google_genai(self):
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                (
+                    "import sys; "
+                    "import langsmith.integrations.gemini_live; "
+                    "assert not any(name == 'google.genai' or "
+                    "name.startswith('google.genai.') for name in sys.modules)"
+                ),
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 0, result.stderr
+
     async def test_proxy_is_transparent_and_tracing_is_fail_open(self, monkeypatch):
         messages = [_message(user="hello"), _message(turn_complete=True)]
+        raw = FakeSession(messages)
         monkeypatch.setattr(
             live_mod._GeminiLiveTracer,
             "observe",
             mock.Mock(side_effect=RuntimeError("broken tracer")),
         )
         seen = []
-        async with wrap_gemini_live(FakeSession(messages)) as session:
+        response = {"id": "call-1", "name": "tool", "response": {"answer": 42}}
+        async with wrap_gemini_live(raw) as session:
             assert session.session_id == "provider-session"
-            assert await session.send_tool_response(answer=42) == {"answer": 42}
+            assert await session.send_tool_response(function_responses=response) is None
             async for message in session.receive():
                 seen.append(message)
         assert seen == messages
+        assert raw.sent_tool_responses == [response]
 
     async def test_transcript_usage_llm_and_markers(self, monkeypatch):
         created = _spy_children(monkeypatch)

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -1667,6 +1667,9 @@ dependencies = [
 claude-agent-sdk = [
     { name = "claude-agent-sdk" },
 ]
+gemini-live = [
+    { name = "google-genai" },
+]
 google-adk = [
     { name = "google-adk" },
     { name = "wrapt" },
@@ -1788,6 +1791,7 @@ requires-dist = [
     { name = "distro", specifier = ">=1.7.0" },
     { name = "google-adk", marker = "extra == 'google-adk'", specifier = ">=1.0.0" },
     { name = "google-adk", marker = "extra == 'google-adk-live'", specifier = ">=2.3.0" },
+    { name = "google-genai", marker = "extra == 'gemini-live'", specifier = ">=1.75" },
     { name = "httpx", specifier = ">=0.23.0,<1" },
     { name = "langsmith-pyo3", marker = "extra == 'langsmith-pyo3'", specifier = ">=0.1.0rc2" },
     { name = "livekit-agents", marker = "extra == 'livekit'", specifier = ">=1.0" },
@@ -1826,7 +1830,7 @@ requires-dist = [
     { name = "xxhash", specifier = ">=3.0.0" },
     { name = "zstandard", specifier = ">=0.23.0" },
 ]
-provides-extras = ["claude-agent-sdk", "google-adk", "google-adk-live", "langsmith-pyo3", "livekit", "openai-agents", "openai-realtime", "otel", "pipecat", "pytest", "sandbox", "strands-agents", "vcr"]
+provides-extras = ["claude-agent-sdk", "gemini-live", "google-adk", "google-adk-live", "langsmith-pyo3", "livekit", "openai-agents", "openai-realtime", "otel", "pipecat", "pytest", "sandbox", "strands-agents", "vcr"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary

- add a `wrap_gemini_live` integration for tracing raw Gemini Live WebSocket sessions
- accumulate bounded transcripts on the session root and record turn usage in run metadata for cost tracking
- trace application tool calls directly without an extra synthetic function-call chain

## Testing

- `python/.venv/bin/python -m pytest python/tests/unit_tests/wrappers/test_gemini_live.py -q` (12 passed)
- Ruff formatting and lint checks
- MyPy checks