### PR TITLE
feat(python): LANGSMITH_EXCLUDE_INPUTS_ON_PATCH to skip inputs on patch

### DIFF
--- a/python/bench/tracing_client_bench.py
+++ b/python/bench/tracing_client_bench.py
@@ -1,3 +1,27 @@
+"""Benchmark client-side tracing throughput for run creation and run patching.
+
+The HTTP session is mocked, so this measures only the SDK's own cost - payload
+serialization, compression and tracing-queue handling - with no network or
+LangSmith backend involved.
+
+Run as a script, it reports three phases: a create-only baseline, then a patch
+phase with and without `inputs`, plus a speedup summary. The latter quantifies
+what is saved by omitting inputs from a patch when they were already sent on the
+create (see `RunTree.patch(exclude_inputs=True)`).
+
+Usage:
+    uv run python bench/tracing_client_bench.py
+    BENCH_SAMPLES=5 uv run python bench/tracing_client_bench.py
+
+`BENCH_SAMPLES` sets the number of timed repetitions (default 1, which reports a
+zero stdev and is dominated by warmup). Payload size and run count are the
+`json_size` and `num_runs` module-level constants.
+
+Note: `create_run_data` is also imported by `tracing_client_via_pyo3.py` and
+`tracing_rust_client_bench.py`, so keep its signature stable.
+"""
+
+import os
 import statistics
 import time
 from datetime import datetime, timedelta, timezone
@@ -57,12 +81,35 @@ def create_run_data(
     }
 
 
-def benchmark_run_creation(num_runs: int, json_size: int, samples: int = 1) -> Dict:
+def _stats(timings: list) -> Dict:
+    return {
+        "mean": statistics.mean(timings),
+        "median": statistics.median(timings),
+        "stdev": statistics.stdev(timings) if len(timings) > 1 else 0,
+        "min": min(timings),
+        "max": max(timings),
+    }
+
+
+def benchmark_run_creation(
+    num_runs: int,
+    json_size: int,
+    samples: int = 1,
+    *,
+    patch: bool = False,
+    exclude_inputs: bool = False,
+) -> Dict:
     """
-    Benchmark run creation with specified parameters.
+    Benchmark run creation (and optionally patching) with specified parameters.
     Returns timing statistics.
+
+    Args:
+        patch: Also benchmark a patch (update_run) phase for each created run.
+        exclude_inputs: When patching, omit inputs from the patch (they were
+            already sent on the create). Mirrors RunTree.patch(exclude_inputs=True).
     """
-    timings = []
+    timings: list = []
+    patch_timings: list = []
 
     project_name = "__tracing_client_bench_python" + datetime.now().strftime(
         "%Y%m%dT%H%M%S"
@@ -86,38 +133,93 @@ def benchmark_run_creation(num_runs: int, json_size: int, samples: int = 1) -> D
         # wait for client.tracing_queue to be empty
         client.tracing_queue.join()
 
-        elapsed = time.perf_counter() - start
+        timings.append(time.perf_counter() - start)
 
-        timings.append(elapsed)
+        if patch:
+            patch_start = time.perf_counter()
+            for run in runs:
+                client.update_run(
+                    run_id=run["id"],
+                    trace_id=run["trace_id"],
+                    dotted_order=run["dotted_order"],
+                    outputs=run["outputs"],
+                    end_time=datetime.now(timezone.utc),
+                    inputs=None if exclude_inputs else run["inputs"],
+                )
+            client.tracing_queue.join()
+            patch_timings.append(time.perf_counter() - patch_start)
 
     return {
-        "mean": statistics.mean(timings),
-        "median": statistics.median(timings),
-        "stdev": statistics.stdev(timings) if len(timings) > 1 else 0,
-        "min": min(timings),
-        "max": max(timings),
+        "create": _stats(timings),
+        "patch": _stats(patch_timings) if patch else None,
     }
 
 
 json_size = 3_000
 num_runs = 1000
+samples = int(os.environ.get("BENCH_SAMPLES", "1"))
 
 
-def main(json_size: int, num_runs: int):
+def _print_stats(label: str, num: int, stats: Dict, unit: str) -> None:
+    print(f"\n{label}:")
+    print(f"Mean time: {stats['mean']:.4f} seconds")
+    print(f"Median time: {stats['median']:.4f} seconds")
+    print(f"Std Dev: {stats['stdev']:.4f} seconds")
+    print(f"Min time: {stats['min']:.4f} seconds")
+    print(f"Max time: {stats['max']:.4f} seconds")
+    print(f"Throughput: {num / stats['mean']:.2f} {unit}")
+
+
+def main(
+    json_size: int,
+    num_runs: int,
+    samples: int = 1,
+    *,
+    patch: bool = False,
+    exclude_inputs: bool = False,
+) -> Dict:
     """
     Run benchmarks with different combinations of parameters and report results.
     """
 
-    results = benchmark_run_creation(num_runs=num_runs, json_size=json_size)
+    results = benchmark_run_creation(
+        num_runs=num_runs,
+        json_size=json_size,
+        samples=samples,
+        patch=patch,
+        exclude_inputs=exclude_inputs,
+    )
 
-    print(f"\nBenchmark Results for {num_runs} runs with JSON size {json_size}:")
-    print(f"Mean time: {results['mean']:.4f} seconds")
-    print(f"Median time: {results['median']:.4f} seconds")
-    print(f"Std Dev: {results['stdev']:.4f} seconds")
-    print(f"Min time: {results['min']:.4f} seconds")
-    print(f"Max time: {results['max']:.4f} seconds")
-    print(f"Throughput: {num_runs / results['mean']:.2f} runs/second")
+    _print_stats(
+        f"Create results for {num_runs} runs with JSON size {json_size}",
+        num_runs,
+        results["create"],
+        "runs/second",
+    )
+    if results["patch"] is not None:
+        _print_stats(
+            f"Patch results (exclude_inputs={exclude_inputs})",
+            num_runs,
+            results["patch"],
+            "patches/second",
+        )
+    return results
 
 
 if __name__ == "__main__":
-    main(json_size, num_runs)
+    # Create-only baseline (default behavior), then the patch phase both ways
+    # to show the exclude_inputs optimization side by side.
+    # Set BENCH_SAMPLES>1 for a measurement that is not dominated by warmup.
+    main(json_size, num_runs, samples)
+    off = main(json_size, num_runs, samples, patch=True, exclude_inputs=False)
+    on = main(json_size, num_runs, samples, patch=True, exclude_inputs=True)
+
+    off_mean = off["patch"]["mean"]
+    on_mean = on["patch"]["mean"]
+    saved = 100 * (1 - on_mean / off_mean)
+    print("\nPatch-phase comparison:")
+    print(
+        f"exclude_inputs=False: {num_runs / off_mean:.2f} patches/s ({off_mean:.4f}s)"
+    )
+    print(f"exclude_inputs=True:  {num_runs / on_mean:.2f} patches/s ({on_mean:.4f}s)")
+    print(f"speedup: {off_mean / on_mean:.2f}x  ({saved:.1f}% faster)")

--- a/python/langsmith/run_trees.py
+++ b/python/langsmith/run_trees.py
@@ -141,6 +141,20 @@ def _filter_replica_for_headers(replica: WriteReplica) -> WriteReplica:
     return cast(WriteReplica, filtered)
 
 
+@functools.lru_cache(maxsize=1)
+def _exclude_inputs_on_patch() -> bool:
+    """Whether `RunTree.patch()` should omit `inputs` by default.
+
+    Controlled by ``LANGSMITH_EXCLUDE_INPUTS_ON_PATCH``; defaults to ``False``, i.e.
+    inputs are re-sent on every patch. Enabling it skips serializing and uploading
+    the inputs a second time, which is a meaningful saving for large payloads, but
+    it also means inputs first set *after* `post()` are never persisted.
+
+    Read once per process and cached; call ``.cache_clear()`` to re-read.
+    """
+    return utils.is_truish(utils.get_env_var("EXCLUDE_INPUTS_ON_PATCH"))
+
+
 LANGSMITH_PREFIX = "langsmith-"
 LANGSMITH_DOTTED_ORDER = sys.intern(f"{LANGSMITH_PREFIX}trace")
 LANGSMITH_DOTTED_ORDER_BYTES = LANGSMITH_DOTTED_ORDER.encode("utf-8")
@@ -522,6 +536,10 @@ class RunTree(ls_schemas.RunBase):
     def add_inputs(self, inputs: dict[str, Any]) -> None:
         """Upsert the given inputs into the run.
 
+        Note: if `LANGSMITH_EXCLUDE_INPUTS_ON_PATCH` is enabled, inputs added
+        after the initial `post()` are not sent by `patch()`. Call
+        `patch(exclude_inputs=False)` explicitly to persist them.
+
         Args:
             inputs: A dictionary containing the inputs to be added.
         """
@@ -820,12 +838,18 @@ class RunTree(ls_schemas.RunBase):
             for child_run in self.child_runs:
                 child_run.post(exclude_child_runs=False)
 
-    def patch(self, *, exclude_inputs: bool = False) -> None:
+    def patch(self, *, exclude_inputs: Optional[bool] = None) -> None:
         """Patch the run tree to the API in a background thread.
 
         Args:
             exclude_inputs: Whether to exclude inputs from the patch request.
+                Defaults to `None`, meaning the value of the
+                `LANGSMITH_EXCLUDE_INPUTS_ON_PATCH` environment variable is used
+                (itself defaulting to `False`). Pass an explicit `True` or `False`
+                to override the environment for this call.
         """
+        if exclude_inputs is None:
+            exclude_inputs = _exclude_inputs_on_patch()
         if not self.end_time:
             self.end()
         attachments = {

--- a/python/tests/unit_tests/test_run_trees.py
+++ b/python/tests/unit_tests/test_run_trees.py
@@ -14,6 +14,7 @@ from requests_toolbelt import MultipartEncoder
 
 from langsmith import run_trees
 from langsmith import schemas as ls_schemas
+from langsmith import utils as ls_utils
 from langsmith._internal._uuid import uuid7_deterministic
 from langsmith.client import Client
 from langsmith.run_trees import RunTree
@@ -744,3 +745,104 @@ def test_runtree_set_accepts_pydantic_basemodel_outputs():
     rt = RunTree(name="test", run_type="chain", inputs={})
     rt.set(outputs=MyOutput(answer="result"))
     assert rt.outputs == {"answer": "result"}
+
+
+@pytest.fixture
+def _reset_exclude_inputs_cache():
+    """Reset the memoized `LANGSMITH_EXCLUDE_INPUTS_ON_PATCH` lookup."""
+
+    def _clear():
+        run_trees._exclude_inputs_on_patch.cache_clear()
+        ls_utils.get_env_var.cache_clear()
+
+    _clear()
+    yield _clear
+    _clear()
+
+
+@pytest.mark.parametrize(
+    "env_name, env_value, explicit, expect_inputs",
+    [
+        # Unset env var keeps today's behaviour: inputs are re-sent on patch.
+        (None, None, None, True),
+        ("LANGSMITH_EXCLUDE_INPUTS_ON_PATCH", "true", None, False),
+        ("LANGSMITH_EXCLUDE_INPUTS_ON_PATCH", "TRUE", None, False),
+        ("LANGSMITH_EXCLUDE_INPUTS_ON_PATCH", "1", None, False),
+        ("LANGSMITH_EXCLUDE_INPUTS_ON_PATCH", "false", None, True),
+        ("LANGSMITH_EXCLUDE_INPUTS_ON_PATCH", "bogus", None, True),
+        # The LANGCHAIN_ namespace is honoured too.
+        ("LANGCHAIN_EXCLUDE_INPUTS_ON_PATCH", "true", None, False),
+        # An explicit argument always wins over the environment.
+        ("LANGSMITH_EXCLUDE_INPUTS_ON_PATCH", "true", False, True),
+        (None, None, True, False),
+    ],
+)
+def test_patch_exclude_inputs_env_flag(
+    monkeypatch,
+    _reset_exclude_inputs_cache,
+    env_name,
+    env_value,
+    explicit,
+    expect_inputs,
+):
+    monkeypatch.delenv("LANGSMITH_EXCLUDE_INPUTS_ON_PATCH", raising=False)
+    monkeypatch.delenv("LANGCHAIN_EXCLUDE_INPUTS_ON_PATCH", raising=False)
+    if env_name is not None:
+        monkeypatch.setenv(env_name, env_value)
+    _reset_exclude_inputs_cache()
+
+    client = MagicMock()
+    run_tree = RunTree(
+        name="test_run", run_type="chain", inputs={"a": 1}, client=client
+    )
+    run_tree.patch(**({} if explicit is None else {"exclude_inputs": explicit}))
+
+    sent = client.update_run.call_args.kwargs["inputs"]
+    if expect_inputs:
+        assert sent == {"a": 1}
+    else:
+        assert sent is None
+
+
+def test_patch_exclude_inputs_env_flag_with_replicas(
+    monkeypatch, _reset_exclude_inputs_cache
+):
+    """The replica patch path honours the flag as well."""
+    monkeypatch.setenv("LANGSMITH_EXCLUDE_INPUTS_ON_PATCH", "true")
+    _reset_exclude_inputs_cache()
+
+    client = MagicMock()
+    run_tree = RunTree(
+        name="test_run",
+        run_type="chain",
+        inputs={"a": 1},
+        client=client,
+        project_name="test-project",
+        replicas=[run_trees.WriteReplica(project_name="replica-project")],
+    )
+    run_tree.patch()
+
+    assert client.update_run.call_args.kwargs["inputs"] is None
+
+
+def test_patch_exclude_inputs_flag_is_cached(monkeypatch, _reset_exclude_inputs_cache):
+    """The env var is read once per process, not on every patch."""
+    monkeypatch.delenv("LANGSMITH_EXCLUDE_INPUTS_ON_PATCH", raising=False)
+    monkeypatch.delenv("LANGCHAIN_EXCLUDE_INPUTS_ON_PATCH", raising=False)
+    _reset_exclude_inputs_cache()
+
+    client = MagicMock()
+    run_tree = RunTree(
+        name="test_run", run_type="chain", inputs={"a": 1}, client=client
+    )
+    run_tree.patch()
+    assert client.update_run.call_args.kwargs["inputs"] == {"a": 1}
+
+    # Flipping the env var mid-process has no effect until the cache is cleared.
+    monkeypatch.setenv("LANGSMITH_EXCLUDE_INPUTS_ON_PATCH", "true")
+    run_tree.patch()
+    assert client.update_run.call_args.kwargs["inputs"] == {"a": 1}
+
+    _reset_exclude_inputs_cache()
+    run_tree.patch()
+    assert client.update_run.call_args.kwargs["inputs"] is None


### PR DESCRIPTION
## Problem

Inputs are serialized and sent when a run is created (`post()`), then serialized and sent **again** on the closing `patch()` even though they have not changed. The cost scales with input size.

#3342 took this on by passing `exclude_inputs=True` at all 21 internal `patch()` call sites across 7 modules unconditionally. This PR aims to make the same on a global level, in a backward-compatible way.

## Change

Same optimization, opt-in behind an environment variable. `RunTree.patch()` now takes `exclude_inputs: Optional[bool] = None` (`run_trees.py:841`); the sentinel resolves to `LANGSMITH_EXCLUDE_INPUTS_ON_PATCH`, read once per process via `utils.get_env_var` and memoized (`run_trees.py:144`).

- Unset → `False` → current behavior, unchanged.
- Every existing bare `run.patch()` inherits the flag, so there is no call-site churn.
- An explicit `exclude_inputs=True`/`False` still wins; the two deliberate `True` sites in `openai_agents_sdk` are untouched.
- `add_inputs()` documents that inputs added after `post()` are not sent while the flag is on.

Resolving through a memoized helper rather than a signature default keeps generated API docs deterministic and lets tests toggle the flag with `cache_clear()`, and binds at first `patch()` rather than at import, so env configured after `run_trees` is imported still applies.

## Benchmarks

`bench/tracing_client_bench.py` gains the patch phase from #3342, plus `BENCH_SAMPLES` for multi-sample runs. 1000 runs, 3000-element JSON inputs and outputs, mocked HTTP session, `BENCH_SAMPLES=5`:

| patch phase | patches/s | mean | min–max |
|---|---|---|---|
| `exclude_inputs=False` | 1076 | 0.930s | 0.758–1.387s |
| `exclude_inputs=True` | 2132 | 0.469s | 0.396–0.559s |

1.98x, 49.6% faster, with non-overlapping ranges. Measured at `Client.update_run`, so it isolates payload serialization and tracing-queue cost. `RunTree.patch()` additionally skips `self.inputs.copy()` when excluding, so the `@traceable` path saves somewhat more than this.

## Test Plan

- [x] 11 new cases in `test_run_trees.py`: env unset / `true` / `TRUE` / `1` / `false` / `bogus`, the `LANGCHAIN_` namespace, both explicit-override directions, the replica patch path, and one pinning that the lookup really is cached
- [x] `make tests` — 1932 passed, 6 skipped
- [x] `ruff format --check`, `ruff check`, `mypy` clean on the changed files
- [x] End to end through `@traceable`: inputs present on the POST in both modes, absent from the PATCH only with the flag enabled
