### PR TITLE
perf(py): default zstd compression to a single worker thread

### DIFF
--- a/python/langsmith/_internal/_compressed_traces.py
+++ b/python/langsmith/_internal/_compressed_traces.py
@@ -12,7 +12,15 @@ except ImportError:
     ZSTD_AVAILABLE = False
 
 compression_level = int(ls_utils.get_env_var("RUN_COMPRESSION_LEVEL") or 1)
-compression_threads = int(ls_utils.get_env_var("RUN_COMPRESSION_THREADS") or -1)
+
+# One zstd worker, not one per logical CPU: every worker holds its own job's
+# uncompressed input until it is consumed, so `threads=-1` kept ~the whole batch
+# in RAM on many-core hosts. Compression still runs off the caller's thread.
+# `RUN_COMPRESSION_THREADS=0` compresses inline on the tracing thread instead.
+_compression_threads_env = ls_utils.get_env_var("RUN_COMPRESSION_THREADS")
+compression_threads = (
+    int(_compression_threads_env) if _compression_threads_env is not None else 1
+)
 
 DEFAULT_MAX_UNCOMPRESSED_QUEUE_BYTES = 1024 * 1024 * 1024  # 1GB
 

--- a/python/tests/unit_tests/test_client.py
+++ b/python/tests/unit_tests/test_client.py
@@ -7865,3 +7865,28 @@ def test_get_test_results_joins_reference_examples(instance_flags, expect_v2) ->
     assert row["outputs.a"] == "yo"
     assert row["feedback.correctness"] == 0.75
     assert row["execution_time"] == 5.0
+
+
+def test_compression_threads_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Default to a single zstd worker; the env var (including "0") still wins."""
+    import importlib
+
+    from langsmith._internal import _compressed_traces
+
+    def _reload() -> int:
+        _clear_env_cache()
+        return importlib.reload(_compressed_traces).compression_threads
+
+    try:
+        monkeypatch.delenv("LANGSMITH_RUN_COMPRESSION_THREADS", raising=False)
+        monkeypatch.delenv("LANGCHAIN_RUN_COMPRESSION_THREADS", raising=False)
+        assert _reload() == 1
+
+        monkeypatch.setenv("LANGSMITH_RUN_COMPRESSION_THREADS", "0")
+        assert _reload() == 0
+
+        monkeypatch.setenv("LANGSMITH_RUN_COMPRESSION_THREADS", "4")
+        assert _reload() == 4
+    finally:
+        monkeypatch.undo()
+        _reload()


### PR DESCRIPTION
## Problem

`LANGSMITH_RUN_COMPRESSION_THREADS` defaults to `-1`, which python-zstandard resolves to one worker per logical CPU. In multithreaded mode zstd buffers each worker's uncompressed input until that job is consumed, so on a many-core host the compressor holds roughly the entire in-flight batch in RAM, bloating memory usage. In addition, running a zstd compression thread on every CPU can put more CPU pressure on the real application being traced.

## Change

Default to `threads=1`. Compression still happens on a zstd worker rather than the calling thread, but only one job's input is buffered at a time.

## Test

`test_compression_threads_default` in `tests/unit_tests/test_client.py` — asserts the unset default is 1 and that the env var (including `"0"`) wins.