### PR TITLE
release(py): 0.10.16

### DIFF
--- a/python/.bumpversion.cfg
+++ b/python/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.10.15
+current_version = 0.10.16
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
 serialize = {major}.{minor}.{patch}
 search = {current_version}

--- a/python/langsmith/__init__.py
+++ b/python/langsmith/__init__.py
@@ -49,7 +49,7 @@ if TYPE_CHECKING:
 
 # Avoid calling into importlib on every call to __version__
 
-__version__ = "0.10.15"
+__version__ = "0.10.16"
 version = __version__  # for backwards compatibility
 
 # Metadata key to hide a traced run from LangSmith's Messages View.


### PR DESCRIPTION
Cuts a Python release so everything merged since 0.10.15 reaches PyPI. Bumps only the two version files (`python/langsmith/__init__.py`, `python/.bumpversion.cfg`) via the documented `bump2version patch` flow; on merge to `main`, `.github/workflows/release.yml` tags `v0.10.16`, builds, and publishes to PyPI.

Ships since 0.10.15:

- **Metadata masking now runs after the runtime-env merge and through the anonymizer** (#3313). Previously the runtime-env values merged in after masking, so anonymizer/mask rules never saw them.
- **`ls_agent_type` handling in the OpenAI integrations** — stamped onto `wrap_openai` LLM runs (#3317) and user-supplied values preserved in the openai-agents-sdk integration (#3318).
- **Profiles resolve the OAuth token endpoint from deployment metadata** (#3333) instead of assuming a fixed path.
- **Compression threads are no longer reset** (#3332) mid-flight.
- **Dependency bumps** — notably `cryptography` 48.0.1 → 50.0.0 (#3331) and `aiohttp` 3.14.1 → 3.14.3 (#3329), plus the grouped minor/patch, dev, npm, and GitHub Actions updates (#3322, #3323, #3324, #3325, #3320, #3321, #3330).

## Rebased on latest `main`

This branch was rebased so the version bump sits on top of the newest `main`. Two commits merged since the release was first cut are now also included in 0.10.16 — both non-functional for the published Python package:

- **#3339** `test(claude-agent-sdk): run subagent in foreground so trace nests correctly` — test-only; fixes a flaky integration test after Claude Code v2.1.198 made sub-agents background-by-default. No change to the shipped `langsmith` package.
- **#3335** `docs(sandbox): fix invalid sizing example in JS sandbox README` — docs-only.