### PR TITLE
perf(py): serialize pydantic models in mode="python"

### DIFF
--- a/python/langsmith/_internal/_serde.py
+++ b/python/langsmith/_internal/_serde.py
@@ -91,8 +91,7 @@ def _simple_default(obj):
 
 _serialization_methods: list[tuple[str, dict[str, Any]]] = [
     # Pydantic v2: python-mode dump only. This leaves non-JSON values as objects
-    # for orjson / _simple_default to serialize, which is cheaper on CPU and
-    # memory than having pydantic coerce every leaf to a JSON-native type.
+    # for orjson / _simple_default to serialize, for better CPU/mem efficiency
     ("model_dump", {"exclude_none": True, "mode": "python"}),
     ("dict", {}),  # Pydantic v1 .dict()
     ("to_dict", {}),  # dataclasses-json to_dict()

--- a/python/langsmith/_internal/_serde.py
+++ b/python/langsmith/_internal/_serde.py
@@ -78,7 +78,11 @@ def _simple_default(obj):
         elif isinstance(obj, re.Pattern):
             return obj.pattern
         elif isinstance(obj, (bytes, bytearray)):
-            return base64.b64encode(obj).decode()
+            try:
+                # Try having bytes as utf-8 human-readable text
+                return bytes(obj).decode("utf-8")
+            except UnicodeDecodeError:
+                return base64.b64encode(obj).decode()
         return str(obj)
     except Exception as e:
         logger.debug(f"Failed to serialize {type(obj)} to JSON: {e}")
@@ -86,12 +90,10 @@ def _simple_default(obj):
 
 
 _serialization_methods: list[tuple[str, dict[str, Any]]] = [
-    # Pydantic v2 primary: coerce fields to JSON-native types.
-    # Raises on truly non-serializable fields -> the next entry handles those.
-    ("model_dump", {"exclude_none": True, "mode": "json"}),
-    # Pydantic v2 fallback: python-mode dump; leaves non-JSON values as objects
-    # for orjson / _simple_default to serialize.
-    ("model_dump", {"exclude_none": True}),
+    # Pydantic v2: python-mode dump only. This leaves non-JSON values as objects
+    # for orjson / _simple_default to serialize, which is cheaper on CPU and
+    # memory than having pydantic coerce every leaf to a JSON-native type.
+    ("model_dump", {"exclude_none": True, "mode": "python"}),
     ("dict", {}),  # Pydantic v1 .dict()
     ("to_dict", {}),  # dataclasses-json to_dict()
 ]

--- a/python/tests/unit_tests/test_client.py
+++ b/python/tests/unit_tests/test_client.py
@@ -53,7 +53,6 @@ from langsmith._internal._beta_decorator import (
     suppress_deprecation_warning as _suppress_deprecation_warning,
 )
 from langsmith._internal._multipart import MultipartPartsAndContext
-from langsmith._internal._serde import _serialize_json
 from langsmith.anonymizer import SECRET_PLACEHOLDER, create_secret_anonymizer
 from langsmith.client import (
     Client,
@@ -2221,7 +2220,10 @@ def test_pydantic_serialize() -> None:
         ),
         path_keys={pathlib.Path("foo"): pathlib.Path("bar")},
     )
-    res = json.loads(json.dumps(obj, default=_serialize_json))
+    # Serialize via the production path (dumps_json = orjson + key-normalization
+    # fallbacks), not stdlib json.dumps: under model_dump(mode="python") the hook
+    # returns non-str dict keys (e.g. PosixPath) that only dumps_json coerces.
+    res = _orjson.loads(_dumps_json(obj))
     expected = {
         "foo": "bar",
         "uid": str(test_uuid),
@@ -2235,7 +2237,7 @@ def test_pydantic_serialize() -> None:
     assert res == expected
 
     obj2 = {"output": obj}
-    res2 = json.loads(json.dumps(obj2, default=_serialize_json))
+    res2 = _orjson.loads(_dumps_json(obj2))
     assert res2 == {"output": expected}
 
 


### PR DESCRIPTION
## What & why

The orjson `default` hook (`_serialize_json`, on the tracing serialization path) tried `model_dump(exclude_none=True, mode="json")` first for every Pydantic v2 object. json mode makes pydantic **stringify each leaf into JSON form** (datetimes/UUIDs/enums/etc.) and hand orjson a fully-materialized dict, which orjson then **re-walks** — even though orjson is already configured to emit those same leaves natively in C.

This PR flips the primary probe to `mode="python"`, so pydantic returns references to the model's **existing** leaf objects and orjson (and `_simple_default`) do the leaf conversion. Fewer intermediate allocations, less CPU. The old no-mode `model_dump` fallback entry is dropped — no-mode already defaults to python mode, so it was identical once json is no longer primary.

Also: `_simple_default` now tries a strict utf-8 decode for `bytes`/`bytearray` before base64, so text bytes stay human-readable while genuine binary still base64s.

## Measured improvement (in serialization path in isolation)

Local repro serializing a 132-message agent thread (~3,322 Pydantic objects reach the hook per invoke). Python-hook CPU via `thread_time`; allocations via `tracemalloc` (retained, so cumulative churn is counted, not just live-peak).

| per invoke | before (json) | after (python) | Δ |
|---|---|---|---|
| hook CPU | 7.16 ms | 6.07 ms | **−15.3%** |
| allocated bytes | 6,534 KiB | 4,227 KiB | **−35.3%** |
| allocation blocks (churn) | 94,598 | 47,535 | **−49.8%** |

Leaf population handed back to orjson is unchanged (identical `_simple_default` re-entry counts), so the Rust/C re-walk cost is unchanged — this delta is the whole Python-side effect. The churn drop (~50%) is the GC pressure this line of work (LSDK-415) targets.

## Wire-format changes

On payloads that serialized cleanly in json mode, three leaf types now render in python-mode form (verified round-tripped against the backend):

| field type | before (json) | after (python) |
|---|---|---|
| `Decimal("1.50")` | `"1.50"` (string) | `1.5` (number) |
| `timedelta(90s)` | `"PT1M30S"` (ISO-8601) | `90.0` (seconds) |
| tz-aware `datetime` | `"…05Z"` | `"…05+00:00"` |

`bytes`: utf-8-decodable bytes now stay readable (`"hi"`) instead of base64 (`"aGk="`); real binary is unchanged (base64). A model carrying binary already fell back to python mode today via the exception path, so such models are unaffected.

## Tests

`test_pydantic_serialize` was asserting against stdlib json.dumps + the **internal** `_serialize_json` (as in `json.dumps(obj, default=_serialize_json)`). With this PR the behavior of `_serialize_json`changes , but the **exported** serializer `dumps_json` coerces them non-base fileds (such as PosixPath) and produces **identical** output. The test now asserts against `dumps_json` (matching the other serde tests); expected values are unchanged.

# Minor version bump
While the serialization outputs are now arguably better and more deterministic, they can differ from the originals as seen in the table above. Releasing this change therefore deserves a Minor version bump.
