### PR TITLE
fix(profiles): resolve the OAuth token endpoint from deployment metadata

### DIFF
--- a/js/src/tests/client.test.ts
+++ b/js/src/tests/client.test.ts
@@ -515,6 +515,13 @@ describe("Client", () => {
       });
       const mockFetch = jest.fn(
         async (input: RequestInfo | URL, init?: RequestInit) => {
+          // This deployment serves no discovery document, so refresh falls back
+          // to the configured mount point.
+          if (
+            String(input).endsWith("/.well-known/oauth-authorization-server")
+          ) {
+            return new Response("", { status: 404 });
+          }
           if (String(input) === "https://profile.example.com/oauth/token") {
             expect(init?.method).toBe("POST");
             expect(String(init?.body)).toContain("grant_type=refresh_token");
@@ -540,8 +547,16 @@ describe("Client", () => {
         headers: (client as any)._mergedHeaders,
       });
 
-      expect(mockFetch).toHaveBeenCalledTimes(2);
-      const requestInit = mockFetch.mock.calls[1][1] as RequestInit;
+      const tokenCalls = mockFetch.mock.calls.filter(
+        ([input]) =>
+          String(input) === "https://profile.example.com/oauth/token",
+      );
+      expect(tokenCalls).toHaveLength(1);
+      const infoCall = mockFetch.mock.calls.find(
+        ([input]) => String(input) === "https://profile.example.com/info",
+      );
+      expect(infoCall).toBeDefined();
+      const requestInit = infoCall![1] as RequestInit;
       expect(requestInit.headers).toMatchObject({
         Authorization: "Bearer new-access-token",
       });
@@ -605,6 +620,11 @@ describe("Client", () => {
       });
       const mockFetch = jest.fn(
         async (input: RequestInfo | URL, init?: RequestInit) => {
+          if (
+            String(input).endsWith("/.well-known/oauth-authorization-server")
+          ) {
+            return new Response("", { status: 404 });
+          }
           if (String(input) === "https://profile.example.com/oauth/token") {
             expect(init?.method).toBe("POST");
             return new Response(
@@ -631,7 +651,15 @@ describe("Client", () => {
         headers: (client as any)._mergedHeaders,
       });
 
-      expect(mockFetch.mock.calls.map(([input]) => String(input))).toEqual([
+      // Discovery probes aside, refresh must target the profile's api_url
+      // rather than the client-level override.
+      expect(
+        mockFetch.mock.calls
+          .map(([input]) => String(input))
+          .filter(
+            (url) => !url.endsWith("/.well-known/oauth-authorization-server"),
+          ),
+      ).toEqual([
         "https://profile.example.com/oauth/token",
         "https://override.example.com/info",
       ]);

--- a/js/src/tests/client.test.ts
+++ b/js/src/tests/client.test.ts
@@ -518,7 +518,7 @@ describe("Client", () => {
           // This deployment serves no discovery document, so refresh falls back
           // to the configured mount point.
           if (
-            String(input).endsWith("/.well-known/oauth-authorization-server")
+            String(input).includes("/.well-known/oauth-authorization-server")
           ) {
             return new Response("", { status: 404 });
           }
@@ -621,7 +621,7 @@ describe("Client", () => {
       const mockFetch = jest.fn(
         async (input: RequestInfo | URL, init?: RequestInit) => {
           if (
-            String(input).endsWith("/.well-known/oauth-authorization-server")
+            String(input).includes("/.well-known/oauth-authorization-server")
           ) {
             return new Response("", { status: 404 });
           }
@@ -657,7 +657,7 @@ describe("Client", () => {
         mockFetch.mock.calls
           .map(([input]) => String(input))
           .filter(
-            (url) => !url.endsWith("/.well-known/oauth-authorization-server"),
+            (url) => !url.includes("/.well-known/oauth-authorization-server"),
           ),
       ).toEqual([
         "https://profile.example.com/oauth/token",

--- a/js/src/tests/profile-lock.test.ts
+++ b/js/src/tests/profile-lock.test.ts
@@ -85,7 +85,7 @@ test("two ProfileAuth instances refresh the token endpoint only once", async () 
     const fakeFetch = jest.fn(async (url: unknown) => {
       // The deployment serves no discovery document, so refresh falls back to
       // the configured mount point. Only the token requests are counted.
-      if (String(url).endsWith("/.well-known/oauth-authorization-server")) {
+      if (String(url).includes("/.well-known/oauth-authorization-server")) {
         return {
           ok: false,
           status: 404,

--- a/js/src/tests/profile-lock.test.ts
+++ b/js/src/tests/profile-lock.test.ts
@@ -82,7 +82,16 @@ test("two ProfileAuth instances refresh the token endpoint only once", async () 
   process.env.LANGSMITH_CONFIG_FILE = configPath;
   try {
     let calls = 0;
-    const fakeFetch = jest.fn(async () => {
+    const fakeFetch = jest.fn(async (url: unknown) => {
+      // The deployment serves no discovery document, so refresh falls back to
+      // the configured mount point. Only the token requests are counted.
+      if (String(url).endsWith("/.well-known/oauth-authorization-server")) {
+        return {
+          ok: false,
+          status: 404,
+          json: async () => ({}),
+        } as unknown as Response;
+      }
       calls += 1;
       return {
         ok: true,

--- a/js/src/tests/profile-oauth-discovery.test.ts
+++ b/js/src/tests/profile-oauth-discovery.test.ts
@@ -1,0 +1,159 @@
+import * as http from "node:http";
+import { resolveTokenEndpoint } from "../utils/profiles.js";
+
+type Doc = Record<string, unknown> | string | null;
+
+/** Start a server whose handler maps (path, base) to JSON, HTML, or a 404. */
+async function serve(
+  handler: (path: string, base: string) => Doc,
+): Promise<{ base: string; close: () => Promise<void> }> {
+  let base = "";
+  const server = http.createServer((req, res) => {
+    const result = handler(req.url ?? "", base);
+    if (result === null) {
+      res.writeHead(404);
+      res.end();
+      return;
+    }
+    if (typeof result === "string") {
+      res.writeHead(200, { "Content-Type": "text/html" });
+      res.end(result);
+      return;
+    }
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify(result));
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  if (address === null || typeof address === "string") {
+    throw new Error("failed to bind test server");
+  }
+  base = `http://127.0.0.1:${address.port}`;
+  return {
+    base,
+    close: () =>
+      new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      }),
+  };
+}
+
+/** Metadata under /api plus an HTML 200 at the root, like the self-hosted SPA. */
+function selfHostedHandler(path: string, base: string): Doc {
+  if (path === "/api/.well-known/oauth-authorization-server") {
+    return {
+      issuer: `${base}/api`,
+      device_authorization_endpoint: `${base}/api/oauth/device/code`,
+      token_endpoint: `${base}/api/oauth/token`,
+    };
+  }
+  if (path === "/.well-known/oauth-authorization-server") {
+    return "<!doctype html><html><body>app</body></html>";
+  }
+  return null;
+}
+
+describe("resolveTokenEndpoint", () => {
+  it("resolves the self-hosted AS from a bare origin", async () => {
+    const { base, close } = await serve(selfHostedHandler);
+    try {
+      expect(await resolveTokenEndpoint(base, fetch)).toBe(
+        `${base}/api/oauth/token`,
+      );
+    } finally {
+      await close();
+    }
+  });
+
+  it("resolves the self-hosted AS from an /api url", async () => {
+    const { base, close } = await serve(selfHostedHandler);
+    try {
+      expect(await resolveTokenEndpoint(`${base}/api`, fetch)).toBe(
+        `${base}/api/oauth/token`,
+      );
+    } finally {
+      await close();
+    }
+  });
+
+  it("resolves SaaS at the root", async () => {
+    const { base, close } = await serve((path, b) =>
+      path === "/.well-known/oauth-authorization-server"
+        ? {
+            issuer: b,
+            device_authorization_endpoint: `${b}/oauth/device/code`,
+            token_endpoint: `${b}/oauth/token`,
+          }
+        : null,
+    );
+    try {
+      expect(await resolveTokenEndpoint(base, fetch)).toBe(
+        `${base}/oauth/token`,
+      );
+    } finally {
+      await close();
+    }
+  });
+
+  it("keeps the /api mount when no metadata is served", async () => {
+    const { base, close } = await serve(() => null);
+    try {
+      expect(await resolveTokenEndpoint(`${base}/api`, fetch)).toBe(
+        `${base}/api/oauth/token`,
+      );
+    } finally {
+      await close();
+    }
+  });
+
+  it("strips /api/v1 in the fallback", async () => {
+    const { base, close } = await serve(() => null);
+    try {
+      expect(await resolveTokenEndpoint(`${base}/api/v1`, fetch)).toBe(
+        `${base}/oauth/token`,
+      );
+    } finally {
+      await close();
+    }
+  });
+
+  // Refresh tokens are posted to this endpoint, so untrusted documents must be
+  // ignored in favour of the fallback.
+  it("ignores a document whose issuer does not match", async () => {
+    const { base, close } = await serve((path, b) =>
+      path === "/.well-known/oauth-authorization-server"
+        ? {
+            issuer: "https://evil.example.com",
+            device_authorization_endpoint: `${b}/oauth/device/code`,
+            token_endpoint: `${b}/oauth/token`,
+          }
+        : null,
+    );
+    try {
+      expect(await resolveTokenEndpoint(base, fetch)).toBe(
+        `${base}/oauth/token`,
+      );
+    } finally {
+      await close();
+    }
+  });
+
+  it("ignores an endpoint on another origin", async () => {
+    const { base, close } = await serve((path, b) =>
+      path === "/.well-known/oauth-authorization-server"
+        ? {
+            issuer: b,
+            device_authorization_endpoint: `${b}/oauth/device/code`,
+            token_endpoint: "https://evil.example.com/oauth/token",
+          }
+        : null,
+    );
+    try {
+      expect(await resolveTokenEndpoint(base, fetch)).toBe(
+        `${base}/oauth/token`,
+      );
+    } finally {
+      await close();
+    }
+  });
+});

--- a/js/src/tests/profile-oauth-discovery.test.ts
+++ b/js/src/tests/profile-oauth-discovery.test.ts
@@ -95,6 +95,27 @@ describe("resolveTokenEndpoint", () => {
     }
   });
 
+  // RFC 8414 inserts the well-known segment before the issuer path; a
+  // deployment serving only that form must still be discovered.
+  it("resolves the RFC 8414 path-inserted form", async () => {
+    const { base, close } = await serve((path, b) =>
+      path === "/.well-known/oauth-authorization-server/api"
+        ? {
+            issuer: `${b}/api`,
+            device_authorization_endpoint: `${b}/api/oauth/device/code`,
+            token_endpoint: `${b}/api/oauth/token`,
+          }
+        : null,
+    );
+    try {
+      expect(await resolveTokenEndpoint(base, fetch)).toBe(
+        `${base}/api/oauth/token`,
+      );
+    } finally {
+      await close();
+    }
+  });
+
   it("keeps the /api mount when no metadata is served", async () => {
     const { base, close } = await serve(() => null);
     try {

--- a/js/src/utils/profiles.ts
+++ b/js/src/utils/profiles.ts
@@ -8,6 +8,7 @@ const OAUTH_CLIENT_ID = "langsmith-cli";
 const TOKEN_REFRESH_LEEWAY_MS = 60_000;
 const TOKEN_REFRESH_TIMEOUT_MS = 10_000;
 const OAUTH_DISCOVERY_TIMEOUT_MS = 5_000;
+const WELL_KNOWN_OAUTH_PATH = "/.well-known/oauth-authorization-server";
 
 type LangSmithProfileOAuth = {
   access_token?: string;
@@ -210,20 +211,38 @@ function isTrustedOAuthMetadata(
   return true;
 }
 
+/**
+ * Metadata URLs for an issuer, RFC 8414 form first. RFC 8414 inserts the
+ * well-known segment between the origin and the issuer path, so
+ * `https://host/api` is described at
+ * `https://host/.well-known/oauth-authorization-server/api`. Deployments
+ * commonly also serve the appended form, and for a path-less issuer the two are
+ * identical.
+ */
+function oauthMetadataUrls(base: string): string[] {
+  const appended = `${base}${WELL_KNOWN_OAUTH_PATH}`;
+  let inserted: string;
+  try {
+    const url = new URL(base);
+    inserted = `${url.origin}${WELL_KNOWN_OAUTH_PATH}${url.pathname === "/" ? "" : url.pathname}`;
+  } catch {
+    return [appended];
+  }
+  return inserted === appended ? [inserted] : [inserted, appended];
+}
+
 async function fetchOAuthMetadata(
+  url: string,
   base: string,
   fetchImplementation: typeof fetch,
 ): Promise<OAuthServerMetadata | undefined> {
   let response: Response;
   try {
-    response = await fetchImplementation(
-      `${base}/.well-known/oauth-authorization-server`,
-      {
-        method: "GET",
-        headers: { Accept: "application/json" },
-        signal: AbortSignal.timeout(OAUTH_DISCOVERY_TIMEOUT_MS),
-      },
-    );
+    response = await fetchImplementation(url, {
+      method: "GET",
+      headers: { Accept: "application/json" },
+      signal: AbortSignal.timeout(OAUTH_DISCOVERY_TIMEOUT_MS),
+    });
   } catch {
     return undefined;
   }
@@ -253,9 +272,11 @@ export async function resolveTokenEndpoint(
   fetchImplementation: typeof fetch,
 ): Promise<string> {
   for (const base of oauthDiscoveryCandidates(apiUrl)) {
-    const doc = await fetchOAuthMetadata(base, fetchImplementation);
-    if (doc) {
-      return doc.token_endpoint as string;
+    for (const url of oauthMetadataUrls(base)) {
+      const doc = await fetchOAuthMetadata(url, base, fetchImplementation);
+      if (doc) {
+        return doc.token_endpoint as string;
+      }
     }
   }
   return `${normalizeConfigUrl(apiUrl)}/oauth/token`;

--- a/js/src/utils/profiles.ts
+++ b/js/src/utils/profiles.ts
@@ -7,6 +7,7 @@ export const DEFAULT_API_URL = "https://api.smith.langchain.com";
 const OAUTH_CLIENT_ID = "langsmith-cli";
 const TOKEN_REFRESH_LEEWAY_MS = 60_000;
 const TOKEN_REFRESH_TIMEOUT_MS = 10_000;
+const OAUTH_DISCOVERY_TIMEOUT_MS = 5_000;
 
 type LangSmithProfileOAuth = {
   access_token?: string;
@@ -139,6 +140,125 @@ function normalizeConfigUrl(apiUrl: string): string {
   return normalized.endsWith(apiV1Suffix)
     ? normalized.slice(0, -apiV1Suffix.length)
     : normalized;
+}
+
+type OAuthServerMetadata = {
+  issuer?: unknown;
+  device_authorization_endpoint?: unknown;
+  token_endpoint?: unknown;
+};
+
+/**
+ * Metadata base URLs to probe, most specific first: the configured mount point,
+ * then the self-hosted and SaaS locations, so both a bare origin and an
+ * explicit `/api` resolve.
+ */
+function oauthDiscoveryCandidates(apiUrl: string): string[] {
+  const given = normalizeConfigUrl(apiUrl);
+  const origin = given.endsWith("/api")
+    ? given.slice(0, -"/api".length)
+    : given;
+
+  const candidates: string[] = [];
+  for (const candidate of [given, `${origin}/api`, origin]) {
+    if (candidate && candidate !== "/api" && !candidates.includes(candidate)) {
+      candidates.push(candidate);
+    }
+  }
+  return candidates;
+}
+
+/**
+ * Check the document describes the deployment we probed. RFC 8414 requires the
+ * issuer to match the URL the well-known path was built from, and every
+ * endpoint must share the issuer's origin. Refresh tokens are posted to these
+ * endpoints, so an unvalidated document could redirect credentials elsewhere.
+ */
+function isTrustedOAuthMetadata(
+  doc: OAuthServerMetadata,
+  base: string,
+): boolean {
+  const { issuer } = doc;
+  if (
+    typeof issuer !== "string" ||
+    issuer.replace(/\/+$/, "") !== base.replace(/\/+$/, "")
+  ) {
+    return false;
+  }
+  let issuerUrl: URL;
+  try {
+    issuerUrl = new URL(issuer);
+  } catch {
+    return false;
+  }
+  for (const endpoint of [
+    doc.device_authorization_endpoint,
+    doc.token_endpoint,
+  ]) {
+    if (typeof endpoint !== "string" || !endpoint) {
+      return false;
+    }
+    try {
+      const url = new URL(endpoint);
+      if (url.protocol !== issuerUrl.protocol || url.host !== issuerUrl.host) {
+        return false;
+      }
+    } catch {
+      return false;
+    }
+  }
+  return true;
+}
+
+async function fetchOAuthMetadata(
+  base: string,
+  fetchImplementation: typeof fetch,
+): Promise<OAuthServerMetadata | undefined> {
+  let response: Response;
+  try {
+    response = await fetchImplementation(
+      `${base}/.well-known/oauth-authorization-server`,
+      {
+        method: "GET",
+        headers: { Accept: "application/json" },
+        signal: AbortSignal.timeout(OAUTH_DISCOVERY_TIMEOUT_MS),
+      },
+    );
+  } catch {
+    return undefined;
+  }
+  if (!response.ok) {
+    return undefined;
+  }
+  let doc: OAuthServerMetadata;
+  try {
+    // Self-hosted answers unknown paths with an HTML 200 from the SPA.
+    doc = (await response.json()) as OAuthServerMetadata;
+  } catch {
+    return undefined;
+  }
+  if (!doc || typeof doc !== "object" || !isTrustedOAuthMetadata(doc, base)) {
+    return undefined;
+  }
+  return doc;
+}
+
+/**
+ * Resolve the token endpoint, preferring the deployment's metadata document.
+ * Falls back to `<mount>/oauth/token`, keeping a trailing `/api` because
+ * self-hosted mounts the authorization server under it.
+ */
+export async function resolveTokenEndpoint(
+  apiUrl: string,
+  fetchImplementation: typeof fetch,
+): Promise<string> {
+  for (const base of oauthDiscoveryCandidates(apiUrl)) {
+    const doc = await fetchOAuthMetadata(base, fetchImplementation);
+    if (doc) {
+      return doc.token_endpoint as string;
+    }
+  }
+  return `${normalizeConfigUrl(apiUrl)}/oauth/token`;
 }
 
 function applyTokenResponse(
@@ -296,17 +416,18 @@ export class ProfileAuth {
         client_id: OAUTH_CLIENT_ID,
         refresh_token: this.state.profile.oauth?.refresh_token ?? refreshToken,
       });
-      const response = await fetchImplementation(
-        `${normalizeConfigUrl(refreshApiUrl)}/oauth/token`,
-        {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/x-www-form-urlencoded",
-          },
-          body: body.toString(),
-          signal: AbortSignal.timeout(Math.max(0, deadline - Date.now())),
-        },
+      const tokenEndpoint = await resolveTokenEndpoint(
+        refreshApiUrl,
+        fetchImplementation,
       );
+      const response = await fetchImplementation(tokenEndpoint, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/x-www-form-urlencoded",
+        },
+        body: body.toString(),
+        signal: AbortSignal.timeout(Math.max(0, deadline - Date.now())),
+      });
       if (!response.ok) {
         return;
       }

--- a/python/langsmith/_internal/_profiles.py
+++ b/python/langsmith/_internal/_profiles.py
@@ -20,6 +20,7 @@ _OAUTH_CLIENT_ID = "langsmith-cli"
 _TOKEN_REFRESH_LEEWAY = datetime.timedelta(minutes=1)
 _TOKEN_REFRESH_TIMEOUT = 10
 _OAUTH_DISCOVERY_TIMEOUT = 5
+_WELL_KNOWN_OAUTH_PATH = "/.well-known/oauth-authorization-server"
 
 
 class ProfileOAuth(TypedDict, total=False):
@@ -175,10 +176,29 @@ def _validate_oauth_metadata(doc: Mapping[str, Any], base: str) -> bool:
     return True
 
 
-def _fetch_oauth_metadata(base: str, timeout: float) -> Optional[Mapping[str, Any]]:
+def _oauth_metadata_urls(base: str) -> list[str]:
+    """Metadata URLs for an issuer, RFC 8414 form first.
+
+    RFC 8414 inserts the well-known segment between the origin and the issuer
+    path, so ``https://host/api`` is described at
+    ``https://host/.well-known/oauth-authorization-server/api``. Deployments
+    commonly also serve the appended form, and for a path-less issuer the two
+    are identical.
+    """
+    parts = urllib.parse.urlsplit(base)
+    inserted = urllib.parse.urlunsplit(
+        (parts.scheme, parts.netloc, f"{_WELL_KNOWN_OAUTH_PATH}{parts.path}", "", "")
+    )
+    appended = f"{base}{_WELL_KNOWN_OAUTH_PATH}"
+    return [inserted] if inserted == appended else [inserted, appended]
+
+
+def _fetch_oauth_metadata(
+    url: str, base: str, timeout: float
+) -> Optional[Mapping[str, Any]]:
     try:
         response = requests.get(
-            f"{base}/.well-known/oauth-authorization-server",
+            url,
             headers={"Accept": "application/json"},
             timeout=timeout,
         )
@@ -208,9 +228,10 @@ def _resolve_token_endpoint(
     authorization server under it.
     """
     for base in _oauth_discovery_candidates(api_url):
-        doc = _fetch_oauth_metadata(base, timeout)
-        if doc is not None:
-            return cast(str, doc["token_endpoint"])
+        for url in _oauth_metadata_urls(base):
+            doc = _fetch_oauth_metadata(url, base, timeout)
+            if doc is not None:
+                return cast(str, doc["token_endpoint"])
     return f"{_normalize_profile_api_url(api_url)}/oauth/token"
 
 

--- a/python/langsmith/_internal/_profiles.py
+++ b/python/langsmith/_internal/_profiles.py
@@ -7,6 +7,7 @@ import json
 import os
 import threading
 import time
+import urllib.parse
 from collections.abc import Mapping
 from pathlib import Path
 from typing import Any, NamedTuple, Optional, TypedDict, cast
@@ -18,6 +19,7 @@ from langsmith._internal._oauth_refresh_lock import oauth_refresh_lock
 _OAUTH_CLIENT_ID = "langsmith-cli"
 _TOKEN_REFRESH_LEEWAY = datetime.timedelta(minutes=1)
 _TOKEN_REFRESH_TIMEOUT = 10
+_OAUTH_DISCOVERY_TIMEOUT = 5
 
 
 class ProfileOAuth(TypedDict, total=False):
@@ -135,6 +137,81 @@ def _normalize_profile_api_url(api_url: str) -> str:
     return api_url
 
 
+def _oauth_discovery_candidates(api_url: str) -> list[str]:
+    """Metadata base URLs to probe, most specific first.
+
+    The configured mount point comes first, then the self-hosted and SaaS
+    locations, so both a bare origin and an explicit ``/api`` resolve.
+    """
+    given = _normalize_profile_api_url(api_url)
+    origin = given[: -len("/api")] if given.endswith("/api") else given
+
+    candidates = []
+    for candidate in (given, f"{origin}/api", origin):
+        if candidate and candidate != "/api" and candidate not in candidates:
+            candidates.append(candidate)
+    return candidates
+
+
+def _validate_oauth_metadata(doc: Mapping[str, Any], base: str) -> bool:
+    """Check the document describes the deployment we probed.
+
+    RFC 8414 requires the issuer to match the URL the well-known path was built
+    from, and every endpoint must share the issuer's origin. Refresh tokens are
+    posted to these endpoints, so an unvalidated document could redirect
+    credentials to another host.
+    """
+    issuer = doc.get("issuer")
+    if not isinstance(issuer, str) or issuer.rstrip("/") != base.rstrip("/"):
+        return False
+    issuer_parts = urllib.parse.urlsplit(issuer)
+    for key in ("device_authorization_endpoint", "token_endpoint"):
+        endpoint = doc.get(key)
+        if not isinstance(endpoint, str) or not endpoint:
+            return False
+        parts = urllib.parse.urlsplit(endpoint)
+        if (parts.scheme, parts.netloc) != (issuer_parts.scheme, issuer_parts.netloc):
+            return False
+    return True
+
+
+def _fetch_oauth_metadata(base: str, timeout: float) -> Optional[Mapping[str, Any]]:
+    try:
+        response = requests.get(
+            f"{base}/.well-known/oauth-authorization-server",
+            headers={"Accept": "application/json"},
+            timeout=timeout,
+        )
+    except requests.RequestException:
+        return None
+    if response.status_code < 200 or response.status_code >= 300:
+        return None
+    try:
+        doc = response.json()
+    except ValueError:
+        # Self-hosted answers unknown paths with an HTML 200 from the SPA.
+        return None
+    if not isinstance(doc, Mapping) or not _validate_oauth_metadata(doc, base):
+        return None
+    return doc
+
+
+def _resolve_token_endpoint(
+    api_url: str, timeout: float = _OAUTH_DISCOVERY_TIMEOUT
+) -> str:
+    """Resolve the token endpoint, preferring the deployment's metadata.
+
+    Falls back to ``<mount>/oauth/token`` when no usable document is served. The
+    fallback keeps a trailing ``/api`` because self-hosted mounts the
+    authorization server under it.
+    """
+    for base in _oauth_discovery_candidates(api_url):
+        doc = _fetch_oauth_metadata(base, timeout)
+        if doc is not None:
+            return cast(str, doc["token_endpoint"])
+    return f"{_normalize_profile_api_url(api_url)}/oauth/token"
+
+
 def _parse_profile_expires_at(expires_at: str) -> Optional[datetime.datetime]:
     try:
         parsed = datetime.datetime.fromisoformat(expires_at.replace("Z", "+00:00"))
@@ -167,12 +244,12 @@ def should_refresh_profile_token(profile: ProfileConfig) -> bool:
 def _refresh_profile_oauth_token(
     api_url: Optional[str], refresh_token: str, timeout: float = _TOKEN_REFRESH_TIMEOUT
 ) -> Optional[dict[str, Any]]:
-    refresh_url = _normalize_profile_api_url(
+    token_endpoint = _resolve_token_endpoint(
         api_url or "https://api.smith.langchain.com"
     )
     try:
         response = requests.post(
-            f"{refresh_url}/oauth/token",
+            token_endpoint,
             data={
                 "grant_type": "refresh_token",
                 "client_id": _OAUTH_CLIENT_ID,

--- a/python/langsmith/_internal/_profiles.py
+++ b/python/langsmith/_internal/_profiles.py
@@ -182,7 +182,9 @@ def _fetch_oauth_metadata(base: str, timeout: float) -> Optional[Mapping[str, An
             headers={"Accept": "application/json"},
             timeout=timeout,
         )
-    except requests.RequestException:
+    except Exception:
+        # Discovery is best effort: any failure falls back to the configured
+        # mount point rather than breaking token refresh.
         return None
     if response.status_code < 200 or response.status_code >= 300:
         return None

--- a/python/tests/unit_tests/test_profiles_oauth_discovery.py
+++ b/python/tests/unit_tests/test_profiles_oauth_discovery.py
@@ -88,6 +88,30 @@ def test_saas_probes_the_origin_first(monkeypatch: pytest.MonkeyPatch) -> None:
     assert seen == [f"{BASE}{WELL_KNOWN}"]
 
 
+def test_rfc8414_path_inserted_form(monkeypatch: pytest.MonkeyPatch) -> None:
+    """RFC 8414 inserts the well-known segment before the issuer path.
+
+    A deployment serving only that form must still be discovered.
+    """
+
+    def handler(url: str) -> Any:
+        if url == f"{BASE}{WELL_KNOWN}/api":
+            return _response(200, _metadata(f"{BASE}/api", f"{BASE}/api/oauth/token"))
+        return _response(404, None, json_error=True)
+
+    _patch_get(monkeypatch, handler)
+    assert _resolve_token_endpoint(BASE) == f"{BASE}/api/oauth/token"
+
+
+def test_bare_origin_probes_each_url_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """For a path-less issuer both forms are identical, so probe it once."""
+    seen = _patch_get(monkeypatch, lambda _: _response(404, None, json_error=True))
+    _resolve_token_endpoint(BASE)
+    assert seen.count(f"{BASE}{WELL_KNOWN}") == 1
+
+
 def test_fallback_keeps_api_mount(monkeypatch: pytest.MonkeyPatch) -> None:
     """Without metadata the /api mount must survive; the AS lives under it."""
     _patch_get(monkeypatch, lambda _: _response(404, None, json_error=True))

--- a/python/tests/unit_tests/test_profiles_oauth_discovery.py
+++ b/python/tests/unit_tests/test_profiles_oauth_discovery.py
@@ -2,149 +2,135 @@
 
 from __future__ import annotations
 
-import json
-import threading
-from http.server import BaseHTTPRequestHandler, HTTPServer
-from typing import Any, Callable, Iterator
+from typing import Any, Callable, Optional
+from unittest import mock
 
 import pytest
+import requests
 
 from langsmith._internal._profiles import _resolve_token_endpoint
 
-
-def _serve(handler_fn: Callable[[str, str], Any]) -> Iterator[str]:
-    """Run an HTTP server whose handler maps (path, base_url) to a response.
-
-    handler_fn returns either a dict (encoded as JSON), a str (sent as HTML), or
-    None for a 404.
-    """
-    base_holder: dict[str, str] = {}
-
-    class Handler(BaseHTTPRequestHandler):
-        def do_GET(self) -> None:  # noqa: N802
-            result = handler_fn(self.path, base_holder["base"])
-            if result is None:
-                self.send_response(404)
-                self.end_headers()
-                return
-            if isinstance(result, dict):
-                body = json.dumps(result).encode()
-                content_type = "application/json"
-            else:
-                body = str(result).encode()
-                content_type = "text/html"
-            self.send_response(200)
-            self.send_header("Content-Type", content_type)
-            self.send_header("Content-Length", str(len(body)))
-            self.end_headers()
-            self.wfile.write(body)
-
-        def log_message(self, *args: Any) -> None:
-            pass
-
-    server = HTTPServer(("127.0.0.1", 0), Handler)
-    base_holder["base"] = f"http://127.0.0.1:{server.server_port}"
-    thread = threading.Thread(target=server.serve_forever, daemon=True)
-    thread.start()
-    try:
-        yield base_holder["base"]
-    finally:
-        server.shutdown()
-        server.server_close()
+BASE = "https://deployment.example.com"
+WELL_KNOWN = "/.well-known/oauth-authorization-server"
 
 
-@pytest.fixture
-def self_hosted() -> Iterator[str]:
-    """Metadata under /api, plus an HTML 200 at the root like the SPA."""
-
-    def handler(path: str, base: str) -> Any:
-        if path == "/api/.well-known/oauth-authorization-server":
-            return {
-                "issuer": f"{base}/api",
-                "device_authorization_endpoint": f"{base}/api/oauth/device/code",
-                "token_endpoint": f"{base}/api/oauth/token",
-            }
-        if path == "/.well-known/oauth-authorization-server":
-            return "<!doctype html><html><body>app</body></html>"
-        return None
-
-    yield from _serve(handler)
+def _response(status: int, payload: Optional[Any], *, json_error: bool = False):
+    response = mock.Mock()
+    response.status_code = status
+    if json_error:
+        response.json.side_effect = ValueError("not json")
+    else:
+        response.json.return_value = payload
+    return response
 
 
-@pytest.fixture
-def saas() -> Iterator[str]:
-    def handler(path: str, base: str) -> Any:
-        if path == "/.well-known/oauth-authorization-server":
-            return {
-                "issuer": base,
-                "device_authorization_endpoint": f"{base}/oauth/device/code",
-                "token_endpoint": f"{base}/oauth/token",
-            }
-        return None
+def _patch_get(
+    monkeypatch: pytest.MonkeyPatch, handler: Callable[[str], Any]
+) -> list[str]:
+    """Route requests.get through handler, recording the URLs probed."""
+    seen: list[str] = []
 
-    yield from _serve(handler)
+    def fake_get(url: str, **_: object) -> Any:
+        seen.append(url)
+        return handler(url)
 
-
-@pytest.fixture
-def no_metadata() -> Iterator[str]:
-    yield from _serve(lambda path, base: None)
+    monkeypatch.setattr(requests, "get", fake_get)
+    return seen
 
 
-def test_self_hosted_bare_origin(self_hosted: str) -> None:
-    assert _resolve_token_endpoint(self_hosted) == f"{self_hosted}/api/oauth/token"
+def _metadata(issuer: str, token_endpoint: str) -> dict[str, str]:
+    return {
+        "issuer": issuer,
+        "device_authorization_endpoint": f"{issuer}/oauth/device/code",
+        "token_endpoint": token_endpoint,
+    }
 
 
-def test_self_hosted_api_suffix(self_hosted: str) -> None:
-    assert (
-        _resolve_token_endpoint(f"{self_hosted}/api")
-        == f"{self_hosted}/api/oauth/token"
-    )
+def _self_hosted(url: str) -> Any:
+    """Metadata under /api, and an HTML 200 at the root like the SPA."""
+    if url == f"{BASE}/api{WELL_KNOWN}":
+        return _response(200, _metadata(f"{BASE}/api", f"{BASE}/api/oauth/token"))
+    if url == f"{BASE}{WELL_KNOWN}":
+        return _response(200, None, json_error=True)
+    return _response(404, None, json_error=True)
 
 
-def test_saas_at_root(saas: str) -> None:
-    assert _resolve_token_endpoint(saas) == f"{saas}/oauth/token"
+def test_self_hosted_bare_origin(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_get(monkeypatch, _self_hosted)
+    assert _resolve_token_endpoint(BASE) == f"{BASE}/api/oauth/token"
 
 
-def test_fallback_keeps_api_mount(no_metadata: str) -> None:
+def test_self_hosted_api_suffix(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_get(monkeypatch, _self_hosted)
+    assert _resolve_token_endpoint(f"{BASE}/api") == f"{BASE}/api/oauth/token"
+
+
+def test_saas_at_root(monkeypatch: pytest.MonkeyPatch) -> None:
+    def handler(url: str) -> Any:
+        if url == f"{BASE}{WELL_KNOWN}":
+            return _response(200, _metadata(BASE, f"{BASE}/oauth/token"))
+        return _response(404, None, json_error=True)
+
+    _patch_get(monkeypatch, handler)
+    assert _resolve_token_endpoint(BASE) == f"{BASE}/oauth/token"
+
+
+def test_saas_probes_the_origin_first(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A bare origin resolves in one request; no wasted /api probe."""
+
+    def handler(url: str) -> Any:
+        if url == f"{BASE}{WELL_KNOWN}":
+            return _response(200, _metadata(BASE, f"{BASE}/oauth/token"))
+        return _response(404, None, json_error=True)
+
+    seen = _patch_get(monkeypatch, handler)
+    _resolve_token_endpoint(BASE)
+    assert seen == [f"{BASE}{WELL_KNOWN}"]
+
+
+def test_fallback_keeps_api_mount(monkeypatch: pytest.MonkeyPatch) -> None:
     """Without metadata the /api mount must survive; the AS lives under it."""
-    assert (
-        _resolve_token_endpoint(f"{no_metadata}/api")
-        == f"{no_metadata}/api/oauth/token"
-    )
+    _patch_get(monkeypatch, lambda _: _response(404, None, json_error=True))
+    assert _resolve_token_endpoint(f"{BASE}/api") == f"{BASE}/api/oauth/token"
 
 
-def test_fallback_strips_api_v1(no_metadata: str) -> None:
-    assert (
-        _resolve_token_endpoint(f"{no_metadata}/api/v1") == f"{no_metadata}/oauth/token"
-    )
+def test_fallback_strips_api_v1(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_get(monkeypatch, lambda _: _response(404, None, json_error=True))
+    assert _resolve_token_endpoint(f"{BASE}/api/v1") == f"{BASE}/oauth/token"
 
 
-def test_rejects_issuer_mismatch() -> None:
+def test_fallback_when_discovery_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Discovery is best effort; a transport failure must not break refresh."""
+
+    def boom(url: str, **_: object) -> Any:
+        raise RuntimeError("network disabled")
+
+    monkeypatch.setattr(requests, "get", boom)
+    assert _resolve_token_endpoint(f"{BASE}/api") == f"{BASE}/api/oauth/token"
+
+
+def test_rejects_issuer_mismatch(monkeypatch: pytest.MonkeyPatch) -> None:
     """Refresh tokens are posted here, so a foreign issuer must be ignored."""
 
-    def handler(path: str, base: str) -> Any:
-        if path == "/.well-known/oauth-authorization-server":
-            return {
-                "issuer": "https://evil.example.com",
-                "device_authorization_endpoint": f"{base}/oauth/device/code",
-                "token_endpoint": f"{base}/oauth/token",
-            }
-        return None
+    def handler(url: str) -> Any:
+        if url == f"{BASE}{WELL_KNOWN}":
+            return _response(
+                200,
+                _metadata("https://evil.example.com", f"{BASE}/oauth/token"),
+            )
+        return _response(404, None, json_error=True)
 
-    for base in _serve(handler):
-        assert _resolve_token_endpoint(base) == f"{base}/oauth/token"
+    _patch_get(monkeypatch, handler)
+    assert _resolve_token_endpoint(BASE) == f"{BASE}/oauth/token"
 
 
-def test_rejects_off_origin_endpoint() -> None:
-    def handler(path: str, base: str) -> Any:
-        if path == "/.well-known/oauth-authorization-server":
-            return {
-                "issuer": base,
-                "device_authorization_endpoint": f"{base}/oauth/device/code",
-                "token_endpoint": "https://evil.example.com/oauth/token",
-            }
-        return None
+def test_rejects_off_origin_endpoint(monkeypatch: pytest.MonkeyPatch) -> None:
+    def handler(url: str) -> Any:
+        if url == f"{BASE}{WELL_KNOWN}":
+            return _response(
+                200, _metadata(BASE, "https://evil.example.com/oauth/token")
+            )
+        return _response(404, None, json_error=True)
 
-    for base in _serve(handler):
-        # Falls back rather than trusting the document.
-        assert _resolve_token_endpoint(base) == f"{base}/oauth/token"
+    _patch_get(monkeypatch, handler)
+    assert _resolve_token_endpoint(BASE) == f"{BASE}/oauth/token"

--- a/python/tests/unit_tests/test_profiles_oauth_discovery.py
+++ b/python/tests/unit_tests/test_profiles_oauth_discovery.py
@@ -1,0 +1,150 @@
+"""Tests for OAuth authorization server discovery in profile token refresh."""
+
+from __future__ import annotations
+
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Any, Callable, Iterator
+
+import pytest
+
+from langsmith._internal._profiles import _resolve_token_endpoint
+
+
+def _serve(handler_fn: Callable[[str, str], Any]) -> Iterator[str]:
+    """Run an HTTP server whose handler maps (path, base_url) to a response.
+
+    handler_fn returns either a dict (encoded as JSON), a str (sent as HTML), or
+    None for a 404.
+    """
+    base_holder: dict[str, str] = {}
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:  # noqa: N802
+            result = handler_fn(self.path, base_holder["base"])
+            if result is None:
+                self.send_response(404)
+                self.end_headers()
+                return
+            if isinstance(result, dict):
+                body = json.dumps(result).encode()
+                content_type = "application/json"
+            else:
+                body = str(result).encode()
+                content_type = "text/html"
+            self.send_response(200)
+            self.send_header("Content-Type", content_type)
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, *args: Any) -> None:
+            pass
+
+    server = HTTPServer(("127.0.0.1", 0), Handler)
+    base_holder["base"] = f"http://127.0.0.1:{server.server_port}"
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield base_holder["base"]
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+@pytest.fixture
+def self_hosted() -> Iterator[str]:
+    """Metadata under /api, plus an HTML 200 at the root like the SPA."""
+
+    def handler(path: str, base: str) -> Any:
+        if path == "/api/.well-known/oauth-authorization-server":
+            return {
+                "issuer": f"{base}/api",
+                "device_authorization_endpoint": f"{base}/api/oauth/device/code",
+                "token_endpoint": f"{base}/api/oauth/token",
+            }
+        if path == "/.well-known/oauth-authorization-server":
+            return "<!doctype html><html><body>app</body></html>"
+        return None
+
+    yield from _serve(handler)
+
+
+@pytest.fixture
+def saas() -> Iterator[str]:
+    def handler(path: str, base: str) -> Any:
+        if path == "/.well-known/oauth-authorization-server":
+            return {
+                "issuer": base,
+                "device_authorization_endpoint": f"{base}/oauth/device/code",
+                "token_endpoint": f"{base}/oauth/token",
+            }
+        return None
+
+    yield from _serve(handler)
+
+
+@pytest.fixture
+def no_metadata() -> Iterator[str]:
+    yield from _serve(lambda path, base: None)
+
+
+def test_self_hosted_bare_origin(self_hosted: str) -> None:
+    assert _resolve_token_endpoint(self_hosted) == f"{self_hosted}/api/oauth/token"
+
+
+def test_self_hosted_api_suffix(self_hosted: str) -> None:
+    assert (
+        _resolve_token_endpoint(f"{self_hosted}/api")
+        == f"{self_hosted}/api/oauth/token"
+    )
+
+
+def test_saas_at_root(saas: str) -> None:
+    assert _resolve_token_endpoint(saas) == f"{saas}/oauth/token"
+
+
+def test_fallback_keeps_api_mount(no_metadata: str) -> None:
+    """Without metadata the /api mount must survive; the AS lives under it."""
+    assert (
+        _resolve_token_endpoint(f"{no_metadata}/api")
+        == f"{no_metadata}/api/oauth/token"
+    )
+
+
+def test_fallback_strips_api_v1(no_metadata: str) -> None:
+    assert (
+        _resolve_token_endpoint(f"{no_metadata}/api/v1") == f"{no_metadata}/oauth/token"
+    )
+
+
+def test_rejects_issuer_mismatch() -> None:
+    """Refresh tokens are posted here, so a foreign issuer must be ignored."""
+
+    def handler(path: str, base: str) -> Any:
+        if path == "/.well-known/oauth-authorization-server":
+            return {
+                "issuer": "https://evil.example.com",
+                "device_authorization_endpoint": f"{base}/oauth/device/code",
+                "token_endpoint": f"{base}/oauth/token",
+            }
+        return None
+
+    for base in _serve(handler):
+        assert _resolve_token_endpoint(base) == f"{base}/oauth/token"
+
+
+def test_rejects_off_origin_endpoint() -> None:
+    def handler(path: str, base: str) -> Any:
+        if path == "/.well-known/oauth-authorization-server":
+            return {
+                "issuer": base,
+                "device_authorization_endpoint": f"{base}/oauth/device/code",
+                "token_endpoint": "https://evil.example.com/oauth/token",
+            }
+        return None
+
+    for base in _serve(handler):
+        # Falls back rather than trusting the document.
+        assert _resolve_token_endpoint(base) == f"{base}/oauth/token"


### PR DESCRIPTION
## Problem

Profile token refresh posts to `<normalized api_url>/oauth/token`, where the normalization only strips a trailing `/api/v1`. That is correct on SaaS, and correct when a self-hosted profile stores an `api_url` ending in `/api` — but wrong when it stores the bare origin:

| profile `api_url` | refresh POST | self-hosted result |
|---|---|---|
| `<origin>/api` | `<origin>/api/oauth/token` | works |
| `<origin>` | `<origin>/oauth/token` | **405** (SPA catch-all) |

Self-hosted mounts the authorization server under `<origin>/api`, and the `langsmith` CLI stores whichever form the user passed to `auth login`. A bare origin therefore leaves the profile unusable for refresh in both SDKs. The failure is quiet: refresh returns without updating the profile, so it surfaces as a `401` on the next request with nothing written back to `~/.langsmith/config.json`.

## Change

Resolve the token endpoint from the deployment's RFC 8414 metadata document, in both Python (`_profiles.py`) and JS (`profiles.ts`).

- Probe `.well-known/oauth-authorization-server` at the configured mount point, then `<origin>/api`, then `<origin>`, so a bare origin and an explicit `/api` both resolve.
- Fall back to the previous `<mount>/oauth/token` when no document is served, so deployments without discovery are unaffected.
- Only trust a document whose `issuer` matches the URL the well-known path was built from and whose endpoints share the issuer's origin. Refresh tokens are posted to these URLs. Self-hosted answers unknown paths with an HTML `200`, so a non-metadata response is ignored rather than trusted.

The equivalent Go SDK fix is langchain-ai/langsmith-go-staging#93, and the CLI-side fix is langchain-ai/langsmith-cli#244.

## Test Plan

- [x] New unit tests in both languages: self-hosted from a bare origin, self-hosted with `/api`, SaaS at root, fallback keeping `/api`, fallback stripping `/api/v1`, and rejection of issuer-mismatch / off-origin documents
- [x] Python: `ruff check`, `ruff format`, `mypy` clean on the changed module. The 6 `test_client.py` failures are pre-existing and identical on `main`
- [x] JS: `tsc --noEmit` clean, no new lint findings, `client.test.ts` + `traceable.test.ts` back to the same 2 pre-existing failures as `main`
- [x] Verified against a live self-hosted deployment that a bare-origin profile refreshes and persists a new token, using the equivalent Go implementation

### Note on the existing tests

`profile-lock.test.ts` and two `client.test.ts` profile cases asserted exact fetch counts and call ordering, which the discovery probes change. They now answer the well-known path with a 404 (these fake hosts serve no metadata) and assert against the token and API requests specifically, so they still pin the original behaviour — one refresh per lock, and refresh targeting the profile's `api_url` rather than the client override.