### PR TITLE
feat(sandbox): add Context Hub mount helpers

### DIFF
--- a/js/src/sandbox/README.md
+++ b/js/src/sandbox/README.md
@@ -292,6 +292,41 @@ Private Git repositories can use low-level `proxyConfig` rules when the remote
 requires proxy-managed auth. There is not yet a high-level private Git auth
 helper.
 
+Context Hub mounts do not require AWS or GCP auth, and unlike bucket and Git
+mounts they can target any path outside the system directories — not just paths
+under `/mnt/mounts`. The repo's latest commit tree is mirrored into the mount
+path and kept in sync for the sandbox's lifetime. The caller's API key must have
+access to the repo:
+
+```typescript
+import { contextHubMount, mountConfig } from "langsmith/sandbox";
+
+const mountCfg = mountConfig({
+  mounts: [
+    contextHubMount({
+      id: "memories",
+      mountPath: "/memories",
+      repo: "-/my-agent",
+    }),
+  ],
+});
+
+const sandbox = await client.createSandbox({
+  name: "context-hub-mount-sandbox",
+  mountConfig: mountCfg,
+});
+
+try {
+  const result = await sandbox.run("ls /memories");
+  console.log(result.stdout);
+} finally {
+  await sandbox.delete();
+}
+```
+
+Pass `initialPullOnly: true` to sync once at startup instead of polling for repo
+updates, and `readOnly: true` to make the mount pull-only.
+
 If one sandbox needs S3, GCS, and Git mounts, build one `mountConfig` with the
 bucket provider auth blocks and all mount specs:
 

--- a/js/src/sandbox/README.md
+++ b/js/src/sandbox/README.md
@@ -292,11 +292,15 @@ Private Git repositories can use low-level `proxyConfig` rules when the remote
 requires proxy-managed auth. There is not yet a high-level private Git auth
 helper.
 
-Context Hub mounts do not require AWS or GCP auth, and unlike bucket and Git
-mounts they can target any path outside the system directories — not just paths
-under `/mnt/mounts`. The repo's latest commit tree is mirrored into the mount
-path and kept in sync for the sandbox's lifetime. The caller's API key must have
-access to the repo:
+Context Hub mounts are **read-only**: the repo's latest commit tree is mirrored
+into the mount path and kept in sync for the sandbox's lifetime, but the sync is
+one-way. Files written under the mount path inside the sandbox are never pushed
+back to the repo, and the next sync overwrites them. Write sandbox output
+somewhere else and push it with the Context Hub SDK if it belongs in the repo.
+
+They do not require AWS or GCP auth, and unlike bucket and Git mounts they can
+target any path outside the system directories — not just paths under
+`/mnt/mounts`. The caller's API key must have access to the repo:
 
 ```typescript
 import { contextHubMount, mountConfig } from "langsmith/sandbox";
@@ -325,7 +329,7 @@ try {
 ```
 
 Pass `initialPullOnly: true` to sync once at startup instead of polling for repo
-updates, and `readOnly: true` to make the mount pull-only.
+updates.
 
 If one sandbox needs S3, GCS, and Git mounts, build one `mountConfig` with the
 bucket provider auth blocks and all mount specs:

--- a/js/src/sandbox/index.ts
+++ b/js/src/sandbox/index.ts
@@ -39,7 +39,13 @@ export {
   proxyConfig,
   workspaceSecret,
 } from "./proxy_config.js";
-export { gcsMount, gitMount, mountConfig, s3Mount } from "./mounts.js";
+export {
+  contextHubMount,
+  gcsMount,
+  gitMount,
+  mountConfig,
+  s3Mount,
+} from "./mounts.js";
 
 // Types
 export type {
@@ -66,6 +72,8 @@ export type {
   SandboxProxySecret,
   SandboxMount,
   MountCacheConfig,
+  ContextHubMountConfig,
+  ContextHubMountSpec,
   GCSMountConfig,
   GCSMountSpec,
   GitMountConfig,

--- a/js/src/sandbox/mounts.ts
+++ b/js/src/sandbox/mounts.ts
@@ -1,4 +1,5 @@
 import type {
+  ContextHubMountSpec,
   GCSMountSpec,
   GitMountRefSpec,
   GitMountSpec,
@@ -198,6 +199,86 @@ export function gcsMount({
   return mount;
 }
 
+const PROTECTED_GUEST_PATHS = [
+  "/bin",
+  "/boot",
+  "/dev",
+  "/etc",
+  "/lib",
+  "/lib64",
+  "/proc",
+  "/root",
+  "/run",
+  "/sbin",
+  "/sys",
+  "/usr",
+  "/var",
+];
+
+function requireContextHubMountPath(mountPath: string): string {
+  const path = requireNonEmptyString(mountPath, "mountPath");
+  const segments = path.slice(1).split("/");
+  const isClean =
+    path.startsWith("/") &&
+    segments.every(
+      (segment) => segment !== "" && segment !== "." && segment !== "..",
+    );
+  if (!isClean) {
+    throw new Error("mountPath must be an absolute, clean path");
+  }
+  for (const protectedPath of PROTECTED_GUEST_PATHS) {
+    if (path === protectedPath || path.startsWith(`${protectedPath}/`)) {
+      throw new Error(
+        `mountPath must not be at or under system directory ${protectedPath}`,
+      );
+    }
+  }
+  return path;
+}
+
+function requireContextHubRepo(repo: string): string {
+  if (typeof repo !== "string" || repo === "") {
+    throw new Error("repo must be a non-empty string");
+  }
+  if (repo.trim() !== repo) {
+    throw new Error("repo must not include leading or trailing whitespace");
+  }
+  if (repo.includes(String.fromCharCode(0))) {
+    throw new Error("repo must not contain NUL bytes");
+  }
+  return repo;
+}
+
+export function contextHubMount({
+  id,
+  mountPath,
+  repo,
+  initialPullOnly,
+  readOnly,
+}: {
+  id: string;
+  mountPath: string;
+  repo: string;
+  initialPullOnly?: boolean;
+  readOnly?: boolean;
+}): ContextHubMountSpec {
+  const mount: ContextHubMountSpec = {
+    id: requireNonEmptyString(id, "id"),
+    type: "contexthub",
+    mount_path: requireContextHubMountPath(mountPath),
+    contexthub: {
+      repo: requireContextHubRepo(repo),
+    },
+  };
+  if (initialPullOnly !== undefined) {
+    mount.contexthub.initial_pull_only = initialPullOnly;
+  }
+  if (readOnly !== undefined) {
+    mount.read_only = readOnly;
+  }
+  return mount;
+}
+
 function normalizeMounts(mounts: SandboxMount[]): SandboxMount[] {
   if (!Array.isArray(mounts) || mounts.length === 0) {
     throw new Error("mounts must be a non-empty array of mount objects");
@@ -206,8 +287,15 @@ function normalizeMounts(mounts: SandboxMount[]): SandboxMount[] {
     if (mount === null || typeof mount !== "object" || Array.isArray(mount)) {
       throw new Error("mounts must be a non-empty array of mount objects");
     }
-    if (mount.type !== "s3" && mount.type !== "gcs" && mount.type !== "git") {
-      throw new Error("mountConfig only supports s3, gcs, and git mounts");
+    if (
+      mount.type !== "s3" &&
+      mount.type !== "gcs" &&
+      mount.type !== "git" &&
+      mount.type !== "contexthub"
+    ) {
+      throw new Error(
+        "mountConfig only supports s3, gcs, git, and contexthub mounts",
+      );
     }
     rejectProviderCredentialsInMount(mount);
     return mount;

--- a/js/src/sandbox/mounts.ts
+++ b/js/src/sandbox/mounts.ts
@@ -199,18 +199,21 @@ export function gcsMount({
   return mount;
 }
 
+/**
+ * Build a read-only Context Hub mount. The sync is one-way: files written
+ * under the mount path inside the sandbox are never pushed back to the repo,
+ * and the next sync overwrites them.
+ */
 export function contextHubMount({
   id,
   mountPath,
   repo,
   initialPullOnly,
-  readOnly,
 }: {
   id: string;
   mountPath: string;
   repo: string;
   initialPullOnly?: boolean;
-  readOnly?: boolean;
 }): ContextHubMountSpec {
   const mount: ContextHubMountSpec = {
     id: requireNonEmptyString(id, "id"),
@@ -222,9 +225,6 @@ export function contextHubMount({
   };
   if (initialPullOnly !== undefined) {
     mount.contexthub.initial_pull_only = initialPullOnly;
-  }
-  if (readOnly !== undefined) {
-    mount.read_only = readOnly;
   }
   return mount;
 }

--- a/js/src/sandbox/mounts.ts
+++ b/js/src/sandbox/mounts.ts
@@ -199,56 +199,6 @@ export function gcsMount({
   return mount;
 }
 
-const PROTECTED_GUEST_PATHS = [
-  "/bin",
-  "/boot",
-  "/dev",
-  "/etc",
-  "/lib",
-  "/lib64",
-  "/proc",
-  "/root",
-  "/run",
-  "/sbin",
-  "/sys",
-  "/usr",
-  "/var",
-];
-
-function requireContextHubMountPath(mountPath: string): string {
-  const path = requireNonEmptyString(mountPath, "mountPath");
-  const segments = path.slice(1).split("/");
-  const isClean =
-    path.startsWith("/") &&
-    segments.every(
-      (segment) => segment !== "" && segment !== "." && segment !== "..",
-    );
-  if (!isClean) {
-    throw new Error("mountPath must be an absolute, clean path");
-  }
-  for (const protectedPath of PROTECTED_GUEST_PATHS) {
-    if (path === protectedPath || path.startsWith(`${protectedPath}/`)) {
-      throw new Error(
-        `mountPath must not be at or under system directory ${protectedPath}`,
-      );
-    }
-  }
-  return path;
-}
-
-function requireContextHubRepo(repo: string): string {
-  if (typeof repo !== "string" || repo === "") {
-    throw new Error("repo must be a non-empty string");
-  }
-  if (repo.trim() !== repo) {
-    throw new Error("repo must not include leading or trailing whitespace");
-  }
-  if (repo.includes(String.fromCharCode(0))) {
-    throw new Error("repo must not contain NUL bytes");
-  }
-  return repo;
-}
-
 export function contextHubMount({
   id,
   mountPath,
@@ -265,9 +215,9 @@ export function contextHubMount({
   const mount: ContextHubMountSpec = {
     id: requireNonEmptyString(id, "id"),
     type: "contexthub",
-    mount_path: requireContextHubMountPath(mountPath),
+    mount_path: requireNonEmptyString(mountPath, "mountPath"),
     contexthub: {
-      repo: requireContextHubRepo(repo),
+      repo: requireNonEmptyString(repo, "repo"),
     },
   };
   if (initialPullOnly !== undefined) {

--- a/js/src/sandbox/types.ts
+++ b/js/src/sandbox/types.ts
@@ -419,8 +419,37 @@ export interface GitMountSpec {
   git: GitMountConfig;
 }
 
+/** Context Hub configuration for a sandbox mount. */
+export interface ContextHubMountConfig {
+  /**
+   * Context Hub repository to sync, as `owner/repo` (e.g. `-/my-agent`, where
+   * `-` is the current workspace).
+   */
+  repo: string;
+  /** Sync once at startup instead of polling for updates. */
+  initial_pull_only?: boolean;
+}
+
+/** Context Hub-backed sandbox mount specification. */
+export interface ContextHubMountSpec {
+  /** Stable mount identifier. */
+  id: string;
+  /** Mount type. */
+  type: "contexthub";
+  /** Absolute path inside the sandbox where the repo tree appears. */
+  mount_path: string;
+  /** Whether the mount should be pull-only. */
+  read_only?: boolean;
+  /** Context Hub mount configuration. */
+  contexthub: ContextHubMountConfig;
+}
+
 /** Sandbox mount specification. */
-export type SandboxMount = S3MountSpec | GCSMountSpec | GitMountSpec;
+export type SandboxMount =
+  | S3MountSpec
+  | GCSMountSpec
+  | GitMountSpec
+  | ContextHubMountSpec;
 
 /** AWS credentials used by the backend to authenticate S3 mounts. */
 export interface SandboxAwsMountAuthConfig {

--- a/js/src/sandbox/types.ts
+++ b/js/src/sandbox/types.ts
@@ -430,7 +430,7 @@ export interface ContextHubMountConfig {
   initial_pull_only?: boolean;
 }
 
-/** Context Hub-backed sandbox mount specification. */
+/** Read-only Context Hub-backed sandbox mount specification. */
 export interface ContextHubMountSpec {
   /** Stable mount identifier. */
   id: string;
@@ -438,8 +438,6 @@ export interface ContextHubMountSpec {
   type: "contexthub";
   /** Absolute path inside the sandbox where the repo tree appears. */
   mount_path: string;
-  /** Whether the mount should be pull-only. */
-  read_only?: boolean;
   /** Context Hub mount configuration. */
   contexthub: ContextHubMountConfig;
 }

--- a/js/src/tests/sandbox.test.ts
+++ b/js/src/tests/sandbox.test.ts
@@ -9,6 +9,7 @@ import { Sandbox } from "../sandbox/sandbox.js";
 import { CommandHandle } from "../sandbox/command_handle.js";
 import {
   awsAuth,
+  contextHubMount,
   gitMount,
   gcpAuth,
   gcsMount,
@@ -320,6 +321,76 @@ describe("sandbox proxy config helpers", () => {
       id: "repo",
       mountPath: "/mnt/repo",
       remoteUrl: "https://github.com/langchain-ai/langsmith-sdk.git",
+    });
+
+    expect(mountConfig({ mounts: [mount] })).toEqual({
+      auth: {},
+      mounts: [mount],
+    });
+  });
+
+  it("contextHubMount serializes the backend shape", () => {
+    expect(
+      contextHubMount({
+        id: "memories",
+        mountPath: "/memories",
+        repo: "-/my-agent",
+        initialPullOnly: true,
+        readOnly: true,
+      }),
+    ).toEqual({
+      id: "memories",
+      type: "contexthub",
+      mount_path: "/memories",
+      read_only: true,
+      contexthub: { repo: "-/my-agent", initial_pull_only: true },
+    });
+  });
+
+  it("contextHubMount omits optional fields", () => {
+    expect(
+      contextHubMount({
+        id: "memories",
+        mountPath: "/memories",
+        repo: "-/my-agent",
+      }),
+    ).toEqual({
+      id: "memories",
+      type: "contexthub",
+      mount_path: "/memories",
+      contexthub: { repo: "-/my-agent" },
+    });
+  });
+
+  it.each([
+    "",
+    "memories",
+    "/",
+    "/memories/",
+    "/memories/../etc",
+    "//memories",
+    "/etc",
+    "/usr/local/share",
+  ])("contextHubMount rejects invalid mount path %p", (mountPath) => {
+    expect(() =>
+      contextHubMount({ id: "memories", mountPath, repo: "-/my-agent" }),
+    ).toThrow();
+  });
+
+  it.each(["", " -/my-agent", "-/my-agent ", "-/my\0agent"])(
+    "contextHubMount rejects invalid repo %p",
+    (repo) => {
+      expect(() =>
+        contextHubMount({ id: "memories", mountPath: "/memories", repo }),
+      ).toThrow();
+    },
+  );
+
+  it("mountConfig accepts Context Hub mounts without provider auth", () => {
+    const mount = contextHubMount({
+      id: "memories",
+      mountPath: "/memories",
+      repo: "-/my-agent",
     });
 
     expect(mountConfig({ mounts: [mount] })).toEqual({

--- a/js/src/tests/sandbox.test.ts
+++ b/js/src/tests/sandbox.test.ts
@@ -362,30 +362,6 @@ describe("sandbox proxy config helpers", () => {
     });
   });
 
-  it.each([
-    "",
-    "memories",
-    "/",
-    "/memories/",
-    "/memories/../etc",
-    "//memories",
-    "/etc",
-    "/usr/local/share",
-  ])("contextHubMount rejects invalid mount path %p", (mountPath) => {
-    expect(() =>
-      contextHubMount({ id: "memories", mountPath, repo: "-/my-agent" }),
-    ).toThrow();
-  });
-
-  it.each(["", " -/my-agent", "-/my-agent ", "-/my\0agent"])(
-    "contextHubMount rejects invalid repo %p",
-    (repo) => {
-      expect(() =>
-        contextHubMount({ id: "memories", mountPath: "/memories", repo }),
-      ).toThrow();
-    },
-  );
-
   it("mountConfig accepts Context Hub mounts without provider auth", () => {
     const mount = contextHubMount({
       id: "memories",

--- a/js/src/tests/sandbox.test.ts
+++ b/js/src/tests/sandbox.test.ts
@@ -336,13 +336,11 @@ describe("sandbox proxy config helpers", () => {
         mountPath: "/memories",
         repo: "-/my-agent",
         initialPullOnly: true,
-        readOnly: true,
       }),
     ).toEqual({
       id: "memories",
       type: "contexthub",
       mount_path: "/memories",
-      read_only: true,
       contexthub: { repo: "-/my-agent", initial_pull_only: true },
     });
   });

--- a/python/langsmith/sandbox/README.md
+++ b/python/langsmith/sandbox/README.md
@@ -287,7 +287,7 @@ path and kept in sync for the sandbox's lifetime. The caller's API key must have
 access to the repo:
 
 ```python
-from langsmith.sandbox import context_hub_mount, mount_config
+from langsmith.sandbox import AsyncSandboxClient, context_hub_mount, mount_config
 
 mount_cfg = mount_config(
     mounts=[
@@ -299,12 +299,14 @@ mount_cfg = mount_config(
     ],
 )
 
-with client.sandbox(
-    name="context-hub-mount-sandbox",
-    mount_config=mount_cfg,
-) as sb:
-    result = sb.run("ls /memories")
-    print(result.stdout)
+async def main():
+    async with AsyncSandboxClient() as client:
+        async with await client.sandbox(
+            name="context-hub-mount-sandbox",
+            mount_config=mount_cfg,
+        ) as sb:
+            result = await sb.run("ls /memories")
+            print(result.stdout)
 ```
 
 Pass `initial_pull_only=True` to sync once at startup instead of polling for

--- a/python/langsmith/sandbox/README.md
+++ b/python/langsmith/sandbox/README.md
@@ -280,11 +280,15 @@ Private Git repositories can use low-level `proxy_config` rules when the remote
 requires proxy-managed auth. There is not yet a high-level private Git auth
 helper.
 
-Context Hub mounts do not require AWS or GCP auth, and unlike bucket and Git
-mounts they can target any path outside the system directories — not just paths
-under `/mnt/mounts`. The repo's latest commit tree is mirrored into the mount
-path and kept in sync for the sandbox's lifetime. The caller's API key must have
-access to the repo:
+Context Hub mounts are **read-only**: the repo's latest commit tree is mirrored
+into the mount path and kept in sync for the sandbox's lifetime, but the sync is
+one-way. Files written under the mount path inside the sandbox are never pushed
+back to the repo, and the next sync overwrites them. Write sandbox output
+somewhere else and push it with the Context Hub SDK if it belongs in the repo.
+
+They do not require AWS or GCP auth, and unlike bucket and Git mounts they can
+target any path outside the system directories — not just paths under
+`/mnt/mounts`. The caller's API key must have access to the repo:
 
 ```python
 from langsmith.sandbox import AsyncSandboxClient, context_hub_mount, mount_config
@@ -310,7 +314,7 @@ async def main():
 ```
 
 Pass `initial_pull_only=True` to sync once at startup instead of polling for
-repo updates, and `read_only=True` to make the mount pull-only.
+repo updates.
 
 If one sandbox needs S3, GCS, and Git mounts, build one `mount_config` with the
 bucket provider auth blocks and all mount specs:

--- a/python/langsmith/sandbox/README.md
+++ b/python/langsmith/sandbox/README.md
@@ -280,6 +280,36 @@ Private Git repositories can use low-level `proxy_config` rules when the remote
 requires proxy-managed auth. There is not yet a high-level private Git auth
 helper.
 
+Context Hub mounts do not require AWS or GCP auth, and unlike bucket and Git
+mounts they can target any path outside the system directories — not just paths
+under `/mnt/mounts`. The repo's latest commit tree is mirrored into the mount
+path and kept in sync for the sandbox's lifetime. The caller's API key must have
+access to the repo:
+
+```python
+from langsmith.sandbox import context_hub_mount, mount_config
+
+mount_cfg = mount_config(
+    mounts=[
+        context_hub_mount(
+            id="memories",
+            mount_path="/memories",
+            repo="-/my-agent",
+        )
+    ],
+)
+
+with client.sandbox(
+    name="context-hub-mount-sandbox",
+    mount_config=mount_cfg,
+) as sb:
+    result = sb.run("ls /memories")
+    print(result.stdout)
+```
+
+Pass `initial_pull_only=True` to sync once at startup instead of polling for
+repo updates, and `read_only=True` to make the mount pull-only.
+
 If one sandbox needs S3, GCS, and Git mounts, build one `mount_config` with the
 bucket provider auth blocks and all mount specs:
 

--- a/python/langsmith/sandbox/__init__.py
+++ b/python/langsmith/sandbox/__init__.py
@@ -67,6 +67,8 @@ from langsmith.sandbox._models import (
 )
 from langsmith.sandbox._mounts import (
     AWSMountAuthConfig,
+    ContextHubMountConfig,
+    ContextHubMountSpec,
     GCPMountAuthConfig,
     GCSMountConfig,
     GCSMountSpec,
@@ -80,6 +82,7 @@ from langsmith.sandbox._mounts import (
     SandboxMountAuth,
     SandboxMountAuthConfig,
     SandboxMountConfig,
+    context_hub_mount,
     gcs_mount,
     git_mount,
     mount_config,
@@ -122,6 +125,8 @@ __all__ = [
     "SandboxMountAuthConfig",
     "SandboxMountConfig",
     "AWSMountAuthConfig",
+    "ContextHubMountConfig",
+    "ContextHubMountSpec",
     "GCPMountAuthConfig",
     "MountCacheConfig",
     "GCSMountConfig",
@@ -132,6 +137,7 @@ __all__ = [
     "S3MountConfig",
     "S3MountSpec",
     "aws_auth",
+    "context_hub_mount",
     "git_mount",
     "gcp_auth",
     "gcs_mount",

--- a/python/langsmith/sandbox/_mounts.py
+++ b/python/langsmith/sandbox/_mounts.py
@@ -113,14 +113,8 @@ class ContextHubMountConfig(ContextHubMountConfigRequired, total=False):
     initial_pull_only: bool
 
 
-class ContextHubMountSpecBase(TypedDict, total=False):
-    """Optional fields applied per Context Hub sandbox mount."""
-
-    read_only: bool
-
-
-class ContextHubMountSpec(ContextHubMountSpecBase):
-    """Context Hub-backed sandbox mount specification."""
+class ContextHubMountSpec(TypedDict):
+    """Read-only Context Hub-backed sandbox mount specification."""
 
     id: str
     type: Literal["contexthub"]
@@ -317,12 +311,13 @@ def context_hub_mount(
     mount_path: str,
     repo: str,
     initial_pull_only: bool | None = None,
-    read_only: bool | None = None,
 ) -> ContextHubMountSpec:
-    """Build a Context Hub-backed sandbox mount specification.
+    """Build a read-only Context Hub-backed sandbox mount specification.
 
     The repo's latest commit tree is mirrored into ``mount_path`` and kept in
-    sync for the sandbox's lifetime unless ``initial_pull_only`` is set.
+    sync for the sandbox's lifetime unless ``initial_pull_only`` is set. The
+    sync is one-way: files written under ``mount_path`` inside the sandbox are
+    never pushed back to the repo, and the next sync overwrites them.
     """
     contexthub: ContextHubMountConfig = {
         "repo": _require_non_empty_string(repo, "repo"),
@@ -336,8 +331,6 @@ def context_hub_mount(
         "mount_path": _require_non_empty_string(mount_path, "mount_path"),
         "contexthub": contexthub,
     }
-    if read_only is not None:
-        mount["read_only"] = read_only
     return mount
 
 

--- a/python/langsmith/sandbox/_mounts.py
+++ b/python/langsmith/sandbox/_mounts.py
@@ -220,52 +220,6 @@ def _copy_git_ref(ref: GitMountRefSpec) -> GitMountRefSpec:
     }
 
 
-_PROTECTED_GUEST_PATHS = (
-    "/bin",
-    "/boot",
-    "/dev",
-    "/etc",
-    "/lib",
-    "/lib64",
-    "/proc",
-    "/root",
-    "/run",
-    "/sbin",
-    "/sys",
-    "/usr",
-    "/var",
-)
-
-
-def _require_context_hub_mount_path(mount_path: str) -> str:
-    """Validate a Context Hub mount path the same way the backend does."""
-    path = _require_non_empty_string(mount_path, "mount_path")
-    if path == "/":
-        raise ValueError("mount_path must not be the filesystem root")
-    # posixpath.normpath preserves a leading "//", which the backend's
-    # filepath.Clean collapses, so check the segments directly instead.
-    if not path.startswith("/") or any(
-        segment in {"", ".", ".."} for segment in path[1:].split("/")
-    ):
-        raise ValueError("mount_path must be an absolute, clean path")
-    for protected in _PROTECTED_GUEST_PATHS:
-        if path == protected or path.startswith(protected + "/"):
-            raise ValueError(
-                f"mount_path must not be at or under system directory {protected}"
-            )
-    return path
-
-
-def _require_context_hub_repo(repo: str) -> str:
-    if not isinstance(repo, str) or repo == "":
-        raise ValueError("repo must be a non-empty string")
-    if repo.strip() != repo:
-        raise ValueError("repo must not include leading or trailing whitespace")
-    if "\x00" in repo:
-        raise ValueError("repo must not contain NUL bytes")
-    return repo
-
-
 def s3_mount(
     *,
     id: str,
@@ -370,14 +324,16 @@ def context_hub_mount(
     The repo's latest commit tree is mirrored into ``mount_path`` and kept in
     sync for the sandbox's lifetime unless ``initial_pull_only`` is set.
     """
-    contexthub: ContextHubMountConfig = {"repo": _require_context_hub_repo(repo)}
+    contexthub: ContextHubMountConfig = {
+        "repo": _require_non_empty_string(repo, "repo"),
+    }
     if initial_pull_only is not None:
         contexthub["initial_pull_only"] = initial_pull_only
 
     mount: ContextHubMountSpec = {
         "id": _require_non_empty_string(id, "id"),
         "type": "contexthub",
-        "mount_path": _require_context_hub_mount_path(mount_path),
+        "mount_path": _require_non_empty_string(mount_path, "mount_path"),
         "contexthub": contexthub,
     }
     if read_only is not None:

--- a/python/langsmith/sandbox/_mounts.py
+++ b/python/langsmith/sandbox/_mounts.py
@@ -101,7 +101,34 @@ class GitMountSpec(TypedDict):
     git: GitMountConfig
 
 
-SandboxMount = Union[S3MountSpec, GCSMountSpec, GitMountSpec]
+class ContextHubMountConfigRequired(TypedDict):
+    """Required Context Hub configuration for a sandbox mount."""
+
+    repo: str
+
+
+class ContextHubMountConfig(ContextHubMountConfigRequired, total=False):
+    """Context Hub configuration for a sandbox mount."""
+
+    initial_pull_only: bool
+
+
+class ContextHubMountSpecBase(TypedDict, total=False):
+    """Optional fields applied per Context Hub sandbox mount."""
+
+    read_only: bool
+
+
+class ContextHubMountSpec(ContextHubMountSpecBase):
+    """Context Hub-backed sandbox mount specification."""
+
+    id: str
+    type: Literal["contexthub"]
+    mount_path: str
+    contexthub: ContextHubMountConfig
+
+
+SandboxMount = Union[S3MountSpec, GCSMountSpec, GitMountSpec, ContextHubMountSpec]
 
 
 class AWSMountAuthConfig(TypedDict):
@@ -191,6 +218,52 @@ def _copy_git_ref(ref: GitMountRefSpec) -> GitMountRefSpec:
         "type": ref_type,
         "name": _require_non_empty_string(ref.get("name", ""), "ref.name"),
     }
+
+
+_PROTECTED_GUEST_PATHS = (
+    "/bin",
+    "/boot",
+    "/dev",
+    "/etc",
+    "/lib",
+    "/lib64",
+    "/proc",
+    "/root",
+    "/run",
+    "/sbin",
+    "/sys",
+    "/usr",
+    "/var",
+)
+
+
+def _require_context_hub_mount_path(mount_path: str) -> str:
+    """Validate a Context Hub mount path the same way the backend does."""
+    path = _require_non_empty_string(mount_path, "mount_path")
+    if path == "/":
+        raise ValueError("mount_path must not be the filesystem root")
+    # posixpath.normpath preserves a leading "//", which the backend's
+    # filepath.Clean collapses, so check the segments directly instead.
+    if not path.startswith("/") or any(
+        segment in {"", ".", ".."} for segment in path[1:].split("/")
+    ):
+        raise ValueError("mount_path must be an absolute, clean path")
+    for protected in _PROTECTED_GUEST_PATHS:
+        if path == protected or path.startswith(protected + "/"):
+            raise ValueError(
+                f"mount_path must not be at or under system directory {protected}"
+            )
+    return path
+
+
+def _require_context_hub_repo(repo: str) -> str:
+    if not isinstance(repo, str) or repo == "":
+        raise ValueError("repo must be a non-empty string")
+    if repo.strip() != repo:
+        raise ValueError("repo must not include leading or trailing whitespace")
+    if "\x00" in repo:
+        raise ValueError("repo must not contain NUL bytes")
+    return repo
 
 
 def s3_mount(
@@ -284,6 +357,34 @@ def gcs_mount(
     return mount
 
 
+def context_hub_mount(
+    *,
+    id: str,
+    mount_path: str,
+    repo: str,
+    initial_pull_only: bool | None = None,
+    read_only: bool | None = None,
+) -> ContextHubMountSpec:
+    """Build a Context Hub-backed sandbox mount specification.
+
+    The repo's latest commit tree is mirrored into ``mount_path`` and kept in
+    sync for the sandbox's lifetime unless ``initial_pull_only`` is set.
+    """
+    contexthub: ContextHubMountConfig = {"repo": _require_context_hub_repo(repo)}
+    if initial_pull_only is not None:
+        contexthub["initial_pull_only"] = initial_pull_only
+
+    mount: ContextHubMountSpec = {
+        "id": _require_non_empty_string(id, "id"),
+        "type": "contexthub",
+        "mount_path": _require_context_hub_mount_path(mount_path),
+        "contexthub": contexthub,
+    }
+    if read_only is not None:
+        mount["read_only"] = read_only
+    return mount
+
+
 def _normalize_mounts(mounts: Sequence[SandboxMount]) -> list[SandboxMount]:
     if isinstance(mounts, dict) or isinstance(mounts, str) or not mounts:
         raise ValueError("mounts must be a non-empty list of mount dictionaries")
@@ -292,8 +393,10 @@ def _normalize_mounts(mounts: Sequence[SandboxMount]) -> list[SandboxMount]:
         if not isinstance(mount, dict) or not mount:
             raise ValueError("mounts must be a non-empty list of mount dictionaries")
         mount_type = mount.get("type")
-        if mount_type not in {"s3", "gcs", "git"}:
-            raise ValueError("mount_config only supports s3, gcs, and git mounts")
+        if mount_type not in {"s3", "gcs", "git", "contexthub"}:
+            raise ValueError(
+                "mount_config only supports s3, gcs, git, and contexthub mounts"
+            )
         _reject_provider_credentials_in_mount(mount)
         normalized.append(mount)
     return normalized

--- a/python/tests/unit_tests/sandbox/test_proxy_config.py
+++ b/python/tests/unit_tests/sandbox/test_proxy_config.py
@@ -8,6 +8,7 @@ from pytest_httpx import HTTPXMock
 from langsmith.sandbox import (
     SandboxClient,
     aws_auth,
+    context_hub_mount,
     gcp_auth,
     gcs_mount,
     git_mount,
@@ -255,6 +256,72 @@ def test_mount_config_accepts_git_mount_without_provider_auth() -> None:
         id="repo",
         mount_path="/mnt/repo",
         remote_url="https://github.com/langchain-ai/langsmith-sdk.git",
+    )
+
+    assert mount_config(mounts=[mount]) == {
+        "auth": {},
+        "mounts": [mount],
+    }
+
+
+def test_context_hub_mount_serializes_backend_shape() -> None:
+    assert context_hub_mount(
+        id="memories",
+        mount_path="/memories",
+        repo="-/my-agent",
+        initial_pull_only=True,
+        read_only=True,
+    ) == {
+        "id": "memories",
+        "type": "contexthub",
+        "mount_path": "/memories",
+        "read_only": True,
+        "contexthub": {"repo": "-/my-agent", "initial_pull_only": True},
+    }
+
+
+def test_context_hub_mount_omits_optional_fields() -> None:
+    assert context_hub_mount(
+        id="memories",
+        mount_path="/memories",
+        repo="-/my-agent",
+    ) == {
+        "id": "memories",
+        "type": "contexthub",
+        "mount_path": "/memories",
+        "contexthub": {"repo": "-/my-agent"},
+    }
+
+
+@pytest.mark.parametrize(
+    "mount_path",
+    [
+        "",
+        "memories",
+        "/",
+        "/memories/",
+        "/memories/../etc",
+        "//memories",
+        "/etc",
+        "/usr/local/share",
+    ],
+)
+def test_context_hub_mount_rejects_invalid_mount_paths(mount_path: str) -> None:
+    with pytest.raises(ValueError):
+        context_hub_mount(id="memories", mount_path=mount_path, repo="-/my-agent")
+
+
+@pytest.mark.parametrize("repo", ["", " -/my-agent", "-/my-agent ", "-/my\x00agent"])
+def test_context_hub_mount_rejects_invalid_repos(repo: str) -> None:
+    with pytest.raises(ValueError):
+        context_hub_mount(id="memories", mount_path="/memories", repo=repo)
+
+
+def test_mount_config_accepts_context_hub_mount_without_provider_auth() -> None:
+    mount = context_hub_mount(
+        id="memories",
+        mount_path="/memories",
+        repo="-/my-agent",
     )
 
     assert mount_config(mounts=[mount]) == {

--- a/python/tests/unit_tests/sandbox/test_proxy_config.py
+++ b/python/tests/unit_tests/sandbox/test_proxy_config.py
@@ -293,30 +293,6 @@ def test_context_hub_mount_omits_optional_fields() -> None:
     }
 
 
-@pytest.mark.parametrize(
-    "mount_path",
-    [
-        "",
-        "memories",
-        "/",
-        "/memories/",
-        "/memories/../etc",
-        "//memories",
-        "/etc",
-        "/usr/local/share",
-    ],
-)
-def test_context_hub_mount_rejects_invalid_mount_paths(mount_path: str) -> None:
-    with pytest.raises(ValueError):
-        context_hub_mount(id="memories", mount_path=mount_path, repo="-/my-agent")
-
-
-@pytest.mark.parametrize("repo", ["", " -/my-agent", "-/my-agent ", "-/my\x00agent"])
-def test_context_hub_mount_rejects_invalid_repos(repo: str) -> None:
-    with pytest.raises(ValueError):
-        context_hub_mount(id="memories", mount_path="/memories", repo=repo)
-
-
 def test_mount_config_accepts_context_hub_mount_without_provider_auth() -> None:
     mount = context_hub_mount(
         id="memories",

--- a/python/tests/unit_tests/sandbox/test_proxy_config.py
+++ b/python/tests/unit_tests/sandbox/test_proxy_config.py
@@ -270,12 +270,10 @@ def test_context_hub_mount_serializes_backend_shape() -> None:
         mount_path="/memories",
         repo="-/my-agent",
         initial_pull_only=True,
-        read_only=True,
     ) == {
         "id": "memories",
         "type": "contexthub",
         "mount_path": "/memories",
-        "read_only": True,
         "contexthub": {"repo": "-/my-agent", "initial_pull_only": True},
     }
 


### PR DESCRIPTION
Context Hub repos have been mountable into sandboxes since the backend made `contexthub` a user-facing mount type, but the Python and TypeScript SDKs had no way to build one: `mount_config`/`mountConfig` explicitly rejected any mount whose type was not `s3`, `gcs`, or `git`.

Adds `context_hub_mount()` / `contextHubMount()` next to the existing bucket and Git helpers, wires `contexthub` through mount normalization, and documents it in both sandbox READMEs alongside the S3/GCS/Git examples.

These mounts are read-only, and the helper says so rather than implying otherwise: the backend's sync loop only pulls, and `read_only` on a mount spec is consumed by the rclone bucket mounts only, so a `read_only` argument here would advertise a choice the backend does not honor. Files an agent writes under the mount path are overwritten by the next sync.

Mount-path and repo validation is left to the backend rather than duplicated here. Unlike bucket and Git mounts, a Context Hub mount is not restricted to `/mnt/mounts`, so `/memories` works.

## Test Plan

- [x] `uv run pytest tests/unit_tests/sandbox/ -q` (524 passed)
- [x] `pnpm test src/tests/sandbox.test.ts` (136 passed)
- [x] `pnpm lint`, `pnpm exec tsc --noEmit`, `ruff check`, `ruff format --check`