### PR TITLE
fix(py): don't swallow KeyboardInterrupt/SystemExit in serde

### DIFF
--- a/python/langsmith/_internal/_serde.py
+++ b/python/langsmith/_internal/_serde.py
@@ -80,7 +80,7 @@ def _simple_default(obj):
         elif isinstance(obj, (bytes, bytearray)):
             return base64.b64encode(obj).decode()
         return str(obj)
-    except BaseException as e:
+    except Exception as e:
         logger.debug(f"Failed to serialize {type(obj)} to JSON: {e}")
     return str(obj)
 
@@ -129,7 +129,7 @@ def _serialize_json(obj: Any) -> Any:
                     )
                     pass
         return _simple_default(obj)
-    except BaseException as e:
+    except Exception as e:
         logger.debug(f"Failed to serialize {type(obj)} to JSON: {e}")
         return str(obj)
 

--- a/python/tests/unit_tests/test_client.py
+++ b/python/tests/unit_tests/test_client.py
@@ -2420,6 +2420,22 @@ def test__dumps_json_normalizes_unsupported_dict_keys():
     }
 
 
+def test__dumps_json_does_not_swallow_keyboard_interrupt():
+    """Serialization must not swallow KeyboardInterrupt/SystemExit.
+
+    The serde error handlers catch ``Exception`` (not ``BaseException``), so a
+    system-exiting signal raised while serializing an object propagates instead
+    of being masked as ``str(obj)``.
+    """
+
+    class _RaisesInterrupt:
+        def model_dump(self, **kwargs):
+            raise KeyboardInterrupt
+
+    with pytest.raises(KeyboardInterrupt):
+        _dumps_json({"x": _RaisesInterrupt()})
+
+
 @patch("langsmith.client.requests.Session", autospec=True)
 def test_host_url(_: MagicMock) -> None:
     client = Client(api_url="https://api.foobar.com/api", api_key="API_KEY")


### PR DESCRIPTION
`_simple_default` and `_serialize_json` wrapped their bodies in `except BaseException`, which swallows `KeyboardInterrupt`/`SystemExit`/`GeneratorExit` raised while serializing an object and returns `str(obj)` instead. Narrowed both to `except Exception` so those signals propagate.

This also makes the two handlers consistent with the inner method loop, which already uses `except Exception`.

- Behavior change: an interrupt raised *during* serialization now propagates instead of being masked. Regular serialization errors are still caught and logged exactly as before.
- Added `test__dumps_json_does_not_swallow_keyboard_interrupt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)