### PR TITLE
fix: prioritize API key over OAuth profile auth [closes LSDK-414]

### DIFF
--- a/python/langsmith/_internal/_profiles.py
+++ b/python/langsmith/_internal/_profiles.py
@@ -146,6 +146,8 @@ def _parse_profile_expires_at(expires_at: str) -> Optional[datetime.datetime]:
 
 
 def should_refresh_profile_token(profile: ProfileConfig) -> bool:
+    if trim_auth_value(profile.get("api_key")):
+        return False
     oauth = profile.get("oauth") or {}
     if not oauth.get("refresh_token"):
         return False

--- a/python/langsmith/_internal/_profiles.py
+++ b/python/langsmith/_internal/_profiles.py
@@ -354,14 +354,14 @@ class ProfileAuth:
     def _headers_from_profile(self, profile: Optional[ProfileConfig]) -> dict[str, str]:
         if profile is None:
             return {}
+        api_key = trim_auth_value(profile.get("api_key"))
+        if api_key:
+            return {self._api_key_header: api_key}
         oauth_access_token = trim_auth_value(
             (profile.get("oauth") or {}).get("access_token")
         )
         if oauth_access_token:
             return {"Authorization": f"Bearer {oauth_access_token}"}
-        api_key = trim_auth_value(profile.get("api_key"))
-        if api_key:
-            return {self._api_key_header: api_key}
         return {}
 
     def _remember_auth_headers(self, headers: Mapping[str, str]) -> None:

--- a/python/tests/unit_tests/test_async_client.py
+++ b/python/tests/unit_tests/test_async_client.py
@@ -131,6 +131,40 @@ def test_async_client_no_custom_headers(mock_client_cls: mock.Mock) -> None:
 
 
 @mock.patch("langsmith.async_client.httpx.AsyncClient")
+def test_async_client_profile_config_uses_oauth_access_token(
+    mock_client_cls: mock.Mock,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: pathlib.Path,
+) -> None:
+    _clear_profile_env(monkeypatch)
+    mock_httpx_client = mock.Mock()
+    mock_httpx_client.headers = httpx.Headers()
+    mock_client_cls.return_value = mock_httpx_client
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "profiles": {
+                    "default": {
+                        "api_url": "https://profile.example.com",
+                        "oauth": {"access_token": "profile-access-token"},
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("LANGSMITH_CONFIG_FILE", str(config_path))
+
+    AsyncClient()
+
+    assert mock_client_cls.call_args.kwargs["base_url"] == "https://profile.example.com"
+    passed_headers = mock_client_cls.call_args.kwargs["headers"]
+    assert passed_headers["Authorization"] == "Bearer profile-access-token"
+    assert "x-api-key" not in passed_headers
+
+
+@mock.patch("langsmith.async_client.httpx.AsyncClient")
 def test_async_client_profile_config_uses_api_key_before_oauth_access_token(
     mock_client_cls: mock.Mock,
     monkeypatch: pytest.MonkeyPatch,

--- a/python/tests/unit_tests/test_async_client.py
+++ b/python/tests/unit_tests/test_async_client.py
@@ -165,14 +165,18 @@ def test_async_client_profile_config_uses_oauth_access_token(
 
 
 @mock.patch("langsmith.async_client.httpx.AsyncClient")
-def test_async_client_profile_config_uses_api_key_before_oauth_access_token(
+@pytest.mark.asyncio
+async def test_async_client_profile_config_uses_api_key_before_oauth_access_token(
     mock_client_cls: mock.Mock,
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: pathlib.Path,
 ) -> None:
     _clear_profile_env(monkeypatch)
-    mock_httpx_client = mock.Mock()
+    mock_httpx_client = mock.AsyncMock()
     mock_httpx_client.headers = httpx.Headers()
+    response = mock.Mock()
+    response.status_code = 200
+    mock_httpx_client.request.return_value = response
     mock_client_cls.return_value = mock_httpx_client
     config_path = tmp_path / "config.json"
     config_path.write_text(
@@ -182,7 +186,11 @@ def test_async_client_profile_config_uses_api_key_before_oauth_access_token(
                     "default": {
                         "api_key": "profile-key",
                         "api_url": "https://profile.example.com",
-                        "oauth": {"access_token": "profile-access-token"},
+                        "oauth": {
+                            "access_token": "profile-access-token",
+                            "refresh_token": "profile-refresh-token",
+                            "expires_at": "2000-01-01T00:00:00Z",
+                        },
                     }
                 }
             }
@@ -190,13 +198,18 @@ def test_async_client_profile_config_uses_api_key_before_oauth_access_token(
         encoding="utf-8",
     )
     monkeypatch.setenv("LANGSMITH_CONFIG_FILE", str(config_path))
+    mock_post = mock.Mock()
+    monkeypatch.setattr(requests, "post", mock_post)
 
-    AsyncClient()
+    client = AsyncClient()
+    await client._arequest_with_retries("GET", "/info")
 
     assert mock_client_cls.call_args.kwargs["base_url"] == "https://profile.example.com"
     passed_headers = mock_client_cls.call_args.kwargs["headers"]
     assert passed_headers["x-api-key"] == "profile-key"
     assert "Authorization" not in passed_headers
+    mock_httpx_client.request.assert_awaited_once()
+    mock_post.assert_not_called()
 
 
 @mock.patch("langsmith.async_client.httpx.AsyncClient")

--- a/python/tests/unit_tests/test_async_client.py
+++ b/python/tests/unit_tests/test_async_client.py
@@ -131,7 +131,7 @@ def test_async_client_no_custom_headers(mock_client_cls: mock.Mock) -> None:
 
 
 @mock.patch("langsmith.async_client.httpx.AsyncClient")
-def test_async_client_profile_config_uses_oauth_access_token(
+def test_async_client_profile_config_uses_api_key_before_oauth_access_token(
     mock_client_cls: mock.Mock,
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: pathlib.Path,
@@ -146,6 +146,7 @@ def test_async_client_profile_config_uses_oauth_access_token(
             {
                 "profiles": {
                     "default": {
+                        "api_key": "profile-key",
                         "api_url": "https://profile.example.com",
                         "oauth": {"access_token": "profile-access-token"},
                     }
@@ -160,8 +161,8 @@ def test_async_client_profile_config_uses_oauth_access_token(
 
     assert mock_client_cls.call_args.kwargs["base_url"] == "https://profile.example.com"
     passed_headers = mock_client_cls.call_args.kwargs["headers"]
-    assert passed_headers["Authorization"] == "Bearer profile-access-token"
-    assert "x-api-key" not in passed_headers
+    assert passed_headers["x-api-key"] == "profile-key"
+    assert "Authorization" not in passed_headers
 
 
 @mock.patch("langsmith.async_client.httpx.AsyncClient")

--- a/python/tests/unit_tests/test_client.py
+++ b/python/tests/unit_tests/test_client.py
@@ -261,7 +261,7 @@ def test_profile_config_loads_api_key_and_workspace(
     assert client._headers["X-Tenant-Id"] == "workspace-id"
 
 
-def test_profile_config_uses_oauth_access_token_before_api_key(
+def test_profile_config_uses_api_key_before_oauth_access_token(
     monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path
 ) -> None:
     _clear_profile_env(monkeypatch)
@@ -284,8 +284,8 @@ def test_profile_config_uses_oauth_access_token_before_api_key(
     client = Client(auto_batch_tracing=False)
 
     assert client.api_key is None
-    assert client._headers["Authorization"] == "Bearer profile-access-token"
-    assert "x-api-key" not in client._headers
+    assert client._headers["x-api-key"] == "profile-key"
+    assert "Authorization" not in client._headers
 
 
 def test_profile_config_env_auth_suppresses_profile_auth(


### PR DESCRIPTION
## Description
Prioritize a configured profile API key over its OAuth bearer token and skip refreshing unused OAuth credentials. Preserve OAuth-only fallback behavior, with sync and async regression coverage for both paths.

## Test Plan
- [x] Sync and async profile-config unit tests
- [x] Ruff format and checks
- [ ] `make lint` (existing Python 3.14 `Executor.map` override mismatch)

Made by [Open SWE](https://openswe.vercel.app/agents/b1b32519-da58-3234-03dc-660844129bdc)