### PR TITLE
fix(js): mask metadata after the runtime env merge and via the anonymizer

### DIFF
--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -165,11 +165,11 @@ export interface ClientConfig {
   timeout_ms?: number;
   webUrl?: string;
   /**
-   * A function applied for masking serialized run inputs and outputs,
-   * before sending to the API. Can be called with raw inputs, raw
-   * outputs, or a nested `{ error: string }` object for errors.
+   * A function applied for masking serialized run inputs, outputs and
+   * metadata, before sending to the API. Can be called with raw inputs, raw
+   * outputs, raw metadata, or a nested `{ error: string }` object for errors.
    *
-   * If a `hideInputs` or `hideOutputs` function is present,
+   * If a `hideInputs`, `hideOutputs` or `hideMetadata` function is present,
    * the client will call it instead of the anonymizer as appropriate.
    */
   anonymizer?: (values: KVMap) => KVMap | Promise<KVMap>;
@@ -1429,7 +1429,8 @@ export class Client implements LangSmithTracingClientInterface {
       config.hideInputs ?? config.anonymizer ?? defaultConfig.hideInputs;
     this.hideOutputs =
       config.hideOutputs ?? config.anonymizer ?? defaultConfig.hideOutputs;
-    this.hideMetadata = config.hideMetadata ?? defaultConfig.hideMetadata;
+    this.hideMetadata =
+      config.hideMetadata ?? config.anonymizer ?? defaultConfig.hideMetadata;
     this.anonymizer = config.anonymizer;
 
     this.omitTracedRuntimeInfo = config.omitTracedRuntimeInfo ?? false;
@@ -2221,6 +2222,9 @@ export class Client implements LangSmithTracingClientInterface {
 
     try {
       if (this.langSmithToOTELTranslator !== undefined) {
+        for (const item of batch) {
+          item.item = await this._maskRunMetadata(item.item);
+        }
         this._sendBatchToOTELTranslator(batch);
       } else {
         const ingestParams = {
@@ -2297,6 +2301,35 @@ export class Client implements LangSmithTracingClientInterface {
       }
       this.langSmithToOTELTranslator.exportBatch(operations, otelContextMap);
     }
+  }
+
+  private async _maskRunMetadata<T extends RunCreate | RunUpdate>(
+    run: T,
+  ): Promise<T> {
+    if (run.extra?.metadata == null) {
+      return run;
+    }
+    return {
+      ...run,
+      extra: {
+        ...run.extra,
+        metadata: await this.processMetadata(run.extra.metadata),
+      },
+    };
+  }
+
+  private async _mergeRuntimeEnvAndMaskMetadata<
+    T extends RunCreate | RunUpdate,
+  >(run: T): Promise<T> {
+    const merged = mergeRuntimeEnvIntoRun(
+      run,
+      this.cachedLSEnvVarsForMetadata,
+      this.omitTracedRuntimeInfo,
+    );
+    if (this.omitTracedRuntimeInfo) {
+      return merged;
+    }
+    return this._maskRunMetadata(merged);
   }
 
   private async processRunOperation(item: AutoBatchQueueItem) {
@@ -2492,11 +2525,8 @@ export class Client implements LangSmithTracingClientInterface {
       }).catch(console.error);
       return;
     }
-    const mergedRunCreateParam = mergeRuntimeEnvIntoRun(
-      runCreate,
-      this.cachedLSEnvVarsForMetadata,
-      this.omitTracedRuntimeInfo,
-    );
+    const mergedRunCreateParam =
+      await this._mergeRuntimeEnvAndMaskMetadata(runCreate);
     if (options?.apiKey !== undefined) {
       headers["x-api-key"] = options.apiKey;
     }

--- a/js/src/tests/anonymizer.test.ts
+++ b/js/src/tests/anonymizer.test.ts
@@ -269,6 +269,82 @@ describe("error field", () => {
   });
 });
 
+describe("metadata field", () => {
+  // Assembled at runtime so no literal secret-shaped string sits in source.
+  const fakeKey = "sk-ant-api03-" + "A".repeat(30);
+  const metadataWithSecret = () => ({
+    config: { authorization: `Bearer ${fakeKey}` },
+  });
+
+  test("anonymizer redacts the metadata field on run create", async () => {
+    const { client, callSpy } = mockClient({
+      anonymizer: createSecretAnonymizer(),
+    });
+
+    await client.createRun({
+      id: uuid(),
+      name: "traced",
+      run_type: "llm",
+      inputs: { in: "put" },
+      extra: { metadata: metadataWithSecret() },
+    });
+
+    const { data } = await getAssumedTreeFromCalls(callSpy.mock.calls, client);
+    const metadata = JSON.stringify(data["traced:0"].extra?.metadata);
+    expect(metadata).not.toContain(fakeKey);
+    expect(metadata).toContain(SECRET_PLACEHOLDER);
+  });
+
+  test("anonymizer redacts the metadata field on run update", async () => {
+    const { client, callSpy } = mockClient({
+      anonymizer: createSecretAnonymizer(),
+    });
+
+    const id = uuid();
+    await client.createRun({
+      id,
+      name: "traced",
+      run_type: "llm",
+      inputs: { in: "put" },
+    });
+    await client.updateRun(id, { extra: { metadata: metadataWithSecret() } });
+
+    const { data } = await getAssumedTreeFromCalls(callSpy.mock.calls, client);
+    const metadata = JSON.stringify(data["traced:0"].extra?.metadata);
+    expect(metadata).not.toContain(fakeKey);
+    expect(metadata).toContain(SECRET_PLACEHOLDER);
+  });
+
+  test("anonymizer redacts metadata merged in from the environment", async () => {
+    // Read once at construction, so it has to be set before the client exists.
+    // eslint-disable-next-line no-process-env
+    process.env.LANGCHAIN_TEST_ENV_METADATA = `Bearer ${fakeKey}`;
+    try {
+      const { client, callSpy } = mockClient({
+        anonymizer: createSecretAnonymizer(),
+      });
+
+      await client.createRun({
+        id: uuid(),
+        name: "traced",
+        run_type: "llm",
+        inputs: { in: "put" },
+      });
+
+      const { data } = await getAssumedTreeFromCalls(
+        callSpy.mock.calls,
+        client,
+      );
+      const metadata = JSON.stringify(data["traced:0"].extra?.metadata);
+      expect(metadata).not.toContain(fakeKey);
+      expect(metadata).toContain(SECRET_PLACEHOLDER);
+    } finally {
+      // eslint-disable-next-line no-process-env
+      delete process.env.LANGCHAIN_TEST_ENV_METADATA;
+    }
+  });
+});
+
 describe("createSecretAnonymizer", () => {
   const redact = createSecretAnonymizer();
 

--- a/js/src/tests/client.test.ts
+++ b/js/src/tests/client.test.ts
@@ -6,9 +6,13 @@ import * as path from "node:path";
 import { inspect } from "node:util";
 import {
   Client,
+  ClientConfig,
   mergeRuntimeEnvIntoRun,
   _checkBackendVersion,
 } from "../client.js";
+import { v4 as uuid } from "../utils/uuid/src/index.js";
+import { mockClient } from "./utils/mock_client.js";
+import { getAssumedTreeFromCalls } from "./utils/tree.js";
 import {
   getLangSmithEnvironmentVariables,
   getLangSmithEnvVarsMetadata,
@@ -1600,6 +1604,78 @@ describe("Client", () => {
       expect(result.extra).toBeDefined();
       expect(result.extra.runtime).toBeDefined();
       expect(result.extra.metadata).toBeDefined();
+    });
+  });
+
+  describe("hideMetadata covers runtime env metadata", () => {
+    const postedMetadata = async (
+      hideMetadata: ClientConfig["hideMetadata"],
+    ) => {
+      // Read once at construction, so it has to be set before the client exists.
+      process.env.LANGCHAIN_TEST_ENV_METADATA = "env-value";
+      try {
+        const { client, callSpy } = mockClient({ hideMetadata });
+        await client.createRun({
+          id: uuid(),
+          name: "traced",
+          run_type: "llm",
+          inputs: { in: "put" },
+          extra: { metadata: { random: 123 } },
+        });
+        const { data } = await getAssumedTreeFromCalls(
+          callSpy.mock.calls,
+          client,
+        );
+        return data["traced:0"].extra?.metadata;
+      } finally {
+        delete process.env.LANGCHAIN_TEST_ENV_METADATA;
+      }
+    };
+
+    it("should hide metadata merged in after masking", async () => {
+      expect(await postedMetadata(true)).toEqual({});
+    });
+
+    it("should pass env metadata to a hideMetadata function", async () => {
+      const metadata = await postedMetadata((metadata) =>
+        Object.fromEntries(
+          Object.entries(metadata).filter(
+            ([key]) => !key.startsWith("LANGCHAIN_"),
+          ),
+        ),
+      );
+
+      expect(metadata).not.toHaveProperty("LANGCHAIN_TEST_ENV_METADATA");
+      expect(metadata?.random).toBe(123);
+    });
+
+    // The OTEL exporter consumes queued runs directly, so it needs the same
+    // re-masking the ingest endpoints get from prepareRunCreateOrUpdateInputs.
+    it("should hide metadata merged in before OTEL export", async () => {
+      process.env.LANGCHAIN_TEST_ENV_METADATA = "env-value";
+      try {
+        const client = new Client({ apiKey: "MOCK", hideMetadata: true });
+        const exportBatch = jest.fn();
+        (client as any).langSmithToOTELTranslator = { exportBatch };
+
+        // What processRunOperation queues: masked metadata, then env merged in.
+        const item = mergeRuntimeEnvIntoRun({
+          id: uuid(),
+          name: "traced",
+          run_type: "llm",
+          inputs: { in: "put" },
+          extra: { metadata: {} },
+        } as any);
+
+        await (client as any)._processBatch([
+          { action: "create", item, otelContext: {} },
+        ]);
+
+        const [operations] = exportBatch.mock.calls[0] as [any[]];
+        expect(operations[0].run.extra.metadata).toEqual({});
+      } finally {
+        delete process.env.LANGCHAIN_TEST_ENV_METADATA;
+      }
     });
   });
 


### PR DESCRIPTION
## Descriotion

- `hideMetadata` was missing from the anonymizer default chain that `hideInputs` and `hideOutputs` already use, so metadata never reached a configured anonymizer. It now falls back to `config.anonymizer`.
- Runtime env metadata (`LANGCHAIN_*`/`LANGSMITH_*`) is merged into a run after its metadata has been masked. Re-masked for the two consumers that don't already re-mask: non-batch `createRun` and the OTEL exporter. The ingest endpoints need no change -- `batchIngestRuns`/`multipartIngestRuns` re-run `prepareRunCreateOrUpdateInputs` after the merge.
- Deliberately not re-masked in `processRunOperation`: awaiting there would push the run into the auto-batch queue a microtask later, changing batching and flush timing.