### PR TITLE
fix: default Dockerfile snapshot capacity

### DIFF
--- a/js/src/sandbox/client.ts
+++ b/js/src/sandbox/client.ts
@@ -952,17 +952,25 @@ export class SandboxClient {
    *
    * @param name - Snapshot name.
    * @param dockerfile - Local Dockerfile path, relative to context by default.
-   * @param fsCapacityBytes - Filesystem capacity in bytes.
-   * @param options - Build context, args, target, build log callback, builder
-   *   vCPUs/memory, timeout.
+   * @param fsCapacityBytesOrOptions - Optional filesystem capacity in bytes, or
+   *   build options. When omitted, the server applies its default capacity.
+   * @param options - Build options when capacity is passed separately.
    * @returns Snapshot in "ready" status.
    */
   async createSnapshotFromDockerfile(
     name: string,
     dockerfile: string,
-    fsCapacityBytes: number,
+    fsCapacityBytesOrOptions?: number | CreateDockerfileSnapshotOptions,
     options: CreateDockerfileSnapshotOptions = {},
   ): Promise<Snapshot> {
+    const fsCapacityBytes =
+      typeof fsCapacityBytesOrOptions === "number"
+        ? fsCapacityBytesOrOptions
+        : undefined;
+    const resolvedOptions =
+      typeof fsCapacityBytesOrOptions === "number"
+        ? options
+        : (fsCapacityBytesOrOptions ?? options);
     const {
       context = ".",
       buildArgs,
@@ -971,7 +979,7 @@ export class SandboxClient {
       vCpus,
       memBytes,
       timeout = 60,
-    } = options;
+    } = resolvedOptions;
     const { contextPath, dockerfileRel } = await resolveDockerfileContext(
       dockerfile,
       context,

--- a/js/src/tests/sandbox.test.ts
+++ b/js/src/tests/sandbox.test.ts
@@ -2150,7 +2150,7 @@ describe("SandboxClient - snapshot operations", () => {
     }
   });
 
-  it("createSnapshotFromDockerfile should forward vCpus/memBytes to the builder", async () => {
+  it("createSnapshotFromDockerfile should default capacity and forward builder size", async () => {
     const context = await mkdtemp(join(tmpdir(), "langsmith-docker-context-"));
     const client = createClientWithMock(jest.fn<typeof fetch>());
     const fakeSandbox = {
@@ -2170,29 +2170,35 @@ describe("SandboxClient - snapshot operations", () => {
     const createSandboxSpy = jest
       .spyOn(client, "createSandbox")
       .mockResolvedValue(fakeSandbox as any);
-    jest.spyOn(client, "captureSnapshot").mockResolvedValue({
-      id: "snap-1",
-      name: "snap",
-      status: "ready",
-      fs_capacity_bytes: 4294967296,
-    });
+    const captureSnapshotSpy = jest
+      .spyOn(client, "captureSnapshot")
+      .mockResolvedValue({
+        id: "snap-1",
+        name: "snap",
+        status: "ready",
+        fs_capacity_bytes: 4294967296,
+      });
 
     try {
       await writeFile(join(context, "Dockerfile"), "FROM scratch\n");
 
-      await client.createSnapshotFromDockerfile(
-        "snap",
-        "Dockerfile",
-        4294967296,
-        {
-          context,
-          vCpus: 2,
-          memBytes: 8589934592,
-        },
-      );
+      await client.createSnapshotFromDockerfile("snap", "Dockerfile", {
+        context,
+        vCpus: 2,
+        memBytes: 8589934592,
+      });
 
       expect(createSandboxSpy).toHaveBeenCalledWith(
-        expect.objectContaining({ vCpus: 2, memBytes: 8589934592 }),
+        expect.objectContaining({
+          vCpus: 2,
+          memBytes: 8589934592,
+          fsCapacityBytes: undefined,
+        }),
+      );
+      expect(captureSnapshotSpy).toHaveBeenCalledWith(
+        "builder",
+        "snap",
+        expect.objectContaining({ fsCapacityBytes: undefined }),
       );
     } finally {
       await rm(context, { recursive: true, force: true });

--- a/python/langsmith/sandbox/_async_client.py
+++ b/python/langsmith/sandbox/_async_client.py
@@ -873,7 +873,7 @@ class AsyncSandboxClient:
         self,
         name: str,
         dockerfile: Union[str, os.PathLike[str]],
-        fs_capacity_bytes: int,
+        fs_capacity_bytes: Optional[int] = None,
         *,
         context: Union[str, os.PathLike[str]] = ".",
         build_args: Optional[Mapping[str, str]] = None,
@@ -886,6 +886,7 @@ class AsyncSandboxClient:
     ) -> Snapshot:
         """Build a snapshot from a local Dockerfile context.
 
+        When ``fs_capacity_bytes`` is omitted, the server applies its default.
         ``vcpus`` and ``mem_bytes`` size the temporary builder sandbox. The
         build runs BuildKit plus the native snapshotter's layer copies inside
         it, which contend for a single core by default, so giving the builder

--- a/python/langsmith/sandbox/_client.py
+++ b/python/langsmith/sandbox/_client.py
@@ -959,7 +959,7 @@ class SandboxClient:
         self,
         name: str,
         dockerfile: Union[str, os.PathLike[str]],
-        fs_capacity_bytes: int,
+        fs_capacity_bytes: Optional[int] = None,
         *,
         context: Union[str, os.PathLike[str]] = ".",
         build_args: Optional[Mapping[str, str]] = None,
@@ -972,6 +972,7 @@ class SandboxClient:
     ) -> Snapshot:
         """Build a snapshot from a local Dockerfile context.
 
+        When ``fs_capacity_bytes`` is omitted, the server applies its default.
         ``vcpus`` and ``mem_bytes`` size the temporary builder sandbox. The
         build runs BuildKit plus the native snapshotter's layer copies inside
         it, which contend for a single core by default, so giving the builder

--- a/python/tests/unit_tests/sandbox/test_async_client.py
+++ b/python/tests/unit_tests/sandbox/test_async_client.py
@@ -995,12 +995,12 @@ class TestAsyncSandboxOperations:
             snapshot = await client.create_snapshot_from_dockerfile(
                 "snap",
                 "Dockerfile",
-                4294967296,
                 context=tmp_path,
             )
 
         assert snapshot.id == "snap-1"
         sandbox_mock.assert_awaited_once()
+        assert sandbox_mock.call_args.kwargs["fs_capacity_bytes"] is None
         # Build scratch must live on the capacity-backed root filesystem, not
         # the RAM-backed /tmp tmpfs that fs_capacity_bytes does not size.
         assert len(fake_sandbox.writes) == 1
@@ -1020,7 +1020,7 @@ class TestAsyncSandboxOperations:
         assert args[0] == "builder"
         assert args[1] == "snap"
         assert kwargs["docker_image"].startswith("langsmith-snapshot-build:")
-        assert kwargs["fs_capacity_bytes"] == 4294967296
+        assert kwargs["fs_capacity_bytes"] is None
 
     async def test_create_snapshot_from_dockerfile_forwards_builder_size(
         self, client: AsyncSandboxClient, tmp_path

--- a/python/tests/unit_tests/sandbox/test_client.py
+++ b/python/tests/unit_tests/sandbox/test_client.py
@@ -1148,12 +1148,12 @@ class TestSnapshotOperations:
             snapshot = client.create_snapshot_from_dockerfile(
                 "snap",
                 "Dockerfile",
-                4294967296,
                 context=tmp_path,
             )
 
         assert snapshot.id == "snap-1"
         sandbox_mock.assert_called_once()
+        assert sandbox_mock.call_args.kwargs["fs_capacity_bytes"] is None
         # Build scratch must live on the capacity-backed root filesystem, not
         # the RAM-backed /tmp tmpfs that fs_capacity_bytes does not size.
         assert len(fake_sandbox.writes) == 1
@@ -1173,7 +1173,7 @@ class TestSnapshotOperations:
         assert args[0] == "builder"
         assert args[1] == "snap"
         assert kwargs["docker_image"].startswith("langsmith-snapshot-build:")
-        assert kwargs["fs_capacity_bytes"] == 4294967296
+        assert kwargs["fs_capacity_bytes"] is None
 
     def test_create_snapshot_from_dockerfile_forwards_builder_size(
         self, client: SandboxClient, tmp_path


### PR DESCRIPTION
## Description
Let Python and TypeScript Dockerfile snapshot helpers omit filesystem capacity so the builder uses the server default and image capture inherits it, while preserving explicit-capacity calls.

## Release Note
Dockerfile snapshot helpers now default filesystem capacity when omitted.

## Test Plan
- [x] Python sync/async sandbox unit tests (138 passed)
- [x] TypeScript sandbox tests (136 passed), type check, format, and lint

Made by [Open SWE](https://openswe.vercel.app/agents/ec45e23c-e028-7ecb-9b7f-dd0dd32e21b8)