### PR TITLE
refactor(py): drop redundant set handling in _serialize_json

### DIFF
--- a/python/langsmith/_internal/_serde.py
+++ b/python/langsmith/_internal/_serde.py
@@ -104,11 +104,13 @@ _serialization_methods: list[tuple[str, dict[str, Any]]] = [
 #               rust/crates/langsmith-pyo3/src/serialization/mod.rs
 def _serialize_json(obj: Any) -> Any:
     try:
-        if isinstance(obj, (set, tuple)):
+        if isinstance(obj, tuple):
             if hasattr(obj, "_asdict") and callable(obj._asdict):
                 # NamedTuple
                 return obj._asdict()
             return list(obj)
+        # NB: bare set/frozenset/deque fall through to _simple_default, which
+        # converts them to lists (same result, one owner for that behavior).
 
         for attr, kwargs in _serialization_methods:
             if (

--- a/python/tests/unit_tests/test_client.py
+++ b/python/tests/unit_tests/test_client.py
@@ -2420,6 +2420,16 @@ def test__dumps_json_normalizes_unsupported_dict_keys():
     }
 
 
+def test__dumps_json_serializes_set_as_array():
+    """A bare set serializes to a JSON array via _simple_default.
+
+    _serialize_json no longer special-cases set (only tuple/NamedTuple); sets
+    are handled solely by _simple_default's set->list branch.
+    """
+    result = _orjson.loads(_dumps_json({"s": {1, 2, 3}}))
+    assert sorted(result["s"]) == [1, 2, 3]
+
+
 def test__dumps_json_does_not_swallow_keyboard_interrupt():
     """Serialization must not swallow KeyboardInterrupt/SystemExit.
 


### PR DESCRIPTION
Stacked on #3358. LSDK-415 cleanup item **S2** (last in the series).

`_serialize_json` special-cased `(set, tuple)` and returned `list(obj)`, which duplicates `_simple_default`'s existing `set/frozenset/deque -> list` branch. Narrowed the check to `tuple` so:

- NamedTuples still convert via `_asdict()` and plain tuples via `list()` (unchanged);
- bare sets fall through to `_simple_default`, producing the identical `list` output with a single owner for that behavior.

Verified equivalent: `_serialize_json({1,2,3})` and `_simple_default({1,2,3})` both yield `[1,2,3]`. (The full `(set, tuple)` branch could **not** be removed — `_simple_default((1,2))` returns the string `"(1, 2)"`, so `tuple` must stay.)

- Tiny trade-off: a set now walks the (cold) method-loop `hasattr` checks before reaching `_simple_default`. Negligible; sets are rare in payloads.
- Added `test__dumps_json_serializes_set_as_array`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)