### PR TITLE
chore: deprecate the run-sharing SDK methods

### DIFF
--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -3833,10 +3833,17 @@ export class Client implements LangSmithTracingClientInterface {
     return result;
   }
 
+  /** @deprecated Use `client.runs.share.create()` instead. See https://docs.langchain.com/langsmith/smithdb-sdk-migration#share-and-read-public-runs for the migration guide. Will be removed after Jan 31, 2027. */
   public async shareRun(
     runId: string,
     { shareId }: { shareId?: string } = {},
   ): Promise<string> {
+    warnOnce(
+      "shareRun() is deprecated and will be removed after Jan 31, 2027. " +
+        "Use client.runs.share.create() instead. " +
+        "See https://docs.langchain.com/langsmith/smithdb-sdk-migration#share-and-read-public-runs for the migration guide.",
+      { type: "DeprecationWarning", code: "LANGSMITH_DEPRECATED_SHARE_RUN" },
+    );
     const data = {
       run_id: runId,
       share_token: shareId || uuid.v4(),
@@ -3861,7 +3868,14 @@ export class Client implements LangSmithTracingClientInterface {
     return `${this.getHostUrl()}/public/${result["share_token"]}/r`;
   }
 
+  /** @deprecated Use `client.runs.share.delete()` instead. See https://docs.langchain.com/langsmith/smithdb-sdk-migration#share-and-read-public-runs for the migration guide. Will be removed after Jan 31, 2027. */
   public async unshareRun(runId: string): Promise<void> {
+    warnOnce(
+      "unshareRun() is deprecated and will be removed after Jan 31, 2027. " +
+        "Use client.runs.share.delete() instead. " +
+        "See https://docs.langchain.com/langsmith/smithdb-sdk-migration#share-and-read-public-runs for the migration guide.",
+      { type: "DeprecationWarning", code: "LANGSMITH_DEPRECATED_UNSHARE_RUN" },
+    );
     assertUuid(runId);
     await this.caller.call(async () => {
       const res = await this._fetch(`${this.apiUrl}/runs/${runId}/share`, {
@@ -3875,7 +3889,17 @@ export class Client implements LangSmithTracingClientInterface {
     });
   }
 
+  /** @deprecated Use `client.runs.retrieve({ selects: ["SHARE_URL"] })` instead. See https://docs.langchain.com/langsmith/smithdb-sdk-migration#share-and-read-public-runs for the migration guide. Will be removed after Jan 31, 2027. */
   public async readRunSharedLink(runId: string): Promise<string | undefined> {
+    warnOnce(
+      "readRunSharedLink() is deprecated and will be removed after Jan 31, 2027. " +
+        'Use client.runs.retrieve({ selects: ["SHARE_URL"] }) instead. ' +
+        "See https://docs.langchain.com/langsmith/smithdb-sdk-migration#share-and-read-public-runs for the migration guide.",
+      {
+        type: "DeprecationWarning",
+        code: "LANGSMITH_DEPRECATED_READ_RUN_SHARED_LINK",
+      },
+    );
     assertUuid(runId);
     const response = await this.caller.call(async () => {
       const res = await this._fetch(`${this.apiUrl}/runs/${runId}/share`, {
@@ -3894,6 +3918,7 @@ export class Client implements LangSmithTracingClientInterface {
     return `${this.getHostUrl()}/public/${result["share_token"]}/r`;
   }
 
+  /** @deprecated Use `client.public.runs.query()` instead. See https://docs.langchain.com/langsmith/smithdb-sdk-migration#share-and-read-public-runs for the migration guide. Will be removed after Jan 31, 2027. */
   public async listSharedRuns(
     shareToken: string,
     {
@@ -3902,6 +3927,15 @@ export class Client implements LangSmithTracingClientInterface {
       runIds?: string[];
     } = {},
   ): Promise<Run[]> {
+    warnOnce(
+      "listSharedRuns() is deprecated and will be removed after Jan 31, 2027. " +
+        "Use client.public.runs.query() instead. " +
+        "See https://docs.langchain.com/langsmith/smithdb-sdk-migration#share-and-read-public-runs for the migration guide.",
+      {
+        type: "DeprecationWarning",
+        code: "LANGSMITH_DEPRECATED_LIST_SHARED_RUNS",
+      },
+    );
     const queryParams = new URLSearchParams({
       share_token: shareToken,
     });

--- a/js/src/tests/client.test.ts
+++ b/js/src/tests/client.test.ts
@@ -2110,3 +2110,78 @@ describe("nested deprecation warnings", () => {
     expect(warnings).toHaveLength(0);
   });
 });
+
+describe("run sharing deprecations", () => {
+  const RUN_ID = "00000000-0000-4000-8000-000000000021";
+  const SHARE_TOKEN = "00000000-0000-4000-8000-000000000022";
+
+  let client: Client;
+  let warnings: string[];
+  let emitWarningSpy: { mockRestore: () => void };
+
+  beforeEach(() => {
+    _resetWarnedMessages();
+    client = new Client({
+      apiKey: "test-key",
+      apiUrl: "https://api.smith.langchain.com",
+    });
+    warnings = [];
+    emitWarningSpy = jest
+      .spyOn(process, "emitWarning")
+      .mockImplementation((message) => {
+        warnings.push(String(message));
+      });
+  });
+
+  afterEach(() => emitWarningSpy.mockRestore());
+
+  /** Stub only the transport, so each real method body still executes. */
+  const stubFetch = (body: unknown) =>
+    jest.spyOn(client as any, "_fetch").mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      json: async () => body,
+      text: async () => "",
+    } as never);
+
+  it.each([
+    [
+      "shareRun",
+      { share_token: SHARE_TOKEN },
+      () => client.shareRun(RUN_ID),
+      "client.runs.share.create()",
+    ],
+    [
+      "unshareRun",
+      {},
+      () => client.unshareRun(RUN_ID),
+      "client.runs.share.delete()",
+    ],
+    [
+      "readRunSharedLink",
+      { share_token: SHARE_TOKEN },
+      () => client.readRunSharedLink(RUN_ID),
+      'client.runs.retrieve({ selects: ["SHARE_URL"] })',
+    ],
+    [
+      "listSharedRuns",
+      [],
+      () => client.listSharedRuns(SHARE_TOKEN),
+      "client.public.runs.query()",
+    ],
+  ])(
+    "%s() warns once and names its replacement",
+    async (name, body, call, replacement) => {
+      stubFetch(body);
+      await call();
+
+      const emitted = warnings.filter((w) =>
+        w.includes(`${name}() is deprecated`),
+      );
+      expect(emitted).toHaveLength(1);
+      expect(emitted[0]).toContain(`Use ${replacement} instead.`);
+      expect(emitted[0]).toContain("#share-and-read-public-runs");
+    },
+  );
+});

--- a/python/langsmith/async_client.py
+++ b/python/langsmith/async_client.py
@@ -24,6 +24,9 @@ import httpx
 
 import langsmith._openapi_client as _langsmith_api_module
 from langsmith._internal._beta_decorator import deprecated as _deprecated
+from langsmith._internal._beta_decorator import (
+    suppress_deprecation_warning as _suppress_deprecation_warning,
+)
 from langsmith.client import _get_openapi_base_url
 
 if TYPE_CHECKING:
@@ -854,10 +857,22 @@ class AsyncClient:
             if limit is not None and ix >= limit:
                 break
 
+    @_deprecated(
+        "share_run() is deprecated and will be removed after Jan 31, 2027. "
+        "Use client.runs.share.create() instead. "
+        "See https://docs.langchain.com/langsmith/smithdb-sdk-migration"
+        "#share-and-read-public-runs for the migration guide."
+    )
     async def share_run(
         self, run_id: ls_client.ID_TYPE, *, share_id: Optional[ls_client.ID_TYPE] = None
     ) -> str:
         """Get a share link for a run asynchronously.
+
+        .. admonition:: Deprecated
+
+            Use :meth:`langsmith.AsyncClient.runs.share.create` instead.
+            See https://docs.langchain.com/langsmith/smithdb-sdk-migration#share-and-read-public-runs for the migration guide.
+            Will be removed after Jan 31, 2027.
 
         Args:
             run_id (ID_TYPE): The ID of the run to share.
@@ -887,11 +902,24 @@ class AsyncClient:
 
     async def run_is_shared(self, run_id: ls_client.ID_TYPE) -> bool:
         """Get share state for a run asynchronously."""
-        link = await self.read_run_shared_link(ls_client._as_uuid(run_id, "run_id"))
+        with _suppress_deprecation_warning():
+            link = await self.read_run_shared_link(ls_client._as_uuid(run_id, "run_id"))
         return link is not None
 
+    @_deprecated(
+        "read_run_shared_link() is deprecated and will be removed after Jan 31, 2027. "
+        'Use client.runs.retrieve(selects=["SHARE_URL"]) instead. '
+        "See https://docs.langchain.com/langsmith/smithdb-sdk-migration"
+        "#share-and-read-public-runs for the migration guide."
+    )
     async def read_run_shared_link(self, run_id: ls_client.ID_TYPE) -> Optional[str]:
         """Retrieve the shared link for a specific run asynchronously.
+
+        .. admonition:: Deprecated
+
+            Use :meth:`langsmith.AsyncClient.runs.retrieve` with ``selects=["SHARE_URL"]`` instead.
+            See https://docs.langchain.com/langsmith/smithdb-sdk-migration#share-and-read-public-runs for the migration guide.
+            Will be removed after Jan 31, 2027.
 
         Args:
             run_id (ID_TYPE): The ID of the run.

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -4821,8 +4821,20 @@ class Client:
             f"r/{run.id}?poll=true"
         )
 
+    @_deprecated(
+        "share_run() is deprecated and will be removed after Jan 31, 2027. "
+        "Use client.runs.share.create() instead. "
+        "See https://docs.langchain.com/langsmith/smithdb-sdk-migration"
+        "#share-and-read-public-runs for the migration guide."
+    )
     def share_run(self, run_id: ID_TYPE, *, share_id: Optional[ID_TYPE] = None) -> str:
         """Get a share link for a run.
+
+        .. admonition:: Deprecated
+
+            Use :meth:`langsmith.Client.runs.share.create` instead.
+            See https://docs.langchain.com/langsmith/smithdb-sdk-migration#share-and-read-public-runs for the migration guide.
+            Will be removed after Jan 31, 2027.
 
         Args:
             run_id (Union[UUID, str]): The ID of the run to share.
@@ -4847,8 +4859,20 @@ class Client:
         share_token = response.json()["share_token"]
         return f"{self._host_url}/public/{share_token}/r"
 
+    @_deprecated(
+        "unshare_run() is deprecated and will be removed after Jan 31, 2027. "
+        "Use client.runs.share.delete() instead. "
+        "See https://docs.langchain.com/langsmith/smithdb-sdk-migration"
+        "#share-and-read-public-runs for the migration guide."
+    )
     def unshare_run(self, run_id: ID_TYPE) -> None:
         """Delete share link for a run.
+
+        .. admonition:: Deprecated
+
+            Use :meth:`langsmith.Client.runs.share.delete` instead.
+            See https://docs.langchain.com/langsmith/smithdb-sdk-migration#share-and-read-public-runs for the migration guide.
+            Will be removed after Jan 31, 2027.
 
         Args:
             run_id (Union[UUID, str]): The ID of the run to unshare.
@@ -4863,8 +4887,20 @@ class Client:
         )
         ls_utils.raise_for_status_with_text(response)
 
+    @_deprecated(
+        "read_run_shared_link() is deprecated and will be removed after Jan 31, 2027. "
+        'Use client.runs.retrieve(selects=["SHARE_URL"]) instead. '
+        "See https://docs.langchain.com/langsmith/smithdb-sdk-migration"
+        "#share-and-read-public-runs for the migration guide."
+    )
     def read_run_shared_link(self, run_id: ID_TYPE) -> Optional[str]:
         """Retrieve the shared link for a specific run.
+
+        .. admonition:: Deprecated
+
+            Use :meth:`langsmith.Client.runs.retrieve` with ``selects=["SHARE_URL"]`` instead.
+            See https://docs.langchain.com/langsmith/smithdb-sdk-migration#share-and-read-public-runs for the migration guide.
+            Will be removed after Jan 31, 2027.
 
         Args:
             run_id (Union[UUID, str]): The ID of the run.
@@ -4893,13 +4929,26 @@ class Client:
         Returns:
             bool: True if the run is shared, False otherwise.
         """
-        link = self.read_run_shared_link(_as_uuid(run_id, "run_id"))
+        with _suppress_deprecation_warning():
+            link = self.read_run_shared_link(_as_uuid(run_id, "run_id"))
         return link is not None
 
+    @_deprecated(
+        "read_shared_run() is deprecated and will be removed after Jan 31, 2027. "
+        "Use client.public.runs.retrieve() instead. "
+        "See https://docs.langchain.com/langsmith/smithdb-sdk-migration"
+        "#share-and-read-public-runs for the migration guide."
+    )
     def read_shared_run(
         self, share_token: Union[ID_TYPE, str], run_id: Optional[ID_TYPE] = None
     ) -> ls_schemas.Run:
         """Get shared runs.
+
+        .. admonition:: Deprecated
+
+            Use :meth:`langsmith.Client.public.runs.retrieve` instead.
+            See https://docs.langchain.com/langsmith/smithdb-sdk-migration#share-and-read-public-runs for the migration guide.
+            Will be removed after Jan 31, 2027.
 
         Args:
             share_token (Union[UUID, str]): The share token or URL of the shared run.
@@ -4921,10 +4970,22 @@ class Client:
         ls_utils.raise_for_status_with_text(response)
         return ls_schemas.Run(**response.json(), _host_url=self._host_url)
 
+    @_deprecated(
+        "list_shared_runs() is deprecated and will be removed after Jan 31, 2027. "
+        "Use client.public.runs.query() instead. "
+        "See https://docs.langchain.com/langsmith/smithdb-sdk-migration"
+        "#share-and-read-public-runs for the migration guide."
+    )
     def list_shared_runs(
         self, share_token: Union[ID_TYPE, str], run_ids: Optional[list[str]] = None
     ) -> Iterator[ls_schemas.Run]:
         """Get shared runs.
+
+        .. admonition:: Deprecated
+
+            Use :meth:`langsmith.Client.public.runs.query` instead.
+            See https://docs.langchain.com/langsmith/smithdb-sdk-migration#share-and-read-public-runs for the migration guide.
+            Will be removed after Jan 31, 2027.
 
         Args:
             share_token (Union[UUID, str]): The share token or URL of the shared run.

--- a/python/tests/unit_tests/test_client.py
+++ b/python/tests/unit_tests/test_client.py
@@ -7415,6 +7415,129 @@ def test_suppress_deprecation_warning_is_scoped() -> None:
         client.list_runs(project_id=uuid.uuid4())
 
 
+_SHARE_TOKEN = uuid.UUID("22222222-2222-2222-2222-222222222222")
+
+
+def _share_response(run_id: uuid.UUID) -> mock.Mock:
+    """One response body that satisfies every sharing endpoint under test."""
+    return mock.Mock(
+        json=lambda: {
+            "share_token": str(_SHARE_TOKEN),
+            "id": str(run_id),
+            "name": "stub",
+            "run_type": "chain",
+            "start_time": _CREATED_AT.isoformat(),
+            "trace_id": str(run_id),
+        }
+    )
+
+
+@pytest.mark.parametrize(
+    "method,takes_share_token,expected",
+    [
+        ("share_run", False, "Use client.runs.share.create() instead."),
+        ("unshare_run", False, "Use client.runs.share.delete() instead."),
+        (
+            "read_run_shared_link",
+            False,
+            'Use client.runs.retrieve(selects=["SHARE_URL"]) instead.',
+        ),
+        ("read_shared_run", True, "Use client.public.runs.retrieve() instead."),
+        ("list_shared_runs", True, "Use client.public.runs.query() instead."),
+    ],
+)
+def test_run_sharing_methods_are_deprecated(
+    method: str, takes_share_token: bool, expected: str
+) -> None:
+    """Every method in the guide's sharing section warns once, naming its replacement."""
+    client = Client(api_url="http://localhost:1984", api_key="123", session=mock.Mock())
+    run_id = uuid.uuid4()
+    arg = _SHARE_TOKEN if takes_share_token else run_id
+
+    with (
+        mock.patch.object(
+            Client, "request_with_retries", return_value=_share_response(run_id)
+        ),
+        mock.patch.object(Client, "_get_cursor_paginated_list", return_value=iter([])),
+    ):
+        with pytest.warns(DeprecationWarning) as recorded:
+            result = getattr(client, method)(arg)
+            if method == "list_shared_runs":
+                list(result)  # a generator; drain it so the body runs too
+
+    messages = _deprecation_messages(recorded)
+    assert len(messages) == 1, messages
+    assert f"{method}() is deprecated" in messages[0]
+    assert expected in messages[0]
+    assert "#share-and-read-public-runs" in messages[0]
+
+
+def test_run_is_shared_does_not_warn_about_read_run_shared_link() -> None:
+    """run_is_shared() is supported; it must not warn about its internal call."""
+    client = Client(api_url="http://localhost:1984", api_key="123", session=mock.Mock())
+    run_id = uuid.uuid4()
+
+    # Only the HTTP layer is stubbed, so the real decorated
+    # read_run_shared_link() still executes.
+    with mock.patch.object(
+        Client, "request_with_retries", return_value=_share_response(run_id)
+    ):
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            assert client.run_is_shared(run_id) is True
+
+
+@pytest.mark.parametrize(
+    "method,expected",
+    [
+        ("share_run", "Use client.runs.share.create() instead."),
+        (
+            "read_run_shared_link",
+            'Use client.runs.retrieve(selects=["SHARE_URL"]) instead.',
+        ),
+    ],
+)
+async def test_async_run_sharing_methods_are_deprecated(
+    method: str, expected: str
+) -> None:
+    """The async client's sharing methods carry the same deprecations."""
+    from langsmith.async_client import AsyncClient
+
+    client = AsyncClient(api_url="http://localhost:1984", api_key="123")
+    run_id = uuid.uuid4()
+
+    with mock.patch.object(
+        AsyncClient,
+        "_arequest_with_retries",
+        new=mock.AsyncMock(return_value=_share_response(run_id)),
+    ):
+        with pytest.warns(DeprecationWarning) as recorded:
+            await getattr(client, method)(run_id)
+
+    messages = _deprecation_messages(recorded)
+    assert len(messages) == 1, messages
+    assert f"{method}() is deprecated" in messages[0]
+    assert expected in messages[0]
+    assert "#share-and-read-public-runs" in messages[0]
+
+
+async def test_async_run_is_shared_does_not_warn_about_read_run_shared_link() -> None:
+    """Same suppression as the sync client, for the async `await` path."""
+    from langsmith.async_client import AsyncClient
+
+    client = AsyncClient(api_url="http://localhost:1984", api_key="123")
+    run_id = uuid.uuid4()
+
+    with mock.patch.object(
+        AsyncClient,
+        "_arequest_with_retries",
+        new=mock.AsyncMock(return_value=_share_response(run_id)),
+    ):
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            assert await client.run_is_shared(run_id) is True
+
+
 def _gtr_example_id() -> uuid.UUID:
     return uuid.UUID("11111111-1111-1111-1111-111111111111")
 


### PR DESCRIPTION
Stacked on #3308 — targets `kiewan/deprecate-legacy-methods-no-nested-warnings`, not `main`.

Addresses https://github.com/langchain-ai/langsmith-sdk/pull/3299#issuecomment-5144704098.

## Problem

The migration guide's [Share and read public runs](https://docs.langchain.com/langsmith/smithdb-sdk-migration#share-and-read-public-runs) section was the only section in the guide with no code-side counterpart. A user reading the guide is told to migrate off `share_run()`; a user reading the SDK gets no runtime warning, nothing in the reference docs, and no IDE strikethrough.

| Method | Replacement |
| --- | --- |
| `Client.share_run`, `AsyncClient.share_run`, `Client.shareRun` | `runs.share.create()` |
| `Client.unshare_run`, `Client.unshareRun` | `runs.share.delete()` |
| `Client.read_run_shared_link`, `AsyncClient.read_run_shared_link`, `Client.readRunSharedLink` | `runs.retrieve(selects=["SHARE_URL"])` |
| `Client.read_shared_run` | `public.runs.retrieve()` |
| `Client.list_shared_runs`, `Client.listSharedRuns` | `public.runs.query()` |

## Changes

**Python** (`client.py`, `async_client.py`) — each method gets the same three parts as the existing `read_run` / `list_runs` / `read_thread` deprecations: an `@_deprecated(...)` decorator naming the replacement, the removal date and the guide anchor; a `.. admonition:: Deprecated` block as the first thing in the docstring; no change to signature or behavior.

**TypeScript** (`client.ts`) — a one-line `@deprecated` JSDoc tag plus a `warnOnce()` call at the top of the body, using the `{ type: "DeprecationWarning", code: "LANGSMITH_DEPRECATED_<NAME>" }` shape already used by `readRun` / `listRuns`.

`AsyncClient` has no `unshare_run` / `read_shared_run` / `list_shared_runs`, and JS has no `runIsShared`, hence the asymmetric coverage.

## Nested warnings

`run_is_shared()` is supported and is not being deprecated, but it calls `read_run_shared_link()` internally in **both** `client.py` and `async_client.py`. Left alone it would reintroduce exactly the bug #3308 fixes — telling the caller to migrate a method they never invoked. Both call sites are wrapped in `_suppress_deprecation_warning()`. The async one wraps the `await`, which is where `deprecated()` fires for a coroutine.

`read_run_shared_link` is the only internal caller of any of these methods in either language — checked with a grep over `python/langsmith` and `js/src`.

## Tests

Python (`tests/unit_tests/test_client.py`):
- parametrized over all five sync methods: exactly one `DeprecationWarning`, naming the method, the replacement and the `#share-and-read-public-runs` anchor
- same for the two async methods
- `run_is_shared()` emits **no** deprecation warning, sync and async

JS (`src/tests/client.test.ts`): all four methods warn exactly once with the right replacement, under the existing `_resetWarnedMessages()` convention.

Every test stubs only the transport (`request_with_retries` / `_arequest_with_retries` / `_fetch`), so the real decorated method executes. I verified they're not vacuous by stripping the decorators (7 Python failures) / the `warnOnce()` calls (4 JS failures) and by removing the two suppressions (2 Python failures).

`pnpm test:single src/tests/client.test.ts` is green apart from `Client › env functions › should return the env variables correctly`, which fails identically on the base branch in my shell (local `LANGSMITH_*` env leakage). The Python unit suite has the same pre-existing local-env failures and none in this area — CI is the check there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
