### PR TITLE
fix(claude_agent_sdk): keep cache_creation_input_tokens authoritative for token totals

### DIFF
--- a/python/langsmith/integrations/claude_agent_sdk/_usage.py
+++ b/python/langsmith/integrations/claude_agent_sdk/_usage.py
@@ -61,8 +61,15 @@ def extract_usage_metadata(usage: Any) -> dict[str, Any]:
     if cache_read:
         input_token_details["cache_read"] = cache_read
 
-    # Structured cache_creation (with ephemeral breakdown) takes precedence
-    # over the flat cache_creation_input_tokens field.
+    # Anthropic reports cache creation twice: cache_creation_input_tokens is
+    # the total, and cache_creation breaks that total down per TTL tier. Read
+    # the breakdown for the details, but keep the flat total authoritative for
+    # the arithmetic. Summing the breakdown instead drops any tier this code
+    # does not name from input_tokens and total_tokens, with nothing raising,
+    # and the set of tiers is not fixed: the 1-hour tier is itself a later
+    # addition to what used to be a single flat field.
+    cache_creation_total = _to_int(get("cache_creation_input_tokens"))
+
     cache_creation = get("cache_creation")
     if isinstance(cache_creation, dict):
         eph_5m = _to_int(cache_creation.get("ephemeral_5m_input_tokens"))
@@ -71,15 +78,14 @@ def extract_usage_metadata(usage: Any) -> dict[str, Any]:
             input_token_details["ephemeral_5m_input_tokens"] = eph_5m
         if eph_1h:
             input_token_details["ephemeral_1hr_input_tokens"] = eph_1h
-    else:
+        if not cache_creation_total:
+            cache_creation_total = eph_5m + eph_1h
+    elif cache_creation_total:
         # Flat/legacy field — assume 5-minute cache
-        flat_cache_create = _to_int(get("cache_creation_input_tokens"))
-        if flat_cache_create:
-            input_token_details["ephemeral_5m_input_tokens"] = flat_cache_create
+        input_token_details["ephemeral_5m_input_tokens"] = cache_creation_total
 
     # Sum cache tokens into input_tokens (Anthropic cache tokens are additive)
-    cache_token_sum = sum(input_token_details.values())
-    adjusted_input = raw_input + cache_token_sum
+    adjusted_input = raw_input + cache_read + cache_creation_total
     total_tokens = adjusted_input + output_tokens
 
     meta: dict[str, Any] = {

--- a/python/tests/unit_tests/wrappers/test_claude_agent_sdk_usage.py
+++ b/python/tests/unit_tests/wrappers/test_claude_agent_sdk_usage.py
@@ -1,0 +1,164 @@
+"""Unit tests for Claude Agent SDK usage normalization."""
+
+import pytest
+
+from langsmith.integrations.claude_agent_sdk._usage import extract_usage_metadata
+
+
+def _authoritative_input(usage: dict) -> int:
+    """Anthropic cache tokens are additive to the raw ``input_tokens``."""
+    return (
+        usage["input_tokens"]
+        + usage.get("cache_read_input_tokens", 0)
+        + usage.get("cache_creation_input_tokens", 0)
+    )
+
+
+@pytest.mark.parametrize(
+    "usage",
+    [
+        pytest.param(
+            {
+                "input_tokens": 25,
+                "output_tokens": 7,
+                "cache_read_input_tokens": 21375,
+                "cache_creation_input_tokens": 0,
+                "cache_creation": {
+                    "ephemeral_5m_input_tokens": 0,
+                    "ephemeral_1h_input_tokens": 0,
+                },
+            },
+            id="cache_read",
+        ),
+        pytest.param(
+            {
+                "input_tokens": 25,
+                "output_tokens": 7,
+                "cache_read_input_tokens": 0,
+                "cache_creation_input_tokens": 1000,
+                "cache_creation": {
+                    "ephemeral_5m_input_tokens": 1000,
+                    "ephemeral_1h_input_tokens": 0,
+                },
+            },
+            id="cache_creation_5m",
+        ),
+        pytest.param(
+            {
+                "input_tokens": 25,
+                "output_tokens": 7,
+                "cache_read_input_tokens": 0,
+                "cache_creation_input_tokens": 1000,
+                "cache_creation": {
+                    "ephemeral_5m_input_tokens": 400,
+                    "ephemeral_1h_input_tokens": 600,
+                },
+            },
+            id="cache_creation_both_tiers",
+        ),
+        pytest.param(
+            {
+                "input_tokens": 25,
+                "output_tokens": 7,
+                "cache_creation_input_tokens": 1000,
+            },
+            id="flat_field_only",
+        ),
+    ],
+)
+def test_input_tokens_match_the_authoritative_total(usage):
+    """input_tokens must equal raw input plus every cache field Anthropic reports."""
+    meta = extract_usage_metadata(usage)
+
+    expected_input = _authoritative_input(usage)
+    assert meta["input_tokens"] == expected_input
+    assert meta["total_tokens"] == expected_input + usage["output_tokens"]
+
+
+def test_unrecognized_cache_tier_is_still_counted():
+    """A TTL tier this code does not name must not vanish from the totals.
+
+    ``cache_creation_input_tokens`` is the total; ``cache_creation`` is a
+    per-tier breakdown of that same total. Deriving the arithmetic from the
+    breakdown means a tier the SDK has not been taught about is dropped from
+    ``input_tokens`` and ``total_tokens``, and nothing raises, so the run just
+    reports fewer tokens than were billed.
+
+    The tier set is not fixed. ``cache_creation`` was introduced alongside the
+    1-hour cache, splitting what had been a single flat field, so the same
+    thing happens again the next time a tier is added.
+    """
+    usage = {
+        "input_tokens": 25,
+        "output_tokens": 7,
+        "cache_creation_input_tokens": 1000,
+        "cache_creation": {"ephemeral_1d_input_tokens": 1000},
+    }
+
+    meta = extract_usage_metadata(usage)
+
+    assert meta["input_tokens"] == 1025
+    assert meta["total_tokens"] == 1032
+
+
+def test_empty_cache_creation_breakdown_falls_back_to_the_total():
+    """An empty breakdown must not zero out a non-zero cache-creation total."""
+    usage = {
+        "input_tokens": 25,
+        "output_tokens": 7,
+        "cache_creation_input_tokens": 1000,
+        "cache_creation": {},
+    }
+
+    meta = extract_usage_metadata(usage)
+
+    assert meta["input_tokens"] == 1025
+    assert meta["total_tokens"] == 1032
+
+
+def test_breakdown_without_a_flat_total_is_still_summed():
+    """When only the per-tier breakdown is present, it supplies the total."""
+    usage = {
+        "input_tokens": 25,
+        "output_tokens": 7,
+        "cache_creation": {
+            "ephemeral_5m_input_tokens": 400,
+            "ephemeral_1h_input_tokens": 600,
+        },
+    }
+
+    meta = extract_usage_metadata(usage)
+
+    assert meta["input_tokens"] == 1025
+    assert meta["total_tokens"] == 1032
+    assert meta["input_token_details"] == {
+        "ephemeral_5m_input_tokens": 400,
+        "ephemeral_1hr_input_tokens": 600,
+    }
+
+
+def test_details_are_preserved():
+    """The per-tier breakdown is still reported, under the canonical keys."""
+    usage = {
+        "input_tokens": 25,
+        "output_tokens": 7,
+        "cache_read_input_tokens": 500,
+        "cache_creation_input_tokens": 1000,
+        "cache_creation": {
+            "ephemeral_5m_input_tokens": 400,
+            "ephemeral_1h_input_tokens": 600,
+        },
+    }
+
+    meta = extract_usage_metadata(usage)
+
+    assert meta["input_token_details"] == {
+        "cache_read": 500,
+        "ephemeral_5m_input_tokens": 400,
+        "ephemeral_1hr_input_tokens": 600,
+    }
+
+
+def test_empty_usage_returns_empty_dict():
+    assert extract_usage_metadata(None) == {}
+    assert extract_usage_metadata({}) == {}


### PR DESCRIPTION
### What

`extract_usage_metadata` derives its arithmetic from the per-tier cache breakdown rather than from the total Anthropic reports.

Anthropic sends cache creation twice. `cache_creation_input_tokens` is the total, and `cache_creation` is a breakdown of that same total per TTL tier. The normalizer sums the two tier keys it knows about and discards the flat total:

```python
cache_token_sum = sum(input_token_details.values())
adjusted_input = raw_input + cache_token_sum
```

While `ephemeral_5m` and `ephemeral_1h` are the only tiers, the two agree and everything is correct. When they disagree, the breakdown wins and the difference disappears from `input_tokens` and `total_tokens` with nothing raising, so the run reports fewer tokens than were billed.

I want to be straight about the status of this: **I could not produce a payload from the current API where the two disagree.** Both tiers in use today are handled correctly. This is hardening against a shape the code does not currently see, not a number that is wrong right now.

What makes it worth doing anyway is that the tier set is not fixed. `cache_creation` exists *because* the 1-hour cache was added and split what had previously been a single flat field. The next tier does the same thing again, and this fails silently rather than loudly, which is the expensive way for a token count to be wrong.

### The change

Use the flat total for the arithmetic and read the breakdown only for `input_token_details`, which is what each field is for:

```python
cache_creation_total = _to_int(get("cache_creation_input_tokens"))

cache_creation = get("cache_creation")
if isinstance(cache_creation, dict):
    ...                                   # details, unchanged
    if not cache_creation_total:
        cache_creation_total = eph_5m + eph_1h
elif cache_creation_total:
    input_token_details["ephemeral_5m_input_tokens"] = cache_creation_total

adjusted_input = raw_input + cache_read + cache_creation_total
```

Payloads carrying only `cache_creation` and no flat total are unchanged, since the breakdown still supplies the total in that case.

### Tests

There were no unit tests for `extract_usage_metadata`, so these are the first. Nine in total.

**Seven pass on `main`.** They pin the existing behaviour: cache read, 5-minute creation, both tiers together, the flat legacy field, the `input_token_details` keys including the `1h` to `1hr` rename, and the empty-usage case. They are there so this change is demonstrably not a regression.

**Two fail on `main`:**

```
FAILED test_unrecognized_cache_tier_is_still_counted
FAILED test_empty_cache_creation_breakdown_falls_back_to_the_total
```

Both currently report `input_tokens=25, total_tokens=32` against an authoritative 1025 and 1032.

`ruff format --check` and `ruff check` are clean on both files.
