### PR TITLE
fix(py): preserve integer precision above 2**64 in dumps_json fallback

### DIFF
--- a/python/langsmith/_internal/_serde.py
+++ b/python/langsmith/_internal/_serde.py
@@ -227,10 +227,13 @@ def dumps_json(obj: Any) -> bytes:
             default=_serialize_json_with_normalized_keys,
             ensure_ascii=True,
         ).encode("utf-8")
-        try:
-            result = _orjson.dumps(
+        if _SURROGATE_RE.search(result):
+            # orjson.loads serves only to detect lone surrogates here (it
+            # rejects them, triggering the elision below). On success the
+            # stdlib bytes are kept as-is: re-dumping the parsed value through
+            # orjson would silently convert integers >= 2**64 to floats.
+            try:
                 _orjson.loads(result.decode("utf-8", errors="surrogateescape"))
-            )
-        except _orjson.JSONDecodeError:
-            result = _elide_surrogates(result)
+            except _orjson.JSONDecodeError:
+                result = _elide_surrogates(result)
         return result

--- a/python/tests/unit_tests/test_client.py
+++ b/python/tests/unit_tests/test_client.py
@@ -2395,6 +2395,29 @@ def test__dumps_json():
     assert "\\uDC00" not in serialized_str
 
 
+def test__dumps_json_preserves_ints_larger_than_64_bits():
+    """Integers >= 2**64 must survive the stdlib-json fallback path exactly.
+
+    orjson can't serialize them (TypeError -> stdlib fallback), and orjson.loads
+    parses them as floats, so the fallback's surrogate-detection round-trip must
+    be skipped when no surrogates are present or distinct values collapse to the
+    same float (e.g. 2**64 and 2**64 + 1 both become 1.8446744073709552e+19).
+    """
+    for value in (2**64, 2**64 + 1, 19_876_543_210_987_654_321, -(2**80)):
+        serialized = _dumps_json({"v": value})
+        deserialized = json.loads(serialized)["v"]
+        assert isinstance(deserialized, int)
+        assert deserialized == value
+    assert _dumps_json({"v": 2**64}) != _dumps_json({"v": 2**64 + 1})
+
+    # Non-BMP characters are escaped as valid surrogate pairs by ensure_ascii,
+    # which must not re-trigger the lossy re-encode alongside a big int.
+    serialized = _dumps_json({"emoji": "\U0001f600", "v": 2**70})
+    deserialized = json.loads(serialized)
+    assert deserialized["emoji"] == "\U0001f600"
+    assert deserialized["v"] == 2**70
+
+
 def test__dumps_json_normalizes_unsupported_dict_keys():
     class TupleKeyedDict:
         def to_dict(self) -> Dict:


### PR DESCRIPTION
Fixes #3391.

`dumps_json` falls back to stdlib `json.dumps` for objects orjson can't serialize, which includes any int outside the 64-bit range. The fallback then round-tripped the correct stdlib output through `orjson.loads`/`orjson.dumps` to detect lone UTF-16 surrogates, and since `orjson.loads` parses out-of-range ints as floats, the exact result was thrown away. Every int >= 2**64 in a run payload lost precision, and nearby values collapsed to byte-identical JSON (`2**64` and `2**64 + 1` produce the same bytes).

```python
dumps_json({"v": 19_876_543_210_987_654_321})
# before: b'{"v":1.9876543210987655e+19}'  (off by 847)
# after:  b'{"v": 19876543210987654321}'
```

The change is scoped to the one mechanism:

- run the surrogate check only when escaped surrogates are present in the stdlib output (`_SURROGATE_RE` already matches exactly what `ensure_ascii` emits)
- use `orjson.loads` purely as a lone-surrogate detector and keep the stdlib bytes on success, instead of re-dumping through orjson

The success-path change also matters for payloads that contain both a non-BMP character and a big int: `ensure_ascii` escapes the character as a valid surrogate pair, `orjson.loads` succeeds, and the old re-dump would corrupt the int anyway. There's a regression test for that case too.

Lone-surrogate elision behaves exactly as before (existing `test__dumps_json` covers it), and the orjson fast path is untouched — the fallback only runs when orjson has already raised.

`make format`, `make lint`, `make tests` pass (1951 passed, 6 skipped; the mypy `langsmith_pyo3` import-untyped error also occurs on a clean checkout of main).
