### PR TITLE
fix(py): mask MCP server credentials in Anthropic wrapper traces

### DIFF
--- a/python/langsmith/wrappers/_anthropic.py
+++ b/python/langsmith/wrappers/_anthropic.py
@@ -18,6 +18,7 @@ from typing_extensions import Self, TypedDict
 from langsmith import client as ls_client
 from langsmith import run_helpers
 from langsmith._internal._orjson import dumps as _dumps
+from langsmith.anonymizer import SECRET_PLACEHOLDER
 from langsmith.schemas import InputTokenDetails, UsageMetadata
 
 if TYPE_CHECKING:
@@ -40,6 +41,36 @@ def _get_not_given() -> Optional[tuple[type, ...]]:
         return None
 
 
+# Keys of Anthropic's MCP server definition that are known to be safe to trace
+_MCP_SERVER_SAFE_KEYS: frozenset[str] = frozenset(
+    {"name", "type", "url", "tool_configuration"}
+)
+
+
+def _redact_mcp_servers(servers: Any) -> Any:
+    """Mask credentials in `mcp_servers` definitions before they are traced.
+
+    Keys outside `_MCP_SERVER_SAFE_KEYS` keep their name but get
+    `SECRET_PLACEHOLDER` as their value: a trace still shows that the field was
+    set, without exposing it.
+
+    Returns new dicts. The caller's `mcp_servers` are also sent to Anthropic and
+    must keep their real values, so nothing is modified in place.
+    """
+    if not isinstance(servers, (list, tuple)):
+        return servers
+
+    redacted: list[Any] = []
+    for server in servers:
+        if isinstance(server, Mapping):
+            server = {
+                key: value if key in _MCP_SERVER_SAFE_KEYS else SECRET_PLACEHOLDER
+                for key, value in server.items()
+            }
+        redacted.append(server)
+    return redacted
+
+
 def _strip_not_given(d: dict) -> dict:
     try:
         if not_given := _get_not_given():
@@ -56,7 +87,11 @@ def _strip_not_given(d: dict) -> dict:
             "messages", []
         )
         d.pop("system")
-    return {k: v for k, v in d.items() if v is not None}
+    result = {k: v for k, v in d.items() if v is not None}
+    # clean up `mcp_servers` to avoid credential leaks
+    if "mcp_servers" in result:
+        result["mcp_servers"] = _redact_mcp_servers(result["mcp_servers"])
+    return result
 
 
 def _infer_ls_params(prepopulated_invocation_params: dict, kwargs: dict):

--- a/python/tests/unit_tests/wrappers/test_anthropic_processing.py
+++ b/python/tests/unit_tests/wrappers/test_anthropic_processing.py
@@ -3,8 +3,16 @@
 import warnings
 from unittest.mock import MagicMock
 
+import pytest
+
 from langsmith._internal._orjson import loads as _loads
-from langsmith.wrappers._anthropic import _create_usage_metadata, _message_to_outputs
+from langsmith.anonymizer import SECRET_PLACEHOLDER
+from langsmith.wrappers._anthropic import (
+    _create_usage_metadata,
+    _infer_ls_params,
+    _message_to_outputs,
+    _strip_not_given,
+)
 
 
 class TestCreateUsageMetadata:
@@ -247,3 +255,81 @@ class TestMessageToOutputsParsedMessage:
 
         assert len(caught) == 1
         assert "some other warning" in str(caught[0].message)
+
+
+FAKE_TOKEN = "fake-token-for-tests-only"
+
+
+def _mcp_servers(token: str = FAKE_TOKEN) -> list:
+    return [
+        {
+            "type": "url",
+            "url": "https://mcp.example.com/sse",
+            "name": "example",
+            "authorization_token": token,
+        }
+    ]
+
+
+class TestRedactMCPServers:
+    """`mcp_servers` may carry a bearer credential that must not be traced."""
+
+    def test_strip_not_given_masks_authorization_token(self) -> None:
+        server = _strip_not_given({"model": "m", "mcp_servers": _mcp_servers()})[
+            "mcp_servers"
+        ][0]
+
+        assert server["authorization_token"] == SECRET_PLACEHOLDER
+        assert server["type"] == "url"
+        assert server["url"] == "https://mcp.example.com/sse"
+        assert server["name"] == "example"
+
+    def test_infer_ls_params_masks_authorization_token(self) -> None:
+        params = _infer_ls_params({}, {"model": "m", "mcp_servers": _mcp_servers()})
+
+        server = params["ls_invocation_params"]["mcp_servers"][0]
+        assert server["authorization_token"] == SECRET_PLACEHOLDER
+
+    def test_does_not_mutate_the_callers_servers(self) -> None:
+        """The same objects are sent to Anthropic, so they keep the real token."""
+        servers = _mcp_servers()
+        kwargs = {"model": "m", "mcp_servers": servers}
+
+        _strip_not_given(kwargs)
+        _infer_ls_params({}, kwargs)
+
+        assert servers[0]["authorization_token"] == FAKE_TOKEN
+
+    def test_masks_fields_that_are_not_explicitly_allowed(self) -> None:
+        """A credential field added to the API later is masked by default."""
+        server = _strip_not_given(
+            {
+                "mcp_servers": [
+                    {"name": "x", "type": "url", "url": "u", "future_secret": "s3cret"}
+                ]
+            }
+        )["mcp_servers"][0]
+
+        assert server["future_secret"] == SECRET_PLACEHOLDER
+        assert server["name"] == "x"
+
+    def test_leaves_allowed_fields_untouched(self) -> None:
+        servers = [{"name": "x", "type": "url", "url": "u"}]
+
+        assert _strip_not_given({"mcp_servers": servers})["mcp_servers"] == servers
+
+    @pytest.mark.parametrize(
+        ("servers", "expected"),
+        [
+            ("not-a-list", "not-a-list"),
+            ([None], [None]),
+            ([["nested"]], [["nested"]]),
+            ([], []),
+            ((), []),  # tuples are normalized to lists
+        ],
+    )
+    def test_tolerates_unexpected_shapes(self, servers, expected) -> None:
+        assert _strip_not_given({"mcp_servers": servers})["mcp_servers"] == expected
+
+    def test_none_is_dropped_by_strip_not_given(self) -> None:
+        assert "mcp_servers" not in _strip_not_given({"mcp_servers": None})


### PR DESCRIPTION
## What & why

`wrap_anthropic` copied Anthropic MCP server definitions into traces verbatim, so sensitive credentials could get uploaded to LangSmith in two places:

- `run.inputs`
- `run.extra.metadata.ls_invocation_params`

## Fix

`_strip_not_given` now masks `mcp_servers` entries. Keys outside an allowlist (`name`, `type`, `url`, `tool_configuration`) keep their name but get `SECRET_PLACEHOLDER` as their value, so a trace still shows the field was set without exposing it, and any potentially sensitive field that Anthropic would add later is masked by default -rather than exported.

`_infer_ls_params` calls `_strip_not_given`, so this single place covers both exposure paths.

## Tests

`TestRedactMCPServers` covers: token masked in `run.inputs`, token masked in `ls_invocation_params`, the caller's dict still holds the real token after both calls, an unknown field is masked, and unexpected shapes (non-list, non-dict entries, empty list, tuple) don't raise.

Also verified end to end against a live backend: the same `beta.messages.create` call traced before and after the fix, read back from the API, shows the token in both inputs and metadata before, and `[SECRET_DETECTED]` in both after.