### PR TITLE
release(py): 0.10.13

### DIFF
--- a/python/.bumpversion.cfg
+++ b/python/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.10.12
+current_version = 0.10.13
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
 serialize = {major}.{minor}.{patch}
 search = {current_version}

--- a/python/langsmith/__init__.py
+++ b/python/langsmith/__init__.py
@@ -49,7 +49,7 @@ if TYPE_CHECKING:
 
 # Avoid calling into importlib on every call to __version__
 
-__version__ = "0.10.12"
+__version__ = "0.10.13"
 version = __version__  # for backwards compatibility
 
 # Metadata key to hide a traced run from LangSmith's Messages View.


### PR DESCRIPTION
Cuts a Python release so the corrected generated-client paths reach PyPI.

`main` has carried them since #3289 merged, but the newest published version is 0.10.12 from before that, so no installed copy has the fixes yet:

- annotation queue item endpoints now target `/api/v1/platform/annotation-queues/...`; they previously pointed at a path the API-host edge does not route, so every item method returned 404
- `/v1/platform/*` endpoints (evaluators, issues) and the v2 endpoints now carry the `/api` prefix the spec declares