### PR TITLE
release(js): 0.8.9

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langsmith",
-  "version": "0.8.8",
+  "version": "0.8.9",
   "description": "Client library to connect to the LangSmith Observability and Evaluation Platform.",
   "packageManager": "pnpm@10.33.0",
   "files": [

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -54,7 +54,7 @@ export {
 } from "./_openapi_client/core/error.js";
 
 // Update using pnpm bump-version
-export const __version__ = "0.8.8";
+export const __version__ = "0.8.9";
 
 // Metadata key to hide a traced run from LangSmith's Messages View.
 export const LS_MESSAGE_VIEW_EXCLUDE = "ls_message_view_exclude" as const;


### PR DESCRIPTION
Cuts a JS release so everything merged since 0.8.8 reaches npm.

- **A silent command no longer dies mid-reconnect** (#3301). The sandbox reconnect budget was cleared only by stdout/stderr, so it counted socket closures since the last output rather than consecutive failed reattachments — a command that was attached, healthy and merely quiet gave up on the sixth loss after six reattachments that had all succeeded. The server's `started` acknowledgement is now treated as proof a reattachment landed. (Python shipped this in 0.10.14.)
- **`config.headers` now reaches the v2 endpoints** (#3305). `new Client({ headers: ... })` silently did nothing for `client.runs`, `client.evaluators`, `client.sandboxes`, `client.datasets`, `client.threads` and `client.traces`, because `defaultHeaders` was only set in the no-auth case.
  - ⚠️ **Behaviour change:** `fetchOptions.headers` is no longer a whole-set replacement. It previously clobbered the entire header set on the handwritten paths — including `x-api-key` — and is now merged.
- **Legacy SmithDB-migration methods are deprecated** (#3299) — `readRun`, `listRuns`, `readThread`, `listThreads`, and the `string[]` path of `addRunsToAnnotationQueue`. JSDoc `@deprecated` plus a `warnOnce()` at call time; no behaviour change beyond the warning.
- **`createFeedback`'s session-id gate routes through the new shared `getQueryBackend` helper** (#3307), matching the Python semantics instead of parsing `ch_query_enabled` ad hoc.
- **Generated client sync** (#3310): all five issue statuses documented on `GET /v1/platform/issues`, and the duplicated `/v2` dropped from the public shared-runs query path.