### PR TITLE
perf: avoid serializing and sending Inputs on Patch

### DIFF
--- a/python/bench/tracing_client_bench.py
+++ b/python/bench/tracing_client_bench.py
@@ -57,12 +57,35 @@ def create_run_data(
     }
 
 
-def benchmark_run_creation(num_runs: int, json_size: int, samples: int = 1) -> Dict:
+def _stats(timings: list) -> Dict:
+    return {
+        "mean": statistics.mean(timings),
+        "median": statistics.median(timings),
+        "stdev": statistics.stdev(timings) if len(timings) > 1 else 0,
+        "min": min(timings),
+        "max": max(timings),
+    }
+
+
+def benchmark_run_creation(
+    num_runs: int,
+    json_size: int,
+    samples: int = 1,
+    *,
+    patch: bool = False,
+    exclude_inputs: bool = False,
+) -> Dict:
     """
-    Benchmark run creation with specified parameters.
+    Benchmark run creation (and optionally patching) with specified parameters.
     Returns timing statistics.
+
+    Args:
+        patch: Also benchmark a patch (update_run) phase for each created run.
+        exclude_inputs: When patching, omit inputs from the patch (they were
+            already sent on the create). Mirrors RunTree.patch(exclude_inputs=True).
     """
-    timings = []
+    timings: list = []
+    patch_timings: list = []
 
     project_name = "__tracing_client_bench_python" + datetime.now().strftime(
         "%Y%m%dT%H%M%S"
@@ -86,16 +109,25 @@ def benchmark_run_creation(num_runs: int, json_size: int, samples: int = 1) -> D
         # wait for client.tracing_queue to be empty
         client.tracing_queue.join()
 
-        elapsed = time.perf_counter() - start
+        timings.append(time.perf_counter() - start)
 
-        timings.append(elapsed)
+        if patch:
+            patch_start = time.perf_counter()
+            for run in runs:
+                client.update_run(
+                    run_id=run["id"],
+                    trace_id=run["trace_id"],
+                    dotted_order=run["dotted_order"],
+                    outputs=run["outputs"],
+                    end_time=datetime.now(timezone.utc),
+                    inputs=None if exclude_inputs else run["inputs"],
+                )
+            client.tracing_queue.join()
+            patch_timings.append(time.perf_counter() - patch_start)
 
     return {
-        "mean": statistics.mean(timings),
-        "median": statistics.median(timings),
-        "stdev": statistics.stdev(timings) if len(timings) > 1 else 0,
-        "min": min(timings),
-        "max": max(timings),
+        "create": _stats(timings),
+        "patch": _stats(patch_timings) if patch else None,
     }
 
 
@@ -103,21 +135,52 @@ json_size = 3_000
 num_runs = 1000
 
 
-def main(json_size: int, num_runs: int):
+def _print_stats(label: str, num: int, stats: Dict, unit: str) -> None:
+    print(f"\n{label}:")
+    print(f"Mean time: {stats['mean']:.4f} seconds")
+    print(f"Median time: {stats['median']:.4f} seconds")
+    print(f"Std Dev: {stats['stdev']:.4f} seconds")
+    print(f"Min time: {stats['min']:.4f} seconds")
+    print(f"Max time: {stats['max']:.4f} seconds")
+    print(f"Throughput: {num / stats['mean']:.2f} {unit}")
+
+
+def main(
+    json_size: int,
+    num_runs: int,
+    *,
+    patch: bool = False,
+    exclude_inputs: bool = False,
+):
     """
     Run benchmarks with different combinations of parameters and report results.
     """
 
-    results = benchmark_run_creation(num_runs=num_runs, json_size=json_size)
+    results = benchmark_run_creation(
+        num_runs=num_runs,
+        json_size=json_size,
+        patch=patch,
+        exclude_inputs=exclude_inputs,
+    )
 
-    print(f"\nBenchmark Results for {num_runs} runs with JSON size {json_size}:")
-    print(f"Mean time: {results['mean']:.4f} seconds")
-    print(f"Median time: {results['median']:.4f} seconds")
-    print(f"Std Dev: {results['stdev']:.4f} seconds")
-    print(f"Min time: {results['min']:.4f} seconds")
-    print(f"Max time: {results['max']:.4f} seconds")
-    print(f"Throughput: {num_runs / results['mean']:.2f} runs/second")
+    _print_stats(
+        f"Create results for {num_runs} runs with JSON size {json_size}",
+        num_runs,
+        results["create"],
+        "runs/second",
+    )
+    if results["patch"] is not None:
+        _print_stats(
+            f"Patch results (exclude_inputs={exclude_inputs})",
+            num_runs,
+            results["patch"],
+            "patches/second",
+        )
 
 
 if __name__ == "__main__":
+    # Create-only baseline (default behavior), then the patch phase both ways
+    # to show the exclude_inputs optimization side by side.
     main(json_size, num_runs)
+    main(json_size, num_runs, patch=True, exclude_inputs=False)
+    main(json_size, num_runs, patch=True, exclude_inputs=True)

--- a/python/langsmith/_internal/voice/session.py
+++ b/python/langsmith/_internal/voice/session.py
@@ -126,7 +126,7 @@ class EventSession:
             return
         msgs = self.messages[self._turn_msg_start :]
         self._current_turn.end(outputs={"messages": msgs} if msgs else {})
-        self._current_turn.patch()
+        self._current_turn.patch(exclude_inputs=True)
         self._current_turn = None
 
     def add_message(self, role: str, content: str) -> None:
@@ -283,7 +283,7 @@ class EventSession:
                 run.end(outputs=scrub(outputs) if outputs is not None else {})
             else:
                 run.end(outputs={} if inbound else payload)
-            run.patch()
+            run.patch(exclude_inputs=True)
 
     def record_llm(
         self,
@@ -332,7 +332,7 @@ class EventSession:
         if usage_metadata is not None:
             run.set(usage_metadata=cast("Any", usage_metadata))
         run.end(outputs=scrub(outputs))
-        run.patch()
+        run.patch(exclude_inputs=True)
 
     def open_span(
         self,
@@ -391,7 +391,7 @@ class EventSession:
             extra["metadata"] = merged
             run.extra = extra
         run.end(outputs=scrub(outputs) if outputs is not None else {})
-        run.patch()
+        run.patch(exclude_inputs=True)
 
     def _audio_exceeds_duration_cap(self) -> bool:
         return session_wav_exceeds_duration_cap(
@@ -445,7 +445,7 @@ class EventSession:
         # the root makes the whole exchange readable in the LangSmith preview
         # pane without expanding a single child span.
         self.run.end(outputs={"messages": self.messages} if self.messages else {})
-        self.run.patch()
+        self.run.patch(exclude_inputs=True)
 
 
 def start_session(

--- a/python/langsmith/integrations/claude_agent_sdk/_client.py
+++ b/python/langsmith/integrations/claude_agent_sdk/_client.py
@@ -152,7 +152,7 @@ class TurnLifecycle:
         """Patch all deferred LLM runs. Call after usage has been set."""
         for run in self._pending_patch:
             try:
-                run.patch()
+                run.patch(exclude_inputs=True)
             except Exception as e:
                 logger.warning(f"Failed to patch LLM run: {e}")
         self._pending_patch.clear()
@@ -621,7 +621,7 @@ def instrument_claude_client(original_class: Any) -> None:
                                             else None,
                                         )
                                         try:
-                                            tool_run.patch()
+                                            tool_run.patch(exclude_inputs=True)
                                         except Exception as e:
                                             logger.warning(
                                                 "Failed to patch"

--- a/python/langsmith/integrations/claude_agent_sdk/_hooks.py
+++ b/python/langsmith/integrations/claude_agent_sdk/_hooks.py
@@ -296,7 +296,7 @@ async def post_tool_use_hook(
         )
 
         try:
-            tool_run.patch()
+            tool_run.patch(exclude_inputs=True)
         except Exception as e:
             logger.warning(f"Failed to patch tool run for {tool_name}: {e}")
 
@@ -361,7 +361,7 @@ async def post_tool_use_failure_hook(
         )
 
         try:
-            tool_run.patch()
+            tool_run.patch(exclude_inputs=True)
         except Exception as e:
             logger.warning(f"Failed to patch failed tool run for {tool_name}: {e}")
 
@@ -506,7 +506,7 @@ async def subagent_stop_hook(
             # No matching Agent tool — just end it now
             subagent_run.end()
             try:
-                subagent_run.patch()
+                subagent_run.patch(exclude_inputs=True)
             except Exception as e:
                 logger.warning(f"Failed to patch subagent run: {e}")
 
@@ -533,7 +533,7 @@ def clear_active_tool_runs(session: Optional[SessionState] = None) -> None:
     for agent_id, subagent_run in session.subagent_runs.items():
         try:
             subagent_run.end(error="Subagent run not completed (conversation ended)")
-            subagent_run.patch()
+            subagent_run.patch(exclude_inputs=True)
         except Exception as e:
             logger.debug(f"Failed to clean up orphaned subagent run {agent_id}: {e}")
 
@@ -541,7 +541,7 @@ def clear_active_tool_runs(session: Optional[SessionState] = None) -> None:
     for tool_use_id, subagent_run in session.ended_subagent_runs.items():
         try:
             subagent_run.end()
-            subagent_run.patch()
+            subagent_run.patch(exclude_inputs=True)
         except Exception as e:
             logger.debug(f"Failed to finalise ended subagent run {tool_use_id}: {e}")
 
@@ -549,7 +549,7 @@ def clear_active_tool_runs(session: Optional[SessionState] = None) -> None:
     for tool_use_id, (tool_run, _) in session.active_tool_runs.items():
         try:
             tool_run.end(error="Tool run not completed (conversation ended)")
-            tool_run.patch()
+            tool_run.patch(exclude_inputs=True)
         except Exception as e:
             logger.debug(f"Failed to clean up orphaned tool run {tool_use_id}: {e}")
 

--- a/python/langsmith/integrations/claude_agent_sdk/_transcripts.py
+++ b/python/langsmith/integrations/claude_agent_sdk/_transcripts.py
@@ -115,7 +115,7 @@ def _create_missing_subagent_llm_runs(
                 llm_run.end(end_time=ts)
                 try:
                     llm_run.post()
-                    llm_run.patch()
+                    llm_run.patch(exclude_inputs=True)
                 except Exception as e:
                     logger.warning(f"Failed to post/patch subagent LLM run: {e}")
 

--- a/python/langsmith/integrations/google_adk/_client.py
+++ b/python/langsmith/integrations/google_adk/_client.py
@@ -303,14 +303,14 @@ async def wrap_tool_run_async(
             outputs = {}
         tool_run.end(outputs=outputs)
         try:
-            tool_run.patch()
+            tool_run.patch(exclude_inputs=True)
         except Exception as e:
             logger.debug(f"Failed to patch tool run: {e}")
         return result
     except Exception as e:
         tool_run.end(error=str(e))
         try:
-            tool_run.patch()
+            tool_run.patch(exclude_inputs=True)
         except Exception as patch_e:
             logger.debug(f"Failed to patch tool run on error: {patch_e}")
         raise
@@ -461,7 +461,7 @@ async def wrap_flow_call_llm_async(
 
         llm_run.end(outputs=outputs)
         try:
-            llm_run.patch()
+            llm_run.patch(exclude_inputs=True)
         except Exception as e:
             logger.debug(f"Failed to patch LLM run: {e}")
 
@@ -470,7 +470,7 @@ async def wrap_flow_call_llm_async(
         _capture_inputs_and_post()
         llm_run.end(error=str(e))
         try:
-            llm_run.patch()
+            llm_run.patch(exclude_inputs=True)
         except Exception as patch_e:
             logger.debug(f"Failed to patch LLM run on error: {patch_e}")
         raise

--- a/python/langsmith/run_helpers.py
+++ b/python/langsmith/run_helpers.py
@@ -1185,7 +1185,7 @@ class trace:
         if self.old_ctx is not None:
             enabled = utils.tracing_is_enabled(self.old_ctx)
             if enabled is True and self._end_on_exit:
-                self.new_run.patch()
+                self.new_run.patch(exclude_inputs=True)
 
             _set_tracing_context(self.old_ctx)
         else:
@@ -1487,7 +1487,9 @@ def _container_end(
     # Patch run if enabled=True (force) or if tracing is enabled globally
     enabled = container.get("enabled")
     if enabled is True or utils.tracing_is_enabled() is True:
-        run_tree.patch()
+        # Inputs are already sent on the initial post() and are not mutated
+        # during the traced call, so skip re-sending them on the patch.
+        run_tree.patch(exclude_inputs=True)
     if (on_end := container.get("on_end")) and callable(on_end):
         try:
             on_end(run_tree)

--- a/python/langsmith/run_trees.py
+++ b/python/langsmith/run_trees.py
@@ -522,6 +522,11 @@ class RunTree(ls_schemas.RunBase):
     def add_inputs(self, inputs: dict[str, Any]) -> None:
         """Upsert the given inputs into the run.
 
+        Note: Updated inputs are not going to sent via .patch() requests by
+        default, as a performance optimization. You have to explicitly call
+        `.patch(exclude_inputs=False)` to send the updated inputs after an
+        initial `.post()` call.
+
         Args:
             inputs: A dictionary containing the inputs to be added.
         """

--- a/python/langsmith/testing/_internal.py
+++ b/python/langsmith/testing/_internal.py
@@ -811,7 +811,7 @@ class _LangSmithTestSuite:
         )
         run_tree.reference_example_id = example_id
         run_tree.end(outputs=outputs, metadata={"reference_example_id": example_id})
-        run_tree.patch()
+        run_tree.patch(exclude_inputs=True)
 
 
 class _TestCase:


### PR DESCRIPTION
## Description

Inputs are serialized and sent when a run is created (`post()`). They were then serialized and sent **again** on the patch (`update_run`) at the end of the run, even though they had not changed. That repeats the input serialization and re-transmits the payload on every traced run, and the cost scales with input size.

`RunTree.patch()` already supports `exclude_inputs` — it omits inputs from the patch, relying on the create having sent them (the ingest combine logic keeps the posted inputs when a later patch carries none). This PR passes `exclude_inputs=True` at the patch call sites where inputs are set at creation and not mutated before the patch, so the redundant second serialization/transmit is skipped.

## Changes

Added `exclude_inputs=True` to `RunTree.patch()` at:

- `run_helpers.py` — the `@traceable` end path and the `trace()` context manager
- `_internal/voice/session.py` (5 spans)
- `integrations/claude_agent_sdk/_client.py`, `_hooks.py`, `_transcripts.py`
- `integrations/google_adk/_client.py`
- `testing/_internal.py`

(`integrations/openai_agents_sdk` already used `exclude_inputs=True`.)

`bench/tracing_client_bench.py` gains an optional patch phase, gated on new keyword flags `patch` / `exclude_inputs` (default `patch=False`, so the existing create-only output is unchanged). When enabled it posts the runs, then times a patch phase and reports patch throughput.

## Benchmark

```
cd python
python -m bench.tracing_client_bench
```

`__main__` runs the create phase plus the patch phase both ways (`exclude_inputs=False` then `True`). The default is single-sample and therefore noisy; for a stable comparison, raise the sample count via the bench API:

```
python -c "import bench.tracing_client_bench as b; \
print({x: round(1000 / b.benchmark_run_creation(1000, 3000, samples=5, patch=True, exclude_inputs=x)['patch']['mean'], 1) for x in (False, True)})"
```

Patch throughput (1000 runs, JSON size 3000, mock transport, samples=5):

| `exclude_inputs` | patch throughput |
| --- | --- |
| `False` | 401.5 patches/s |
| `True` | **900.6 patches/s** |

~2.2× on the patch phase. The gain scales with input size and is a no-op for runs with no inputs. (Absolute numbers are machine-dependent; the ratio is the signal.)

## Behavior note

At the `trace()` context-manager exit in `run_helpers.py`, the run is posted on entry and the `RunTree` is handed to user code. Assigning `run.inputs` inside the `with` block will no longer be persisted, because the patch now omits inputs. Every other updated site sets inputs before `post()` and does not mutate them before the patch, so recorded inputs are unaffected.
