### PR TITLE
docs: link to the langchainplus SDK release process

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,8 @@ The directories `python/langsmith/_openapi_client/` and `js/src/_openapi_client/
 
 Updates are applied automatically by the [`stlc_sync_python_and_js_sdks`](https://github.com/langchain-ai/langchainplus/actions/workflows/stlc_sync_python_and_js_sdks.yml) workflow in `langchain-ai/langchainplus`, which opens PRs from the `sync/langsmith-api` branch. A CI check ([`protect-openapi-client.yml`](.github/workflows/protect-openapi-client.yml)) blocks any PR that touches these directories from a source other than that workflow.
 
+For the full end-to-end process — how the spec is generated, how the sync PRs are produced, and how to review and land them — see [Releasing the SDKs](https://github.com/langchain-ai/langchainplus/tree/main/smith-sdks#releasing-the-sdks) in `langchain-ai/langchainplus` (internal).
+
 ## Cutting a release
 
 Releases are published by GitHub Actions workflows that fire on `main` when specific files change:


### PR DESCRIPTION
Adds a pointer from the **Auto-generated OpenAPI client** section of `CONTRIBUTING.md` to the [Releasing the SDKs](https://github.com/langchain-ai/langchainplus/tree/main/smith-sdks#releasing-the-sdks) docs in `langchain-ai/langchainplus`.

That section already explains *what* the generated client directories are and *which* workflow syncs them, but there was no link to the internal docs covering the full end-to-end process (spec generation, sync PR production, review and landing). This closes that gap.

Docs-only change; no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)