### PR TITLE
feat(py): add AsyncClient.update_feedback and update_example

### DIFF
--- a/python/langsmith/async_client.py
+++ b/python/langsmith/async_client.py
@@ -1186,6 +1186,11 @@ class AsyncClient:
             include_dataset_id=False,
             dangerously_allow_filesystem=dangerously_allow_filesystem,
         )
+        # Over ~20MB _prepare_multipart_data returns the encoder itself for the
+        # sync path to stream; httpx rejects that object, and retries could not
+        # rewind it, so materialize.
+        if not isinstance(data, (bytes, str)):
+            data = encoder.to_string()
         try:
             response = await self._arequest_with_retries(
                 "PATCH",

--- a/python/langsmith/async_client.py
+++ b/python/langsmith/async_client.py
@@ -1079,6 +1079,61 @@ class AsyncClient:
         )
         return ls_schemas.Example(**response.json())
 
+    async def update_example(
+        self,
+        example_id: ls_client.ID_TYPE,
+        *,
+        inputs: Optional[dict[str, Any]] = None,
+        outputs: Optional[Mapping[str, Any]] = None,
+        metadata: Optional[dict] = None,
+        split: Optional[Union[str, list[str]]] = None,
+        dataset_id: Optional[ls_client.ID_TYPE] = None,
+    ) -> dict[str, Any]:
+        """Update an example.
+
+        Args:
+            example_id: The ID of the example to update.
+            inputs: The input values to update.
+            outputs: The output values to update.
+            metadata: The metadata to update.
+            split: The dataset split to update, such as 'train', 'test', or
+                'validation'.
+            dataset_id: The ID of the dataset the example belongs to. Read from
+                the example when omitted.
+
+        Returns:
+            The updated example.
+        """
+        example_dict = dict(
+            inputs=inputs,
+            outputs=outputs,
+            id=example_id,
+            metadata=metadata,
+            split=split,
+        )
+        example = ls_schemas.ExampleUpdate(
+            **{k: v for k, v in example_dict.items() if v is not None}
+        )
+        if dataset_id is None:
+            dataset_id = (await self.read_example(example_id)).dataset_id
+
+        response = await self._arequest_with_retries(
+            "PATCH",
+            f"/examples/{ls_client._as_uuid(example_id, 'example_id')}",
+            content=ls_client._dumps_json(
+                {
+                    **{
+                        k: v
+                        for k, v in ls_client.dump_model(example).items()
+                        if v is not None
+                    },
+                    "dataset_id": str(dataset_id),
+                }
+            ),
+        )
+        ls_utils.raise_for_status_with_text(response)
+        return response.json()
+
     async def read_example(self, example_id: ls_client.ID_TYPE) -> ls_schemas.Example:
         """Read an example."""
         response = await self._arequest_with_retries(
@@ -1407,6 +1462,40 @@ class AsyncClient:
             ix += 1
             if limit is not None and ix >= limit:
                 break
+
+    async def update_feedback(
+        self,
+        feedback_id: ID_TYPE,
+        *,
+        score: Union[float, int, bool, None] = None,
+        value: Union[float, int, bool, str, dict, None] = None,
+        correction: Union[dict, None] = None,
+        comment: Union[str, None] = None,
+    ) -> None:
+        """Update a feedback by ID.
+
+        Args:
+            feedback_id: The ID of the feedback to update.
+            score: The score to update the feedback with.
+            value: The value to update the feedback with.
+            correction: The correction to update the feedback with.
+            comment: The comment to update the feedback with.
+        """
+        feedback_update: dict[str, Any] = {}
+        if score is not None:
+            feedback_update["score"] = ls_client._format_feedback_score(score)
+        if value is not None:
+            feedback_update["value"] = value
+        if correction is not None:
+            feedback_update["correction"] = correction
+        if comment is not None:
+            feedback_update["comment"] = comment
+        response = await self._arequest_with_retries(
+            "PATCH",
+            f"/feedback/{ls_client._as_uuid(feedback_id, 'feedback_id')}",
+            content=ls_client._dumps_json(feedback_update),
+        )
+        ls_utils.raise_for_status_with_text(response)
 
     async def delete_feedback(self, feedback_id: ID_TYPE) -> None:
         """Delete a feedback by ID.

--- a/python/langsmith/async_client.py
+++ b/python/langsmith/async_client.py
@@ -1088,6 +1088,9 @@ class AsyncClient:
         metadata: Optional[dict] = None,
         split: Optional[Union[str, list[str]]] = None,
         dataset_id: Optional[ls_client.ID_TYPE] = None,
+        attachments_operations: Optional[ls_schemas.AttachmentsOperations] = None,
+        attachments: Optional[ls_schemas.Attachments] = None,
+        dangerously_allow_filesystem: bool = False,
     ) -> dict[str, Any]:
         """Update an example.
 
@@ -1100,22 +1103,46 @@ class AsyncClient:
                 'validation'.
             dataset_id: The ID of the dataset the example belongs to. Read from
                 the example when omitted.
+            attachments_operations: The attachments operations to perform.
+            attachments: The attachments to add to the example.
+            dangerously_allow_filesystem: Whether to allow attachments to be
+                read from local filesystem paths.
 
         Returns:
             The updated example.
         """
+        info = await self.info()
+        multipart_enabled = (info.instance_flags or {}).get(
+            "dataset_examples_multipart_enabled", False
+        )
+        if attachments_operations is not None and not multipart_enabled:
+            raise ValueError(
+                "Your LangSmith deployment does not allow using the attachment "
+                "operations, please upgrade your deployment to the latest version."
+            )
         example_dict = dict(
             inputs=inputs,
             outputs=outputs,
             id=example_id,
             metadata=metadata,
             split=split,
+            attachments_operations=attachments_operations,
+            attachments=attachments,
         )
         example = ls_schemas.ExampleUpdate(
             **{k: v for k, v in example_dict.items() if v is not None}
         )
         if dataset_id is None:
             dataset_id = (await self.read_example(example_id)).dataset_id
+
+        if multipart_enabled:
+            return dict(
+                await self._update_examples_multipart(
+                    dataset_id=dataset_id,
+                    updates=[example],
+                    dangerously_allow_filesystem=dangerously_allow_filesystem,
+                )
+            )
 
         response = await self._arequest_with_retries(
             "PATCH",
@@ -1132,6 +1159,43 @@ class AsyncClient:
             ),
         )
         ls_utils.raise_for_status_with_text(response)
+        return response.json()
+
+    async def _update_examples_multipart(
+        self,
+        *,
+        dataset_id: ls_client.ID_TYPE,
+        updates: Optional[list[ls_schemas.ExampleUpdate]] = None,
+        dangerously_allow_filesystem: bool = False,
+    ) -> ls_schemas.UpsertExamplesResponse:
+        """Update examples using the multipart examples endpoint."""
+        info = await self.info()
+        if not (info.instance_flags or {}).get(
+            "dataset_examples_multipart_enabled", False
+        ):
+            raise ValueError(
+                "Your LangSmith deployment does not allow using the latest examples "
+                "endpoints, please upgrade your deployment to the latest version or "
+                "downgrade your SDK to langsmith<0.3.9."
+            )
+        if updates is None:
+            updates = []
+
+        encoder, data, opened_files_dict = ls_client._prepare_multipart_data(
+            updates,
+            include_dataset_id=False,
+            dangerously_allow_filesystem=dangerously_allow_filesystem,
+        )
+        try:
+            response = await self._arequest_with_retries(
+                "PATCH",
+                ls_client._dataset_examples_path(self._api_url, dataset_id),
+                content=data,
+                headers={"Content-Type": encoder.content_type},
+            )
+            ls_utils.raise_for_status_with_text(response)
+        finally:
+            ls_client._close_files(list(opened_files_dict.values()))
         return response.json()
 
     async def read_example(self, example_id: ls_client.ID_TYPE) -> ls_schemas.Example:

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -6413,184 +6413,11 @@ class Client:
         include_dataset_id: bool = False,
         dangerously_allow_filesystem: bool = False,
     ) -> tuple[Any, bytes, dict[str, io.BufferedReader]]:
-        parts: list[MultipartPart] = []
-        opened_files_dict: dict[str, io.BufferedReader] = {}
-        if include_dataset_id:
-            if not isinstance(examples[0], ls_schemas.ExampleUpsertWithAttachments):
-                raise ValueError(
-                    "The examples must be of type ExampleUpsertWithAttachments"
-                    " if include_dataset_id is True"
-                )
-            dataset_id = examples[0].dataset_id
-
-        for example in examples:
-            if (
-                not isinstance(example, ls_schemas.ExampleCreate)
-                and not isinstance(example, ls_schemas.ExampleUpsertWithAttachments)
-                and not isinstance(example, ls_schemas.ExampleUpdate)
-            ):
-                raise ValueError(
-                    "The examples must be of type ExampleCreate"
-                    " or ExampleUpsertWithAttachments"
-                    " or ExampleUpdate"
-                )
-            if example.id is not None:
-                example_id = str(example.id)
-            else:
-                example_id = str(uuid.uuid4())
-
-            if isinstance(example, ls_schemas.ExampleUpdate):
-                created_at = None
-            else:
-                created_at = example.created_at
-
-            if isinstance(example, ls_schemas.ExampleCreate):
-                use_source_run_io = example.use_source_run_io
-                use_source_run_attachments = example.use_source_run_attachments
-                source_run_id = example.source_run_id
-            else:
-                use_source_run_io, use_source_run_attachments, source_run_id = (
-                    None,
-                    None,
-                    None,
-                )
-
-            example_body = {
-                **({"dataset_id": dataset_id} if include_dataset_id else {}),
-                **({"created_at": created_at} if created_at is not None else {}),
-                **(
-                    {"use_source_run_io": use_source_run_io}
-                    if use_source_run_io
-                    else {}
-                ),
-                **(
-                    {"use_source_run_attachments": use_source_run_attachments}
-                    if use_source_run_attachments
-                    else {}
-                ),
-                **({"source_run_id": source_run_id} if source_run_id else {}),
-            }
-            if example.metadata is not None:
-                example_body["metadata"] = example.metadata
-            if example.split is not None:
-                example_body["split"] = example.split
-            valb = _dumps_json(example_body)
-
-            parts.append(
-                (
-                    f"{example_id}",
-                    (
-                        None,
-                        valb,
-                        "application/json",
-                        {},
-                    ),
-                )
-            )
-
-            if example.inputs is not None:
-                inputsb = _dumps_json(example.inputs)
-                parts.append(
-                    (
-                        f"{example_id}.inputs",
-                        (
-                            None,
-                            inputsb,
-                            "application/json",
-                            {},
-                        ),
-                    )
-                )
-
-            if example.outputs is not None:
-                outputsb = _dumps_json(example.outputs)
-                parts.append(
-                    (
-                        f"{example_id}.outputs",
-                        (
-                            None,
-                            outputsb,
-                            "application/json",
-                            {},
-                        ),
-                    )
-                )
-
-            if example.attachments:
-                for name, attachment in example.attachments.items():
-                    if isinstance(attachment, dict):
-                        mime_type = attachment["mime_type"]
-                        attachment_data = attachment["data"]
-                    else:
-                        mime_type, attachment_data = attachment
-                    if isinstance(attachment_data, Path):
-                        if dangerously_allow_filesystem:
-                            try:
-                                file_size = os.path.getsize(attachment_data)
-                                file = open(attachment_data, "rb")
-                            except FileNotFoundError:
-                                logger.warning(
-                                    "Attachment file not found for example %s: %s",
-                                    example_id,
-                                    attachment_data,
-                                )
-                                continue
-                            opened_files_dict[
-                                str(attachment_data) + str(uuid.uuid4())
-                            ] = file
-
-                            parts.append(
-                                (
-                                    f"{example_id}.attachment.{name}",
-                                    (
-                                        None,
-                                        file,  # type: ignore[arg-type]
-                                        f"{mime_type}; length={file_size}",
-                                        {},
-                                    ),
-                                )
-                            )
-                        else:
-                            raise ValueError(
-                                "dangerously_allow_filesystem must be True to upload files from the filesystem"
-                            )
-                    else:
-                        parts.append(
-                            (
-                                f"{example_id}.attachment.{name}",
-                                (
-                                    None,
-                                    attachment_data,
-                                    f"{mime_type}; length={len(attachment_data)}",
-                                    {},
-                                ),
-                            )
-                        )
-
-            if (
-                isinstance(example, ls_schemas.ExampleUpdate)
-                and example.attachments_operations
-            ):
-                attachments_operationsb = _dumps_json(example.attachments_operations)
-                parts.append(
-                    (
-                        f"{example_id}.attachments_operations",
-                        (
-                            None,
-                            attachments_operationsb,
-                            "application/json",
-                            {},
-                        ),
-                    )
-                )
-
-        encoder = rqtb_multipart.MultipartEncoder(parts, boundary=_BOUNDARY)
-        if encoder.len <= 20_000_000:  # ~20 MB
-            data = encoder.to_string()
-        else:
-            data = encoder
-
-        return encoder, data, opened_files_dict
+        return _prepare_multipart_data(
+            examples,
+            include_dataset_id=include_dataset_id,
+            dangerously_allow_filesystem=dangerously_allow_filesystem,
+        )
 
     def update_examples_multipart(
         self,
@@ -11710,6 +11537,191 @@ def _close_files(files: list[io.BufferedReader]) -> None:
         except Exception:
             logger.debug("Could not close file: %s", file.name)
             pass
+
+
+def _prepare_multipart_data(
+    examples: Union[
+        list[ls_schemas.ExampleCreate]
+        | list[ls_schemas.ExampleUpsertWithAttachments]
+        | list[ls_schemas.ExampleUpdate],
+    ],
+    include_dataset_id: bool = False,
+    dangerously_allow_filesystem: bool = False,
+) -> tuple[Any, bytes, dict[str, io.BufferedReader]]:
+    parts: list[MultipartPart] = []
+    opened_files_dict: dict[str, io.BufferedReader] = {}
+    if include_dataset_id:
+        if not isinstance(examples[0], ls_schemas.ExampleUpsertWithAttachments):
+            raise ValueError(
+                "The examples must be of type ExampleUpsertWithAttachments"
+                " if include_dataset_id is True"
+            )
+        dataset_id = examples[0].dataset_id
+
+    for example in examples:
+        if (
+            not isinstance(example, ls_schemas.ExampleCreate)
+            and not isinstance(example, ls_schemas.ExampleUpsertWithAttachments)
+            and not isinstance(example, ls_schemas.ExampleUpdate)
+        ):
+            raise ValueError(
+                "The examples must be of type ExampleCreate"
+                " or ExampleUpsertWithAttachments"
+                " or ExampleUpdate"
+            )
+        if example.id is not None:
+            example_id = str(example.id)
+        else:
+            example_id = str(uuid.uuid4())
+
+        if isinstance(example, ls_schemas.ExampleUpdate):
+            created_at = None
+        else:
+            created_at = example.created_at
+
+        if isinstance(example, ls_schemas.ExampleCreate):
+            use_source_run_io = example.use_source_run_io
+            use_source_run_attachments = example.use_source_run_attachments
+            source_run_id = example.source_run_id
+        else:
+            use_source_run_io, use_source_run_attachments, source_run_id = (
+                None,
+                None,
+                None,
+            )
+
+        example_body = {
+            **({"dataset_id": dataset_id} if include_dataset_id else {}),
+            **({"created_at": created_at} if created_at is not None else {}),
+            **({"use_source_run_io": use_source_run_io} if use_source_run_io else {}),
+            **(
+                {"use_source_run_attachments": use_source_run_attachments}
+                if use_source_run_attachments
+                else {}
+            ),
+            **({"source_run_id": source_run_id} if source_run_id else {}),
+        }
+        if example.metadata is not None:
+            example_body["metadata"] = example.metadata
+        if example.split is not None:
+            example_body["split"] = example.split
+        valb = _dumps_json(example_body)
+
+        parts.append(
+            (
+                f"{example_id}",
+                (
+                    None,
+                    valb,
+                    "application/json",
+                    {},
+                ),
+            )
+        )
+
+        if example.inputs is not None:
+            inputsb = _dumps_json(example.inputs)
+            parts.append(
+                (
+                    f"{example_id}.inputs",
+                    (
+                        None,
+                        inputsb,
+                        "application/json",
+                        {},
+                    ),
+                )
+            )
+
+        if example.outputs is not None:
+            outputsb = _dumps_json(example.outputs)
+            parts.append(
+                (
+                    f"{example_id}.outputs",
+                    (
+                        None,
+                        outputsb,
+                        "application/json",
+                        {},
+                    ),
+                )
+            )
+
+        if example.attachments:
+            for name, attachment in example.attachments.items():
+                if isinstance(attachment, dict):
+                    mime_type = attachment["mime_type"]
+                    attachment_data = attachment["data"]
+                else:
+                    mime_type, attachment_data = attachment
+                if isinstance(attachment_data, Path):
+                    if dangerously_allow_filesystem:
+                        try:
+                            file_size = os.path.getsize(attachment_data)
+                            file = open(attachment_data, "rb")
+                        except FileNotFoundError:
+                            logger.warning(
+                                "Attachment file not found for example %s: %s",
+                                example_id,
+                                attachment_data,
+                            )
+                            continue
+                        opened_files_dict[str(attachment_data) + str(uuid.uuid4())] = (
+                            file
+                        )
+
+                        parts.append(
+                            (
+                                f"{example_id}.attachment.{name}",
+                                (
+                                    None,
+                                    file,  # type: ignore[arg-type]
+                                    f"{mime_type}; length={file_size}",
+                                    {},
+                                ),
+                            )
+                        )
+                    else:
+                        raise ValueError(
+                            "dangerously_allow_filesystem must be True to upload files from the filesystem"
+                        )
+                else:
+                    parts.append(
+                        (
+                            f"{example_id}.attachment.{name}",
+                            (
+                                None,
+                                attachment_data,
+                                f"{mime_type}; length={len(attachment_data)}",
+                                {},
+                            ),
+                        )
+                    )
+
+        if (
+            isinstance(example, ls_schemas.ExampleUpdate)
+            and example.attachments_operations
+        ):
+            attachments_operationsb = _dumps_json(example.attachments_operations)
+            parts.append(
+                (
+                    f"{example_id}.attachments_operations",
+                    (
+                        None,
+                        attachments_operationsb,
+                        "application/json",
+                        {},
+                    ),
+                )
+            )
+
+    encoder = rqtb_multipart.MultipartEncoder(parts, boundary=_BOUNDARY)
+    if encoder.len <= 20_000_000:  # ~20 MB
+        data = encoder.to_string()
+    else:
+        data = encoder
+
+    return encoder, data, opened_files_dict
 
 
 def _dataset_examples_path(api_url: str, dataset_id: ID_TYPE) -> str:

--- a/python/tests/unit_tests/test_async_client.py
+++ b/python/tests/unit_tests/test_async_client.py
@@ -7,6 +7,7 @@ import pathlib
 import uuid
 import warnings
 from datetime import datetime
+from typing import Any
 from unittest import mock
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
@@ -16,6 +17,7 @@ import pytest
 import requests
 
 from langsmith import AsyncClient
+from langsmith import client as ls_client
 from langsmith import schemas as ls_schemas
 from langsmith import utils as ls_utils
 
@@ -1137,3 +1139,49 @@ async def test_update_example_rejects_attachment_ops_without_flag(
             uuid4(),
             attachments_operations=ls_schemas.AttachmentsOperations(retain=["f"]),
         )
+
+
+@mock.patch("langsmith.async_client.httpx.AsyncClient")
+@pytest.mark.asyncio
+@patch("langsmith.async_client.ls_utils.raise_for_status_with_text")
+async def test_update_example_materializes_streaming_multipart_encoder(
+    mock_raise_for_status: mock.Mock,
+    mock_client_cls: mock.Mock,
+) -> None:
+    """Over ~20MB the helper returns the encoder itself; httpx only takes bytes."""
+    mock_httpx_client = AsyncMock()
+    mock_client_cls.return_value = mock_httpx_client
+    mock_raise_for_status.return_value = None
+
+    response = MagicMock()
+    response.status_code = 200
+    response.json.return_value = {"count": 1}
+    mock_httpx_client.request.return_value = response
+
+    example_id = uuid4()
+    dataset_id = uuid4()
+    client = AsyncClient(api_url="http://localhost:1984", api_key="test")
+    client._info = ls_schemas.LangSmithInfo(
+        instance_flags={"dataset_examples_multipart_enabled": True}
+    )
+
+    from requests_toolbelt.multipart import encoder as rqtb_encoder
+
+    def _stream_instead_of_bytes(*args: Any, **kwargs: Any):
+        # Mirrors the >20MB branch: data is the unconsumed encoder, not bytes.
+        enc = rqtb_encoder.MultipartEncoder(
+            [("f", ("f", b"hello", "text/plain"))], boundary="testboundary"
+        )
+        return enc, enc, {}
+
+    with patch.object(ls_client, "_prepare_multipart_data", _stream_instead_of_bytes):
+        await client.update_example(
+            example_id,
+            inputs={"a": 1},
+            dataset_id=dataset_id,
+            attachments={"f": ("text/plain", b"hello")},
+        )
+
+    content = mock_httpx_client.request.call_args.kwargs["content"]
+    assert isinstance(content, bytes)
+    assert b"hello" in content

--- a/python/tests/unit_tests/test_async_client.py
+++ b/python/tests/unit_tests/test_async_client.py
@@ -1029,6 +1029,7 @@ async def test_update_example_sends_dataset_id_and_updates(
     mock_httpx_client.request.return_value = response
 
     client = AsyncClient(api_url="http://localhost:1984", api_key="test")
+    client._info = ls_schemas.LangSmithInfo(instance_flags={})
     result = await client.update_example(
         example_id,
         inputs={"a": 1},
@@ -1076,9 +1077,63 @@ async def test_update_example_reads_dataset_id_when_omitted(
     mock_httpx_client.request.side_effect = [read_response, patch_response]
 
     client = AsyncClient(api_url="http://localhost:1984", api_key="test")
+    client._info = ls_schemas.LangSmithInfo(instance_flags={})
     await client.update_example(example_id, inputs={"a": 1})
 
     read_call, patch_call = mock_httpx_client.request.call_args_list
     assert read_call.args[0] == "GET"
     assert patch_call.args[0] == "PATCH"
     assert json.loads(patch_call.kwargs["content"])["dataset_id"] == str(dataset_id)
+
+
+@mock.patch("langsmith.async_client.httpx.AsyncClient")
+@pytest.mark.asyncio
+@patch("langsmith.async_client.ls_utils.raise_for_status_with_text")
+async def test_update_example_uses_multipart_when_flag_enabled(
+    mock_raise_for_status: mock.Mock,
+    mock_client_cls: mock.Mock,
+) -> None:
+    mock_httpx_client = AsyncMock()
+    mock_client_cls.return_value = mock_httpx_client
+    mock_raise_for_status.return_value = None
+
+    example_id = uuid4()
+    dataset_id = uuid4()
+    response = MagicMock()
+    response.status_code = 200
+    response.json.return_value = {"count": 1}
+    mock_httpx_client.request.return_value = response
+
+    client = AsyncClient(api_url="http://localhost:1984", api_key="test")
+    client._info = ls_schemas.LangSmithInfo(
+        instance_flags={"dataset_examples_multipart_enabled": True}
+    )
+    result = await client.update_example(
+        example_id,
+        inputs={"a": 1},
+        dataset_id=dataset_id,
+        attachments={"f": ("text/plain", b"hello")},
+    )
+
+    call = mock_httpx_client.request.call_args
+    assert call.args[0] == "PATCH"
+    assert call.args[1].endswith(f"/platform/datasets/{dataset_id}/examples")
+    assert call.kwargs["headers"]["Content-Type"].startswith("multipart/form-data")
+    assert b"hello" in call.kwargs["content"]
+    assert result == {"count": 1}
+
+
+@mock.patch("langsmith.async_client.httpx.AsyncClient")
+@pytest.mark.asyncio
+async def test_update_example_rejects_attachment_ops_without_flag(
+    mock_client_cls: mock.Mock,
+) -> None:
+    mock_client_cls.return_value = AsyncMock()
+    client = AsyncClient(api_url="http://localhost:1984", api_key="test")
+    client._info = ls_schemas.LangSmithInfo(instance_flags={})
+
+    with pytest.raises(ValueError, match="attachment"):
+        await client.update_example(
+            uuid4(),
+            attachments_operations=ls_schemas.AttachmentsOperations(retain=["f"]),
+        )

--- a/python/tests/unit_tests/test_async_client.py
+++ b/python/tests/unit_tests/test_async_client.py
@@ -982,3 +982,103 @@ async def test_async_client_resource_version_check(
 
     version_warnings = [r for r in caplog.records if r.name == _VERSION_LOGGER]
     assert bool(version_warnings) is expect_warning
+
+
+@mock.patch("langsmith.async_client.httpx.AsyncClient")
+@pytest.mark.asyncio
+@patch("langsmith.async_client.ls_utils.raise_for_status_with_text")
+async def test_update_feedback_patches_only_provided_fields(
+    mock_raise_for_status: mock.Mock,
+    mock_client_cls: mock.Mock,
+) -> None:
+    mock_httpx_client = AsyncMock()
+    mock_client_cls.return_value = mock_httpx_client
+    mock_raise_for_status.return_value = None
+
+    response = MagicMock()
+    response.status_code = 200
+    mock_httpx_client.request.return_value = response
+
+    feedback_id = uuid4()
+    client = AsyncClient(api_url="http://localhost:1984", api_key="test")
+    await client.update_feedback(feedback_id, score=1, comment="looks right")
+
+    call = mock_httpx_client.request.call_args
+    assert call.args[0] == "PATCH"
+    assert call.args[1] == f"/feedback/{feedback_id}"
+    body = json.loads(call.kwargs["content"])
+    assert body == {"score": 1, "comment": "looks right"}
+
+
+@mock.patch("langsmith.async_client.httpx.AsyncClient")
+@pytest.mark.asyncio
+@patch("langsmith.async_client.ls_utils.raise_for_status_with_text")
+async def test_update_example_sends_dataset_id_and_updates(
+    mock_raise_for_status: mock.Mock,
+    mock_client_cls: mock.Mock,
+) -> None:
+    mock_httpx_client = AsyncMock()
+    mock_client_cls.return_value = mock_httpx_client
+    mock_raise_for_status.return_value = None
+
+    example_id = uuid4()
+    dataset_id = uuid4()
+    response = MagicMock()
+    response.status_code = 200
+    response.json.return_value = {"id": str(example_id)}
+    mock_httpx_client.request.return_value = response
+
+    client = AsyncClient(api_url="http://localhost:1984", api_key="test")
+    result = await client.update_example(
+        example_id,
+        inputs={"a": 1},
+        outputs={"b": 2},
+        metadata={"granularity": "finding"},
+        dataset_id=dataset_id,
+    )
+
+    call = mock_httpx_client.request.call_args
+    assert call.args[0] == "PATCH"
+    assert call.args[1] == f"/examples/{example_id}"
+    body = json.loads(call.kwargs["content"])
+    assert body["inputs"] == {"a": 1}
+    assert body["outputs"] == {"b": 2}
+    assert body["metadata"] == {"granularity": "finding"}
+    assert body["dataset_id"] == str(dataset_id)
+    assert result == {"id": str(example_id)}
+
+
+@mock.patch("langsmith.async_client.httpx.AsyncClient")
+@pytest.mark.asyncio
+@patch("langsmith.async_client.ls_utils.raise_for_status_with_text")
+async def test_update_example_reads_dataset_id_when_omitted(
+    mock_raise_for_status: mock.Mock,
+    mock_client_cls: mock.Mock,
+) -> None:
+    mock_httpx_client = AsyncMock()
+    mock_client_cls.return_value = mock_httpx_client
+    mock_raise_for_status.return_value = None
+
+    example_id = uuid4()
+    dataset_id = uuid4()
+    now = datetime(2024, 1, 1).isoformat()
+    read_response = MagicMock()
+    read_response.status_code = 200
+    read_response.json.return_value = {
+        "id": str(example_id),
+        "dataset_id": str(dataset_id),
+        "inputs": {},
+        "created_at": now,
+    }
+    patch_response = MagicMock()
+    patch_response.status_code = 200
+    patch_response.json.return_value = {"id": str(example_id)}
+    mock_httpx_client.request.side_effect = [read_response, patch_response]
+
+    client = AsyncClient(api_url="http://localhost:1984", api_key="test")
+    await client.update_example(example_id, inputs={"a": 1})
+
+    read_call, patch_call = mock_httpx_client.request.call_args_list
+    assert read_call.args[0] == "GET"
+    assert patch_call.args[0] == "PATCH"
+    assert json.loads(patch_call.kwargs["content"])["dataset_id"] == str(dataset_id)


### PR DESCRIPTION
## Summary

`AsyncClient` exposed `create`/`read`/`delete` for both feedback and examples, but no `update`. Async callers had to keep a synchronous `Client` around and dispatch the update path to a worker thread — the exact thing `AsyncClient` exists to avoid.

Adds:

- **`AsyncClient.update_feedback`** — mirrors `Client.update_feedback`; PATCHes only the fields provided.
- **`AsyncClient.update_example`** — full parity with `Client.update_example`, including `attachments`, `attachments_operations`, `dangerously_allow_filesystem`, and the multipart update route gated on the `dataset_examples_multipart_enabled` instance flag. Falls back to the plain PATCH path when the flag is off, and raises the same `ValueError` when attachment operations are requested against a deployment that does not support them.

`_prepare_multipart_data` never referenced `self`, so it moves to a module-level function that both clients call. `Client._prepare_multipart_data` stays as a thin delegate, so no existing caller changes. The `client.py` diff is only that move — two hunks, no other edits.

Not included: `load_child_runs` on `AsyncClient.read_run`. It is deprecated on the sync client and raises outright on SmithDB-only backends, so it did not seem right to add it to a newer surface.

## Test plan

- [x] `AsyncClient.update_feedback` PATCHes only provided fields, to the right path
- [x] `AsyncClient.update_example` sends inputs/outputs/metadata plus `dataset_id`
- [x] `AsyncClient.update_example` reads `dataset_id` from the example when omitted
- [x] `AsyncClient.update_example` uses the multipart endpoint and encodes attachments when the flag is on
- [x] `AsyncClient.update_example` raises when attachment operations are used without the flag
- [x] `tests/unit_tests/test_async_client.py` — 31 passed
- [x] `tests/unit_tests/test_client.py` — no new failures; the 3 remaining (`test_validate_multiple_urls`, `test_validate_api_key_if_hosted_with_tracing[Client|AsyncClient]`) reproduce unchanged on the base commit