### PR TITLE
fix(js): mask Claude Agent SDK option credentials in traces

### DIFF
--- a/js/src/experimental/anthropic/index.ts
+++ b/js/src/experimental/anthropic/index.ts
@@ -6,6 +6,10 @@ import {
 import { StreamManager, type WrapClaudeAgentSDKConfig } from "./context.js";
 import { convertFromAnthropicMessage, mergeMessagesById } from "./messages.js";
 import type { SDKMessage, SDKUserMessage, QueryOptions } from "./types.js";
+import { mask } from "../../utils/redaction.js";
+
+/** Options that are credentials by construction: `env` is documented as `{ ...process.env }`. */
+const OPTION_SECRET_KEYS = ["env", "extraArgs"] as const;
 
 const WRAPPED_TOOL_SYMBOL = Symbol.for(
   "langsmith:claude_agent_sdk:wrapped_tool",
@@ -108,6 +112,12 @@ function wrapClaudeAgentQuery<
               { name: value.name, type: value.type },
             ]),
           );
+        }
+
+        if (options != null) {
+          for (const key of OPTION_SECRET_KEYS) {
+            if (options[key] != null) options[key] = mask(options[key]);
+          }
         }
 
         return { messages: convertFromAnthropicMessage(prompt), options };

--- a/js/src/tests/claude_agent_sdk_secrets.test.ts
+++ b/js/src/tests/claude_agent_sdk_secrets.test.ts
@@ -1,0 +1,143 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, test, expect } from "@jest/globals";
+import { wrapClaudeAgentSDK } from "../experimental/anthropic/index.js";
+import { SECRET_PLACEHOLDER } from "../anonymizer/index.js";
+import { mockClient } from "./utils/mock_client.js";
+
+const FAKE_TOKEN = "fake-token-for-tests-only";
+
+function parseRequestBody(body: any) {
+  // eslint-disable-next-line no-instanceof/no-instanceof
+  return body instanceof Uint8Array
+    ? JSON.parse(new TextDecoder().decode(body))
+    : JSON.parse(body);
+}
+
+/** Stub Claude Agent SDK, so input processing runs without a subprocess. */
+function stubSDK(): any {
+  return {
+    query: (_params: any) =>
+      (async function* () {
+        yield { type: "system", session_id: "session_1" };
+        yield {
+          type: "assistant",
+          message: { role: "assistant", content: "hi" },
+        };
+        yield { type: "result", num_turns: 1 };
+      })(),
+  };
+}
+
+/** The runs the SDK would have uploaded. */
+function uploadedRuns(callSpy: any): any[] {
+  return (callSpy.mock.calls as any[])
+    .map(([, init]: any) => {
+      try {
+        return parseRequestBody(init?.body);
+      } catch {
+        return undefined;
+      }
+    })
+    .filter(Boolean)
+    .flatMap((body: any) => body?.post ?? body?.patch ?? [body])
+    .filter((run: any) => run?.inputs);
+}
+
+async function traceQuery(options: Record<string, unknown>) {
+  const { client, callSpy } = mockClient();
+  const wrapped: any = wrapClaudeAgentSDK(stubSDK(), {
+    client,
+    tracingEnabled: true,
+  });
+
+  for await (const _ of wrapped.query({ prompt: "hi", options })) {
+    // drain
+  }
+
+  const runs = uploadedRuns(callSpy);
+  return { runs, wire: JSON.stringify(runs) };
+}
+
+describe("Claude Agent SDK option credentials are masked before tracing", () => {
+  test("env never reaches the uploaded run", async () => {
+    const { runs, wire } = await traceQuery({
+      model: "claude-sonnet-4-5",
+      env: { ANTHROPIC_API_KEY: FAKE_TOKEN, PATH: "/usr/bin" },
+    });
+
+    expect(wire).not.toContain(FAKE_TOKEN);
+    const options = runs[0].inputs.options;
+    expect(options.env).toEqual({
+      ANTHROPIC_API_KEY: SECRET_PLACEHOLDER,
+      PATH: SECRET_PLACEHOLDER,
+    });
+    expect(options.model).toBe("claude-sonnet-4-5");
+  });
+
+  test("extraArgs is masked", async () => {
+    const { runs, wire } = await traceQuery({
+      extraArgs: { "some-flag": FAKE_TOKEN },
+    });
+
+    expect(wire).not.toContain(FAKE_TOKEN);
+    expect(runs[0].inputs.options.extraArgs).toEqual({
+      "some-flag": SECRET_PLACEHOLDER,
+    });
+  });
+
+  test("mcpServers are still reduced to name and type", async () => {
+    const { runs, wire } = await traceQuery({
+      mcpServers: {
+        example: {
+          type: "http",
+          name: "example",
+          url: "https://mcp.example.com/mcp",
+          headers: { Authorization: `Bearer ${FAKE_TOKEN}` },
+        },
+      },
+    });
+
+    expect(wire).not.toContain(FAKE_TOKEN);
+    expect(runs[0].inputs.options.mcpServers.example).toEqual({
+      name: "example",
+      type: "http",
+    });
+  });
+
+  test("the caller's options are left intact for the SDK call", async () => {
+    const env = { ANTHROPIC_API_KEY: FAKE_TOKEN };
+    const options = { model: "claude-sonnet-4-5", env };
+
+    await traceQuery(options);
+
+    expect(env.ANTHROPIC_API_KEY).toBe(FAKE_TOKEN);
+    expect(options.env).toBe(env);
+  });
+
+  test("non-secret options are preserved", async () => {
+    const { runs } = await traceQuery({
+      model: "claude-sonnet-4-5",
+      maxTurns: 3,
+      allowedTools: ["Read", "Grep"],
+    });
+
+    const options = runs[0].inputs.options;
+    expect(options.model).toBe("claude-sonnet-4-5");
+    expect(options.maxTurns).toBe(3);
+    expect(options.allowedTools).toEqual(["Read", "Grep"]);
+  });
+
+  test("tolerates absent options", async () => {
+    const { client, callSpy } = mockClient();
+    const wrapped: any = wrapClaudeAgentSDK(stubSDK(), {
+      client,
+      tracingEnabled: true,
+    });
+
+    for await (const _ of wrapped.query({ prompt: "hi" })) {
+      // drain
+    }
+
+    expect(uploadedRuns(callSpy).length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
Stacked on #3385. Final PR in the JS stream.

## What & why

`processInputs` in the experimental Claude Agent SDK wrapper reduces `options.mcpServers` to `{ name, type }`, but passes every other option key through to the traced run inputs verbatim.

`QueryOptions.env` is the problem. The Claude Agent SDK's own documented usage is:

```js
env: { ...process.env, SOME_VAR: "value" }
```

so in normal use it holds every API key on the machine. `extraArgs` passes raw CLI flag values and can carry the same.

This surface was untouched by #3372, which covers only `js/src/wrappers/anthropic.ts`.

## Fix

`env` and `extraArgs` are masked with the shared `mask` helper, so key names survive and a trace still shows what was set:

```json
{ "env": { "ANTHROPIC_API_KEY": "[SECRET_DETECTED]", "PATH": "[SECRET_DETECTED]" } }
```

A denylist rather than an allowlist here, because the useful option keys (`model`, `maxTurns`, `allowedTools`, `systemPrompt`, `permissionMode`, …) are numerous and non-sensitive, while the credential-bearing ones are exactly two.

Safe to mutate `options` in place at that point — the enclosing `toJSON` already made a shallow copy — and a test confirms the caller's object is untouched.

## Tests

`claude_agent_sdk_secrets.test.ts` asserts against the payload the SDK would upload, via the existing `mockClient()` fetch spy — no subprocess, no network, no API keys.

Covers: `env` masked with key names kept, `extraArgs` masked, `mcpServers` still reduced to name and type (including that an `http` server's `headers` never lands), the caller's options unmutated, non-secret options preserved, and absent options not raising.

## Audit status

| Stream | PRs |
|---|---|
| Python | #3380 (OpenAI) → #3382 (Gemini) |
| JS | #3378 (Anthropic argument shape) → #3381 (OpenAI) → #3385 (Gemini) → this |

The remaining high-severity finding is the OpenAI Realtime session leak. #3384 attempted it and was withdrawn: the key-based masking it used corrupted function tool schemas in `session.tools[]`, the same way the first Gemini revision did. That PR records the leak, the reproduction, and the structural shape a fix needs.

Left for separate issues, all medium severity:

- `integrations/openai_realtime/_session.py` — `_clean` bails to `_shallow` past `_MAX_DEPTH`, which returns a `repr()` string that `scrub` cannot mask inside
- OTEL exporters promote `extra_headers` to a `langsmith.request.headers` span attribute
- Vercel middleware spreads `providerOptions` and `headers` into run inputs
- openai-agents copies `model_config` verbatim into invocation params
