### PR TITLE
chore: Use a common function for backend detection

### DIFF
--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -86,6 +86,7 @@ import { Traces } from "./_openapi_client/resources/traces.js";
 import { Public } from "./_openapi_client/resources/public/public.js";
 import { assertUuid } from "./utils/_uuid.js";
 import { warnOnce } from "./utils/warn.js";
+import { getQueryBackend, QueryBackend } from "./utils/v2_migration.js";
 import { parseHubIdentifier } from "./utils/prompts.js";
 import {
   raiseForStatus,
@@ -2225,7 +2226,7 @@ export class Client implements LangSmithTracingClientInterface {
     const docs =
       "https://docs.langchain.com/langsmith/smithdb-sdk-migration#feedback-create";
     const serverInfo = await this._ensureServerInfo();
-    if (serverInfo.instance_flags?.ch_query_enabled === false) {
+    if (getQueryBackend(serverInfo.instance_flags) === QueryBackend.SMITHDB_ONLY) {
       throw new Error(
         `sessionId must be provided when creating feedback for a run: this ` +
           `deployment cannot locate the run without it. See ${docs}`,

--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -2226,7 +2226,9 @@ export class Client implements LangSmithTracingClientInterface {
     const docs =
       "https://docs.langchain.com/langsmith/smithdb-sdk-migration#feedback-create";
     const serverInfo = await this._ensureServerInfo();
-    if (getQueryBackend(serverInfo.instance_flags) === QueryBackend.SMITHDB_ONLY) {
+    if (
+      getQueryBackend(serverInfo.instance_flags) === QueryBackend.SMITHDB_ONLY
+    ) {
       throw new Error(
         `sessionId must be provided when creating feedback for a run: this ` +
           `deployment cannot locate the run without it. See ${docs}`,

--- a/js/src/tests/client.test.ts
+++ b/js/src/tests/client.test.ts
@@ -79,15 +79,16 @@ describe("Client", () => {
       );
     });
 
-    const infoClient = (chQueryEnabled: boolean) => {
+    const infoClient = (smithdbOnly: boolean) => {
+      const instance_flags = smithdbOnly
+        ? { ch_query_enabled: false, sdb_query_enabled: true }
+        : { ch_query_enabled: true };
       const mockFetch = jest.fn<typeof fetch>().mockImplementation(
         async () =>
-          new Response(
-            JSON.stringify({
-              instance_flags: { ch_query_enabled: chQueryEnabled },
-            }),
-            { status: 200, headers: { "content-type": "application/json" } },
-          ),
+          new Response(JSON.stringify({ instance_flags }), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          }),
       );
       const client = new Client({
         apiUrl: "http://localhost:1984",
@@ -100,7 +101,7 @@ describe("Client", () => {
     };
 
     it("throws without a sessionId on a SmithDB-only deployment", async () => {
-      const { client, paths } = infoClient(false);
+      const { client, paths } = infoClient(true);
 
       await expect(
         client.createFeedback("550e8400-e29b-41d4-a716-446655440000", "Foo", {
@@ -129,7 +130,7 @@ describe("Client", () => {
     });
 
     it("accepts the params-object overload, which requires sessionId", async () => {
-      const { client, paths } = infoClient(false);
+      const { client, paths } = infoClient(true);
 
       await client.createFeedback({
         runId: "550e8400-e29b-41d4-a716-446655440000",
@@ -151,7 +152,7 @@ describe("Client", () => {
     });
 
     it("warns without a sessionId on other deployments", async () => {
-      const { client, paths } = infoClient(true);
+      const { client, paths } = infoClient(false);
       // warnOnce dedupes per process, so this must be the only test that warns.
       const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
 

--- a/js/src/tests/v2_migration.test.ts
+++ b/js/src/tests/v2_migration.test.ts
@@ -33,10 +33,7 @@ describe("v2 migration utils", () => {
     [{}, QueryBackend.CLICKHOUSE_ONLY],
     [{ ch_query_enabled: true }, QueryBackend.CLICKHOUSE_ONLY],
     [{ sdb_query_enabled: true }, QueryBackend.DUAL],
-    [
-      { ch_query_enabled: true, sdb_query_enabled: true },
-      QueryBackend.DUAL,
-    ],
+    [{ ch_query_enabled: true, sdb_query_enabled: true }, QueryBackend.DUAL],
     [
       { ch_query_enabled: false, sdb_query_enabled: true },
       QueryBackend.SMITHDB_ONLY,

--- a/js/src/tests/v2_migration.test.ts
+++ b/js/src/tests/v2_migration.test.ts
@@ -1,6 +1,10 @@
 import type { Run as V2Run } from "../_openapi_client/resources/runs/runs.js";
 import type { TracerSession } from "../schemas.js";
-import { v2RunToRun } from "../utils/v2_migration.js";
+import {
+  getQueryBackend,
+  QueryBackend,
+  v2RunToRun,
+} from "../utils/v2_migration.js";
 
 const project: TracerSession = {
   id: "00000000-0000-0000-0000-000000000001",
@@ -24,6 +28,27 @@ const v2Run: V2Run = {
 };
 
 describe("v2 migration utils", () => {
+  test.each([
+    [undefined, QueryBackend.CLICKHOUSE_ONLY],
+    [{}, QueryBackend.CLICKHOUSE_ONLY],
+    [{ ch_query_enabled: true }, QueryBackend.CLICKHOUSE_ONLY],
+    [{ sdb_query_enabled: true }, QueryBackend.DUAL],
+    [
+      { ch_query_enabled: true, sdb_query_enabled: true },
+      QueryBackend.DUAL,
+    ],
+    [
+      { ch_query_enabled: false, sdb_query_enabled: true },
+      QueryBackend.SMITHDB_ONLY,
+    ],
+    [
+      { ch_query_enabled: false, sdb_query_enabled: false },
+      QueryBackend.CLICKHOUSE_ONLY,
+    ],
+  ])("getQueryBackend(%j) -> %s", (flags, expected) => {
+    expect(getQueryBackend(flags)).toBe(expected);
+  });
+
   test("maps generated v2 runs to legacy runs", () => {
     expect(v2RunToRun(v2Run)).toEqual(
       expect.objectContaining({

--- a/js/src/utils/v2_migration.ts
+++ b/js/src/utils/v2_migration.ts
@@ -5,6 +5,26 @@ import type {
 import type { Client } from "../client.js";
 import type { Run, TracerSession } from "../schemas.js";
 
+export const QueryBackend = {
+  CLICKHOUSE_ONLY: "clickhouse_only",
+  SMITHDB_ONLY: "smithdb_only",
+  DUAL: "dual",
+} as const;
+
+export type QueryBackend = (typeof QueryBackend)[keyof typeof QueryBackend];
+
+/** Which backend(s) `/info`'s `instance_flags` indicate for run/trace queries. */
+export function getQueryBackend(
+  instanceFlags?: Record<string, unknown> | null,
+): QueryBackend {
+  const flags = instanceFlags ?? {};
+  const chEnabled = Boolean(flags.ch_query_enabled ?? true);
+  const sdbEnabled = Boolean(flags.sdb_query_enabled ?? false);
+  if (!chEnabled && sdbEnabled) return QueryBackend.SMITHDB_ONLY;
+  if (chEnabled && sdbEnabled) return QueryBackend.DUAL;
+  return QueryBackend.CLICKHOUSE_ONLY;
+}
+
 // Omitting selects from `/v2/runs/query` returns only the run ID.
 const V2_RUN_SELECTS: RunSelectField[] = [
   "ID",

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -72,6 +72,7 @@ from langsmith import schemas as ls_schemas
 from langsmith import utils as ls_utils
 from langsmith._internal import _aiter as aitertools
 from langsmith._internal import _orjson, _profiles, _v2_migration_utils
+from langsmith._internal._v2_migration_utils import QueryBackend, get_query_backend
 from langsmith._internal._backend_version import _check_backend_version
 from langsmith._internal._background_thread import (
     TracingQueueItem,
@@ -754,10 +755,7 @@ def _check_feedback_session_id(info: ls_schemas.LangSmithInfo) -> None:
     Call only when run-level feedback has no ``session_id``.
     """
     docs = "https://docs.langchain.com/langsmith/smithdb-sdk-migration#feedback-create"
-    if (
-        _v2_migration_utils.get_query_backend(info.instance_flags)
-        == _v2_migration_utils.QueryBackend.SMITHDB_ONLY
-    ):
+    if get_query_backend(info.instance_flags) == QueryBackend.SMITHDB_ONLY:
         raise ValueError(
             "session_id must be provided when creating feedback for a run:"
             f" this deployment cannot locate the run without it. See {docs}"

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -72,7 +72,6 @@ from langsmith import schemas as ls_schemas
 from langsmith import utils as ls_utils
 from langsmith._internal import _aiter as aitertools
 from langsmith._internal import _orjson, _profiles, _v2_migration_utils
-from langsmith._internal._v2_migration_utils import QueryBackend, get_query_backend
 from langsmith._internal._backend_version import _check_backend_version
 from langsmith._internal._background_thread import (
     TracingQueueItem,
@@ -113,6 +112,7 @@ from langsmith._internal._operations import (
 )
 from langsmith._internal._serde import dumps_json as _dumps_json
 from langsmith._internal._uuid import uuid7
+from langsmith._internal._v2_migration_utils import QueryBackend, get_query_backend
 from langsmith._openapi_client import AsyncLangsmith as LangsmithOpenAPIClient
 from langsmith._openapi_client import Langsmith as SyncLangsmithOpenAPIClient
 from langsmith._openapi_client._base_client import (

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -754,7 +754,10 @@ def _check_feedback_session_id(info: ls_schemas.LangSmithInfo) -> None:
     Call only when run-level feedback has no ``session_id``.
     """
     docs = "https://docs.langchain.com/langsmith/smithdb-sdk-migration#feedback-create"
-    if (info.instance_flags or {}).get("ch_query_enabled") is False:
+    if (
+        _v2_migration_utils.get_query_backend(info.instance_flags)
+        == _v2_migration_utils.QueryBackend.SMITHDB_ONLY
+    ):
         raise ValueError(
             "session_id must be provided when creating feedback for a run:"
             f" this deployment cannot locate the run without it. See {docs}"

--- a/python/tests/unit_tests/test_async_client.py
+++ b/python/tests/unit_tests/test_async_client.py
@@ -415,7 +415,9 @@ async def test_async_create_feedback_requires_session_id_on_smithdb(
     mock_httpx_client = AsyncMock()
     mock_client_cls.return_value = mock_httpx_client
     client = AsyncClient(api_url="http://localhost:1984", api_key="test-api-key")
-    client._info = ls_schemas.LangSmithInfo(instance_flags={"ch_query_enabled": False})
+    client._info = ls_schemas.LangSmithInfo(
+        instance_flags={"ch_query_enabled": False, "sdb_query_enabled": True}
+    )
 
     with pytest.raises(ValueError, match="session_id must be provided"):
         await client.create_feedback(uuid4(), key="quality")

--- a/python/tests/unit_tests/test_client.py
+++ b/python/tests/unit_tests/test_client.py
@@ -2023,9 +2023,7 @@ def _feedback_client(session: mock.Mock, **flags: bool) -> Client:
 def test_create_feedback_requires_session_id_when_ch_query_disabled() -> None:
     """SmithDB-only backends cannot locate the run without session_id."""
     session = mock.Mock()
-    client = _feedback_client(
-        session, ch_query_enabled=False, sdb_query_enabled=True
-    )
+    client = _feedback_client(session, ch_query_enabled=False, sdb_query_enabled=True)
 
     with pytest.raises(ValueError, match="session_id must be provided"):
         client.create_feedback(uuid.uuid4(), key="Foo")

--- a/python/tests/unit_tests/test_client.py
+++ b/python/tests/unit_tests/test_client.py
@@ -2023,7 +2023,9 @@ def _feedback_client(session: mock.Mock, **flags: bool) -> Client:
 def test_create_feedback_requires_session_id_when_ch_query_disabled() -> None:
     """SmithDB-only backends cannot locate the run without session_id."""
     session = mock.Mock()
-    client = _feedback_client(session, ch_query_enabled=False)
+    client = _feedback_client(
+        session, ch_query_enabled=False, sdb_query_enabled=True
+    )
 
     with pytest.raises(ValueError, match="session_id must be provided"):
         client.create_feedback(uuid.uuid4(), key="Foo")


### PR DESCRIPTION
## Summary
Follow-up to #3274 addressing [review feedback](https://github.com/langchain-ai/langsmith-sdk/pull/3274#discussion_r3675467254): route the `create_feedback` / `createFeedback` session-id gate through the shared backend-detection helpers instead of ad-hoc `ch_query_enabled` parsing.
Python already had `get_query_backend()` in `_v2_migration_utils.py` (#3262); this PR wires it into `_check_feedback_session_id` and adds the matching `getQueryBackend` / `QueryBackend` to `js/src/utils/v2_migration.ts`.

## Changes
- **Python.** `_check_feedback_session_id` now raises when `get_query_backend(info.instance_flags) == QueryBackend.SMITHDB_ONLY`, matching `read_run`, `_resolve_run`, and the other SmithDB migration paths.
- **JavaScript.** Add `getQueryBackend` to `js/src/utils/v2_migration.ts` (same flag semantics as Python) and use it in `_checkFeedbackSessionId`.
- **Tests.** SmithDB-only fixtures now set `{ch_query_enabled: false, sdb_query_enabled: true}`. Flag-parsing coverage lives in `test_v2_migration_utils.py` / `v2_migration.test.ts`; feedback tests only assert raise/warn behavior.

## Testing

- [x] Python: `test_create_feedback_requires_session_id_when_ch_query_disabled`, `test_create_feedback_warns_without_session_id`, `test_async_create_feedback_requires_session_id_on_smithdb`
- [x] JS: `createFeedback` raise/warn matrix in `client.test.ts`
- [x] JS: `getQueryBackend` parametrized cases in `v2_migration.test.ts`