### PR TITLE
docs(py): remove stale default param from dumps_json docstring

### DIFF
--- a/python/langsmith/_internal/_serde.py
+++ b/python/langsmith/_internal/_serde.py
@@ -188,13 +188,11 @@ def dumps_json(obj: Any) -> bytes:
     ----------
     obj : Any
         The object to serialize.
-    default : Callable[[Any], Any] or None, default=None
-        The default function to use for serialization.
 
     Returns:
     -------
-    str
-        The JSON formatted string.
+    bytes
+        The JSON formatted string, encoded as UTF-8 bytes.
     """
     try:
         return _orjson.dumps(


### PR DESCRIPTION
Part of a stacked series cleaning up superfluous code in `_serde.py` (LSDK-415, item **S3**).

`dumps_json(obj)` no longer accepts a `default` parameter, but the docstring still documented it and claimed a `str` return type. Removed the phantom parameter and corrected the return type to `bytes`.

Docs-only; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)