### PR TITLE
fix(js): allow-list fields accepted from baggage replica updates

### DIFF
--- a/js/src/run_trees.ts
+++ b/js/src/run_trees.ts
@@ -184,6 +184,69 @@ const HEADER_SAFE_REPLICA_FIELDS = new Set([
   "reroot",
 ]);
 
+// Untrusted header-supplied replica `updates` is merged into the run, so restrict it
+// to a fail-closed allow-list. `reroot` (re-parenting control) is always kept;
+// `metadata`/`tags` are the default annotation fields, and everything else is dropped.
+const HEADER_REQUIRED_UPDATE_FIELDS = ["reroot"];
+const HEADER_SAFE_UPDATE_FIELDS_DEFAULT = ["reroot", "metadata", "tags"];
+
+/**
+ * Allow-list of replica `updates` keys accepted from a `baggage` header.
+ *
+ * Overridable via `LANGSMITH_BAGGAGE_ALLOWED_UPDATE_FIELDS` (comma-separated);
+ * replaces the default `{reroot, metadata, tags}` but always keeps `reroot`.
+ */
+function getHeaderSafeUpdateFields(): Set<string> {
+  const raw = getLangSmithEnvironmentVariable("BAGGAGE_ALLOWED_UPDATE_FIELDS");
+  if (raw == null) {
+    return new Set(HEADER_SAFE_UPDATE_FIELDS_DEFAULT);
+  }
+  const configured = raw
+    .split(",")
+    .map((field) => field.trim())
+    .filter((field) => field.length > 0);
+  return new Set([...HEADER_REQUIRED_UPDATE_FIELDS, ...configured]);
+}
+
+/**
+ * Filter untrusted header-supplied `updates` to the allow-list (fail closed).
+ *
+ * Non-object input passes through unchanged; dropped fields are warned about,
+ * never thrown.
+ */
+function sanitizeHeaderUpdates<T>(updates: T): T {
+  if (
+    typeof updates !== "object" ||
+    updates === null ||
+    Array.isArray(updates)
+  ) {
+    return updates;
+  }
+  const allowed = getHeaderSafeUpdateFields();
+  const sanitized: Record<string, unknown> = {};
+  const dropped: string[] = [];
+  for (const [key, value] of Object.entries(updates)) {
+    if (allowed.has(key)) {
+      sanitized[key] = value;
+    } else {
+      dropped.push(key);
+    }
+  }
+  if (dropped.length > 0) {
+    console.warn(
+      `Ignored non-allow-listed field(s) ${JSON.stringify(dropped.sort())} in ` +
+        "a distributed-tracing `baggage` replica `updates` payload; they are " +
+        "dropped for security reasons. If these come from a trusted upstream " +
+        "and are legitimate, add them to the allow-list via the " +
+        "LANGSMITH_BAGGAGE_ALLOWED_UPDATE_FIELDS environment variable " +
+        `(comma-separated). Currently allowed: ${JSON.stringify(
+          [...allowed].sort(),
+        )}.`,
+    );
+  }
+  return sanitized as T;
+}
+
 function filterReplicaForHeaders(replica: WriteReplica): WriteReplica {
   const filtered: WriteReplica = {};
   for (const key of Object.keys(replica) as (keyof WriteReplica)[]) {
@@ -193,6 +256,9 @@ function filterReplicaForHeaders(replica: WriteReplica): WriteReplica {
     if (HEADER_SAFE_REPLICA_FIELDS.has(key)) {
       (filtered as Record<string, unknown>)[key] = replica[key];
     }
+  }
+  if ("updates" in filtered) {
+    filtered.updates = sanitizeHeaderUpdates(filtered.updates);
   }
   return filtered;
 }
@@ -236,7 +302,10 @@ class Baggage {
         const parsed = JSON.parse(value) as Replica[];
         replicas = parsed.map((replica) => {
           if (Array.isArray(replica)) {
-            return replica;
+            return [
+              replica[0],
+              sanitizeHeaderUpdates(replica[1]),
+            ] as ProjectReplica;
           }
           return filterReplicaForHeaders(replica);
         });

--- a/js/src/tests/run_trees.test.ts
+++ b/js/src/tests/run_trees.test.ts
@@ -650,3 +650,157 @@ test("fromHeaders drops a non-boolean replica primary value", () => {
   const remapped = (parsed as any)._remapForProject(replica);
   expect(remapped.id).not.toBe(parsed!.id);
 });
+
+function replicasFromBaggage(replicas: unknown) {
+  const parsed = RunTree.fromHeaders({
+    "langsmith-trace":
+      "20240101T000000000000Z00000000-0000-0000-0000-000000000001",
+    baggage: `langsmith-replicas=${encodeURIComponent(
+      JSON.stringify(replicas),
+    )}`,
+  });
+  expect(parsed).toBeDefined();
+  expect(parsed!.replicas).toBeDefined();
+  return parsed!.replicas!;
+}
+
+test("fromHeaders allow-lists replica update fields", () => {
+  const replicas = replicasFromBaggage([
+    {
+      projectName: "legit-project",
+      updates: {
+        reroot: true,
+        metadata: { k: "v" },
+        tags: ["a"],
+        session_name: "attacker-project",
+        outputs: { forged: "attacker-controlled-output" },
+        environment: "prod",
+      },
+    },
+  ]);
+
+  expect(replicas[0].projectName).toBe("legit-project");
+  expect(replicas[0].updates).toEqual({
+    reroot: true,
+    metadata: { k: "v" },
+    tags: ["a"],
+  });
+});
+
+test("fromHeaders allow-lists replica update fields in the legacy array form", () => {
+  const replicas = replicasFromBaggage([
+    [
+      "legit-project",
+      {
+        reroot: true,
+        metadata: { k: "v" },
+        trace_id: "22222222-2222-2222-2222-222222222222",
+        outputs: { forged: "attacker-controlled-output" },
+        environment: "prod",
+      },
+    ],
+  ]);
+
+  expect(replicas[0].projectName).toBe("legit-project");
+  expect(replicas[0].updates).toEqual({ reroot: true, metadata: { k: "v" } });
+});
+
+test("fromHeaders update allow-list is configurable and always keeps reroot", () => {
+  process.env.LANGSMITH_BAGGAGE_ALLOWED_UPDATE_FIELDS = "environment";
+  try {
+    const replicas = replicasFromBaggage([
+      {
+        projectName: "legit-project",
+        updates: { reroot: true, environment: "prod", metadata: { k: "v" } },
+      },
+    ]);
+
+    // `environment` is now allowed, `reroot` is always kept, and the default
+    // `metadata` is no longer allowed.
+    expect(replicas[0].updates).toEqual({ reroot: true, environment: "prod" });
+  } finally {
+    delete process.env.LANGSMITH_BAGGAGE_ALLOWED_UPDATE_FIELDS;
+  }
+});
+
+test("fromHeaders warns about dropped replica update fields", () => {
+  const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+  try {
+    replicasFromBaggage([
+      {
+        projectName: "legit-project",
+        updates: { reroot: true, outputs: { forged: "value" } },
+      },
+    ]);
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const message = String(warnSpy.mock.calls[0][0]);
+    expect(message).toContain("outputs");
+    expect(message).toContain("LANGSMITH_BAGGAGE_ALLOWED_UPDATE_FIELDS");
+
+    warnSpy.mockClear();
+    replicasFromBaggage([
+      { projectName: "legit-project", updates: { reroot: true, tags: ["a"] } },
+    ]);
+    expect(warnSpy).not.toHaveBeenCalled();
+  } finally {
+    warnSpy.mockRestore();
+  }
+});
+
+test("fromHeaders passes through non-object replica updates unchanged", () => {
+  expect(
+    replicasFromBaggage([{ projectName: "legit-project", updates: "nope" }])[0]
+      .updates,
+  ).toBe("nope");
+  expect(
+    replicasFromBaggage([{ projectName: "legit-project" }])[0].updates,
+  ).toBeUndefined();
+  expect(replicasFromBaggage([["legit-project", null]])[0].updates).toBeNull();
+});
+
+test("baggage replica updates cannot inject fields into the run update payload", async () => {
+  const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+  try {
+    const { client, callSpy } = mockClient();
+    const updates = {
+      session_name: "attacker-chosen-project",
+      trace_id: "22222222-2222-2222-2222-222222222222",
+      parent_run_id: "33333333-3333-3333-3333-333333333333",
+      outputs: { forged: "attacker-controlled-output" },
+      reference_example_id: "44444444-4444-4444-4444-444444444444",
+      metadata: { k: "v" },
+    };
+    const runTree = RunTree.fromHeaders(
+      {
+        "langsmith-trace":
+          "20240101T000000000000Z00000000-0000-0000-0000-000000000001",
+        baggage: `langsmith-replicas=${encodeURIComponent(
+          JSON.stringify([{ projectName: "victim-project", updates }]),
+        )}`,
+      },
+      { client },
+    );
+    expect(runTree).toBeDefined();
+
+    await runTree!.patchRun();
+
+    const patchCalls = callSpy.mock.calls.filter(
+      ([, init]: [unknown, RequestInit | undefined]) =>
+        init?.method === "PATCH",
+    );
+    expect(patchCalls).toHaveLength(1);
+    const rawBody = patchCalls[0][1].body;
+    const body = JSON.parse(
+      typeof rawBody === "string" ? rawBody : new TextDecoder().decode(rawBody),
+    );
+
+    expect(body.session_name).toBe("victim-project");
+    expect(body.outputs).toBeUndefined();
+    expect(body.reference_example_id).toBeUndefined();
+    expect(body.trace_id).not.toBe(updates.trace_id);
+    expect(body.parent_run_id).not.toBe(updates.parent_run_id);
+  } finally {
+    warnSpy.mockRestore();
+  }
+});


### PR DESCRIPTION
## Summary

- Restrict header-supplied `baggage` replica `updates` to a fail-closed allow-list. Previously any field in the `updates` payload was merged straight into the run.
- Default allow-list: `{reroot, metadata, tags}`. `reroot` is required for distributed re-parenting; `metadata`/`tags` are benign annotation fields.
- Applies to both the object form and the legacy `[projectName, updates]` array form, which skipped `filterReplicaForHeaders` entirely.
- Configurable via `LANGSMITH_BAGGAGE_ALLOWED_UPDATE_FIELDS` (comma-separated); replaces the default but `reroot` is always kept.
- Dropped fields emit an actionable warning naming the field and the env var - never thrown, so unexpected fields don't break tracing.

Ports the Python behavior in #3067 to JS.

## Potential breaking change

Callers relying on arbitrary fields in a `baggage` replica `updates` payload will have those fields silently dropped. They can restore prior behavior by setting `LANGSMITH_BAGGAGE_ALLOWED_UPDATE_FIELDS` to a comma-separated list of the fields they need.