### PR TITLE
feat(sandbox): support proxy rule env vars in the Python and JS helpers

### DIFF
--- a/js/src/sandbox/proxy_config.ts
+++ b/js/src/sandbox/proxy_config.ts
@@ -21,6 +21,28 @@ function requireNonEmptyStringArray(values: string[], field: string): string[] {
   return values.map((value) => requireNonEmptyString(value, field));
 }
 
+function requireEnvVars(
+  envVars: Record<string, string>,
+): Record<string, string> {
+  if (
+    envVars === null ||
+    typeof envVars !== "object" ||
+    Array.isArray(envVars)
+  ) {
+    throw new Error("envVars must be a non-empty object of names to values");
+  }
+  const entries = Object.entries(envVars);
+  if (entries.length === 0) {
+    throw new Error("envVars must be a non-empty object of names to values");
+  }
+  return Object.fromEntries(
+    entries.map(([name, value]) => [
+      requireNonEmptyString(name, "envVars name"),
+      requireNonEmptyString(value, `envVars[${name}]`),
+    ]),
+  );
+}
+
 function requireProxyRules(
   rules: SandboxProxyRule[] | undefined,
 ): SandboxProxyRule[] {
@@ -103,13 +125,15 @@ export function awsAuth({
   secretAccessKey,
   name = "aws",
   enabled = true,
+  envVars,
 }: {
   accessKeyId: SandboxProxySecret;
   secretAccessKey: SandboxProxySecret;
   name?: string;
   enabled?: boolean;
+  envVars?: Record<string, string>;
 }): SandboxAwsAuthRule {
-  return {
+  const rule: SandboxAwsAuthRule = {
     name: requireNonEmptyString(name, "name"),
     type: "aws",
     enabled,
@@ -118,6 +142,10 @@ export function awsAuth({
       secret_access_key: secretAccessKey,
     },
   };
+  if (envVars !== undefined) {
+    rule.env_vars = requireEnvVars(envVars);
+  }
+  return rule;
 }
 
 /** Build a sandbox proxy rule that injects GCP OAuth bearer auth. */
@@ -126,11 +154,13 @@ export function gcpAuth({
   scopes,
   name = "gcp",
   enabled = true,
+  envVars,
 }: {
   serviceAccountJson: SandboxProxySecret;
   scopes?: string[];
   name?: string;
   enabled?: boolean;
+  envVars?: Record<string, string>;
 }): SandboxGcpAuthRule {
   const gcp: SandboxGcpAuthRule["gcp"] = {
     service_account_json: serviceAccountJson,
@@ -138,10 +168,14 @@ export function gcpAuth({
   if (scopes !== undefined) {
     gcp.scopes = requireNonEmptyStringArray(scopes, "scopes");
   }
-  return {
+  const rule: SandboxGcpAuthRule = {
     name: requireNonEmptyString(name, "name"),
     type: "gcp",
     enabled,
     gcp,
   };
+  if (envVars !== undefined) {
+    rule.env_vars = requireEnvVars(envVars);
+  }
+  return rule;
 }

--- a/js/src/sandbox/proxy_config.ts
+++ b/js/src/sandbox/proxy_config.ts
@@ -36,10 +36,11 @@ function requireEnvVars(
     throw new Error("envVars must be a non-empty object of names to values");
   }
   return Object.fromEntries(
-    entries.map(([name, value]) => [
-      requireNonEmptyString(name, "envVars name"),
-      requireNonEmptyString(value, `envVars[${name}]`),
-    ]),
+    entries.map(([name, value]) => {
+      // Validated on the trimmed form, stored verbatim: whitespace can be significant.
+      requireNonEmptyString(value, `envVars[${name}]`);
+      return [requireNonEmptyString(name, "envVars name"), value];
+    }),
   );
 }
 

--- a/js/src/sandbox/types.ts
+++ b/js/src/sandbox/types.ts
@@ -287,6 +287,13 @@ export interface SandboxAwsAuthRule {
   type: "aws";
   /** Whether the rule is enabled. */
   enabled?: boolean;
+  /**
+   * Plaintext environment variables set for every command in the sandbox while
+   * the rule is enabled, for tools that refuse to run unless a credential
+   * variable is present even though the proxy injects the real credential on
+   * the wire.
+   */
+  env_vars?: Record<string, string>;
   /** AWS credentials used by the proxy signer. */
   aws: {
     access_key_id: SandboxProxySecret;
@@ -302,6 +309,13 @@ export interface SandboxGcpAuthRule {
   type: "gcp";
   /** Whether the rule is enabled. */
   enabled?: boolean;
+  /**
+   * Plaintext environment variables set for every command in the sandbox while
+   * the rule is enabled, for tools that refuse to run unless a credential
+   * variable is present even though the proxy injects the real credential on
+   * the wire.
+   */
+  env_vars?: Record<string, string>;
   /** GCP service-account credential and OAuth scopes. */
   gcp: {
     service_account_json: SandboxProxySecret;

--- a/js/src/tests/sandbox.test.ts
+++ b/js/src/tests/sandbox.test.ts
@@ -149,6 +149,15 @@ describe("sandbox proxy config helpers", () => {
     ).not.toHaveProperty("env_vars");
   });
 
+  it("preserves surrounding whitespace in env var values", () => {
+    expect(
+      gcpAuth({
+        serviceAccountJson: workspaceSecret("GCP_SERVICE_ACCOUNT_JSON"),
+        envVars: { PREFIX: "  /opt/bin  " },
+      }).env_vars,
+    ).toEqual({ PREFIX: "  /opt/bin  " });
+  });
+
   it.each<Record<string, string>>([{}, { "": "value" }, { NAME: "" }])(
     "rejects invalid env vars %j",
     (envVars) => {

--- a/js/src/tests/sandbox.test.ts
+++ b/js/src/tests/sandbox.test.ts
@@ -127,6 +127,41 @@ describe("sandbox proxy config helpers", () => {
     });
   });
 
+  it("provider rules carry env vars and omit them when unset", () => {
+    expect(
+      awsAuth({
+        accessKeyId: workspaceSecret("AWS_KEY_ID_REF"),
+        secretAccessKey: workspaceSecret("AWS_KEY_VALUE_REF"),
+        envVars: { AWS_ACCESS_KEY_ID: "dummy" },
+      }).env_vars,
+    ).toEqual({ AWS_ACCESS_KEY_ID: "dummy" });
+
+    const gcpRule = gcpAuth({
+      serviceAccountJson: workspaceSecret("GCP_SERVICE_ACCOUNT_JSON"),
+      envVars: { GOOGLE_API_KEY: "dummy" },
+    });
+    expect(gcpRule.env_vars).toEqual({ GOOGLE_API_KEY: "dummy" });
+
+    expect(
+      gcpAuth({
+        serviceAccountJson: workspaceSecret("GCP_SERVICE_ACCOUNT_JSON"),
+      }),
+    ).not.toHaveProperty("env_vars");
+  });
+
+  it.each<Record<string, string>>([{}, { "": "value" }, { NAME: "" }])(
+    "rejects invalid env vars %j",
+    (envVars) => {
+      expect(() =>
+        awsAuth({
+          accessKeyId: workspaceSecret("AWS_KEY_ID_REF"),
+          secretAccessKey: workspaceSecret("AWS_KEY_VALUE_REF"),
+          envVars,
+        }),
+      ).toThrow();
+    },
+  );
+
   it("gcpAuth builds a GCP auth rule with built-in Google API host matching", () => {
     expect(
       gcpAuth({

--- a/python/langsmith/sandbox/_proxy_config.py
+++ b/python/langsmith/sandbox/_proxy_config.py
@@ -33,12 +33,12 @@ def _require_non_empty_string_list(values: Sequence[str], field: str) -> list[st
 def _require_env_vars(env_vars: Mapping[str, str]) -> dict[str, str]:
     if not isinstance(env_vars, Mapping) or not env_vars:
         raise ValueError("env_vars must be a non-empty mapping of names to values")
-    return {
-        _require_non_empty_string(name, "env_vars name"): _require_non_empty_string(
-            value, f"env_vars[{name}]"
-        )
-        for name, value in env_vars.items()
-    }
+    resolved: dict[str, str] = {}
+    for name, value in env_vars.items():
+        # Validated on the trimmed form, stored verbatim: whitespace can be significant.
+        _require_non_empty_string(value, f"env_vars[{name}]")
+        resolved[_require_non_empty_string(name, "env_vars name")] = value
+    return resolved
 
 
 def workspace_secret(name: str) -> SandboxProxySecret:

--- a/python/langsmith/sandbox/_proxy_config.py
+++ b/python/langsmith/sandbox/_proxy_config.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from typing import Any, Literal, TypedDict
 
 
@@ -28,6 +28,17 @@ def _require_non_empty_string_list(values: Sequence[str], field: str) -> list[st
         raise ValueError(f"{field} must be a non-empty list of strings")
     normalized = [_require_non_empty_string(value, field) for value in values]
     return normalized
+
+
+def _require_env_vars(env_vars: Mapping[str, str]) -> dict[str, str]:
+    if not isinstance(env_vars, Mapping) or not env_vars:
+        raise ValueError("env_vars must be a non-empty mapping of names to values")
+    return {
+        _require_non_empty_string(name, "env_vars name"): _require_non_empty_string(
+            value, f"env_vars[{name}]"
+        )
+        for name, value in env_vars.items()
+    }
 
 
 def workspace_secret(name: str) -> SandboxProxySecret:
@@ -112,6 +123,7 @@ def aws_auth(
     secret_access_key: SandboxProxySecret,
     name: str = "aws",
     enabled: bool = True,
+    env_vars: Mapping[str, str] | None = None,
 ) -> SandboxProxyRule:
     """Build a sandbox proxy rule that signs AWS HTTPS requests.
 
@@ -119,9 +131,15 @@ def aws_auth(
     signs supported AWS requests with SigV4 on the sandbox's behalf. AWS
     credentials must be supplied as ``workspace_secret`` or ``opaque`` values;
     plaintext AWS credentials are intentionally not supported.
+
+    Args:
+        env_vars: Plaintext environment variables set for every command in the
+            sandbox while this rule is enabled, for tools that refuse to run
+            unless a credential variable is present even though the proxy
+            injects the real credential on the wire.
     """
     rule_name = _require_non_empty_string(name, "name")
-    return {
+    rule: SandboxProxyRule = {
         "name": rule_name,
         "type": "aws",
         "enabled": enabled,
@@ -130,6 +148,9 @@ def aws_auth(
             "secret_access_key": secret_access_key,
         },
     }
+    if env_vars is not None:
+        rule["env_vars"] = _require_env_vars(env_vars)
+    return rule
 
 
 def gcp_auth(
@@ -138,6 +159,7 @@ def gcp_auth(
     scopes: Sequence[str] | None = None,
     name: str = "gcp",
     enabled: bool = True,
+    env_vars: Mapping[str, str] | None = None,
 ) -> SandboxProxyRule:
     """Build a sandbox proxy rule that injects GCP OAuth bearer auth.
 
@@ -146,6 +168,12 @@ def gcp_auth(
     ``service_account_json`` must be supplied as a ``workspace_secret`` or
     ``opaque`` value; plaintext service account JSON is intentionally not
     supported.
+
+    Args:
+        env_vars: Plaintext environment variables set for every command in the
+            sandbox while this rule is enabled, for tools that refuse to run
+            unless a credential variable is present even though the proxy
+            injects the real credential on the wire.
     """
     rule_name = _require_non_empty_string(name, "name")
     gcp_config: dict[str, Any] = {
@@ -153,9 +181,12 @@ def gcp_auth(
     }
     if scopes is not None:
         gcp_config["scopes"] = _require_non_empty_string_list(scopes, "scopes")
-    return {
+    rule: SandboxProxyRule = {
         "name": rule_name,
         "type": "gcp",
         "enabled": enabled,
         "gcp": gcp_config,
     }
+    if env_vars is not None:
+        rule["env_vars"] = _require_env_vars(env_vars)
+    return rule

--- a/python/tests/unit_tests/sandbox/test_proxy_config.py
+++ b/python/tests/unit_tests/sandbox/test_proxy_config.py
@@ -86,6 +86,15 @@ def test_gcp_auth_includes_env_vars() -> None:
     assert rule["env_vars"] == {"GOOGLE_API_KEY": "dummy"}
 
 
+def test_env_vars_preserve_surrounding_whitespace_in_values() -> None:
+    rule = gcp_auth(
+        service_account_json=workspace_secret("GCP_SERVICE_ACCOUNT_JSON"),
+        env_vars={"PREFIX": "  /opt/bin  "},
+    )
+
+    assert rule["env_vars"] == {"PREFIX": "  /opt/bin  "}
+
+
 def test_provider_rules_omit_env_vars_when_unset() -> None:
     rule = gcp_auth(service_account_json=workspace_secret("GCP_SERVICE_ACCOUNT_JSON"))
 

--- a/python/tests/unit_tests/sandbox/test_proxy_config.py
+++ b/python/tests/unit_tests/sandbox/test_proxy_config.py
@@ -67,6 +67,41 @@ def test_aws_auth_builds_aws_rule() -> None:
     }
 
 
+def test_aws_auth_includes_env_vars() -> None:
+    rule = aws_auth(
+        access_key_id=workspace_secret("AWS_ACCESS_KEY_ID"),
+        secret_access_key=workspace_secret("AWS_SECRET_ACCESS_KEY"),
+        env_vars={"AWS_ACCESS_KEY_ID": "dummy"},
+    )
+
+    assert rule["env_vars"] == {"AWS_ACCESS_KEY_ID": "dummy"}
+
+
+def test_gcp_auth_includes_env_vars() -> None:
+    rule = gcp_auth(
+        service_account_json=workspace_secret("GCP_SERVICE_ACCOUNT_JSON"),
+        env_vars={"GOOGLE_API_KEY": "dummy"},
+    )
+
+    assert rule["env_vars"] == {"GOOGLE_API_KEY": "dummy"}
+
+
+def test_provider_rules_omit_env_vars_when_unset() -> None:
+    rule = gcp_auth(service_account_json=workspace_secret("GCP_SERVICE_ACCOUNT_JSON"))
+
+    assert "env_vars" not in rule
+
+
+@pytest.mark.parametrize("env_vars", [{}, {"": "value"}, {"NAME": ""}])
+def test_env_vars_rejects_empty_names_and_values(env_vars: dict[str, str]) -> None:
+    with pytest.raises(ValueError):
+        aws_auth(
+            access_key_id=workspace_secret("AWS_ACCESS_KEY_ID"),
+            secret_access_key=workspace_secret("AWS_SECRET_ACCESS_KEY"),
+            env_vars=env_vars,
+        )
+
+
 def test_gcp_auth_builds_gcp_rule_with_builtin_google_api_host_matching() -> None:
     rule = gcp_auth(
         service_account_json=workspace_secret("GCP_SERVICE_ACCOUNT_JSON"),


### PR DESCRIPTION
Sandbox proxy rules accept `env_vars`: plaintext variables set for every command in the sandbox while the rule is enabled, for tools that refuse to run without a credential variable even though the proxy injects the real credential on the wire. The Go and Java SDKs already carry the field (generated from `openapi.json`); the Python and JS helpers only passed it through untyped.

- `aws_auth` / `gcp_auth` take `env_vars`, `awsAuth` / `gcpAuth` take `envVars`. Both validate a non-empty mapping of non-empty names and values, and omit the key when unset.
- `SandboxAwsAuthRule` and `SandboxGcpAuthRule` declare `env_vars?: Record<string, string>`.

## Test Plan

- [x] `uv run pytest tests/unit_tests/sandbox/test_proxy_config.py` — 48 passed
- [x] `jest src/tests/sandbox.test.ts` — 140 passed
- [x] `ruff check`, `mypy langsmith/sandbox/_proxy_config.py`, `tsc --noEmit`, oxlint, oxfmt