### PR TITLE
fix(py): mask hosted MCP tool credentials in the OpenAI wrapper

### DIFF
--- a/python/langsmith/_internal/_redaction.py
+++ b/python/langsmith/_internal/_redaction.py
@@ -1,0 +1,47 @@
+"""Mask credentials in provider request params on the way into a trace.
+
+Helpers return new containers: the caller's objects also go to the provider API
+and must keep their real values.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Collection, Mapping
+from typing import Any, Optional
+
+from langsmith.anonymizer import SECRET_PLACEHOLDER
+
+__all__ = ["as_mapping", "mask", "redact_outside"]
+
+
+def as_mapping(value: Any) -> Optional[Mapping]:
+    """Return ``value`` as a mapping; Pydantic configs need a dump to see into."""
+    if isinstance(value, Mapping):
+        return value
+    dump = getattr(value, "model_dump", None)
+    if callable(dump):
+        try:
+            dumped = dump()
+        except Exception:
+            return None
+        return dumped if isinstance(dumped, Mapping) else None
+    return None
+
+
+def mask(value: Any) -> Any:
+    """Mask ``value``, keeping key names so a trace shows what was set."""
+    mapping = as_mapping(value)
+    if mapping is not None:
+        return {key: SECRET_PLACEHOLDER for key in mapping}
+    return SECRET_PLACEHOLDER
+
+
+def redact_outside(entry: Any, safe_keys: Collection[str]) -> Any:
+    """Copy ``entry``, masking values outside ``safe_keys``; unknown keys fail shut."""
+    mapping = as_mapping(entry)
+    if mapping is None:
+        return entry
+    return {
+        key: value if key in safe_keys else SECRET_PLACEHOLDER
+        for key, value in mapping.items()
+    }

--- a/python/langsmith/_internal/_redaction.py
+++ b/python/langsmith/_internal/_redaction.py
@@ -6,12 +6,15 @@ and must keep their real values.
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Collection, Mapping
 from typing import Any, Optional
 
 from langsmith.anonymizer import SECRET_PLACEHOLDER
 
 __all__ = ["as_mapping", "mask", "redact_outside"]
+
+logger = logging.getLogger(__name__)
 
 
 def as_mapping(value: Any) -> Optional[Mapping]:
@@ -22,7 +25,10 @@ def as_mapping(value: Any) -> Optional[Mapping]:
     if callable(dump):
         try:
             dumped = dump()
-        except Exception:
+        except Exception as e:
+            logger.warning(
+                "Could not read %s to redact it: %s", type(value).__name__, e
+            )
             return None
         return dumped if isinstance(dumped, Mapping) else None
     return None

--- a/python/langsmith/wrappers/_openai.py
+++ b/python/langsmith/wrappers/_openai.py
@@ -24,6 +24,7 @@ from langsmith._internal._redaction import as_mapping, mask, redact_outside
 # integrations can reuse it without importing the ``wrappers`` package (whose
 # ``__init__`` warns at import time). Re-exported here for backwards compat.
 from langsmith._internal._usage import _create_usage_metadata
+from langsmith.anonymizer import SECRET_PLACEHOLDER
 
 if TYPE_CHECKING:
     from openai import AsyncOpenAI, OpenAI
@@ -90,6 +91,11 @@ _MCP_TOOL_SAFE_KEYS: frozenset[str] = frozenset(
 _TRANSPORT_SECRET_KEYS = ("extra_headers", "extra_body", "extra_query")
 
 
+def _is_model(value: Any) -> bool:
+    """Whether ``value`` claims to be a Pydantic model."""
+    return callable(getattr(value, "model_dump", None))
+
+
 def _redact_tools(tools: Any) -> Any:
     """Mask hosted MCP entries; function tools carry the caller's schema."""
     if not isinstance(tools, (list, tuple)):
@@ -98,9 +104,13 @@ def _redact_tools(tools: Any) -> Any:
     redacted: list[Any] = []
     for tool in tools:
         mapping = as_mapping(tool)
-        if mapping is not None and mapping.get("type") == "mcp":
-            tool = redact_outside(mapping, _MCP_TOOL_SAFE_KEYS)
-        redacted.append(tool)
+        if mapping is None:
+            # An unreadable model would reach the trace as a repr of its fields.
+            redacted.append(SECRET_PLACEHOLDER if _is_model(tool) else tool)
+        elif mapping.get("type") == "mcp":
+            redacted.append(redact_outside(mapping, _MCP_TOOL_SAFE_KEYS))
+        else:
+            redacted.append(tool)
     return redacted
 
 

--- a/python/langsmith/wrappers/_openai.py
+++ b/python/langsmith/wrappers/_openai.py
@@ -18,6 +18,7 @@ from typing_extensions import TypedDict
 from langsmith import client as ls_client
 from langsmith import run_helpers
 from langsmith._internal._ls_agent_type import apply_default_ls_agent_type
+from langsmith._internal._redaction import as_mapping, mask, redact_outside
 
 # ``_create_usage_metadata`` lives in a non-deprecated internal module so
 # integrations can reuse it without importing the ``wrappers`` package (whose
@@ -69,9 +70,55 @@ def _strip_not_given(d: dict) -> dict:
         return d
 
 
+# Keys of `openai.types.responses.tool_param.Mcp` that are safe to trace.
+_MCP_TOOL_SAFE_KEYS: frozenset[str] = frozenset(
+    {
+        "type",
+        "server_label",
+        "server_description",
+        "server_url",
+        "connector_id",
+        "tunnel_id",
+        "require_approval",
+        "allowed_tools",
+        "allowed_callers",
+        "defer_loading",
+    }
+)
+
+# Per-request transport overrides: credentials by construction.
+_TRANSPORT_SECRET_KEYS = ("extra_headers", "extra_body", "extra_query")
+
+
+def _redact_tools(tools: Any) -> Any:
+    """Mask hosted MCP entries; function tools carry the caller's schema."""
+    if not isinstance(tools, (list, tuple)):
+        return tools
+
+    redacted: list[Any] = []
+    for tool in tools:
+        mapping = as_mapping(tool)
+        if mapping is not None and mapping.get("type") == "mcp":
+            tool = redact_outside(mapping, _MCP_TOOL_SAFE_KEYS)
+        redacted.append(tool)
+    return redacted
+
+
+def _redact_secrets(d: dict) -> dict:
+    """Mask credential-bearing request params. Returns a new dict."""
+    redacted = dict(d)
+    if "tools" in redacted:
+        redacted["tools"] = _redact_tools(redacted["tools"])
+    for key in _TRANSPORT_SECRET_KEYS:
+        if redacted.get(key) is not None:
+            redacted[key] = mask(redacted[key])
+    return redacted
+
+
 def _process_inputs(d: dict) -> dict:
-    """Strip `NotGiven` values and serialize `text_format` to JSON schema."""
+    """Strip `NotGiven` values, mask credentials, serialize `text_format`."""
     d = _strip_not_given(d)
+    d = _redact_secrets(d)
 
     # Convert text_format (Pydantic model) to JSON schema if present
     if "text_format" in d:

--- a/python/tests/unit_tests/wrappers/test_openai_processing.py
+++ b/python/tests/unit_tests/wrappers/test_openai_processing.py
@@ -1,5 +1,6 @@
 """Unit tests for OpenAI wrapper processing functions."""
 
+import logging
 from types import SimpleNamespace
 
 import pytest
@@ -340,3 +341,50 @@ class TestRedactTransportOverrides:
 
     def test_unset_overrides_are_left_alone(self) -> None:
         assert _process_inputs({"model": "gpt-5"}) == {"model": "gpt-5"}
+
+
+class TestUnreadableValuesAreDropped:
+    """A value we cannot read must not reach the trace.
+
+    The serializer falls back to ``repr()``, which renders every field value,
+    so passing an unreadable model through leaks whatever it holds.
+    """
+
+    @staticmethod
+    def _broken_mcp_tool():
+        tool_types = pytest.importorskip("openai.types.responses.tool")
+
+        class BrokenMcp(tool_types.Mcp):
+            def model_dump(self, *args, **kwargs):
+                raise RuntimeError("serializer blew up")
+
+        return BrokenMcp(
+            type="mcp",
+            server_label="example",
+            server_url="https://mcp.example.com/sse",
+            authorization=FAKE_TOKEN,
+            headers={"Authorization": f"Bearer {FAKE_TOKEN}"},
+        )
+
+    def test_tool_whose_model_dump_raises_is_dropped(self, caplog) -> None:
+        with caplog.at_level(logging.WARNING, logger="langsmith._internal._redaction"):
+            result = _process_inputs(
+                {"model": "gpt-5", "tools": [self._broken_mcp_tool()]}
+            )
+
+        assert FAKE_TOKEN not in dumps_json(result).decode()
+        assert result["tools"][0] == SECRET_PLACEHOLDER
+        assert "BrokenMcp" in caplog.text
+
+    def test_ordinary_values_are_not_logged(self, caplog) -> None:
+        """The warning must stay rare, or it is noise nobody reads."""
+        with caplog.at_level(logging.WARNING, logger="langsmith._internal._redaction"):
+            _process_inputs(
+                {
+                    "model": "gpt-5",
+                    "tools": [{"type": "function", "name": "lookup"}, "junk", None],
+                    "extra_headers": {"Authorization": FAKE_TOKEN},
+                }
+            )
+
+        assert caplog.text == ""

--- a/python/tests/unit_tests/wrappers/test_openai_processing.py
+++ b/python/tests/unit_tests/wrappers/test_openai_processing.py
@@ -5,8 +5,11 @@ from types import SimpleNamespace
 import pytest
 
 from langsmith import run_helpers
+from langsmith._internal._serde import dumps_json
+from langsmith.anonymizer import SECRET_PLACEHOLDER
 from langsmith.wrappers._openai import (
     _infer_invocation_params,
+    _process_inputs,
     _traceable_kwargs_with_ls_agent_type,
 )
 
@@ -187,3 +190,153 @@ def test_nested_none_opt_out_overrides_propagated_tag():
     )
     assert "ls_agent_type" in result["child_metadata"]
     assert result["child_metadata"]["ls_agent_type"] is None
+
+
+# ---------------------------------------------------------------------------
+# credential masking
+# ---------------------------------------------------------------------------
+
+FAKE_TOKEN = "fake-token-for-tests-only"
+
+
+def _mcp_tools(**extra) -> list:
+    return [
+        {
+            "type": "mcp",
+            "server_label": "example",
+            "server_url": "https://mcp.example.com/sse",
+            "authorization": FAKE_TOKEN,
+            "headers": {"Authorization": f"Bearer {FAKE_TOKEN}"},
+            **extra,
+        }
+    ]
+
+
+class TestRedactHostedMCPTools:
+    """Responses API `tools` may carry a bearer credential and auth headers."""
+
+    def test_process_inputs_masks_authorization_and_headers(self) -> None:
+        tool = _process_inputs({"model": "gpt-5", "tools": _mcp_tools()})["tools"][0]
+
+        assert tool["authorization"] == SECRET_PLACEHOLDER
+        assert tool["headers"] == SECRET_PLACEHOLDER
+        assert tool["type"] == "mcp"
+        assert tool["server_label"] == "example"
+        assert tool["server_url"] == "https://mcp.example.com/sse"
+
+    def test_infer_invocation_params_never_carries_the_token(self) -> None:
+        """Guards against building invocation params from the raw kwargs."""
+        params = _infer_invocation_params(
+            "chat", "openai", {}, True, {"model": "gpt-5", "tools": _mcp_tools()}
+        )
+
+        assert FAKE_TOKEN not in str(params)
+
+    def test_does_not_mutate_the_callers_tools(self) -> None:
+        """The same objects are sent to OpenAI, so they keep the real token."""
+        tools = _mcp_tools()
+        kwargs = {"model": "gpt-5", "tools": tools}
+
+        _process_inputs(kwargs)
+        _infer_invocation_params("chat", "openai", {}, True, kwargs)
+
+        assert tools[0]["authorization"] == FAKE_TOKEN
+        assert tools[0]["headers"] == {"Authorization": f"Bearer {FAKE_TOKEN}"}
+
+    def test_masks_fields_that_are_not_explicitly_allowed(self) -> None:
+        """A credential field added to the API later is masked by default."""
+        tool = _process_inputs({"tools": _mcp_tools(future_secret="s3cret")})["tools"][
+            0
+        ]
+
+        assert tool["future_secret"] == SECRET_PLACEHOLDER
+
+    def test_function_tools_keep_their_schema(self) -> None:
+        tools = [
+            {
+                "type": "function",
+                "name": "get_weather",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"city": {"type": "string"}},
+                },
+            }
+        ]
+
+        assert _process_inputs({"tools": tools})["tools"] == tools
+
+    @pytest.mark.parametrize(
+        ("tools", "expected"),
+        [
+            ("not-a-list", "not-a-list"),
+            ([None], [None]),
+            ([["nested"]], [["nested"]]),
+            ([], []),
+            ((), []),  # tuples are normalized to lists
+        ],
+    )
+    def test_tolerates_unexpected_shapes(self, tools, expected) -> None:
+        assert _process_inputs({"tools": tools})["tools"] == expected
+
+    def test_masks_pydantic_mcp_tool_objects(self) -> None:
+        """A caller may hand back an `Mcp` object taken from a prior response.
+
+        The tracer serializes Pydantic models, so an unmasked object reaches
+        `run.inputs` with the credential intact.
+        """
+        tool_types = pytest.importorskip("openai.types.responses.tool")
+
+        tool = tool_types.Mcp(
+            type="mcp",
+            server_label="example",
+            server_url="https://mcp.example.com/sse",
+            authorization=FAKE_TOKEN,
+            headers={"Authorization": f"Bearer {FAKE_TOKEN}"},
+        )
+
+        result = _process_inputs({"model": "gpt-5", "tools": [tool]})
+
+        assert FAKE_TOKEN not in dumps_json(result).decode()
+        redacted = result["tools"][0]
+        assert redacted["authorization"] == SECRET_PLACEHOLDER
+        assert redacted["headers"] == SECRET_PLACEHOLDER
+        assert redacted["server_url"] == "https://mcp.example.com/sse"
+        # The caller's object still goes to the API and keeps its real values.
+        assert tool.authorization == FAKE_TOKEN
+
+    def test_leaves_pydantic_function_tools_untouched(self) -> None:
+        """Only `mcp` entries are rewritten; a function tool keeps its schema."""
+        tool_types = pytest.importorskip("openai.types.responses.tool")
+
+        tool = tool_types.FunctionTool(
+            type="function",
+            name="lookup",
+            parameters={"type": "object", "properties": {"q": {"type": "string"}}},
+            strict=True,
+        )
+
+        result = _process_inputs({"model": "gpt-5", "tools": [tool]})
+
+        assert result["tools"][0] is tool
+
+
+class TestRedactTransportOverrides:
+    """`extra_*` are credentials by construction; only key names survive."""
+
+    @pytest.mark.parametrize("key", ["extra_headers", "extra_body", "extra_query"])
+    def test_masks_values_but_keeps_key_names(self, key) -> None:
+        result = _process_inputs({key: {"Authorization": f"Bearer {FAKE_TOKEN}"}})
+
+        assert result[key] == {"Authorization": SECRET_PLACEHOLDER}
+
+    def test_does_not_mutate_the_callers_headers(self) -> None:
+        headers = {"Authorization": f"Bearer {FAKE_TOKEN}"}
+        kwargs = {"model": "gpt-5", "extra_headers": headers}
+
+        _process_inputs(kwargs)
+
+        assert headers["Authorization"] == f"Bearer {FAKE_TOKEN}"
+        assert kwargs["extra_headers"] is headers
+
+    def test_unset_overrides_are_left_alone(self) -> None:
+        assert _process_inputs({"model": "gpt-5"}) == {"model": "gpt-5"}


### PR DESCRIPTION
## What & why

The OpenAI Responses API accepts hosted MCP tool entries that carry an OAuth access token and arbitrary auth headers (`openai.types.responses.tool_param.Mcp`):

```json
{"type": "mcp", "server_url": "...", "authorization": "...", "headers": {"Authorization": "Bearer ..."}}
```

`_process_inputs` only strips `NotGiven` sentinels, so the wrapper uploads the credential verbatim in `run.inputs` on every traced call. `extra_headers` / `extra_body` / `extra_query` reach `run.inputs` by the same route whenever the caller sets them — the follow-up #3372 flagged.

Same bug class as #3371, different provider field.

Verified against the payload the SDK would actually send. Before:

```
{"model":"gpt-5","input":"hi","tools":[{"type":"mcp","server_label":"example",
 "server_url":"https://mcp.example.com/sse","authorization":"<token>",
 "headers":{"Authorization":"Bearer <token>"}}],
 "extra_headers":{"Authorization":"Bearer <token>"}}
```

After: `[SECRET_DETECTED]` in all three places, with the caller's own objects still holding their real values.

The metadata path is already safe — `_infer_invocation_params` has an allowlist that excludes `tools` and `extra_*`. Tests pin that so it cannot regress.

## Fix

Only `type == "mcp"` tool entries are redacted, against an allowlist derived from the `Mcp` TypedDict. **Function tools keep their JSON schema**, which is the useful part of a trace — a blanket redaction of `tools` would gut it.

`extra_headers` / `extra_body` / `extra_query` keep their key names but not their values.

New `langsmith/_internal/_redaction.py` holds the two shared primitives: `mask` (replace a value, keeping key names) and `redact_outside` (allowlist a known container, so unknown keys fail shut). #3382 reuses both.

`server_url` stays visible, matching #3371's treatment of Anthropic's `url`, but that should be a very niche option (URL-based authentication)

## Tests

`TestRedactHostedMCPTools` and `TestRedactTransportOverrides`. No network, no API keys. Cover: credentials masked in `run.inputs`, never present in `ls_invocation_params`, allowed fields survive, an unknown field masked by default, function-tool schemas untouched, the caller's dicts unmutated, and unexpected shapes (non-list, null entries, nested arrays, empty, tuple) not raising.

## Stack

Python: this → #3382 (Gemini). Based on `main`; independent of the JS stack.
JS counterpart: #3381.
