### PR TITLE
docs(py): clarify _serialization_methods table comments

### DIFF
--- a/python/langsmith/_internal/_serde.py
+++ b/python/langsmith/_internal/_serde.py
@@ -77,13 +77,14 @@ def _simple_default(obj):
 
 
 _serialization_methods: list[tuple[str, dict[str, Any]]] = [
-    (
-        "model_dump",
-        {"exclude_none": True, "mode": "json"},
-    ),  # Pydantic V2 with non-serializable fields
-    ("model_dump", {"exclude_none": True}),  # Pydantic V2 without json mode
-    ("dict", {}),  # Pydantic V1 with non-serializable field
-    ("to_dict", {}),  # dataclasses-json
+    # Pydantic v2 primary: coerce fields to JSON-native types.
+    # Raises on truly non-serializable fields -> the next entry handles those.
+    ("model_dump", {"exclude_none": True, "mode": "json"}),
+    # Pydantic v2 fallback: python-mode dump; leaves non-JSON values as objects
+    # for orjson / _simple_default to serialize.
+    ("model_dump", {"exclude_none": True}),
+    ("dict", {}),  # Pydantic v1 .dict()
+    ("to_dict", {}),  # dataclasses-json to_dict()
 ]
 
 


### PR DESCRIPTION
The inline comments on the `_serialization_methods` table read backwards — the `mode="json"` entry was labeled "with non-serializable fields" and the python-mode entry "without json mode". Rewrote them to describe each entry's real role:

- `mode="json"` = primary path, coerces to JSON-native types, raises on truly non-serializable fields → falls through;
- plain `model_dump` = python-mode fallback, leaves non-JSON values for orjson/`_simple_default`.

Docs-only; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)