### PR TITLE
fix(py,js): mask hosted MCP tool credentials in the OpenAI wrappers

### DIFF
--- a/js/src/tests/wrapped_openai_mcp.test.ts
+++ b/js/src/tests/wrapped_openai_mcp.test.ts
@@ -1,0 +1,192 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { wrapOpenAI } from "../wrappers/openai.js";
+import { SECRET_PLACEHOLDER } from "../anonymizer/index.js";
+import { mockClient } from "./utils/mock_client.js";
+
+const FAKE_TOKEN = "fake-token-for-tests-only";
+
+function parseRequestBody(body: any) {
+  // eslint-disable-next-line no-instanceof/no-instanceof
+  return body instanceof Uint8Array
+    ? JSON.parse(new TextDecoder().decode(body))
+    : JSON.parse(body);
+}
+
+/** Stub provider, so input processing runs without a network call. */
+function stubOpenAI(): any {
+  const response = { id: "resp_stub", output: [], usage: {} };
+  return {
+    responses: {
+      create: async () => response,
+      parse: async () => response,
+    },
+    chat: { completions: { create: async () => ({ id: "cc_stub" }) } },
+    completions: { create: async () => ({ id: "c_stub" }) },
+    beta: { chat: { completions: {} } },
+  };
+}
+
+/** The runs the SDK would have uploaded. */
+function uploadedRuns(callSpy: any): any[] {
+  return (callSpy.mock.calls as any[])
+    .map(([, init]: any) => {
+      try {
+        return parseRequestBody(init?.body);
+      } catch {
+        return undefined;
+      }
+    })
+    .filter(Boolean)
+    .flatMap((body: any) => body?.post ?? body?.patch ?? [body])
+    .filter((run: any) => run?.inputs);
+}
+
+async function traceResponse(
+  params: Record<string, unknown>,
+  requestOptions?: Record<string, unknown>,
+) {
+  const { client, callSpy } = mockClient();
+  const patched: any = wrapOpenAI(stubOpenAI(), {
+    client,
+    tracingEnabled: true,
+  });
+
+  const args: unknown[] = [{ model: "gpt-5", input: "hi", ...params }];
+  if (requestOptions !== undefined) args.push(requestOptions);
+
+  await patched.responses.create(...args);
+
+  const runs = uploadedRuns(callSpy);
+  return { runs, wire: JSON.stringify(runs) };
+}
+
+/**
+ * The traced provider params. A multi-argument call is recorded as
+ * `{ args: [params, requestOptions] }` rather than as the params object.
+ */
+function tracedParams(run: any): any {
+  return Array.isArray(run.inputs.args) ? run.inputs.args[0] : run.inputs;
+}
+
+const mcpTool = (extra: Record<string, unknown> = {}) => [
+  {
+    type: "mcp",
+    server_label: "example",
+    server_url: "https://mcp.example.com/sse",
+    authorization: FAKE_TOKEN,
+    headers: { Authorization: `Bearer ${FAKE_TOKEN}` },
+    ...extra,
+  },
+];
+
+describe("hosted MCP tool credentials are masked before tracing", () => {
+  test("authorization and headers never reach the uploaded run", async () => {
+    const { runs, wire } = await traceResponse({ tools: mcpTool() });
+
+    expect(wire).not.toContain(FAKE_TOKEN);
+    const tool = runs[0].inputs.tools[0];
+    expect(tool.authorization).toBe(SECRET_PLACEHOLDER);
+    expect(tool.headers).toBe(SECRET_PLACEHOLDER);
+    expect(tool).toMatchObject({
+      type: "mcp",
+      server_label: "example",
+      server_url: "https://mcp.example.com/sse",
+    });
+  });
+
+  test("fields that are not explicitly allowed are masked too", async () => {
+    const { runs, wire } = await traceResponse({
+      tools: mcpTool({ future_secret: "s3cret" }),
+    });
+
+    expect(wire).not.toContain("s3cret");
+    expect(runs[0].inputs.tools[0].future_secret).toBe(SECRET_PLACEHOLDER);
+  });
+
+  test("the caller's params are left intact for the API call", async () => {
+    const tools = mcpTool();
+    await traceResponse({ tools });
+
+    expect(tools[0].authorization).toBe(FAKE_TOKEN);
+    expect(tools[0].headers).toEqual({
+      Authorization: `Bearer ${FAKE_TOKEN}`,
+    });
+  });
+
+  test("function tools keep their schema", async () => {
+    const tools = [
+      {
+        type: "function",
+        name: "get_weather",
+        parameters: {
+          type: "object",
+          properties: { city: { type: "string" } },
+        },
+      },
+    ];
+    const { runs } = await traceResponse({ tools });
+
+    expect(runs[0].inputs.tools[0]).toEqual(tools[0]);
+  });
+
+  test("masking survives a second argument", async () => {
+    const { runs, wire } = await traceResponse(
+      { tools: mcpTool() },
+      { langsmithExtra: { metadata: { foo: "bar" } } },
+    );
+
+    expect(wire).not.toContain(FAKE_TOKEN);
+    expect(tracedParams(runs[0]).tools[0].authorization).toBe(
+      SECRET_PLACEHOLDER,
+    );
+  });
+
+  test("credentials in the request options are masked", async () => {
+    const { runs, wire } = await traceResponse(
+      {},
+      { headers: { Authorization: `Bearer ${FAKE_TOKEN}` } },
+    );
+
+    expect(wire).not.toContain(FAKE_TOKEN);
+    expect(runs[0].inputs.args[1].headers).toEqual({
+      Authorization: SECRET_PLACEHOLDER,
+    });
+  });
+
+  test.each([
+    ["a non-array value", "not-an-array"],
+    ["null entries", [null]],
+    ["nested arrays", [["nested"]]],
+    ["an empty list", []],
+  ])("tolerates %s", async (_label, tools) => {
+    const { runs } = await traceResponse({ tools });
+
+    expect(runs[0].inputs.tools).toEqual(tools);
+  });
+});
+
+describe("per-request transport overrides are masked", () => {
+  test.each(["extra_headers", "extra_body", "extra_query"])(
+    "%s keeps its key names but not its values",
+    async (key) => {
+      const { runs, wire } = await traceResponse({
+        [key]: { Authorization: `Bearer ${FAKE_TOKEN}` },
+      });
+
+      expect(wire).not.toContain(FAKE_TOKEN);
+      expect(runs[0].inputs[key]).toEqual({
+        Authorization: SECRET_PLACEHOLDER,
+      });
+    },
+  );
+});
+
+describe("invocation params metadata stays clean", () => {
+  test("tools are not copied into ls_invocation_params", async () => {
+    const { runs } = await traceResponse({ tools: mcpTool() });
+
+    const metadata = runs[0].extra.metadata;
+    expect(JSON.stringify(metadata)).not.toContain(FAKE_TOKEN);
+    expect(metadata.ls_invocation_params.tools).toBeUndefined();
+  });
+});

--- a/js/src/wrappers/openai.ts
+++ b/js/src/wrappers/openai.ts
@@ -9,6 +9,76 @@ import {
 import { InvocationParamsSchema, KVMap } from "../schemas.js";
 import { getCurrentRunTree } from "../singletons/traceable.js";
 import { defaultLsAgentTypeMetadata } from "../utils/ls_agent_type.js";
+import { mask, overParams, redactOutside } from "../utils/redaction.js";
+
+/**
+ * Keys of OpenAI's hosted MCP tool entry that are safe to trace
+ * (`OpenAI.Responses.Tool.Mcp`). `authorization`, `headers`, and any credential
+ * field added later are masked.
+ */
+const MCP_TOOL_SAFE_KEYS: ReadonlySet<string> = new Set([
+  "type",
+  "server_label",
+  "server_description",
+  "server_url",
+  "connector_id",
+  "tunnel_id",
+  "require_approval",
+  "allowed_tools",
+  "allowed_callers",
+  "defer_loading",
+]);
+
+/**
+ * Request-transport keys that are credentials by construction. They carry no
+ * diagnostic value in a trace, so only their key names survive.
+ */
+const TRANSPORT_SECRET_KEYS: ReadonlySet<string> = new Set([
+  "headers",
+  "query",
+  "extra_headers",
+  "extra_body",
+  "extra_query",
+]);
+
+/**
+ * Mask credentials in OpenAI request params before they are traced.
+ *
+ * Returns a new object; the caller's params are also sent to OpenAI and must
+ * keep their real values.
+ */
+function redactOpenAIParams(params: KVMap): KVMap {
+  const processed: KVMap = { ...params };
+
+  if (Array.isArray(processed.tools)) {
+    processed.tools = processed.tools.map((tool) =>
+      typeof tool === "object" &&
+      tool !== null &&
+      !Array.isArray(tool) &&
+      (tool as KVMap).type === "mcp"
+        ? redactOutside(tool, MCP_TOOL_SAFE_KEYS)
+        : tool,
+    );
+  }
+
+  for (const key of TRANSPORT_SECRET_KEYS) {
+    if (processed[key] != null) {
+      processed[key] = mask(processed[key]);
+    }
+  }
+
+  return processed;
+}
+
+/**
+ * `traceable` hands `processInputs` either the params object itself or, for any
+ * call with a second argument, `{ args: [params, requestOptions] }`. Redact
+ * every object argument so the shape of the call cannot defeat masking, and so
+ * a credential in the request options is masked too.
+ */
+function processTracedInputs(inputs: KVMap): KVMap {
+  return overParams(inputs, redactOpenAIParams);
+}
 
 // Extra leniency around types in case multiple OpenAI SDK versions get installed
 type OpenAIType = {
@@ -121,7 +191,9 @@ function _combineChatCompletionChoices(
     }
   }
   const toolCalls: {
-    [key: number]: Partial<OpenAI.Chat.Completions.ChatCompletionChunk.Choice.Delta.ToolCall>[];
+    [
+      key: number
+    ]: Partial<OpenAI.Chat.Completions.ChatCompletionChunk.Choice.Delta.ToolCall>[];
   } = {};
   for (const c of choices) {
     if (c.delta.content) {
@@ -253,8 +325,7 @@ function isChatCompletionUsage(
 
 function processChatCompletion(outputs: KVMap): KVMap {
   const openAICompletion = outputs as
-    | OpenAI.ChatCompletion
-    | OpenAI.Responses.Response;
+    OpenAI.ChatCompletion | OpenAI.Responses.Response;
   const recognizedServiceTier = ["priority", "flex"].includes(
     openAICompletion.service_tier ?? "",
   )
@@ -459,6 +530,7 @@ export const wrapOpenAI = <T extends OpenAIType>(
     run_type: "llm",
     aggregator: chatAggregator,
     argsConfigPath: [1, "langsmithExtra"],
+    processInputs: processTracedInputs,
     getInvocationParams: getChatModelInvocationParamsFn(
       provider,
       prepopulatedInvocationParams,
@@ -571,6 +643,7 @@ export const wrapOpenAI = <T extends OpenAIType>(
       run_type: "llm",
       aggregator: textAggregator,
       argsConfigPath: [1, "langsmithExtra"],
+      processInputs: processTracedInputs,
       getInvocationParams: (payload: unknown) => {
         if (typeof payload !== "object" || payload == null) return undefined;
         // we can safely do so, as the types are not exported in TSC
@@ -629,6 +702,7 @@ export const wrapOpenAI = <T extends OpenAIType>(
           run_type: "llm",
           aggregator: responsesAggregator,
           argsConfigPath: [1, "langsmithExtra"],
+          processInputs: processTracedInputs,
           getInvocationParams: getChatModelInvocationParamsFn(
             provider,
             prepopulatedInvocationParams,
@@ -651,6 +725,7 @@ export const wrapOpenAI = <T extends OpenAIType>(
           run_type: "llm",
           aggregator: responsesAggregator,
           argsConfigPath: [1, "langsmithExtra"],
+          processInputs: processTracedInputs,
           getInvocationParams: getChatModelInvocationParamsFn(
             provider,
             prepopulatedInvocationParams,
@@ -673,6 +748,7 @@ export const wrapOpenAI = <T extends OpenAIType>(
           run_type: "llm",
           aggregator: responsesAggregator,
           argsConfigPath: [1, "langsmithExtra"],
+          processInputs: processTracedInputs,
           getInvocationParams: getChatModelInvocationParamsFn(
             provider,
             prepopulatedInvocationParams,

--- a/python/langsmith/_internal/_redaction.py
+++ b/python/langsmith/_internal/_redaction.py
@@ -1,0 +1,88 @@
+"""Mask credentials in provider request params on the way into a trace.
+
+The wrappers copy the caller's request kwargs into ``run.inputs``. Several
+providers accept credentials inside those kwargs -- remote MCP server tokens,
+per-request auth headers -- so anything that is a credential by construction is
+masked here before it is traced.
+
+Every helper returns new containers. The caller's own objects are still sent to
+the provider API and must keep their real values.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Collection, Mapping
+from typing import Any, Optional
+
+from langsmith.anonymizer import SECRET_PLACEHOLDER
+
+__all__ = ["mask", "redact_outside", "redact_keys"]
+
+# Request params are shallow; a cyclic or pathological payload must not turn
+# tracing into a hang.
+_MAX_DEPTH = 12
+
+
+def _as_mapping(value: Any) -> Optional[Mapping]:
+    """Return ``value`` as a mapping, converting Pydantic models best-effort.
+
+    Some provider configs reach tracing as model instances whose credential
+    fields are only visible after a dump.
+    """
+    if isinstance(value, Mapping):
+        return value
+    dump = getattr(value, "model_dump", None)
+    if callable(dump):
+        try:
+            dumped = dump()
+        except Exception:
+            return None
+        return dumped if isinstance(dumped, Mapping) else None
+    return None
+
+
+def mask(value: Any) -> Any:
+    """Mask ``value``, keeping key names so a trace still shows what was set."""
+    mapping = _as_mapping(value)
+    if mapping is not None:
+        return {key: SECRET_PLACEHOLDER for key in mapping}
+    return SECRET_PLACEHOLDER
+
+
+def redact_outside(entry: Any, safe_keys: Collection[str]) -> Any:
+    """Copy ``entry`` with every value outside ``safe_keys`` masked.
+
+    Keys keep their names, so a trace still shows the field was set, and a
+    credential field the provider adds later is masked by default rather than
+    exported.
+    """
+    mapping = _as_mapping(entry)
+    if mapping is None:
+        return entry
+    return {
+        key: value if key in safe_keys else SECRET_PLACEHOLDER
+        for key, value in mapping.items()
+    }
+
+
+def redact_keys(value: Any, secret_keys: Collection[str], _depth: int = 0) -> Any:
+    """Recursively mask the value of any mapping key named in ``secret_keys``.
+
+    Use where a provider hides credentials across several unrelated subtrees and
+    a per-site allowlist would need a new patch every release. Scope it to the
+    config-shaped part of a payload; walking user message content would mask
+    legitimate tool arguments and schema properties.
+    """
+    if _depth > _MAX_DEPTH:
+        return SECRET_PLACEHOLDER
+    mapping = _as_mapping(value)
+    if mapping is not None:
+        return {
+            key: mask(item)
+            if key in secret_keys
+            else redact_keys(item, secret_keys, _depth + 1)
+            for key, item in mapping.items()
+        }
+    if isinstance(value, (list, tuple)):
+        return [redact_keys(item, secret_keys, _depth + 1) for item in value]
+    return value

--- a/python/langsmith/wrappers/_openai.py
+++ b/python/langsmith/wrappers/_openai.py
@@ -18,6 +18,7 @@ from typing_extensions import TypedDict
 from langsmith import client as ls_client
 from langsmith import run_helpers
 from langsmith._internal._ls_agent_type import apply_default_ls_agent_type
+from langsmith._internal._redaction import mask, redact_outside
 
 # ``_create_usage_metadata`` lives in a non-deprecated internal module so
 # integrations can reuse it without importing the ``wrappers`` package (whose
@@ -69,9 +70,65 @@ def _strip_not_given(d: dict) -> dict:
         return d
 
 
+# Keys of OpenAI's hosted MCP tool entry that are safe to trace
+# (`openai.types.responses.tool_param.Mcp`). `authorization`, `headers`, and any
+# credential field added later are masked.
+_MCP_TOOL_SAFE_KEYS: frozenset[str] = frozenset(
+    {
+        "type",
+        "server_label",
+        "server_description",
+        "server_url",
+        "connector_id",
+        "tunnel_id",
+        "require_approval",
+        "allowed_tools",
+        "allowed_callers",
+        "defer_loading",
+    }
+)
+
+# Per-request transport overrides: credentials by construction, and of no
+# diagnostic value in a trace, so only their key names survive.
+_TRANSPORT_SECRET_KEYS = ("extra_headers", "extra_body", "extra_query")
+
+
+def _redact_tools(tools: Any) -> Any:
+    """Mask credentials in hosted MCP tool entries before they are traced.
+
+    Only ``type == "mcp"`` entries are touched. Function tools carry the
+    caller's JSON schema, which is the useful part of the trace.
+    """
+    if not isinstance(tools, (list, tuple)):
+        return tools
+
+    redacted: list[Any] = []
+    for tool in tools:
+        if isinstance(tool, Mapping) and tool.get("type") == "mcp":
+            tool = redact_outside(tool, _MCP_TOOL_SAFE_KEYS)
+        redacted.append(tool)
+    return redacted
+
+
+def _redact_secrets(d: dict) -> dict:
+    """Mask credential-bearing request params. Returns a new dict.
+
+    The caller's kwargs go on to the OpenAI API and must keep real values, so
+    nothing is modified in place.
+    """
+    redacted = dict(d)
+    if "tools" in redacted:
+        redacted["tools"] = _redact_tools(redacted["tools"])
+    for key in _TRANSPORT_SECRET_KEYS:
+        if redacted.get(key) is not None:
+            redacted[key] = mask(redacted[key])
+    return redacted
+
+
 def _process_inputs(d: dict) -> dict:
-    """Strip `NotGiven` values and serialize `text_format` to JSON schema."""
+    """Strip `NotGiven` values, mask credentials, serialize `text_format`."""
     d = _strip_not_given(d)
+    d = _redact_secrets(d)
 
     # Convert text_format (Pydantic model) to JSON schema if present
     if "text_format" in d:

--- a/python/tests/unit_tests/wrappers/test_openai_processing.py
+++ b/python/tests/unit_tests/wrappers/test_openai_processing.py
@@ -5,8 +5,10 @@ from types import SimpleNamespace
 import pytest
 
 from langsmith import run_helpers
+from langsmith.anonymizer import SECRET_PLACEHOLDER
 from langsmith.wrappers._openai import (
     _infer_invocation_params,
+    _process_inputs,
     _traceable_kwargs_with_ls_agent_type,
 )
 
@@ -187,3 +189,112 @@ def test_nested_none_opt_out_overrides_propagated_tag():
     )
     assert "ls_agent_type" in result["child_metadata"]
     assert result["child_metadata"]["ls_agent_type"] is None
+
+
+# ---------------------------------------------------------------------------
+# credential masking
+# ---------------------------------------------------------------------------
+
+FAKE_TOKEN = "fake-token-for-tests-only"
+
+
+def _mcp_tools(**extra) -> list:
+    return [
+        {
+            "type": "mcp",
+            "server_label": "example",
+            "server_url": "https://mcp.example.com/sse",
+            "authorization": FAKE_TOKEN,
+            "headers": {"Authorization": f"Bearer {FAKE_TOKEN}"},
+            **extra,
+        }
+    ]
+
+
+class TestRedactHostedMCPTools:
+    """Responses API `tools` may carry a bearer credential and auth headers."""
+
+    def test_process_inputs_masks_authorization_and_headers(self) -> None:
+        tool = _process_inputs({"model": "gpt-5", "tools": _mcp_tools()})["tools"][0]
+
+        assert tool["authorization"] == SECRET_PLACEHOLDER
+        assert tool["headers"] == SECRET_PLACEHOLDER
+        assert tool["type"] == "mcp"
+        assert tool["server_label"] == "example"
+        assert tool["server_url"] == "https://mcp.example.com/sse"
+
+    def test_infer_invocation_params_never_carries_the_token(self) -> None:
+        """Guards against building invocation params from the raw kwargs."""
+        params = _infer_invocation_params(
+            "chat", "openai", {}, True, {"model": "gpt-5", "tools": _mcp_tools()}
+        )
+
+        assert FAKE_TOKEN not in str(params)
+
+    def test_does_not_mutate_the_callers_tools(self) -> None:
+        """The same objects are sent to OpenAI, so they keep the real token."""
+        tools = _mcp_tools()
+        kwargs = {"model": "gpt-5", "tools": tools}
+
+        _process_inputs(kwargs)
+        _infer_invocation_params("chat", "openai", {}, True, kwargs)
+
+        assert tools[0]["authorization"] == FAKE_TOKEN
+        assert tools[0]["headers"] == {"Authorization": f"Bearer {FAKE_TOKEN}"}
+
+    def test_masks_fields_that_are_not_explicitly_allowed(self) -> None:
+        """A credential field added to the API later is masked by default."""
+        tool = _process_inputs({"tools": _mcp_tools(future_secret="s3cret")})["tools"][
+            0
+        ]
+
+        assert tool["future_secret"] == SECRET_PLACEHOLDER
+
+    def test_function_tools_keep_their_schema(self) -> None:
+        tools = [
+            {
+                "type": "function",
+                "name": "get_weather",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"city": {"type": "string"}},
+                },
+            }
+        ]
+
+        assert _process_inputs({"tools": tools})["tools"] == tools
+
+    @pytest.mark.parametrize(
+        ("tools", "expected"),
+        [
+            ("not-a-list", "not-a-list"),
+            ([None], [None]),
+            ([["nested"]], [["nested"]]),
+            ([], []),
+            ((), []),  # tuples are normalized to lists
+        ],
+    )
+    def test_tolerates_unexpected_shapes(self, tools, expected) -> None:
+        assert _process_inputs({"tools": tools})["tools"] == expected
+
+
+class TestRedactTransportOverrides:
+    """`extra_*` are credentials by construction; only key names survive."""
+
+    @pytest.mark.parametrize("key", ["extra_headers", "extra_body", "extra_query"])
+    def test_masks_values_but_keeps_key_names(self, key) -> None:
+        result = _process_inputs({key: {"Authorization": f"Bearer {FAKE_TOKEN}"}})
+
+        assert result[key] == {"Authorization": SECRET_PLACEHOLDER}
+
+    def test_does_not_mutate_the_callers_headers(self) -> None:
+        headers = {"Authorization": f"Bearer {FAKE_TOKEN}"}
+        kwargs = {"model": "gpt-5", "extra_headers": headers}
+
+        _process_inputs(kwargs)
+
+        assert headers["Authorization"] == f"Bearer {FAKE_TOKEN}"
+        assert kwargs["extra_headers"] is headers
+
+    def test_unset_overrides_are_left_alone(self) -> None:
+        assert _process_inputs({"model": "gpt-5"}) == {"model": "gpt-5"}


### PR DESCRIPTION
Stacked on #3378 — review that one first; it adds the JS redaction helpers this PR reuses.

## What & why

The OpenAI Responses API accepts hosted MCP tool entries that carry an OAuth access token and arbitrary auth headers (`openai.types.responses.tool_param.Mcp`):

```json
{"type": "mcp", "server_url": "...", "authorization": "...", "headers": {"Authorization": "Bearer ..."}}
```

Neither wrapper filtered them:

- **Python** — `_process_inputs` only stripped `NotGiven` sentinels (`_openai.py:57-87`)
- **JS** — no `processInputs` registered on any traceable config

So both uploaded the credential verbatim in `run.inputs` on every traced call. `extra_headers` / `extra_body` / `extra_query` reached `run.inputs` through the same path whenever the caller set them — the follow-up #3372 flagged.

Verified against the payload the SDK would actually send. Before:

```
{"model":"gpt-5","input":"hi","tools":[{"type":"mcp","server_label":"example",
 "server_url":"https://mcp.example.com/sse","authorization":"<token>",
 "headers":{"Authorization":"Bearer <token>"}}],
 "extra_headers":{"Authorization":"Bearer <token>"}}
```

After: `[SECRET_DETECTED]` in all three places, with the caller's own objects still holding the real values.

The metadata path was already safe — `_infer_invocation_params` has an allowlist (`_openai.py:105-127`) that excludes `tools` and `extra_*`. Tests pin that so it cannot regress.

## Fix

Only `type == "mcp"` tool entries are redacted, against an allowlist derived from the real `Mcp` TypedDict. **Function tools keep their JSON schema**, which is the useful part of a trace — a blanket redaction of `tools` would have gutted it.

`extra_headers` / `extra_body` / `extra_query` keep their key names but not their values.

New `python/langsmith/_internal/_redaction.py` mirrors the JS helpers from #3378: `mask`, `redact_outside`, `redact_keys`. `redact_keys` is unused here and lands ready for the Gemini follow-up, where google-genai scatters credentials across `http_options.headers`, `tools[].mcp_servers[].streamable_http_transport.headers`, `tools[].google_maps.auth_config`, and `tools[].retrieval.external_api.api_auth` — a per-site allowlist there would need a new patch every release.

The JS side routes through `overParams` from #3378, so the argument-shape bypass fixed there cannot reappear, and the second-argument `RequestOptions.headers` is masked too.

### Note on `server_url`

Kept visible, matching #3371's treatment of Anthropic's `url`. A token embedded in the URL still reaches the trace. Happy to mask it if you'd rather be strict — it's a one-line change to the allowlist in both SDKs.

## Tests

Python asserts on `_process_inputs` and `_infer_invocation_params`; JS asserts against the uploaded payload via the existing `mockClient()` fetch spy. No network, no API keys.

Both cover: credentials masked, allowed fields survive, an unknown field masked by default, function-tool schemas untouched, caller objects unmutated, transport overrides masked, and unexpected shapes (non-list, null entries, nested arrays, empty, tuple) not raising. JS additionally covers the two-argument call shape.

## Follow-ups (not here)

Still unremediated, from the same audit: both Gemini wrappers (`config.http_options.headers`, MCP tool headers, `google_maps.auth_config`), the OpenAI Realtime integration (`session.tools[].authorization` in span outputs), and `js/src/experimental/anthropic` (`options.env`, whose documented usage is `{ ...process.env }`).
