### PR TITLE
fix: report incomplete pytest suites accurately

### DIFF
--- a/python/langsmith/pytest_plugin.py
+++ b/python/langsmith/pytest_plugin.py
@@ -15,8 +15,6 @@ from langsmith import utils as ls_utils
 from langsmith.testing._internal import _get_test_suite_name
 from langsmith.testing._internal import test as ls_test
 
-_REPORTED_STATUSES = {"passed", "failed", "skipped"}
-
 logger = logging.getLogger(__name__)
 
 
@@ -120,8 +118,6 @@ class LangSmithPlugin:
 
         self.test_suites = defaultdict(list)
         self.test_suite_urls = {}
-        self.langsmith_nodeids = set()
-        self.completed_nodeids = set()
 
         self.process_status = {}  # Track process status
         self.status_lock = Lock()  # Thread-safe updates
@@ -136,13 +132,10 @@ class LangSmithPlugin:
     def pytest_collection_finish(self, session):
         """Group collected LangSmith tests by suite."""
         self.collected_nodeids = set()
-        self.langsmith_nodeids = set()
-        self.completed_nodeids = set()
         for item in session.items:
             self.collected_nodeids.add(item.nodeid)
             marker = item.get_closest_marker("langsmith")
             if marker:
-                self.langsmith_nodeids.add(item.nodeid)
                 test_suite = marker.kwargs.get("test_suite_name") or (
                     _get_test_suite_name(item.obj)
                 )
@@ -159,8 +152,6 @@ class LangSmithPlugin:
         if not self.process_status:
             self.live.console.print("Running tests...")
 
-        if status.get("status") in _REPORTED_STATUSES:
-            status = {**status, "_reported": True}
         with self.status_lock:
             current_status = self.process_status.get(process_id, {})
             self.process_status[process_id] = _merge_statuses(
@@ -173,36 +164,6 @@ class LangSmithPlugin:
     def pytest_runtest_logstart(self, nodeid):
         """Initialize live display when first test starts."""
         self.update_process_status(nodeid, {"status": "running"})
-
-    def pytest_runtest_logreport(self, report):
-        """Track pytest completion and failures for LangSmith tests."""
-        if report.nodeid not in self.langsmith_nodeids:
-            return
-        should_render = False
-        with self.status_lock:
-            current_status = self.process_status.get(report.nodeid, {})
-            if report.failed and not (
-                report.when == "call" and current_status.get("status") == "failed"
-            ):
-                self.process_status[report.nodeid] = {
-                    **current_status,
-                    "status": "error",
-                }
-                should_render = True
-            elif (
-                report.when == "teardown"
-                and report.skipped
-                and current_status.get("status") == "passed"
-            ):
-                self.process_status[report.nodeid] = {
-                    **current_status,
-                    "status": "skipped",
-                }
-                should_render = True
-            if report.when == "teardown":
-                self.completed_nodeids.add(report.nodeid)
-        if should_render:
-            self.live.update(self.generate_tables())
 
     def generate_tables(self):
         """Generate a collection of tables—one per suite.
@@ -252,9 +213,13 @@ LangSmith URL: [bright_cyan]{self.test_suite_urls.get(suite_name, "--")}[/bright
             max_duration = max(len(f"{duration:.2f}s"), max_duration)
             max_status = max(len(status.get("status", "queued")), max_status)
 
-        aggregate_status = _format_aggregate_status(
-            suite_statuses.values(), len(process_ids)
-        )
+        passed_count = sum(s.get("status") == "passed" for s in suite_statuses.values())
+        if suite_statuses:
+            rate = passed_count / len(suite_statuses)
+            color = "green" if rate == 1 else "red"
+            aggregate_status = f"[{color}]{rate:.0%}[/{color}]"
+        else:
+            aggregate_status = "Passed: --"
         if durations:
             aggregate_duration = f"{sum(durations) / len(durations):.2f}s"
         else:
@@ -273,10 +238,8 @@ LangSmith URL: [bright_cyan]{self.test_suite_urls.get(suite_name, "--")}[/bright
         for pid, status in suite_statuses.items():
             status_color = {
                 "running": "yellow",
-                "unreported": "yellow",
                 "passed": "green",
                 "failed": "red",
-                "error": "red",
                 "skipped": "cyan",
             }.get(status.get("status", "queued"), "white")
 
@@ -328,20 +291,7 @@ LangSmith URL: [bright_cyan]{self.test_suite_urls.get(suite_name, "--")}[/bright
             reporter.warning_summary = lambda *args, **kwargs: None
 
     def pytest_sessionfinish(self, session):
-        """Finalize and stop Rich Live rendering."""
-        with self.status_lock:
-            for process_ids in self.test_suites.values():
-                for process_id in process_ids:
-                    status = self.process_status.get(process_id, {})
-                    incomplete = process_id not in self.completed_nodeids
-                    if status.get("status") != "error" and (
-                        incomplete or status.get("status") not in _REPORTED_STATUSES
-                    ):
-                        self.process_status[process_id] = {
-                            **status,
-                            "status": "unreported",
-                        }
-        self.live.update(self.generate_tables())
+        """Stop Rich Live rendering at the end of the session."""
         self.live.stop()
         self.live.console.print("\nFinishing up...")
 
@@ -375,29 +325,6 @@ def pytest_configure(config):
         config.pluginmanager.register(LangSmithPlugin(), "langsmith_output_plugin")
         # Suppress warnings summary
         config.option.showwarnings = False
-
-
-def _format_aggregate_status(statuses, expected_count: int) -> str:
-    """Format a suite's pass and reporting rates."""
-    if not expected_count:
-        return "Passed: --"
-    statuses = list(statuses)
-    passed_count = sum(s.get("status") == "passed" for s in statuses)
-    failed_count = sum(s.get("status") in {"failed", "error"} for s in statuses)
-    reported_count = sum(
-        s.get("_reported", s.get("status") in _REPORTED_STATUSES) for s in statuses
-    )
-    rate = passed_count / expected_count
-    if failed_count:
-        color = "red"
-    elif reported_count == expected_count and passed_count == expected_count:
-        color = "green"
-    else:
-        color = "yellow"
-    return (
-        f"[{color}]{rate:.0%} passed "
-        f"({reported_count}/{expected_count} reported)[/{color}]"
-    )
 
 
 def _abbreviate(x: str, max_len: int) -> str:

--- a/python/langsmith/pytest_plugin.py
+++ b/python/langsmith/pytest_plugin.py
@@ -12,7 +12,10 @@ from typing import Any
 import pytest
 
 from langsmith import utils as ls_utils
+from langsmith.testing._internal import _get_test_suite_name
 from langsmith.testing._internal import test as ls_test
+
+_REPORTED_STATUSES = {"passed", "failed", "skipped"}
 
 logger = logging.getLogger(__name__)
 
@@ -117,6 +120,8 @@ class LangSmithPlugin:
 
         self.test_suites = defaultdict(list)
         self.test_suite_urls = {}
+        self.langsmith_nodeids = set()
+        self.completed_nodeids = set()
 
         self.process_status = {}  # Track process status
         self.status_lock = Lock()  # Thread-safe updates
@@ -129,14 +134,24 @@ class LangSmithPlugin:
         self.live.console.print("Collecting tests...")
 
     def pytest_collection_finish(self, session):
-        """Call after collection phase is completed and session.items is populated."""
+        """Group collected LangSmith tests by suite."""
         self.collected_nodeids = set()
+        self.langsmith_nodeids = set()
+        self.completed_nodeids = set()
         for item in session.items:
             self.collected_nodeids.add(item.nodeid)
+            marker = item.get_closest_marker("langsmith")
+            if marker:
+                self.langsmith_nodeids.add(item.nodeid)
+                test_suite = marker.kwargs.get("test_suite_name") or (
+                    _get_test_suite_name(item.obj)
+                )
+                self.add_process_to_test_suite(test_suite, item.nodeid)
 
     def add_process_to_test_suite(self, test_suite, process_id):
         """Group a test case with its test suite."""
-        self.test_suites[test_suite].append(process_id)
+        if process_id not in self.test_suites[test_suite]:
+            self.test_suites[test_suite].append(process_id)
 
     def update_process_status(self, process_id, status):
         """Update test results."""
@@ -144,6 +159,8 @@ class LangSmithPlugin:
         if not self.process_status:
             self.live.console.print("Running tests...")
 
+        if status.get("status") in _REPORTED_STATUSES:
+            status = {**status, "_reported": True}
         with self.status_lock:
             current_status = self.process_status.get(process_id, {})
             self.process_status[process_id] = _merge_statuses(
@@ -156,6 +173,36 @@ class LangSmithPlugin:
     def pytest_runtest_logstart(self, nodeid):
         """Initialize live display when first test starts."""
         self.update_process_status(nodeid, {"status": "running"})
+
+    def pytest_runtest_logreport(self, report):
+        """Track pytest completion and failures for LangSmith tests."""
+        if report.nodeid not in self.langsmith_nodeids:
+            return
+        should_render = False
+        with self.status_lock:
+            current_status = self.process_status.get(report.nodeid, {})
+            if report.failed and not (
+                report.when == "call" and current_status.get("status") == "failed"
+            ):
+                self.process_status[report.nodeid] = {
+                    **current_status,
+                    "status": "error",
+                }
+                should_render = True
+            elif (
+                report.when == "teardown"
+                and report.skipped
+                and current_status.get("status") == "passed"
+            ):
+                self.process_status[report.nodeid] = {
+                    **current_status,
+                    "status": "skipped",
+                }
+                should_render = True
+            if report.when == "teardown":
+                self.completed_nodeids.add(report.nodeid)
+        if should_render:
+            self.live.update(self.generate_tables())
 
     def generate_tables(self):
         """Generate a collection of tables—one per suite.
@@ -178,7 +225,7 @@ class LangSmithPlugin:
         process_ids = self.test_suites[suite_name]
 
         title = f"""Test Suite: [bold]{suite_name}[/bold]
-LangSmith URL: [bright_cyan]{self.test_suite_urls[suite_name]}[/bright_cyan]"""  # noqa: E501
+LangSmith URL: [bright_cyan]{self.test_suite_urls.get(suite_name, "--")}[/bright_cyan]"""  # noqa: E501
         table = Table(title=title, title_justify="left")
         table.add_column("Test")
         table.add_column("Inputs")
@@ -195,7 +242,7 @@ LangSmith URL: [bright_cyan]{self.test_suite_urls[suite_name]}[/bright_cyan]""" 
         durations = []
         numeric_feedbacks = defaultdict(list)
         # Gather data only for this suite
-        suite_statuses = {pid: self.process_status[pid] for pid in process_ids}
+        suite_statuses = {pid: self.process_status.get(pid, {}) for pid in process_ids}
         for pid, status in suite_statuses.items():
             duration = status.get("end_time", now) - status.get("start_time", now)
             durations.append(duration)
@@ -205,16 +252,9 @@ LangSmith URL: [bright_cyan]{self.test_suite_urls[suite_name]}[/bright_cyan]""" 
             max_duration = max(len(f"{duration:.2f}s"), max_duration)
             max_status = max(len(status.get("status", "queued")), max_status)
 
-        passed_count = sum(s.get("status") == "passed" for s in suite_statuses.values())
-        failed_count = sum(s.get("status") == "failed" for s in suite_statuses.values())
-
-        # You could arrange a row to show the aggregated data—here, in the last column:
-        if passed_count + failed_count:
-            rate = passed_count / (passed_count + failed_count)
-            color = "green" if rate == 1 else "red"
-            aggregate_status = f"[{color}]{rate:.0%}[/{color}]"
-        else:
-            aggregate_status = "Passed: --"
+        aggregate_status = _format_aggregate_status(
+            suite_statuses.values(), len(process_ids)
+        )
         if durations:
             aggregate_duration = f"{sum(durations) / len(durations):.2f}s"
         else:
@@ -233,8 +273,10 @@ LangSmith URL: [bright_cyan]{self.test_suite_urls[suite_name]}[/bright_cyan]""" 
         for pid, status in suite_statuses.items():
             status_color = {
                 "running": "yellow",
+                "unreported": "yellow",
                 "passed": "green",
                 "failed": "red",
+                "error": "red",
                 "skipped": "cyan",
             }.get(status.get("status", "queued"), "white")
 
@@ -286,7 +328,20 @@ LangSmith URL: [bright_cyan]{self.test_suite_urls[suite_name]}[/bright_cyan]""" 
             reporter.warning_summary = lambda *args, **kwargs: None
 
     def pytest_sessionfinish(self, session):
-        """Stop Rich Live rendering at the end of the session."""
+        """Finalize and stop Rich Live rendering."""
+        with self.status_lock:
+            for process_ids in self.test_suites.values():
+                for process_id in process_ids:
+                    status = self.process_status.get(process_id, {})
+                    incomplete = process_id not in self.completed_nodeids
+                    if status.get("status") != "error" and (
+                        incomplete or status.get("status") not in _REPORTED_STATUSES
+                    ):
+                        self.process_status[process_id] = {
+                            **status,
+                            "status": "unreported",
+                        }
+        self.live.update(self.generate_tables())
         self.live.stop()
         self.live.console.print("\nFinishing up...")
 
@@ -320,6 +375,29 @@ def pytest_configure(config):
         config.pluginmanager.register(LangSmithPlugin(), "langsmith_output_plugin")
         # Suppress warnings summary
         config.option.showwarnings = False
+
+
+def _format_aggregate_status(statuses, expected_count: int) -> str:
+    """Format a suite's pass and reporting rates."""
+    if not expected_count:
+        return "Passed: --"
+    statuses = list(statuses)
+    passed_count = sum(s.get("status") == "passed" for s in statuses)
+    failed_count = sum(s.get("status") in {"failed", "error"} for s in statuses)
+    reported_count = sum(
+        s.get("_reported", s.get("status") in _REPORTED_STATUSES) for s in statuses
+    )
+    rate = passed_count / expected_count
+    if failed_count:
+        color = "red"
+    elif reported_count == expected_count and passed_count == expected_count:
+        color = "green"
+    else:
+        color = "yellow"
+    return (
+        f"[{color}]{rate:.0%} passed "
+        f"({reported_count}/{expected_count} reported)[/{color}]"
+    )
 
 
 def _abbreviate(x: str, max_len: int) -> str:

--- a/python/langsmith/pytest_plugin.py
+++ b/python/langsmith/pytest_plugin.py
@@ -118,6 +118,7 @@ class LangSmithPlugin:
 
         self.test_suites = defaultdict(list)
         self.test_suite_urls = {}
+        self.langsmith_nodeids = set()
 
         self.process_status = {}  # Track process status
         self.status_lock = Lock()  # Thread-safe updates
@@ -132,10 +133,12 @@ class LangSmithPlugin:
     def pytest_collection_finish(self, session):
         """Group collected LangSmith tests by suite."""
         self.collected_nodeids = set()
+        self.langsmith_nodeids = set()
         for item in session.items:
             self.collected_nodeids.add(item.nodeid)
             marker = item.get_closest_marker("langsmith")
             if marker:
+                self.langsmith_nodeids.add(item.nodeid)
                 test_suite = marker.kwargs.get("test_suite_name") or (
                     _get_test_suite_name(item.obj)
                 )
@@ -164,6 +167,16 @@ class LangSmithPlugin:
     def pytest_runtest_logstart(self, nodeid):
         """Initialize live display when first test starts."""
         self.update_process_status(nodeid, {"status": "running"})
+
+    def pytest_runtest_logreport(self, report):
+        """Track setup failures and skips for LangSmith tests."""
+        if (
+            report.nodeid in self.langsmith_nodeids
+            and report.when == "setup"
+            and (report.failed or report.skipped)
+        ):
+            status = "failed" if report.failed else "skipped"
+            self.update_process_status(report.nodeid, {"status": status})
 
     def generate_tables(self):
         """Generate a collection of tables—one per suite.

--- a/python/tests/unit_tests/test_pytest_plugin.py
+++ b/python/tests/unit_tests/test_pytest_plugin.py
@@ -1,6 +1,9 @@
 from collections import defaultdict
+from threading import Lock
 from types import SimpleNamespace
+from unittest.mock import Mock
 
+import pytest
 from rich.console import Console
 
 from langsmith import pytest_plugin
@@ -30,6 +33,32 @@ def test_collection_groups_langsmith_tests_by_suite(monkeypatch):
     plugin.add_process_to_test_suite("default-suite", langsmith_item.nodeid)
 
     assert plugin.test_suites == {"default-suite": [langsmith_item.nodeid]}
+
+
+@pytest.mark.parametrize(
+    ("failed", "skipped", "expected_status"),
+    [(True, False, "failed"), (False, True, "skipped")],
+)
+def test_setup_outcome_replaces_running_status(failed, skipped, expected_status):
+    plugin = object.__new__(pytest_plugin.LangSmithPlugin)
+    nodeid = "test_example.py::test_setup_outcome"
+    plugin.langsmith_nodeids = {nodeid}
+    plugin.process_status = {}
+    plugin.status_lock = Lock()
+    plugin.live = Mock()
+    plugin.generate_tables = Mock(return_value="tables")
+
+    plugin.pytest_runtest_logstart(nodeid)
+    plugin.pytest_runtest_logreport(
+        SimpleNamespace(
+            nodeid=nodeid,
+            when="setup",
+            failed=failed,
+            skipped=skipped,
+        )
+    )
+
+    assert plugin.process_status[nodeid]["status"] == expected_status
 
 
 def test_table_counts_collected_tests_without_results():

--- a/python/tests/unit_tests/test_pytest_plugin.py
+++ b/python/tests/unit_tests/test_pytest_plugin.py
@@ -1,57 +1,19 @@
 from collections import defaultdict
 from types import SimpleNamespace
-from unittest.mock import Mock
 
-import pytest
 from rich.console import Console
 
 from langsmith import pytest_plugin
 
 
-@pytest.mark.parametrize(
-    ("statuses", "expected_count", "formatted"),
-    [
-        (
-            [{"status": "passed"}, {"status": "passed"}],
-            2,
-            "[green]100% passed (2/2 reported)[/green]",
-        ),
-        (
-            [{"status": "passed"}] * 3 + [{}] * 7,
-            10,
-            "[yellow]30% passed (3/10 reported)[/yellow]",
-        ),
-        (
-            [{"status": "passed"}, {"status": "failed"}],
-            2,
-            "[red]50% passed (2/2 reported)[/red]",
-        ),
-        (
-            [{"status": "passed"}, {"status": "skipped"}],
-            2,
-            "[yellow]50% passed (2/2 reported)[/yellow]",
-        ),
-        ([], 0, "Passed: --"),
-    ],
-)
-def test_format_aggregate_status(statuses, expected_count, formatted):
-    assert pytest_plugin._format_aggregate_status(statuses, expected_count) == formatted
-
-
 def test_collection_groups_langsmith_tests_by_suite(monkeypatch):
     plugin = object.__new__(pytest_plugin.LangSmithPlugin)
     plugin.test_suites = defaultdict(list)
-    explicit_marker = SimpleNamespace(kwargs={"test_suite_name": "explicit-suite"})
-    default_marker = SimpleNamespace(kwargs={})
-    explicit_item = SimpleNamespace(
-        nodeid="test_example.py::test_explicit",
+    marker = SimpleNamespace(kwargs={})
+    langsmith_item = SimpleNamespace(
+        nodeid="test_example.py::test_tracked",
         obj=object(),
-        get_closest_marker=lambda name: explicit_marker,
-    )
-    default_item = SimpleNamespace(
-        nodeid="test_example.py::test_default",
-        obj=object(),
-        get_closest_marker=lambda name: default_marker,
+        get_closest_marker=lambda name: marker,
     )
     regular_item = SimpleNamespace(
         nodeid="test_example.py::test_regular",
@@ -63,27 +25,22 @@ def test_collection_groups_langsmith_tests_by_suite(monkeypatch):
     )
 
     plugin.pytest_collection_finish(
-        SimpleNamespace(items=[explicit_item, default_item, regular_item])
+        SimpleNamespace(items=[langsmith_item, regular_item])
     )
-    plugin.add_process_to_test_suite("explicit-suite", explicit_item.nodeid)
+    plugin.add_process_to_test_suite("default-suite", langsmith_item.nodeid)
 
-    assert plugin.collected_nodeids == {
-        explicit_item.nodeid,
-        default_item.nodeid,
-        regular_item.nodeid,
-    }
-    assert plugin.langsmith_nodeids == {explicit_item.nodeid, default_item.nodeid}
-    assert plugin.test_suites == {
-        "explicit-suite": [explicit_item.nodeid],
-        "default-suite": [default_item.nodeid],
-    }
+    assert plugin.test_suites == {"default-suite": [langsmith_item.nodeid]}
 
 
-def test_table_includes_expected_tests_without_results():
+def test_table_counts_collected_tests_without_results():
     plugin = object.__new__(pytest_plugin.LangSmithPlugin)
-    plugin.test_suites = {"suite": ["test_example.py::test_missing"]}
+    plugin.test_suites = {
+        "suite": ["test_example.py::test_passed", "test_example.py::test_missing"]
+    }
     plugin.test_suite_urls = {}
-    plugin.process_status = {}
+    plugin.process_status = {
+        "test_example.py::test_passed": {"status": "passed"},
+    }
     plugin.console = Console(width=300, record=True)
 
     plugin.console.print(plugin._generate_table("suite"))
@@ -92,134 +49,4 @@ def test_table_includes_expected_tests_without_results():
     assert "LangSmith URL: --" in output
     assert "test_example.py::test_missing" in output
     assert "queued" in output
-    assert "0% passed (0/1 reported)" in output
-
-
-def test_terminal_langsmith_status_is_marked_reported():
-    plugin = object.__new__(pytest_plugin.LangSmithPlugin)
-    plugin.process_status = {}
-    plugin.status_lock = pytest_plugin.Lock()
-    plugin.generate_tables = Mock(return_value="tables")
-    plugin.live = Mock()
-
-    plugin.update_process_status("test_example.py::test_passed", {"status": "passed"})
-
-    assert plugin.process_status == {
-        "test_example.py::test_passed": {"status": "passed", "_reported": True}
-    }
-
-
-def test_call_failure_keeps_langsmith_failed_status():
-    plugin = object.__new__(pytest_plugin.LangSmithPlugin)
-    nodeid = "test_example.py::test_failed"
-    plugin.langsmith_nodeids = {nodeid}
-    plugin.completed_nodeids = set()
-    plugin.process_status = {nodeid: {"status": "failed", "_reported": True}}
-    plugin.status_lock = pytest_plugin.Lock()
-    plugin.generate_tables = Mock(return_value="tables")
-    plugin.live = Mock()
-
-    plugin.pytest_runtest_logreport(
-        SimpleNamespace(nodeid=nodeid, failed=True, skipped=False, when="call")
-    )
-
-    assert plugin.process_status[nodeid] == {
-        "status": "failed",
-        "_reported": True,
-    }
-    plugin.live.update.assert_not_called()
-
-
-def test_skipped_teardown_invalidates_reported_pass():
-    plugin = object.__new__(pytest_plugin.LangSmithPlugin)
-    nodeid = "test_example.py::test_teardown_skip"
-    plugin.langsmith_nodeids = {nodeid}
-    plugin.completed_nodeids = set()
-    plugin.process_status = {nodeid: {"status": "passed", "_reported": True}}
-    plugin.status_lock = pytest_plugin.Lock()
-    plugin.generate_tables = Mock(return_value="tables")
-    plugin.live = Mock()
-
-    plugin.pytest_runtest_logreport(
-        SimpleNamespace(nodeid=nodeid, failed=False, skipped=True, when="teardown")
-    )
-
-    status = plugin.process_status[nodeid]
-    assert status == {"status": "skipped", "_reported": True}
-    assert pytest_plugin._format_aggregate_status([status], 1) == (
-        "[yellow]0% passed (1/1 reported)[/yellow]"
-    )
-    assert plugin.completed_nodeids == {nodeid}
-    plugin.live.update.assert_called_once_with("tables")
-
-
-def test_pytest_failure_overrides_reported_pass():
-    plugin = object.__new__(pytest_plugin.LangSmithPlugin)
-    plugin.langsmith_nodeids = {"test_example.py::test_error"}
-    plugin.completed_nodeids = set()
-    plugin.process_status = {
-        "test_example.py::test_error": {"status": "passed", "_reported": True}
-    }
-    plugin.status_lock = pytest_plugin.Lock()
-    plugin.generate_tables = Mock(return_value="tables")
-    plugin.live = Mock()
-
-    plugin.pytest_runtest_logreport(
-        SimpleNamespace(
-            nodeid="test_example.py::test_error", failed=True, when="teardown"
-        )
-    )
-
-    status = plugin.process_status["test_example.py::test_error"]
-    assert status == {"status": "error", "_reported": True}
-    assert plugin.completed_nodeids == {"test_example.py::test_error"}
-    assert pytest_plugin._format_aggregate_status([status], 1) == (
-        "[red]0% passed (1/1 reported)[/red]"
-    )
-    plugin.live.update.assert_called_once_with("tables")
-
-
-def test_session_finish_invalidates_pass_without_teardown():
-    plugin = object.__new__(pytest_plugin.LangSmithPlugin)
-    plugin.test_suites = {"suite": ["test_example.py::test_incomplete"]}
-    plugin.process_status = {
-        "test_example.py::test_incomplete": {
-            "status": "passed",
-            "_reported": True,
-        }
-    }
-    plugin.status_lock = pytest_plugin.Lock()
-    plugin.completed_nodeids = set()
-    plugin.generate_tables = Mock(return_value="tables")
-    plugin.live = Mock()
-
-    plugin.pytest_sessionfinish(SimpleNamespace())
-
-    status = plugin.process_status["test_example.py::test_incomplete"]
-    assert status == {"status": "unreported", "_reported": True}
-    assert pytest_plugin._format_aggregate_status([status], 1) == (
-        "[yellow]0% passed (1/1 reported)[/yellow]"
-    )
-
-
-def test_session_finish_marks_incomplete_tests_unreported():
-    plugin = object.__new__(pytest_plugin.LangSmithPlugin)
-    plugin.test_suites = {"suite": ["passed", "running", "missing"]}
-    plugin.process_status = {
-        "passed": {"status": "passed"},
-        "running": {"status": "running"},
-    }
-    plugin.status_lock = pytest_plugin.Lock()
-    plugin.completed_nodeids = {"passed", "running", "missing"}
-    plugin.generate_tables = Mock(return_value="tables")
-    plugin.live = Mock()
-
-    plugin.pytest_sessionfinish(SimpleNamespace())
-
-    assert plugin.process_status == {
-        "passed": {"status": "passed"},
-        "running": {"status": "unreported"},
-        "missing": {"status": "unreported"},
-    }
-    plugin.live.update.assert_called_once_with("tables")
-    plugin.live.stop.assert_called_once_with()
+    assert "50%" in output

--- a/python/tests/unit_tests/test_pytest_plugin.py
+++ b/python/tests/unit_tests/test_pytest_plugin.py
@@ -1,0 +1,225 @@
+from collections import defaultdict
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+from rich.console import Console
+
+from langsmith import pytest_plugin
+
+
+@pytest.mark.parametrize(
+    ("statuses", "expected_count", "formatted"),
+    [
+        (
+            [{"status": "passed"}, {"status": "passed"}],
+            2,
+            "[green]100% passed (2/2 reported)[/green]",
+        ),
+        (
+            [{"status": "passed"}] * 3 + [{}] * 7,
+            10,
+            "[yellow]30% passed (3/10 reported)[/yellow]",
+        ),
+        (
+            [{"status": "passed"}, {"status": "failed"}],
+            2,
+            "[red]50% passed (2/2 reported)[/red]",
+        ),
+        (
+            [{"status": "passed"}, {"status": "skipped"}],
+            2,
+            "[yellow]50% passed (2/2 reported)[/yellow]",
+        ),
+        ([], 0, "Passed: --"),
+    ],
+)
+def test_format_aggregate_status(statuses, expected_count, formatted):
+    assert pytest_plugin._format_aggregate_status(statuses, expected_count) == formatted
+
+
+def test_collection_groups_langsmith_tests_by_suite(monkeypatch):
+    plugin = object.__new__(pytest_plugin.LangSmithPlugin)
+    plugin.test_suites = defaultdict(list)
+    explicit_marker = SimpleNamespace(kwargs={"test_suite_name": "explicit-suite"})
+    default_marker = SimpleNamespace(kwargs={})
+    explicit_item = SimpleNamespace(
+        nodeid="test_example.py::test_explicit",
+        obj=object(),
+        get_closest_marker=lambda name: explicit_marker,
+    )
+    default_item = SimpleNamespace(
+        nodeid="test_example.py::test_default",
+        obj=object(),
+        get_closest_marker=lambda name: default_marker,
+    )
+    regular_item = SimpleNamespace(
+        nodeid="test_example.py::test_regular",
+        obj=object(),
+        get_closest_marker=lambda name: None,
+    )
+    monkeypatch.setattr(
+        pytest_plugin, "_get_test_suite_name", lambda obj: "default-suite"
+    )
+
+    plugin.pytest_collection_finish(
+        SimpleNamespace(items=[explicit_item, default_item, regular_item])
+    )
+    plugin.add_process_to_test_suite("explicit-suite", explicit_item.nodeid)
+
+    assert plugin.collected_nodeids == {
+        explicit_item.nodeid,
+        default_item.nodeid,
+        regular_item.nodeid,
+    }
+    assert plugin.langsmith_nodeids == {explicit_item.nodeid, default_item.nodeid}
+    assert plugin.test_suites == {
+        "explicit-suite": [explicit_item.nodeid],
+        "default-suite": [default_item.nodeid],
+    }
+
+
+def test_table_includes_expected_tests_without_results():
+    plugin = object.__new__(pytest_plugin.LangSmithPlugin)
+    plugin.test_suites = {"suite": ["test_example.py::test_missing"]}
+    plugin.test_suite_urls = {}
+    plugin.process_status = {}
+    plugin.console = Console(width=300, record=True)
+
+    plugin.console.print(plugin._generate_table("suite"))
+
+    output = " ".join(plugin.console.export_text().split())
+    assert "LangSmith URL: --" in output
+    assert "test_example.py::test_missing" in output
+    assert "queued" in output
+    assert "0% passed (0/1 reported)" in output
+
+
+def test_terminal_langsmith_status_is_marked_reported():
+    plugin = object.__new__(pytest_plugin.LangSmithPlugin)
+    plugin.process_status = {}
+    plugin.status_lock = pytest_plugin.Lock()
+    plugin.generate_tables = Mock(return_value="tables")
+    plugin.live = Mock()
+
+    plugin.update_process_status("test_example.py::test_passed", {"status": "passed"})
+
+    assert plugin.process_status == {
+        "test_example.py::test_passed": {"status": "passed", "_reported": True}
+    }
+
+
+def test_call_failure_keeps_langsmith_failed_status():
+    plugin = object.__new__(pytest_plugin.LangSmithPlugin)
+    nodeid = "test_example.py::test_failed"
+    plugin.langsmith_nodeids = {nodeid}
+    plugin.completed_nodeids = set()
+    plugin.process_status = {nodeid: {"status": "failed", "_reported": True}}
+    plugin.status_lock = pytest_plugin.Lock()
+    plugin.generate_tables = Mock(return_value="tables")
+    plugin.live = Mock()
+
+    plugin.pytest_runtest_logreport(
+        SimpleNamespace(nodeid=nodeid, failed=True, skipped=False, when="call")
+    )
+
+    assert plugin.process_status[nodeid] == {
+        "status": "failed",
+        "_reported": True,
+    }
+    plugin.live.update.assert_not_called()
+
+
+def test_skipped_teardown_invalidates_reported_pass():
+    plugin = object.__new__(pytest_plugin.LangSmithPlugin)
+    nodeid = "test_example.py::test_teardown_skip"
+    plugin.langsmith_nodeids = {nodeid}
+    plugin.completed_nodeids = set()
+    plugin.process_status = {nodeid: {"status": "passed", "_reported": True}}
+    plugin.status_lock = pytest_plugin.Lock()
+    plugin.generate_tables = Mock(return_value="tables")
+    plugin.live = Mock()
+
+    plugin.pytest_runtest_logreport(
+        SimpleNamespace(nodeid=nodeid, failed=False, skipped=True, when="teardown")
+    )
+
+    status = plugin.process_status[nodeid]
+    assert status == {"status": "skipped", "_reported": True}
+    assert pytest_plugin._format_aggregate_status([status], 1) == (
+        "[yellow]0% passed (1/1 reported)[/yellow]"
+    )
+    assert plugin.completed_nodeids == {nodeid}
+    plugin.live.update.assert_called_once_with("tables")
+
+
+def test_pytest_failure_overrides_reported_pass():
+    plugin = object.__new__(pytest_plugin.LangSmithPlugin)
+    plugin.langsmith_nodeids = {"test_example.py::test_error"}
+    plugin.completed_nodeids = set()
+    plugin.process_status = {
+        "test_example.py::test_error": {"status": "passed", "_reported": True}
+    }
+    plugin.status_lock = pytest_plugin.Lock()
+    plugin.generate_tables = Mock(return_value="tables")
+    plugin.live = Mock()
+
+    plugin.pytest_runtest_logreport(
+        SimpleNamespace(
+            nodeid="test_example.py::test_error", failed=True, when="teardown"
+        )
+    )
+
+    status = plugin.process_status["test_example.py::test_error"]
+    assert status == {"status": "error", "_reported": True}
+    assert plugin.completed_nodeids == {"test_example.py::test_error"}
+    assert pytest_plugin._format_aggregate_status([status], 1) == (
+        "[red]0% passed (1/1 reported)[/red]"
+    )
+    plugin.live.update.assert_called_once_with("tables")
+
+
+def test_session_finish_invalidates_pass_without_teardown():
+    plugin = object.__new__(pytest_plugin.LangSmithPlugin)
+    plugin.test_suites = {"suite": ["test_example.py::test_incomplete"]}
+    plugin.process_status = {
+        "test_example.py::test_incomplete": {
+            "status": "passed",
+            "_reported": True,
+        }
+    }
+    plugin.status_lock = pytest_plugin.Lock()
+    plugin.completed_nodeids = set()
+    plugin.generate_tables = Mock(return_value="tables")
+    plugin.live = Mock()
+
+    plugin.pytest_sessionfinish(SimpleNamespace())
+
+    status = plugin.process_status["test_example.py::test_incomplete"]
+    assert status == {"status": "unreported", "_reported": True}
+    assert pytest_plugin._format_aggregate_status([status], 1) == (
+        "[yellow]0% passed (1/1 reported)[/yellow]"
+    )
+
+
+def test_session_finish_marks_incomplete_tests_unreported():
+    plugin = object.__new__(pytest_plugin.LangSmithPlugin)
+    plugin.test_suites = {"suite": ["passed", "running", "missing"]}
+    plugin.process_status = {
+        "passed": {"status": "passed"},
+        "running": {"status": "running"},
+    }
+    plugin.status_lock = pytest_plugin.Lock()
+    plugin.completed_nodeids = {"passed", "running", "missing"}
+    plugin.generate_tables = Mock(return_value="tables")
+    plugin.live = Mock()
+
+    plugin.pytest_sessionfinish(SimpleNamespace())
+
+    assert plugin.process_status == {
+        "passed": {"status": "passed"},
+        "running": {"status": "unreported"},
+        "missing": {"status": "unreported"},
+    }
+    plugin.live.update.assert_called_once_with("tables")
+    plugin.live.stop.assert_called_once_with()


### PR DESCRIPTION
## Description
Pre-registers collected LangSmith tests and computes the displayed pass rate against the full suite so incomplete runs cannot appear fully passing. Setup failures and skips are finalized from pytest reports.

## Test Plan
- [x] Verify collected but unrun tests remain queued and reduce the displayed pass rate.
- [x] Verify setup failures and skips replace the running status.

Made by [Open SWE](https://openswe.vercel.app/agents/bd2bd11e-e968-bee2-0f08-ed74914dbb94)