### PR TITLE
fix: sanitize git remote credentials [closes JKB-51]

### DIFF
--- a/js/src/tests/git_info.test.ts
+++ b/js/src/tests/git_info.test.ts
@@ -1,0 +1,134 @@
+import { jest, describe, test, expect, beforeEach } from "@jest/globals";
+import type { Example } from "../schemas.js";
+
+let remoteUrl = "https://github.com/langchain-ai/langsmith-sdk.git";
+
+const execMock = jest.fn(
+  (
+    command: string,
+    callback: (error: Error | null, stdout: string) => void,
+  ) => {
+    const outputs: Record<string, string> = {
+      "git rev-parse --is-inside-work-tree": "true",
+      "git remote get-url origin": remoteUrl,
+      "git rev-parse HEAD": "abc123",
+      "git log -1 --format=%ct": "1720000000",
+      "git rev-parse --abbrev-ref HEAD": "main",
+      "git describe --tags --exact-match --always --dirty": "abc123",
+      "git status --porcelain": "",
+      "git log -1 --format=%an": "LangSmith",
+      "git log -1 --format=%ae": "langsmith@example.com",
+    };
+    const output = outputs[command];
+    if (output === undefined) {
+      callback(new Error(`Unexpected command: ${command}`), "");
+      return;
+    }
+    callback(null, `${output}\n`);
+  },
+);
+
+jest.unstable_mockModule("child_process", () => ({
+  exec: execMock,
+}));
+
+const { getGitInfo } = await import("../utils/_git.js");
+const { _ExperimentManager } = await import("../evaluation/_runner.js");
+
+function makeExample(): Example {
+  const now = new Date().toISOString();
+  return {
+    id: "00000000-0000-0000-0000-000000000001",
+    inputs: { input: "hello" },
+    outputs: {},
+    dataset_id: "00000000-0000-0000-0000-000000000000",
+    created_at: now,
+    modified_at: now,
+    runs: [],
+  };
+}
+
+describe("git info", () => {
+  beforeEach(() => {
+    remoteUrl = "https://github.com/langchain-ai/langsmith-sdk.git";
+    execMock.mockClear();
+  });
+
+  test.each([
+    [
+      "credential-bearing HTTPS",
+      "https://user:token@github.com/langchain-ai/langsmith-sdk.git",
+      "https://github.com/langchain-ai/langsmith-sdk.git",
+    ],
+    [
+      "percent-encoded userinfo",
+      "https://user%40example.com:p%40ss%2Fword@github.com/org/repo.git",
+      "https://github.com/org/repo.git",
+    ],
+    [
+      "safe HTTPS",
+      "https://github.com/langchain-ai/langsmith-sdk.git",
+      "https://github.com/langchain-ai/langsmith-sdk.git",
+    ],
+    [
+      "SSH URL",
+      "ssh://git@github.com/langchain-ai/langsmith-sdk.git",
+      "ssh://git@github.com/langchain-ai/langsmith-sdk.git",
+    ],
+    [
+      "scp-style remote",
+      "git@github.com:langchain-ai/langsmith-sdk.git",
+      "git@github.com:langchain-ai/langsmith-sdk.git",
+    ],
+  ])("getGitInfo handles %s", async (_name, input, expected) => {
+    remoteUrl = input;
+    const gitInfo = await getGitInfo();
+    expect(gitInfo?.remoteUrl).toBe(expected);
+  });
+
+  test("evaluation project payloads use sanitized git remotes", async () => {
+    const rawRemoteUrl =
+      "https://user:token@github.com/langchain-ai/langsmith-sdk.git";
+    const sanitizedRemoteUrl =
+      "https://github.com/langchain-ai/langsmith-sdk.git";
+    remoteUrl = rawRemoteUrl;
+    const createProjectCalls: any[] = [];
+    const updateProjectCalls: any[] = [];
+    const client = {
+      createProject: async (params: any) => {
+        createProjectCalls.push(params);
+        return {
+          id: "00000000-0000-0000-0000-000000000004",
+          name: "test-project",
+          reference_dataset_id: "00000000-0000-0000-0000-000000000000",
+          extra: { metadata: {} },
+        };
+      },
+      updateProject: async (id: string, params: any) => {
+        updateProjectCalls.push([id, params]);
+        return {};
+      },
+      getDatasetUrl: async () => "http://test.com",
+    } as any;
+
+    const manager = new _ExperimentManager({
+      examples: [makeExample()],
+      client,
+    });
+    const startedManager = await manager.start();
+    await startedManager._end();
+
+    expect(createProjectCalls).toHaveLength(1);
+    expect(createProjectCalls[0].metadata.git.remoteUrl).toBe(
+      sanitizedRemoteUrl,
+    );
+    expect(JSON.stringify(createProjectCalls[0])).not.toContain(rawRemoteUrl);
+    expect(updateProjectCalls).toHaveLength(1);
+    expect(updateProjectCalls[0][1].metadata.git.remoteUrl).toBe(
+      sanitizedRemoteUrl,
+    );
+    expect(JSON.stringify(updateProjectCalls[0][1])).not.toContain(
+      rawRemoteUrl,
+    );
+  });
+});

--- a/js/src/utils/_git.ts
+++ b/js/src/utils/_git.ts
@@ -30,6 +30,38 @@ const execGit = (
   });
 };
 
+function sanitizeRemoteUrl(
+  remoteUrl?: string | null,
+): string | null | undefined {
+  if (remoteUrl == null) {
+    return remoteUrl;
+  }
+  const schemeSeparator = remoteUrl.indexOf("://");
+  if (schemeSeparator === -1) {
+    return remoteUrl;
+  }
+  const scheme = remoteUrl.slice(0, schemeSeparator).toLowerCase();
+  if (scheme !== "http" && scheme !== "https") {
+    return remoteUrl;
+  }
+  const authorityStart = schemeSeparator + "://".length;
+  let authorityEnd = remoteUrl.length;
+  for (const delimiter of ["/", "?", "#"]) {
+    const delimiterIndex = remoteUrl.indexOf(delimiter, authorityStart);
+    if (delimiterIndex !== -1) {
+      authorityEnd = Math.min(authorityEnd, delimiterIndex);
+    }
+  }
+  const authority = remoteUrl.slice(authorityStart, authorityEnd);
+  const userinfoEnd = authority.lastIndexOf("@");
+  if (userinfoEnd === -1) {
+    return remoteUrl;
+  }
+  return `${remoteUrl.slice(0, authorityStart)}${authority.slice(
+    userinfoEnd + 1,
+  )}${remoteUrl.slice(authorityEnd)}`;
+}
+
 export const getGitInfo = async (
   remote = "origin",
 ): Promise<GitInfo | null> => {
@@ -74,7 +106,7 @@ export const getGitInfo = async (
   ]);
 
   return {
-    remoteUrl,
+    remoteUrl: sanitizeRemoteUrl(remoteUrl),
     commit,
     commitTime,
     branch,

--- a/python/langsmith/env/_git.py
+++ b/python/langsmith/env/_git.py
@@ -21,6 +21,27 @@ def exec_git(command: List[str]) -> Optional[str]:
         return None
 
 
+def _sanitize_remote_url(remote_url: Optional[str]) -> Optional[str]:
+    if remote_url is None:
+        return None
+    scheme_separator = remote_url.find("://")
+    if scheme_separator == -1:
+        return remote_url
+    scheme = remote_url[:scheme_separator].lower()
+    if scheme not in ("http", "https"):
+        return remote_url
+    authority_start = scheme_separator + len("://")
+    authority_end = len(remote_url)
+    for delimiter in ("/", "?", "#"):
+        delimiter_index = remote_url.find(delimiter, authority_start)
+        if delimiter_index != -1:
+            authority_end = min(authority_end, delimiter_index)
+    userinfo_end = remote_url.rfind("@", authority_start, authority_end)
+    if userinfo_end == -1:
+        return remote_url
+    return remote_url[:authority_start] + remote_url[userinfo_end + 1 :]
+
+
 class GitInfo(TypedDict, total=False):
     repo_name: Optional[str]
     remote_url: Optional[str]
@@ -50,7 +71,7 @@ def get_git_info(remote: str = "origin") -> GitInfo:
         )
 
     return {
-        "remote_url": exec_git(["remote", "get-url", remote]),
+        "remote_url": _sanitize_remote_url(exec_git(["remote", "get-url", remote])),
         "commit": exec_git(["rev-parse", "HEAD"]),
         "commit_time": exec_git(["log", "-1", "--format=%ct"]),
         "branch": exec_git(["rev-parse", "--abbrev-ref", "HEAD"]),

--- a/python/tests/unit_tests/test_env.py
+++ b/python/tests/unit_tests/test_env.py
@@ -1,5 +1,6 @@
 import pytest
 
+import langsmith.env._git as git_env
 from langsmith.env import __all__ as env_all
 from langsmith.env import get_git_info, get_langchain_env_var_metadata
 
@@ -32,6 +33,83 @@ def test_git_info() -> None:
         assert "langsmith-sdk" in git_info["remote_url"]
     except AssertionError:
         pytest.skip("Git information is not available, skipping test.")
+
+
+def _patch_git_remote(
+    monkeypatch: pytest.MonkeyPatch, remote_url: str
+) -> list[list[str]]:
+    calls: list[list[str]] = []
+    outputs = {
+        ("rev-parse", "--is-inside-work-tree"): "true",
+        ("remote", "get-url", "origin"): remote_url,
+        ("rev-parse", "HEAD"): "abc123",
+        ("log", "-1", "--format=%ct"): "1720000000",
+        ("rev-parse", "--abbrev-ref", "HEAD"): "main",
+        ("describe", "--tags", "--exact-match", "--always", "--dirty"): "abc123",
+        ("status", "--porcelain"): "",
+        ("log", "-1", "--format=%an"): "LangSmith",
+        ("log", "-1", "--format=%ae"): "langsmith@example.com",
+        ("rev-parse", "--show-toplevel"): "/workspace/langsmith-sdk",
+    }
+
+    def fake_exec_git(command: list[str]) -> str | None:
+        calls.append(command)
+        return outputs.get(tuple(command))
+
+    monkeypatch.setattr(git_env, "exec_git", fake_exec_git)
+    get_git_info.cache_clear()
+    return calls
+
+
+@pytest.mark.parametrize(
+    ("remote_url", "expected_remote_url"),
+    [
+        (
+            "https://user:token@github.com/langchain-ai/langsmith-sdk.git",
+            "https://github.com/langchain-ai/langsmith-sdk.git",
+        ),
+        (
+            "https://user%40example.com:p%40ss%2Fword@github.com/org/repo.git",
+            "https://github.com/org/repo.git",
+        ),
+        (
+            "https://github.com/langchain-ai/langsmith-sdk.git",
+            "https://github.com/langchain-ai/langsmith-sdk.git",
+        ),
+        (
+            "ssh://git@github.com/langchain-ai/langsmith-sdk.git",
+            "ssh://git@github.com/langchain-ai/langsmith-sdk.git",
+        ),
+        (
+            "git@github.com:langchain-ai/langsmith-sdk.git",
+            "git@github.com:langchain-ai/langsmith-sdk.git",
+        ),
+    ],
+)
+def test_git_info_sanitizes_remote_urls(
+    monkeypatch: pytest.MonkeyPatch, remote_url: str, expected_remote_url: str
+) -> None:
+    _patch_git_remote(monkeypatch, remote_url)
+    try:
+        git_info = get_git_info()
+        assert git_info["remote_url"] == expected_remote_url
+    finally:
+        get_git_info.cache_clear()
+
+
+def test_git_info_caches_sanitized_remote_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    remote_url = "https://user:token@github.com/langchain-ai/langsmith-sdk.git"
+    calls = _patch_git_remote(monkeypatch, remote_url)
+    try:
+        assert get_git_info()["remote_url"] == (
+            "https://github.com/langchain-ai/langsmith-sdk.git"
+        )
+        assert get_git_info()["remote_url"] == (
+            "https://github.com/langchain-ai/langsmith-sdk.git"
+        )
+        assert calls.count(["remote", "get-url", "origin"]) == 1
+    finally:
+        get_git_info.cache_clear()
 
 
 @pytest.mark.parametrize(

--- a/python/tests/unit_tests/test_experiment_metadata.py
+++ b/python/tests/unit_tests/test_experiment_metadata.py
@@ -1,12 +1,16 @@
 """Unit tests for experiment-level metadata in the pytest integration."""
 
+import json
 import uuid
 from unittest.mock import MagicMock, patch
 
 import pytest
 
+import langsmith.env._git as git_env
+from langsmith.evaluation._runner import _ExperimentManager
 from langsmith.testing._internal import (
     _end_tests,
+    _get_test_suite,
     _LangSmithTestSuite,
     _start_experiment,
 )
@@ -37,6 +41,27 @@ def _make_client(dataset: MagicMock, experiment: MagicMock) -> MagicMock:
     client.read_dataset.return_value = dataset
     client.create_project.return_value = experiment
     return client
+
+
+def _patch_git_remote(monkeypatch: pytest.MonkeyPatch, remote_url: str) -> None:
+    outputs = {
+        ("rev-parse", "--is-inside-work-tree"): "true",
+        ("remote", "get-url", "origin"): remote_url,
+        ("rev-parse", "HEAD"): "abc123",
+        ("log", "-1", "--format=%ct"): "1720000000",
+        ("rev-parse", "--abbrev-ref", "HEAD"): "main",
+        ("describe", "--tags", "--exact-match", "--always", "--dirty"): "abc123",
+        ("status", "--porcelain"): "",
+        ("log", "-1", "--format=%an"): "LangSmith",
+        ("log", "-1", "--format=%ae"): "langsmith@example.com",
+        ("rev-parse", "--show-toplevel"): "/workspace/langsmith-sdk",
+    }
+
+    def fake_exec_git(command: list[str]) -> str | None:
+        return outputs.get(tuple(command))
+
+    monkeypatch.setattr(git_env, "exec_git", fake_exec_git)
+    git_env.get_git_info.cache_clear()
 
 
 # ---------------------------------------------------------------------------
@@ -163,6 +188,73 @@ def test_end_tests_system_keys_take_precedence():
     metadata = update_kwargs["metadata"]
     assert metadata["__ls_runner"] == "pytest"
     assert metadata["revision_id"] == "sys-rev"
+
+
+def test_git_remote_sanitized_in_test_suite_payloads(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    raw_remote_url = "https://user:token@github.com/langchain-ai/langsmith-sdk.git"
+    sanitized_remote_url = "https://github.com/langchain-ai/langsmith-sdk.git"
+    dataset = _make_dataset()
+    experiment = _make_experiment()
+    client = _make_client(dataset, experiment)
+    client.has_dataset.return_value = False
+    client.create_dataset.return_value = dataset
+    _patch_git_remote(monkeypatch, raw_remote_url)
+    try:
+        assert _get_test_suite(client, "my-suite") is dataset
+        _, create_kwargs = client.create_dataset.call_args
+        assert raw_remote_url not in create_kwargs["description"]
+        assert sanitized_remote_url in create_kwargs["description"]
+
+        suite = _LangSmithTestSuite(client, experiment, dataset)
+        suite._executor = MagicMock()
+        suite._executor.shutdown = MagicMock()
+        suite._dataset_version = None
+        _end_tests(suite)
+
+        _, update_kwargs = client.update_project.call_args
+        metadata = update_kwargs["metadata"]
+        assert metadata["remote_url"] == sanitized_remote_url
+        assert raw_remote_url not in json.dumps(metadata, default=str)
+    finally:
+        git_env.get_git_info.cache_clear()
+
+
+def test_git_remote_sanitized_in_evaluation_project_payloads(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    raw_remote_url = "https://user:token@github.com/langchain-ai/langsmith-sdk.git"
+    sanitized_remote_url = "https://github.com/langchain-ai/langsmith-sdk.git"
+    dataset_id = uuid.uuid4()
+    example = MagicMock()
+    example.dataset_id = dataset_id
+    example.modified_at = None
+    example.metadata = {}
+    experiment = _make_experiment()
+    experiment.metadata = {}
+    experiment.reference_dataset_id = dataset_id
+    experiment.url = None
+    client = MagicMock()
+    client.create_project.return_value = experiment
+    _patch_git_remote(monkeypatch, raw_remote_url)
+    try:
+        manager = _ExperimentManager(
+            [example], experiment="my-experiment", client=client, num_examples=1
+        )
+        started_manager = manager.start()
+        _, create_kwargs = client.create_project.call_args
+        create_metadata = create_kwargs["metadata"]
+        assert create_metadata["git"]["remote_url"] == sanitized_remote_url
+        assert raw_remote_url not in json.dumps(create_metadata, default=str)
+
+        started_manager._end()
+        _, update_kwargs = client.update_project.call_args
+        update_metadata = update_kwargs["metadata"]
+        assert update_metadata["git"]["remote_url"] == sanitized_remote_url
+        assert raw_remote_url not in json.dumps(update_metadata, default=str)
+    finally:
+        git_env.get_git_info.cache_clear()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description
Sanitizes HTTP(S) Git remotes at the Python and JS collector choke points before SDK metadata or dataset payloads can persist embedded credentials. Adds focused collector and downstream payload regression coverage for the affected Python and JS paths.

## Test Plan
- [x] `make -C python format`; focused `make -C python tests TEST="tests/unit_tests/test_env.py tests/unit_tests/test_experiment_metadata.py"`
- [x] `pnpm format`; `pnpm lint`; `pnpm run check:types`; focused `jest src/tests/git_info.test.ts`
- [x] `make -C python lint` (blocked by existing mypy error in `langsmith/utils.py:792` under Python 3.14)

Made by [Open SWE](https://openswe.vercel.app/agents/38ddba2a-cb07-d8fa-6aad-f7bab833cd9c)

## References
- Plan: https://openswe.vercel.app/agents/38ddba2a-cb07-d8fa-6aad-f7bab833cd9c/plan