### PR TITLE
fix(js): mask MCP server credentials in Anthropic wrapper traces

### DIFF
--- a/js/src/tests/wrapped_anthropic_mcp.test.ts
+++ b/js/src/tests/wrapped_anthropic_mcp.test.ts
@@ -1,0 +1,138 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { wrapAnthropic } from "../wrappers/anthropic.js";
+import { SECRET_PLACEHOLDER } from "../anonymizer/index.js";
+import { mockClient } from "./utils/mock_client.js";
+
+const FAKE_TOKEN = "fake-token-for-tests-only";
+
+function parseRequestBody(body: any) {
+  // eslint-disable-next-line no-instanceof/no-instanceof
+  return body instanceof Uint8Array
+    ? JSON.parse(new TextDecoder().decode(body))
+    : JSON.parse(body);
+}
+
+/** Stub provider, so input processing runs without a network call. */
+function stubAnthropic(): any {
+  const message = {
+    id: "msg_stub",
+    type: "message",
+    role: "assistant",
+    model: "claude-haiku-4-5",
+    content: [{ type: "text", text: "hi" }],
+    stop_reason: "end_turn",
+    usage: { input_tokens: 1, output_tokens: 1 },
+  };
+  return {
+    messages: {
+      create: async () => message,
+      stream: async () => {
+        throw new Error("not used by these tests");
+      },
+    },
+  };
+}
+
+/** The runs the SDK would have uploaded. */
+function uploadedRuns(callSpy: any): any[] {
+  return (callSpy.mock.calls as any[])
+    .map(([, init]: any) => {
+      try {
+        return parseRequestBody(init?.body);
+      } catch {
+        return undefined;
+      }
+    })
+    .filter(Boolean)
+    .flatMap((body: any) => body?.post ?? body?.patch ?? [body])
+    .filter((run: any) => run?.inputs);
+}
+
+async function traceCreate(params: Record<string, unknown>) {
+  const { client, callSpy } = mockClient();
+  const patched = wrapAnthropic(stubAnthropic(), {
+    client,
+    tracingEnabled: true,
+  });
+
+  await patched.messages.create({
+    model: "claude-haiku-4-5",
+    max_tokens: 16,
+    messages: [{ role: "user", content: "hi" }],
+    ...params,
+  } as any);
+
+  const runs = uploadedRuns(callSpy);
+  return { runs, wire: JSON.stringify(runs) };
+}
+
+const mcpServers = (extra: Record<string, unknown> = {}) => [
+  {
+    type: "url",
+    url: "https://mcp.example.com/sse",
+    name: "example",
+    authorization_token: FAKE_TOKEN,
+    ...extra,
+  },
+];
+
+describe("mcp_servers credentials are masked before tracing", () => {
+  test("authorization_token never reaches the uploaded run", async () => {
+    const { runs, wire } = await traceCreate({ mcp_servers: mcpServers() });
+
+    expect(wire).not.toContain(FAKE_TOKEN);
+    const server = runs[0].inputs.mcp_servers[0];
+    expect(server.authorization_token).toBe(SECRET_PLACEHOLDER);
+    expect(server).toMatchObject({
+      type: "url",
+      url: "https://mcp.example.com/sse",
+      name: "example",
+    });
+  });
+
+  test("fields that are not explicitly allowed are masked too", async () => {
+    const { runs, wire } = await traceCreate({
+      mcp_servers: mcpServers({ future_secret: "s3cret" }),
+    });
+
+    expect(wire).not.toContain("s3cret");
+    expect(runs[0].inputs.mcp_servers[0].future_secret).toBe(
+      SECRET_PLACEHOLDER,
+    );
+  });
+
+  test("the caller's params are left intact for the API call", async () => {
+    const servers = mcpServers();
+    await traceCreate({ mcp_servers: servers });
+
+    expect(servers[0].authorization_token).toBe(FAKE_TOKEN);
+  });
+
+  test("masking also applies when a system prompt is present", async () => {
+    const { runs, wire } = await traceCreate({
+      system: "be brief",
+      mcp_servers: mcpServers(),
+    });
+
+    expect(wire).not.toContain(FAKE_TOKEN);
+    expect(runs[0].inputs.mcp_servers[0].authorization_token).toBe(
+      SECRET_PLACEHOLDER,
+    );
+    expect(runs[0].inputs.messages[0]).toEqual({
+      role: "system",
+      content: "be brief",
+    });
+    expect(runs[0].inputs.system).toBeUndefined();
+  });
+
+  test.each([
+    ["a non-array value", "not-an-array"],
+    ["null entries", [null]],
+    ["nested arrays", [["nested"]]],
+    ["an empty list", []],
+  ])("tolerates %s", async (_label, servers) => {
+    const { runs } = await traceCreate({ mcp_servers: servers });
+
+    expect(runs[0].inputs.mcp_servers).toEqual(servers);
+  });
+});

--- a/js/src/wrappers/anthropic.ts
+++ b/js/src/wrappers/anthropic.ts
@@ -10,8 +10,41 @@ import {
 } from "../traceable.js";
 import { KVMap } from "../schemas.js";
 import { convertAnthropicUsageToInputTokenDetails } from "../utils/usage.js";
+import { SECRET_PLACEHOLDER } from "../anonymizer/index.js";
 
 const TRACED_INVOCATION_KEYS = ["top_k", "top_p", "stream", "thinking"];
+
+/** Keys of an MCP server definition that are safe to trace. */
+const MCP_SERVER_SAFE_KEYS = new Set([
+  "name",
+  "type",
+  "url",
+  "tool_configuration",
+]);
+
+/**
+ * Mask credentials in `mcp_servers` before tracing. Anything outside
+ * {@link MCP_SERVER_SAFE_KEYS} keeps its name but gets
+ * {@link SECRET_PLACEHOLDER} as its value, so the trace shows the field was set
+ * without exposing it, and fields the API adds later are masked by default.
+ *
+ * Returns new objects; the caller's are also sent to Anthropic.
+ */
+function redactMcpServers(servers: unknown): unknown {
+  if (!Array.isArray(servers)) return servers;
+
+  return servers.map((server) => {
+    if (typeof server !== "object" || server == null || Array.isArray(server)) {
+      return server;
+    }
+    return Object.fromEntries(
+      Object.entries(server).map(([key, value]) => [
+        key,
+        MCP_SERVER_SAFE_KEYS.has(key) ? value : SECRET_PLACEHOLDER,
+      ]),
+    );
+  });
+}
 
 type ExtraRunTreeConfig = Pick<
   Partial<RunTreeConfig>,
@@ -348,14 +381,19 @@ export const wrapAnthropic = <T extends AnthropicType>(
    * This provides parity with the Python SDK behavior and enables system prompts
    * to be viewed and edited in the LangSmith playground.
    */
-  function processSystemMessage(
+  function processTracedInputs(
     params: Record<string, unknown>,
   ): Record<string, unknown> {
-    if (!params.system) {
-      return params;
+    // Copy first: `params` also goes to the API and must keep its real values.
+    const processed = { ...params };
+
+    if (processed.mcp_servers != null) {
+      processed.mcp_servers = redactMcpServers(processed.mcp_servers);
     }
 
-    const processed = { ...params };
+    if (!params.system) {
+      return processed;
+    }
 
     // Handle both string and ContentBlock[] formats
     const systemContent = Array.isArray(params.system)
@@ -386,7 +424,7 @@ export const wrapAnthropic = <T extends AnthropicType>(
     run_type: "llm",
     aggregator: messageAggregator,
     argsConfigPath: [1, "langsmithExtra"],
-    processInputs: processSystemMessage,
+    processInputs: processTracedInputs,
     getInvocationParams: (payload: unknown) => {
       if (typeof payload !== "object" || payload == null) return undefined;
       const params = payload as Anthropic.MessageCreateParams;
@@ -470,7 +508,7 @@ export const wrapAnthropic = <T extends AnthropicType>(
       run_type: "llm",
       aggregator: messageAggregator,
       argsConfigPath: [1, "langsmithExtra"],
-      processInputs: processSystemMessage,
+      processInputs: processTracedInputs,
       getInvocationParams: messagesCreateConfig.getInvocationParams,
       processOutputs: processMessageOutput,
       ...cleanedOptions,
@@ -516,7 +554,7 @@ export const wrapAnthropic = <T extends AnthropicType>(
             run_type: "llm",
             aggregator: messageAggregator,
             argsConfigPath: [1, "langsmithExtra"],
-            processInputs: processSystemMessage,
+            processInputs: processTracedInputs,
             getInvocationParams: messagesCreateConfig.getInvocationParams,
             processOutputs: processMessageOutput,
             ...cleanedOptions,


### PR DESCRIPTION
Stacked on #3371 — review that one first; this PR's diff is JS-only.

## What & why

The JS wrapper copied Anthropic MCP server definitions into `run.inputs` verbatim, so an `authorization_token` bearer credential was uploaded to LangSmith on every traced call.

Unlike Python, the metadata path is **not** affected here: `TRACED_INVOCATION_KEYS` is `["top_k", "top_p", "stream", "thinking"]` and excludes `mcp_servers`. Only `run.inputs` leaked, because `processInputs` passed every parameter through.

## Fix

Keys outside an allowlist (`name`, `type`, `url`, `tool_configuration`) keep their name but get `SECRET_PLACEHOLDER` as their value — the same placeholder the anonymizer uses. A trace still shows the field was set without exposing it, and a credential field Anthropic adds later is masked by default rather than exported.

`processSystemMessage` returned the caller's `params` object untouched when no `system` was set, so it now copies first and then redacts: that same object is passed to the Anthropic API and must keep the real token. Renamed to `processTracedInputs`, since it no longer only handles the system message.

## Tests

`wrapped_anthropic_mcp.test.ts` uses the existing `mockClient()` fetch spy, so it asserts against the payload the SDK would actually upload — no network or API keys. Covers: the token never appears in the uploaded run, allowed fields survive, an unknown field is masked, the caller's params keep the real token, masking still applies on the `system`-present branch, and non-array / null / nested-array / empty values don't throw.

## Follow-ups (not here)

`extra_headers` / `extra_body` reach `run.inputs` through the same unfiltered-parameter path in both SDKs. The two SDKs' invocation-parameter allowlists have also drifted apart — Python traces `mcp_servers`, `service_tier` and `tool_choice` in metadata while JS traces none of them; worth reconciling deliberately.
