### PR TITLE
docs(sandbox): fix invalid sizing example in JS sandbox README

### DIFF
--- a/js/src/sandbox/README.md
+++ b/js/src/sandbox/README.md
@@ -696,13 +696,22 @@ await client.deleteSnapshot(snapshot.id);
 ### Sizing and Resources
 
 `createSandbox` accepts optional per-sandbox resource limits. If omitted, the
-server-side defaults are used.
+server-side defaults are used — prefer that unless you have a specific need.
+
+```typescript
+const sandbox = await client.createSandbox({
+  fsCapacityBytes: 5_368_709_120, // 5 GiB
+});
+```
+
+`vCpus` and `memBytes` may also be set, but they are validated together:
+`memBytes` must be within 50% of 4 GiB per vCPU, so a 2-vCPU sandbox accepts
+4–12 GiB. Requests outside that range are rejected.
 
 ```typescript
 const sandbox = await client.createSandbox({
   vCpus: 2,
-  memBytes: 2_147_483_648,        // 2 GiB
-  fsCapacityBytes: 5_368_709_120, // 5 GiB
+  memBytes: 8_589_934_592, // 8 GiB
 });
 ```
 


### PR DESCRIPTION
The "Sizing and Resources" example passed `vCpus: 2, memBytes: 2 GiB`. The API validates the two together — `mem_bytes` must be within 50% of 4 GiB per vCPU — so a 2-vCPU sandbox accepts 4–12 GiB and this example is rejected.

Since this section exists specifically to document sizing, I kept the options rather than deleting them: the leading example now shows `fsCapacityBytes` alone (no paired constraint), followed by a valid `vCpus`/`memBytes` pair and a note stating the ratio. The constraint being undocumented was the substance of a customer complaint (Pylon #28308).

## Test Plan
- [x] none — documentation only