### PR TITLE
perf(py): call pydantic core serializer directly, skip orjson key checks

### DIFF
--- a/python/langsmith/_internal/_serde.py
+++ b/python/langsmith/_internal/_serde.py
@@ -263,6 +263,15 @@ def dumps_json(obj: Any) -> bytes:
     except TypeError as e:
         # Usually caused by UTF surrogate characters or non-str dict keys
         logger.debug(f"Orjson serialization failed: {repr(e)}. Falling back to json.")
+        try:
+            # Let orjson coerce non-str keys. Only stringify the ones it can't handle.
+            return _orjson.dumps(
+                obj,
+                default=_serialize_json,
+                option=_ORJSON_OPTIONS,
+            )
+        except TypeError:
+            pass
         normalized_obj = _normalize_json_keys(obj)
         try:
             return _orjson.dumps(

--- a/python/langsmith/_internal/_serde.py
+++ b/python/langsmith/_internal/_serde.py
@@ -12,6 +12,8 @@ import re
 import uuid
 from typing import Any
 
+from pydantic import BaseModel
+
 from langsmith._internal import _orjson
 
 try:
@@ -29,6 +31,9 @@ _ORJSON_OPTIONS = (
     | _orjson.OPT_SERIALIZE_UUID
     | _orjson.OPT_NON_STR_KEYS
 )
+# Turn off OPT_NON_STR_KEYS, trading better speed in the general case where
+# all dict keys are strings for worse speed in the exceptional case
+_ORJSON_OPTIONS_FAST = _ORJSON_OPTIONS & ~_orjson.OPT_NON_STR_KEYS
 _JSON_KEY_TYPES = (str, int, float, bool, type(None))
 # Matches escaped lone UTF-16 surrogates (e.g. b"\\ud800") in ensure_ascii
 # json.dumps output; used to strip them on the stdlib-json fallback path.
@@ -85,6 +90,49 @@ def _simple_default(obj):
     return str(obj)
 
 
+_MISSING = object()
+# Maps a Class to its Pydantic core serializer, or to None when the fast path
+# below does not apply to it. Bounded rather than weakly keyed.
+_PYDANTIC_SERIALIZER_CACHE_MAX = 1024
+_pydantic_core_serializers: dict[type, Any] = {}
+
+
+def _remember_pydantic_serializer(cls: type, serializer: Any) -> None:
+    if len(_pydantic_core_serializers) >= _PYDANTIC_SERIALIZER_CACHE_MAX:
+        _pydantic_core_serializers.clear()
+    _pydantic_core_serializers[cls] = serializer
+
+
+def _pydantic_json_dump(obj: Any) -> Any:
+    """Serialize a Pydantic v2 model with its low level core serializer.
+
+    `model_dump()` is a Python wrapper around this serializer. Calling the
+    low-level serializer is measurably cheaper, if it hasn't been overridden.
+
+    Returns `_MISSING` when the shortcut doesn't apply, so callers fall back to
+    other methods. A raise is remembered per class, because
+    `_serialization_methods` starts with the same json-mode dump: retrying it
+    per object would only raise twice instead of once.
+    """
+    cls = type(obj)
+    serializer = _pydantic_core_serializers.get(cls, _MISSING)
+    if serializer is _MISSING:
+        serializer = None
+        if isinstance(obj, BaseModel) and cls.model_dump is BaseModel.model_dump:
+            # getattr: a model whose schema build is still deferred has a
+            # placeholder here, which the try below handles.
+            serializer = getattr(cls, "__pydantic_serializer__", None)
+        _remember_pydantic_serializer(cls, serializer)
+    if serializer is None:
+        return _MISSING
+
+    try:
+        return serializer.to_python(obj, mode="json", exclude_none=True, warnings=False)
+    except Exception:
+        _remember_pydantic_serializer(cls, None)
+        return _MISSING
+
+
 _serialization_methods: list[tuple[str, dict[str, Any]]] = [
     # Pydantic v2 primary: coerce fields to JSON-native types.
     # Raises on truly non-serializable fields -> the next entry handles those.
@@ -113,6 +161,11 @@ def _serialize_json(obj: Any) -> Any:
         # A class object has no useful instance serialization method
         if isinstance(obj, type):
             return _simple_default(obj)
+
+        # Try using the speedier Pydantic serialization first
+        fast_serialized = _pydantic_json_dump(obj)
+        if fast_serialized is not _MISSING:
+            return fast_serialized
 
         for attr, kwargs in _serialization_methods:
             method = getattr(obj, attr, None)
@@ -205,10 +258,10 @@ def dumps_json(obj: Any) -> bytes:
         return _orjson.dumps(
             obj,
             default=_serialize_json,
-            option=_ORJSON_OPTIONS,
+            option=_ORJSON_OPTIONS_FAST,
         )
     except TypeError as e:
-        # Usually caused by UTF surrogate characters
+        # Usually caused by UTF surrogate characters or non-str dict keys
         logger.debug(f"Orjson serialization failed: {repr(e)}. Falling back to json.")
         normalized_obj = _normalize_json_keys(obj)
         try:

--- a/python/tests/unit_tests/test_client.py
+++ b/python/tests/unit_tests/test_client.py
@@ -2423,9 +2423,9 @@ def test__dumps_json_normalizes_unsupported_dict_keys():
 def test__dumps_json_coerces_json_native_dict_keys():
     """Keys orjson can coerce must still round-trip to their string form.
 
-    The fast path omits ``OPT_NON_STR_KEYS``, so these now reach the
-    normalizing fallback rather than being coerced by orjson directly. The
-    output must not change either way.
+    The fast path omits ``OPT_NON_STR_KEYS``, so these are coerced by the
+    retry with the full options rather than on the first attempt. The output
+    must not change either way.
     """
     serialized_json = _dumps_json(
         {1: "int", 2.5: "float", None: "none", date(2020, 1, 2): "date"}
@@ -2439,6 +2439,28 @@ def test__dumps_json_coerces_json_native_dict_keys():
     }
     # `True` is kept apart: it would collide with the `1` key above (True == 1).
     assert _orjson.loads(_dumps_json({True: "bool"})) == {"true": "bool"}
+
+
+def test__dumps_json_coerces_enum_dict_keys_by_value():
+    """Enum keys must serialize as their value, not ``str(member)``.
+
+    orjson does this coercion itself, but only with ``OPT_NON_STR_KEYS``; the
+    normalizing fallback would emit ``"StrValued.FOO"`` instead.
+    """
+
+    class StrValued(Enum):
+        FOO = "foo"
+
+    class IntValued(Enum):
+        BAR = 3
+
+    class BytesValued(Enum):
+        BAZ = b"x"
+
+    assert _orjson.loads(_dumps_json({StrValued.FOO: 1})) == {"foo": 1}
+    assert _orjson.loads(_dumps_json({IntValued.BAR: 1})) == {"3": 1}
+    # A value orjson can't use as a key falls back to the member name.
+    assert _orjson.loads(_dumps_json({BytesValued.BAZ: 1})) == {"BytesValued.BAZ": 1}
 
 
 def test__dumps_json_honors_json_only_field_serializer():

--- a/python/tests/unit_tests/test_client.py
+++ b/python/tests/unit_tests/test_client.py
@@ -18,7 +18,7 @@ import time
 import uuid
 import warnings
 import weakref
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from enum import Enum
 from io import BytesIO
 from types import SimpleNamespace
@@ -41,7 +41,7 @@ import httpx
 import pytest
 import requests
 from multipart import MultipartParser, MultipartPart, parse_options_header
-from pydantic import BaseModel
+from pydantic import BaseModel, field_serializer
 from requests import HTTPError
 
 import langsmith.env as ls_env
@@ -2418,6 +2418,62 @@ def test__dumps_json_normalizes_unsupported_dict_keys():
         "nested": [{"('a', 'b')": "c"}],
         "custom": {"(1, 2)": "custom"},
     }
+
+
+def test__dumps_json_coerces_json_native_dict_keys():
+    """Keys orjson can coerce must still round-trip to their string form.
+
+    The fast path omits ``OPT_NON_STR_KEYS``, so these now reach the
+    normalizing fallback rather than being coerced by orjson directly. The
+    output must not change either way.
+    """
+    serialized_json = _dumps_json(
+        {1: "int", 2.5: "float", None: "none", date(2020, 1, 2): "date"}
+    )
+
+    assert _orjson.loads(serialized_json) == {
+        "1": "int",
+        "2.5": "float",
+        "null": "none",
+        "2020-01-02": "date",
+    }
+    # `True` is kept apart: it would collide with the `1` key above (True == 1).
+    assert _orjson.loads(_dumps_json({True: "bool"})) == {"true": "bool"}
+
+
+def test__dumps_json_honors_json_only_field_serializer():
+    """A field redacted for JSON must stay redacted, including when nested.
+
+    Serializing Pydantic models in python mode would bypass
+    ``when_used="json"`` serializers and emit the raw value.
+    """
+
+    class Redacted(BaseModel):
+        token: str
+
+        @field_serializer("token", when_used="json")
+        def _redact(self, _value: str) -> str:
+            return "REDACTED"
+
+    class Holder(BaseModel):
+        payload: Any = None
+
+    secret = Redacted(token="actual-secret")
+
+    for obj in (secret, Holder(payload=secret), {"k": secret}, [secret]):
+        assert b"actual-secret" not in _dumps_json(obj)
+
+
+def test__dumps_json_honors_model_dump_override():
+    """A model overriding model_dump keeps control of its serialization."""
+
+    class Overridden(BaseModel):
+        value: str
+
+        def model_dump(self, **kwargs: Any) -> Dict:
+            return {"overridden": True}
+
+    assert _orjson.loads(_dumps_json(Overridden(value="x"))) == {"overridden": True}
 
 
 def test__dumps_json_does_not_swallow_keyboard_interrupt():


### PR DESCRIPTION
## What & why

Two changes to the tracing serialization path. Both keep Pydantic's json-mode output exactly as it is today.

**1. Call the Pydantic core serializer directly.** `model_dump()` is a Python wrapper that processes its keyword arguments and then calls the model's fast, compiled serializer. `_serialize_json` now calls that compiled serializer directly. Our 132msg repro reaches this hook ~2,000 times per traced invoke, so the savings add up.

Only used where it is safe:
- the object is a Pydantic v2 model whose class did not override `model_dump()`. Everything else falls through to the existing `_serialization_methods` list, unchanged.
- the lookup is cached per **class** (not per instance) in a dict capped at 1024 entries.
- if the serializer raises, the class is marked ineligible just once.

**2. Drop `OPT_NON_STR_KEYS` from `dumps_json`'s first attempt.** That option makes orjson check the type of **every** dict key. Non-`str` keys now raise `TypeError`, and the same payload is retried with the full options, so orjson coerces those keys exactly as it did before. Only the keys orjson cannot coerce itself go on to `_normalize_json_keys`. Payloads with non-`str` keys serialize twice; payloads without them skip the check.

## Measured improvement

**What is measured:** `dumps_json()` on the 77 payloads it receives during one traced invoke of a 132-message agent thread — 2,126 `default` hook calls, 2,027 of them Pydantic models. Serialization only: no multipart, compression, HTTP or background threads.

**How:** main's `_serde.py` and this branch's are loaded as two modules in one process and run on the same payload objects, alternating rep by rep.

| metric | main | this PR | delta |
|---|---|---|---|
| CPU per pass | 7.111 ms | **5.745 ms** | **−19.2%** |
| Allocations per pass (memray) | 29,424 | 29,420 | −0.0% |
| Peak allocated per pass (tracemalloc) | 1034.2 KiB | 1030.0 KiB | −0.4% |

Output is unchanged: identical bytes on all 77 payloads, and the same 2,126 hook calls.

Python 3.13.10, pydantic 2.13.4, orjson 3.11.9, langchain-core 1.4.9.

## Tests

- `test__dumps_json_honors_json_only_field_serializer` — a field redacted with `@field_serializer(when_used="json")` stays redacted, including nested behind `Any`, in a dict and in a list. Custom serializers live in the core schema, so calling that serializer directly still applies them.
- `test__dumps_json_honors_model_dump_override` — a class that overrides `model_dump()` keeps control of its serialization.
- `test__dumps_json_coerces_json_native_dict_keys` — `int`/`float`/`bool`/`None`/`date` keys still produce the same strings. They now reach the retry, so the output needed pinning.
- `test__dumps_json_coerces_enum_dict_keys_by_value` — `Enum` keys still serialize as their value. Without the retry they would arrive as `"Color.RED"` instead of `"red"`.
