### PR TITLE
fix(sandbox): retry transient WebSocket upgrades in Python and JS

### DIFF
--- a/js/src/sandbox/errors.ts
+++ b/js/src/sandbox/errors.ts
@@ -52,6 +52,19 @@ export class LangSmithSandboxConnectionError extends LangSmithSandboxError {
   }
 }
 
+/**
+ * Raised when a transient connection failure occurs before a command starts.
+ *
+ * `run()` retries this error with the same command ID so the server can
+ * deduplicate an attempt whose outcome is unknown.
+ */
+export class LangSmithSandboxRetryableConnectionError extends LangSmithSandboxConnectionError {
+  constructor(message: string) {
+    super(message);
+    this.name = "LangSmithSandboxRetryableConnectionError";
+  }
+}
+
 // =============================================================================
 // Resource Errors (type-based, with resourceType property)
 // =============================================================================
@@ -318,12 +331,10 @@ export class LangSmithStreamEndedBeforeStartedError extends LangSmithSandboxOper
 /**
  * Thrown when the socket fails or times out before the WebSocket handshake.
  *
- * Distinct from its parent because it is safely retryable: the execute frame
- * was never sent, so re-issuing the same command_id cannot double-run a
- * command. run() retries this with backoff; a plain connection error (a
- * rejected handshake) is permanent and propagates immediately.
+ * The execute frame was never sent, so re-issuing the same command ID cannot
+ * double-run a command.
  */
-export class LangSmithSandboxConnectTimeoutError extends LangSmithSandboxConnectionError {
+export class LangSmithSandboxConnectTimeoutError extends LangSmithSandboxRetryableConnectionError {
   constructor(message: string) {
     super(message);
     this.name = "LangSmithSandboxConnectTimeoutError";

--- a/js/src/sandbox/index.ts
+++ b/js/src/sandbox/index.ts
@@ -98,6 +98,7 @@ export {
   LangSmithSandboxAPIError,
   LangSmithSandboxAuthenticationError,
   LangSmithSandboxConnectionError,
+  LangSmithSandboxRetryableConnectionError,
   LangSmithSandboxConnectTimeoutError,
   LangSmithSandboxServerReloadError,
   // Resource errors (type-based with resourceType attribute)

--- a/js/src/sandbox/sandbox.ts
+++ b/js/src/sandbox/sandbox.ts
@@ -14,7 +14,7 @@ import type {
 import { uuid7 } from "../uuid.js";
 import {
   LangSmithDataplaneNotConfiguredError,
-  LangSmithSandboxConnectTimeoutError,
+  LangSmithSandboxRetryableConnectionError,
   LangSmithStreamEndedBeforeStartedError,
 } from "./errors.js";
 import { handleSandboxHttpError } from "./helpers.js";
@@ -301,7 +301,7 @@ export class Sandbox {
         // failed connect can have started a second command.
         if (
           !(e instanceof LangSmithStreamEndedBeforeStartedError) &&
-          !(e instanceof LangSmithSandboxConnectTimeoutError)
+          !(e instanceof LangSmithSandboxRetryableConnectionError)
         ) {
           throw e;
         }

--- a/js/src/sandbox/ws_execute.ts
+++ b/js/src/sandbox/ws_execute.ts
@@ -10,6 +10,7 @@ import {
   LangSmithSandboxConnectionError,
   LangSmithSandboxConnectTimeoutError,
   LangSmithSandboxOperationError,
+  LangSmithSandboxRetryableConnectionError,
   LangSmithSandboxServerReloadError,
 } from "./errors.js";
 import type { WsMessage, WsRunOptions } from "./types.js";
@@ -37,6 +38,7 @@ export const WS_CONNECT_BUDGET = envTimeout(
   "SANDBOX_WS_TIMEOUT_CONNECT_BUDGET",
   120,
 );
+const RETRYABLE_HANDSHAKE_STATUS_CODES = new Set([500, 502, 503, 504]);
 
 function nowSeconds(): number {
   return performance.now() / 1000;
@@ -224,8 +226,8 @@ export function raiseForWsError(msg: WsMessage, commandId = ""): never {
  * Create a ws WebSocket connection and return a promise that resolves when open
  * or rejects on error.
  *
- * A socket-level failure rejects with the retryable connect-timeout error; a
- * non-101 response rejects with the permanent connection error.
+ * Socket-level failures and transient 5xx responses are retryable. Other
+ * non-101 responses are permanent connection errors.
  */
 async function connectWs(
   url: string,
@@ -260,8 +262,13 @@ async function connectWs(
         req.destroy?.();
         if (settled) return;
         settled = true;
+        const ErrorType = RETRYABLE_HANDSHAKE_STATUS_CODES.has(
+          res.statusCode ?? 0,
+        )
+          ? LangSmithSandboxRetryableConnectionError
+          : LangSmithSandboxConnectionError;
         reject(
-          new LangSmithSandboxConnectionError(
+          new ErrorType(
             `WebSocket upgrade to ${url} rejected by server (HTTP ${res.statusCode})`,
           ),
         );

--- a/js/src/tests/sandbox_command_id_retry.test.ts
+++ b/js/src/tests/sandbox_command_id_retry.test.ts
@@ -4,13 +4,15 @@
  * run() sends a client-generated command_id and the server does get-or-create
  * keyed on it, so re-issuing a command whose tunnel closed before 'started' —
  * or whose connect never completed — reattaches to the same session instead of
- * spawning a second one. A rejected handshake is permanent and must not retry.
+ * spawning a second one. Transient 5xx handshake rejections are safe to retry;
+ * permanent 4xx rejections still propagate immediately.
  */
 import { jest, describe, it, expect, beforeEach } from "@jest/globals";
 import type { WsMessage } from "../sandbox/types.js";
 import {
   LangSmithSandboxConnectionError,
   LangSmithSandboxConnectTimeoutError,
+  LangSmithSandboxRetryableConnectionError,
 } from "../sandbox/errors.js";
 
 // Virtual clock so budget assertions do not depend on real elapsed time.
@@ -113,6 +115,38 @@ describe("run() early-close retry", () => {
     runWsStream
       .mockImplementationOnce((..._args: unknown[]) => [
         failingStream(new LangSmithSandboxConnectTimeoutError("timed out")),
+        null,
+      ])
+      .mockImplementationOnce((...args: unknown[]) => {
+        const opts = args[3] as { commandId: string };
+        return [
+          makeStream([
+            { type: "started", command_id: opts.commandId, pid: 1 },
+            { type: "exit", exit_code: 0 },
+          ]),
+          null,
+        ];
+      });
+
+    const result = await sandbox.run("echo hi");
+
+    expect(result.exit_code).toBe(0);
+    expect(runWsStream).toHaveBeenCalledTimes(2);
+    const first = runWsStream.mock.calls[0][3] as { commandId: string };
+    const second = runWsStream.mock.calls[1][3] as { commandId: string };
+    expect(first.commandId).toBe(second.commandId);
+  });
+
+  it("retries a transient rejected handshake with the same command_id", async () => {
+    const sandbox = makeSandbox();
+
+    runWsStream
+      .mockImplementationOnce((..._args: unknown[]) => [
+        failingStream(
+          new LangSmithSandboxRetryableConnectionError(
+            "WebSocket upgrade rejected by server (HTTP 503)",
+          ),
+        ),
         null,
       ])
       .mockImplementationOnce((...args: unknown[]) => {

--- a/js/src/tests/sandbox_ws_handshake.test.ts
+++ b/js/src/tests/sandbox_ws_handshake.test.ts
@@ -1,0 +1,68 @@
+import { EventEmitter } from "node:events";
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import {
+  LangSmithSandboxConnectionError,
+  LangSmithSandboxRetryableConnectionError,
+} from "../sandbox/errors.js";
+
+const response = {
+  statusCode: 503,
+  resume: jest.fn(),
+};
+const request = { destroy: jest.fn() };
+
+class MockWebSocket extends EventEmitter {
+  readyState = 0;
+
+  constructor() {
+    super();
+    queueMicrotask(() => {
+      this.emit("unexpected-response", request, response);
+    });
+  }
+}
+
+jest.unstable_mockModule("ws", () => ({ default: MockWebSocket }));
+
+const { runWsStream } = await import("../sandbox/ws_execute.js");
+
+async function rejectedUpgrade(statusCode: number): Promise<unknown> {
+  response.statusCode = statusCode;
+  const [stream] = await runWsStream(
+    "https://dp.example.com/sb-123",
+    undefined,
+    "echo hi",
+  );
+  return stream.next();
+}
+
+describe("WebSocket upgrade rejection", () => {
+  beforeEach(() => {
+    response.resume.mockClear();
+    request.destroy.mockClear();
+  });
+
+  it.each([500, 502, 503, 504])(
+    "treats HTTP %i as retryable",
+    async (statusCode) => {
+      await expect(rejectedUpgrade(statusCode)).rejects.toBeInstanceOf(
+        LangSmithSandboxRetryableConnectionError,
+      );
+      expect(response.resume).toHaveBeenCalledTimes(1);
+      expect(request.destroy).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it.each([400, 401, 403, 404, 429, 505])(
+    "keeps HTTP %i permanent",
+    async (statusCode) => {
+      const error = await rejectedUpgrade(statusCode).catch(
+        (rejection: unknown) => rejection,
+      );
+      expect(error).toBeInstanceOf(LangSmithSandboxConnectionError);
+      expect(error).not.toBeInstanceOf(
+        LangSmithSandboxRetryableConnectionError,
+      );
+    },
+  );
+});

--- a/python/langsmith/sandbox/__init__.py
+++ b/python/langsmith/sandbox/__init__.py
@@ -48,6 +48,7 @@ from langsmith.sandbox._exceptions import (
     SandboxConnectTimeoutError,
     SandboxNotReadyError,
     SandboxOperationError,
+    SandboxRetryableConnectionError,
     SandboxServerReloadError,
     TunnelConnectionRefusedError,
     TunnelError,
@@ -151,6 +152,7 @@ __all__ = [
     "SandboxAPIError",
     "SandboxAuthenticationError",
     "SandboxConnectionError",
+    "SandboxRetryableConnectionError",
     "SandboxConnectTimeoutError",
     "SandboxServerReloadError",
     # Resource errors (type-based with resource_type attribute)

--- a/python/langsmith/sandbox/_async_sandbox.py
+++ b/python/langsmith/sandbox/_async_sandbox.py
@@ -13,7 +13,6 @@ import httpx
 from langsmith.sandbox._exceptions import (
     DataplaneNotConfiguredError,
     ResourceNotFoundError,
-    SandboxNotReadyError,
     SandboxRetryableConnectionError,
 )
 from langsmith.sandbox._helpers import handle_sandbox_http_error
@@ -440,7 +439,6 @@ class AsyncSandbox:
             except (
                 _StreamEndedBeforeStarted,
                 SandboxRetryableConnectionError,
-                SandboxNotReadyError,
             ):
                 # Idempotent re-issue (same command_id): neither an early close
                 # nor a failed connect can have started a second command.

--- a/python/langsmith/sandbox/_async_sandbox.py
+++ b/python/langsmith/sandbox/_async_sandbox.py
@@ -13,7 +13,8 @@ import httpx
 from langsmith.sandbox._exceptions import (
     DataplaneNotConfiguredError,
     ResourceNotFoundError,
-    SandboxConnectTimeoutError,
+    SandboxNotReadyError,
+    SandboxRetryableConnectionError,
 )
 from langsmith.sandbox._helpers import handle_sandbox_http_error
 from langsmith.sandbox._models import (
@@ -436,7 +437,11 @@ class AsyncSandbox:
             try:
                 await handle._ensure_started()
                 break
-            except (_StreamEndedBeforeStarted, SandboxConnectTimeoutError):
+            except (
+                _StreamEndedBeforeStarted,
+                SandboxRetryableConnectionError,
+                SandboxNotReadyError,
+            ):
                 # Idempotent re-issue (same command_id): neither an early close
                 # nor a failed connect can have started a second command.
                 attempt += 1

--- a/python/langsmith/sandbox/_exceptions.py
+++ b/python/langsmith/sandbox/_exceptions.py
@@ -44,13 +44,21 @@ class SandboxConnectionError(SandboxClientError):
     pass
 
 
-class SandboxConnectTimeoutError(SandboxConnectionError):
+class SandboxRetryableConnectionError(SandboxConnectionError):
+    """Raised when a transient failure occurs before a command can start.
+
+    ``run()`` retries this error with the same command ID, so the server can
+    deduplicate an attempt whose outcome is unknown.
+    """
+
+    pass
+
+
+class SandboxConnectTimeoutError(SandboxRetryableConnectionError):
     """Raised when the socket fails or times out before the WebSocket handshake.
 
-    Distinct from its parent because it is safely retryable: the execute frame
-    was never sent, so re-issuing the same command_id cannot double-run a
-    command. run() retries this with backoff; a plain SandboxConnectionError
-    (a rejected handshake) is permanent and propagates immediately.
+    The execute frame was never sent, so re-issuing the same command ID cannot
+    double-run a command.
     """
 
     pass

--- a/python/langsmith/sandbox/_sandbox.py
+++ b/python/langsmith/sandbox/_sandbox.py
@@ -11,7 +11,8 @@ import httpx
 from langsmith.sandbox._exceptions import (
     DataplaneNotConfiguredError,
     ResourceNotFoundError,
-    SandboxConnectTimeoutError,
+    SandboxNotReadyError,
+    SandboxRetryableConnectionError,
 )
 from langsmith.sandbox._helpers import handle_sandbox_http_error
 from langsmith.sandbox._models import (
@@ -432,7 +433,11 @@ class Sandbox:
                     on_stderr=on_stderr,
                 )
                 break
-            except (_StreamEndedBeforeStarted, SandboxConnectTimeoutError):
+            except (
+                _StreamEndedBeforeStarted,
+                SandboxRetryableConnectionError,
+                SandboxNotReadyError,
+            ):
                 # Idempotent re-issue (same command_id): neither an early close
                 # nor a failed connect can have started a second command.
                 attempt += 1

--- a/python/langsmith/sandbox/_sandbox.py
+++ b/python/langsmith/sandbox/_sandbox.py
@@ -11,7 +11,6 @@ import httpx
 from langsmith.sandbox._exceptions import (
     DataplaneNotConfiguredError,
     ResourceNotFoundError,
-    SandboxNotReadyError,
     SandboxRetryableConnectionError,
 )
 from langsmith.sandbox._helpers import handle_sandbox_http_error
@@ -436,7 +435,6 @@ class Sandbox:
             except (
                 _StreamEndedBeforeStarted,
                 SandboxRetryableConnectionError,
-                SandboxNotReadyError,
             ):
                 # Idempotent re-issue (same command_id): neither an early close
                 # nor a failed connect can have started a second command.

--- a/python/langsmith/sandbox/_ws_execute.py
+++ b/python/langsmith/sandbox/_ws_execute.py
@@ -13,7 +13,6 @@ from langsmith.sandbox._exceptions import (
     CommandTimeoutError,
     SandboxConnectionError,
     SandboxConnectTimeoutError,
-    SandboxNotReadyError,
     SandboxOperationError,
     SandboxRetryableConnectionError,
     SandboxServerReloadError,
@@ -210,7 +209,7 @@ class _AsyncWSStreamControl:
 # =============================================================================
 
 
-_TRANSIENT_HANDSHAKE_STATUSES = frozenset({500, 502, 504})
+_TRANSIENT_HANDSHAKE_STATUSES = frozenset({500, 502, 503, 504})
 _MAX_HANDSHAKE_ERROR_BYTES = 16 * 1024
 
 
@@ -258,10 +257,6 @@ def _raise_for_invalid_handshake(exc: Exception, ws_url: str) -> None:
             f"(endpoint {ws_url} returned 404). Ensure the server is updated "
             f"to a version that supports the /execute/ws endpoint, or use "
             f"run() without wait=False or callbacks."
-        ) from exc
-    if status == 503:
-        raise SandboxNotReadyError(
-            f"Sandbox is not ready for WebSocket command execution{suffix}"
         ) from exc
     if status in _TRANSIENT_HANDSHAKE_STATUSES:
         raise SandboxRetryableConnectionError(

--- a/python/langsmith/sandbox/_ws_execute.py
+++ b/python/langsmith/sandbox/_ws_execute.py
@@ -15,6 +15,7 @@ from langsmith.sandbox._exceptions import (
     SandboxConnectTimeoutError,
     SandboxNotReadyError,
     SandboxOperationError,
+    SandboxRetryableConnectionError,
     SandboxServerReloadError,
 )
 from langsmith.sandbox._helpers import merge_headers
@@ -209,6 +210,36 @@ class _AsyncWSStreamControl:
 # =============================================================================
 
 
+_TRANSIENT_HANDSHAKE_STATUSES = frozenset({500, 502, 504})
+_MAX_HANDSHAKE_ERROR_BYTES = 16 * 1024
+
+
+def _handshake_server_detail(exc: Exception) -> Optional[str]:
+    """Return bounded, user-facing detail from a rejected handshake."""
+    body = getattr(getattr(exc, "response", None), "body", None)
+    if isinstance(body, bytes):
+        body = body[:_MAX_HANDSHAKE_ERROR_BYTES].decode("utf-8", errors="replace")
+    elif isinstance(body, str):
+        body = body[:_MAX_HANDSHAKE_ERROR_BYTES]
+    else:
+        return None
+
+    try:
+        payload = json.loads(body)
+    except (TypeError, ValueError):
+        return None
+    detail = payload.get("detail") if isinstance(payload, dict) else None
+    if not isinstance(detail, dict):
+        return None
+
+    message = detail.get("message")
+    error_id = detail.get("error_id")
+    parts = [message] if isinstance(message, str) and message else []
+    if isinstance(error_id, str) and error_id:
+        parts.append(f"error_id={error_id}")
+    return " (".join(parts) + ("" if len(parts) < 2 else ")") if parts else None
+
+
 def _raise_for_invalid_handshake(exc: Exception, ws_url: str) -> None:
     """Raise a clear error when the WebSocket upgrade handshake fails.
 
@@ -219,6 +250,8 @@ def _raise_for_invalid_handshake(exc: Exception, ws_url: str) -> None:
     upgrade with garbage. Both subclass ``InvalidHandshake``.
     """
     status = getattr(getattr(exc, "response", None), "status_code", None)
+    server_detail = _handshake_server_detail(exc)
+    suffix = f": {server_detail}" if server_detail else f": {exc}"
     if status == 404:
         raise SandboxConnectionError(
             f"The sandbox server does not support WebSocket command execution "
@@ -228,7 +261,11 @@ def _raise_for_invalid_handshake(exc: Exception, ws_url: str) -> None:
         ) from exc
     if status == 503:
         raise SandboxNotReadyError(
-            f"Sandbox is not ready for WebSocket command execution: {exc}"
+            f"Sandbox is not ready for WebSocket command execution{suffix}"
+        ) from exc
+    if status in _TRANSIENT_HANDSHAKE_STATUSES:
+        raise SandboxRetryableConnectionError(
+            f"WebSocket upgrade temporarily rejected by server (HTTP {status}){suffix}"
         ) from exc
     if status is not None:
         raise SandboxConnectionError(

--- a/python/tests/unit_tests/sandbox/test_command_id_retry.py
+++ b/python/tests/unit_tests/sandbox/test_command_id_retry.py
@@ -19,7 +19,6 @@ from langsmith.sandbox._async_sandbox import AsyncSandbox
 from langsmith.sandbox._exceptions import (
     SandboxConnectionError,
     SandboxConnectTimeoutError,
-    SandboxNotReadyError,
     SandboxRetryableConnectionError,
 )
 from langsmith.sandbox._models import (
@@ -118,7 +117,7 @@ class TestSyncRetry:
         "error",
         [
             SandboxRetryableConnectionError("HTTP 502"),
-            SandboxNotReadyError("HTTP 503"),
+            SandboxRetryableConnectionError("HTTP 503"),
         ],
     )
     def test_retries_transient_rejected_handshake(self, monkeypatch, error):
@@ -277,7 +276,7 @@ class TestAsyncRetry:
         "error",
         [
             SandboxRetryableConnectionError("HTTP 502"),
-            SandboxNotReadyError("HTTP 503"),
+            SandboxRetryableConnectionError("HTTP 503"),
         ],
     )
     async def test_retries_transient_rejected_handshake(self, monkeypatch, error):

--- a/python/tests/unit_tests/sandbox/test_command_id_retry.py
+++ b/python/tests/unit_tests/sandbox/test_command_id_retry.py
@@ -4,8 +4,8 @@ A proxied exec tunnel can be torn down gracefully before the guest emits its
 'started' frame, and a cold-starting sandbox can refuse the connection outright.
 run() sends a client-generated command_id and the server does get-or-create
 keyed on it, so re-issuing the same command reattaches to the existing session
-instead of spawning a second one. A rejected handshake is permanent and must
-not be retried.
+instead of spawning a second one. Transient 5xx handshake rejections are safe
+to retry; permanent 4xx rejections still propagate immediately.
 """
 
 import pytest
@@ -19,6 +19,8 @@ from langsmith.sandbox._async_sandbox import AsyncSandbox
 from langsmith.sandbox._exceptions import (
     SandboxConnectionError,
     SandboxConnectTimeoutError,
+    SandboxNotReadyError,
+    SandboxRetryableConnectionError,
 )
 from langsmith.sandbox._models import (
     CommandHandle,
@@ -100,6 +102,33 @@ class TestSyncRetry:
             calls.append(kwargs)
             if len(calls) == 1:
                 return _raises(SandboxConnectTimeoutError("timed out")), None
+            return _started_then_exit(kwargs["command_id"]), None
+
+        monkeypatch.setattr(
+            "langsmith.sandbox._ws_execute.run_ws_stream", fake_run_ws_stream
+        )
+
+        result = sandbox.run("echo hi")
+
+        assert result.exit_code == 0
+        assert len(calls) == 2
+        assert calls[0]["command_id"] == calls[1]["command_id"]
+
+    @pytest.mark.parametrize(
+        "error",
+        [
+            SandboxRetryableConnectionError("HTTP 502"),
+            SandboxNotReadyError("HTTP 503"),
+        ],
+    )
+    def test_retries_transient_rejected_handshake(self, monkeypatch, error):
+        sandbox = _sandbox()
+        calls: list[dict] = []
+
+        def fake_run_ws_stream(dataplane_url, api_key, command, **kwargs):
+            calls.append(kwargs)
+            if len(calls) == 1:
+                return _raises(error), None
             return _started_then_exit(kwargs["command_id"]), None
 
         monkeypatch.setattr(
@@ -230,6 +259,35 @@ class TestAsyncRetry:
             calls.append(kwargs)
             if len(calls) == 1:
                 return _araises(SandboxConnectTimeoutError("timed out")), None
+            return _astarted_then_exit(kwargs["command_id"]), None
+
+        async def _no_sleep(_s):
+            return None
+
+        monkeypatch.setattr("asyncio.sleep", _no_sleep)
+        monkeypatch.setattr("langsmith.sandbox._ws_execute.run_ws_stream_async", fake)
+
+        result = await sandbox.run("echo hi")
+
+        assert result.exit_code == 0
+        assert len(calls) == 2
+        assert calls[0]["command_id"] == calls[1]["command_id"]
+
+    @pytest.mark.parametrize(
+        "error",
+        [
+            SandboxRetryableConnectionError("HTTP 502"),
+            SandboxNotReadyError("HTTP 503"),
+        ],
+    )
+    async def test_retries_transient_rejected_handshake(self, monkeypatch, error):
+        sandbox = _async_sandbox()
+        calls: list[dict] = []
+
+        async def fake(dataplane_url, api_key, command, **kwargs):
+            calls.append(kwargs)
+            if len(calls) == 1:
+                return _araises(error), None
             return _astarted_then_exit(kwargs["command_id"]), None
 
         async def _no_sleep(_s):

--- a/python/tests/unit_tests/sandbox/test_ws_execute.py
+++ b/python/tests/unit_tests/sandbox/test_ws_execute.py
@@ -11,7 +11,6 @@ import pytest
 from langsmith.sandbox._exceptions import (
     CommandTimeoutError,
     SandboxConnectionError,
-    SandboxNotReadyError,
     SandboxOperationError,
     SandboxRetryableConnectionError,
     SandboxServerReloadError,
@@ -1025,7 +1024,7 @@ class TestRaiseForInvalidHandshake:
         with pytest.raises(SandboxConnectionError, match="HTTP 403"):
             _raise_for_invalid_handshake(exc, "ws://example.com/sb-123/execute/ws")
 
-    def test_503_raises_not_ready(self):
+    def test_503_is_retryable(self):
         from langsmith.sandbox._ws_execute import _raise_for_invalid_handshake
 
         mock_response = MagicMock()
@@ -1042,7 +1041,7 @@ class TestRaiseForInvalidHandshake:
         exc = Exception("server rejected WebSocket connection: HTTP 503")
         exc.response = mock_response
 
-        with pytest.raises(SandboxNotReadyError, match="error_id=err-503"):
+        with pytest.raises(SandboxRetryableConnectionError, match="error_id=err-503"):
             _raise_for_invalid_handshake(exc, "ws://example.com/sb-123/execute/ws")
 
     @pytest.mark.parametrize("status", [500, 502, 504])

--- a/python/tests/unit_tests/sandbox/test_ws_execute.py
+++ b/python/tests/unit_tests/sandbox/test_ws_execute.py
@@ -13,6 +13,7 @@ from langsmith.sandbox._exceptions import (
     SandboxConnectionError,
     SandboxNotReadyError,
     SandboxOperationError,
+    SandboxRetryableConnectionError,
     SandboxServerReloadError,
 )
 from langsmith.sandbox._models import (
@@ -1029,11 +1030,56 @@ class TestRaiseForInvalidHandshake:
 
         mock_response = MagicMock()
         mock_response.status_code = 503
+        mock_response.body = json.dumps(
+            {
+                "detail": {
+                    "error": "ServiceUnavailable",
+                    "message": "Service unavailable.",
+                    "error_id": "err-503",
+                }
+            }
+        ).encode()
         exc = Exception("server rejected WebSocket connection: HTTP 503")
         exc.response = mock_response
 
-        with pytest.raises(SandboxNotReadyError, match="not ready"):
+        with pytest.raises(SandboxNotReadyError, match="error_id=err-503"):
             _raise_for_invalid_handshake(exc, "ws://example.com/sb-123/execute/ws")
+
+    @pytest.mark.parametrize("status", [500, 502, 504])
+    def test_transient_5xx_is_retryable_and_preserves_error_id(self, status):
+        from langsmith.sandbox._ws_execute import _raise_for_invalid_handshake
+
+        mock_response = MagicMock()
+        mock_response.status_code = status
+        mock_response.body = json.dumps(
+            {
+                "detail": {
+                    "error": "ServiceUnavailable",
+                    "message": "Service unavailable.",
+                    "error_id": f"err-{status}",
+                }
+            }
+        ).encode()
+        exc = Exception(f"server rejected WebSocket connection: HTTP {status}")
+        exc.response = mock_response
+
+        with pytest.raises(
+            SandboxRetryableConnectionError, match=f"error_id=err-{status}"
+        ):
+            _raise_for_invalid_handshake(exc, "ws://example.com/sb-123/execute/ws")
+
+    def test_unstructured_body_is_not_exposed(self):
+        from langsmith.sandbox._ws_execute import _raise_for_invalid_handshake
+
+        mock_response = MagicMock()
+        mock_response.status_code = 502
+        mock_response.body = b"internal database failure details"
+        exc = Exception("server rejected WebSocket connection: HTTP 502")
+        exc.response = mock_response
+
+        with pytest.raises(SandboxRetryableConnectionError) as exc_info:
+            _raise_for_invalid_handshake(exc, "ws://example.com/sb-123/execute/ws")
+        assert "internal database failure details" not in str(exc_info.value)
 
     def test_no_http_response_gives_unreachable_message(self):
         """InvalidMessage carries no .response — a stopped/unreachable peer."""


### PR DESCRIPTION
Transient HTTP 500, 502, 503, and 504 responses during the command WebSocket upgrade currently fail command startup immediately.

This adds retry parity to the Python and JavaScript SDKs. Both reuse the same command ID and existing 120-second connection budget so the server can deduplicate attempts, while permanent upgrade failures still fail immediately.

The Python rejected-handshake parser remains bounded to 16 KiB and exposes only structured message and error ID fields rather than raw bodies or headers.

## Release Note

Python and JavaScript sandbox command startup now retry transient WebSocket upgrade failures with HTTP status 500, 502, 503, or 504.

## Test Plan

- [x] Python sync and async tests cover retry with the same command ID and immediate failure for permanent handshake errors
- [x] Python error classification tests cover transient statuses, structured detail extraction, and raw-body redaction
- [x] JavaScript tests cover retry with the same command ID and transient versus permanent handshake statuses
- [x] JavaScript type check, lint, and formatting checks