### PR TITLE
release(py): 0.10.17

### DIFF
--- a/python/.bumpversion.cfg
+++ b/python/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.10.16
+current_version = 0.10.17
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
 serialize = {major}.{minor}.{patch}
 search = {current_version}

--- a/python/langsmith/__init__.py
+++ b/python/langsmith/__init__.py
@@ -49,7 +49,7 @@ if TYPE_CHECKING:
 
 # Avoid calling into importlib on every call to __version__
 
-__version__ = "0.10.16"
+__version__ = "0.10.17"
 version = __version__  # for backwards compatibility
 
 # Metadata key to hide a traced run from LangSmith's Messages View.


### PR DESCRIPTION
Cuts a Python release so everything merged since 0.10.16 reaches PyPI. Bumps only the two version files (`python/langsmith/__init__.py`, `python/.bumpversion.cfg`) via the documented `bump2version patch` flow; on merge to `main`, `.github/workflows/release.yml` tags `v0.10.17`, builds, and publishes to PyPI.

Ships since 0.10.16:

- **`replicas` now reach RunTrees created from headers / dotted-order** (#3346). `tracing_context(replicas=[...])` was silently ignored for runs created under a parent reconstructed from an incoming distributed trace context, so the downstream service's runs landed in the default project instead of the configured replica. `_get_parent_run` now forwards `replicas` to `RunTree.from_headers` / `from_dotted_order`, and `LangSmithExtra` gained a `replicas` field. Fixes LSDK-449 / #3344.

That is the only commit on `main` since 0.10.16.