### PR TITLE
fix(py): serialize non-dict model dumps as native JSON

### DIFF
--- a/python/langsmith/_internal/_serde.py
+++ b/python/langsmith/_internal/_serde.py
@@ -109,7 +109,15 @@ def _serialize_json(obj: Any) -> Any:
                 try:
                     method = getattr(obj, attr)
                     response = method(**kwargs)
-                    if not isinstance(response, dict):
+                    if isinstance(response, dict):
+                        return response
+                    # A method may legitimately return a JSON-native non-dict
+                    # (e.g. a pydantic RootModel dumps to a list/scalar). Return
+                    # it as-is so orjson emits real JSON instead of stringifying
+                    # it to "[1, 2, 3]". Guard the degenerate case where the
+                    # method hands back the same object, which would re-enter
+                    # this default hook until orjson's recursion limit.
+                    if response is obj:
                         return str(response)
                     return response
                 except Exception as e:

--- a/python/tests/unit_tests/test_client.py
+++ b/python/tests/unit_tests/test_client.py
@@ -41,7 +41,7 @@ import httpx
 import pytest
 import requests
 from multipart import MultipartParser, MultipartPart, parse_options_header
-from pydantic import BaseModel
+from pydantic import BaseModel, RootModel
 from requests import HTTPError
 
 import langsmith.env as ls_env
@@ -2418,6 +2418,33 @@ def test__dumps_json_normalizes_unsupported_dict_keys():
         "nested": [{"('a', 'b')": "c"}],
         "custom": {"(1, 2)": "custom"},
     }
+
+
+def test__dumps_json_rootmodel_list_serializes_as_array():
+    # A RootModel wrapping a list dumps to a list; it must serialize as a JSON
+    # array, not the stringified "[1, 2, 3]".
+    class Nums(RootModel):
+        root: List[int]
+
+    assert _orjson.loads(_dumps_json({"v": Nums([1, 2, 3])})) == {"v": [1, 2, 3]}
+
+
+def test__dumps_json_rootmodel_scalar_serializes_as_number():
+    class Scalar(RootModel):
+        root: int
+
+    assert _orjson.loads(_dumps_json({"v": Scalar(7)})) == {"v": 7}
+
+
+def test__dumps_json_self_returning_method_does_not_recurse():
+    # A serialization method that returns the same object must not re-enter the
+    # default hook forever; it falls back to str().
+    class Loop:
+        def model_dump(self, **kwargs):
+            return self
+
+    result = _orjson.loads(_dumps_json({"v": Loop()}))
+    assert isinstance(result["v"], str)
 
 
 @patch("langsmith.client.requests.Session", autospec=True)


### PR DESCRIPTION
## What

In `_serialize_json` (the orjson `default` hook every traced run's inputs/outputs flow through), when a serialization method (`model_dump`/`dict`/`to_dict`) returns a **non-dict**, the code did `return str(response)`. That stringifies valid JSON-native values:

- `RootModel[list[int]]([1, 2, 3])` → `"[1, 2, 3]"` (a JSON **string**) instead of `[1, 2, 3]`
- scalar `RootModel[int](7)` → `"7"` instead of `7`

`model_dump(mode="json")` already returns the native `[1, 2, 3]`/`7`; the `str()` was corrupting it. This returns the value directly so orjson emits real JSON.

## Format change (intentional)

⚠️ This **changes the serialized wire format** for any object whose `model_dump`/`dict`/`to_dict` returns a non-dict (RootModels, custom `to_dict` returning a list/scalar, etc.): they now serialize as native JSON arrays/scalars instead of strings. Objects whose methods return a `dict` (the overwhelming majority — LangChain messages/state) are **unaffected**. This is a fidelity fix, but downstream consumers that were parsing the old stringified form should be aware.

## Safety

Returning a non-native object from a `default` hook can re-enter it. Verified: returning the **same** object recurses to orjson's limit (255 calls) then raises; returning a *different* non-native object terminates. A minimal identity guard (`response is obj`) falls back to `str()` for the degenerate self-returning case. Realistic dumps return fresh native values, so they hit the fast path.

## Tests

Three regression tests in `test_client.py`: RootModel-list → array, RootModel-scalar → number, and a self-returning `model_dump` → serializes to `str` without recursing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)