### PR TITLE
fix(py): stop recording mcp_servers in Anthropic run metadata

### DIFF
--- a/python/langsmith/wrappers/_anthropic.py
+++ b/python/langsmith/wrappers/_anthropic.py
@@ -104,7 +104,6 @@ def _infer_ls_params(prepopulated_invocation_params: dict, kwargs: dict):
     # Allowlist of safe invocation parameters to include
     # Only include known, non-sensitive parameters
     allowed_invocation_keys = {
-        "mcp_servers",
         "service_tier",
         "tool_choice",
         "top_k",

--- a/python/tests/unit_tests/wrappers/test_anthropic_processing.py
+++ b/python/tests/unit_tests/wrappers/test_anthropic_processing.py
@@ -284,11 +284,11 @@ class TestRedactMCPServers:
         assert server["url"] == "https://mcp.example.com/sse"
         assert server["name"] == "example"
 
-    def test_infer_ls_params_masks_authorization_token(self) -> None:
+    def test_infer_ls_params_never_carries_the_token(self) -> None:
+        """Guards against building invocation params from the raw kwargs."""
         params = _infer_ls_params({}, {"model": "m", "mcp_servers": _mcp_servers()})
 
-        server = params["ls_invocation_params"]["mcp_servers"][0]
-        assert server["authorization_token"] == SECRET_PLACEHOLDER
+        assert FAKE_TOKEN not in str(params)
 
     def test_does_not_mutate_the_callers_servers(self) -> None:
         """The same objects are sent to Anthropic, so they keep the real token."""


### PR DESCRIPTION
## What & why

The Anthropic wrapper recorded `mcp_servers` twice: once in `run.inputs` and again in `extra.metadata.ls_invocation_params`. The two copies were byte-identical, so the metadata one added no information while duplicating a structure that carries an `authorization_token`.

The JS SDK never traced it — its `TRACED_INVOCATION_KEYS` is `["top_k", "top_p", "stream", "thinking"]`. This drops `mcp_servers` from the Python allowlist so the two match.

## Effect

- `extra.metadata.ls_invocation_params` no longer contains `mcp_servers`.
- `run.inputs` still records it, masked by `_redact_mcp_servers` (#3371)
- Other allowlisted parameters are unchanged.

```
metadata ls_invocation_params: {'top_k': 5}
inputs   mcp_servers:          [{'type': 'url', 'url': '…', 'name': 'example',
                                 'authorization_token': '[SECRET_DETECTED]'}]
```

## Compatibility

Anyone filtering or grouping runs on `metadata.ls_invocation_params.mcp_servers` will see it stop populating for new runs.
