### PR TITLE
release(py): 0.10.14

### DIFF
--- a/python/.bumpversion.cfg
+++ b/python/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.10.13
+current_version = 0.10.14
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
 serialize = {major}.{minor}.{patch}
 search = {current_version}

--- a/python/langsmith/__init__.py
+++ b/python/langsmith/__init__.py
@@ -49,7 +49,7 @@ if TYPE_CHECKING:
 
 # Avoid calling into importlib on every call to __version__
 
-__version__ = "0.10.13"
+__version__ = "0.10.14"
 version = __version__  # for backwards compatibility
 
 # Metadata key to hide a traced run from LangSmith's Messages View.


### PR DESCRIPTION
## Description

Bumps the Python SDK to 0.10.14 using the repository bump2version configuration. On merge, `.github/workflows/release.yml` tags `v0.10.14` and publishes to PyPI.

Ships two changes since 0.10.13:

- #3291 — raw Gemini Live session tracing, including transcript accumulation, tool spans, usage normalization, typing, and tests.
- #3301 — sandbox reattachment acknowledgements now count as progress.

## Test Plan

- [x] `.venv/bin/ruff format --check langsmith/__init__.py`
- [x] `.venv/bin/ruff check langsmith/__init__.py`
- [x] Verified `.bumpversion.cfg` and `langsmith/__init__.py` both declare 0.10.14
- [x] Verified local `v0.10.14` tag is absent so the release workflow creates the authoritative tag on merge