### PR TITLE
Fix create_child() ignoring tracing_context(replicas=...) when a parent is set

### DIFF
--- a/python/langsmith/run_trees.py
+++ b/python/langsmith/run_trees.py
@@ -652,7 +652,7 @@ class RunTree(ls_schemas.RunBase):
             extra=child_extra,
             parent_run=self,
             project_name=self.session_name,
-            replicas=self.replicas,
+            replicas=self.replicas or _REPLICAS.get(),
             ls_client=self.ls_client,
             tags=tags,
             attachments=attachments or {},  # type: ignore

--- a/python/tests/unit_tests/test_replica_endpoints.py
+++ b/python/tests/unit_tests/test_replica_endpoints.py
@@ -10,6 +10,7 @@ import pytest
 
 from langsmith import Client, compute_run_id_for_secondary_replica
 from langsmith import utils as ls_utils
+from langsmith.run_helpers import tracing_context
 from langsmith.run_trees import (
     ApiKeyAuth,
     AuthHeaders,
@@ -806,6 +807,41 @@ class TestRunTreeReplicas:
         assert calls[1][1]["id"] == compute_run_id_for_secondary_replica(
             run_tree.id, "replica2-project"
         )
+
+    def test_create_child_honors_ambient_replicas_when_parent_has_none(self):
+        """create_child() must fall back to the ambient tracing_context(replicas=...)
+        when the parent itself carries no replicas -- e.g. any distributed-tracing
+        scenario, where the parent is reconstructed via RunTree.from_headers() and
+        starts with an empty replicas list unless the caller explicitly forwarded
+        one via baggage.
+
+        Regression test: create_child() used to pass ``replicas=self.replicas``
+        unconditionally, which is never ``None`` (an empty list, not ``None``), so
+        the contextvar fallback in RunTree's own validator never triggered and the
+        ambient override was silently dropped for every child run.
+        """
+        client = Mock()
+        parent = RunTree(
+            name="parent_run",
+            inputs={"input": "test"},
+            client=client,
+            project_name="test-project",
+        )
+        assert parent.replicas == []  # sanity check: the parent itself has none
+
+        with tracing_context(
+            replicas=[WriteReplica(project_name="ambient-project", primary=True)]
+        ):
+            child = parent.create_child(name="child_run")
+
+        assert len(child.replicas) == 1
+        assert child.replicas[0]["project_name"] == "ambient-project"
+        assert child.replicas[0]["primary"] is True
+
+        child.post()
+
+        assert client.create_run.call_count == 1
+        assert client.create_run.call_args[1]["session_name"] == "ambient-project"
 
     def test_run_tree_with_service_auth_replicas(self):
         """Test RunTree with ServiceAuth replicas."""


### PR DESCRIPTION
Fixes #3344

## Description

`RunTree.create_child()` passed `replicas=self.replicas` unconditionally when constructing the child. Since this is never `None` (an empty list, not `None`, when the parent has no replicas of its own), it bypassed the `if values.get("replicas") is None: values["replicas"] = _REPLICAS.get()` fallback in `RunTree`'s validator — the only place the ambient `_REPLICAS` contextvar is consulted for a non-root run. So `tracing_context(replicas=...)` was silently ignored for any run with a parent, including every run inside a distributed-tracing scenario (`tracing_context(parent=<headers>)`), since the placeholder parent from `RunTree.from_headers()` starts with an empty replicas list unless the caller forwarded one via baggage.

## Fix

```python
replicas=self.replicas or _REPLICAS.get(),
```

in `create_child()`, matching the fallback already used for root-level runs.

## Testing

Added `test_create_child_honors_ambient_replicas_when_parent_has_none` to `TestRunTreeReplicas`. Fails on `main` before this change, passes after; full `test_replica_endpoints.py` suite still passes.
