### PR TITLE
docs(py): document _simple_default datetime/UUID branches

### DIFF
--- a/python/langsmith/_internal/_serde.py
+++ b/python/langsmith/_internal/_serde.py
@@ -36,6 +36,12 @@ def _simple_default(obj):
     try:
         # Only need to handle types that orjson doesn't serialize by default
         # https://github.com/ijl/orjson#serialize
+        #
+        # datetime/UUID look redundant with orjson's native encoders, but this
+        # function is reached via two paths that bypass them, so keep them:
+        #   (a) non-str dict keys normalized through _normalize_json_keys, and
+        #   (b) the stdlib json.dumps fallback in dumps_json (surrogate path),
+        #       which routes these *values* through this hook.
         if isinstance(obj, datetime.datetime):
             return obj.isoformat()
         elif isinstance(obj, uuid.UUID):


### PR DESCRIPTION
`_simple_default`'s `datetime`/`UUID` branches appear redundant with orjson's native encoders (which handle both on the fast value path). They're kept because the function is reached via two paths that bypass orjson:

1. non-str dict keys normalized through `_normalize_json_keys`;
2. the stdlib `json.dumps` fallback in `dumps_json` (surrogate path), which routes these *values* through the hook.

Verified empirically: on the orjson value path `_simple_default` is not called for datetime/UUID; on the stdlib fallback path it is. Added a comment so they aren't deleted as "dead code" later. Docs-only; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)