### PR TITLE
fix(python): use inspect.iscoroutinefunction() instead of the asyncio alias

### DIFF
--- a/python/langsmith/_internal/_beta_decorator.py
+++ b/python/langsmith/_internal/_beta_decorator.py
@@ -1,7 +1,7 @@
-import asyncio
 import contextlib
 import contextvars
 import functools
+import inspect
 import warnings
 from collections.abc import Iterator
 from typing import Any, Callable
@@ -67,7 +67,7 @@ def deprecated(message: str) -> Callable:
     """
 
     def decorator(func: Callable) -> Callable:
-        if asyncio.iscoroutinefunction(func):
+        if inspect.iscoroutinefunction(func):
 
             @functools.wraps(func)
             async def async_wrapper(*args: Any, **kwargs: Any) -> Any:


### PR DESCRIPTION
Python 3.14 deprecates `asyncio.iscoroutinefunction()` (removal scheduled for 3.16) and directs callers to `inspect.iscoroutinefunction()` instead.

The `deprecated()` decorator in `langsmith/_internal/_beta_decorator.py` runs at class-definition time, so merely importing `langsmith.client` emits a `DeprecationWarning` per decorated method on 3.14. Under `-W error` that turns the import itself into a failure — which is how it shows up in `tests/unit_tests/test_otel_url.py`.

`inspect.iscoroutinefunction()` unwraps `functools.partial` the same way, so this is a drop-in replacement on every Python this package supports (`>= 3.10`) and needs no version guard.

### Verification

Per `python/AGENTS.md`:

- `make lint` — `ruff` clean. `mypy` reports one error, `langsmith/utils.py:792` (`Executor.map` signature override); I confirmed it is **pre-existing** by re-running `mypy` on an unmodified checkout, which produces the identical error. It is in a different file and unrelated to this change.
- `make tests` — **1911 passed, 6 skipped**.

### Context

openSUSE has been carrying this as a downstream patch on `python-langsmith`; sending it upstream so the distro patch can be dropped.