### PR TITLE
release(js): 0.8.8

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langsmith",
-  "version": "0.8.7",
+  "version": "0.8.8",
   "description": "Client library to connect to the LangSmith Observability and Evaluation Platform.",
   "packageManager": "pnpm@10.33.0",
   "files": [

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -54,7 +54,7 @@ export {
 } from "./_openapi_client/core/error.js";
 
 // Update using pnpm bump-version
-export const __version__ = "0.8.7";
+export const __version__ = "0.8.8";
 
 // Metadata key to hide a traced run from LangSmith's Messages View.
 export const LS_MESSAGE_VIEW_EXCLUDE = "ls_message_view_exclude" as const;


### PR DESCRIPTION
Cuts a JS release so the corrected generated-client paths reach npm.

`main` has carried them since #3289 merged, but the newest published version is 0.8.7 from before that, so no installed copy has the fixes yet:

- annotation queue item endpoints now target `/api/v1/platform/annotation-queues/...`; they previously pointed at a path the API-host edge does not route, so every item method returned 404
- `/v1/platform/*` endpoints (evaluators, issues) and the v2 endpoints now carry the `/api` prefix the spec declares