### PR TITLE
release(py): 0.10.14

### DIFF
--- a/python/.bumpversion.cfg
+++ b/python/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.10.13
+current_version = 0.10.14
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
 serialize = {major}.{minor}.{patch}
 search = {current_version}

--- a/python/langsmith/__init__.py
+++ b/python/langsmith/__init__.py
@@ -49,7 +49,7 @@ if TYPE_CHECKING:
 
 # Avoid calling into importlib on every call to __version__
 
-__version__ = "0.10.13"
+__version__ = "0.10.14"
 version = __version__  # for backwards compatibility
 
 # Metadata key to hide a traced run from LangSmith's Messages View.


### PR DESCRIPTION
Patch release for the sandbox exec reconnect fix (#3301).

A command and its WebSocket are separate things: the command keeps running on the server, and the socket is only a client's attachment to it. The reconnect budget was cleared only by stdout/stderr, so it counted socket closures since the last output rather than consecutive failed reattachments — and a command that was attached, healthy and merely silent died on the sixth loss after six reattachments that had all succeeded. 0.10.14 treats the server's `started` acknowledgement as proof a reattachment landed.

Also unblocks the sandbox reconnect e2e case in the server repo, which is gated on `langsmith >= 0.10.14`.

JS carries the same fix on `main` and needs its own release PR — the two workflows fire on different files.