### PR TITLE
test: exercise public run-read APIs and fix backend routing in run integration tests

### DIFF
--- a/python/tests/integration_tests/test_async_client.py
+++ b/python/tests/integration_tests/test_async_client.py
@@ -52,18 +52,14 @@ async def test_create_run(async_client: AsyncClient):
 
     async def check_run():
         try:
-            run = await async_client.runs.retrieve(
-                run_id, project_id=project_id, selects=["NAME"], start_time=start_time
-            )
+            run = await async_client.read_run(run_id, project_id=project_id)
             return run.name == "test_run"
         except ls_utils.LangSmithError:
             return False
 
     await wait_for(check_run)
 
-    run = await async_client.runs.retrieve(
-        run_id, project_id=project_id, selects=["NAME", "INPUTS"], start_time=start_time
-    )
+    run = await async_client.read_run(run_id, project_id=project_id)
     assert run.name == "test_run"
     assert run.inputs == {"input": "hello"}
 

--- a/python/tests/integration_tests/test_runs.py
+++ b/python/tests/integration_tests/test_runs.py
@@ -845,6 +845,7 @@ async def test_langchain_trace_to_multiple_projects(langchain_client: Client):
 # v2 migration routing / adaptation layer integration tests
 # ---------------------------------------------------------------------------
 
+
 @skip_if_rate_limited
 def test_load_nested_traces_builds_tree(langchain_client: Client):
     """_load_nested_traces must return root runs with child_runs attached.

--- a/python/tests/integration_tests/test_runs.py
+++ b/python/tests/integration_tests/test_runs.py
@@ -845,59 +845,6 @@ async def test_langchain_trace_to_multiple_projects(langchain_client: Client):
 # v2 migration routing / adaptation layer integration tests
 # ---------------------------------------------------------------------------
 
-
-@skip_if_rate_limited
-def test_load_child_runs_populates_tree(langchain_client: Client):
-    """_load_child_runs must return child runs with correctly-mapped fields.
-
-    This exercises the SDB-aware routing in Client._load_child_runs: when the
-    backend has sdb_query_enabled the v2 helper is used, otherwise the legacy
-    list_runs fallback is used. Either way the contract must hold.
-    """
-    project_name = "__test_load_child_runs_" + uuid.uuid4().hex
-    run_meta = uuid.uuid4().hex
-
-    @traceable(run_type="chain")
-    def parent_fn(x: int) -> int:
-        return child_fn(x)
-
-    @traceable(run_type="llm")
-    def child_fn(x: int) -> int:
-        return x + 1
-
-    parent_fn(
-        1,
-        langsmith_extra=dict(
-            project_name=project_name, metadata={"test_run": run_meta}
-        ),
-    )
-    filter_ = f'and(eq(metadata_key,"test_run"),eq(metadata_value,"{run_meta}"))'
-    poll_runs_until_count(
-        langchain_client, project_name, 2, max_retries=20, filter_=filter_
-    )
-
-    # Get the root run from the API — no child_runs yet.
-    [parent] = list(
-        langchain_client.list_runs(
-            project_name=project_name,
-            filter=filter_,
-            execution_order=1,
-        )
-    )
-    assert parent.child_runs is None or parent.child_runs == []
-
-    populated = langchain_client._load_child_runs(parent)
-
-    assert populated.child_runs is not None
-    assert len(populated.child_runs) == 1
-    child = populated.child_runs[0]
-    # run_type must be lowercase regardless of path (v2 uppercases it on the wire)
-    assert child.run_type == "llm"
-    # status must also be lowercase
-    assert child.status in {"success", "error"}
-    assert child.parent_run_id == parent.id
-
-
 @skip_if_rate_limited
 def test_load_nested_traces_builds_tree(langchain_client: Client):
     """_load_nested_traces must return root runs with child_runs attached.

--- a/python/tests/integration_tests/test_runs.py
+++ b/python/tests/integration_tests/test_runs.py
@@ -921,6 +921,8 @@ def poll_nested_traces_until_tree(
             if len(roots) == 1 and roots[0].child_runs:
                 return roots
             last_error = None
+        except ls_utils.LangSmithRateLimitError:
+            raise
         except ls_utils.LangSmithError as e:
             last_error = e
             logger.debug("Error polling nested traces", exc_info=True)

--- a/python/tests/integration_tests/test_runs.py
+++ b/python/tests/integration_tests/test_runs.py
@@ -846,6 +846,59 @@ async def test_langchain_trace_to_multiple_projects(langchain_client: Client):
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.require_clickhouse
+@skip_if_rate_limited
+def test_load_child_runs_populates_tree(langchain_client: Client):
+    """_load_child_runs must return child runs with correctly-mapped fields.
+
+    Child-run loading is unsupported on SmithDB-only backends (`_load_child_runs`
+    raises there), so this is ClickHouse-only: it pins the legacy path's contract,
+    including the uppercase-to-lowercase `run_type`/`status` normalization.
+    """
+    project_name = "__test_load_child_runs_" + uuid.uuid4().hex
+    run_meta = uuid.uuid4().hex
+
+    @traceable(run_type="chain")
+    def parent_fn(x: int) -> int:
+        return child_fn(x)
+
+    @traceable(run_type="llm")
+    def child_fn(x: int) -> int:
+        return x + 1
+
+    parent_fn(
+        1,
+        langsmith_extra=dict(
+            project_name=project_name, metadata={"test_run": run_meta}
+        ),
+    )
+    filter_ = f'and(eq(metadata_key,"test_run"),eq(metadata_value,"{run_meta}"))'
+    poll_runs_until_count(
+        langchain_client, project_name, 2, max_retries=20, filter_=filter_
+    )
+
+    # Get the root run from the API — no child_runs yet.
+    [parent] = list(
+        langchain_client.list_runs(
+            project_name=project_name,
+            filter=filter_,
+            execution_order=1,
+        )
+    )
+    assert parent.child_runs is None or parent.child_runs == []
+
+    populated = langchain_client._load_child_runs(parent)
+
+    assert populated.child_runs is not None
+    assert len(populated.child_runs) == 1
+    child = populated.child_runs[0]
+    # run_type must be lowercase regardless of path (v2 uppercases it on the wire)
+    assert child.run_type == "llm"
+    # status must also be lowercase
+    assert child.status in {"success", "error"}
+    assert child.parent_run_id == parent.id
+
+
 @skip_if_rate_limited
 def test_load_nested_traces_builds_tree(langchain_client: Client):
     """_load_nested_traces must return root runs with child_runs attached.

--- a/python/tests/integration_tests/test_runs.py
+++ b/python/tests/integration_tests/test_runs.py
@@ -10,6 +10,7 @@ from typing import AsyncGenerator, Generator, Optional, Sequence
 
 import pytest  # type: ignore
 
+from langsmith import schemas as ls_schemas
 from langsmith import utils as ls_utils
 from langsmith import uuid7
 from langsmith.client import Client
@@ -899,16 +900,52 @@ def test_load_child_runs_populates_tree(langchain_client: Client):
     assert child.parent_run_id == parent.id
 
 
-@skip_if_rate_limited
-def test_load_nested_traces_builds_tree(langchain_client: Client):
-    """_load_nested_traces must return root runs with child_runs attached.
+def poll_nested_traces_until_tree(
+    client: Client,
+    project_name: str,
+    max_retries: int = 20,
+    sleep_time: int = 2,
+) -> list[ls_schemas.Run]:
+    """Poll _load_nested_traces until one root with at least one child appears.
 
-    Exercises the SDB-aware routing in beta/_evals._load_nested_traces.
+    Deliberately polls _load_nested_traces rather than poll_runs_until_count:
+    the latter is built on list_runs, which has no v2 routing and so returns 501
+    on SmithDB-only backends.
     """
     from langsmith.beta._evals import _load_nested_traces
 
+    last_error: Optional[Exception] = None
+    for _ in range(max_retries):
+        try:
+            roots = _load_nested_traces(project_name, client)
+            if len(roots) == 1 and roots[0].child_runs:
+                return roots
+            last_error = None
+        except ls_utils.LangSmithError as e:
+            last_error = e
+            logger.debug("Error polling nested traces", exc_info=True)
+        time.sleep(sleep_time)
+    # Surface the underlying API error instead of a bare "no runs" assertion.
+    raise AssertionError(
+        f"Failed to load a nested trace for {project_name} after "
+        f"{max_retries} attempts."
+        + (f" Last error: {last_error!r}" if last_error else "")
+    )
+
+
+@skip_if_rate_limited
+def test_load_nested_traces_builds_tree():
+    """_load_nested_traces must return root runs with child_runs attached.
+
+    Exercises the SDB-aware routing in beta/_evals._load_nested_traces, which
+    dispatches on the deployment's real `/info` instance_flags. The shared
+    `langchain_client` fixture can't be used here: it hardcodes a partial
+    `info=`, which makes get_query_backend always resolve CLICKHOUSE_ONLY and
+    so would pin this test to the legacy path on every deployment.
+    """
+    client = Client()
+
     project_name = "__test_load_nested_traces_" + uuid.uuid4().hex
-    run_meta = uuid.uuid4().hex
 
     @traceable(run_type="chain")
     def outer(x: int) -> int:
@@ -918,18 +955,9 @@ def test_load_nested_traces_builds_tree(langchain_client: Client):
     def inner(x: int) -> int:
         return x * 2
 
-    outer(
-        3,
-        langsmith_extra=dict(
-            project_name=project_name, metadata={"test_run": run_meta}
-        ),
-    )
-    filter_ = f'and(eq(metadata_key,"test_run"),eq(metadata_value,"{run_meta}"))'
-    poll_runs_until_count(
-        langchain_client, project_name, 2, max_retries=20, filter_=filter_
-    )
+    outer(3, langsmith_extra=dict(project_name=project_name))
 
-    roots = _load_nested_traces(project_name, langchain_client)
+    roots = poll_nested_traces_until_tree(client, project_name)
 
     assert len(roots) == 1
     root = roots[0]


### PR DESCRIPTION
## Summary

Three related fixes to the run-reading integration tests, so each one exercises the code path SDK users actually hit on the backend it's running against.

### 1. `test_create_run` — use the public `AsyncClient.read_run`

`python/tests/integration_tests/test_async_client.py` was reaching into the generated v2 client directly:

```python
run = await async_client.runs.retrieve(
    run_id, project_id=project_id, selects=["NAME"], start_time=start_time
)
```

That bypasses `AsyncClient.read_run`, which is the public entry point the SmithDB v2 migration (#3262) actually routes — v1 `GET /runs/{id}` by default, falling back to the v2 `runs.retrieve_v2` path only on SmithDB-only backends. Restored to:

```python
run = await async_client.read_run(run_id, project_id=project_id)
```

- `project_id` is still passed, since `read_run` requires it on SmithDB-only backends.
- `start_time` is no longer forwarded — the async `read_run` signature doesn't take it. The local variable is still used by the `create_run` call above.
- Dropping `selects=["NAME", "INPUTS"]` is fine: `read_run` returns a full `schemas.Run`, so `run.name` and `run.inputs` stay populated.

### 2. `test_load_child_runs_populates_tree` — mark `require_clickhouse`

`Client._load_child_runs` raises on SmithDB-only backends, so the test can't pass there. Rather than delete the only integration coverage for that helper, it's now gated on ClickHouse and its docstring says why. The legacy path is still live, and its contract — `child_runs` populated, `run_type`/`status` normalized to lowercase — stays covered in CI.

### 3. `test_load_nested_traces_builds_tree` — don't pin routing to the legacy path

Two problems:

- The shared `langchain_client` fixture hardcodes a partial `info=`, which makes `get_query_backend` always resolve `CLICKHOUSE_ONLY`. That silently pinned this test to the legacy path on every deployment, defeating the point of testing `_load_nested_traces`' SDB-aware routing. The test now builds its own `Client()` so dispatch runs against the deployment's real `/info` instance flags.
- Polling used `poll_runs_until_count`, which is built on `list_runs` — no v2 routing, so it returns 501 on SmithDB-only backends. Replaced with a local `poll_nested_traces_until_tree` helper that polls `_load_nested_traces` itself and surfaces the underlying API error instead of a bare "no runs" assertion.

## Notes

Test-only change; no library code touched.

## Testing

`ruff check` and `ruff format --check` pass. These are integration tests and run in CI against a live backend.
