### PR TITLE
test(claude-agent-sdk): run subagent in foreground so trace nests correctly

### DIFF
--- a/python/tests/integration_tests/wrappers/test_claude_agent_sdk.py
+++ b/python/tests/integration_tests/wrappers/test_claude_agent_sdk.py
@@ -85,7 +85,11 @@ async def test_subagent():
 
     options = ClaudeAgentOptions(
         model="claude-haiku-4-5",
-        system_prompt="You must always call the foo subagent.",
+        system_prompt=(
+            "You must always call the foo subagent, wait for it to finish, and"
+            " report its exact result. You need its result before you can"
+            " respond."
+        ),
         allowed_tools=["Agent"],
         agents={
             "foo": AgentDefinition(
@@ -121,7 +125,7 @@ async def test_subagent():
 
     with patch.object(RunTree, "post", tracked_post):
         async with ClaudeSDKClient(options=options) as client:
-            await client.query("Call foo.")
+            await client.query("Call foo and tell me exactly what it returns.")
             async for message in client.receive_response():
                 pass
 


### PR DESCRIPTION
Fixes the flaky/failing `test_subagent` integration test in the Claude Agent SDK wrapper.

## Root cause

`test_subagent` builds a live `Agent → foo → Bash` conversation and asserts the sub-agent's `Bash`/LLM runs are traced **nested under** the `foo` sub-agent chain (via `parent_run_id`). It started failing today - presumabley because the updated **Claude Code v2.1.198 changed the Agent tool to launch sub-agents in the background by default** (`isAsync: true`) - and [we bumped it in this commit](https://github.com/langchain-ai/langsmith-sdk/commit/1e70bf5c526a518916bd477f1c4e785a73a9f7d8). The sub-agent then completes in a *later* turn than the single `receive_response()` stream that created its `Agent`/`foo` runs, so its `Bash`/LLM runs either:
- never post before the conversation ends (`foo` errors with `Subagent run not completed (conversation ended)`, 0 Bash), or
- get posted under a **separate `claude.conversation` trace root** when the stream is pumped again — orphaned from `foo`, so the `>=2 Bash under foo` / `>=2 LLM turns under foo` assertions see 0.

Per the SDK docs, Claude sets `run_in_background: false` (foreground) **"when it needs the result before continuing."** Neither `AgentDefinition.background=False` nor a `can_use_tool` override reliably flips it here — the documented lever is the prompt.

## Fix

Make the main agent depend on the sub-agent's result, so Claude runs the sub-agent **synchronously**. It then executes inline within the single `receive_response()` stream and the whole `Agent → foo → Bash` tree traces under one root with correct nesting.

- `system_prompt`: also wait for and report the sub-agent's exact result before responding.
- `query`: ask for the sub-agent's result.

No integration/product change, no assertion changes, and the baseline `haiku` sub-agent is unchanged.

## Verification

Ran locally against a LangSmith instance:
- **haiku sub-agent (this PR): 5/5 pass, all on the first attempt** (no flaky reruns), ~22–37s each.
- Server traces confirm a single `claude.conversation` root with `Agent → foo → Bash(echo hello) + Bash(echo world)` correctly nested.

`@pytest.mark.flaky(reruns=2)` is retained as a safety net for residual live-model variance.