### PR TITLE
fix(python): apply the caller-supplied session's config to v2 endpoints

### DIFF
--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -194,7 +194,10 @@ def _httpx_kwargs_from_session(session: requests.Session) -> dict[str, Any]:
     if headers:
         kwargs["headers"] = headers
     if session.cookies:
-        kwargs["cookies"] = dict(session.cookies)
+        # Pass the jar itself, not `dict(...)`: flattening drops each cookie's
+        # domain/path/secure scope (leaking cookies meant for another host to
+        # the API) and raises `CookieConflictError` on same-name cookies.
+        kwargs["cookies"] = session.cookies
     # `verify` may be a bool or a path to a CA bundle; both are valid in httpx.
     if session.verify is not True:
         kwargs["verify"] = session.verify
@@ -205,7 +208,14 @@ def _httpx_kwargs_from_session(session: requests.Session) -> dict[str, Any]:
     # is https in practice, so prefer that entry.
     proxy = session.proxies.get("https") or session.proxies.get("http")
     if proxy:
-        kwargs["proxy"] = proxy
+        # httpx renamed `proxies` to `proxy` in 0.26 and dropped `proxies` in
+        # 0.28; we support >=0.23, so pick whichever this version accepts.
+        proxy_kwarg = (
+            "proxy"
+            if "proxy" in signature(_httpx.Client.__init__).parameters
+            else "proxies"
+        )
+        kwargs[proxy_kwarg] = proxy
     return kwargs
 
 

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -114,6 +114,12 @@ from langsmith._internal._serde import dumps_json as _dumps_json
 from langsmith._internal._uuid import uuid7
 from langsmith._openapi_client import AsyncLangsmith as LangsmithOpenAPIClient
 from langsmith._openapi_client import Langsmith as SyncLangsmithOpenAPIClient
+from langsmith._openapi_client._base_client import (
+    AsyncHttpxClientWrapper as _AsyncHttpxClientWrapper,
+)
+from langsmith._openapi_client._base_client import (
+    SyncHttpxClientWrapper as _SyncHttpxClientWrapper,
+)
 from langsmith.prompt_cache import PromptCache, prompt_cache_singleton
 from langsmith.schemas import AttachmentInfo, ExampleWithRuns
 
@@ -160,6 +166,47 @@ def _get_openapi_base_url(api_url: str) -> str:
         if api_url.endswith(suffix):
             return api_url[: -len(suffix)]
     return api_url
+
+
+def _httpx_kwargs_from_session(session: requests.Session) -> dict[str, Any]:
+    """Translate a `requests.Session`'s transport config into `httpx` kwargs.
+
+    The generated OpenAPI client is `httpx`-based, so a `requests.Session`
+    cannot be shared with it directly. Instead we carry over the settings that
+    have a direct `httpx` equivalent, so that a caller-supplied session's TLS,
+    proxy, cookie and header configuration also applies to the v2 endpoints.
+
+    Not carried over (no `httpx` equivalent): custom mounted `HTTPAdapter`s,
+    `session.auth`, and `session.hooks`. Connection pool bounds and retries are
+    left at the generated client's own defaults rather than being derived from
+    the session's adapter.
+    """
+    kwargs: dict[str, Any] = {"trust_env": session.trust_env}
+
+    # Only user-added headers; `requests`' own defaults (its `User-Agent`,
+    # `Accept-Encoding`, ...) must not shadow the ones httpx/the SDK sets.
+    requests_defaults = requests.utils.default_headers()
+    headers = {
+        key: value
+        for key, value in session.headers.items()
+        if value is not None and requests_defaults.get(key) != value
+    }
+    if headers:
+        kwargs["headers"] = headers
+    if session.cookies:
+        kwargs["cookies"] = dict(session.cookies)
+    # `verify` may be a bool or a path to a CA bundle; both are valid in httpx.
+    if session.verify is not True:
+        kwargs["verify"] = session.verify
+    if session.cert:
+        kwargs["cert"] = session.cert
+    # `requests` keys proxies per-scheme; httpx takes a single proxy (or
+    # `mounts`, which would require rebuilding the transport). The API base URL
+    # is https in practice, so prefer that entry.
+    proxy = session.proxies.get("https") or session.proxies.get("http")
+    if proxy:
+        kwargs["proxy"] = proxy
+    return kwargs
 
 
 _TRACING_SEND_TIMEOUT = (3, 10)  # (connect, read) seconds for background sends
@@ -951,6 +998,7 @@ class Client:
         "_profile_auth_headers",
         "_langsmith_api",
         "_langsmith_api_sync",
+        "_session_provided",
     ]
 
     _api_key: Optional[str]
@@ -963,6 +1011,7 @@ class Client:
     _profile_auth_headers: dict[str, str]
     _langsmith_api: Optional[LangsmithOpenAPIClient]
     _langsmith_api_sync: Optional[SyncLangsmithOpenAPIClient]
+    _session_provided: bool
 
     def __init__(
         self,
@@ -1018,6 +1067,12 @@ class Client:
             session: The session to use for requests.
 
                 If `None`, a new session will be created.
+
+                v2 endpoints are served by an `httpx`-based client, which cannot
+                share the session itself. Its headers, cookies, `verify`, `cert`,
+                proxies and `trust_env` settings are translated onto that client;
+                custom mounted `HTTPAdapter`s, `session.auth` and `session.hooks`
+                are not.
             auto_batch_tracing: Whether to automatically batch tracing.
             anonymizer: A function applied for masking serialized run inputs and
                 outputs, before sending to the API.
@@ -1267,6 +1322,10 @@ class Client:
         # Create a session and register a finalizer to close it
         session_ = session if session else requests.Session()
         self.session = session_
+        # Whether to derive the generated OpenAPI client's httpx config from the
+        # session. Only meaningful for a caller-supplied one; the default
+        # session carries no user configuration.
+        self._session_provided = session is not None
         self._info = (
             info
             if info is None or isinstance(info, ls_schemas.LangSmithInfo)
@@ -1511,35 +1570,53 @@ class Client:
     # __dict__; the stainless client caches each resource internally.
     # ------------------------------------------------------------------
 
+    def _openapi_timeout(self) -> _httpx.Timeout:
+        return _httpx.Timeout(
+            connect=self._timeout[0],
+            read=self._timeout[1],
+            write=self._timeout[1],
+            pool=self._timeout[0],
+        )
+
     def _get_langsmith_api(self) -> LangsmithOpenAPIClient:
         if self._langsmith_api is None:
+            base_url = _get_openapi_base_url(self.api_url)
+            timeout = self._openapi_timeout()
+            http_client = None
+            if self._session_provided:
+                http_client = _AsyncHttpxClientWrapper(
+                    base_url=base_url,
+                    timeout=timeout,
+                    **_httpx_kwargs_from_session(self.session),
+                )
             self._langsmith_api = LangsmithOpenAPIClient(
                 api_key=self._api_key,
                 tenant_id=str(self._workspace_id) if self._workspace_id else None,
-                base_url=_get_openapi_base_url(self.api_url),
-                timeout=_httpx.Timeout(
-                    connect=self._timeout[0],
-                    read=self._timeout[1],
-                    write=self._timeout[1],
-                    pool=self._timeout[0],
-                ),
+                base_url=base_url,
+                timeout=timeout,
                 default_headers=self._headers or None,
+                http_client=http_client,
             )
         return self._langsmith_api
 
     def _get_langsmith_api_sync(self) -> SyncLangsmithOpenAPIClient:
         if self._langsmith_api_sync is None:
+            base_url = _get_openapi_base_url(self.api_url)
+            timeout = self._openapi_timeout()
+            http_client = None
+            if self._session_provided:
+                http_client = _SyncHttpxClientWrapper(
+                    base_url=base_url,
+                    timeout=timeout,
+                    **_httpx_kwargs_from_session(self.session),
+                )
             self._langsmith_api_sync = SyncLangsmithOpenAPIClient(
                 api_key=self._api_key,
                 tenant_id=str(self._workspace_id) if self._workspace_id else None,
-                base_url=_get_openapi_base_url(self.api_url),
-                timeout=_httpx.Timeout(
-                    connect=self._timeout[0],
-                    read=self._timeout[1],
-                    write=self._timeout[1],
-                    pool=self._timeout[0],
-                ),
+                base_url=base_url,
+                timeout=timeout,
                 default_headers=self._headers or None,
+                http_client=http_client,
             )
         return self._langsmith_api_sync
 

--- a/python/tests/unit_tests/test_client.py
+++ b/python/tests/unit_tests/test_client.py
@@ -27,6 +27,7 @@ from unittest import mock
 from unittest.mock import MagicMock, patch
 
 import dataclasses_json
+import httpx
 import pytest
 import requests
 from multipart import MultipartParser, MultipartPart, parse_options_header
@@ -5728,11 +5729,33 @@ def test_httpx_kwargs_from_session_translates_transport_config() -> None:
     kwargs = _httpx_kwargs_from_session(session)
 
     assert kwargs["headers"] == {"X-Custom": "custom-value"}
-    assert kwargs["cookies"] == {"cookie-name": "cookie-value"}
+    assert kwargs["cookies"] is session.cookies
     assert kwargs["verify"] == "/path/to/ca-bundle.pem"
     assert kwargs["cert"] == ("/path/to/client.crt", "/path/to/client.key")
-    assert kwargs["proxy"] == "http://proxy.internal:8080"
     assert kwargs["trust_env"] is False
+    # httpx renamed `proxies` to `proxy` in 0.26; either name is accepted here.
+    proxy_kwarg = (
+        "proxy"
+        if "proxy" in inspect.signature(httpx.Client.__init__).parameters
+        else "proxies"
+    )
+    assert kwargs[proxy_kwarg] == "http://proxy.internal:8080"
+    # Whichever name this httpx accepts, the kwargs must be usable as-is.
+    httpx.Client(**{**kwargs, "verify": False, "cert": None}).close()
+
+
+def test_httpx_kwargs_from_session_preserves_cookie_scope() -> None:
+    """Cookies keep their domain/path scope instead of being flattened."""
+    session = requests.Session()
+    session.cookies.set("shared", "other-service", domain="internal.example", path="/x")
+    session.cookies.set("shared", "langsmith", domain="api.smith.langchain.com")
+
+    cookies = httpx.Cookies(_httpx_kwargs_from_session(session)["cookies"])
+    request = httpx.Request("GET", "https://api.smith.langchain.com/api/v2/runs")
+    cookies.set_cookie_header(request)
+
+    # The cookie scoped to another host must not be sent to the API.
+    assert request.headers["cookie"] == "shared=langsmith"
 
 
 def test_httpx_kwargs_from_session_omits_requests_defaults() -> None:
@@ -5744,6 +5767,7 @@ def test_httpx_kwargs_from_session_omits_requests_defaults() -> None:
     assert "verify" not in kwargs
     assert "cert" not in kwargs
     assert "proxy" not in kwargs
+    assert "proxies" not in kwargs
     assert kwargs["trust_env"] is True
 
 

--- a/python/tests/unit_tests/test_client.py
+++ b/python/tests/unit_tests/test_client.py
@@ -11,6 +11,7 @@ import logging
 import math
 import os
 import pathlib
+import ssl
 import sys
 import threading
 import time
@@ -52,6 +53,7 @@ from langsmith.client import (
     _default_retry_config,
     _dumps_json,
     _get_openapi_base_url,
+    _httpx_kwargs_from_session,
     _is_langchain_hosted,
     _parse_token_or_url,
     _reject_filesystem_attachments,
@@ -5711,6 +5713,91 @@ def test_async_client_uses_normalized_base_url(
 
     client = AsyncClient(api_url=api_url, api_key="test-api-key")
     assert str(client._langsmith_api.base_url).rstrip("/") == expected_base_url
+
+
+def test_httpx_kwargs_from_session_translates_transport_config() -> None:
+    """A caller-supplied session's transport config carries over to httpx."""
+    session = requests.Session()
+    session.headers["X-Custom"] = "custom-value"
+    session.cookies.set("cookie-name", "cookie-value")
+    session.verify = "/path/to/ca-bundle.pem"
+    session.cert = ("/path/to/client.crt", "/path/to/client.key")
+    session.proxies = {"https": "http://proxy.internal:8080"}
+    session.trust_env = False
+
+    kwargs = _httpx_kwargs_from_session(session)
+
+    assert kwargs["headers"] == {"X-Custom": "custom-value"}
+    assert kwargs["cookies"] == {"cookie-name": "cookie-value"}
+    assert kwargs["verify"] == "/path/to/ca-bundle.pem"
+    assert kwargs["cert"] == ("/path/to/client.crt", "/path/to/client.key")
+    assert kwargs["proxy"] == "http://proxy.internal:8080"
+    assert kwargs["trust_env"] is False
+
+
+def test_httpx_kwargs_from_session_omits_requests_defaults() -> None:
+    """`requests`' own default headers must not shadow the httpx/SDK ones."""
+    kwargs = _httpx_kwargs_from_session(requests.Session())
+
+    assert "headers" not in kwargs
+    assert "cookies" not in kwargs
+    assert "verify" not in kwargs
+    assert "cert" not in kwargs
+    assert "proxy" not in kwargs
+    assert kwargs["trust_env"] is True
+
+
+def test_openapi_clients_apply_provided_session_config() -> None:
+    """Both generated clients honor a caller-supplied session's config."""
+    from langsmith._openapi_client._models import FinalRequestOptions
+
+    session = requests.Session()
+    session.headers["X-Custom"] = "custom-value"
+    session.headers["x-api-key"] = "hijacked"
+    session.cookies.set("cookie-name", "cookie-value")
+    session.verify = False
+
+    client = Client(
+        api_url="http://localhost:1984",
+        api_key="test-api-key",
+        auto_batch_tracing=False,
+        session=session,
+    )
+
+    for openapi_client in (
+        client._get_langsmith_api(),
+        client._get_langsmith_api_sync(),
+    ):
+        http_client = openapi_client._client
+        assert http_client.headers["X-Custom"] == "custom-value"
+        assert str(http_client.base_url).rstrip("/") == "http://localhost:1984"
+        # verify=False disables certificate verification on the transport.
+        assert http_client._transport._pool._ssl_context.verify_mode == ssl.CERT_NONE
+
+        request = openapi_client._build_request(
+            FinalRequestOptions(method="get", url="/api/v2/runs")
+        )
+        assert request.headers["cookie"] == "cookie-name=cookie-value"
+        # The SDK's own auth headers still win over the session's.
+        assert "hijacked" not in request.headers["x-api-key"]
+        assert "test-api-key" in request.headers["x-api-key"]
+
+
+def test_openapi_clients_keep_defaults_without_provided_session() -> None:
+    """Without an explicit session there is nothing to port over."""
+    client = Client(
+        api_url="http://localhost:1984",
+        api_key="test-api-key",
+        auto_batch_tracing=False,
+    )
+
+    assert "python-requests" not in client._get_langsmith_api()._client.headers.get(
+        "user-agent", ""
+    )
+    assert (
+        "python-requests"
+        not in client._get_langsmith_api_sync()._client.headers.get("user-agent", "")
+    )
 
 
 def test_process_buffered_run_ops_core_functionality():


### PR DESCRIPTION
## Problem

`Client(session=...)` only affected the handwritten `requests` code paths. The v2 endpoints are served by the generated OpenAPI client, which is `httpx`-based (`langsmith/_openapi_client`), so it silently ignored the session entirely. A caller passing a session to configure a custom CA bundle, a corporate proxy, or extra headers got that configuration applied to only half of their traffic — and had no way to reach the other half.

## Approach

A `requests.Session` cannot be shared with an `httpx` client, so instead of bridging the object, this translates the settings that have a direct `httpx` equivalent onto the generated client's `http_client`:

| Ported | Not ported |
|---|---|
| headers, cookies, `verify`, `cert`, proxy, `trust_env` | custom mounted `HTTPAdapter`s, `session.auth`, `session.hooks` |

The unsupported cases are now called out in the `session` docstring rather than failing silently.

Details worth reviewing:

- **Only applied when a session was explicitly supplied.** The default session the `Client` creates for itself carries no user configuration, so there is nothing to port and the generated client keeps its stock setup.
- **`requests`' own default headers are filtered out** (its `User-Agent: python-requests/...`, `Accept-Encoding`, …) so they cannot shadow the headers httpx and the SDK set.
- **The SDK's auth headers still win.** `x-api-key`/`X-Tenant-Id` are applied per-request by the generated client and take precedence over anything on the session, so a session header cannot hijack auth. There's a test asserting this.
- **Pool bounds and retries are deliberately left at the generated client's defaults.** Our `HTTPAdapter` is sized for the batch-tracing thread pool (`pool_maxsize = _AUTO_SCALE_UP_NTHREADS_LIMIT + 1` = 33); deriving the openapi client's limits from it would *lower* them below the generated default of 100. Status-code retries stay with the generated client's own request-layer `max_retries`, since httpx has no urllib3-style `Retry`.
- **Proxies map to httpx's single `proxy=`**, preferring the `https` entry then `http`. Per-scheme proxying would mean hand-building `mounts` transports and re-threading `verify`/`cert`/limits through each of them; the API base URL is https in practice.
- Uses the generated SDK's own `SyncHttpxClientWrapper`/`AsyncHttpxClientWrapper` rather than a bare `httpx.Client`, so `follow_redirects`, the connection limits, and the `__del__`-close behavior match what the client would have built for itself.

## Testing

Four new tests in `tests/unit_tests/test_client.py`: the translation itself, that a bare session ports nothing, that both generated clients pick up a supplied session's headers/cookies/`verify=False`, and that a session header cannot override `x-api-key`.

`make format`, `make lint` and `make tests` were run. `make tests` reports 8 failures (`test_utils.py` project-name/api-url tests and `test_validate_api_key_if_hosted_with_tracing`) that reproduce identically on stock `main` in my environment and are unrelated to this change.