### PR TITLE
release(js): 0.8.10

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langsmith",
-  "version": "0.8.9",
+  "version": "0.8.10",
   "description": "Client library to connect to the LangSmith Observability and Evaluation Platform.",
   "packageManager": "pnpm@10.33.0",
   "files": [

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -54,7 +54,7 @@ export {
 } from "./_openapi_client/core/error.js";
 
 // Update using pnpm bump-version
-export const __version__ = "0.8.9";
+export const __version__ = "0.8.10";
 
 // Metadata key to hide a traced run from LangSmith's Messages View.
 export const LS_MESSAGE_VIEW_EXCLUDE = "ls_message_view_exclude" as const;


### PR DESCRIPTION
## Description
Cuts JavaScript 0.8.10 so the eleven JS changes merged since 0.8.9 reach npm. Uses the documented `pnpm run bump-version` flow and changes only the two version files; merging triggers the existing publish workflow.

## Test Plan
- [x] `pnpm format` and `pnpm lint` (0 errors)
- [x] Unit tests: 839 passed, 2 skipped
- [x] Version and npm publication checks

Made by [Open SWE](https://openswe.vercel.app/agents/e41e78b7-2e92-da2b-45f9-5a073a1bf5fc)