### PR TITLE
fix(js,py): preserve user-supplied ls_agent_type in openai-agents-sdk integration

### DIFF
--- a/js/src/tests/ls_agent_type.test.ts
+++ b/js/src/tests/ls_agent_type.test.ts
@@ -1,5 +1,6 @@
 import { RunTree } from "../run_trees.js";
 import {
+  NON_ROOT_LS_AGENT_TYPES,
   defaultLsAgentTypeMetadata,
   lsAgentTypeMetadata,
   resolveDefaultLsAgentType,
@@ -57,4 +58,10 @@ test("defaultLsAgentTypeMetadata preserves null opt-out (returns empty delta)", 
   expect(
     defaultLsAgentTypeMetadata({ ls_agent_type: null }, undefined),
   ).toEqual({});
+});
+
+test("NON_ROOT_LS_AGENT_TYPES has the three non-root tags", () => {
+  expect(NON_ROOT_LS_AGENT_TYPES).toEqual(
+    new Set(["middleware", "subagent", "compaction"]),
+  );
 });

--- a/js/src/tests/openai_agents_sdk.test.ts
+++ b/js/src/tests/openai_agents_sdk.test.ts
@@ -246,7 +246,7 @@ describe("OpenAIAgentsTracingProcessor", () => {
       },
     );
 
-    test("null in trace.metadata opts out and deletes the key", async () => {
+    test("null in trace.metadata opts out; null value flows through so it overrides create_child inheritance", async () => {
       const trace = createMockTrace("trace-lst-optout", "Agent", {
         metadata: { ls_agent_type: null },
       });
@@ -258,9 +258,7 @@ describe("OpenAIAgentsTracingProcessor", () => {
       const rootNode = tree.nodes.find((n) => n.includes("Agent"));
       expect(rootNode).toBeDefined();
       if (rootNode) {
-        expect(
-          "ls_agent_type" in (tree.data[rootNode].extra?.metadata ?? {}),
-        ).toBe(false);
+        expect(tree.data[rootNode].extra?.metadata?.ls_agent_type).toBeNull();
       }
     });
 

--- a/js/src/tests/openai_agents_sdk.test.ts
+++ b/js/src/tests/openai_agents_sdk.test.ts
@@ -210,6 +210,92 @@ describe("OpenAIAgentsTracingProcessor", () => {
         );
       }
     });
+
+    test("defaults ls_agent_type to root when trace has no metadata", async () => {
+      const trace = createMockTrace("trace-lst-1", "Agent");
+      await processor.onTraceStart(trace);
+      await processor.onTraceEnd(trace);
+      await client.awaitPendingTraceBatches();
+
+      const tree = await getAssumedTreeFromCalls(callSpy.mock.calls, client);
+      const rootNode = tree.nodes.find((n) => n.includes("Agent"));
+      expect(rootNode).toBeDefined();
+      if (rootNode) {
+        expect(tree.data[rootNode].extra?.metadata?.ls_agent_type).toBe(
+          "root",
+        );
+      }
+    });
+
+    test.each(["middleware", "subagent", "compaction", "root"] as const)(
+      "preserves user-supplied ls_agent_type='%s' from trace.metadata",
+      async (userTag) => {
+        const trace = createMockTrace(`trace-lst-${userTag}`, "Agent", {
+          metadata: { ls_agent_type: userTag },
+        });
+        await processor.onTraceStart(trace);
+        await processor.onTraceEnd(trace);
+        await client.awaitPendingTraceBatches();
+
+        const tree = await getAssumedTreeFromCalls(callSpy.mock.calls, client);
+        const rootNode = tree.nodes.find((n) => n.includes("Agent"));
+        expect(rootNode).toBeDefined();
+        if (rootNode) {
+          expect(tree.data[rootNode].extra?.metadata?.ls_agent_type).toBe(
+            userTag,
+          );
+        }
+      },
+    );
+
+    test("force-sets ls_integration even if user overrides via trace.metadata", async () => {
+      const trace = createMockTrace("trace-lst-integ", "Agent", {
+        metadata: {
+          ls_integration: "user-override",
+          ls_agent_type: "middleware",
+        },
+      });
+      await processor.onTraceStart(trace);
+      await processor.onTraceEnd(trace);
+      await client.awaitPendingTraceBatches();
+
+      const tree = await getAssumedTreeFromCalls(callSpy.mock.calls, client);
+      const rootNode = tree.nodes.find((n) => n.includes("Agent"));
+      expect(rootNode).toBeDefined();
+      if (rootNode) {
+        expect(tree.data[rootNode].extra?.metadata?.ls_integration).toBe(
+          "openai-agents-sdk",
+        );
+        expect(tree.data[rootNode].extra?.metadata?.ls_agent_type).toBe(
+          "middleware",
+        );
+      }
+    });
+
+    test("preserves other user trace.metadata alongside ls_agent_type", async () => {
+      const trace = createMockTrace("trace-lst-other", "Agent", {
+        metadata: {
+          middleware_name: "entry_guardrail",
+          phase: "entry",
+        },
+      });
+      await processor.onTraceStart(trace);
+      await processor.onTraceEnd(trace);
+      await client.awaitPendingTraceBatches();
+
+      const tree = await getAssumedTreeFromCalls(callSpy.mock.calls, client);
+      const rootNode = tree.nodes.find((n) => n.includes("Agent"));
+      expect(rootNode).toBeDefined();
+      if (rootNode) {
+        expect(tree.data[rootNode].extra?.metadata?.middleware_name).toBe(
+          "entry_guardrail",
+        );
+        expect(tree.data[rootNode].extra?.metadata?.phase).toBe("entry");
+        expect(tree.data[rootNode].extra?.metadata?.ls_agent_type).toBe(
+          "root",
+        );
+      }
+    });
   });
 
   describe("span handling", () => {

--- a/js/src/tests/openai_agents_sdk.test.ts
+++ b/js/src/tests/openai_agents_sdk.test.ts
@@ -284,6 +284,66 @@ describe("OpenAIAgentsTracingProcessor", () => {
         expect(tree.data[rootNode].extra?.metadata?.ls_agent_type).toBe("root");
       }
     });
+
+    test("no default stamp when nested under a parent runtree", async () => {
+      const trace = createMockTrace("trace-lst-nested", "Agent");
+      await traceable(
+        async () => {
+          await processor.onTraceStart(trace);
+          await processor.onTraceEnd(trace);
+        },
+        { name: "parent", client },
+      )();
+      await client.awaitPendingTraceBatches();
+
+      const tree = await getAssumedTreeFromCalls(callSpy.mock.calls, client);
+      const agentNode = tree.nodes.find((n) => n.includes("Agent"));
+      if (agentNode) {
+        expect(
+          tree.data[agentNode].extra?.metadata?.ls_agent_type,
+        ).toBeUndefined();
+      }
+    });
+
+    test("trace.metadata wins over processor metadata", async () => {
+      const customProcessor = new OpenAIAgentsTracingProcessor({
+        client,
+        metadata: { env: "test" },
+      });
+      const trace = createMockTrace("trace-lst-prec", "Agent", {
+        metadata: { env: "prod" },
+      });
+      await customProcessor.onTraceStart(trace);
+      await customProcessor.onTraceEnd(trace);
+      await client.awaitPendingTraceBatches();
+
+      const tree = await getAssumedTreeFromCalls(callSpy.mock.calls, client);
+      const rootNode = tree.nodes.find((n) => n.includes("Agent"));
+      if (rootNode) {
+        expect(tree.data[rootNode].extra?.metadata?.env).toBe("prod");
+      }
+    });
+
+    test("trace_end preserves trace.metadata precedence over processor metadata", async () => {
+      const customProcessor = new OpenAIAgentsTracingProcessor({
+        client,
+        metadata: { ls_agent_type: "root" },
+      });
+      const trace = createMockTrace("trace-lst-end", "Agent", {
+        metadata: { ls_agent_type: "middleware" },
+      });
+      await customProcessor.onTraceStart(trace);
+      await customProcessor.onTraceEnd(trace);
+      await client.awaitPendingTraceBatches();
+
+      const tree = await getAssumedTreeFromCalls(callSpy.mock.calls, client);
+      const rootNode = tree.nodes.find((n) => n.includes("Agent"));
+      if (rootNode) {
+        expect(tree.data[rootNode].extra?.metadata?.ls_agent_type).toBe(
+          "middleware",
+        );
+      }
+    });
   });
 
   describe("span handling", () => {
@@ -679,6 +739,123 @@ describe("OpenAIAgentsTracingProcessor", () => {
       const tree = await getAssumedTreeFromCalls(callSpy.mock.calls, client);
       const subagentNode = tree.nodes.find((n) => n.includes("SubAgent"));
       expect(subagentNode).toBeDefined();
+      if (subagentNode) {
+        expect(tree.data[subagentNode].extra?.metadata?.ls_agent_type).toBe(
+          "subagent",
+        );
+      }
+    });
+
+    test("subagent detection overrides inherited root at agent-as-tool site", async () => {
+      const trace = createMockTrace("trace-11d", "Test Agent", {
+        metadata: { ls_agent_type: "root" },
+      });
+      const functionSpan = createMockSpan("trace-11d", "span-fn-d", null, {
+        type: "function",
+        name: "invoke_subagent",
+        input: "{}",
+        output: "{}",
+      });
+      const subagentSpan = createMockSpan(
+        "trace-11d",
+        "span-agent-d",
+        "span-fn-d",
+        { type: "agent", name: "SubAgentD" },
+      );
+
+      await processor.onTraceStart(trace);
+      await processor.onSpanStart(functionSpan);
+      await processor.onSpanStart(subagentSpan);
+      await processor.onSpanEnd(subagentSpan);
+      await processor.onSpanEnd(functionSpan);
+      await processor.onTraceEnd(trace);
+      await client.awaitPendingTraceBatches();
+
+      const tree = await getAssumedTreeFromCalls(callSpy.mock.calls, client);
+      const subagentNode = tree.nodes.find((n) => n.includes("SubAgentD"));
+      if (subagentNode) {
+        expect(tree.data[subagentNode].extra?.metadata?.ls_agent_type).toBe(
+          "subagent",
+        );
+      }
+    });
+
+    test.each(["middleware", "compaction"] as const)(
+      "subagent detection preserves user-supplied '%s' at agent-as-tool site",
+      async (userTag) => {
+        const trace = createMockTrace(`trace-11e-${userTag}`, "Test Agent", {
+          metadata: { ls_agent_type: userTag },
+        });
+        const functionSpan = createMockSpan(
+          `trace-11e-${userTag}`,
+          `span-fn-e-${userTag}`,
+          null,
+          {
+            type: "function",
+            name: "invoke_subagent",
+            input: "{}",
+            output: "{}",
+          },
+        );
+        const subagentSpan = createMockSpan(
+          `trace-11e-${userTag}`,
+          `span-agent-e-${userTag}`,
+          `span-fn-e-${userTag}`,
+          { type: "agent", name: `SubAgentE_${userTag}` },
+        );
+
+        await processor.onTraceStart(trace);
+        await processor.onSpanStart(functionSpan);
+        await processor.onSpanStart(subagentSpan);
+        await processor.onSpanEnd(subagentSpan);
+        await processor.onSpanEnd(functionSpan);
+        await processor.onTraceEnd(trace);
+        await client.awaitPendingTraceBatches();
+
+        const tree = await getAssumedTreeFromCalls(callSpy.mock.calls, client);
+        const subagentNode = tree.nodes.find((n) =>
+          n.includes(`SubAgentE_${userTag}`),
+        );
+        if (subagentNode) {
+          expect(tree.data[subagentNode].extra?.metadata?.ls_agent_type).toBe(
+            userTag,
+          );
+        }
+      },
+    );
+
+    test("subagent detection is idempotent on existing subagent tag", async () => {
+      const trace = createMockTrace("trace-11f-idem", "Test Agent", {
+        metadata: { ls_agent_type: "subagent" },
+      });
+      const functionSpan = createMockSpan(
+        "trace-11f-idem",
+        "span-fn-idem",
+        null,
+        {
+          type: "function",
+          name: "invoke_subagent",
+          input: "{}",
+          output: "{}",
+        },
+      );
+      const subagentSpan = createMockSpan(
+        "trace-11f-idem",
+        "span-agent-idem",
+        "span-fn-idem",
+        { type: "agent", name: "SubAgentIdem" },
+      );
+
+      await processor.onTraceStart(trace);
+      await processor.onSpanStart(functionSpan);
+      await processor.onSpanStart(subagentSpan);
+      await processor.onSpanEnd(subagentSpan);
+      await processor.onSpanEnd(functionSpan);
+      await processor.onTraceEnd(trace);
+      await client.awaitPendingTraceBatches();
+
+      const tree = await getAssumedTreeFromCalls(callSpy.mock.calls, client);
+      const subagentNode = tree.nodes.find((n) => n.includes("SubAgentIdem"));
       if (subagentNode) {
         expect(tree.data[subagentNode].extra?.metadata?.ls_agent_type).toBe(
           "subagent",

--- a/js/src/tests/openai_agents_sdk.test.ts
+++ b/js/src/tests/openai_agents_sdk.test.ts
@@ -221,9 +221,7 @@ describe("OpenAIAgentsTracingProcessor", () => {
       const rootNode = tree.nodes.find((n) => n.includes("Agent"));
       expect(rootNode).toBeDefined();
       if (rootNode) {
-        expect(tree.data[rootNode].extra?.metadata?.ls_agent_type).toBe(
-          "root",
-        );
+        expect(tree.data[rootNode].extra?.metadata?.ls_agent_type).toBe("root");
       }
     });
 
@@ -285,9 +283,7 @@ describe("OpenAIAgentsTracingProcessor", () => {
           "entry_guardrail",
         );
         expect(tree.data[rootNode].extra?.metadata?.phase).toBe("entry");
-        expect(tree.data[rootNode].extra?.metadata?.ls_agent_type).toBe(
-          "root",
-        );
+        expect(tree.data[rootNode].extra?.metadata?.ls_agent_type).toBe("root");
       }
     });
   });

--- a/js/src/tests/openai_agents_sdk.test.ts
+++ b/js/src/tests/openai_agents_sdk.test.ts
@@ -211,7 +211,7 @@ describe("OpenAIAgentsTracingProcessor", () => {
       }
     });
 
-    test("defaults ls_agent_type to root when trace has no metadata", async () => {
+    test("stamps default ls_agent_type=root at trace root with no user tag", async () => {
       const trace = createMockTrace("trace-lst-1", "Agent");
       await processor.onTraceStart(trace);
       await processor.onTraceEnd(trace);
@@ -227,7 +227,7 @@ describe("OpenAIAgentsTracingProcessor", () => {
       }
     });
 
-    test.each(["middleware", "subagent", "compaction", "root"] as const)(
+    test.each(["root", "middleware", "subagent", "compaction"] as const)(
       "preserves user-supplied ls_agent_type='%s' from trace.metadata",
       async (userTag) => {
         const trace = createMockTrace(`trace-lst-${userTag}`, "Agent", {
@@ -248,12 +248,9 @@ describe("OpenAIAgentsTracingProcessor", () => {
       },
     );
 
-    test("force-sets ls_integration even if user overrides via trace.metadata", async () => {
-      const trace = createMockTrace("trace-lst-integ", "Agent", {
-        metadata: {
-          ls_integration: "user-override",
-          ls_agent_type: "middleware",
-        },
+    test("null in trace.metadata opts out and deletes the key", async () => {
+      const trace = createMockTrace("trace-lst-optout", "Agent", {
+        metadata: { ls_agent_type: null },
       });
       await processor.onTraceStart(trace);
       await processor.onTraceEnd(trace);
@@ -263,16 +260,13 @@ describe("OpenAIAgentsTracingProcessor", () => {
       const rootNode = tree.nodes.find((n) => n.includes("Agent"));
       expect(rootNode).toBeDefined();
       if (rootNode) {
-        expect(tree.data[rootNode].extra?.metadata?.ls_integration).toBe(
-          "openai-agents-sdk",
-        );
-        expect(tree.data[rootNode].extra?.metadata?.ls_agent_type).toBe(
-          "middleware",
-        );
+        expect(
+          "ls_agent_type" in (tree.data[rootNode].extra?.metadata ?? {}),
+        ).toBe(false);
       }
     });
 
-    test("preserves other user trace.metadata alongside ls_agent_type", async () => {
+    test("preserves other user trace.metadata alongside default root", async () => {
       const trace = createMockTrace("trace-lst-other", "Agent", {
         metadata: {
           middleware_name: "entry_guardrail",

--- a/js/src/utils/ls_agent_type.ts
+++ b/js/src/utils/ls_agent_type.ts
@@ -7,6 +7,13 @@ import { isRunTree } from "../run_trees.js";
 
 export type LsAgentType = "root" | "middleware" | "subagent" | "compaction";
 
+// Non-root tags: preserved against default/structural stamping.
+export const NON_ROOT_LS_AGENT_TYPES: ReadonlySet<string> = new Set([
+  "middleware",
+  "subagent",
+  "compaction",
+]);
+
 // `"root"` at trace root; `undefined` when nested (rely on propagation).
 export function resolveDefaultLsAgentType(
   parentRunTree?: unknown,

--- a/js/src/wrappers/openai_agents.ts
+++ b/js/src/wrappers/openai_agents.ts
@@ -12,6 +12,7 @@ import {
   AsyncLocalStorageProviderSingleton,
   getCurrentRunTree,
 } from "../singletons/traceable.js";
+import { defaultLsAgentTypeMetadata } from "../utils/ls_agent_type.js";
 import type { ContextPlaceholder } from "../singletons/types.js";
 import type {
   AgentSpanData,
@@ -589,10 +590,10 @@ export class OpenAIAgentsTracingProcessor implements TracingProcessor {
       ...((trace.metadata as Record<string, unknown> | undefined) ?? {}),
       ls_integration: "openai-agents-sdk",
     };
-    // Default root only at true trace root; nested traces inherit via create_child.
-    if (!("ls_agent_type" in mergedMetadata) && currentRunTree === undefined) {
-      mergedMetadata.ls_agent_type = "root";
-    }
+    Object.assign(
+      mergedMetadata,
+      defaultLsAgentTypeMetadata(mergedMetadata, currentRunTree),
+    );
     const runExtra: Record<string, unknown> = { metadata: mergedMetadata };
 
     const traceDict = (trace.toJSON() as Record<string, unknown>) ?? {};

--- a/js/src/wrappers/openai_agents.ts
+++ b/js/src/wrappers/openai_agents.ts
@@ -583,15 +583,13 @@ export class OpenAIAgentsTracingProcessor implements TracingProcessor {
       runName = "Agent workflow";
     }
 
-    // Build metadata; honor user trace.metadata but force-set SDK identity.
+    // Build metadata; trace.metadata wins over processor defaults, ls_integration force-set.
     const mergedMetadata: Record<string, unknown> = {
       ...this._metadata,
       ...((trace.metadata as Record<string, unknown> | undefined) ?? {}),
       ls_integration: "openai-agents-sdk",
     };
-    // Default root only at true trace root; nested traces inherit via
-    // create_child. User-supplied null flows through unchanged so it overrides
-    // create_child's inherited parent tag on the child run.
+    // Default root only at true trace root; nested traces inherit via create_child.
     if (!("ls_agent_type" in mergedMetadata) && currentRunTree === undefined) {
       mergedMetadata.ls_agent_type = "root";
     }
@@ -664,8 +662,7 @@ export class OpenAIAgentsTracingProcessor implements TracingProcessor {
     this._runs.delete(trace.traceId);
 
     const traceDict = (trace.toJSON() as Record<string, unknown>) ?? {};
-    // Match onTraceStart precedence: per-invocation trace.metadata wins over
-    // processor-level defaults.
+    // trace.metadata wins over processor defaults (matches onTraceStart).
     const metadata: Record<string, unknown> = {
       ...this._metadata,
       ...(traceDict.metadata as Record<string, unknown>),

--- a/js/src/wrappers/openai_agents.ts
+++ b/js/src/wrappers/openai_agents.ts
@@ -590,13 +590,10 @@ export class OpenAIAgentsTracingProcessor implements TracingProcessor {
       ls_integration: "openai-agents-sdk",
     };
     // Default root only at true trace root; nested traces inherit via
-    // create_child. `null` opt-out removes the key.
-    if (!("ls_agent_type" in mergedMetadata)) {
-      if (currentRunTree === undefined) {
-        mergedMetadata.ls_agent_type = "root";
-      }
-    } else if (mergedMetadata.ls_agent_type === null) {
-      delete mergedMetadata.ls_agent_type;
+    // create_child. User-supplied null flows through unchanged so it overrides
+    // create_child's inherited parent tag on the child run.
+    if (!("ls_agent_type" in mergedMetadata) && currentRunTree === undefined) {
+      mergedMetadata.ls_agent_type = "root";
     }
     const runExtra: Record<string, unknown> = { metadata: mergedMetadata };
 
@@ -667,14 +664,12 @@ export class OpenAIAgentsTracingProcessor implements TracingProcessor {
     this._runs.delete(trace.traceId);
 
     const traceDict = (trace.toJSON() as Record<string, unknown>) ?? {};
+    // Match onTraceStart precedence: per-invocation trace.metadata wins over
+    // processor-level defaults.
     const metadata: Record<string, unknown> = {
-      ...(traceDict.metadata as Record<string, unknown>),
       ...this._metadata,
+      ...(traceDict.metadata as Record<string, unknown>),
     };
-    // Honor null opt-out from trace.metadata (mirror of onTraceStart).
-    if (metadata.ls_agent_type === null) {
-      delete metadata.ls_agent_type;
-    }
 
     try {
       // Update run with final inputs/outputs

--- a/js/src/wrappers/openai_agents.ts
+++ b/js/src/wrappers/openai_agents.ts
@@ -589,8 +589,14 @@ export class OpenAIAgentsTracingProcessor implements TracingProcessor {
       ...((trace.metadata as Record<string, unknown> | undefined) ?? {}),
       ls_integration: "openai-agents-sdk",
     };
+    // Default root only at true trace root; nested traces inherit via
+    // create_child. `null` opt-out removes the key.
     if (!("ls_agent_type" in mergedMetadata)) {
-      mergedMetadata.ls_agent_type = "root";
+      if (currentRunTree === undefined) {
+        mergedMetadata.ls_agent_type = "root";
+      }
+    } else if (mergedMetadata.ls_agent_type === null) {
+      delete mergedMetadata.ls_agent_type;
     }
     const runExtra: Record<string, unknown> = { metadata: mergedMetadata };
 
@@ -665,8 +671,10 @@ export class OpenAIAgentsTracingProcessor implements TracingProcessor {
       ...(traceDict.metadata as Record<string, unknown>),
       ...this._metadata,
     };
-    // Force-set SDK identity; user trace.metadata cannot spoof it here either.
-    metadata.ls_integration = "openai-agents-sdk";
+    // Honor null opt-out from trace.metadata (mirror of onTraceStart).
+    if (metadata.ls_agent_type === null) {
+      delete metadata.ls_agent_type;
+    }
 
     try {
       // Update run with final inputs/outputs

--- a/js/src/wrappers/openai_agents.ts
+++ b/js/src/wrappers/openai_agents.ts
@@ -587,7 +587,8 @@ export class OpenAIAgentsTracingProcessor implements TracingProcessor {
       runName = "Agent workflow";
     }
 
-    // Build metadata; trace.metadata wins over processor defaults, ls_integration force-set.
+    // Merge three sources: processor defaults, trace.metadata (user's per-run
+    // ls_agent_type), and force-set ls_integration.
     const mergedMetadata: Record<string, unknown> = {
       ...this._metadata,
       ...((trace.metadata as Record<string, unknown> | undefined) ?? {}),

--- a/js/src/wrappers/openai_agents.ts
+++ b/js/src/wrappers/openai_agents.ts
@@ -667,7 +667,7 @@ export class OpenAIAgentsTracingProcessor implements TracingProcessor {
     this._runs.delete(trace.traceId);
 
     const traceDict = (trace.toJSON() as Record<string, unknown>) ?? {};
-    // trace.metadata wins over processor defaults (matches onTraceStart).
+    // trace.metadata may have new keys since onTraceStart; pull them in.
     const metadata: Record<string, unknown> = {
       ...this._metadata,
       ...(traceDict.metadata as Record<string, unknown>),

--- a/js/src/wrappers/openai_agents.ts
+++ b/js/src/wrappers/openai_agents.ts
@@ -583,14 +583,18 @@ export class OpenAIAgentsTracingProcessor implements TracingProcessor {
       runName = "Agent workflow";
     }
 
-    // Build metadata
-    const runExtra: Record<string, unknown> = {
-      metadata: {
-        ...this._metadata,
-        ls_integration: "openai-agents-sdk",
-        ls_agent_type: "root",
-      },
+    // Build metadata. User-supplied trace.metadata (e.g. Runner's
+    // traceMetadata) is honored for ls_agent_type; SDK identity
+    // (ls_integration) is force-set as ground truth.
+    const mergedMetadata: Record<string, unknown> = {
+      ...this._metadata,
+      ...((trace.metadata as Record<string, unknown> | undefined) ?? {}),
+      ls_integration: "openai-agents-sdk",
     };
+    if (!("ls_agent_type" in mergedMetadata)) {
+      mergedMetadata.ls_agent_type = "root";
+    }
+    const runExtra: Record<string, unknown> = { metadata: mergedMetadata };
 
     const traceDict = (trace.toJSON() as Record<string, unknown>) ?? {};
     const groupId =
@@ -659,10 +663,13 @@ export class OpenAIAgentsTracingProcessor implements TracingProcessor {
     this._runs.delete(trace.traceId);
 
     const traceDict = (trace.toJSON() as Record<string, unknown>) ?? {};
-    const metadata = {
+    const metadata: Record<string, unknown> = {
       ...(traceDict.metadata as Record<string, unknown>),
       ...this._metadata,
     };
+    // SDK identity fields are force-set; user's trace.metadata cannot spoof
+    // them via this later-lifecycle write site either.
+    metadata.ls_integration = "openai-agents-sdk";
 
     try {
       // Update run with final inputs/outputs
@@ -772,10 +779,14 @@ export class OpenAIAgentsTracingProcessor implements TracingProcessor {
         if (!childRun.extra.metadata) {
           childRun.extra.metadata = {};
         }
-        childRun.extra.metadata = {
-          ...childRun.extra.metadata,
-          ls_agent_type: "subagent",
-        };
+        const meta = childRun.extra.metadata as Record<string, unknown>;
+        // Preserve user narrowing intent (middleware / compaction); otherwise
+        // apply structural subagent detection. Still overrides an inherited
+        // "root" or missing tag with "subagent".
+        const current = meta.ls_agent_type;
+        if (current !== "middleware" && current !== "compaction") {
+          meta.ls_agent_type = "subagent";
+        }
       }
     }
 

--- a/js/src/wrappers/openai_agents.ts
+++ b/js/src/wrappers/openai_agents.ts
@@ -12,7 +12,10 @@ import {
   AsyncLocalStorageProviderSingleton,
   getCurrentRunTree,
 } from "../singletons/traceable.js";
-import { defaultLsAgentTypeMetadata } from "../utils/ls_agent_type.js";
+import {
+  NON_ROOT_LS_AGENT_TYPES,
+  defaultLsAgentTypeMetadata,
+} from "../utils/ls_agent_type.js";
 import type { ContextPlaceholder } from "../singletons/types.js";
 import type {
   AgentSpanData,
@@ -778,9 +781,7 @@ export class OpenAIAgentsTracingProcessor implements TracingProcessor {
           childRun.extra.metadata = {};
         }
         const meta = childRun.extra.metadata as Record<string, unknown>;
-        // Preserve user middleware/compaction; else apply subagent detection.
-        const current = meta.ls_agent_type;
-        if (current !== "middleware" && current !== "compaction") {
+        if (!NON_ROOT_LS_AGENT_TYPES.has(meta.ls_agent_type as string)) {
           meta.ls_agent_type = "subagent";
         }
       }

--- a/js/src/wrappers/openai_agents.ts
+++ b/js/src/wrappers/openai_agents.ts
@@ -583,9 +583,7 @@ export class OpenAIAgentsTracingProcessor implements TracingProcessor {
       runName = "Agent workflow";
     }
 
-    // Build metadata. User-supplied trace.metadata (e.g. Runner's
-    // traceMetadata) is honored for ls_agent_type; SDK identity
-    // (ls_integration) is force-set as ground truth.
+    // Build metadata; honor user trace.metadata but force-set SDK identity.
     const mergedMetadata: Record<string, unknown> = {
       ...this._metadata,
       ...((trace.metadata as Record<string, unknown> | undefined) ?? {}),
@@ -667,8 +665,7 @@ export class OpenAIAgentsTracingProcessor implements TracingProcessor {
       ...(traceDict.metadata as Record<string, unknown>),
       ...this._metadata,
     };
-    // SDK identity fields are force-set; user's trace.metadata cannot spoof
-    // them via this later-lifecycle write site either.
+    // Force-set SDK identity; user trace.metadata cannot spoof it here either.
     metadata.ls_integration = "openai-agents-sdk";
 
     try {
@@ -780,9 +777,7 @@ export class OpenAIAgentsTracingProcessor implements TracingProcessor {
           childRun.extra.metadata = {};
         }
         const meta = childRun.extra.metadata as Record<string, unknown>;
-        // Preserve user narrowing intent (middleware / compaction); otherwise
-        // apply structural subagent detection. Still overrides an inherited
-        // "root" or missing tag with "subagent".
+        // Preserve user middleware/compaction; else apply subagent detection.
         const current = meta.ls_agent_type;
         if (current !== "middleware" && current !== "compaction") {
           meta.ls_agent_type = "subagent";

--- a/python/langsmith/_internal/_ls_agent_type.py
+++ b/python/langsmith/_internal/_ls_agent_type.py
@@ -14,6 +14,11 @@ if TYPE_CHECKING:
 
 LsAgentType = Literal["root", "middleware", "subagent", "compaction"]
 
+# Non-root tags: preserved against default/structural stamping.
+NON_ROOT_LS_AGENT_TYPES: frozenset[str] = frozenset(
+    {"middleware", "subagent", "compaction"}
+)
+
 
 def resolve_default_ls_agent_type(
     parent_runtree: Optional[RunTree],

--- a/python/langsmith/integrations/openai_agents_sdk/_openai_agents.py
+++ b/python/langsmith/integrations/openai_agents_sdk/_openai_agents.py
@@ -5,7 +5,10 @@ from typing import Optional
 
 from langsmith import run_trees as rt
 from langsmith._internal import _context
-from langsmith._internal._ls_agent_type import apply_default_ls_agent_type
+from langsmith._internal._ls_agent_type import (
+    NON_ROOT_LS_AGENT_TYPES,
+    apply_default_ls_agent_type,
+)
 from langsmith._internal._package_version import get_package_version
 from langsmith.run_helpers import get_current_run_tree
 
@@ -330,14 +333,9 @@ if HAVE_AGENTS:
                         else None
                     )
                     if parent_span_data_type is tracing.FunctionSpanData:
-                        if "metadata" not in child_run.extra:
-                            child_run.extra["metadata"] = {}
-                        # Preserve user middleware/compaction; else stamp subagent.
-                        if child_run.extra["metadata"].get("ls_agent_type") not in (
-                            "middleware",
-                            "compaction",
-                        ):
-                            child_run.extra["metadata"]["ls_agent_type"] = "subagent"
+                        metadata = child_run.extra.setdefault("metadata", {})
+                        if metadata.get("ls_agent_type") not in NON_ROOT_LS_AGENT_TYPES:
+                            metadata["ls_agent_type"] = "subagent"
 
                 # Track span data type for parent lookups
                 self._span_data_types[span.span_id] = type(span.span_data)

--- a/python/langsmith/integrations/openai_agents_sdk/_openai_agents.py
+++ b/python/langsmith/integrations/openai_agents_sdk/_openai_agents.py
@@ -187,16 +187,14 @@ if HAVE_AGENTS:
             else:
                 run_name = "Agent workflow"
 
-            # Build metadata; honor user trace.metadata but force-set SDK identity.
+            # trace.metadata wins over processor defaults; ls_integration force-set.
             merged_metadata = {
                 **(self._metadata or {}),
                 **(getattr(trace, "metadata", None) or {}),
                 "ls_integration": "openai-agents-sdk",
                 "ls_integration_version": get_package_version("openai-agents"),
             }
-            # Default root only at true trace root; nested traces inherit via
-            # create_child. User-supplied None flows through unchanged so it
-            # overrides create_child's inherited parent tag on the child run.
+            # Default root only at trace root; nested traces inherit via create_child.
             if "ls_agent_type" not in merged_metadata and current_run_tree is None:
                 merged_metadata["ls_agent_type"] = "root"
             run_extra = {"metadata": merged_metadata}
@@ -243,8 +241,7 @@ if HAVE_AGENTS:
                 return
 
             trace_dict = trace.export() or {}
-            # Match on_trace_start precedence: per-invocation trace.metadata
-            # wins over processor-level defaults.
+            # trace.metadata wins over processor defaults (matches on_trace_start).
             metadata = {
                 **(self._metadata or {}),
                 **(trace_dict.get("metadata") or {}),

--- a/python/langsmith/integrations/openai_agents_sdk/_openai_agents.py
+++ b/python/langsmith/integrations/openai_agents_sdk/_openai_agents.py
@@ -244,7 +244,7 @@ if HAVE_AGENTS:
                 return
 
             trace_dict = trace.export() or {}
-            # trace.metadata wins over processor defaults (matches on_trace_start).
+            # trace.metadata may have new keys since trace-start; pull them in.
             metadata = {
                 **(self._metadata or {}),
                 **(trace_dict.get("metadata") or {}),

--- a/python/langsmith/integrations/openai_agents_sdk/_openai_agents.py
+++ b/python/langsmith/integrations/openai_agents_sdk/_openai_agents.py
@@ -187,9 +187,7 @@ if HAVE_AGENTS:
             else:
                 run_name = "Agent workflow"
 
-            # Build metadata. User-supplied trace.metadata (e.g. from
-            # RunConfig.trace_metadata) is honored for ls_agent_type; SDK
-            # identity fields (ls_integration*) are force-set as ground truth.
+            # Build metadata; honor user trace.metadata but force-set SDK identity.
             merged_metadata = {
                 **(self._metadata or {}),
                 **(getattr(trace, "metadata", None) or {}),
@@ -242,8 +240,7 @@ if HAVE_AGENTS:
 
             trace_dict = trace.export() or {}
             metadata = {**(trace_dict.get("metadata") or {}), **(self._metadata or {})}
-            # SDK identity fields are force-set; user's trace.metadata cannot
-            # spoof them via this later-lifecycle write site either.
+            # Force-set SDK identity; user trace.metadata cannot spoof it here either.
             metadata["ls_integration"] = "openai-agents-sdk"
 
             try:
@@ -332,9 +329,7 @@ if HAVE_AGENTS:
                     if parent_span_data_type is tracing.FunctionSpanData:
                         if "metadata" not in child_run.extra:
                             child_run.extra["metadata"] = {}
-                        # Preserve user narrowing intent (middleware / compaction);
-                        # otherwise apply structural subagent detection. This still
-                        # overrides an inherited "root" or missing tag with "subagent".
+                        # Preserve user middleware/compaction; else stamp subagent.
                         if child_run.extra["metadata"].get("ls_agent_type") not in (
                             "middleware",
                             "compaction",

--- a/python/langsmith/integrations/openai_agents_sdk/_openai_agents.py
+++ b/python/langsmith/integrations/openai_agents_sdk/_openai_agents.py
@@ -195,12 +195,10 @@ if HAVE_AGENTS:
                 "ls_integration_version": get_package_version("openai-agents"),
             }
             # Default root only at true trace root; nested traces inherit via
-            # create_child. `None` opt-out removes the key.
-            if "ls_agent_type" not in merged_metadata:
-                if current_run_tree is None:
-                    merged_metadata["ls_agent_type"] = "root"
-            elif merged_metadata["ls_agent_type"] is None:
-                del merged_metadata["ls_agent_type"]
+            # create_child. User-supplied None flows through unchanged so it
+            # overrides create_child's inherited parent tag on the child run.
+            if "ls_agent_type" not in merged_metadata and current_run_tree is None:
+                merged_metadata["ls_agent_type"] = "root"
             run_extra = {"metadata": merged_metadata}
             trace_dict = trace.export() or {}
             if trace_dict.get("group_id") is not None:
@@ -245,10 +243,12 @@ if HAVE_AGENTS:
                 return
 
             trace_dict = trace.export() or {}
-            metadata = {**(trace_dict.get("metadata") or {}), **(self._metadata or {})}
-            # Honor null opt-out from trace.metadata (mirror of on_trace_start).
-            if metadata.get("ls_agent_type") is None and "ls_agent_type" in metadata:
-                del metadata["ls_agent_type"]
+            # Match on_trace_start precedence: per-invocation trace.metadata
+            # wins over processor-level defaults.
+            metadata = {
+                **(self._metadata or {}),
+                **(trace_dict.get("metadata") or {}),
+            }
 
             try:
                 # Update run with final inputs/outputs

--- a/python/langsmith/integrations/openai_agents_sdk/_openai_agents.py
+++ b/python/langsmith/integrations/openai_agents_sdk/_openai_agents.py
@@ -187,15 +187,17 @@ if HAVE_AGENTS:
             else:
                 run_name = "Agent workflow"
 
-            # Build metadata
-            run_extra = {
-                "metadata": {
-                    **(self._metadata or {}),
-                    "ls_integration": "openai-agents-sdk",
-                    "ls_integration_version": get_package_version("openai-agents"),
-                    "ls_agent_type": "root",
-                }
+            # Build metadata. User-supplied trace.metadata (e.g. from
+            # RunConfig.trace_metadata) is honored for ls_agent_type; SDK
+            # identity fields (ls_integration*) are force-set as ground truth.
+            merged_metadata = {
+                **(self._metadata or {}),
+                **(getattr(trace, "metadata", None) or {}),
+                "ls_integration": "openai-agents-sdk",
+                "ls_integration_version": get_package_version("openai-agents"),
             }
+            merged_metadata.setdefault("ls_agent_type", "root")
+            run_extra = {"metadata": merged_metadata}
             trace_dict = trace.export() or {}
             if trace_dict.get("group_id") is not None:
                 run_extra["metadata"]["thread_id"] = trace_dict["group_id"]
@@ -240,6 +242,9 @@ if HAVE_AGENTS:
 
             trace_dict = trace.export() or {}
             metadata = {**(trace_dict.get("metadata") or {}), **(self._metadata or {})}
+            # SDK identity fields are force-set; user's trace.metadata cannot
+            # spoof them via this later-lifecycle write site either.
+            metadata["ls_integration"] = "openai-agents-sdk"
 
             try:
                 # Update run with final inputs/outputs
@@ -327,7 +332,14 @@ if HAVE_AGENTS:
                     if parent_span_data_type is tracing.FunctionSpanData:
                         if "metadata" not in child_run.extra:
                             child_run.extra["metadata"] = {}
-                        child_run.extra["metadata"]["ls_agent_type"] = "subagent"
+                        # Preserve user narrowing intent (middleware / compaction);
+                        # otherwise apply structural subagent detection. This still
+                        # overrides an inherited "root" or missing tag with "subagent".
+                        if child_run.extra["metadata"].get("ls_agent_type") not in (
+                            "middleware",
+                            "compaction",
+                        ):
+                            child_run.extra["metadata"]["ls_agent_type"] = "subagent"
 
                 # Track span data type for parent lookups
                 self._span_data_types[span.span_id] = type(span.span_data)

--- a/python/langsmith/integrations/openai_agents_sdk/_openai_agents.py
+++ b/python/langsmith/integrations/openai_agents_sdk/_openai_agents.py
@@ -194,7 +194,13 @@ if HAVE_AGENTS:
                 "ls_integration": "openai-agents-sdk",
                 "ls_integration_version": get_package_version("openai-agents"),
             }
-            merged_metadata.setdefault("ls_agent_type", "root")
+            # Default root only at true trace root; nested traces inherit via
+            # create_child. `None` opt-out removes the key.
+            if "ls_agent_type" not in merged_metadata:
+                if current_run_tree is None:
+                    merged_metadata["ls_agent_type"] = "root"
+            elif merged_metadata["ls_agent_type"] is None:
+                del merged_metadata["ls_agent_type"]
             run_extra = {"metadata": merged_metadata}
             trace_dict = trace.export() or {}
             if trace_dict.get("group_id") is not None:
@@ -240,8 +246,9 @@ if HAVE_AGENTS:
 
             trace_dict = trace.export() or {}
             metadata = {**(trace_dict.get("metadata") or {}), **(self._metadata or {})}
-            # Force-set SDK identity; user trace.metadata cannot spoof it here either.
-            metadata["ls_integration"] = "openai-agents-sdk"
+            # Honor null opt-out from trace.metadata (mirror of on_trace_start).
+            if metadata.get("ls_agent_type") is None and "ls_agent_type" in metadata:
+                del metadata["ls_agent_type"]
 
             try:
                 # Update run with final inputs/outputs

--- a/python/langsmith/integrations/openai_agents_sdk/_openai_agents.py
+++ b/python/langsmith/integrations/openai_agents_sdk/_openai_agents.py
@@ -191,7 +191,8 @@ if HAVE_AGENTS:
             else:
                 run_name = "Agent workflow"
 
-            # trace.metadata wins over processor defaults; ls_integration force-set.
+            # Merge three sources: processor defaults, trace.metadata (user's
+            # per-run ls_agent_type), and force-set ls_integration.
             merged_metadata = {
                 **(self._metadata or {}),
                 **(getattr(trace, "metadata", None) or {}),

--- a/python/langsmith/integrations/openai_agents_sdk/_openai_agents.py
+++ b/python/langsmith/integrations/openai_agents_sdk/_openai_agents.py
@@ -5,6 +5,7 @@ from typing import Optional
 
 from langsmith import run_trees as rt
 from langsmith._internal import _context
+from langsmith._internal._ls_agent_type import apply_default_ls_agent_type
 from langsmith._internal._package_version import get_package_version
 from langsmith.run_helpers import get_current_run_tree
 
@@ -194,9 +195,7 @@ if HAVE_AGENTS:
                 "ls_integration": "openai-agents-sdk",
                 "ls_integration_version": get_package_version("openai-agents"),
             }
-            # Default root only at trace root; nested traces inherit via create_child.
-            if "ls_agent_type" not in merged_metadata and current_run_tree is None:
-                merged_metadata["ls_agent_type"] = "root"
+            apply_default_ls_agent_type(merged_metadata, current_run_tree)
             run_extra = {"metadata": merged_metadata}
             trace_dict = trace.export() or {}
             if trace_dict.get("group_id") is not None:

--- a/python/tests/unit_tests/test_ls_agent_type.py
+++ b/python/tests/unit_tests/test_ls_agent_type.py
@@ -3,9 +3,16 @@
 from types import SimpleNamespace
 
 from langsmith._internal._ls_agent_type import (
+    NON_ROOT_LS_AGENT_TYPES,
     apply_default_ls_agent_type,
     resolve_default_ls_agent_type,
 )
+
+
+def test_non_root_ls_agent_types_shape():
+    assert NON_ROOT_LS_AGENT_TYPES == frozenset(
+        {"middleware", "subagent", "compaction"}
+    )
 
 
 def test_resolves_root_when_no_parent_runtree():

--- a/python/tests/unit_tests/wrappers/test_openai_agents_processor.py
+++ b/python/tests/unit_tests/wrappers/test_openai_agents_processor.py
@@ -1,0 +1,189 @@
+"""Unit tests for OpenAIAgentsTracingProcessor metadata stamping.
+
+Covers LSO-3608: user-supplied ls_agent_type via RunConfig.trace_metadata must
+be preserved through on_trace_start and subagent stamping (check-then-set).
+"""
+
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+
+pytest.importorskip("agents")
+
+from agents import tracing  # noqa: E402
+
+from langsmith import Client  # noqa: E402
+from langsmith.integrations.openai_agents_sdk import (  # noqa: E402
+    OpenAIAgentsTracingProcessor,
+)
+
+
+def _fake_trace(metadata=None, name="workflow", trace_id="trace-1"):
+    trace = SimpleNamespace(
+        name=name,
+        trace_id=trace_id,
+        metadata=metadata,
+        export=lambda: {},
+    )
+    return trace
+
+
+def _capture_run_extra(processor):
+    """Run on_trace_start against a fake trace and return the resulting extra."""
+    captured = {}
+
+    def fake_create_child(**kwargs):
+        captured.update(kwargs)
+        run = mock.MagicMock()
+        run.id = "run-id"
+        return run
+
+    with mock.patch(
+        "langsmith.integrations.openai_agents_sdk._openai_agents.get_current_run_tree",
+        return_value=SimpleNamespace(create_child=fake_create_child),
+    ):
+        return captured
+
+
+def _run_trace_start(trace_metadata, processor_metadata=None):
+    client = mock.MagicMock(spec=Client)
+    processor = OpenAIAgentsTracingProcessor(
+        client=client, metadata=processor_metadata
+    )
+    trace = _fake_trace(metadata=trace_metadata)
+
+    fake_parent = mock.MagicMock()
+    fake_parent.create_child.return_value = mock.MagicMock()
+    with mock.patch(
+        "langsmith.integrations.openai_agents_sdk._openai_agents.get_current_run_tree",
+        return_value=fake_parent,
+    ):
+        processor.on_trace_start(trace)
+
+    call = fake_parent.create_child.call_args
+    return call.kwargs["extra"]["metadata"]
+
+
+def test_on_trace_start_defaults_to_root_when_no_user_tag():
+    meta = _run_trace_start(trace_metadata=None)
+    assert meta["ls_agent_type"] == "root"
+    assert meta["ls_integration"] == "openai-agents-sdk"
+
+
+@pytest.mark.parametrize(
+    "user_tag", ["middleware", "subagent", "compaction", "root"]
+)
+def test_on_trace_start_preserves_user_supplied_ls_agent_type(user_tag):
+    meta = _run_trace_start(trace_metadata={"ls_agent_type": user_tag})
+    assert meta["ls_agent_type"] == user_tag
+
+
+def test_on_trace_start_force_sets_ls_integration_even_if_user_overrides():
+    meta = _run_trace_start(
+        trace_metadata={"ls_integration": "user-override", "ls_agent_type": "middleware"}
+    )
+    assert meta["ls_integration"] == "openai-agents-sdk"
+    assert meta["ls_agent_type"] == "middleware"
+
+
+def test_on_trace_start_preserves_other_user_trace_metadata():
+    meta = _run_trace_start(
+        trace_metadata={"middleware_name": "entry_guardrail", "phase": "entry"}
+    )
+    assert meta["middleware_name"] == "entry_guardrail"
+    assert meta["phase"] == "entry"
+    assert meta["ls_agent_type"] == "root"
+
+
+def test_on_trace_start_processor_metadata_still_applied():
+    meta = _run_trace_start(
+        trace_metadata=None, processor_metadata={"env": "test"}
+    )
+    assert meta["env"] == "test"
+    assert meta["ls_agent_type"] == "root"
+
+
+def test_on_trace_start_trace_metadata_wins_over_processor_metadata():
+    meta = _run_trace_start(
+        trace_metadata={"env": "prod"},
+        processor_metadata={"env": "test"},
+    )
+    assert meta["env"] == "prod"
+
+
+def _run_subagent_stamp(existing_tag):
+    """Fire the subagent-detection path with a pre-existing tag on child_run."""
+    client = mock.MagicMock(spec=Client)
+    processor = OpenAIAgentsTracingProcessor(client=client)
+
+    parent_span_id = "parent-fn"
+    child_span_id = "child-agent"
+    processor._span_data_types[parent_span_id] = tracing.FunctionSpanData
+
+    parent_run = mock.MagicMock()
+    parent_run.id = "parent-run"
+    processor._runs[parent_span_id] = parent_run
+
+    child_run = mock.MagicMock()
+    initial_meta = (
+        {"ls_agent_type": existing_tag} if existing_tag is not None else {}
+    )
+    child_run.extra = {"metadata": initial_meta}
+    parent_run.create_child.return_value = child_run
+
+    child_span = SimpleNamespace(
+        span_id=child_span_id,
+        parent_id=parent_span_id,
+        trace_id="trace-1",
+        started_at=None,
+        span_data=mock.MagicMock(spec=tracing.AgentSpanData),
+    )
+    child_span.span_data.export = mock.MagicMock(return_value={})
+    child_span.span_data.name = "Some Subagent"
+
+    processor.on_span_start(child_span)
+    return child_run.extra["metadata"]["ls_agent_type"]
+
+
+@pytest.mark.parametrize("existing_tag", ["middleware", "compaction"])
+def test_subagent_stamp_preserves_user_narrowing_tags(existing_tag):
+    """User-supplied middleware/compaction beats structural subagent detection."""
+    assert _run_subagent_stamp(existing_tag) == existing_tag
+
+
+@pytest.mark.parametrize("existing_tag", [None, "root", "subagent"])
+def test_subagent_stamp_applies_structural_detection(existing_tag):
+    """Missing tag, inherited root, or already-subagent all resolve to subagent."""
+    assert _run_subagent_stamp(existing_tag) == "subagent"
+
+
+def _run_trace_end(trace_metadata):
+    """Fire on_trace_end with the given trace.metadata and return run's final metadata."""
+    client = mock.MagicMock(spec=Client)
+    processor = OpenAIAgentsTracingProcessor(client=client)
+
+    run = mock.MagicMock()
+    run.extra = {"metadata": {}}
+    processor._runs["trace-1"] = run
+    processor._last_response_outputs["trace-1"] = {}
+
+    trace = SimpleNamespace(
+        trace_id="trace-1",
+        name="Agent workflow",
+        metadata=trace_metadata,
+        export=lambda: {"metadata": trace_metadata} if trace_metadata else {},
+    )
+    processor.on_trace_end(trace)
+    return run.extra["metadata"]
+
+
+def test_on_trace_end_force_sets_ls_integration():
+    meta = _run_trace_end({"ls_integration": "user-override"})
+    assert meta["ls_integration"] == "openai-agents-sdk"
+
+
+def test_on_trace_end_preserves_other_user_metadata():
+    meta = _run_trace_end({"middleware_name": "exit_guardrail"})
+    assert meta["middleware_name"] == "exit_guardrail"
+    assert meta["ls_integration"] == "openai-agents-sdk"

--- a/python/tests/unit_tests/wrappers/test_openai_agents_processor.py
+++ b/python/tests/unit_tests/wrappers/test_openai_agents_processor.py
@@ -16,93 +16,94 @@ from langsmith.integrations.openai_agents_sdk import (  # noqa: E402
 
 
 def _fake_trace(metadata=None, name="workflow", trace_id="trace-1"):
-    trace = SimpleNamespace(
+    return SimpleNamespace(
         name=name,
         trace_id=trace_id,
         metadata=metadata,
         export=lambda: {},
     )
-    return trace
 
 
-def _capture_run_extra(processor):
-    """Run on_trace_start against a fake trace and return the resulting extra."""
-    captured = {}
+def _run_trace_start(trace_metadata, processor_metadata=None, has_parent_runtree=True):
+    """Fire on_trace_start and return the resulting run_extra.metadata.
 
-    def fake_create_child(**kwargs):
-        captured.update(kwargs)
-        run = mock.MagicMock()
-        run.id = "run-id"
-        return run
-
-    with mock.patch(
-        "langsmith.integrations.openai_agents_sdk._openai_agents.get_current_run_tree",
-        return_value=SimpleNamespace(create_child=fake_create_child),
-    ):
-        return captured
-
-
-def _run_trace_start(trace_metadata, processor_metadata=None):
+    ``has_parent_runtree`` controls whether get_current_run_tree returns a
+    parent (nested) or None (true trace root).
+    """
     client = mock.MagicMock(spec=Client)
     processor = OpenAIAgentsTracingProcessor(client=client, metadata=processor_metadata)
     trace = _fake_trace(metadata=trace_metadata)
 
-    fake_parent = mock.MagicMock()
-    fake_parent.create_child.return_value = mock.MagicMock()
+    if has_parent_runtree:
+        fake_parent = mock.MagicMock()
+        fake_parent.create_child.return_value = mock.MagicMock()
+        parent_return = fake_parent
+    else:
+        parent_return = None
+
     with mock.patch(
         "langsmith.integrations.openai_agents_sdk._openai_agents.get_current_run_tree",
-        return_value=fake_parent,
+        return_value=parent_return,
     ):
         processor.on_trace_start(trace)
 
-    call = fake_parent.create_child.call_args
-    return call.kwargs["extra"]["metadata"]
+    if has_parent_runtree:
+        call = parent_return.create_child.call_args
+        return call.kwargs["extra"]["metadata"]
+
+    # No parent: on_trace_start creates a new RunTree directly. Grab it from
+    # the processor's stored runs mapping.
+    stored = next(iter(processor._runs.values()))
+    return stored.extra["metadata"]
 
 
-def test_on_trace_start_defaults_to_root_when_no_user_tag():
-    meta = _run_trace_start(trace_metadata=None)
+# ---------------------------------------------------------------------------
+# on_trace_start
+# ---------------------------------------------------------------------------
+
+
+def test_stamps_default_root_when_no_parent_runtree():
+    meta = _run_trace_start(trace_metadata=None, has_parent_runtree=False)
     assert meta["ls_agent_type"] == "root"
-    assert meta["ls_integration"] == "openai-agents-sdk"
 
 
-@pytest.mark.parametrize("user_tag", ["middleware", "subagent", "compaction", "root"])
-def test_on_trace_start_preserves_user_supplied_ls_agent_type(user_tag):
+def test_no_default_stamp_when_nested_under_parent_runtree():
+    meta = _run_trace_start(trace_metadata=None, has_parent_runtree=True)
+    assert "ls_agent_type" not in meta
+
+
+@pytest.mark.parametrize("user_tag", ["root", "middleware", "subagent", "compaction"])
+def test_preserves_user_supplied_ls_agent_type(user_tag):
+    """Any user-supplied tag via trace.metadata is preserved (any known value)."""
     meta = _run_trace_start(trace_metadata={"ls_agent_type": user_tag})
     assert meta["ls_agent_type"] == user_tag
 
 
-def test_on_trace_start_force_sets_ls_integration_even_if_user_overrides():
-    meta = _run_trace_start(
-        trace_metadata={
-            "ls_integration": "user-override",
-            "ls_agent_type": "middleware",
-        }
-    )
-    assert meta["ls_integration"] == "openai-agents-sdk"
-    assert meta["ls_agent_type"] == "middleware"
+def test_none_opt_out_at_trace_start_deletes_key():
+    meta = _run_trace_start(trace_metadata={"ls_agent_type": None})
+    assert "ls_agent_type" not in meta
 
 
-def test_on_trace_start_preserves_other_user_trace_metadata():
+def test_preserves_other_user_trace_metadata():
     meta = _run_trace_start(
         trace_metadata={"middleware_name": "entry_guardrail", "phase": "entry"}
     )
     assert meta["middleware_name"] == "entry_guardrail"
     assert meta["phase"] == "entry"
-    assert meta["ls_agent_type"] == "root"
 
 
-def test_on_trace_start_processor_metadata_still_applied():
-    meta = _run_trace_start(trace_metadata=None, processor_metadata={"env": "test"})
-    assert meta["env"] == "test"
-    assert meta["ls_agent_type"] == "root"
-
-
-def test_on_trace_start_trace_metadata_wins_over_processor_metadata():
+def test_trace_metadata_wins_over_processor_metadata():
+    """Per-invocation trace.metadata overrides processor-level defaults."""
     meta = _run_trace_start(
         trace_metadata={"env": "prod"},
         processor_metadata={"env": "test"},
     )
     assert meta["env"] == "prod"
+
+
+# ---------------------------------------------------------------------------
+# Subagent structural detection (agent-as-tool)
+# ---------------------------------------------------------------------------
 
 
 def _run_subagent_stamp(existing_tag):
@@ -134,47 +135,29 @@ def _run_subagent_stamp(existing_tag):
     child_span.span_data.name = "Some Subagent"
 
     processor.on_span_start(child_span)
-    return child_run.extra["metadata"]["ls_agent_type"]
+    return child_run.extra["metadata"].get("ls_agent_type")
 
 
-@pytest.mark.parametrize("existing_tag", ["middleware", "compaction"])
-def test_subagent_stamp_preserves_user_narrowing_tags(existing_tag):
-    """User-supplied middleware/compaction beats structural subagent detection."""
-    assert _run_subagent_stamp(existing_tag) == existing_tag
+def test_subagent_stamps_when_child_untagged():
+    """Untagged child: structural detection stamps subagent."""
+    assert _run_subagent_stamp(None) == "subagent"
 
 
-@pytest.mark.parametrize("existing_tag", [None, "root", "subagent"])
-def test_subagent_stamp_applies_structural_detection(existing_tag):
-    """Missing tag, inherited root, or already-subagent all resolve to subagent."""
-    assert _run_subagent_stamp(existing_tag) == "subagent"
+def test_subagent_overrides_inherited_root():
+    """Documented trade: default/user root at trace propagates to child, then
+    structural detection overrides it to subagent at agent-as-tool spans. We
+    can't distinguish user-set root from default-stamped root at this write
+    site, so we allow structural detection to fire.
+    """
+    assert _run_subagent_stamp("root") == "subagent"
 
 
-def _run_trace_end(trace_metadata):
-    """Fire on_trace_end and return the run's final metadata."""
-    client = mock.MagicMock(spec=Client)
-    processor = OpenAIAgentsTracingProcessor(client=client)
-
-    run = mock.MagicMock()
-    run.extra = {"metadata": {}}
-    processor._runs["trace-1"] = run
-    processor._last_response_outputs["trace-1"] = {}
-
-    trace = SimpleNamespace(
-        trace_id="trace-1",
-        name="Agent workflow",
-        metadata=trace_metadata,
-        export=lambda: {"metadata": trace_metadata} if trace_metadata else {},
-    )
-    processor.on_trace_end(trace)
-    return run.extra["metadata"]
+@pytest.mark.parametrize("narrowing_tag", ["middleware", "compaction"])
+def test_subagent_preserves_user_narrowing_tag(narrowing_tag):
+    """User narrowing intent (middleware/compaction) beats structural detection."""
+    assert _run_subagent_stamp(narrowing_tag) == narrowing_tag
 
 
-def test_on_trace_end_force_sets_ls_integration():
-    meta = _run_trace_end({"ls_integration": "user-override"})
-    assert meta["ls_integration"] == "openai-agents-sdk"
-
-
-def test_on_trace_end_preserves_other_user_metadata():
-    meta = _run_trace_end({"middleware_name": "exit_guardrail"})
-    assert meta["middleware_name"] == "exit_guardrail"
-    assert meta["ls_integration"] == "openai-agents-sdk"
+def test_subagent_preserves_existing_subagent_tag():
+    """Already-subagent is a no-op (idempotent)."""
+    assert _run_subagent_stamp("subagent") == "subagent"

--- a/python/tests/unit_tests/wrappers/test_openai_agents_processor.py
+++ b/python/tests/unit_tests/wrappers/test_openai_agents_processor.py
@@ -25,11 +25,7 @@ def _fake_trace(metadata=None, name="workflow", trace_id="trace-1"):
 
 
 def _run_trace_start(trace_metadata, processor_metadata=None, has_parent_runtree=True):
-    """Fire on_trace_start and return the resulting run_extra.metadata.
-
-    ``has_parent_runtree`` controls whether get_current_run_tree returns a
-    parent (nested) or None (true trace root).
-    """
+    """Fire on_trace_start and return the resulting run_extra.metadata."""
     client = mock.MagicMock(spec=Client)
     processor = OpenAIAgentsTracingProcessor(client=client, metadata=processor_metadata)
     trace = _fake_trace(metadata=trace_metadata)
@@ -50,9 +46,6 @@ def _run_trace_start(trace_metadata, processor_metadata=None, has_parent_runtree
     if has_parent_runtree:
         call = parent_return.create_child.call_args
         return call.kwargs["extra"]["metadata"]
-
-    # No parent: on_trace_start creates a new RunTree directly. Grab it from
-    # the processor's stored runs mapping.
     stored = next(iter(processor._runs.values()))
     return stored.extra["metadata"]
 
@@ -74,23 +67,16 @@ def test_no_default_stamp_when_nested_under_parent_runtree():
 
 @pytest.mark.parametrize("user_tag", ["root", "middleware", "subagent", "compaction"])
 def test_preserves_user_supplied_ls_agent_type(user_tag):
-    """Any user-supplied tag via trace.metadata is preserved (any known value)."""
     meta = _run_trace_start(trace_metadata={"ls_agent_type": user_tag})
     assert meta["ls_agent_type"] == user_tag
 
 
 def test_none_opt_out_at_trace_start_preserves_null():
-    """None passes through unchanged; the null value overrides create_child's
-    inherited parent tag on the resulting child run.
-    """
     meta = _run_trace_start(trace_metadata={"ls_agent_type": None})
     assert meta["ls_agent_type"] is None
 
 
 def test_trace_end_matches_trace_start_precedence():
-    """trace.metadata wins over processor metadata at both trace-start and
-    trace-end (previously reversed at trace-end).
-    """
     from unittest import mock as _mock
 
     from langsmith import Client
@@ -126,7 +112,6 @@ def test_preserves_other_user_trace_metadata():
 
 
 def test_trace_metadata_wins_over_processor_metadata():
-    """Per-invocation trace.metadata overrides processor-level defaults."""
     meta = _run_trace_start(
         trace_metadata={"env": "prod"},
         processor_metadata={"env": "test"},
@@ -140,7 +125,6 @@ def test_trace_metadata_wins_over_processor_metadata():
 
 
 def _run_subagent_stamp(existing_tag):
-    """Fire the subagent-detection path with a pre-existing tag on child_run."""
     client = mock.MagicMock(spec=Client)
     processor = OpenAIAgentsTracingProcessor(client=client)
 
@@ -172,25 +156,18 @@ def _run_subagent_stamp(existing_tag):
 
 
 def test_subagent_stamps_when_child_untagged():
-    """Untagged child: structural detection stamps subagent."""
     assert _run_subagent_stamp(None) == "subagent"
 
 
 def test_subagent_overrides_inherited_root():
-    """Documented trade: default/user root at trace propagates to child, then
-    structural detection overrides it to subagent at agent-as-tool spans. We
-    can't distinguish user-set root from default-stamped root at this write
-    site, so we allow structural detection to fire.
-    """
+    # Structural detection overrides propagated root at agent-as-tool spans.
     assert _run_subagent_stamp("root") == "subagent"
 
 
 @pytest.mark.parametrize("narrowing_tag", ["middleware", "compaction"])
 def test_subagent_preserves_user_narrowing_tag(narrowing_tag):
-    """User narrowing intent (middleware/compaction) beats structural detection."""
     assert _run_subagent_stamp(narrowing_tag) == narrowing_tag
 
 
 def test_subagent_preserves_existing_subagent_tag():
-    """Already-subagent is a no-op (idempotent)."""
     assert _run_subagent_stamp("subagent") == "subagent"

--- a/python/tests/unit_tests/wrappers/test_openai_agents_processor.py
+++ b/python/tests/unit_tests/wrappers/test_openai_agents_processor.py
@@ -1,8 +1,4 @@
-"""Unit tests for OpenAIAgentsTracingProcessor metadata stamping.
-
-Covers LSO-3608: user-supplied ls_agent_type via RunConfig.trace_metadata must
-be preserved through on_trace_start and subagent stamping (check-then-set).
-"""
+"""Unit tests for OpenAIAgentsTracingProcessor metadata stamping."""
 
 from types import SimpleNamespace
 from unittest import mock
@@ -48,9 +44,7 @@ def _capture_run_extra(processor):
 
 def _run_trace_start(trace_metadata, processor_metadata=None):
     client = mock.MagicMock(spec=Client)
-    processor = OpenAIAgentsTracingProcessor(
-        client=client, metadata=processor_metadata
-    )
+    processor = OpenAIAgentsTracingProcessor(client=client, metadata=processor_metadata)
     trace = _fake_trace(metadata=trace_metadata)
 
     fake_parent = mock.MagicMock()
@@ -71,9 +65,7 @@ def test_on_trace_start_defaults_to_root_when_no_user_tag():
     assert meta["ls_integration"] == "openai-agents-sdk"
 
 
-@pytest.mark.parametrize(
-    "user_tag", ["middleware", "subagent", "compaction", "root"]
-)
+@pytest.mark.parametrize("user_tag", ["middleware", "subagent", "compaction", "root"])
 def test_on_trace_start_preserves_user_supplied_ls_agent_type(user_tag):
     meta = _run_trace_start(trace_metadata={"ls_agent_type": user_tag})
     assert meta["ls_agent_type"] == user_tag
@@ -81,7 +73,10 @@ def test_on_trace_start_preserves_user_supplied_ls_agent_type(user_tag):
 
 def test_on_trace_start_force_sets_ls_integration_even_if_user_overrides():
     meta = _run_trace_start(
-        trace_metadata={"ls_integration": "user-override", "ls_agent_type": "middleware"}
+        trace_metadata={
+            "ls_integration": "user-override",
+            "ls_agent_type": "middleware",
+        }
     )
     assert meta["ls_integration"] == "openai-agents-sdk"
     assert meta["ls_agent_type"] == "middleware"
@@ -97,9 +92,7 @@ def test_on_trace_start_preserves_other_user_trace_metadata():
 
 
 def test_on_trace_start_processor_metadata_still_applied():
-    meta = _run_trace_start(
-        trace_metadata=None, processor_metadata={"env": "test"}
-    )
+    meta = _run_trace_start(trace_metadata=None, processor_metadata={"env": "test"})
     assert meta["env"] == "test"
     assert meta["ls_agent_type"] == "root"
 
@@ -126,9 +119,7 @@ def _run_subagent_stamp(existing_tag):
     processor._runs[parent_span_id] = parent_run
 
     child_run = mock.MagicMock()
-    initial_meta = (
-        {"ls_agent_type": existing_tag} if existing_tag is not None else {}
-    )
+    initial_meta = {"ls_agent_type": existing_tag} if existing_tag is not None else {}
     child_run.extra = {"metadata": initial_meta}
     parent_run.create_child.return_value = child_run
 
@@ -159,7 +150,7 @@ def test_subagent_stamp_applies_structural_detection(existing_tag):
 
 
 def _run_trace_end(trace_metadata):
-    """Fire on_trace_end with the given trace.metadata and return run's final metadata."""
+    """Fire on_trace_end and return the run's final metadata."""
     client = mock.MagicMock(spec=Client)
     processor = OpenAIAgentsTracingProcessor(client=client)
 

--- a/python/tests/unit_tests/wrappers/test_openai_agents_processor.py
+++ b/python/tests/unit_tests/wrappers/test_openai_agents_processor.py
@@ -79,9 +79,42 @@ def test_preserves_user_supplied_ls_agent_type(user_tag):
     assert meta["ls_agent_type"] == user_tag
 
 
-def test_none_opt_out_at_trace_start_deletes_key():
+def test_none_opt_out_at_trace_start_preserves_null():
+    """None passes through unchanged; the null value overrides create_child's
+    inherited parent tag on the resulting child run.
+    """
     meta = _run_trace_start(trace_metadata={"ls_agent_type": None})
-    assert "ls_agent_type" not in meta
+    assert meta["ls_agent_type"] is None
+
+
+def test_trace_end_matches_trace_start_precedence():
+    """trace.metadata wins over processor metadata at both trace-start and
+    trace-end (previously reversed at trace-end).
+    """
+    from unittest import mock as _mock
+
+    from langsmith import Client
+    from langsmith.integrations.openai_agents_sdk import (
+        OpenAIAgentsTracingProcessor,
+    )
+
+    client = _mock.MagicMock(spec=Client)
+    processor = OpenAIAgentsTracingProcessor(
+        client=client, metadata={"ls_agent_type": "root"}
+    )
+    run = _mock.MagicMock()
+    run.extra = {"metadata": {}}
+    processor._runs["trace-1"] = run
+    processor._last_response_outputs["trace-1"] = {}
+
+    trace = SimpleNamespace(
+        trace_id="trace-1",
+        name="Agent workflow",
+        metadata={"ls_agent_type": "middleware"},
+        export=lambda: {"metadata": {"ls_agent_type": "middleware"}},
+    )
+    processor.on_trace_end(trace)
+    assert run.extra["metadata"]["ls_agent_type"] == "middleware"
 
 
 def test_preserves_other_user_trace_metadata():


### PR DESCRIPTION
## What
OpenAI Agents SDK integration had two bugs preventing users from controlling ls_agent_type:

1. `on_trace_start` never read `trace.metadata` — so `RunConfig.trace_metadata` (Py) / `RunConfig.traceMetadata` (JS) was silently dropped.
2. The processor unconditionally stamped `ls_agent_type: "root"` on trace-start and `"subagent"` on the subagent-detection path — so even wrapper-level metadata (`OpenAIAgentsTracingProcessor(metadata=...)`) got overwritten.

## How

Both hook sites in both languages now :
1. Read `trace.metadata`
2. Delegate default-tag resolution to the shared  ls_agent_type util (Py) /(JS) util where key-presence check preserves whatever the user set, including `None`/`null` opt-out, and stamping root if it's a root run that's not been tagged.
3. Use `NON_ROOT_LS_AGENT_TYPES` from the util at the subagent-detection site 

In Py, updated `on_trace_start` and the subagent stamp in `on_span_start` (`_openai_agents.py`).
In JS, updated `onTraceStart` and the subagent stamp in `onSpanStart` (`openai_agents.ts`).

Fixes [LSO-3608](https://linear.app/langchain/issue/LSO-3608).

## Test Plan

- [x] Python unit tests: `python/tests/unit_tests/wrappers/test_openai_agents_processor.py` — trace-start + subagent cases 15/15 pass.
- [x] Python util tests: `python/tests/unit_tests/test_ls_agent_type.py`  7/7 pass.
- [x] JS unit tests: `js/src/tests/openai_agents_sdk.test.ts` — parallels the Python precedence coverage 39/39 pass.
- [x] JS util tests: `js/src/tests/ls_agent_type.test.ts`. 10/10 pass.
- [ ] Post-merge: fixture regen on langchainplus — 6 