### PR TITLE
perf(py): stop re-sending run inputs on patch by default

### DIFF
--- a/python/langsmith/run_trees.py
+++ b/python/langsmith/run_trees.py
@@ -145,14 +145,16 @@ def _filter_replica_for_headers(replica: WriteReplica) -> WriteReplica:
 def _exclude_inputs_on_patch() -> bool:
     """Whether `RunTree.patch()` should omit `inputs` by default.
 
-    Controlled by ``LANGSMITH_EXCLUDE_INPUTS_ON_PATCH``; defaults to ``False``, i.e.
-    inputs are re-sent on every patch. Enabling it skips serializing and uploading
-    the inputs a second time, which is a meaningful saving for large payloads, but
-    it also means inputs first set *after* `post()` are never persisted.
+    Controlled by ``LANGSMITH_EXCLUDE_INPUTS_ON_PATCH``; defaults to ``True``, i.e.
+    inputs are not re-sent on patch. Skipping them avoids serializing and uploading
+    a second copy of what `post()` already sent, which is a meaningful saving for
+    large payloads, but it also means inputs first set *after* `post()` are never
+    persisted. Set the variable to ``false`` to re-send them.
 
     Read once per process and cached; call ``.cache_clear()`` to re-read.
     """
-    return utils.is_truish(utils.get_env_var("EXCLUDE_INPUTS_ON_PATCH"))
+    env = utils.get_env_var("EXCLUDE_INPUTS_ON_PATCH")
+    return True if env is None else utils.is_truish(env)
 
 
 LANGSMITH_PREFIX = "langsmith-"
@@ -536,7 +538,7 @@ class RunTree(ls_schemas.RunBase):
     def add_inputs(self, inputs: dict[str, Any]) -> None:
         """Upsert the given inputs into the run.
 
-        Note: if `LANGSMITH_EXCLUDE_INPUTS_ON_PATCH` is enabled, inputs added
+        Note: unless `LANGSMITH_EXCLUDE_INPUTS_ON_PATCH` is disabled, inputs added
         after the initial `post()` are not sent by `patch()`. Call
         `patch(exclude_inputs=False)` explicitly to persist them.
 
@@ -845,7 +847,7 @@ class RunTree(ls_schemas.RunBase):
             exclude_inputs: Whether to exclude inputs from the patch request.
                 Defaults to `None`, meaning the value of the
                 `LANGSMITH_EXCLUDE_INPUTS_ON_PATCH` environment variable is used
-                (itself defaulting to `False`). Pass an explicit `True` or `False`
+                (itself defaulting to `True`). Pass an explicit `True` or `False`
                 to override the environment for this call.
         """
         if exclude_inputs is None:

--- a/python/tests/unit_tests/test_run_trees.py
+++ b/python/tests/unit_tests/test_run_trees.py
@@ -763,8 +763,8 @@ def _reset_exclude_inputs_cache():
 @pytest.mark.parametrize(
     "env_name, env_value, explicit, expect_inputs",
     [
-        # Unset env var keeps today's behaviour: inputs are re-sent on patch.
-        (None, None, None, True),
+        # Unset env var: inputs are not re-sent on patch.
+        (None, None, None, False),
         ("LANGSMITH_EXCLUDE_INPUTS_ON_PATCH", "true", None, False),
         ("LANGSMITH_EXCLUDE_INPUTS_ON_PATCH", "TRUE", None, False),
         ("LANGSMITH_EXCLUDE_INPUTS_ON_PATCH", "1", None, False),
@@ -836,13 +836,13 @@ def test_patch_exclude_inputs_flag_is_cached(monkeypatch, _reset_exclude_inputs_
         name="test_run", run_type="chain", inputs={"a": 1}, client=client
     )
     run_tree.patch()
-    assert client.update_run.call_args.kwargs["inputs"] == {"a": 1}
+    assert client.update_run.call_args.kwargs["inputs"] is None
 
     # Flipping the env var mid-process has no effect until the cache is cleared.
-    monkeypatch.setenv("LANGSMITH_EXCLUDE_INPUTS_ON_PATCH", "true")
+    monkeypatch.setenv("LANGSMITH_EXCLUDE_INPUTS_ON_PATCH", "false")
     run_tree.patch()
-    assert client.update_run.call_args.kwargs["inputs"] == {"a": 1}
+    assert client.update_run.call_args.kwargs["inputs"] is None
 
     _reset_exclude_inputs_cache()
     run_tree.patch()
-    assert client.update_run.call_args.kwargs["inputs"] is None
+    assert client.update_run.call_args.kwargs["inputs"] == {"a": 1}


### PR DESCRIPTION
## Problem

`RunTree.post()` uploads the run's `inputs`; the closing `RunTree.patch()` then sends the typically identical payload a second time. For a large input payload that is a full re-serialization (orjson + zstd) and a second upload of bytes the backend already has.

`LANGSMITH_EXCLUDE_INPUTS_ON_PATCH` exists to skip it - this PR turns this ON by default.

## Change
Default `LANGSMITH_EXCLUDE_INPUTS_ON_PATCH` to `true`. 

Notes:
- `LANGSMITH_EXCLUDE_INPUTS_ON_PATCH=false` restores the old behaviour globally.
- `patch(exclude_inputs=False)` overrides per call.

## Behaviour change to be aware of

By default, inputs first set *after* `post()` — `set(inputs=...)` / `add_inputs()` inside a `with trace(...)` block — are no longer persisted unless the caller passes `patch(exclude_inputs=False)`. 

The in-repo integrations that build inputs late (`google_adk`, `openai_agents_sdk`) defer `post()` until inputs are known, so they are unaffected.

Note this does **not** affect `langchain`/`langgraph` traces: `LangChainTracer._update_run_single` passes `exclude_inputs` explicitly (`run.extra.get("inputs_is_truthy", False)`), so the default here never applies to that path.

## Tests

`tests/unit_tests/test_run_trees.py` — existing env-flag parametrization updated for the new default, and the caching test inverted (unset → excluded; a mid-process `false` has no effect until `cache_clear()`).