### PR TITLE
fix: avoid resetting compression threads

### DIFF
--- a/python/langsmith/_internal/_compressed_traces.py
+++ b/python/langsmith/_internal/_compressed_traces.py
@@ -52,5 +52,5 @@ class CompressedTraces:
         self.uncompressed_size = 0
         self._context = []
         self.compressor_writer = ZstdCompressor(
-            level=compression_level, threads=-1
+            level=compression_level, threads=compression_threads
         ).stream_writer(self.buffer, closefd=False)


### PR DESCRIPTION
## Description

`CompressedTraces` streams trace payloads into a shared zstd compressor. The number of zstd worker threads is configurable via `LANGSMITH_RUN_COMPRESSION_THREADS.`, read once into the module-level `compression_threads` and applied when the compressor is first created in `__init__`.

`reset()` — called after every flush to start a fresh buffer — re-created the `ZstdCompressor` with a hardcoded `threads=-1` instead of the configured value. So the setting only ever took effect for the first batch: after the first flush, every subsequent compressor ignored `LANGSMITH_RUN_COMPRESSION_THREADS` and reverted to `-1` (use all available cores). There was no way to actually pin the thread count for the lifetime of a client.

## Change

`reset()` now creates the compressor with `threads=compression_threads`, mirroring `__init__`, so the configured value is honored on every flush rather than just the first.

This does not change default behavior: with `LANGSMITH_RUN_COMPRESSION_THREADS` unset, `compression_threads` remains `-1`, exactly as before.
