### PR TITLE
fix(js): mask hosted MCP tool credentials in the OpenAI wrapper

### DIFF
--- a/js/src/tests/wrapped_openai_mcp.test.ts
+++ b/js/src/tests/wrapped_openai_mcp.test.ts
@@ -1,0 +1,189 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { wrapOpenAI } from "../wrappers/openai.js";
+import { SECRET_PLACEHOLDER } from "../anonymizer/index.js";
+import { mockClient } from "./utils/mock_client.js";
+
+const FAKE_TOKEN = "fake-token-for-tests-only";
+
+function parseRequestBody(body: any) {
+  // eslint-disable-next-line no-instanceof/no-instanceof
+  return body instanceof Uint8Array
+    ? JSON.parse(new TextDecoder().decode(body))
+    : JSON.parse(body);
+}
+
+/** Stub provider, so input processing runs without a network call. */
+function stubOpenAI(): any {
+  const response = { id: "resp_stub", output: [], usage: {} };
+  return {
+    responses: {
+      create: async () => response,
+      parse: async () => response,
+    },
+    chat: { completions: { create: async () => ({ id: "cc_stub" }) } },
+    completions: { create: async () => ({ id: "c_stub" }) },
+    beta: { chat: { completions: {} } },
+  };
+}
+
+/** The runs the SDK would have uploaded. */
+function uploadedRuns(callSpy: any): any[] {
+  return (callSpy.mock.calls as any[])
+    .map(([, init]: any) => {
+      try {
+        return parseRequestBody(init?.body);
+      } catch {
+        return undefined;
+      }
+    })
+    .filter(Boolean)
+    .flatMap((body: any) => body?.post ?? body?.patch ?? [body])
+    .filter((run: any) => run?.inputs);
+}
+
+async function traceResponse(
+  params: Record<string, unknown>,
+  requestOptions?: Record<string, unknown>,
+) {
+  const { client, callSpy } = mockClient();
+  const patched: any = wrapOpenAI(stubOpenAI(), {
+    client,
+    tracingEnabled: true,
+  });
+
+  const args: unknown[] = [{ model: "gpt-5", input: "hi", ...params }];
+  if (requestOptions !== undefined) args.push(requestOptions);
+
+  await patched.responses.create(...args);
+
+  const runs = uploadedRuns(callSpy);
+  return { runs, wire: JSON.stringify(runs) };
+}
+
+/** Traced provider params; a multi-argument call is recorded as `{ args: [...] }`. */
+function tracedParams(run: any): any {
+  return Array.isArray(run.inputs.args) ? run.inputs.args[0] : run.inputs;
+}
+
+const mcpTool = (extra: Record<string, unknown> = {}) => [
+  {
+    type: "mcp",
+    server_label: "example",
+    server_url: "https://mcp.example.com/sse",
+    authorization: FAKE_TOKEN,
+    headers: { Authorization: `Bearer ${FAKE_TOKEN}` },
+    ...extra,
+  },
+];
+
+describe("hosted MCP tool credentials are masked before tracing", () => {
+  test("authorization and headers never reach the uploaded run", async () => {
+    const { runs, wire } = await traceResponse({ tools: mcpTool() });
+
+    expect(wire).not.toContain(FAKE_TOKEN);
+    const tool = runs[0].inputs.tools[0];
+    expect(tool.authorization).toBe(SECRET_PLACEHOLDER);
+    expect(tool.headers).toBe(SECRET_PLACEHOLDER);
+    expect(tool).toMatchObject({
+      type: "mcp",
+      server_label: "example",
+      server_url: "https://mcp.example.com/sse",
+    });
+  });
+
+  test("fields that are not explicitly allowed are masked too", async () => {
+    const { runs, wire } = await traceResponse({
+      tools: mcpTool({ future_secret: "s3cret" }),
+    });
+
+    expect(wire).not.toContain("s3cret");
+    expect(runs[0].inputs.tools[0].future_secret).toBe(SECRET_PLACEHOLDER);
+  });
+
+  test("the caller's params are left intact for the API call", async () => {
+    const tools = mcpTool();
+    await traceResponse({ tools });
+
+    expect(tools[0].authorization).toBe(FAKE_TOKEN);
+    expect(tools[0].headers).toEqual({
+      Authorization: `Bearer ${FAKE_TOKEN}`,
+    });
+  });
+
+  test("function tools keep their schema", async () => {
+    const tools = [
+      {
+        type: "function",
+        name: "get_weather",
+        parameters: {
+          type: "object",
+          properties: { city: { type: "string" } },
+        },
+      },
+    ];
+    const { runs } = await traceResponse({ tools });
+
+    expect(runs[0].inputs.tools[0]).toEqual(tools[0]);
+  });
+
+  test("masking survives a second argument", async () => {
+    const { runs, wire } = await traceResponse(
+      { tools: mcpTool() },
+      { langsmithExtra: { metadata: { foo: "bar" } } },
+    );
+
+    expect(wire).not.toContain(FAKE_TOKEN);
+    expect(tracedParams(runs[0]).tools[0].authorization).toBe(
+      SECRET_PLACEHOLDER,
+    );
+  });
+
+  test("credentials in the request options are masked", async () => {
+    const { runs, wire } = await traceResponse(
+      {},
+      { headers: { Authorization: `Bearer ${FAKE_TOKEN}` } },
+    );
+
+    expect(wire).not.toContain(FAKE_TOKEN);
+    expect(runs[0].inputs.args[1].headers).toEqual({
+      Authorization: SECRET_PLACEHOLDER,
+    });
+  });
+
+  test.each([
+    ["a non-array value", "not-an-array"],
+    ["null entries", [null]],
+    ["nested arrays", [["nested"]]],
+    ["an empty list", []],
+  ])("tolerates %s", async (_label, tools) => {
+    const { runs } = await traceResponse({ tools });
+
+    expect(runs[0].inputs.tools).toEqual(tools);
+  });
+});
+
+describe("per-request transport overrides are masked", () => {
+  test.each(["extra_headers", "extra_body", "extra_query"])(
+    "%s keeps its key names but not its values",
+    async (key) => {
+      const { runs, wire } = await traceResponse({
+        [key]: { Authorization: `Bearer ${FAKE_TOKEN}` },
+      });
+
+      expect(wire).not.toContain(FAKE_TOKEN);
+      expect(runs[0].inputs[key]).toEqual({
+        Authorization: SECRET_PLACEHOLDER,
+      });
+    },
+  );
+});
+
+describe("invocation params metadata stays clean", () => {
+  test("tools are not copied into ls_invocation_params", async () => {
+    const { runs } = await traceResponse({ tools: mcpTool() });
+
+    const metadata = runs[0].extra.metadata;
+    expect(JSON.stringify(metadata)).not.toContain(FAKE_TOKEN);
+    expect(metadata.ls_invocation_params.tools).toBeUndefined();
+  });
+});

--- a/js/src/wrappers/openai.ts
+++ b/js/src/wrappers/openai.ts
@@ -9,6 +9,60 @@ import {
 import { InvocationParamsSchema, KVMap } from "../schemas.js";
 import { getCurrentRunTree } from "../singletons/traceable.js";
 import { defaultLsAgentTypeMetadata } from "../utils/ls_agent_type.js";
+import { mask, overParams, redactOutside } from "../utils/redaction.js";
+
+/** Keys of `OpenAI.Responses.Tool.Mcp` that are safe to trace. */
+const MCP_TOOL_SAFE_KEYS: ReadonlySet<string> = new Set([
+  "type",
+  "server_label",
+  "server_description",
+  "server_url",
+  "connector_id",
+  "tunnel_id",
+  "require_approval",
+  "allowed_tools",
+  "allowed_callers",
+  "defer_loading",
+]);
+
+/** Request-transport keys that are credentials by construction. */
+const TRANSPORT_SECRET_KEYS: ReadonlySet<string> = new Set([
+  "headers",
+  "query",
+  "extra_headers",
+  "extra_body",
+  "extra_query",
+]);
+
+/** Mask credentials in OpenAI request params. Only hosted MCP tools are touched;
+ * function tools carry the caller's schema. */
+function redactOpenAIParams(params: KVMap): KVMap {
+  // Copy first: `params` also goes to the API and must keep its real values.
+  const processed: KVMap = { ...params };
+
+  if (Array.isArray(processed.tools)) {
+    processed.tools = processed.tools.map((tool) =>
+      typeof tool === "object" &&
+      tool !== null &&
+      !Array.isArray(tool) &&
+      (tool as KVMap).type === "mcp"
+        ? redactOutside(tool, MCP_TOOL_SAFE_KEYS)
+        : tool,
+    );
+  }
+
+  for (const key of TRANSPORT_SECRET_KEYS) {
+    if (processed[key] != null) {
+      processed[key] = mask(processed[key]);
+    }
+  }
+
+  return processed;
+}
+
+function processTracedInputs(inputs: KVMap): KVMap {
+  return overParams(inputs, redactOpenAIParams);
+}
 
 // Extra leniency around types in case multiple OpenAI SDK versions get installed
 type OpenAIType = {
@@ -459,6 +513,7 @@ export const wrapOpenAI = <T extends OpenAIType>(
     run_type: "llm",
     aggregator: chatAggregator,
     argsConfigPath: [1, "langsmithExtra"],
+    processInputs: processTracedInputs,
     getInvocationParams: getChatModelInvocationParamsFn(
       provider,
       prepopulatedInvocationParams,
@@ -571,6 +626,7 @@ export const wrapOpenAI = <T extends OpenAIType>(
       run_type: "llm",
       aggregator: textAggregator,
       argsConfigPath: [1, "langsmithExtra"],
+      processInputs: processTracedInputs,
       getInvocationParams: (payload: unknown) => {
         if (typeof payload !== "object" || payload == null) return undefined;
         // we can safely do so, as the types are not exported in TSC
@@ -629,6 +685,7 @@ export const wrapOpenAI = <T extends OpenAIType>(
           run_type: "llm",
           aggregator: responsesAggregator,
           argsConfigPath: [1, "langsmithExtra"],
+          processInputs: processTracedInputs,
           getInvocationParams: getChatModelInvocationParamsFn(
             provider,
             prepopulatedInvocationParams,
@@ -651,6 +708,7 @@ export const wrapOpenAI = <T extends OpenAIType>(
           run_type: "llm",
           aggregator: responsesAggregator,
           argsConfigPath: [1, "langsmithExtra"],
+          processInputs: processTracedInputs,
           getInvocationParams: getChatModelInvocationParamsFn(
             provider,
             prepopulatedInvocationParams,
@@ -673,6 +731,7 @@ export const wrapOpenAI = <T extends OpenAIType>(
           run_type: "llm",
           aggregator: responsesAggregator,
           argsConfigPath: [1, "langsmithExtra"],
+          processInputs: processTracedInputs,
           getInvocationParams: getChatModelInvocationParamsFn(
             provider,
             prepopulatedInvocationParams,


### PR DESCRIPTION
Stacked on #3378 — review that one first; it adds the `overParams` helper this PR depends on. Python counterpart is #3380, which is independent of both.

## What & why

The OpenAI Responses API accepts hosted MCP tool entries that carry an OAuth access token and arbitrary auth headers:

```json
{"type": "mcp", "server_url": "...", "authorization": "...", "headers": {"Authorization": "Bearer ..."}}
```

`wrapOpenAI` registers **no `processInputs`** on any traceable config, so the caller's request params are recorded verbatim as `run.inputs` and the credential is uploaded on every traced call. `extra_headers` / `extra_body` / `extra_query`, and the `headers` on the second-argument `RequestOptions`, reach `run.inputs` by the same route.

Same bug class as #3372, different provider field.

Verified against the payload the SDK would actually send. Before:

```
{"model":"gpt-5","input":"hi","tools":[{"type":"mcp","server_label":"example",
 "server_url":"https://mcp.example.com/sse","authorization":"<token>",
 "headers":{"Authorization":"Bearer <token>"}}]}
```

After: `[SECRET_DETECTED]`, with the caller's own objects intact.

The metadata path is already safe — `getChatModelInvocationParamsFn` filters against `TRACED_INVOCATION_KEYS`, which excludes `tools`. Tests pin that.

## Fix

Only `type == "mcp"` tool entries are redacted, against an allowlist derived from `OpenAI.Responses.Tool.Mcp`. **Function tools keep their JSON schema**, which is the useful part of a trace.

`extra_headers` / `extra_body` / `extra_query` keep their key names but not their values.

Routed through `overParams` from #3378, so the argument-shape bypass fixed there cannot reappear and a credential in the `RequestOptions` is masked too.

Covers all nine wrapped methods, via the five config objects they share: `chatCompletionParseMetadata` (`chat.completions.create` / `.parse` / `.stream`, `beta.chat.completions.parse` / `.stream`), `completions.create`, and `responses.create` / `.parse` / `.stream`.

`server_url` stays visible, matching #3372's treatment of Anthropic's `url`. A token embedded in the URL still reaches the trace; one line in the allowlist if you'd rather be strict.

## Tests

`wrapped_openai_mcp.test.ts` asserts against the payload the SDK would upload, via the existing `mockClient()` fetch spy — no network, no API keys.

Covers: credentials masked, allowed fields survive, an unknown field masked by default, function-tool schemas untouched, masking survives a second argument, credentials in the request options masked, the caller's params unmutated, transport overrides masked, `ls_invocation_params` clean, and unexpected shapes (non-array, null entries, nested arrays, empty) not raising.
