### PR TITLE
fix: add replicas to RunTrees created from headers/dotted-order

### DIFF
--- a/python/langsmith/run_helpers.py
+++ b/python/langsmith/run_helpers.py
@@ -180,7 +180,9 @@ def tracing_context(
         )
     current_context = get_tracing_context()
     parent_run = (
-        _get_parent_run({"parent": parent or kwargs.get("parent_run")})
+        _get_parent_run(
+            {"parent": parent or kwargs.get("parent_run"), "replicas": replicas}
+        )
         if parent is not False
         else None
     )
@@ -281,6 +283,8 @@ class LangSmithExtra(TypedDict, total=False):
     """Optional ID for the run."""
     client: Optional[ls_client.Client]
     """Optional LangSmith client."""
+    replicas: Optional[Sequence[WriteReplica]]
+    """Optional write replicas to apply to the run and its descendants."""
     # Optional callback function to be called if the run succeeds and before it is sent.
     _on_success: Optional[Callable[[run_trees.RunTree], None]]
     on_end: Optional[Callable[[run_trees.RunTree], Any]]
@@ -1519,6 +1523,7 @@ def _get_parent_run(
             client=langsmith_extra.get("client"),
             # Precedence: headers -> cvar -> explicit -> env var
             project_name=_get_project_name(langsmith_extra.get("project_name")),
+            replicas=langsmith_extra.get("replicas"),
         )
     if isinstance(parent, str):
         dort = run_trees.RunTree.from_dotted_order(
@@ -1526,6 +1531,7 @@ def _get_parent_run(
             client=langsmith_extra.get("client"),
             # Precedence: cvar -> explicit ->  env var
             project_name=_get_project_name(langsmith_extra.get("project_name")),
+            replicas=langsmith_extra.get("replicas"),
         )
         return dort
     run_tree = langsmith_extra.get("run_tree")

--- a/python/tests/unit_tests/test_run_helpers.py
+++ b/python/tests/unit_tests/test_run_helpers.py
@@ -6,6 +6,7 @@ import json
 import os
 import sys
 import time
+import urllib.parse
 import uuid
 import warnings
 import weakref
@@ -2587,3 +2588,44 @@ def test_ls_message_view_exclude_metadata_cascades_to_child_runs() -> None:
         f"expected all {len(payloads)} runs to carry "
         f"{LS_MESSAGE_VIEW_EXCLUDE}=True, only {len(excluded)} did"
     )
+
+
+@pytest.mark.parametrize("parent_kind", ["dict", "str"])
+def test_tracing_context_replicas_apply_to_distributed_root_run(parent_kind: str):
+    """`tracing_context(parent=<headers|dotted_order>, replicas=[...])` applies.
+
+    Regression test for LSDK-449. The downstream service's root run is created as
+    a child of the placeholder parent rebuilt from the incoming trace context.
+    That placeholder used to be constructed before `_REPLICAS` was set and without
+    the explicit `replicas` argument, so it ended up with `[]`, and `create_child`
+    propagated that `[]` to the root run and every descendant.
+    """
+    replicas = [{"project_name": "project-b", "primary": True}]
+    upstream = RunTree(name="a_root", run_type="chain", project_name="project-a")
+    parent = upstream.to_headers() if parent_kind == "dict" else upstream.dotted_order
+
+    seen = {}
+
+    @traceable(run_type="chain", name="b_root")
+    def b_root():
+        run = get_current_run_tree()
+        seen["replicas"] = run.replicas
+        seen["parent_run_id"] = run.parent_run_id
+        return nested()
+
+    @traceable(run_type="llm", name="nested")
+    def nested():
+        seen["nested_replicas"] = get_current_run_tree().replicas
+        return "ok"
+
+    with tracing_context(enabled="local"):
+        with tracing_context(parent=parent, replicas=replicas):
+            placeholder = get_current_run_tree()
+            assert placeholder is not None
+            assert placeholder.replicas == replicas
+            b_root()
+
+    assert seen["replicas"] == replicas
+    assert seen["nested_replicas"] == replicas
+    # No reroot: the downstream root still points at the real upstream run id.
+    assert seen["parent_run_id"] == upstream.id

--- a/python/tests/unit_tests/test_run_helpers.py
+++ b/python/tests/unit_tests/test_run_helpers.py
@@ -6,7 +6,6 @@ import json
 import os
 import sys
 import time
-import urllib.parse
 import uuid
 import warnings
 import weakref


### PR DESCRIPTION
## Problem

`tracing_context(replicas=[...])` is silently ignored for every run created under a parent reconstructed from an incoming distributed trace context, so the downstream service's runs land in the default project instead of the configured replica. Fixes LSDK-449 / #3344.

Two things have to line up for the replicas to reach the run, and neither did:

- `tracing_context` resolves `parent` (`run_helpers.py:182`) **before** it sets `_REPLICAS` (`:194`), so the placeholder parent is built while the contextvar still holds the outer value.
- `_get_parent_run` forwards `client` and `project_name` to `RunTree.from_headers` / `from_dotted_order`, but not `replicas` (`:1516-1530`).

```python
# ServiceB, with the same replica config as ServiceA
with tracing_context(parent=headers, replicas=[{"project_name": "project-b", "primary": True}]):
    handle_request()          # -> replicas == [], written to the default project
```

## Change

Forward the explicit `replicas` to the placeholder parent, so the whole subtree inherits it through the existing `self.replicas` path:

- `_get_parent_run` passes `replicas` to both `RunTree.from_headers` and `RunTree.from_dotted_order`.
- `tracing_context` includes `replicas` in the dict it hands to `_get_parent_run`.
- `LangSmithExtra` gains a `replicas` field, so `@traceable(langsmith_extra={"parent": headers, "replicas": [...]})` works the same way.

`create_child()` is untouched. #3344 suggests `replicas=self.replicas or _REPLICAS.get()` there instead; fixing the placeholder keeps `create_child()` a pure function of its parent, so siblings can't diverge and a parent with `replicas=[]` can't have children silently pick up ambient replicas or `LANGSMITH_RUNS_ENDPOINTS`.

Behavior is unchanged when no `replicas` are passed, and header-supplied replicas keep their existing precedence.

## Test Plan

- [x] New `test_tracing_context_replicas_apply_to_distributed_root_run`, parametrized over both parent forms (`dict` headers and `str` dotted order). Asserts the placeholder parent, the downstream root run, and a nested child all carry the replicas, and that `parent_run_id` still points at the real upstream run id.
- [x] Both parametrizations fail with the `_get_parent_run` change reverted, and pass with it.
- [x] `ruff check` and `ruff format --check` clean on both changed files.
- [x] Verified end to end against a two-service handoff — ServiceA root in `project-a`, headers over the wire carrying no replicas, ServiceB configured with the same replica list — that ServiceB's root run and its children resolve to `project-b`.