### PR TITLE
fix(ci): stop uv run from resyncing the deepagent compat env

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -507,9 +507,12 @@ jobs:
           uv venv
           uv pip install -e .
       - name: Install deepagents
-        run: uv pip install deepagents
+        # pytest is installed here rather than coming from the dev group, because
+        # the smoke test runs with --no-sync: otherwise `uv run` resyncs .venv from
+        # uv.lock and downgrades langchain-core underneath deepagents.
+        run: uv pip install deepagents pytest
       - name: Run smoke test
-        run: uv run python -m pytest tests/external/test_deepagent_compat.py -v --noconftest
+        run: uv run --no-sync python -m pytest tests/external/test_deepagent_compat.py -v --noconftest
 
   # ============================================================================
   # Integration Tests


### PR DESCRIPTION
## Problem

`Python deepagent compat` fails on every run, regardless of the PR it runs on:

```
langchain/chat_models/base.py:21: in <module>
    from langchain_core.utils._gateway import _apply_gateway_config
E   ModuleNotFoundError: No module named 'langchain_core.utils._gateway'
```

The job installs deepagents, then runs the test through `uv run`:

```yaml
uv pip install deepagents      # resolves langchain 1.3.15 + langchain-core 1.5.4
uv run python -m pytest tests/external/test_deepagent_compat.py -v --noconftest
```

`uv run` syncs `.venv` from `uv.lock` before executing. Our dev group caps `langchain-core` at `<1.5.0`, so the lock pins 1.4.9 and the sync downgrades it. `langchain` is not in the lock, so it stays at 1.3.15:

| package | after `uv pip install deepagents` | after `uv run` sync |
| --- | --- | --- |
| `langchain` | 1.3.15 | 1.3.15 (untouched) |
| `langchain-core` | 1.5.4 | **1.4.9** (downgraded) |

That pair was never resolved together. `langchain_core.utils._gateway` exists only in langchain-core 1.5.x, and langchain 1.3.15 imports it at module scope, so the import fails.

The job also depends on the sync for `pytest`: neither `langsmith` nor `deepagents` requires it, so it arrived only via the dev group. `--no-sync` alone would fail with `No module named pytest`.

## Fix

```yaml
- name: Install deepagents
  run: uv pip install deepagents pytest
- name: Run smoke test
  run: uv run --no-sync python -m pytest tests/external/test_deepagent_compat.py -v --noconftest
```

`--no-sync` keeps the environment as deepagents resolved it, which is what a compatibility smoke test should exercise. It also skips installing the ~200-package dev group for two import tests. Verified locally by replaying the fixed steps: `2 passed`.

## Why not bump uv.lock instead

Raising the cap and relocking would go green today, but:

- **It doesn't address the cause.** The bug is that `uv run` replaces the resolution the job just created. That remains true at any lock version.
- **It recurs.** The lock is fixed; deepagents floats. The next time deepagents resolves a newer pair, the sync mismatches them again and the next cross-package import breaks the job again.
- **It's not ours to bump.** `langchain-core>=1.0.0,<1.5.0` came from the Dependabot bump in #3322, and Dependabot already owns raising it. Relocking also shifts versions for the unit-test, lint, and integration jobs that legitimately read the lock.

If a dev-group package later needs `langchain-core>=1.5`, that cap should be raised on its own merits. It is not what breaks this job.
