### PR TITLE
feat(python): support httpx2 with httpx fallback [closes LSDK-448]

### DIFF
--- a/python/Makefile
+++ b/python/Makefile
@@ -32,6 +32,7 @@ tests:
 	 -u LANGSMITH_TRACING \
 	 PYTHONDEVMODE=1 \
 	 PYTHONASYNCIODEBUG=1 \
+	 PYTHONPATH=tests/httpx2_alias \
 	 uv run python -m pytest --disable-socket --allow-unix-socket -n auto --durations=10 ${TEST}
 
 tests_watch:
@@ -78,8 +79,21 @@ test-wheel-imports:
 	uv pip install -r /tmp/langsmith-declared-deps.txt --python /tmp/langsmith-strict-test
 	/tmp/langsmith-strict-test/bin/python -c "\
 from langsmith._openapi_client import Langsmith; \
-from langsmith.client import Client"
-	rm -rf /tmp/langsmith-strict-test /tmp/langsmith-declared-deps.txt
+from langsmith.client import Client; \
+assert __import__('langsmith._internal._httpx', fromlist=['httpx']).httpx.__name__ == 'httpx2'; \
+Langsmith(base_url='https://example.com').close(); \
+Client(api_url='https://example.com', api_key='test', auto_batch_tracing=False, info={}).close()"
+	uv run python3 -c "p='/tmp/langsmith-declared-deps.txt'; lines=open(p).read().splitlines(); open('/tmp/langsmith-httpx-deps.txt','w').write('\n'.join(x for x in lines if not x.startswith('httpx2')) + '\nhttpx>=0.23.0,<1\n')"
+	uv venv /tmp/langsmith-httpx-test
+	uv pip install dist/langsmith-*.whl --no-deps --python /tmp/langsmith-httpx-test
+	uv pip install -r /tmp/langsmith-httpx-deps.txt --python /tmp/langsmith-httpx-test
+	/tmp/langsmith-httpx-test/bin/python -c "\
+from langsmith._openapi_client import Langsmith; \
+from langsmith.client import Client; \
+assert __import__('langsmith._internal._httpx', fromlist=['httpx']).httpx.__name__ == 'httpx'; \
+Langsmith(base_url='https://example.com').close(); \
+Client(api_url='https://example.com', api_key='test', auto_batch_tracing=False, info={}).close()"
+	rm -rf /tmp/langsmith-strict-test /tmp/langsmith-httpx-test /tmp/langsmith-declared-deps.txt /tmp/langsmith-httpx-deps.txt
 
 api_docs_build:
 	uv run python docs/create_api_rst.py

--- a/python/langsmith/_internal/_httpx.py
+++ b/python/langsmith/_internal/_httpx.py
@@ -1,0 +1,49 @@
+"""Select the installed HTTPX-compatible backend."""
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import httpx2 as httpx
+    from httpx2 import (
+        URL,
+        AsyncBaseTransport,
+        BaseTransport,
+        Proxy,
+        Response,
+        Timeout,
+    )
+    from httpx2._config import DEFAULT_TIMEOUT_CONFIG
+else:
+    try:
+        import httpx2 as httpx
+        from httpx2 import (
+            URL,
+            AsyncBaseTransport,
+            BaseTransport,
+            Proxy,
+            Response,
+            Timeout,
+        )
+        from httpx2._config import DEFAULT_TIMEOUT_CONFIG
+    except ModuleNotFoundError:
+        import httpx
+        from httpx import (
+            URL,
+            AsyncBaseTransport,
+            BaseTransport,
+            Proxy,
+            Response,
+            Timeout,
+        )
+        from httpx._config import DEFAULT_TIMEOUT_CONFIG
+
+__all__ = [
+    "AsyncBaseTransport",
+    "BaseTransport",
+    "DEFAULT_TIMEOUT_CONFIG",
+    "Proxy",
+    "Response",
+    "Timeout",
+    "URL",
+    "httpx",
+]

--- a/python/langsmith/_openapi_client/_base_client.py
+++ b/python/langsmith/_openapi_client/_base_client.py
@@ -33,10 +33,10 @@ from typing import (
 from typing_extensions import Literal, override, get_origin
 
 import anyio
-import httpx
+from langsmith._internal._httpx import httpx
 import distro
 import pydantic
-from httpx import URL
+from langsmith._internal._httpx import URL
 from pydantic import PrivateAttr
 
 from . import _exceptions
@@ -102,14 +102,14 @@ _StreamT = TypeVar("_StreamT", bound=Stream[Any])
 _AsyncStreamT = TypeVar("_AsyncStreamT", bound=AsyncStream[Any])
 
 if TYPE_CHECKING:
-    from httpx._config import (
-        DEFAULT_TIMEOUT_CONFIG,  # pyright: ignore[reportPrivateImportUsage]
-    )
+    from langsmith._internal._httpx import DEFAULT_TIMEOUT_CONFIG
 
     HTTPX_DEFAULT_TIMEOUT = DEFAULT_TIMEOUT_CONFIG
 else:
     try:
-        from httpx._config import DEFAULT_TIMEOUT_CONFIG as HTTPX_DEFAULT_TIMEOUT
+        from langsmith._internal._httpx import (
+            DEFAULT_TIMEOUT_CONFIG as HTTPX_DEFAULT_TIMEOUT,
+        )
     except ImportError:
         # taken from https://github.com/encode/httpx/blob/3ba5fe0d7ac70222590e759c31442b1cab263791/httpx/_config.py#L366
         HTTPX_DEFAULT_TIMEOUT = Timeout(5.0)

--- a/python/langsmith/_openapi_client/_client.py
+++ b/python/langsmith/_openapi_client/_client.py
@@ -6,7 +6,7 @@ import os
 from typing import TYPE_CHECKING, Any, Mapping
 from typing_extensions import Self, override
 
-import httpx
+from langsmith._internal._httpx import httpx
 
 from . import _exceptions
 from ._qs import Querystring

--- a/python/langsmith/_openapi_client/_constants.py
+++ b/python/langsmith/_openapi_client/_constants.py
@@ -1,6 +1,6 @@
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
-import httpx
+from langsmith._internal._httpx import httpx
 
 RAW_RESPONSE_HEADER = "X-Stainless-Raw-Response"
 OVERRIDE_CAST_TO_HEADER = "____stainless_override_cast_to"

--- a/python/langsmith/_openapi_client/_exceptions.py
+++ b/python/langsmith/_openapi_client/_exceptions.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing_extensions import Literal
 
-import httpx
+from langsmith._internal._httpx import httpx
 
 __all__ = [
     "BadRequestError",

--- a/python/langsmith/_openapi_client/_response.py
+++ b/python/langsmith/_openapi_client/_response.py
@@ -21,7 +21,7 @@ from typing import (
 from typing_extensions import Awaitable, ParamSpec, override, get_origin
 
 import anyio
-import httpx
+from langsmith._internal._httpx import httpx
 import pydantic
 
 from ._types import NoneType

--- a/python/langsmith/_openapi_client/_streaming.py
+++ b/python/langsmith/_openapi_client/_streaming.py
@@ -7,7 +7,7 @@ from types import TracebackType
 from typing import TYPE_CHECKING, Any, Generic, TypeVar, Iterator, Optional, AsyncIterator, cast
 from typing_extensions import Self, Protocol, TypeGuard, override, get_origin, runtime_checkable
 
-import httpx
+from langsmith._internal._httpx import httpx
 
 from ._utils import extract_type_var_from_base
 

--- a/python/langsmith/_openapi_client/_types.py
+++ b/python/langsmith/_openapi_client/_types.py
@@ -31,9 +31,16 @@ from typing_extensions import (
     runtime_checkable,
 )
 
-import httpx
+from langsmith._internal._httpx import httpx
 import pydantic
-from httpx import URL, Proxy, Timeout, Response, BaseTransport, AsyncBaseTransport
+from langsmith._internal._httpx import (
+    AsyncBaseTransport,
+    BaseTransport,
+    Proxy,
+    Response,
+    Timeout,
+    URL,
+)
 
 if TYPE_CHECKING:
     from ._models import BaseModel

--- a/python/langsmith/_openapi_client/pagination.py
+++ b/python/langsmith/_openapi_client/pagination.py
@@ -3,7 +3,7 @@
 from typing import Any, List, Type, Generic, Mapping, TypeVar, Optional, cast
 from typing_extensions import override
 
-from httpx import Response
+from langsmith._internal._httpx import Response
 
 from ._utils import is_mapping
 from ._models import BaseModel

--- a/python/langsmith/_openapi_client/resources/annotation_queues/annotation_queues.py
+++ b/python/langsmith/_openapi_client/resources/annotation_queues/annotation_queues.py
@@ -7,7 +7,7 @@ from typing import Dict, Union, Iterable, Optional
 from datetime import datetime
 from typing_extensions import Literal
 
-import httpx
+from langsmith._internal._httpx import httpx
 
 from .runs import (
     RunsResource,

--- a/python/langsmith/_openapi_client/resources/annotation_queues/items.py
+++ b/python/langsmith/_openapi_client/resources/annotation_queues/items.py
@@ -6,7 +6,7 @@ from typing import Union, Iterable
 from datetime import datetime
 from typing_extensions import Literal
 
-import httpx
+from langsmith._internal._httpx import httpx
 
 from ..._types import Body, Omit, Query, Headers, NotGiven, SequenceNotStr, omit, not_given
 from ..._utils import path_template, maybe_transform, async_maybe_transform

--- a/python/langsmith/_openapi_client/resources/annotation_queues/runs.py
+++ b/python/langsmith/_openapi_client/resources/annotation_queues/runs.py
@@ -7,7 +7,7 @@ from typing import Union, Iterable, Optional
 from datetime import datetime
 from typing_extensions import Literal, overload
 
-import httpx
+from langsmith._internal._httpx import httpx
 
 from ..._types import Body, Omit, Query, Headers, NotGiven, SequenceNotStr, omit, not_given
 from ..._utils import path_template, required_args, maybe_transform, async_maybe_transform

--- a/python/langsmith/_openapi_client/resources/datasets/experiment_runs.py
+++ b/python/langsmith/_openapi_client/resources/datasets/experiment_runs.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Dict, List
 
-import httpx
+from langsmith._internal._httpx import httpx
 
 from ..._types import Body, Omit, Query, Headers, NotGiven, SequenceNotStr, omit, not_given
 from ..._utils import path_template, maybe_transform

--- a/python/langsmith/_openapi_client/resources/info.py
+++ b/python/langsmith/_openapi_client/resources/info.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import httpx
+from langsmith._internal._httpx import httpx
 
 from .._types import Body, Query, Headers, NotGiven, not_given
 from .._compat import cached_property

--- a/python/langsmith/_openapi_client/resources/issues.py
+++ b/python/langsmith/_openapi_client/resources/issues.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing_extensions import Literal
 
-import httpx
+from langsmith._internal._httpx import httpx
 
 from ..types import issue_list_params
 from .._types import Body, Omit, Query, Headers, NotGiven, omit, not_given

--- a/python/langsmith/_openapi_client/resources/online_evaluators.py
+++ b/python/langsmith/_openapi_client/resources/online_evaluators.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import httpx
+from langsmith._internal._httpx import httpx
 
 from ..types import (
     OnlineEvaluatorType,

--- a/python/langsmith/_openapi_client/resources/public/runs.py
+++ b/python/langsmith/_openapi_client/resources/public/runs.py
@@ -6,7 +6,7 @@ from typing import List, Union
 from datetime import datetime
 from typing_extensions import Literal
 
-import httpx
+from langsmith._internal._httpx import httpx
 
 from ..._types import Body, Omit, Query, Headers, NotGiven, SequenceNotStr, omit, not_given
 from ..._utils import path_template, maybe_transform, strip_not_given, async_maybe_transform

--- a/python/langsmith/_openapi_client/resources/runs/runs.py
+++ b/python/langsmith/_openapi_client/resources/runs/runs.py
@@ -6,7 +6,7 @@ from typing import List, Union
 from datetime import datetime
 from typing_extensions import Literal
 
-import httpx
+from langsmith._internal._httpx import httpx
 
 from .share import (
     ShareResource,

--- a/python/langsmith/_openapi_client/resources/runs/share.py
+++ b/python/langsmith/_openapi_client/resources/runs/share.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import httpx
+from langsmith._internal._httpx import httpx
 
 from ..._types import Body, Omit, Query, Headers, NoneType, NotGiven, omit, not_given
 from ..._utils import path_template, maybe_transform, async_maybe_transform

--- a/python/langsmith/_openapi_client/resources/sandboxes/boxes.py
+++ b/python/langsmith/_openapi_client/resources/sandboxes/boxes.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Dict
 
-import httpx
+from langsmith._internal._httpx import httpx
 
 from ..._types import Body, Omit, Query, Headers, NoneType, NotGiven, SequenceNotStr, omit, not_given
 from ..._utils import path_template, maybe_transform, async_maybe_transform

--- a/python/langsmith/_openapi_client/resources/sandboxes/registries.py
+++ b/python/langsmith/_openapi_client/resources/sandboxes/registries.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import httpx
+from langsmith._internal._httpx import httpx
 
 from ..._types import Body, Omit, Query, Headers, NoneType, NotGiven, omit, not_given
 from ..._utils import path_template, maybe_transform, async_maybe_transform

--- a/python/langsmith/_openapi_client/resources/sandboxes/snapshots.py
+++ b/python/langsmith/_openapi_client/resources/sandboxes/snapshots.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Dict
 
-import httpx
+from langsmith._internal._httpx import httpx
 
 from ..._types import Body, Omit, Query, Headers, NoneType, NotGiven, SequenceNotStr, omit, not_given
 from ..._utils import path_template, maybe_transform, async_maybe_transform

--- a/python/langsmith/_openapi_client/resources/threads.py
+++ b/python/langsmith/_openapi_client/resources/threads.py
@@ -6,7 +6,7 @@ from typing import List, Union
 from datetime import datetime
 from typing_extensions import Literal
 
-import httpx
+from langsmith._internal._httpx import httpx
 
 from ..types import thread_query_params, thread_stats_params, thread_list_traces_params
 from .._types import Body, Omit, Query, Headers, NotGiven, omit, not_given

--- a/python/langsmith/_openapi_client/resources/traces.py
+++ b/python/langsmith/_openapi_client/resources/traces.py
@@ -6,7 +6,7 @@ from typing import List, Union
 from datetime import datetime
 from typing_extensions import Literal
 
-import httpx
+from langsmith._internal._httpx import httpx
 
 from ..types import trace_query_params, trace_list_runs_params
 from .._types import Body, Omit, Query, Headers, NotGiven, SequenceNotStr, omit, not_given

--- a/python/langsmith/async_client.py
+++ b/python/langsmith/async_client.py
@@ -20,13 +20,12 @@ from typing import (
     cast,
 )
 
-import httpx
-
 import langsmith._openapi_client as _langsmith_api_module
 from langsmith._internal._beta_decorator import deprecated as _deprecated
 from langsmith._internal._beta_decorator import (
     suppress_deprecation_warning as _suppress_deprecation_warning,
 )
+from langsmith._internal._httpx import httpx
 from langsmith.client import _get_openapi_base_url
 
 if TYPE_CHECKING:

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -54,7 +54,6 @@ from typing import (
 )
 from urllib import parse as urllib_parse
 
-import httpx as _httpx
 import packaging.version
 import requests
 from pydantic import Field
@@ -92,6 +91,7 @@ from langsmith._internal._constants import (
     _SIZE_LIMIT_BYTES,
     _TRACING_QUEUE_MAX_SIZE,
 )
+from langsmith._internal._httpx import httpx as _httpx
 from langsmith._internal._hub import (
     HUB,
     REPO_HANDLE_PATTERN,

--- a/python/langsmith/sandbox/_async_client.py
+++ b/python/langsmith/sandbox/_async_client.py
@@ -9,9 +9,8 @@ import uuid
 from collections.abc import Callable, Mapping
 from typing import TYPE_CHECKING, Any, Optional, Union
 
-import httpx
-
 from langsmith import utils as ls_utils
+from langsmith._internal._httpx import httpx
 from langsmith._openapi_client import AsyncLangsmith
 from langsmith.sandbox._async_sandbox import AsyncSandbox
 from langsmith.sandbox._client import (

--- a/python/langsmith/sandbox/_async_sandbox.py
+++ b/python/langsmith/sandbox/_async_sandbox.py
@@ -8,8 +8,7 @@ from collections.abc import Mapping
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Callable, Literal, Optional, Union, overload
 
-import httpx
-
+from langsmith._internal._httpx import httpx
 from langsmith.sandbox._exceptions import (
     DataplaneNotConfiguredError,
     ResourceNotFoundError,

--- a/python/langsmith/sandbox/_client.py
+++ b/python/langsmith/sandbox/_client.py
@@ -13,9 +13,8 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional, Union
 from urllib.parse import quote
 
-import httpx
-
 from langsmith import utils as ls_utils
+from langsmith._internal._httpx import httpx
 from langsmith._openapi_client import Langsmith
 from langsmith.sandbox._exceptions import (
     ResourceCreationError,

--- a/python/langsmith/sandbox/_helpers.py
+++ b/python/langsmith/sandbox/_helpers.py
@@ -9,8 +9,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 from typing import Any, Optional
 
-import httpx
-
+from langsmith._internal._httpx import httpx
 from langsmith.sandbox._exceptions import (
     QuotaExceededError,
     ResourceCreationError,

--- a/python/langsmith/sandbox/_models.py
+++ b/python/langsmith/sandbox/_models.py
@@ -8,8 +8,7 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Optional
 
-import httpx
-
+from langsmith._internal._httpx import httpx
 from langsmith.sandbox._exceptions import (
     SandboxConnectionError,
     SandboxOperationError,

--- a/python/langsmith/sandbox/_sandbox.py
+++ b/python/langsmith/sandbox/_sandbox.py
@@ -6,8 +6,7 @@ from collections.abc import Mapping
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Callable, Literal, Optional, Union, overload
 
-import httpx
-
+from langsmith._internal._httpx import httpx
 from langsmith.sandbox._exceptions import (
     DataplaneNotConfiguredError,
     ResourceNotFoundError,

--- a/python/langsmith/sandbox/_transport.py
+++ b/python/langsmith/sandbox/_transport.py
@@ -13,8 +13,7 @@ import logging
 import random
 import time
 
-import httpx
-
+from langsmith._internal._httpx import httpx
 from langsmith.sandbox._exceptions import SandboxConnectionError
 
 logger = logging.getLogger(__name__)

--- a/python/langsmith/utils.py
+++ b/python/langsmith/utils.py
@@ -29,12 +29,12 @@ from typing import (
 )
 from urllib import parse as urllib_parse
 
-import httpx
 import requests
 from typing_extensions import ParamSpec
 from urllib3.util import Retry  # type: ignore[import-untyped]
 
 from langsmith import schemas as ls_schemas
+from langsmith._internal._httpx import httpx
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "pydantic>=2,<3",
     "requests>=2.0.0",
     "orjson>=3.9.14; platform_python_implementation != 'PyPy'",
-    "httpx>=0.23.0,<1",
+    "httpx2>=2,<3",
     "requests-toolbelt>=1.0.0",
     "zstandard>=0.23.0",
     "packaging>=23.2",

--- a/python/tests/httpx2_alias/sitecustomize.py
+++ b/python/tests/httpx2_alias/sitecustomize.py
@@ -1,0 +1,5 @@
+"""Use HTTPX2 for tests that import the legacy HTTPX module name."""
+
+import httpx2
+
+httpx2.alias_httpx()

--- a/python/tests/unit_tests/test_httpx_compat.py
+++ b/python/tests/unit_tests/test_httpx_compat.py
@@ -1,0 +1,30 @@
+import pytest
+
+from langsmith._internal._httpx import httpx
+from langsmith._openapi_client import AsyncLangsmith, Langsmith
+
+
+def _info_response(request: httpx.Request) -> httpx.Response:
+    assert request.url.path == "/api/v1/info"
+    return httpx.Response(200, json={"version": "test"})
+
+
+def test_prefers_httpx2_for_sync_requests() -> None:
+    assert httpx.__name__ == "httpx2"
+    with httpx.Client(transport=httpx.MockTransport(_info_response)) as http_client:
+        with Langsmith(
+            api_key="test", base_url="https://example.com", http_client=http_client
+        ) as client:
+            assert client.info.list().version == "test"
+
+
+@pytest.mark.asyncio
+async def test_prefers_httpx2_for_async_requests() -> None:
+    assert httpx.__name__ == "httpx2"
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(_info_response)
+    ) as http_client:
+        async with AsyncLangsmith(
+            api_key="test", base_url="https://example.com", http_client=http_client
+        ) as client:
+            assert (await client.info.list()).version == "test"

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -11,7 +11,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer = "2026-08-04T20:00:07.698697314Z"
 exclude-newer-span = "P1D"
 
 [manifest]
@@ -995,7 +995,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -1360,6 +1360,19 @@ wheels = [
 ]
 
 [[package]]
+name = "httpcore2"
+version = "2.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+    { name = "truststore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/39/a8/20ed1ed79cbc2ecdf5301c0968ab7c85547212e2a7bd126ddd2d986e206e/httpcore2-2.9.1.tar.gz", hash = "sha256:4d8acbf8b306f48c9d6046591fd5ba4037d1b1b1000d140fc2c3eab1e9a0c0e2", size = 67089, upload-time = "2026-07-24T09:21:03.867Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/fb/46c52b781975c335a2bcf1072c7bbc007cbdc8d674217f5ee1daba2c848b/httpcore2-2.9.1-py3-none-any.whl", hash = "sha256:6182472379e855fe4221246a2bb7ecede403bc61c6798062ae1787d051ccde26", size = 82809, upload-time = "2026-07-24T09:21:01.178Z" },
+]
+
+[[package]]
 name = "httpx"
 version = "0.28.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1384,12 +1397,28 @@ wheels = [
 ]
 
 [[package]]
-name = "idna"
-version = "3.15"
+name = "httpx2"
+version = "2.9.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc", size = 199245, upload-time = "2026-05-12T22:45:57.011Z" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpcore2" },
+    { name = "idna" },
+    { name = "truststore" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/14/38128fbafd7e0ed41d874df6c9a653d47c2d111cfe59e2b4ac95161b4abd/httpx2-2.9.1.tar.gz", hash = "sha256:1932a768737e3666291582833da748cc4e563c337cf96706fccc04fa6e58764a", size = 95458, upload-time = "2026-07-24T09:21:04.972Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8", size = 72340, upload-time = "2026-05-12T22:45:55.733Z" },
+    { url = "https://files.pythonhosted.org/packages/13/b8/cfd91c4ab9134d386d48f0b6ac662ff3d4be6efdee59ee1c67ebc3c0487c/httpx2-2.9.1-py3-none-any.whl", hash = "sha256:1820fe14a9ab1107bfeff39259987429450b070ec0ff38cc87eb0d8c97fdc71a", size = 91191, upload-time = "2026-07-24T09:21:02.6Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.18"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]
@@ -1651,7 +1680,7 @@ source = { editable = "." }
 dependencies = [
     { name = "anyio" },
     { name = "distro" },
-    { name = "httpx" },
+    { name = "httpx2" },
     { name = "orjson", marker = "platform_python_implementation != 'PyPy'" },
     { name = "packaging" },
     { name = "pydantic" },
@@ -1794,7 +1823,7 @@ requires-dist = [
     { name = "google-adk", marker = "extra == 'google-adk'", specifier = ">=1.0.0" },
     { name = "google-adk", marker = "extra == 'google-adk-live'", specifier = ">=2.3.0" },
     { name = "google-genai", marker = "extra == 'gemini-live'", specifier = ">=1.75" },
-    { name = "httpx", specifier = ">=0.23.0,<1" },
+    { name = "httpx2", specifier = ">=2,<3" },
     { name = "langsmith-pyo3", marker = "extra == 'langsmith-pyo3'", specifier = ">=0.1.0rc2" },
     { name = "livekit-agents", marker = "extra == 'livekit'", specifier = ">=1.0" },
     { name = "openai", marker = "extra == 'openai-realtime'", specifier = ">=1.50" },
@@ -2207,8 +2236,8 @@ name = "loguru"
 version = "0.7.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "win32-setctime", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "python_full_version >= '3.11' and sys_platform == 'win32'" },
+    { name = "win32-setctime", marker = "python_full_version >= '3.11' and sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3a/05/a1dae3dffd1116099471c643b8924f5aa6524411dc6c63fdae648c4f1aca/loguru-0.7.3.tar.gz", hash = "sha256:19480589e77d47b8d85b2c827ad95d49bf31b0dcde16593892eb51dd18706eb6", size = 63559, upload-time = "2024-12-06T11:20:56.608Z" }
 wheels = [
@@ -2534,11 +2563,11 @@ name = "nltk"
 version = "3.10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click" },
-    { name = "defusedxml" },
-    { name = "joblib" },
-    { name = "regex" },
-    { name = "tqdm" },
+    { name = "click", marker = "python_full_version >= '3.11'" },
+    { name = "defusedxml", marker = "python_full_version >= '3.11'" },
+    { name = "joblib", marker = "python_full_version >= '3.11'" },
+    { name = "regex", marker = "python_full_version >= '3.11'" },
+    { name = "tqdm", marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/96/02/df4f105b28a7c16b0e41423bc09cf0f1b8a305df4ef0b10ca74a2e4c648c/nltk-3.10.0.tar.gz", hash = "sha256:4fbac1d98203cbcd1b5d94a2877fb822300072d80604a5e7fae49d2c5f84e8c1", size = 3089244, upload-time = "2026-07-08T02:39:13.562Z" }
 wheels = [
@@ -2550,8 +2579,8 @@ name = "numba"
 version = "0.65.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "llvmlite" },
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "llvmlite", marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f6/c5/db2ac3685833d626c0dcae6bd2330cd68433e1fd248d15f70998160d3ad7/numba-0.65.1.tar.gz", hash = "sha256:19357146c32fe9ed25059ab915e8465fb13951cf6b0aace3826b76886373ab23", size = 2765600, upload-time = "2026-04-24T02:02:56.551Z" }
 wheels = [
@@ -2737,11 +2766,11 @@ name = "onnxruntime"
 version = "1.24.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "flatbuffers" },
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" } },
-    { name = "packaging" },
-    { name = "protobuf" },
-    { name = "sympy" },
+    { name = "flatbuffers", marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "packaging", marker = "python_full_version >= '3.11'" },
+    { name = "protobuf", marker = "python_full_version >= '3.11'" },
+    { name = "sympy", marker = "python_full_version >= '3.11'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/60/69/6c40720201012c6af9aa7d4ecdd620e521bd806dc6269d636fdd5c5aeebe/onnxruntime-1.24.4-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:0bdfce8e9a6497cec584aab407b71bf697dac5e1b7b7974adc50bf7533bdb3a2", size = 17332131, upload-time = "2026-03-17T22:05:49.005Z" },
@@ -3047,8 +3076,8 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
-    { name = "types-pytz" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "types-pytz", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/92/5d/be23854a73fda69f1dbdda7bc10fbd6f930bd1fa87aaec389f00c901c1e8/pandas_stubs-2.3.3.260113.tar.gz", hash = "sha256:076e3724bcaa73de78932b012ec64b3010463d377fa63116f4e6850643d93800", size = 116131, upload-time = "2026-01-13T22:30:16.704Z" }
 wheels = [
@@ -3067,7 +3096,7 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/27/1d/297ff2c7ea50a768a2247621d6451abb2a07c0e9be7ca6d36ebe371658e5/pandas_stubs-3.0.0.260204.tar.gz", hash = "sha256:bf9294b76352effcffa9cb85edf0bed1339a7ec0c30b8e1ac3d66b4228f1fbc3", size = 109383, upload-time = "2026-02-04T15:17:17.247Z" }
 wheels = [
@@ -3182,28 +3211,28 @@ name = "pipecat-ai"
 version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "aiofiles" },
-    { name = "aiohttp" },
+    { name = "aiofiles", marker = "python_full_version >= '3.11'" },
+    { name = "aiohttp", marker = "python_full_version >= '3.11'" },
     { name = "audioop-lts", marker = "python_full_version >= '3.13'" },
-    { name = "docstring-parser" },
-    { name = "loguru" },
-    { name = "markdown" },
-    { name = "nltk" },
-    { name = "numba" },
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" } },
-    { name = "onnxruntime" },
-    { name = "openai" },
-    { name = "pillow" },
-    { name = "protobuf" },
-    { name = "pydantic" },
-    { name = "pyloudnorm" },
-    { name = "pyyaml" },
-    { name = "pyyaml-include" },
-    { name = "resampy" },
-    { name = "soxr" },
-    { name = "typing-extensions" },
-    { name = "wait-for2", marker = "python_full_version < '3.12'" },
-    { name = "websockets" },
+    { name = "docstring-parser", marker = "python_full_version >= '3.11'" },
+    { name = "loguru", marker = "python_full_version >= '3.11'" },
+    { name = "markdown", marker = "python_full_version >= '3.11'" },
+    { name = "nltk", marker = "python_full_version >= '3.11'" },
+    { name = "numba", marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "onnxruntime", marker = "python_full_version >= '3.11'" },
+    { name = "openai", marker = "python_full_version >= '3.11'" },
+    { name = "pillow", marker = "python_full_version >= '3.11'" },
+    { name = "protobuf", marker = "python_full_version >= '3.11'" },
+    { name = "pydantic", marker = "python_full_version >= '3.11'" },
+    { name = "pyloudnorm", marker = "python_full_version >= '3.11'" },
+    { name = "pyyaml", marker = "python_full_version >= '3.11'" },
+    { name = "pyyaml-include", marker = "python_full_version >= '3.11'" },
+    { name = "resampy", marker = "python_full_version >= '3.11'" },
+    { name = "soxr", marker = "python_full_version >= '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.11'" },
+    { name = "wait-for2", marker = "python_full_version == '3.11.*'" },
+    { name = "websockets", marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d5/ed/4bcf67703996ac6a0896dc64232e79fdfcb23eccff36929a7a234587a085/pipecat_ai-1.4.0.tar.gz", hash = "sha256:4d1e68da79e0632dcdaf66581fbf07e840249dfb715dc6e57b423d20fc3520d7", size = 11505429, upload-time = "2026-06-17T03:27:48.83Z" }
 wheels = [
@@ -3618,8 +3647,8 @@ name = "pyloudnorm"
 version = "0.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" } },
-    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
     { name = "scipy", version = "1.18.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/23/00/f915eaa75326f4209941179c2b93ac477f2040e4aeff5bb21d16eb8058f9/pyloudnorm-0.2.0.tar.gz", hash = "sha256:8bf597658ea4e1975c275adf490f6deb5369ea409f2901f939915efa4b681b16", size = 14037, upload-time = "2026-01-04T11:43:35.265Z" }
@@ -3920,7 +3949,7 @@ name = "pyyaml-include"
 version = "1.4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyyaml" },
+    { name = "pyyaml", marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7f/be/2d07ad85e3d593d69640876a8686eae2c533db8cb7bf298d25c421b4d2d5/pyyaml-include-1.4.1.tar.gz", hash = "sha256:1a96e33a99a3e56235f5221273832464025f02ff3d8539309a3bf00dec624471", size = 20592, upload-time = "2024-03-25T14:56:43.748Z" }
 wheels = [
@@ -4094,8 +4123,8 @@ name = "resampy"
 version = "0.4.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numba" },
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "numba", marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/29/f1/34be702a69a5d272e844c98cee82351f880985cfbca0cc86378011078497/resampy-0.4.3.tar.gz", hash = "sha256:a0d1c28398f0e55994b739650afef4e3974115edbe96cd4bb81968425e916e47", size = 3080604, upload-time = "2024-03-05T20:36:08.119Z" }
 wheels = [
@@ -4282,7 +4311,7 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
 wheels = [
@@ -4359,7 +4388,7 @@ resolution-markers = [
     "python_full_version == '3.12.*'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a7/25/c2700dfaf6442b4effaa91af24ebce5dc9d31bb4a69706313aae70d72cd0/scipy-1.18.0.tar.gz", hash = "sha256:67b2ad2ad54c72ca6d04975a9b2df8c3638c34ddd5b28738e94fc2b57929d378", size = 30774447, upload-time = "2026-06-19T15:01:43.456Z" }
 wheels = [
@@ -4483,7 +4512,7 @@ name = "soxr"
 version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/7e/f4b461944662ad75036df65277d6130f9411002bfb79e9df7dff40a31db9/soxr-1.0.0.tar.gz", hash = "sha256:e07ee6c1d659bc6957034f4800c60cb8b98de798823e34d2a2bba1caa85a4509", size = 171415, upload-time = "2025-09-07T13:22:21.317Z" }
 wheels = [
@@ -4733,6 +4762,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
+]
+
+[[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description
Prefer maintained `httpx2` across the Python SDK while retaining an `httpx` fallback for existing dependency-suppressed environments. A shared compatibility module keeps client, response, transport, timeout, and exception types on one backend. Tracks [LSDK-448](https://linear.app/langchain/issue/LSDK-448/feature-request-support-httpx2-maintained-fork-alongside-httpx).

`httpx2>=2,<3` is maintained by Pydantic, BSD-3-Clause licensed, actively released by multiple contributors, and has no known PyPI advisories; retaining required `httpx` or making `httpx2` optional would not let downstream installs remove the old package.

## Test Plan
- [x] Verify sync and async generated-client requests use `httpx2`
- [x] Verify built wheels import with default `httpx2` and isolated `httpx`-only dependencies
- [x] Run all 1,913 Python unit tests; Ruff passes (Mypy retains the pre-existing Python 3.14 `Executor.map` override error)

Made by [Open SWE](https://openswe.vercel.app/agents/f655c09f-d295-b94f-8f66-c36e957a28cd)

## References
- Plan: https://openswe.vercel.app/agents/f655c09f-d295-b94f-8f66-c36e957a28cd/plan