### PR TITLE
fix(js): mask credentials in the Gemini wrapper config

### DIFF
--- a/js/src/tests/wrapped_gemini_config.test.ts
+++ b/js/src/tests/wrapped_gemini_config.test.ts
@@ -1,0 +1,316 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { wrapGemini } from "../wrappers/gemini.js";
+import { SECRET_PLACEHOLDER } from "../anonymizer/index.js";
+import { mockClient } from "./utils/mock_client.js";
+
+const FAKE_TOKEN = "fake-token-for-tests-only";
+
+const authHeaders = () => ({ Authorization: `Bearer ${FAKE_TOKEN}` });
+
+function parseRequestBody(body: any) {
+  // eslint-disable-next-line no-instanceof/no-instanceof
+  return body instanceof Uint8Array
+    ? JSON.parse(new TextDecoder().decode(body))
+    : JSON.parse(body);
+}
+
+/** Stub provider, so input processing runs without a network call. */
+function stubGemini(): any {
+  const response = {
+    candidates: [{ content: { role: "model", parts: [{ text: "hi" }] } }],
+    usageMetadata: { promptTokenCount: 1, candidatesTokenCount: 1 },
+  };
+  return {
+    models: {
+      generateContent: async () => response,
+      generateContentStream: async () => response,
+    },
+  };
+}
+
+/** The runs the SDK would have uploaded. */
+function uploadedRuns(callSpy: any): any[] {
+  return (callSpy.mock.calls as any[])
+    .map(([, init]: any) => {
+      try {
+        return parseRequestBody(init?.body);
+      } catch {
+        return undefined;
+      }
+    })
+    .filter(Boolean)
+    .flatMap((body: any) => body?.post ?? body?.patch ?? [body])
+    .filter((run: any) => run?.inputs);
+}
+
+async function traceGenerate(params: Record<string, unknown>) {
+  const { client, callSpy } = mockClient();
+  const patched: any = wrapGemini(stubGemini(), {
+    client,
+    tracingEnabled: true,
+  });
+
+  await patched.models.generateContent({
+    model: "gemini-2.5-flash",
+    contents: "hi",
+    ...params,
+  });
+
+  const runs = uploadedRuns(callSpy);
+  return { runs, wire: JSON.stringify(runs) };
+}
+
+describe("config credentials are masked before tracing", () => {
+  test("httpOptions credentials never reach the uploaded run", async () => {
+    const { runs, wire } = await traceGenerate({
+      config: {
+        temperature: 0.5,
+        httpOptions: {
+          headers: authHeaders(),
+          baseUrl: "https://generativelanguage.googleapis.com",
+          timeout: 30,
+        },
+      },
+    });
+
+    expect(wire).not.toContain(FAKE_TOKEN);
+    const httpOptions = runs[0].inputs.config.httpOptions;
+    expect(httpOptions.headers).toBe(SECRET_PLACEHOLDER);
+    expect(httpOptions.baseUrl).toBe(
+      "https://generativelanguage.googleapis.com",
+    );
+    expect(httpOptions.timeout).toBe(30);
+    expect(runs[0].inputs.config.temperature).toBe(0.5);
+  });
+
+  test("httpOptions fields that are not explicitly allowed are masked", async () => {
+    const { runs } = await traceGenerate({
+      config: { httpOptions: { futureSecret: "s3cret" } },
+    });
+
+    expect(runs[0].inputs.config.httpOptions.futureSecret).toBe(
+      SECRET_PLACEHOLDER,
+    );
+  });
+
+  test("MCP server transport headers are masked, url survives", async () => {
+    const { runs, wire } = await traceGenerate({
+      config: {
+        tools: [
+          {
+            mcpServers: [
+              {
+                name: "example",
+                streamableHttpTransport: {
+                  url: "https://mcp.example.com/mcp",
+                  headers: authHeaders(),
+                },
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    expect(wire).not.toContain(FAKE_TOKEN);
+    const transport =
+      runs[0].inputs.config.tools[0].mcpServers[0].streamableHttpTransport;
+    expect(transport.headers).toBe(SECRET_PLACEHOLDER);
+    expect(transport.url).toBe("https://mcp.example.com/mcp");
+  });
+
+  test("transport fields that are not explicitly allowed are masked", async () => {
+    const { runs } = await traceGenerate({
+      config: {
+        tools: [
+          {
+            mcpServers: [
+              {
+                streamableHttpTransport: { url: "u", futureSecret: "s3cret" },
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    const transport =
+      runs[0].inputs.config.tools[0].mcpServers[0].streamableHttpTransport;
+    expect(transport.futureSecret).toBe(SECRET_PLACEHOLDER);
+    expect(transport.url).toBe("u");
+  });
+
+  test("googleMaps authConfig is masked", async () => {
+    const { runs, wire } = await traceGenerate({
+      config: {
+        tools: [
+          {
+            googleMaps: {
+              authConfig: { apiKeyConfig: { apiKeyString: FAKE_TOKEN } },
+              enableWidget: true,
+            },
+          },
+        ],
+      },
+    });
+
+    expect(wire).not.toContain(FAKE_TOKEN);
+    const googleMaps = runs[0].inputs.config.tools[0].googleMaps;
+    expect(googleMaps.authConfig).toEqual({
+      apiKeyConfig: SECRET_PLACEHOLDER,
+    });
+    expect(googleMaps.enableWidget).toBe(true);
+  });
+
+  test.each(["apiAuth", "authConfig"])(
+    "retrieval %s is masked",
+    async (key) => {
+      const { runs, wire } = await traceGenerate({
+        config: {
+          tools: [
+            {
+              retrieval: {
+                externalApi: {
+                  [key]: { apiKeyConfig: { apiKeyString: FAKE_TOKEN } },
+                  apiSpec: "SIMPLE_SEARCH",
+                },
+              },
+            },
+          ],
+        },
+      });
+
+      expect(wire).not.toContain(FAKE_TOKEN);
+      const externalApi = runs[0].inputs.config.tools[0].retrieval.externalApi;
+      expect(externalApi[key]).toEqual({ apiKeyConfig: SECRET_PLACEHOLDER });
+      expect(externalApi.apiSpec).toBe("SIMPLE_SEARCH");
+    },
+  );
+
+  test.each(["exaAiSearch", "parallelAiSearch"])(
+    "%s apiKey is masked",
+    async (tool) => {
+      const { runs, wire } = await traceGenerate({
+        config: {
+          tools: [{ [tool]: { apiKey: FAKE_TOKEN, customConfigs: { a: 1 } } }],
+        },
+      });
+
+      expect(wire).not.toContain(FAKE_TOKEN);
+      expect(runs[0].inputs.config.tools[0][tool].apiKey).toBe(
+        SECRET_PLACEHOLDER,
+      );
+      expect(runs[0].inputs.config.tools[0][tool].customConfigs).toEqual({
+        a: 1,
+      });
+    },
+  );
+
+  test("functionDeclarations schemas are left intact", async () => {
+    const tools = [
+      {
+        functionDeclarations: [
+          {
+            name: "send_request",
+            parameters: {
+              type: "object",
+              properties: {
+                url: { type: "string" },
+                headers: { type: "object" },
+                apiKey: { type: "string" },
+              },
+            },
+          },
+        ],
+      },
+    ];
+
+    const { runs } = await traceGenerate({ config: { tools } });
+
+    expect(runs[0].inputs.config.tools).toEqual(tools);
+  });
+
+  test.each(["responseSchema", "responseJsonSchema"])(
+    "%s is left intact",
+    async (key) => {
+      const schema = {
+        type: "object",
+        properties: { headers: { type: "object" } },
+      };
+
+      const { runs } = await traceGenerate({ config: { [key]: schema } });
+
+      expect(runs[0].inputs.config[key]).toEqual(schema);
+    },
+  );
+
+  test("unknown tool variants are left intact", async () => {
+    const tools = [
+      { futureTool: { headers: { type: "object" }, apiKey: "shape" } },
+    ];
+
+    const { runs } = await traceGenerate({ config: { tools } });
+
+    expect(runs[0].inputs.config.tools).toEqual(tools);
+  });
+
+  test("the caller's config is left intact for the API call", async () => {
+    const headers = authHeaders();
+    const config = { httpOptions: { headers } };
+
+    await traceGenerate({ config });
+
+    expect(headers.Authorization).toBe(`Bearer ${FAKE_TOKEN}`);
+    expect(config.httpOptions.headers).toBe(headers);
+  });
+
+  test("non-secret config is preserved", async () => {
+    const config = { temperature: 0.5, maxOutputTokens: 100, topK: 4 };
+    const { runs } = await traceGenerate({ config });
+
+    expect(runs[0].inputs.config).toEqual(config);
+  });
+
+  test("user content is not walked", async () => {
+    const { wire } = await traceGenerate({
+      contents: [
+        {
+          role: "user",
+          parts: [{ text: "call it with headers: {'apiKey': 'abc'}" }],
+        },
+      ],
+    });
+
+    expect(wire).toContain("abc");
+  });
+
+  test.each([
+    ["null", null],
+    ["a string", "not-an-object"],
+    ["a number", 42],
+  ])("tolerates a config that is %s", async (_label, config) => {
+    const { runs } = await traceGenerate({ config });
+
+    if (config == null) {
+      expect(runs[0].inputs.config ?? null).toBeNull();
+    } else {
+      expect(runs[0].inputs.config).toEqual(config);
+    }
+  });
+
+  test("tolerates a non-array tools value", async () => {
+    const { runs } = await traceGenerate({ config: { tools: "not-an-array" } });
+
+    expect(runs[0].inputs.config.tools).toBe("not-an-array");
+  });
+});
+
+describe("invocation params metadata stays clean", () => {
+  test("config is not copied into ls_invocation_params", async () => {
+    const { runs } = await traceGenerate({
+      config: { httpOptions: { headers: authHeaders() } },
+    });
+
+    expect(JSON.stringify(runs[0].extra.metadata)).not.toContain(FAKE_TOKEN);
+  });
+});

--- a/js/src/wrappers/gemini.ts
+++ b/js/src/wrappers/gemini.ts
@@ -5,6 +5,7 @@ import {
   type TraceableConfig,
 } from "../traceable.js";
 import { KVMap, InvocationParamsSchema } from "../schemas.js";
+import { mask, overParams, redactOutside } from "../utils/redaction.js";
 import type {
   Content,
   GenerateContentParameters,
@@ -169,7 +170,98 @@ const chatAggregator = (input: unknown): KVMap => {
   return result;
 };
 
+/** Keys of `@google/genai`'s `HttpOptions` that are safe to trace. */
+const HTTP_OPTIONS_SAFE_KEYS: ReadonlySet<string> = new Set([
+  "baseUrl",
+  "baseUrlResourceScope",
+  "apiVersion",
+  "timeout",
+  "retryOptions",
+]);
+
+/** Keys of `@google/genai`'s `StreamableHttpTransport` that are safe to trace. */
+const MCP_TRANSPORT_SAFE_KEYS: ReadonlySet<string> = new Set([
+  "url",
+  "timeout",
+  "sseReadTimeout",
+  "terminateOnClose",
+]);
+
+/**
+ * Credential-bearing paths inside a `Tool`, masked outright. Enumerated from the
+ * google-genai type graph; the Python twin has a test that fails if a release
+ * adds one that is not listed. Paths absent from the installed version are
+ * simply skipped, so listing one early is harmless.
+ */
+const TOOL_SECRET_PATHS: ReadonlyArray<readonly string[]> = [
+  ["exaAiSearch", "apiKey"],
+  ["googleMaps", "authConfig"],
+  ["parallelAiSearch", "apiKey"],
+  ["retrieval", "externalApi", "apiAuth"], // deprecated by `authConfig`
+  ["retrieval", "externalApi", "authConfig"],
+];
+
+/** Copy `obj` with the value at `path` masked; unchanged if absent. */
+function maskPath(obj: unknown, path: readonly string[]): unknown {
+  const [key, ...rest] = path;
+  const value = (obj as KVMap)?.[key];
+  if (value == null) return obj;
+  return {
+    ...(obj as KVMap),
+    [key]: rest.length > 0 ? maskPath(value, rest) : mask(value),
+  };
+}
+
+/** Allowlist the MCP transport, so a credential added to it later fails closed. */
+function redactMcpServer(server: unknown): unknown {
+  const transport = (server as KVMap)?.streamableHttpTransport;
+  if (transport == null) return server;
+  return {
+    ...(server as KVMap),
+    streamableHttpTransport: redactOutside(transport, MCP_TRANSPORT_SAFE_KEYS),
+  };
+}
+
+/**
+ * Mask only the credential-bearing subtrees of one `Tool`.
+ *
+ * Untouched subtrees are never walked, so a caller's `functionDeclarations`
+ * schema — which may legitimately declare a property named `headers` — and any
+ * variant `@google/genai` adds later reach the trace intact.
+ */
+function redactTool(tool: unknown): unknown {
+  let redacted = tool;
+  for (const path of TOOL_SECRET_PATHS) redacted = maskPath(redacted, path);
+  const servers = (redacted as KVMap)?.mcpServers;
+  if (!Array.isArray(servers)) return redacted;
+  return { ...(redacted as KVMap), mcpServers: servers.map(redactMcpServer) };
+}
+
+/** Mask the known credential sites in the caller's `config`. Returns a new object. */
+function redactGeminiConfig(inputs: KVMap): KVMap {
+  const config = inputs?.config as KVMap | undefined;
+  if (config == null || typeof config !== "object") return inputs;
+
+  const redacted: KVMap = { ...config };
+  if (redacted.httpOptions != null) {
+    redacted.httpOptions = redactOutside(
+      redacted.httpOptions,
+      HTTP_OPTIONS_SAFE_KEYS,
+    );
+  }
+  if (Array.isArray(redacted.tools)) {
+    redacted.tools = redacted.tools.map(redactTool);
+  }
+  return { ...inputs, config: redacted };
+}
+
 function processGeminiInputs(inputs: KVMap): KVMap {
+  return overParams(inputs, (params) =>
+    redactGeminiConfig(normalizeGeminiInputs(params)),
+  );
+}
+
+function normalizeGeminiInputs(inputs: KVMap): KVMap {
   const { contents, ...rest } = inputs as GenerateContentParameters;
   if (!contents) return inputs;
 


### PR DESCRIPTION
Stacked on #3381. Python counterpart is #3382.

## What & why

`processGeminiInputs` destructures only `contents` and spreads everything else into the traced run inputs, so the caller's `config` is recorded verbatim. `@google/genai` accepts credentials at several sites inside it:

| Path | Credential |
|---|---|
| `config.httpOptions.headers` | `Authorization`, `x-goog-api-key` |
| `config.httpOptions.extraBody` | arbitrary |
| `config.tools[].mcpServers[].streamableHttpTransport.headers` | bearer token |
| `config.tools[].googleMaps.authConfig` | API key / OAuth token |
| `config.tools[].retrieval.externalApi.authConfig` | API key |
| `config.tools[].retrieval.externalApi.apiAuth` | API key (deprecated field) |
| `config.tools[].parallelAiSearch.apiKey` | API key |

The MCP transport headers are the `@google/genai` analogue of the Anthropic `mcp_servers[].authorization_token` bug fixed in #3372.

Two fallback branches — `contents` falsy, and `contents` neither string nor array — also return the caller's own object rather than a copy.

## Fix

Each credential site is addressed explicitly. Nothing else in `config` is walked.

- `httpOptions` → allowlist (`redactOutside`). A flat struct with known fields, so `headers` and `extraBody` are masked, and a credential field added to it later is masked by default.
- `mcpServers[].streamableHttpTransport` → allowlist, same reasoning.
- The remaining paths → masked outright.

`exaAiSearch.apiKey` is listed too. It does not exist in the pinned `@google/genai` 2.10.0 but does in the Python SDK; an absent path is skipped, so listing it early is harmless.

An earlier revision of this PR walked the whole `config` with a recursive denylist of credential key names. That was wrong: `config` also holds user-authored JSON schemas in `tools[].functionDeclarations[].parameters`, `responseSchema` and `responseJsonSchema`, and a declared parameter may legitimately be named `headers` or `apiKey`. The walk rewrote those schema nodes to `{"type": "[SECRET_DETECTED]"}` — not merely redacting the trace but corrupting it into a schema claiming a type that does not exist. Caught by @open-swe on the Python twin, #3382.

Addressing only the known sites makes that class of corruption structurally impossible rather than merely unlikely: a subtree that is never visited cannot be rewritten, whatever `@google/genai` adds later.

Paths are camelCase, matching the SDK's declared types. #3382 carries a test that walks the google-genai type graph and fails if a release adds a credential field the list does not cover; TypeScript types are erased at runtime, so that test guards the shared enumeration for both wrappers.

The normalization body is unchanged: renamed to `normalizeGeminiInputs` and wrapped, which covers both fallback paths and routes through `overParams` from #3378 so no argument shape can defeat masking.

## Tests

`wrapped_gemini_config.test.ts` asserts against the payload the SDK would upload, via the existing `mockClient()` fetch spy — no network, no API keys.

Covers each credential site masked; the allowlists rejecting unknown fields; `functionDeclarations` parameter schemas, `responseSchema`, `responseJsonSchema` and unknown tool variants surviving byte-for-byte; the caller's config unmutated; non-secret config preserved; user content not walked; `ls_invocation_params` clean; and unexpected shapes (null, string, number, non-array `tools`) not raising.
