### PR TITLE
fix(py): mask credentials in traced voice event payloads

### DIFF
--- a/python/langsmith/_internal/_redaction.py
+++ b/python/langsmith/_internal/_redaction.py
@@ -1,0 +1,71 @@
+"""Mask credentials in provider request params on the way into a trace.
+
+Helpers return new containers: the caller's objects also go to the provider API
+and must keep their real values.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Collection, Mapping
+from typing import Any, Optional
+
+from langsmith.anonymizer import SECRET_PLACEHOLDER
+
+__all__ = ["mask", "redact_outside", "redact_keys"]
+
+# Guard against cyclic payloads; request params are shallow.
+_MAX_DEPTH = 12
+
+
+def _as_mapping(value: Any) -> Optional[Mapping]:
+    """Return ``value`` as a mapping; Pydantic configs need a dump to see into."""
+    if isinstance(value, Mapping):
+        return value
+    dump = getattr(value, "model_dump", None)
+    if callable(dump):
+        try:
+            dumped = dump()
+        except Exception:
+            return None
+        return dumped if isinstance(dumped, Mapping) else None
+    return None
+
+
+def mask(value: Any) -> Any:
+    """Mask ``value``, keeping key names so a trace shows what was set."""
+    mapping = _as_mapping(value)
+    if mapping is not None:
+        return {key: SECRET_PLACEHOLDER for key in mapping}
+    return SECRET_PLACEHOLDER
+
+
+def redact_outside(entry: Any, safe_keys: Collection[str]) -> Any:
+    """Copy ``entry``, masking values outside ``safe_keys``; unknown keys fail shut."""
+    mapping = _as_mapping(entry)
+    if mapping is None:
+        return entry
+    return {
+        key: value if key in safe_keys else SECRET_PLACEHOLDER
+        for key, value in mapping.items()
+    }
+
+
+def redact_keys(value: Any, secret_keys: Collection[str], _depth: int = 0) -> Any:
+    """Recursively mask values under ``secret_keys``.
+
+    Scope to config-shaped data, never user content, where these key names are
+    legitimate.
+    """
+    if _depth > _MAX_DEPTH:
+        return SECRET_PLACEHOLDER
+    mapping = _as_mapping(value)
+    if mapping is not None:
+        return {
+            key: mask(item)
+            if key in secret_keys
+            else redact_keys(item, secret_keys, _depth + 1)
+            for key, item in mapping.items()
+        }
+    if isinstance(value, (list, tuple)):
+        return [redact_keys(item, secret_keys, _depth + 1) for item in value]
+    return value

--- a/python/langsmith/_internal/voice/helpers.py
+++ b/python/langsmith/_internal/voice/helpers.py
@@ -2,9 +2,9 @@
 
 * ``dump_event`` — best-effort conversion of an event object to a plain dict
   (Pydantic ``model_dump`` → ``dict`` → ``repr`` fallback).
-* ``scrub`` — replace raw audio ``bytes`` with a ``<N bytes>`` placeholder and
-  truncate long strings, recursing through dicts and sequences, so a span never
-  carries megabytes of audio or un-serializable junk.
+* ``scrub`` — recurse through dicts and sequences replacing raw audio ``bytes``
+  with a ``<N bytes>`` placeholder, masking credential keys and truncating long
+  strings, so a span carries no audio, live credential, or un-serializable junk.
 * ``observe_safely`` — run an adapter's per-event ``observe`` so a tracing error
   never escapes into the caller's live loop.
 """
@@ -14,6 +14,8 @@ from __future__ import annotations
 import logging
 from typing import Any, Callable
 
+from langsmith._internal._redaction import mask
+
 logger = logging.getLogger(__name__)
 
 __all__ = ["dump_event", "scrub", "observe_safely"]
@@ -21,6 +23,26 @@ __all__ = ["dump_event", "scrub", "observe_safely"]
 # Longest string kept on a span before truncating. Transcripts are short; this
 # only ever trims an unexpectedly large blob.
 MAX_STR = 2000
+
+# Credential keys wherever they appear in a provider event. Adapters pass
+# arbitrary payloads, so this is a denylist; exact match keeps `max_tokens` safe.
+SECRET_KEYS: frozenset[str] = frozenset(
+    {
+        "authorization",
+        "api_key",
+        "apiKey",
+        "headers",
+        "env",
+        "access_token",
+        "accessToken",
+        "refresh_token",
+        "refreshToken",
+        "client_secret",
+        "clientSecret",
+        "password",
+        "secret",
+    }
+)
 
 
 def observe_safely(observe: Callable[[Any], None], event: Any) -> None:
@@ -40,10 +62,8 @@ def observe_safely(observe: Callable[[Any], None], event: Any) -> None:
 def scrub(obj: Any) -> Any:
     """Make an event payload safe and compact for a span.
 
-    Replaces raw ``bytes`` (audio / base64 blobs) with a ``<N bytes>``
-    placeholder and truncates very long strings, recursing through dicts and
-    sequences, so a span never ships megabytes of payload or breaks JSON
-    serialization.
+    Replaces raw ``bytes`` with a ``<N bytes>`` placeholder, masks values under
+    :data:`SECRET_KEYS`, and truncates long strings.
     """
     if isinstance(obj, bytes):
         return f"<{len(obj)} bytes>"
@@ -52,7 +72,7 @@ def scrub(obj: Any) -> Any:
             return obj[:MAX_STR] + f"... <+{len(obj) - MAX_STR} chars>"
         return obj
     if isinstance(obj, dict):
-        return {k: scrub(v) for k, v in obj.items()}
+        return {k: mask(v) if k in SECRET_KEYS else scrub(v) for k, v in obj.items()}
     if isinstance(obj, (list, tuple)):
         return [scrub(v) for v in obj]
     return obj

--- a/python/langsmith/wrappers/_gemini.py
+++ b/python/langsmith/wrappers/_gemini.py
@@ -19,6 +19,7 @@ from langsmith import client as ls_client
 from langsmith import run_helpers
 from langsmith._internal._beta_decorator import warn_beta
 from langsmith._internal._orjson import dumps as _dumps
+from langsmith._internal._redaction import redact_keys, redact_outside
 from langsmith.schemas import InputTokenDetails, OutputTokenDetails, UsageMetadata
 
 if TYPE_CHECKING:
@@ -50,7 +51,83 @@ def _to_dict(obj: Any) -> Any:
     return obj
 
 
+# Credential keys anywhere inside a google-genai `config`: `Tool` is a union of a
+# dozen variants, so secrets sit at many paths rather than one.
+_CONFIG_SECRET_KEYS: frozenset[str] = frozenset(
+    {
+        "headers",
+        "api_key",
+        "apiKey",
+        "auth_config",
+        "authConfig",
+        "api_auth",
+        "apiAuth",
+        "client_args",
+        "clientArgs",
+        "async_client_args",
+        "asyncClientArgs",
+        "extra_body",
+        "extraBody",
+        "access_token",
+        "accessToken",
+    }
+)
+
+# Keys of google-genai's `StreamableHttpTransport` that are safe to trace.
+_MCP_TRANSPORT_SAFE_KEYS: frozenset[str] = frozenset(
+    {"url", "timeout", "sse_read_timeout", "terminate_on_close"}
+)
+
+
+def _redact_mcp_transports(config: Any) -> Any:
+    """Allowlist the MCP transport, so a credential added to it later fails shut.
+
+    Runs after `redact_keys`, which has already normalized models to dicts.
+    """
+    if not isinstance(config, Mapping):
+        return config
+    tools = config.get("tools")
+    if not isinstance(tools, list):
+        return config
+
+    def redact_server(server: Any) -> Any:
+        if not isinstance(server, Mapping):
+            return server
+        transport = server.get("streamable_http_transport")
+        if transport is None:
+            return server
+        return {
+            **server,
+            "streamable_http_transport": redact_outside(
+                transport, _MCP_TRANSPORT_SAFE_KEYS
+            ),
+        }
+
+    def redact_tool(tool: Any) -> Any:
+        if not isinstance(tool, Mapping):
+            return tool
+        servers = tool.get("mcp_servers")
+        if not isinstance(servers, list):
+            return tool
+        return {**tool, "mcp_servers": [redact_server(s) for s in servers]}
+
+    return {**config, "tools": [redact_tool(t) for t in tools]}
+
+
+def _redact_config(inputs: dict) -> dict:
+    """Mask credentials in the caller's `config`. Returns a new dict."""
+    if inputs.get("config") is None:
+        return inputs
+    config = redact_keys(inputs["config"], _CONFIG_SECRET_KEYS)
+    return {**inputs, "config": _redact_mcp_transports(config)}
+
+
 def _process_gemini_inputs(inputs: dict) -> dict:
+    """Normalize Gemini inputs for tracing, with credentials masked."""
+    return _redact_config(_normalize_gemini_inputs(inputs))
+
+
+def _normalize_gemini_inputs(inputs: dict) -> dict:
     r"""Process Gemini inputs to normalize them for LangSmith tracing.
 
     Example:

--- a/python/langsmith/wrappers/_openai.py
+++ b/python/langsmith/wrappers/_openai.py
@@ -18,6 +18,7 @@ from typing_extensions import TypedDict
 from langsmith import client as ls_client
 from langsmith import run_helpers
 from langsmith._internal._ls_agent_type import apply_default_ls_agent_type
+from langsmith._internal._redaction import mask, redact_outside
 
 # ``_create_usage_metadata`` lives in a non-deprecated internal module so
 # integrations can reuse it without importing the ``wrappers`` package (whose
@@ -69,9 +70,54 @@ def _strip_not_given(d: dict) -> dict:
         return d
 
 
+# Keys of `openai.types.responses.tool_param.Mcp` that are safe to trace.
+_MCP_TOOL_SAFE_KEYS: frozenset[str] = frozenset(
+    {
+        "type",
+        "server_label",
+        "server_description",
+        "server_url",
+        "connector_id",
+        "tunnel_id",
+        "require_approval",
+        "allowed_tools",
+        "allowed_callers",
+        "defer_loading",
+    }
+)
+
+# Per-request transport overrides: credentials by construction.
+_TRANSPORT_SECRET_KEYS = ("extra_headers", "extra_body", "extra_query")
+
+
+def _redact_tools(tools: Any) -> Any:
+    """Mask hosted MCP entries; function tools carry the caller's schema."""
+    if not isinstance(tools, (list, tuple)):
+        return tools
+
+    redacted: list[Any] = []
+    for tool in tools:
+        if isinstance(tool, Mapping) and tool.get("type") == "mcp":
+            tool = redact_outside(tool, _MCP_TOOL_SAFE_KEYS)
+        redacted.append(tool)
+    return redacted
+
+
+def _redact_secrets(d: dict) -> dict:
+    """Mask credential-bearing request params. Returns a new dict."""
+    redacted = dict(d)
+    if "tools" in redacted:
+        redacted["tools"] = _redact_tools(redacted["tools"])
+    for key in _TRANSPORT_SECRET_KEYS:
+        if redacted.get(key) is not None:
+            redacted[key] = mask(redacted[key])
+    return redacted
+
+
 def _process_inputs(d: dict) -> dict:
-    """Strip `NotGiven` values and serialize `text_format` to JSON schema."""
+    """Strip `NotGiven` values, mask credentials, serialize `text_format`."""
     d = _strip_not_given(d)
+    d = _redact_secrets(d)
 
     # Convert text_format (Pydantic model) to JSON schema if present
     if "text_format" in d:

--- a/python/tests/unit_tests/wrappers/test_gemini_processing.py
+++ b/python/tests/unit_tests/wrappers/test_gemini_processing.py
@@ -1,6 +1,10 @@
 """Unit tests for Gemini wrapper processing functions."""
 
+import pytest
+
+from langsmith.anonymizer import SECRET_PLACEHOLDER
 from langsmith.wrappers._gemini import (
+    _convert_config_for_tracing,
     _create_usage_metadata,
     _infer_invocation_params,
     _process_gemini_inputs,
@@ -735,3 +739,230 @@ class TestProcessGeminiInputsWithObjects:
         result = _process_gemini_inputs(inputs)
 
         assert result["messages"][0]["content"] == "from part object"
+
+
+# ---------------------------------------------------------------------------
+# credential masking
+# ---------------------------------------------------------------------------
+
+FAKE_TOKEN = "fake-token-for-tests-only"
+
+
+def _auth_headers() -> dict:
+    return {"Authorization": f"Bearer {FAKE_TOKEN}"}
+
+
+class TestRedactConfigCredentials:
+    """google-genai `config` carries credentials in several subtrees."""
+
+    def test_masks_http_options_headers(self) -> None:
+        result = _process_gemini_inputs(
+            {
+                "contents": "hi",
+                "model": "gemini-2.5-flash",
+                "config": {"http_options": {"headers": _auth_headers()}},
+            }
+        )
+
+        assert FAKE_TOKEN not in str(result)
+        assert result["config"]["http_options"]["headers"] == {
+            "Authorization": SECRET_PLACEHOLDER
+        }
+
+    @pytest.mark.parametrize("key", ["client_args", "async_client_args", "extra_body"])
+    def test_masks_other_http_options_secrets(self, key) -> None:
+        result = _process_gemini_inputs(
+            {
+                "contents": "hi",
+                "config": {"http_options": {key: {"auth": FAKE_TOKEN}}},
+            }
+        )
+
+        assert FAKE_TOKEN not in str(result)
+
+    def test_masks_mcp_server_transport_headers(self) -> None:
+        """Remote MCP servers authenticate with a bearer token in the transport."""
+        result = _process_gemini_inputs(
+            {
+                "contents": "hi",
+                "config": {
+                    "tools": [
+                        {
+                            "mcp_servers": [
+                                {
+                                    "name": "example",
+                                    "streamable_http_transport": {
+                                        "url": "https://mcp.example.com/mcp",
+                                        "headers": _auth_headers(),
+                                    },
+                                }
+                            ]
+                        }
+                    ]
+                },
+            }
+        )
+
+        assert FAKE_TOKEN not in str(result)
+        transport = result["config"]["tools"][0]["mcp_servers"][0][
+            "streamable_http_transport"
+        ]
+        assert transport["headers"] == SECRET_PLACEHOLDER
+        assert transport["url"] == "https://mcp.example.com/mcp"
+
+    def test_masks_transport_fields_that_are_not_allowed(self) -> None:
+        """A credential field added to the transport later is masked."""
+        result = _process_gemini_inputs(
+            {
+                "contents": "hi",
+                "config": {
+                    "tools": [
+                        {
+                            "mcp_servers": [
+                                {
+                                    "streamable_http_transport": {
+                                        "url": "u",
+                                        "future_secret": "s3cret",
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+            }
+        )
+
+        transport = result["config"]["tools"][0]["mcp_servers"][0][
+            "streamable_http_transport"
+        ]
+        assert transport["future_secret"] == SECRET_PLACEHOLDER
+        assert transport["url"] == "u"
+
+    def test_masks_google_maps_auth_config(self) -> None:
+        result = _process_gemini_inputs(
+            {
+                "contents": "hi",
+                "config": {
+                    "tools": [{"google_maps": {"auth_config": {"api_key": FAKE_TOKEN}}}]
+                },
+            }
+        )
+
+        assert FAKE_TOKEN not in str(result)
+
+    def test_masks_retrieval_api_auth(self) -> None:
+        result = _process_gemini_inputs(
+            {
+                "contents": "hi",
+                "config": {
+                    "tools": [
+                        {
+                            "retrieval": {
+                                "external_api": {
+                                    "api_auth": {
+                                        "api_key_config": {"api_key_string": FAKE_TOKEN}
+                                    }
+                                }
+                            }
+                        }
+                    ]
+                },
+            }
+        )
+
+        assert FAKE_TOKEN not in str(result)
+
+    def test_does_not_mutate_the_callers_config(self) -> None:
+        """The same config is sent to Gemini, so it keeps the real values."""
+        headers = _auth_headers()
+        config = {"http_options": {"headers": headers}}
+
+        _process_gemini_inputs({"contents": "hi", "config": config})
+
+        assert headers["Authorization"] == f"Bearer {FAKE_TOKEN}"
+        assert config["http_options"]["headers"] is headers
+
+    def test_leaves_non_secret_config_untouched(self) -> None:
+        config = {"temperature": 0.5, "max_output_tokens": 100, "top_k": 4}
+
+        result = _process_gemini_inputs({"contents": "hi", "config": config})
+
+        assert result["config"] == config
+
+    def test_does_not_walk_user_content(self) -> None:
+        """`contents` is user data; a key named `headers` there is not a secret."""
+        contents = [
+            {
+                "role": "user",
+                "parts": [{"text": "call it with headers: {'api_key': 'abc'}"}],
+            }
+        ]
+
+        result = _process_gemini_inputs({"contents": contents, "model": "m"})
+
+        assert "abc" in str(result["messages"])
+
+    def test_masks_when_contents_is_absent(self) -> None:
+        """The early-return path must redact too."""
+        result = _process_gemini_inputs(
+            {"config": {"http_options": {"headers": _auth_headers()}}}
+        )
+
+        assert FAKE_TOKEN not in str(result)
+
+    @pytest.mark.parametrize("config", [None, "not-a-mapping", 42])
+    def test_tolerates_unexpected_config_shapes(self, config) -> None:
+        result = _process_gemini_inputs({"contents": "hi", "config": config})
+
+        assert result["config"] == config
+
+    def test_tolerates_unexpected_tool_shapes(self) -> None:
+        config = {"tools": "not-a-list"}
+
+        result = _process_gemini_inputs({"contents": "hi", "config": config})
+
+        assert result["config"]["tools"] == "not-a-list"
+
+    def test_masks_credentials_on_real_pydantic_config_objects(self) -> None:
+        """The wrapper receives model instances, not dicts, in normal use.
+
+        `google.genai` is imported lazily to keep it out of this module's imports.
+        """
+        types = pytest.importorskip("google.genai").types
+
+        config = types.GenerateContentConfig(
+            temperature=0.5,
+            http_options=types.HttpOptions(headers=_auth_headers()),
+            tools=[
+                types.Tool(
+                    mcp_servers=[
+                        types.McpServer(
+                            name="example",
+                            streamable_http_transport=(
+                                types.StreamableHttpTransport(
+                                    url="https://mcp.example.com/mcp",
+                                    headers=_auth_headers(),
+                                )
+                            ),
+                        )
+                    ]
+                )
+            ],
+        )
+        kwargs = {"model": "m", "contents": "hi", "config": config}
+        _convert_config_for_tracing(kwargs)
+
+        result = _process_gemini_inputs(kwargs)
+
+        assert FAKE_TOKEN not in str(result)
+        assert result["config"]["temperature"] == 0.5
+        transport = result["config"]["tools"][0]["mcp_servers"][0][
+            "streamable_http_transport"
+        ]
+        assert transport["url"] == "https://mcp.example.com/mcp"
+        # The caller's config still goes to the API and keeps its real values.
+        assert config.http_options.headers == _auth_headers()
+        assert (
+            config.tools[0].mcp_servers[0].streamable_http_transport.headers
+            == _auth_headers()
+        )

--- a/python/tests/unit_tests/wrappers/test_openai_processing.py
+++ b/python/tests/unit_tests/wrappers/test_openai_processing.py
@@ -5,8 +5,10 @@ from types import SimpleNamespace
 import pytest
 
 from langsmith import run_helpers
+from langsmith.anonymizer import SECRET_PLACEHOLDER
 from langsmith.wrappers._openai import (
     _infer_invocation_params,
+    _process_inputs,
     _traceable_kwargs_with_ls_agent_type,
 )
 
@@ -187,3 +189,112 @@ def test_nested_none_opt_out_overrides_propagated_tag():
     )
     assert "ls_agent_type" in result["child_metadata"]
     assert result["child_metadata"]["ls_agent_type"] is None
+
+
+# ---------------------------------------------------------------------------
+# credential masking
+# ---------------------------------------------------------------------------
+
+FAKE_TOKEN = "fake-token-for-tests-only"
+
+
+def _mcp_tools(**extra) -> list:
+    return [
+        {
+            "type": "mcp",
+            "server_label": "example",
+            "server_url": "https://mcp.example.com/sse",
+            "authorization": FAKE_TOKEN,
+            "headers": {"Authorization": f"Bearer {FAKE_TOKEN}"},
+            **extra,
+        }
+    ]
+
+
+class TestRedactHostedMCPTools:
+    """Responses API `tools` may carry a bearer credential and auth headers."""
+
+    def test_process_inputs_masks_authorization_and_headers(self) -> None:
+        tool = _process_inputs({"model": "gpt-5", "tools": _mcp_tools()})["tools"][0]
+
+        assert tool["authorization"] == SECRET_PLACEHOLDER
+        assert tool["headers"] == SECRET_PLACEHOLDER
+        assert tool["type"] == "mcp"
+        assert tool["server_label"] == "example"
+        assert tool["server_url"] == "https://mcp.example.com/sse"
+
+    def test_infer_invocation_params_never_carries_the_token(self) -> None:
+        """Guards against building invocation params from the raw kwargs."""
+        params = _infer_invocation_params(
+            "chat", "openai", {}, True, {"model": "gpt-5", "tools": _mcp_tools()}
+        )
+
+        assert FAKE_TOKEN not in str(params)
+
+    def test_does_not_mutate_the_callers_tools(self) -> None:
+        """The same objects are sent to OpenAI, so they keep the real token."""
+        tools = _mcp_tools()
+        kwargs = {"model": "gpt-5", "tools": tools}
+
+        _process_inputs(kwargs)
+        _infer_invocation_params("chat", "openai", {}, True, kwargs)
+
+        assert tools[0]["authorization"] == FAKE_TOKEN
+        assert tools[0]["headers"] == {"Authorization": f"Bearer {FAKE_TOKEN}"}
+
+    def test_masks_fields_that_are_not_explicitly_allowed(self) -> None:
+        """A credential field added to the API later is masked by default."""
+        tool = _process_inputs({"tools": _mcp_tools(future_secret="s3cret")})["tools"][
+            0
+        ]
+
+        assert tool["future_secret"] == SECRET_PLACEHOLDER
+
+    def test_function_tools_keep_their_schema(self) -> None:
+        tools = [
+            {
+                "type": "function",
+                "name": "get_weather",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"city": {"type": "string"}},
+                },
+            }
+        ]
+
+        assert _process_inputs({"tools": tools})["tools"] == tools
+
+    @pytest.mark.parametrize(
+        ("tools", "expected"),
+        [
+            ("not-a-list", "not-a-list"),
+            ([None], [None]),
+            ([["nested"]], [["nested"]]),
+            ([], []),
+            ((), []),  # tuples are normalized to lists
+        ],
+    )
+    def test_tolerates_unexpected_shapes(self, tools, expected) -> None:
+        assert _process_inputs({"tools": tools})["tools"] == expected
+
+
+class TestRedactTransportOverrides:
+    """`extra_*` are credentials by construction; only key names survive."""
+
+    @pytest.mark.parametrize("key", ["extra_headers", "extra_body", "extra_query"])
+    def test_masks_values_but_keeps_key_names(self, key) -> None:
+        result = _process_inputs({key: {"Authorization": f"Bearer {FAKE_TOKEN}"}})
+
+        assert result[key] == {"Authorization": SECRET_PLACEHOLDER}
+
+    def test_does_not_mutate_the_callers_headers(self) -> None:
+        headers = {"Authorization": f"Bearer {FAKE_TOKEN}"}
+        kwargs = {"model": "gpt-5", "extra_headers": headers}
+
+        _process_inputs(kwargs)
+
+        assert headers["Authorization"] == f"Bearer {FAKE_TOKEN}"
+        assert kwargs["extra_headers"] is headers
+
+    def test_unset_overrides_are_left_alone(self) -> None:
+        assert _process_inputs({"model": "gpt-5"}) == {"model": "gpt-5"}

--- a/python/tests/unit_tests/wrappers/test_voice_helpers.py
+++ b/python/tests/unit_tests/wrappers/test_voice_helpers.py
@@ -9,9 +9,12 @@ import io
 import wave
 from unittest.mock import MagicMock
 
+import pytest
+
 from langsmith._internal._package_version import get_package_version
 from langsmith._internal.voice import audio as audio_utils
 from langsmith._internal.voice import helpers
+from langsmith.anonymizer import SECRET_PLACEHOLDER
 
 
 class TestVoiceAudio:
@@ -51,6 +54,67 @@ class TestVoiceHelpers:
             "a": "<2 bytes>",
             "b": ["<1 bytes>"],
         }
+
+    def test_scrub_masks_realtime_session_tool_credentials(self):
+        """Hosted MCP tools in a session carry a bearer token and auth headers."""
+        token = "fake-token-for-tests-only"
+        event = {
+            "type": "session.updated",
+            "session": {
+                "model": "gpt-realtime",
+                "tools": [
+                    {
+                        "type": "mcp",
+                        "server_label": "example",
+                        "server_url": "https://mcp.example.com/sse",
+                        "authorization": token,
+                        "headers": {"Authorization": f"Bearer {token}"},
+                    }
+                ],
+            },
+        }
+
+        scrubbed = helpers.scrub(event)
+
+        assert token not in str(scrubbed)
+        tool = scrubbed["session"]["tools"][0]
+        assert tool["authorization"] == SECRET_PLACEHOLDER
+        assert tool["headers"] == {"Authorization": SECRET_PLACEHOLDER}
+        assert tool["server_label"] == "example"
+        assert scrubbed["session"]["model"] == "gpt-realtime"
+
+    @pytest.mark.parametrize(
+        "key",
+        ["authorization", "api_key", "headers", "env", "access_token", "password"],
+    )
+    def test_scrub_masks_credential_keys(self, key):
+        assert helpers.scrub({key: "s3cret"}) == {key: SECRET_PLACEHOLDER}
+
+    def test_scrub_keeps_mapping_key_names_when_masking(self):
+        scrubbed = helpers.scrub({"env": {"ANTHROPIC_API_KEY": "s3cret"}})
+
+        assert scrubbed == {"env": {"ANTHROPIC_API_KEY": SECRET_PLACEHOLDER}}
+
+    @pytest.mark.parametrize(
+        "key", ["max_tokens", "token_count", "input_tokens", "top_logprobs"]
+    )
+    def test_scrub_leaves_lookalike_keys_alone(self, key):
+        """Matching is on exact keys, so `token` substrings survive."""
+        assert helpers.scrub({key: 128}) == {key: 128}
+
+    def test_scrub_masks_inside_lists(self):
+        event = {"items": [{"headers": {"Authorization": "s3cret"}}]}
+
+        assert helpers.scrub(event) == {
+            "items": [{"headers": {"Authorization": SECRET_PLACEHOLDER}}]
+        }
+
+    def test_scrub_does_not_mutate_the_caller(self):
+        event = {"session": {"authorization": "s3cret"}}
+
+        helpers.scrub(event)
+
+        assert event["session"]["authorization"] == "s3cret"
 
     def test_dump_event_variants(self):
         model = MagicMock()


### PR DESCRIPTION
Stacked on #3382. Completes the Python stream.

## What & why

`EventSession.event_span` writes the scrubbed provider event straight into a span's I/O when the adapter supplies no curated payload:

```python
run.end(outputs={} if inbound else payload)
```

OpenAI Realtime `session.created` and `session.updated` take that path — `_connection.py` spans every readable event, and `_span_kwargs` curates only transcription and `response.done`. So the entire session object, including `session.tools[].authorization` and `session.tools[].headers` on hosted MCP tools, is uploaded verbatim as `run.outputs`.

`scrub` is the only sanitizer in that path, and it only replaces `bytes` and truncates long strings.

## Fix

`scrub` now masks values under a set of keys that are credentials by construction. It is the shared sink for every voice adapter, so one change covers **OpenAI Realtime, Pipecat, and Google ADK Live**.

A denylist rather than an allowlist, deliberately: adapters hand `scrub` arbitrary provider payloads, so unlike the Anthropic/OpenAI/Gemini MCP containers there is no shape to allowlist against. Matching is on **exact** key names — a substring rule on `token` would eat `max_tokens`, `token_count`, `input_tokens`, `top_logprobs`. A test pins that.

Mapping key names are preserved when masking, so a trace still shows *what* was set:

```python
{"env": {"ANTHROPIC_API_KEY": "[SECRET_DETECTED]"}}
```

## Not covered — filing separately

In `integrations/openai_realtime/_session.py`, `_clean` bails to `_shallow` at `_MAX_DEPTH`, and `_shallow` returns a truncated `repr()`. A credential nested past that depth reaches the trace as text inside that string, which `scrub` cannot see into. That is the medium-severity `handoff` / `tool_approval_required` finding from the audit; it needs its own change at the repr boundary.

## Tests

Realtime `session.updated` carrying a hosted MCP tool: token absent from the scrubbed payload, `authorization` and `headers` masked, `server_label` and `model` preserved.

Plus: each credential key masked, mapping key names kept, lookalike keys untouched, masking inside lists, and the caller's event left unmutated.

## Reproducing locally

A set `LANGSMITH_ENDPOINT` or `OTEL_EXPORTER_OTLP_HEADERS` makes ~20 unrelated tests fail in `test_utils.py` / `test_run_helpers.py` / `test_otel_exporter.py` — they patch the `LANGCHAIN_*` equivalents, which the `LANGSMITH_*` names take precedence over. Unrelated to this PR.
