### PR TITLE
release(py): 0.10.18

### DIFF
--- a/python/.bumpversion.cfg
+++ b/python/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.10.17
+current_version = 0.10.18
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
 serialize = {major}.{minor}.{patch}
 search = {current_version}

--- a/python/langsmith/__init__.py
+++ b/python/langsmith/__init__.py
@@ -49,7 +49,7 @@ if TYPE_CHECKING:
 
 # Avoid calling into importlib on every call to __version__
 
-__version__ = "0.10.17"
+__version__ = "0.10.18"
 version = __version__  # for backwards compatibility
 
 # Metadata key to hide a traced run from LangSmith's Messages View.


### PR DESCRIPTION
## Description
Cuts Python 0.10.18 so the eight Python changes merged since 0.10.17 reach PyPI. Uses the documented `bump2version patch` flow and changes only the two version files; merging triggers the existing publish workflow.

## Test Plan
- [x] `make format`
- [x] Unit tests: 1,936 passed, 6 skipped
- [ ] `make lint` (pre-existing Python 3.14 `Executor.map` override mismatch)

Made by [Open SWE](https://openswe.vercel.app/agents/e41e78b7-2e92-da2b-45f9-5a073a1bf5fc)