### PR TITLE
fix(sandbox): identify the SDK on data-plane requests and surface upgrade rejections

### DIFF
--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -75,6 +75,7 @@ import {
 
 import { EvaluationResult, EvaluationResults } from "./evaluation/evaluator.js";
 import { __version__ } from "./index.js";
+import { userAgent } from "./utils/user_agent.js";
 import { Langsmith as OpenAPILangsmith } from "./_openapi_client/index.js";
 import { OnlineEvaluators as Evaluators } from "./_openapi_client/resources/online-evaluators.js";
 import { Runs as OpenAPIRuns } from "./_openapi_client/resources/runs.js";
@@ -1601,7 +1602,7 @@ export class Client implements LangSmithTracingClientInterface {
   private get _mergedHeaders(): { [header: string]: string } {
     // Start with caller-supplied headers so they don't override required headers
     const headers: { [header: string]: string } = {
-      "User-Agent": `langsmith-js/${__version__}`,
+      "User-Agent": userAgent(),
       ...this._callerHeaders,
     };
     // Required headers that should not be overridden

--- a/js/src/sandbox/client.ts
+++ b/js/src/sandbox/client.ts
@@ -439,10 +439,6 @@ export class SandboxClient {
    */
   async _fetch(url: string, init: RequestInit = {}): Promise<Response> {
     const headers = new Headers(init.headers);
-    // Set before the caller's defaults below so an explicit one still wins.
-    if (!headers.has("User-Agent")) {
-      headers.set("User-Agent", sandboxUserAgent());
-    }
     if (this._apiKey) {
       headers.set("X-Api-Key", this._apiKey);
     }
@@ -450,6 +446,11 @@ export class SandboxClient {
       if (!headers.has(name)) {
         headers.set(name, value);
       }
+    }
+    // Last, so it fills in only when neither the request nor the client
+    // defaults named one.
+    if (!headers.has("User-Agent")) {
+      headers.set("User-Agent", sandboxUserAgent());
     }
     return this._caller.call(() =>
       this._fetchImpl(url, {

--- a/js/src/sandbox/client.ts
+++ b/js/src/sandbox/client.ts
@@ -34,6 +34,7 @@ import {
 import {
   handleClientHttpError,
   handleSandboxCreationError,
+  sandboxUserAgent,
   validateTtl,
 } from "./helpers.js";
 import { validateMountConfigProxyConfig } from "./mounts.js";
@@ -438,6 +439,10 @@ export class SandboxClient {
    */
   async _fetch(url: string, init: RequestInit = {}): Promise<Response> {
     const headers = new Headers(init.headers);
+    // Set before the caller's defaults below so an explicit one still wins.
+    if (!headers.has("User-Agent")) {
+      headers.set("User-Agent", sandboxUserAgent());
+    }
     if (this._apiKey) {
       headers.set("X-Api-Key", this._apiKey);
     }

--- a/js/src/sandbox/helpers.ts
+++ b/js/src/sandbox/helpers.ts
@@ -18,6 +18,22 @@ import {
   LangSmithSandboxOperationError,
   LangSmithValidationError,
 } from "./errors.js";
+import { __version__ } from "../index.js";
+
+// =============================================================================
+// Request identity
+// =============================================================================
+
+/**
+ * `User-Agent` for a sandbox data-plane request.
+ *
+ * The data-plane paths use `fetch` and `ws` directly rather than the main
+ * `Client`, so without this a server sees only the runtime's default agent and
+ * cannot tell which SDK, or which version of it, a request came from.
+ */
+export function sandboxUserAgent(): string {
+  return `langsmith-js/${__version__}`;
+}
 
 // =============================================================================
 // Input validation

--- a/js/src/sandbox/helpers.ts
+++ b/js/src/sandbox/helpers.ts
@@ -18,7 +18,7 @@ import {
   LangSmithSandboxOperationError,
   LangSmithValidationError,
 } from "./errors.js";
-import { __version__ } from "../index.js";
+import { userAgent } from "../utils/user_agent.js";
 
 // =============================================================================
 // Request identity
@@ -32,7 +32,7 @@ import { __version__ } from "../index.js";
  * cannot tell which SDK, or which version of it, a request came from.
  */
 export function sandboxUserAgent(): string {
-  return `langsmith-js/${__version__}`;
+  return userAgent();
 }
 
 // =============================================================================

--- a/js/src/sandbox/helpers.ts
+++ b/js/src/sandbox/helpers.ts
@@ -1,8 +1,8 @@
 /**
- * Shared helper functions for error handling.
+ * Shared helpers for the sandbox clients: request identity, input validation,
+ * and error-response parsing.
  *
- * These functions are used to parse error responses and raise appropriate
- * exceptions. They contain no I/O operations.
+ * They contain no I/O operations.
  */
 
 import {

--- a/js/src/sandbox/ws_execute.ts
+++ b/js/src/sandbox/ws_execute.ts
@@ -13,6 +13,7 @@ import {
   LangSmithSandboxServerReloadError,
 } from "./errors.js";
 import type { WsMessage, WsRunOptions } from "./types.js";
+import { sandboxUserAgent } from "./helpers.js";
 import { getLangSmithEnvironmentVariable } from "../utils/env.js";
 
 /** Read a WebSocket timeout override, in seconds. `<= 0` disables it. */
@@ -115,14 +116,45 @@ export function buildWsUrl(dataplaneUrl: string): string {
   return `${wsUrl}/execute/ws`;
 }
 
+/** Enough of a rejection body to carry a remedy; a hostile peer cannot stream forever. */
+const MAX_REJECTION_BODY_CHUNKS = 16;
+
+type UnexpectedResponse = { statusCode?: number };
+
 /**
- * Build auth headers for the WebSocket upgrade request.
+ * Server-supplied explanation from a rejected upgrade body, if there is one.
+ */
+export function rejectionDetail(body: string): string {
+  if (!body) return "";
+  try {
+    const detail = JSON.parse(body)?.detail;
+    const message = typeof detail === "string" ? detail : detail?.message;
+    return typeof message === "string" ? message.trim() : "";
+  } catch {
+    return "";
+  }
+}
+
+/** Message for a non-101 upgrade response, preferring the server's own remedy. */
+export function rejectedUpgradeMessage(
+  url: string,
+  statusCode: number | undefined,
+  detail: string,
+): string {
+  const base = `WebSocket upgrade to ${url} rejected by server (HTTP ${statusCode})`;
+  return detail ? `${base}: ${detail}` : base;
+}
+
+/**
+ * Build auth and identity headers for the WebSocket upgrade request.
  */
 export function buildAuthHeaders(
   apiKey: string | undefined,
   extraHeaders?: Record<string, string>,
 ): Record<string, string> {
-  const headers: Record<string, string> = {};
+  const headers: Record<string, string> = {
+    "User-Agent": sandboxUserAgent(),
+  };
   if (apiKey) {
     headers["X-Api-Key"] = apiKey;
   }
@@ -254,17 +286,37 @@ async function connectWs(
       "unexpected-response",
       (
         req: { destroy?: () => void },
-        res: { statusCode?: number; resume?: () => void },
+        res: UnexpectedResponse & {
+          on?: (event: string, cb: (chunk?: unknown) => void) => void;
+          resume?: () => void;
+        },
       ) => {
-        res.resume?.();
-        req.destroy?.();
-        if (settled) return;
-        settled = true;
-        reject(
-          new LangSmithSandboxConnectionError(
-            `WebSocket upgrade to ${url} rejected by server (HTTP ${res.statusCode})`,
-          ),
-        );
+        const settleWith = (detail: string) => {
+          req.destroy?.();
+          if (settled) return;
+          settled = true;
+          reject(
+            new LangSmithSandboxConnectionError(
+              rejectedUpgradeMessage(url, res.statusCode, detail),
+            ),
+          );
+        };
+        // The body is read rather than discarded: a rejection whose purpose is
+        // to redirect the caller (410 for a sandbox that moved) carries the
+        // replacement URL there, and a bare status code strands the user.
+        if (typeof res.on !== "function") {
+          res.resume?.();
+          settleWith("");
+          return;
+        }
+        const chunks: string[] = [];
+        res.on("data", (chunk) => {
+          if (chunks.length < MAX_REJECTION_BODY_CHUNKS) {
+            chunks.push(String(chunk));
+          }
+        });
+        res.on("end", () => settleWith(rejectionDetail(chunks.join(""))));
+        res.on("error", () => settleWith(""));
       },
     );
 

--- a/js/src/sandbox/ws_execute.ts
+++ b/js/src/sandbox/ws_execute.ts
@@ -116,8 +116,8 @@ export function buildWsUrl(dataplaneUrl: string): string {
   return `${wsUrl}/execute/ws`;
 }
 
-/** Enough of a rejection body to carry a remedy; a hostile peer cannot stream forever. */
-const MAX_REJECTION_BODY_CHUNKS = 16;
+/** Enough of a rejection body to carry a remedy; past this the read is cut short. */
+const MAX_REJECTION_BODY_BYTES = 64 * 1024;
 
 type UnexpectedResponse = { statusCode?: number };
 
@@ -292,9 +292,9 @@ async function connectWs(
         },
       ) => {
         const settleWith = (detail: string) => {
-          req.destroy?.();
           if (settled) return;
           settled = true;
+          req.destroy?.();
           reject(
             new LangSmithSandboxConnectionError(
               rejectedUpgradeMessage(url, res.statusCode, detail),
@@ -309,13 +309,18 @@ async function connectWs(
           settleWith("");
           return;
         }
-        const chunks: string[] = [];
+        // Settle at the byte cap rather than waiting for EOF: a peer that
+        // trickles a rejection body forever would otherwise keep this promise
+        // pending, refreshing any activity-based handshake timeout as it goes.
+        let body = "";
         res.on("data", (chunk) => {
-          if (chunks.length < MAX_REJECTION_BODY_CHUNKS) {
-            chunks.push(String(chunk));
+          if (settled) return;
+          body += String(chunk);
+          if (body.length >= MAX_REJECTION_BODY_BYTES) {
+            settleWith(rejectionDetail(body));
           }
         });
-        res.on("end", () => settleWith(rejectionDetail(chunks.join(""))));
+        res.on("end", () => settleWith(rejectionDetail(body)));
         res.on("error", () => settleWith(""));
       },
     );

--- a/js/src/tests/sandbox.test.ts
+++ b/js/src/tests/sandbox.test.ts
@@ -4,6 +4,7 @@ import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { inspect } from "node:util";
+import { __version__ } from "../index.js";
 import { SandboxClient } from "../sandbox/client.js";
 import { Sandbox } from "../sandbox/sandbox.js";
 import { CommandHandle } from "../sandbox/command_handle.js";
@@ -23,6 +24,8 @@ import {
   buildAuthHeaders,
   WSStreamControl,
   raiseForWsError,
+  rejectionDetail,
+  rejectedUpgradeMessage,
 } from "../sandbox/ws_execute.js";
 import {
   LangSmithResourceCreationError,
@@ -1470,30 +1473,90 @@ describe("buildWsUrl", () => {
   });
 });
 
-describe("buildAuthHeaders", () => {
-  it("should return X-Api-Key header when key is provided", () => {
-    expect(buildAuthHeaders("test-key")).toEqual({ "X-Api-Key": "test-key" });
+describe("rejected upgrade responses", () => {
+  // A rejection whose whole purpose is to redirect the caller is useless if
+  // only the status code survives.
+  it("should surface the server's remedy from the body", () => {
+    const body = JSON.stringify({
+      detail: {
+        error: "SandboxMoved",
+        message: "Connect to wss://api/x instead.",
+      },
+    });
+    expect(rejectionDetail(body)).toBe("Connect to wss://api/x instead.");
+    expect(rejectedUpgradeMessage("ws://a/b", 410, rejectionDetail(body))).toBe(
+      "WebSocket upgrade to ws://a/b rejected by server (HTTP 410): " +
+        "Connect to wss://api/x instead.",
+    );
   });
 
-  it("should return empty headers when no key", () => {
-    expect(buildAuthHeaders(undefined)).toEqual({});
+  it("should accept a plain string detail", () => {
+    expect(rejectionDetail(JSON.stringify({ detail: "gone for good" }))).toBe(
+      "gone for good",
+    );
+  });
+
+  it.each([
+    ["empty", ""],
+    ["not json", "not json at all"],
+    ["no detail", "{}"],
+    ["no message", JSON.stringify({ detail: {} })],
+    ["non-string message", JSON.stringify({ detail: { message: 42 } })],
+    ["array", "[1,2,3]"],
+    ["null", "null"],
+  ])("should return no detail for %s", (_name, body) => {
+    expect(rejectionDetail(body)).toBe("");
+  });
+
+  it("should fall back to the bare status when there is no detail", () => {
+    expect(rejectedUpgradeMessage("ws://a/b", 502, "")).toBe(
+      "WebSocket upgrade to ws://a/b rejected by server (HTTP 502)",
+    );
+  });
+});
+
+describe("buildAuthHeaders", () => {
+  it("should return X-Api-Key header when key is provided", () => {
+    expect(buildAuthHeaders("test-key")).toMatchObject({
+      "X-Api-Key": "test-key",
+    });
+  });
+
+  it("should omit X-Api-Key when no key", () => {
+    expect(buildAuthHeaders(undefined)["X-Api-Key"]).toBeUndefined();
+  });
+
+  // The upgrade must name the SDK and its version: a server otherwise sees only
+  // the runtime's default agent and cannot attribute the request.
+  it("should identify the SDK and version in User-Agent", () => {
+    expect(buildAuthHeaders("test-key")["User-Agent"]).toBe(
+      `langsmith-js/${__version__}`,
+    );
+  });
+
+  it("should let a caller-supplied User-Agent win", () => {
+    expect(
+      buildAuthHeaders("test-key", { "User-Agent": "caller/1.0" })[
+        "User-Agent"
+      ],
+    ).toBe("caller/1.0");
   });
 
   it("should return extra headers when provided", () => {
-    expect(buildAuthHeaders(undefined, { "X-Service-Key": "svc-jwt" })).toEqual(
-      {
-        "X-Service-Key": "svc-jwt",
-      },
-    );
+    expect(
+      buildAuthHeaders(undefined, { "X-Service-Key": "svc-jwt" }),
+    ).toMatchObject({
+      "X-Service-Key": "svc-jwt",
+    });
   });
 
   it("should merge X-Api-Key with extra headers", () => {
-    expect(buildAuthHeaders("api-key", { "X-Service-Key": "svc-jwt" })).toEqual(
-      {
-        "X-Api-Key": "api-key",
-        "X-Service-Key": "svc-jwt",
-      },
-    );
+    expect(
+      buildAuthHeaders("api-key", { "X-Service-Key": "svc-jwt" }),
+    ).toMatchObject({
+      "X-Api-Key": "api-key",
+      "X-Service-Key": "svc-jwt",
+    });
   });
 });
 

--- a/js/src/tests/sandbox.test.ts
+++ b/js/src/tests/sandbox.test.ts
@@ -452,6 +452,57 @@ describe("sandbox proxy config helpers", () => {
   });
 });
 
+describe("SandboxClient - data-plane request headers", () => {
+  const capture = (client: SandboxClient) => {
+    const seen: Headers[] = [];
+    (client as any)._fetchImpl = async (_url: string, init: RequestInit) => {
+      seen.push(init.headers as Headers);
+      return new Response("{}", {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    };
+    return seen;
+  };
+
+  it("should identify the SDK and version", async () => {
+    const client = new SandboxClient({
+      apiEndpoint: "https://api.test",
+      apiKey: "k",
+    });
+    const seen = capture(client);
+    await (client as any)._fetch("https://api.test/x");
+    expect(seen[0].get("User-Agent")).toBe(`langsmith-js/${__version__}`);
+  });
+
+  // Regression: the SDK agent used to be set before the constructor defaults
+  // were merged in, and that merge only fills absent headers — so a caller's
+  // explicit User-Agent was silently dropped.
+  it("should let a constructor-supplied User-Agent win", async () => {
+    const client = new SandboxClient({
+      apiEndpoint: "https://api.test",
+      apiKey: "k",
+      headers: { "User-Agent": "caller/1.0" },
+    });
+    const seen = capture(client);
+    await (client as any)._fetch("https://api.test/x");
+    expect(seen[0].get("User-Agent")).toBe("caller/1.0");
+  });
+
+  it("should let a per-request User-Agent win", async () => {
+    const client = new SandboxClient({
+      apiEndpoint: "https://api.test",
+      apiKey: "k",
+      headers: { "User-Agent": "caller/1.0" },
+    });
+    const seen = capture(client);
+    await (client as any)._fetch("https://api.test/x", {
+      headers: { "User-Agent": "per-request/2.0" },
+    });
+    expect(seen[0].get("User-Agent")).toBe("per-request/2.0");
+  });
+});
+
 describe("SandboxClient", () => {
   describe("constructor", () => {
     it("should trim trailing slash from endpoint", () => {

--- a/js/src/utils/user_agent.ts
+++ b/js/src/utils/user_agent.ts
@@ -1,0 +1,13 @@
+import { __version__ } from "../index.js";
+
+/**
+ * Single source of the SDK's `User-Agent`.
+ *
+ * The tracing client and the sandbox data-plane clients issue requests through
+ * different machinery, so they cannot share a session — but a server should
+ * still see one token identifying the SDK and its version. Keeping the token
+ * here is what stops a second path from silently shipping without one.
+ */
+export function userAgent(): string {
+  return `langsmith-js/${__version__}`;
+}

--- a/python/langsmith/_internal/_user_agent.py
+++ b/python/langsmith/_internal/_user_agent.py
@@ -1,0 +1,22 @@
+"""Single source of the SDK's ``User-Agent``.
+
+The tracing client and the sandbox data-plane clients are built on different
+HTTP stacks (requests and httpx), so they cannot share a session — but a server
+should still see one token identifying the SDK and its version. Keeping the
+token here is what stops a second stack from silently shipping without one.
+"""
+
+from __future__ import annotations
+
+
+def user_agent(transport_default: str = "") -> str:
+    """``User-Agent`` for an outbound request from this SDK.
+
+    ``transport_default`` is appended rather than replaced, so the underlying
+    stack's own agent (``python-httpx/x.y.z``, ``Python/3.x websockets/x.y``)
+    stays visible alongside ours.
+    """
+    import langsmith
+
+    agent = f"langsmith-py/{langsmith.__version__}"
+    return f"{agent} {transport_default}" if transport_default else agent

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -66,7 +66,6 @@ from typing_extensions import TypeGuard, deprecated, overload
 from urllib3.poolmanager import PoolKey  # type: ignore[attr-defined, import-untyped]
 from urllib3.util import Retry  # type: ignore[import-untyped]
 
-import langsmith
 from langsmith import env as ls_env
 from langsmith import schemas as ls_schemas
 from langsmith import utils as ls_utils
@@ -115,6 +114,7 @@ from langsmith._internal._operations import (
     serialized_run_operation_to_multipart_parts_and_context,
 )
 from langsmith._internal._serde import dumps_json as _dumps_json
+from langsmith._internal._user_agent import user_agent
 from langsmith._internal._uuid import uuid7
 from langsmith._internal._v2_migration_utils import QueryBackend, get_query_backend
 from langsmith._openapi_client import AsyncLangsmith as LangsmithOpenAPIClient
@@ -1821,7 +1821,7 @@ class Client:
 
     def _compute_headers(self) -> dict[str, str]:
         headers = {
-            "User-Agent": f"langsmith-py/{langsmith.__version__}",
+            "User-Agent": user_agent(),
             "Accept": "application/json",
         }
         # Merge custom headers first so they don't override required headers

--- a/python/langsmith/sandbox/_async_client.py
+++ b/python/langsmith/sandbox/_async_client.py
@@ -31,6 +31,7 @@ from langsmith.sandbox._exceptions import (
 from langsmith.sandbox._helpers import (
     handle_client_http_error,
     handle_sandbox_creation_error,
+    httpx_user_agent,
     merge_headers,
     validate_service_params,
     validate_ttl,
@@ -115,7 +116,8 @@ class AsyncSandboxClient:
         self._timeout = timeout
         self._max_retries = max_retries
         self._default_headers: dict[str, str] = dict(headers) if headers else {}
-        client_headers: dict[str, str] = {}
+        # Seeded before the caller's headers so an explicit User-Agent still wins.
+        client_headers: dict[str, str] = {"User-Agent": httpx_user_agent()}
         if resolved_api_key:
             client_headers["X-Api-Key"] = resolved_api_key
         if self._default_headers:

--- a/python/langsmith/sandbox/_client.py
+++ b/python/langsmith/sandbox/_client.py
@@ -27,6 +27,7 @@ from langsmith.sandbox._exceptions import (
 from langsmith.sandbox._helpers import (
     handle_client_http_error,
     handle_sandbox_creation_error,
+    httpx_user_agent,
     merge_headers,
     validate_service_params,
     validate_ttl,
@@ -224,7 +225,8 @@ class SandboxClient:
         self._timeout = timeout
         self._max_retries = max_retries
         self._default_headers: dict[str, str] = dict(headers) if headers else {}
-        client_headers: dict[str, str] = {}
+        # Seeded before the caller's headers so an explicit User-Agent still wins.
+        client_headers: dict[str, str] = {"User-Agent": httpx_user_agent()}
         if resolved_api_key:
             client_headers["X-Api-Key"] = resolved_api_key
         if self._default_headers:

--- a/python/langsmith/sandbox/_helpers.py
+++ b/python/langsmith/sandbox/_helpers.py
@@ -48,6 +48,26 @@ def merge_headers(
     return merged
 
 
+def user_agent(transport_default: str = "") -> str:
+    """``User-Agent`` for a sandbox data-plane request.
+
+    The data-plane clients are built on httpx and websockets directly rather
+    than on :class:`langsmith.Client`, so without this they send only their
+    transport's default agent and a server cannot tell which SDK, or which
+    version of it, a request came from. ``transport_default`` is appended
+    rather than replaced so that detail survives too.
+    """
+    import langsmith
+
+    agent = f"langsmith-py/{langsmith.__version__}"
+    return f"{agent} {transport_default}" if transport_default else agent
+
+
+def httpx_user_agent() -> str:
+    """``User-Agent`` for the httpx-backed data-plane clients."""
+    return user_agent(f"python-httpx/{httpx.__version__}")
+
+
 # =============================================================================
 # Input Validation
 # =============================================================================

--- a/python/langsmith/sandbox/_helpers.py
+++ b/python/langsmith/sandbox/_helpers.py
@@ -1,7 +1,7 @@
-"""Shared helper functions for error handling.
+"""Shared helpers for the sandbox clients.
 
-These functions are used by both sync and async clients to parse error responses
-and raise appropriate exceptions. They contain no I/O operations.
+Header building and request identity, input validation, and error-response
+parsing. Used by both the sync and async clients; no I/O operations.
 """
 
 from __future__ import annotations

--- a/python/langsmith/sandbox/_helpers.py
+++ b/python/langsmith/sandbox/_helpers.py
@@ -11,6 +11,7 @@ from typing import Any, Optional
 
 import httpx
 
+from langsmith._internal._user_agent import user_agent
 from langsmith.sandbox._exceptions import (
     QuotaExceededError,
     ResourceCreationError,
@@ -46,21 +47,6 @@ def merge_headers(
         for name, value in (headers or {}).items():
             merged[name.lower()] = value
     return merged
-
-
-def user_agent(transport_default: str = "") -> str:
-    """``User-Agent`` for a sandbox data-plane request.
-
-    The data-plane clients are built on httpx and websockets directly rather
-    than on :class:`langsmith.Client`, so without this they send only their
-    transport's default agent and a server cannot tell which SDK, or which
-    version of it, a request came from. ``transport_default`` is appended
-    rather than replaced so that detail survives too.
-    """
-    import langsmith
-
-    agent = f"langsmith-py/{langsmith.__version__}"
-    return f"{agent} {transport_default}" if transport_default else agent
 
 
 def httpx_user_agent() -> str:

--- a/python/langsmith/sandbox/_ws_execute.py
+++ b/python/langsmith/sandbox/_ws_execute.py
@@ -9,6 +9,7 @@ from collections.abc import AsyncIterator, Iterator, Mapping
 from typing import Any, Callable, Optional
 
 from langsmith import utils as ls_utils
+from langsmith._internal._user_agent import user_agent
 from langsmith.sandbox._exceptions import (
     CommandTimeoutError,
     SandboxConnectionError,
@@ -17,7 +18,7 @@ from langsmith.sandbox._exceptions import (
     SandboxOperationError,
     SandboxServerReloadError,
 )
-from langsmith.sandbox._helpers import merge_headers, user_agent
+from langsmith.sandbox._helpers import merge_headers
 
 logger = logging.getLogger(__name__)
 

--- a/python/langsmith/sandbox/_ws_execute.py
+++ b/python/langsmith/sandbox/_ws_execute.py
@@ -17,7 +17,7 @@ from langsmith.sandbox._exceptions import (
     SandboxOperationError,
     SandboxServerReloadError,
 )
-from langsmith.sandbox._helpers import merge_headers
+from langsmith.sandbox._helpers import merge_headers, user_agent
 
 logger = logging.getLogger(__name__)
 
@@ -27,12 +27,14 @@ logger = logging.getLogger(__name__)
 try:
     from websockets.asyncio.client import connect as _ws_connect_async
     from websockets.exceptions import ConnectionClosed, InvalidHandshake
+    from websockets.http11 import USER_AGENT as _WS_TRANSPORT_AGENT
     from websockets.sync.client import connect as _ws_connect_sync
 
     WEBSOCKETS_AVAILABLE = True
 except ImportError:
     _ws_connect_async = _ws_connect_sync = None  # type: ignore[assignment,misc]
     ConnectionClosed = InvalidHandshake = None  # type: ignore[assignment,misc]
+    _WS_TRANSPORT_AGENT = ""
     WEBSOCKETS_AVAILABLE = False
 
 
@@ -106,9 +108,11 @@ def _build_ws_url(dataplane_url: str) -> str:
 def _build_auth_headers(
     api_key: Optional[str], headers: Optional[Mapping[str, str]] = None
 ) -> dict[str, str]:
-    """Build auth headers for the WebSocket upgrade request."""
-    auth_headers = {"X-Api-Key": api_key} if api_key else None
-    return merge_headers(auth_headers, headers)
+    """Build auth and identity headers for the WebSocket upgrade request."""
+    base_headers = {"User-Agent": user_agent(_WS_TRANSPORT_AGENT)}
+    if api_key:
+        base_headers["X-Api-Key"] = api_key
+    return merge_headers(base_headers, headers)
 
 
 # =============================================================================
@@ -209,6 +213,26 @@ class _AsyncWSStreamControl:
 # =============================================================================
 
 
+def _handshake_rejection_detail(exc: Exception) -> str:
+    """Server-supplied explanation from a rejected upgrade, if there is one.
+
+    ``str(exc)`` is only ``"server rejected WebSocket connection: HTTP <n>"`` —
+    the response body never reaches it. Without this, a rejection whose whole
+    point is to tell the caller what to do instead (the platform answers a moved
+    sandbox with 410 and the URL to use) surfaces as a bare status code.
+    """
+    body = getattr(getattr(exc, "response", None), "body", None)
+    if not body:
+        return ""
+    try:
+        payload = json.loads(body)
+        detail = payload["detail"]
+        message = detail["message"] if isinstance(detail, dict) else detail
+    except (ValueError, TypeError, KeyError):
+        return ""
+    return message.strip() if isinstance(message, str) else ""
+
+
 def _raise_for_invalid_handshake(exc: Exception, ws_url: str) -> None:
     """Raise a clear error when the WebSocket upgrade handshake fails.
 
@@ -231,8 +255,9 @@ def _raise_for_invalid_handshake(exc: Exception, ws_url: str) -> None:
             f"Sandbox is not ready for WebSocket command execution: {exc}"
         ) from exc
     if status is not None:
+        detail = _handshake_rejection_detail(exc)
         raise SandboxConnectionError(
-            f"WebSocket upgrade rejected by server (HTTP {status}): {exc}"
+            f"WebSocket upgrade rejected by server (HTTP {status}): {detail or exc}"
         ) from exc
     # No HTTP status at all — the peer didn't return a valid HTTP response,
     # typically a stopped/unreachable sandbox dataplane.

--- a/python/tests/unit_tests/sandbox/test_client.py
+++ b/python/tests/unit_tests/sandbox/test_client.py
@@ -51,6 +51,25 @@ class TestSandboxClientInit:
         with SandboxClient(api_endpoint="http://localhost:8080") as client:
             assert client._base_url == "http://localhost:8080"
 
+    def test_user_agent_names_sdk_and_transport(self):
+        """Data-plane requests must be attributable to this SDK and version."""
+        import httpx
+
+        import langsmith
+
+        with SandboxClient(api_endpoint="http://localhost:8080") as client:
+            assert client._http.headers["user-agent"] == (
+                f"langsmith-py/{langsmith.__version__} python-httpx/{httpx.__version__}"
+            )
+
+    def test_caller_user_agent_overrides_default(self):
+        """An explicit User-Agent wins, like any other caller-supplied header."""
+        with SandboxClient(
+            api_endpoint="http://localhost:8080",
+            headers={"User-Agent": "caller/1.0"},
+        ) as client:
+            assert client._http.headers["user-agent"] == "caller/1.0"
+
     def test_derives_endpoint_from_langsmith_endpoint(self):
         """Test endpoint derivation from LANGSMITH_ENDPOINT."""
         with patch(

--- a/python/tests/unit_tests/sandbox/test_ws_execute.py
+++ b/python/tests/unit_tests/sandbox/test_ws_execute.py
@@ -76,21 +76,33 @@ class TestBuildAuthHeaders:
     def test_builds_header(self):
         # Header names are normalized to lowercase.
         headers = _build_auth_headers("my-key")
-        assert headers == {"x-api-key": "my-key"}
+        assert headers["x-api-key"] == "my-key"
 
-    def test_none_key_returns_empty(self):
+    def test_none_key_omits_api_key(self):
         headers = _build_auth_headers(None)
-        assert headers == {}
+        assert "x-api-key" not in headers
+
+    # The upgrade must name the SDK and its version: a server otherwise sees
+    # only the websockets default and cannot attribute the request.
+    def test_user_agent_carries_sdk_version_and_transport(self):
+        from websockets.http11 import USER_AGENT
+
+        import langsmith
+
+        agent = _build_auth_headers("my-key")["user-agent"]
+        assert agent == f"langsmith-py/{langsmith.__version__} {USER_AGENT}"
 
     def test_custom_headers_override_auth_header(self):
         headers = _build_auth_headers(
             "default-key",
             {"X-Api-Key": "override-key", "X-Test-Header": "ws-value"},
         )
-        assert headers == {
-            "x-api-key": "override-key",
-            "x-test-header": "ws-value",
-        }
+        assert headers["x-api-key"] == "override-key"
+        assert headers["x-test-header"] == "ws-value"
+
+    def test_custom_user_agent_wins(self):
+        headers = _build_auth_headers("k", {"User-Agent": "caller/1.0"})
+        assert headers["user-agent"] == "caller/1.0"
 
 
 # =============================================================================
@@ -1033,6 +1045,54 @@ class TestRaiseForInvalidHandshake:
         exc.response = mock_response
 
         with pytest.raises(SandboxNotReadyError, match="not ready"):
+            _raise_for_invalid_handshake(exc, "ws://example.com/sb-123/execute/ws")
+
+    @staticmethod
+    def _rejection(status_code: int, body: object) -> Exception:
+        mock_response = MagicMock()
+        mock_response.status_code = status_code
+        mock_response.body = body
+        exc = Exception(f"server rejected WebSocket connection: HTTP {status_code}")
+        exc.response = mock_response
+        return exc
+
+    # A rejection whose whole purpose is to redirect the caller is useless if
+    # only the status code survives.
+    def test_rejection_body_detail_reaches_the_caller(self):
+        from langsmith.sandbox._ws_execute import _raise_for_invalid_handshake
+
+        exc = self._rejection(
+            410,
+            b'{"detail":{"error":"SandboxMoved",'
+            b'"message":"Connect to wss://api/x instead."}}',
+        )
+
+        with pytest.raises(SandboxConnectionError) as exc_info:
+            _raise_for_invalid_handshake(exc, "ws://example.com/sb-123/execute/ws")
+        msg = str(exc_info.value)
+        assert "HTTP 410" in msg
+        assert "Connect to wss://api/x instead." in msg
+
+    @pytest.mark.parametrize(
+        "body",
+        [
+            None,
+            b"",
+            b"not json at all",
+            b"{}",
+            b'{"detail":{}}',
+            b'{"detail":{"message":42}}',
+            b"[1, 2, 3]",
+        ],
+        ids=["none", "empty", "not-json", "no-detail", "no-message", "non-str", "list"],
+    )
+    def test_unusable_rejection_body_falls_back_to_the_exception(self, body):
+        """A body we can't read must not mask the error or raise from parsing."""
+        from langsmith.sandbox._ws_execute import _raise_for_invalid_handshake
+
+        exc = self._rejection(410, body)
+
+        with pytest.raises(SandboxConnectionError, match="HTTP 410"):
             _raise_for_invalid_handshake(exc, "ws://example.com/sb-123/execute/ws")
 
     def test_no_http_response_gives_unreachable_message(self):


### PR DESCRIPTION
Two fixes to the sandbox data-plane clients, both about a request or its failure
being unattributable.

### The clients did not identify themselves

The data-plane paths are built on `httpx`/`fetch` and `websockets`/`ws` directly
rather than on the tracing `Client`, so they inherited none of its `User-Agent`.
Server-side they appeared only as `python-httpx/0.28.1`, `Python/3.12
websockets/15.0.1`, or `node` — enough to guess a language, not enough to name
an SDK or a version.

| | before | after |
|---|---|---|
| Python HTTP | `python-httpx/0.28.1` | `langsmith-py/<v> python-httpx/0.28.1` |
| Python WS | `Python/3.12 websockets/15.0.1` | `langsmith-py/<v> Python/3.12 websockets/15.0.1` |
| JS HTTP + WS | `node` / none | `langsmith-js/<v>` |

The transport default is appended rather than replaced, so the httpx/websockets
version stays visible. A caller-supplied `User-Agent` still wins, on every path.

Go needs no change: its sandbox HTTP and WebSocket paths both go through
`requestconfig`, so they already send `langsmith-go/<v>`. Java has no data-plane
client.

### A rejected WebSocket upgrade dropped the server's explanation

Python read only `response.status_code`; JS drained the body with `res.resume()`
before rejecting. So a rejection whose entire purpose is to tell the caller
where to reconnect arrived as a bare `HTTP 410`. Both now read `detail.message`
from the body and include it.

Parsing is total — absent, empty, non-JSON, wrong-shaped, and non-string bodies
all fall back to the previous message rather than raising or masking the error.
The JS reader caps buffered chunks so a hostile peer cannot stream forever.

## Test Plan

- [x] Python: 533 unit tests pass (`pytest tests/unit_tests/sandbox`); ruff check and format clean
- [x] JS: 158 unit tests pass (`jest src/tests/sandbox`); `tsc --noEmit` clean
- [x] New tests assert the version string on all four paths (Python sync/async HTTP, Python WS, JS HTTP, JS WS) and that a caller-supplied `User-Agent` overrides it
- [x] New tests cover remedy extraction plus 7 Python and 7 JS unusable-body cases falling back to the old message
- [x] Verified Go already sends `langsmith-go/<v>` on its WebSocket handshake via a throwaway test against `sandboxHeaders`
