### PR TITLE
fix(js): close the argument-shape bypass in Anthropic MCP redaction

### DIFF
--- a/js/src/tests/wrapped_anthropic_mcp.test.ts
+++ b/js/src/tests/wrapped_anthropic_mcp.test.ts
@@ -48,22 +48,35 @@ function uploadedRuns(callSpy: any): any[] {
     .filter((run: any) => run?.inputs);
 }
 
-async function traceCreate(params: Record<string, unknown>) {
+async function traceCreate(
+  params: Record<string, unknown>,
+  requestOptions?: Record<string, unknown>,
+) {
   const { client, callSpy } = mockClient();
   const patched = wrapAnthropic(stubAnthropic(), {
     client,
     tracingEnabled: true,
   });
 
-  await patched.messages.create({
-    model: "claude-haiku-4-5",
-    max_tokens: 16,
-    messages: [{ role: "user", content: "hi" }],
-    ...params,
-  } as any);
+  const args: unknown[] = [
+    {
+      model: "claude-haiku-4-5",
+      max_tokens: 16,
+      messages: [{ role: "user", content: "hi" }],
+      ...params,
+    },
+  ];
+  if (requestOptions !== undefined) args.push(requestOptions);
+
+  await (patched.messages.create as any)(...args);
 
   const runs = uploadedRuns(callSpy);
   return { runs, wire: JSON.stringify(runs) };
+}
+
+/** Traced provider params; a multi-argument call is recorded as `{ args: [...] }`. */
+function tracedParams(run: any): any {
+  return Array.isArray(run.inputs.args) ? run.inputs.args[0] : run.inputs;
 }
 
 const mcpServers = (extra: Record<string, unknown> = {}) => [
@@ -135,4 +148,60 @@ describe("mcp_servers credentials are masked before tracing", () => {
 
     expect(runs[0].inputs.mcp_servers).toEqual(servers);
   });
+});
+
+describe("masking survives every argument shape", () => {
+  test.each([
+    ["langsmithExtra only", { langsmithExtra: { metadata: { foo: "bar" } } }],
+    ["an empty options object", {}],
+    ["real request options", { timeout: 5000 }],
+  ])("masks mcp_servers when called with %s", async (_label, options) => {
+    const { runs, wire } = await traceCreate(
+      { mcp_servers: mcpServers() },
+      options,
+    );
+
+    expect(wire).not.toContain(FAKE_TOKEN);
+    expect(tracedParams(runs[0]).mcp_servers[0].authorization_token).toBe(
+      SECRET_PLACEHOLDER,
+    );
+  });
+
+  test("masks credentials in the request options themselves", async () => {
+    const { runs, wire } = await traceCreate(
+      {},
+      { headers: { Authorization: `Bearer ${FAKE_TOKEN}` } },
+    );
+
+    expect(wire).not.toContain(FAKE_TOKEN);
+    expect(runs[0].inputs.args[1].headers).toEqual({
+      Authorization: SECRET_PLACEHOLDER,
+    });
+  });
+
+  test("the caller's arguments are left intact for the API call", async () => {
+    const servers = mcpServers();
+    const options = { headers: { Authorization: `Bearer ${FAKE_TOKEN}` } };
+
+    await traceCreate({ mcp_servers: servers }, options);
+
+    expect(servers[0].authorization_token).toBe(FAKE_TOKEN);
+    expect(options.headers.Authorization).toBe(`Bearer ${FAKE_TOKEN}`);
+  });
+});
+
+describe("per-request transport overrides are masked", () => {
+  test.each(["extra_headers", "extra_body", "extra_query"])(
+    "%s keeps its key names but not its values",
+    async (key) => {
+      const { runs, wire } = await traceCreate({
+        [key]: { Authorization: `Bearer ${FAKE_TOKEN}` },
+      });
+
+      expect(wire).not.toContain(FAKE_TOKEN);
+      expect(runs[0].inputs[key]).toEqual({
+        Authorization: SECRET_PLACEHOLDER,
+      });
+    },
+  );
 });

--- a/js/src/utils/redaction.ts
+++ b/js/src/utils/redaction.ts
@@ -1,0 +1,49 @@
+import { SECRET_PLACEHOLDER } from "../anonymizer/index.js";
+import type { KVMap } from "../schemas.js";
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** Mask a value, keeping object key names so a trace shows what was set. */
+export function mask(value: unknown): unknown {
+  if (isPlainObject(value)) {
+    return Object.fromEntries(
+      Object.keys(value).map((key) => [key, SECRET_PLACEHOLDER]),
+    );
+  }
+  return SECRET_PLACEHOLDER;
+}
+
+/** Copy `entry`, masking values outside `safeKeys`, so unknown keys fail closed. */
+export function redactOutside(
+  entry: unknown,
+  safeKeys: ReadonlySet<string>,
+): unknown {
+  if (!isPlainObject(entry)) return entry;
+  return Object.fromEntries(
+    Object.entries(entry).map(([key, value]) => [
+      key,
+      safeKeys.has(key) ? value : SECRET_PLACEHOLDER,
+    ]),
+  );
+}
+
+/**
+ * Apply `redact` to every object argument, since `traceable` shapes a
+ * multi-argument call as `{ args: [params, requestOptions] }`.
+ */
+export function overParams(
+  inputs: KVMap,
+  redact: (params: KVMap) => KVMap,
+): KVMap {
+  if (Array.isArray(inputs?.args)) {
+    return {
+      ...inputs,
+      args: inputs.args.map((arg) =>
+        isPlainObject(arg) ? redact(arg as KVMap) : arg,
+      ),
+    };
+  }
+  return redact(inputs);
+}

--- a/js/src/wrappers/anthropic.ts
+++ b/js/src/wrappers/anthropic.ts
@@ -10,7 +10,7 @@ import {
 } from "../traceable.js";
 import { KVMap } from "../schemas.js";
 import { convertAnthropicUsageToInputTokenDetails } from "../utils/usage.js";
-import { SECRET_PLACEHOLDER } from "../anonymizer/index.js";
+import { mask, overParams, redactOutside } from "../utils/redaction.js";
 
 const TRACED_INVOCATION_KEYS = ["top_k", "top_p", "stream", "thinking"];
 
@@ -22,29 +22,21 @@ const MCP_SERVER_SAFE_KEYS = new Set([
   "tool_configuration",
 ]);
 
-/**
- * Mask credentials in `mcp_servers` before tracing. Anything outside
- * {@link MCP_SERVER_SAFE_KEYS} keeps its name but gets
- * {@link SECRET_PLACEHOLDER} as its value, so the trace shows the field was set
- * without exposing it, and fields the API adds later are masked by default.
- *
- * Returns new objects; the caller's are also sent to Anthropic.
- */
+/** Mask `mcp_servers` credentials outside {@link MCP_SERVER_SAFE_KEYS}. */
 function redactMcpServers(servers: unknown): unknown {
   if (!Array.isArray(servers)) return servers;
 
-  return servers.map((server) => {
-    if (typeof server !== "object" || server == null || Array.isArray(server)) {
-      return server;
-    }
-    return Object.fromEntries(
-      Object.entries(server).map(([key, value]) => [
-        key,
-        MCP_SERVER_SAFE_KEYS.has(key) ? value : SECRET_PLACEHOLDER,
-      ]),
-    );
-  });
+  return servers.map((server) => redactOutside(server, MCP_SERVER_SAFE_KEYS));
 }
+
+/** Request-transport keys that are credentials by construction. */
+const TRANSPORT_SECRET_KEYS: ReadonlySet<string> = new Set([
+  "headers",
+  "query",
+  "extra_headers",
+  "extra_body",
+  "extra_query",
+]);
 
 type ExtraRunTreeConfig = Pick<
   Partial<RunTreeConfig>,
@@ -376,12 +368,8 @@ export const wrapAnthropic = <T extends AnthropicType>(
     metadata: restMetadata,
   };
 
-  /**
-   * Transform system parameter into visible message for playground editability.
-   * This provides parity with the Python SDK behavior and enables system prompts
-   * to be viewed and edited in the LangSmith playground.
-   */
-  function processTracedInputs(
+  /** Mask credentials and surface `system` as a message the playground can edit. */
+  function redactAnthropicParams(
     params: Record<string, unknown>,
   ): Record<string, unknown> {
     // Copy first: `params` also goes to the API and must keep its real values.
@@ -389,6 +377,12 @@ export const wrapAnthropic = <T extends AnthropicType>(
 
     if (processed.mcp_servers != null) {
       processed.mcp_servers = redactMcpServers(processed.mcp_servers);
+    }
+
+    for (const key of TRANSPORT_SECRET_KEYS) {
+      if (processed[key] != null) {
+        processed[key] = mask(processed[key]);
+      }
     }
 
     if (!params.system) {
@@ -414,6 +408,10 @@ export const wrapAnthropic = <T extends AnthropicType>(
     delete processed.system;
 
     return processed;
+  }
+
+  function processTracedInputs(inputs: KVMap): KVMap {
+    return overParams(inputs, redactAnthropicParams);
   }
 
   // Common configuration for messages.create


### PR DESCRIPTION
## What & why

#3372 masks `mcp_servers` credentials by reading `params.mcp_servers`. That lookup only fires when the params object *is* the traced input, which holds only for a single-argument call.

`traceable` records any call with a second argument as `{ args: [params, requestOptions] }` (`runInputsToMap`), and `argsConfigPath` leaves `args[1]` in place after extracting `langsmithExtra`. So the documented form

```js
messages.create(params, { langsmithExtra: { metadata: { ... } } })
```

skips redaction and uploads `authorization_token` in the clear. Verified against the payload the SDK would send:

```
inputs: {"args":[{...,"mcp_servers":[{...,"authorization_token":"<token>"}]},{}]}
```

`wrapped_anthropic_mcp.test.ts` passed throughout, because its `traceCreate` helper only ever passed one argument.

`extra_headers` / `extra_body` and the `headers` on the second-argument `RequestOptions` reach `run.inputs` by the same route, so they are masked here too.

## Fix

New `js/src/utils/redaction.ts` holds the primitives the remaining wrappers reuse:

- `mask` — replace a value, keeping object key names
- `redactOutside` — the #3371 / #3372 allowlist primitive
- `overParams` — apply a redaction function to every object argument

`redactMcpServers` keeps its allowlist and delegates to `redactOutside`. Single-argument behavior is unchanged.

## Tests

Assertions run against the payload the SDK would upload, via the existing `mockClient()` fetch spy — no network, no API keys.

Added: masking holds when called with `langsmithExtra`, an empty options object, and real request options; credentials in the request options are masked; both caller arguments keep their real values; `extra_headers` / `extra_body` / `extra_query` keep their key names but not their values.

`traceCreate` now takes optional request options.