### PR TITLE
fix(sandbox): count an acknowledged reattachment as progress

### DIFF
--- a/js/src/sandbox/command_handle.ts
+++ b/js/src/sandbox/command_handle.ts
@@ -16,6 +16,29 @@ import {
 } from "./errors.js";
 
 /**
+ * Whether a 'started' frame proves *this* command was reattached to.
+ *
+ * A command and its WebSocket are separate things: the command keeps running on
+ * the server and the socket is only this client's attachment to it. The server
+ * acknowledges every successful reattachment with 'started', which for a command
+ * that produces no output is the only evidence it landed. One naming a different
+ * command is not evidence, and must not clear the reconnect budget.
+ */
+function acknowledgesReconnect(
+  msg: WsMessage,
+  commandId: string | null,
+): boolean {
+  const acked = msg.command_id;
+  if (acked === commandId) return true;
+  console.warn(
+    `Ignoring reconnect acknowledgement for command ${String(
+      acked,
+    )} while attached to ${String(commandId)}`,
+  );
+  return false;
+}
+
+/**
  * Async handle to a running command with streaming output and auto-reconnect.
  *
  * Async iterable, yielding OutputChunk objects (stdout and stderr interleaved
@@ -56,6 +79,7 @@ export class CommandHandle {
   private _lastStdoutOffset: number;
   private _lastStderrOffset: number;
   private _started: boolean;
+  private _reconnectAttempts = 0;
   private _onStdout?: (data: string) => void;
   private _onStderr?: (data: string) => void;
 
@@ -159,7 +183,11 @@ export class CommandHandle {
 
     for await (const msg of this._stream) {
       const msgType = msg.type;
-      if (msgType === "stdout" || msgType === "stderr") {
+      if (msgType === "started") {
+        if (acknowledgesReconnect(msg, this._commandId)) {
+          this._reconnectAttempts = 0;
+        }
+      } else if (msgType === "stdout" || msgType === "stderr") {
         const chunk: OutputChunk = {
           stream: msgType,
           data: msg.data as string,
@@ -195,12 +223,12 @@ export class CommandHandle {
    * - After kill():                  no reconnect, error propagates
    */
   async *[Symbol.asyncIterator](): AsyncIterableIterator<OutputChunk> {
-    let reconnectAttempts = 0;
+    this._reconnectAttempts = 0;
 
     while (true) {
       try {
         for await (const chunk of this._iterStream()) {
-          reconnectAttempts = 0; // Reset on successful data
+          this._reconnectAttempts = 0; // Reset on successful data
           if (chunk.stream === "stdout") {
             this._lastStdoutOffset =
               chunk.offset + new TextEncoder().encode(chunk.data).length;
@@ -224,17 +252,17 @@ export class CommandHandle {
           throw e;
         }
 
-        reconnectAttempts++;
-        if (reconnectAttempts > CommandHandle.MAX_AUTO_RECONNECTS) {
+        this._reconnectAttempts++;
+        if (this._reconnectAttempts > CommandHandle.MAX_AUTO_RECONNECTS) {
           throw new LangSmithSandboxConnectionError(
-            `Lost connection ${reconnectAttempts} times in succession, giving up`,
+            `Failed to reattach to the command ${this._reconnectAttempts} times in succession, giving up`,
           );
         }
 
         const isHotReload = e instanceof LangSmithSandboxServerReloadError;
         if (!isHotReload) {
           const delay = Math.min(
-            CommandHandle.BACKOFF_BASE * 2 ** (reconnectAttempts - 1),
+            CommandHandle.BACKOFF_BASE * 2 ** (this._reconnectAttempts - 1),
             CommandHandle.BACKOFF_MAX,
           );
           await new Promise((r) => setTimeout(r, delay * 1000));

--- a/js/src/sandbox/ws_execute.ts
+++ b/js/src/sandbox/ws_execute.ts
@@ -473,8 +473,10 @@ export async function runWsStream(
  * Reconnect to an existing command over WebSocket.
  *
  * Returns a tuple of [async_message_iterator, control], same as runWsStream.
- * The iterator yields stdout, stderr, exit, and error messages.
- * No 'started' message is sent on reconnection.
+ * The iterator yields the server's 'started' acknowledgement, then stdout,
+ * stderr, exit, and error messages. That acknowledgement is the only evidence a
+ * reattachment landed for a command producing no output, so it is forwarded
+ * rather than dropped.
  */
 export async function reconnectWsStream(
   dataplaneUrl: string,
@@ -512,7 +514,11 @@ export async function reconnectWsStream(
       for await (const msg of readWsMessages(ws)) {
         const msgType = msg.type;
 
-        if (msgType === "stdout" || msgType === "stderr") {
+        if (
+          msgType === "started" ||
+          msgType === "stdout" ||
+          msgType === "stderr"
+        ) {
           yield msg;
         } else if (msgType === "exit") {
           yield msg;

--- a/js/src/tests/sandbox_reconnect_ack.test.ts
+++ b/js/src/tests/sandbox_reconnect_ack.test.ts
@@ -1,0 +1,207 @@
+/**
+ * A silent command must outlive more socket losses than the reconnect budget.
+ *
+ * A command and its WebSocket are separate things: the command keeps running on
+ * the server and the socket is only this client's attachment to it. The server
+ * acknowledges every successful reattachment with a 'started' frame, which for a
+ * command producing no output is the only evidence the reattachment landed.
+ *
+ * The budget is meant to bound *consecutive failed* reattachments. Reset it only
+ * on stdout/stderr and it instead counts socket closures since the last output,
+ * so a healthy, attached, quiet command dies one loss at a time.
+ */
+import { jest, describe, it, expect, beforeEach } from "@jest/globals";
+import type { WsMessage } from "../sandbox/types.js";
+import { LangSmithSandboxConnectionError } from "../sandbox/errors.js";
+
+const runWsStream = jest.fn<any>();
+const reconnectWsStream = jest.fn<any>();
+
+jest.unstable_mockModule("../sandbox/ws_execute.js", () => ({
+  runWsStream,
+  reconnectWsStream,
+  WSStreamControl: class {},
+  isWsAvailable: () => Promise.resolve(true),
+  WS_OPEN_TIMEOUT: 30,
+  WS_CONNECT_BUDGET: 120,
+  connectDeadline: () => 120,
+  remainingBudget: () => 120,
+  openTimeoutFor: () => 30,
+}));
+
+const { Sandbox } = await import("../sandbox/sandbox.js");
+const { CommandHandle } = await import("../sandbox/command_handle.js");
+
+const COMMAND_ID = "cmd-123";
+
+function makeStream(messages: WsMessage[]): AsyncIterableIterator<WsMessage> {
+  let i = 0;
+  return {
+    next: async () =>
+      i < messages.length
+        ? { value: messages[i++], done: false }
+        : { value: undefined as never, done: true },
+    [Symbol.asyncIterator]() {
+      return this;
+    },
+  };
+}
+
+/** Yields the given frames, then loses the socket. */
+function thenLost(
+  messages: WsMessage[],
+  err: Error,
+): AsyncIterableIterator<WsMessage> {
+  let i = 0;
+  return {
+    next: async () => {
+      if (i < messages.length) return { value: messages[i++], done: false };
+      throw err;
+    },
+    [Symbol.asyncIterator]() {
+      return this;
+    },
+  } as AsyncIterableIterator<WsMessage>;
+}
+
+function startedMsg(commandId: string = COMMAND_ID): WsMessage {
+  return { type: "started", command_id: commandId, pid: 42 } as WsMessage;
+}
+
+function makeSandbox() {
+  const client = {
+    getApiKey: () => "test-key",
+    getDefaultHeaders: () => ({}),
+  };
+  return new Sandbox(
+    {
+      name: "sb",
+      dataplane_url: "https://dp.example.com/sb-123",
+      status: "ready",
+    } as never,
+    client as never,
+  );
+}
+
+/** A handle already attached to a running command, whose socket then drops. */
+async function handleThatLosesItsSocket(sandbox: InstanceType<typeof Sandbox>) {
+  runWsStream.mockImplementationOnce(() => [
+    thenLost(
+      [startedMsg()],
+      new LangSmithSandboxConnectionError("connection lost"),
+    ),
+    null,
+  ]);
+  return (await sandbox.run("sleep 60", {
+    wait: false,
+    commandId: COMMAND_ID,
+  })) as InstanceType<typeof CommandHandle>;
+}
+
+describe("reconnect acknowledgement", () => {
+  beforeEach(() => {
+    runWsStream.mockReset();
+    reconnectWsStream.mockReset();
+    jest.spyOn(global, "setTimeout").mockImplementation(((fn: () => void) => {
+      fn();
+      return 0 as never;
+    }) as never);
+  });
+
+  it("resets the budget on a 'started' ack with no output", async () => {
+    const sandbox = makeSandbox();
+    const losses = CommandHandle.MAX_AUTO_RECONNECTS + 3;
+    let attempts = 0;
+
+    reconnectWsStream.mockImplementation(() => {
+      attempts += 1;
+      if (attempts < losses) {
+        return [
+          thenLost(
+            [startedMsg()],
+            new LangSmithSandboxConnectionError("lost again"),
+          ),
+          null,
+        ];
+      }
+      return [
+        makeStream([startedMsg(), { type: "exit", exit_code: 7 } as WsMessage]),
+        null,
+      ];
+    });
+
+    const handle = await handleThatLosesItsSocket(sandbox);
+    const chunks = [];
+    for await (const chunk of handle) chunks.push(chunk);
+
+    expect(chunks).toEqual([]);
+    expect(attempts).toBe(losses);
+    expect((await handle.result).exit_code).toBe(7);
+  });
+
+  it("does not reset the budget on an ack for a different command", async () => {
+    const sandbox = makeSandbox();
+
+    reconnectWsStream.mockImplementation(() => [
+      thenLost(
+        [startedMsg("someone-elses-cmd")],
+        new LangSmithSandboxConnectionError("lost again"),
+      ),
+      null,
+    ]);
+
+    const handle = await handleThatLosesItsSocket(sandbox);
+    await expect(
+      (async () => {
+        for await (const _ of handle) {
+          /* drain */
+        }
+      })(),
+    ).rejects.toThrow(/giving up/);
+    expect(reconnectWsStream).toHaveBeenCalledTimes(
+      CommandHandle.MAX_AUTO_RECONNECTS,
+    );
+  });
+
+  it("consumes the ack without yielding a chunk or moving offsets", async () => {
+    const sandbox = makeSandbox();
+    const seen: string[] = [];
+
+    runWsStream.mockImplementationOnce(() => [
+      thenLost(
+        [
+          startedMsg(),
+          { type: "stdout", data: "before", offset: 0 } as WsMessage,
+        ],
+        new LangSmithSandboxConnectionError("connection lost"),
+      ),
+      null,
+    ]);
+    reconnectWsStream.mockImplementationOnce(() => [
+      makeStream([
+        startedMsg(),
+        { type: "stdout", data: "after", offset: 6 } as WsMessage,
+        { type: "exit", exit_code: 0 } as WsMessage,
+      ]),
+      null,
+    ]);
+
+    const handle = (await sandbox.run("cmd", {
+      wait: false,
+      commandId: COMMAND_ID,
+      onStdout: (d: string) => seen.push(d),
+    })) as InstanceType<typeof CommandHandle>;
+
+    const chunks = [];
+    for await (const chunk of handle) chunks.push(chunk);
+
+    expect(chunks.map((c) => c.data)).toEqual(["before", "after"]);
+    expect(seen).toEqual(["before", "after"]);
+    // Offsets are the ones "before" left behind: the ack carried no bytes.
+    expect(reconnectWsStream.mock.calls[0][3]).toMatchObject({
+      stdoutOffset: 6,
+      stderrOffset: 0,
+    });
+    expect((await handle.result).stdout).toBe("beforeafter");
+  });
+});

--- a/python/langsmith/sandbox/_models.py
+++ b/python/langsmith/sandbox/_models.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from collections.abc import AsyncIterator, Awaitable, Callable, Iterator
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -22,6 +23,28 @@ if TYPE_CHECKING:
         _AsyncWSStreamControl,
         _WSStreamControl,
     )
+
+logger = logging.getLogger(__name__)
+
+
+def _acknowledges_reconnect(msg: dict, command_id: Optional[str]) -> bool:
+    """Whether a 'started' frame proves *this* command was reattached to.
+
+    A command and its WebSocket are separate things: the command keeps running on
+    the server and the socket is only this client's attachment to it. The server
+    acknowledges every successful reattachment with 'started', which for a
+    command that produces no output is the only evidence it landed. One naming a
+    different command is not evidence, and must not clear the reconnect budget.
+    """
+    acked = msg.get("command_id")
+    if acked == command_id:
+        return True
+    logger.warning(
+        "Ignoring reconnect acknowledgement for command %r while attached to %r",
+        acked,
+        command_id,
+    )
+    return False
 
 
 class _StreamEndedBeforeStarted(SandboxOperationError):
@@ -479,7 +502,10 @@ class CommandHandle:
       eagerly reads the server's ``"started"`` message to populate
       ``command_id`` and ``pid`` before returning.
     - **Reconnection** (``command_id`` set): skips the started-message
-      read, since reconnect streams don't emit one.
+      read. A reconnect stream's ``"started"`` message is the server's
+      acknowledgement that the reattachment landed, consumed while iterating to
+      clear the reconnect budget — the only such signal for a command that
+      emits no output.
 
     Example:
         handle = sandbox.run("make build", timeout=600, wait=False)
@@ -520,10 +546,11 @@ class CommandHandle:
         self._exhausted = False
         self._last_stdout_offset = stdout_offset
         self._last_stderr_offset = stderr_offset
+        self._reconnect_attempts = 0
 
         # New executions (command_id=""): eager_start reads "started" message.
-        # Reconnections (command_id set): skip eager_start since reconnect
-        # streams don't send a "started" message.
+        # Reconnections (command_id set): the "started" message is the server's
+        # reattachment acknowledgement, consumed by _iter_stream instead.
         if command_id:
             self._command_id = command_id
         else:
@@ -585,7 +612,10 @@ class CommandHandle:
             return
         for msg in self._stream:
             msg_type = msg.get("type")
-            if msg_type in ("stdout", "stderr"):
+            if msg_type == "started":
+                if _acknowledges_reconnect(msg, self._command_id):
+                    self._reconnect_attempts = 0
+            elif msg_type in ("stdout", "stderr"):
                 chunk = OutputChunk(
                     stream=msg_type,
                     data=msg["data"],
@@ -616,11 +646,11 @@ class CommandHandle:
         """
         import time
 
-        reconnect_attempts = 0
+        self._reconnect_attempts = 0
         while True:
             try:
                 for chunk in self._iter_stream():
-                    reconnect_attempts = 0  # Reset on successful data
+                    self._reconnect_attempts = 0  # Reset on successful data
                     if chunk.stream == "stdout":
                         self._last_stdout_offset = chunk.offset + len(
                             chunk.data.encode("utf-8")
@@ -640,17 +670,18 @@ class CommandHandle:
                 if self._control and self._control.killed:
                     raise
 
-                reconnect_attempts += 1
-                if reconnect_attempts > self.MAX_AUTO_RECONNECTS:
+                self._reconnect_attempts += 1
+                if self._reconnect_attempts > self.MAX_AUTO_RECONNECTS:
                     raise SandboxConnectionError(
-                        f"Lost connection {reconnect_attempts} times in "
-                        f"succession, giving up"
+                        f"Failed to reattach to the command "
+                        f"{self._reconnect_attempts} times in succession, "
+                        f"giving up"
                     ) from e
 
                 is_hot_reload = isinstance(e, SandboxServerReloadError)
                 if not is_hot_reload:
                     delay = min(
-                        self._BACKOFF_BASE * (2 ** (reconnect_attempts - 1)),
+                        self._BACKOFF_BASE * (2 ** (self._reconnect_attempts - 1)),
                         self._BACKOFF_MAX,
                     )
                     time.sleep(delay)
@@ -739,7 +770,10 @@ class AsyncCommandHandle:
       ``await handle._ensure_started()`` after construction to read the
       server's ``"started"`` message and populate ``command_id`` / ``pid``.
     - **Reconnection** (``command_id`` set): skips the started-message
-      read, since reconnect streams don't emit one.
+      read. A reconnect stream's ``"started"`` message is the server's
+      acknowledgement that the reattachment landed, consumed while iterating to
+      clear the reconnect budget — the only such signal for a command that
+      emits no output.
 
     Example:
         handle = await sandbox.run("make build", timeout=600, wait=False)
@@ -780,10 +814,11 @@ class AsyncCommandHandle:
         self._exhausted = False
         self._last_stdout_offset = stdout_offset
         self._last_stderr_offset = stderr_offset
+        self._reconnect_attempts = 0
 
         # New executions (command_id=""): _ensure_started reads "started".
-        # Reconnections (command_id set): skip since reconnect streams
-        # don't send a "started" message.
+        # Reconnections (command_id set): the "started" message is the server's
+        # reattachment acknowledgement, consumed by _aiter_stream instead.
         if command_id:
             self._command_id = command_id
             self._started = True
@@ -840,7 +875,10 @@ class AsyncCommandHandle:
             return
         async for msg in self._stream:
             msg_type = msg.get("type")
-            if msg_type in ("stdout", "stderr"):
+            if msg_type == "started":
+                if _acknowledges_reconnect(msg, self._command_id):
+                    self._reconnect_attempts = 0
+            elif msg_type in ("stdout", "stderr"):
                 chunk = OutputChunk(
                     stream=msg_type,
                     data=msg["data"],
@@ -865,11 +903,11 @@ class AsyncCommandHandle:
         """Async iterate with auto-reconnect on transient errors."""
         import asyncio
 
-        reconnect_attempts = 0
+        self._reconnect_attempts = 0
         while True:
             try:
                 async for chunk in self._aiter_stream():
-                    reconnect_attempts = 0
+                    self._reconnect_attempts = 0
                     if chunk.stream == "stdout":
                         self._last_stdout_offset = chunk.offset + len(
                             chunk.data.encode("utf-8")
@@ -889,17 +927,18 @@ class AsyncCommandHandle:
                 if self._control and self._control.killed:
                     raise
 
-                reconnect_attempts += 1
-                if reconnect_attempts > self.MAX_AUTO_RECONNECTS:
+                self._reconnect_attempts += 1
+                if self._reconnect_attempts > self.MAX_AUTO_RECONNECTS:
                     raise SandboxConnectionError(
-                        f"Lost connection {reconnect_attempts} times "
-                        f"in succession, giving up"
+                        f"Failed to reattach to the command "
+                        f"{self._reconnect_attempts} times in succession, "
+                        f"giving up"
                     ) from e
 
                 is_hot_reload = isinstance(e, SandboxServerReloadError)
                 if not is_hot_reload:
                     delay = min(
-                        self._BACKOFF_BASE * (2 ** (reconnect_attempts - 1)),
+                        self._BACKOFF_BASE * (2 ** (self._reconnect_attempts - 1)),
                         self._BACKOFF_MAX,
                     )
                     await asyncio.sleep(delay)

--- a/python/langsmith/sandbox/_ws_execute.py
+++ b/python/langsmith/sandbox/_ws_execute.py
@@ -401,8 +401,10 @@ def reconnect_ws_stream(
     """Reconnect to an existing command over WebSocket.
 
     Returns a tuple of (message_iterator, control), same as run_ws_stream.
-    The iterator yields stdout, stderr, exit, and error messages.
-    No 'started' message is sent on reconnection.
+    The iterator yields the server's ``started`` acknowledgement, then stdout,
+    stderr, exit, and error messages. That acknowledgement is the only evidence
+    a reattachment landed for a command producing no output, so it is forwarded
+    rather than dropped.
 
     With the ring buffer reader server model, there is no replay/live
     phase distinction and no deduplication needed. The server reads from
@@ -444,7 +446,7 @@ def reconnect_ws_stream(
                     msg = json.loads(raw_msg)
                     msg_type = msg.get("type")
 
-                    if msg_type in ("stdout", "stderr"):
+                    if msg_type in ("started", "stdout", "stderr"):
                         yield msg
 
                     elif msg_type == "exit":
@@ -620,7 +622,7 @@ async def reconnect_ws_stream_async(
                     msg = json.loads(raw_msg)
                     msg_type = msg.get("type")
 
-                    if msg_type in ("stdout", "stderr"):
+                    if msg_type in ("started", "stdout", "stderr"):
                         yield msg
                     elif msg_type == "exit":
                         yield msg

--- a/python/tests/unit_tests/sandbox/test_async_ws_execute.py
+++ b/python/tests/unit_tests/sandbox/test_async_ws_execute.py
@@ -502,6 +502,145 @@ class TestAsyncCommandHandle:
                 _ = [c async for c in handle]
 
     @pytest.mark.asyncio
+    async def test_reconnect_ack_resets_counter_without_output(self):
+        """A silent command survives more socket losses than the reconnect budget.
+
+        Every reattachment is acknowledged with 'started' and produces no output.
+        The budget bounds *failed* reattachments, so it must never be consumed by
+        a command that is simply quiet.
+        """
+        losses = AsyncCommandHandle.MAX_AUTO_RECONNECTS + 3
+        attempts = [0]
+
+        async def initial_stream():
+            yield _started_msg()
+            raise SandboxConnectionError("lost")
+
+        sandbox = self._make_sandbox_mock()
+
+        def make_reconnect_handle(*args, **kwargs):
+            attempts[0] += 1
+            h = MagicMock()
+            if attempts[0] < losses:
+
+                async def acked_then_lost():
+                    yield _started_msg()
+                    raise SandboxConnectionError("lost again")
+
+                h._stream = acked_then_lost()
+            else:
+                h._stream = _make_async_stream([_started_msg(), _exit_msg(7)])
+            h._control = None
+            return h
+
+        sandbox.reconnect.side_effect = make_reconnect_handle
+        handle = AsyncCommandHandle(initial_stream(), None, sandbox)
+        await handle._ensure_started()
+
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            chunks = [c async for c in handle]
+
+        assert chunks == []
+        assert attempts[0] == losses
+        assert (await handle.result).exit_code == 7
+
+    @pytest.mark.asyncio
+    async def test_reconnect_ack_for_another_command_does_not_reset(self):
+        """An acknowledgement naming a different command is not proof of anything."""
+
+        async def initial_stream():
+            yield _started_msg()
+            raise SandboxConnectionError("lost")
+
+        sandbox = self._make_sandbox_mock()
+
+        def make_reconnect_handle(*args, **kwargs):
+            h = MagicMock()
+
+            async def foreign_ack_then_lost():
+                yield _started_msg("someone-elses-cmd")
+                raise SandboxConnectionError("lost again")
+
+            h._stream = foreign_ack_then_lost()
+            h._control = None
+            return h
+
+        sandbox.reconnect.side_effect = make_reconnect_handle
+        handle = AsyncCommandHandle(initial_stream(), None, sandbox)
+        await handle._ensure_started()
+
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            with pytest.raises(SandboxConnectionError, match="giving up"):
+                _ = [c async for c in handle]
+
+        assert sandbox.reconnect.call_count == AsyncCommandHandle.MAX_AUTO_RECONNECTS
+
+    @pytest.mark.asyncio
+    async def test_reconnect_ack_is_consumed_and_leaves_offsets_alone(self):
+        """The acknowledgement yields no chunk, fires no callback, moves no offset."""
+
+        async def initial_stream():
+            yield _started_msg()
+            yield _stdout_msg("before", 0)
+            raise SandboxConnectionError("lost")
+
+        sandbox = self._make_sandbox_mock()
+
+        def make_reconnect_handle(*args, **kwargs):
+            h = MagicMock()
+            h._stream = _make_async_stream(
+                [
+                    _started_msg(),
+                    _stdout_msg("after", 6),
+                    _exit_msg(0),
+                ]
+            )
+            h._control = None
+            return h
+
+        sandbox.reconnect.side_effect = make_reconnect_handle
+        seen: list[str] = []
+        handle = AsyncCommandHandle(
+            initial_stream(), None, sandbox, on_stdout=seen.append
+        )
+        await handle._ensure_started()
+
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            chunks = [c async for c in handle]
+
+        assert [chunk.data for chunk in chunks] == ["before", "after"]
+        assert seen == ["before", "after"]
+        # Offsets are the ones "before" left behind: the ack carried no bytes.
+        sandbox.reconnect.assert_called_once_with(
+            "cmd-123", stdout_offset=6, stderr_offset=0
+        )
+        assert (await handle.result).stdout == "beforeafter"
+
+    @pytest.mark.asyncio
+    async def test_command_not_found_not_retried(self):
+        """A permanently gone command fails on the first reattachment attempt."""
+
+        async def failing_stream():
+            yield _started_msg()
+            raise SandboxConnectionError("lost")
+
+        sandbox = self._make_sandbox_mock()
+        sandbox.reconnect.side_effect = SandboxOperationError(
+            "Command not found: cmd-123",
+            operation="reconnect",
+            error_type="CommandNotFound",
+        )
+
+        handle = AsyncCommandHandle(failing_stream(), None, sandbox)
+        await handle._ensure_started()
+
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            with pytest.raises(SandboxOperationError, match="Command not found"):
+                _ = [c async for c in handle]
+
+        assert sandbox.reconnect.call_count == 1
+
+    @pytest.mark.asyncio
     async def test_manual_reconnect(self):
         """handle.reconnect() delegates to sandbox.reconnect()."""
         stream = _make_async_stream(
@@ -936,6 +1075,32 @@ class TestAsyncSandboxReconnect:
 # =============================================================================
 # Tests: async handshake failures are wrapped as SandboxConnectionError
 # =============================================================================
+
+
+class TestAsyncReconnectStreamFrames:
+    @pytest.mark.asyncio
+    async def test_forwards_started_acknowledgement(self):
+        """The reattachment ack must reach the handle, not be dropped in transport."""
+        frames = [
+            {"type": "started", "command_id": "cmd-123", "pid": 42},
+            {"type": "stdout", "data": "resumed", "offset": 10},
+            {"type": "exit", "exit_code": 0},
+        ]
+
+        async def raw_frames():
+            for frame in frames:
+                yield json.dumps(frame)
+
+        ws = MagicMock()
+        ws.send = AsyncMock()
+        ws.__aiter__ = lambda self: raw_frames()
+        with patch("langsmith.sandbox._ws_execute._ws_connect_async") as mock_connect:
+            mock_connect.return_value.__aenter__ = AsyncMock(return_value=ws)
+            mock_connect.return_value.__aexit__ = AsyncMock(return_value=False)
+            msg_stream, _ = await reconnect_ws_stream_async(
+                "https://sb.example.com", "key", "cmd-123", stdout_offset=10
+            )
+            assert [msg async for msg in msg_stream] == frames
 
 
 class TestAsyncHandshakeFailureWrapping:

--- a/python/tests/unit_tests/sandbox/test_ws_execute.py
+++ b/python/tests/unit_tests/sandbox/test_ws_execute.py
@@ -503,6 +503,135 @@ class TestCommandHandle:
         assert len(chunks) == max_reconnects_to_do + 1
         assert reconnect_count[0] == max_reconnects_to_do
 
+    def test_reconnect_ack_resets_counter_without_output(self):
+        """A silent command survives more socket losses than the reconnect budget.
+
+        Every reattachment is acknowledged with 'started' and produces no output.
+        The budget bounds *failed* reattachments, so it must never be consumed by
+        a command that is simply quiet.
+        """
+        losses = CommandHandle.MAX_AUTO_RECONNECTS + 3
+        attempts = [0]
+
+        def initial_stream():
+            yield _started_msg()
+            raise SandboxConnectionError("lost")
+
+        sandbox = self._make_sandbox_mock()
+
+        def make_reconnect_handle(*args, **kwargs):
+            attempts[0] += 1
+            h = MagicMock()
+            if attempts[0] < losses:
+
+                def acked_then_lost():
+                    yield _started_msg()
+                    raise SandboxConnectionError("lost again")
+
+                h._stream = acked_then_lost()
+            else:
+                h._stream = _make_stream([_started_msg(), _exit_msg(7)])
+            h._control = None
+            return h
+
+        sandbox.reconnect.side_effect = make_reconnect_handle
+        handle = CommandHandle(initial_stream(), None, sandbox)
+
+        with patch("time.sleep"):
+            chunks = list(handle)
+
+        assert chunks == []
+        assert attempts[0] == losses
+        assert handle.result.exit_code == 7
+
+    def test_reconnect_ack_for_another_command_does_not_reset(self):
+        """An acknowledgement naming a different command is not proof of anything."""
+
+        def initial_stream():
+            yield _started_msg()
+            raise SandboxConnectionError("lost")
+
+        sandbox = self._make_sandbox_mock()
+
+        def make_reconnect_handle(*args, **kwargs):
+            h = MagicMock()
+
+            def foreign_ack_then_lost():
+                yield _started_msg("someone-elses-cmd")
+                raise SandboxConnectionError("lost again")
+
+            h._stream = foreign_ack_then_lost()
+            h._control = None
+            return h
+
+        sandbox.reconnect.side_effect = make_reconnect_handle
+        handle = CommandHandle(initial_stream(), None, sandbox)
+
+        with patch("time.sleep"):
+            with pytest.raises(SandboxConnectionError, match="giving up"):
+                list(handle)
+
+        assert sandbox.reconnect.call_count == CommandHandle.MAX_AUTO_RECONNECTS
+
+    def test_reconnect_ack_is_consumed_and_leaves_offsets_alone(self):
+        """The acknowledgement yields no chunk, fires no callback, moves no offset."""
+
+        def initial_stream():
+            yield _started_msg()
+            yield _stdout_msg("before", 0)
+            raise SandboxConnectionError("lost")
+
+        sandbox = self._make_sandbox_mock()
+
+        def make_reconnect_handle(*args, **kwargs):
+            h = MagicMock()
+            h._stream = _make_stream(
+                [
+                    _started_msg(),
+                    _stdout_msg("after", 6),
+                    _exit_msg(0),
+                ]
+            )
+            h._control = None
+            return h
+
+        sandbox.reconnect.side_effect = make_reconnect_handle
+        seen: list[str] = []
+        handle = CommandHandle(initial_stream(), None, sandbox, on_stdout=seen.append)
+
+        with patch("time.sleep"):
+            chunks = list(handle)
+
+        assert [chunk.data for chunk in chunks] == ["before", "after"]
+        assert seen == ["before", "after"]
+        # Offsets are the ones "before" left behind: the ack carried no bytes.
+        sandbox.reconnect.assert_called_once_with(
+            "cmd-123", stdout_offset=6, stderr_offset=0
+        )
+        assert handle.result.stdout == "beforeafter"
+
+    def test_command_not_found_not_retried(self):
+        """A permanently gone command fails on the first reattachment attempt."""
+
+        def failing_stream():
+            yield _started_msg()
+            raise SandboxConnectionError("lost")
+
+        sandbox = self._make_sandbox_mock()
+        sandbox.reconnect.side_effect = SandboxOperationError(
+            "Command not found: cmd-123",
+            operation="reconnect",
+            error_type="CommandNotFound",
+        )
+
+        handle = CommandHandle(failing_stream(), None, sandbox)
+
+        with patch("time.sleep"):
+            with pytest.raises(SandboxOperationError, match="Command not found"):
+                list(handle)
+
+        assert sandbox.reconnect.call_count == 1
+
     def test_manual_reconnect(self):
         """handle.reconnect() delegates to sandbox.reconnect()."""
         stream = _make_stream(
@@ -924,6 +1053,24 @@ class TestRaiseForInvalidHandshake:
 # =============================================================================
 # Tests: handshake failures are wrapped as SandboxConnectionError
 # =============================================================================
+
+
+class TestReconnectStreamFrames:
+    def test_forwards_started_acknowledgement(self):
+        """The reattachment ack must reach the handle, not be dropped in transport."""
+        frames = [
+            {"type": "started", "command_id": "cmd-123", "pid": 42},
+            {"type": "stdout", "data": "resumed", "offset": 10},
+            {"type": "exit", "exit_code": 0},
+        ]
+        ws = MagicMock()
+        ws.__iter__.return_value = iter([json.dumps(frame) for frame in frames])
+        with patch("langsmith.sandbox._ws_execute._ws_connect_sync") as mock_connect:
+            mock_connect.return_value.__enter__.return_value = ws
+            msg_stream, _ = reconnect_ws_stream(
+                "https://sb.example.com", "key", "cmd-123", stdout_offset=10
+            )
+            assert list(msg_stream) == frames
 
 
 class TestHandshakeFailureWrapping:


### PR DESCRIPTION
## Problem

A command and its WebSocket are separate things: the command keeps running on the server, and the socket is only a client's attachment to it. When the socket drops, the SDK reattaches with the same `command_id` and byte offsets, and bounds how many **consecutive failed** reattachments it tolerates (`MAX_AUTO_RECONNECTS`).

That budget was cleared only by stdout or stderr. The server acknowledges every successful reattachment with a `started` frame, but `reconnect_ws_stream` / `reconnectWsStream` discarded it — so the counter really meant *"socket closures since the last output"*. A command that was attached, healthy and merely **silent** therefore burned one budget slot per socket loss and gave up on the sixth.

Seen in production: one session reattached five times over ~10m35s, each reattachment reporting stdout/stderr offsets `0`, with only ~17s of actual reconnect gaps — then died on the sixth closure with `Lost connection 6 times in succession, giving up`. The relay pods carrying these sockets recycle constantly, so this is not an exotic case.

## Fix

Treat a valid `started` frame as proof the reattachment landed:

1. Both reconnect streams (sync and async, Python and JS) **forward** the frame instead of dropping it.
2. The handle consumes it internally: validates that `command_id` matches the command it is attached to, then clears the reconnect budget.
3. It yields no `OutputChunk` and fires no stdout/stderr callback — it is not output.
4. Offsets are untouched, so nothing is replayed and nothing is skipped.
5. Real stdout/stderr still clears the budget, for servers that predate the acknowledgement.
6. An acknowledgement naming a **different** command does not clear it (logged instead).
7. `CommandNotFound` / `SessionExpired` still raise immediately — they are permanent, not transport failures.

The budget now bounds what it was always meant to, so the error reads `Failed to reattach to the command N times in succession` rather than `Lost connection`.

## Scope

Python and JS both had this bug and both are fixed here. Go had it too (fixed separately in `langsmith-go-staging`). Java has no sandbox exec/WebSocket surface.

## Tests

Sync and async, mirrored across both languages:

- More socket losses than the budget, every reattachment acknowledged, no output → the command still returns its exit code. **This is the regression test: it fails on the previous code with the exact production error.**
- Reattachments that fail before any acknowledgement → still reach the limit and raise.
- An acknowledgement for a different `command_id` → does not clear the budget.
- Acknowledgement followed by real output → callbacks receive only the real output, and the recorded offsets show the ack carried no bytes.
- `CommandNotFound` → fails on the first attempt, not retried.
- Transport level: `reconnect_ws_stream{,_async}` / `reconnectWsStream` forward the `started` frame.

Verified failing before the fix (4 Python, 1 JS), passing after: `521 passed` in the Python sandbox suite, `146 passed` across the JS sandbox suites. `make format`, `make lint` and `mypy` clean.

Server-side e2e coverage lives in the LangSmith source repo and drives a real sandbox through six forced socket losses; it is gated on the SDK version that carries this fix.
