### PR TITLE
perf(py): collapse redundant attribute lookups in _serialize_json probe loop

### DIFF
--- a/python/langsmith/_internal/_serde.py
+++ b/python/langsmith/_internal/_serde.py
@@ -110,14 +110,14 @@ def _serialize_json(obj: Any) -> Any:
                 return obj._asdict()
             return list(obj)
 
+        # A class object has no useful instance serialization method
+        if isinstance(obj, type):
+            return _simple_default(obj)
+
         for attr, kwargs in _serialization_methods:
-            if (
-                hasattr(obj, attr)
-                and callable(getattr(obj, attr))
-                and not isinstance(obj, type)
-            ):
+            method = getattr(obj, attr, None)
+            if callable(method):
                 try:
-                    method = getattr(obj, attr)
                     response = method(**kwargs)
                     if not isinstance(response, dict):
                         return str(response)
@@ -127,7 +127,6 @@ def _serialize_json(obj: Any) -> Any:
                         f"Failed to use {attr} to serialize {type(obj)} to"
                         f" JSON: {repr(e)}"
                     )
-                    pass
         return _simple_default(obj)
     except Exception as e:
         logger.debug(f"Failed to serialize {type(obj)} to JSON: {e}")

--- a/python/tests/unit_tests/test_client.py
+++ b/python/tests/unit_tests/test_client.py
@@ -2436,6 +2436,12 @@ def test__dumps_json_does_not_swallow_keyboard_interrupt():
         _dumps_json({"x": _RaisesInterrupt()})
 
 
+def test__dumps_json_type_object_serializes_as_str():
+    # A class object has no useful instance serialization method; it must fall
+    # through to _simple_default -> str rather than be probed like an instance.
+    assert isinstance(_orjson.loads(_dumps_json({"cls": dict}))["cls"], str)
+
+
 @patch("langsmith.client.requests.Session", autospec=True)
 def test_host_url(_: MagicMock) -> None:
     client = Client(api_url="https://api.foobar.com/api", api_key="API_KEY")

--- a/python/tests/unit_tests/test_client.py
+++ b/python/tests/unit_tests/test_client.py
@@ -2439,7 +2439,20 @@ def test__dumps_json_does_not_swallow_keyboard_interrupt():
 def test__dumps_json_type_object_serializes_as_str():
     # A class object has no useful instance serialization method; it must fall
     # through to _simple_default -> str rather than be probed like an instance.
-    assert isinstance(_orjson.loads(_dumps_json({"cls": dict}))["cls"], str)
+    # The probe attribute has to live at the class level (via a metaclass) for
+    # this to distinguish the guarded and unguarded implementations.
+    class Meta(type):
+        def to_dict(cls):
+            return {"meta": "yes"}
+
+    class WithClassLevelToDict(metaclass=Meta):
+        pass
+
+    # Guarded: falls through to _simple_default -> str.
+    # Unguarded: probed like an instance, emits {"meta": "yes"}.
+    assert isinstance(
+        _orjson.loads(_dumps_json({"cls": WithClassLevelToDict}))["cls"], str
+    )
 
 
 @patch("langsmith.client.requests.Session", autospec=True)


### PR DESCRIPTION
## What

Micro-cleanup of the `_serialize_json` probe loop (the orjson `default` hook on the tracing serialization path). Per method probe it did **three** attribute accesses — `hasattr(obj, attr)`, `callable(getattr(obj, attr))`, then `getattr(obj, attr)` again — and re-evaluated the loop-invariant `isinstance(obj, type)` on every iteration.

Now:
```python
if isinstance(obj, type):          # invariant — checked once, hoisted out
    return _simple_default(obj)
for attr, kwargs in _serialization_methods:
    method = getattr(obj, attr, None)   # one lookup per probe
    if callable(method):
        ...
```
Also drops a dead `pass`.

## Behavior

Unchanged. Verified `pydantic model → dict`, `namedtuple → field names preserved`, `plain tuple/set → array`, `class object → str`, and `to_dict → dict` all serialize identically to `main`. Added a small regression test locking the hoisted class-object case; existing `dumps_json` tests cover the rest (3 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)