### PR TITLE
chore: deprecate evaluate_run and aevaluate_run

### DIFF
--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -7586,6 +7586,11 @@ class Client:
             )
         return results_
 
+    @_deprecated(
+        "evaluate_run() is deprecated and will be removed after Jan 31, 2027. "
+        "There is no replacement: run the evaluator yourself and log the result "
+        "with client.create_feedback()."
+    )
     def evaluate_run(
         self,
         run: Union[ls_schemas.Run, ls_schemas.RunBase, str, uuid.UUID],
@@ -7598,6 +7603,11 @@ class Client:
         load_child_runs: bool = False,
     ) -> ls_evaluator.EvaluationResult:
         """Evaluate a run.
+
+        .. deprecated:: 0.10.11
+            There is no replacement. Run the evaluator yourself and log the
+            result with :meth:`langsmith.Client.create_feedback`.
+            Will be removed after Jan 31, 2027.
 
         Args:
             run (Union[Run, RunBase, str, UUID]):
@@ -7682,6 +7692,11 @@ class Client:
             )
         return results
 
+    @_deprecated(
+        "aevaluate_run() is deprecated and will be removed after Jan 31, 2027. "
+        "There is no replacement: run the evaluator yourself and log the result "
+        "with client.create_feedback()."
+    )
     async def aevaluate_run(
         self,
         run: Union[ls_schemas.Run, str, uuid.UUID],
@@ -7694,6 +7709,11 @@ class Client:
         load_child_runs: bool = False,
     ) -> ls_evaluator.EvaluationResult:
         """Evaluate a run asynchronously.
+
+        .. deprecated:: 0.10.11
+            There is no replacement. Run the evaluator yourself and log the
+            result with :meth:`langsmith.Client.create_feedback`.
+            Will be removed after Jan 31, 2027.
 
         Args:
             run (Union[Run, str, UUID]):

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -7604,7 +7604,7 @@ class Client:
     ) -> ls_evaluator.EvaluationResult:
         """Evaluate a run.
 
-        .. deprecated:: 0.10.11
+        .. deprecated::
             There is no replacement. Run the evaluator yourself and log the
             result with :meth:`langsmith.Client.create_feedback`.
             Will be removed after Jan 31, 2027.
@@ -7710,7 +7710,7 @@ class Client:
     ) -> ls_evaluator.EvaluationResult:
         """Evaluate a run asynchronously.
 
-        .. deprecated:: 0.10.11
+        .. deprecated::
             There is no replacement. Run the evaluator yourself and log the
             result with :meth:`langsmith.Client.create_feedback`.
             Will be removed after Jan 31, 2027.

--- a/python/tests/unit_tests/test_client.py
+++ b/python/tests/unit_tests/test_client.py
@@ -55,6 +55,7 @@ from langsmith.client import (
     _reject_filesystem_attachments,
     _resolve_tracing_mode,
 )
+from langsmith.evaluation.evaluator import RunEvaluator
 from langsmith.run_trees import RunTree
 from langsmith.utils import LangSmithRateLimitError, LangSmithUserError
 from tests.unit_tests.conftest import parse_request_data
@@ -6784,3 +6785,52 @@ def test_removed_sdk_methods_absent() -> None:
     assert not hasattr(DatasetsResource, "experiments"), (
         "datasets.experiments.grouped was de-publicized in PR #28358 and should not exist"
     )
+
+
+class _StubEvaluator(RunEvaluator):
+    """Minimal evaluator that returns a fixed result without doing any work."""
+
+    def evaluate_run(self, run, example=None) -> EvaluationResult:
+        return EvaluationResult(key="stub", score=1)
+
+    async def aevaluate_run(self, run, example=None) -> EvaluationResult:
+        return EvaluationResult(key="stub", score=1)
+
+
+def _stub_run() -> ls_schemas.Run:
+    run_id = uuid.uuid4()
+    return ls_schemas.Run(
+        id=run_id,
+        name="stub",
+        run_type="chain",
+        start_time=_CREATED_AT,
+        trace_id=run_id,
+    )
+
+
+def test_evaluate_run_deprecation_warning() -> None:
+    """evaluate_run is deprecated with no replacement."""
+    client = Client(api_url="http://localhost:1984", api_key="123", session=mock.Mock())
+    result = EvaluationResult(key="stub", score=1)
+
+    with mock.patch.object(
+        Client, "_log_evaluation_feedback", return_value=[result]
+    ) as log_feedback:
+        with pytest.warns(DeprecationWarning, match="evaluate_run\\(\\) is deprecated"):
+            assert client.evaluate_run(_stub_run(), _StubEvaluator()) is result
+    log_feedback.assert_called_once()
+
+
+async def test_aevaluate_run_deprecation_warning() -> None:
+    """aevaluate_run is deprecated with no replacement."""
+    client = Client(api_url="http://localhost:1984", api_key="123", session=mock.Mock())
+    result = EvaluationResult(key="stub", score=1)
+
+    with mock.patch.object(
+        Client, "_log_evaluation_feedback", return_value=[result]
+    ) as log_feedback:
+        with pytest.warns(
+            DeprecationWarning, match="aevaluate_run\\(\\) is deprecated"
+        ):
+            assert await client.aevaluate_run(_stub_run(), _StubEvaluator()) is result
+    log_feedback.assert_called_once()


### PR DESCRIPTION
## Summary

Marks `Client.evaluate_run` and `Client.aevaluate_run` as deprecated. **There is no replacement** — callers should run the evaluator themselves and log the result with `client.create_feedback()`.

Follows the same pattern as the other deprecations on this branch:
- `@_deprecated(...)` decorator (from `langsmith._internal._beta_decorator`) so a `DeprecationWarning` fires at call time, for both the sync and async method.
- A `.. deprecated:: 0.10.11` RST directive at the top of each docstring, noting there is no replacement and that removal happens after Jan 31, 2027.

No behavior change beyond the warning.

## Notes

- Python only — there is no `evaluateRun`/`aevaluateRun` on the JS client and no `AsyncClient` equivalent, so nothing else to annotate.
- `langsmith.beta._evals.compute_test_metrics` calls `client.evaluate_run` internally and will therefore surface the warning to its callers. Left as-is, matching how the earlier deprecations in this series treated internal call sites.
- `python/README.md` still shows `client.evaluate_run(run, evaluator)` in its evaluation example. Not touched here since there is no replacement snippet to swap in — worth a follow-up.

## Test Plan

- [x] New unit tests assert `DeprecationWarning` fires for both `evaluate_run` and `aevaluate_run`
- [x] `uv run pytest tests/unit_tests/test_client.py` — 232 passed; the 2 failures in `test_validate_api_key_if_hosted_with_tracing` are pre-existing locally (reproduce on the base commit, caused by shell `LANGSMITH_*` env leakage)
- [x] `uv run ruff check` / `ruff format` / `mypy langsmith` clean