### PR TITLE
perf(py): hoist surrogate regex to module scope

### DIFF
--- a/python/langsmith/_internal/_serde.py
+++ b/python/langsmith/_internal/_serde.py
@@ -30,6 +30,9 @@ _ORJSON_OPTIONS = (
     | _orjson.OPT_NON_STR_KEYS
 )
 _JSON_KEY_TYPES = (str, int, float, bool, type(None))
+# Matches escaped lone UTF-16 surrogates (e.g. b"\\ud800") in ensure_ascii
+# json.dumps output; used to strip them on the stdlib-json fallback path.
+_SURROGATE_RE = re.compile(rb"\\ud[89a-f][0-9a-f]{2}", re.IGNORECASE)
 
 
 def _simple_default(obj):
@@ -183,9 +186,7 @@ def _serialize_json_with_normalized_keys(obj: Any) -> Any:
 
 
 def _elide_surrogates(s: bytes) -> bytes:
-    pattern = re.compile(rb"\\ud[89a-f][0-9a-f]{2}", re.IGNORECASE)
-    result = pattern.sub(b"", s)
-    return result
+    return _SURROGATE_RE.sub(b"", s)
 
 
 def dumps_json(obj: Any) -> bytes:


### PR DESCRIPTION
`_elide_surrogates` called `re.compile(...)` on every invocation. Moved the pattern to a module-level `_SURROGATE_RE` compiled once at import.

Cold path (only the double-fallback surrogate case in `dumps_json`), so the win is small — but recompiling per call is pure waste. Behavior unchanged; covered by existing surrogate tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)