### PR TITLE
release(py): 0.10.15

### DIFF
--- a/python/.bumpversion.cfg
+++ b/python/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.10.14
+current_version = 0.10.15
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
 serialize = {major}.{minor}.{patch}
 search = {current_version}

--- a/python/langsmith/__init__.py
+++ b/python/langsmith/__init__.py
@@ -49,7 +49,7 @@ if TYPE_CHECKING:
 
 # Avoid calling into importlib on every call to __version__
 
-__version__ = "0.10.14"
+__version__ = "0.10.15"
 version = __version__  # for backwards compatibility
 
 # Metadata key to hide a traced run from LangSmith's Messages View.


### PR DESCRIPTION
Cuts a Python release so everything merged since 0.10.14 reaches PyPI.

- **`Client(session=...)` now reaches the v2 endpoints** (#3304). The session only ever configured the handwritten `requests` paths; the generated `httpx` client ignored it, so a custom CA bundle, corporate proxy, or extra headers applied to only half of a caller's traffic. Headers, cookies, `verify`, `cert`, proxy and `trust_env` are now translated onto the generated client; the cases with no `httpx` equivalent (mounted `HTTPAdapter`s, `session.auth`, `session.hooks`) are documented in the `session` docstring instead of failing silently.
- **A configured profile API key now wins over its OAuth bearer token** (#3295), and unused OAuth credentials are no longer refreshed. OAuth-only fallback is unchanged.
- **Legacy SmithDB-migration methods are deprecated** (#3299) — `read_run`, `list_runs`, `read_thread`, `list_threads`, `get_experiment_results`, and `add_runs_to_annotation_queue(run_ids=...)`. Annotation and warning only; no signature or behaviour changes.
- **`create_feedback`'s session-id gate routes through the shared backend detection helper** (#3307) instead of parsing `ch_query_enabled` ad hoc, matching `read_run` and the other migration paths.
- **Generated client sync** (#3310): all five issue statuses documented on `GET /v1/platform/issues`, and the duplicated `/v2` dropped from the public shared-runs query path.

JS carries its own subset of these on `main` and has a separate release PR — the two workflows fire on different files.