### PR TITLE
fix(serde): collapse plain container cycles instead of raising

### DIFF
--- a/python/langsmith/_internal/_serde.py
+++ b/python/langsmith/_internal/_serde.py
@@ -133,7 +133,7 @@ def _serialize_json(obj: Any) -> Any:
         return str(obj)
 
 
-def _normalize_json_keys(obj: Any) -> Any:
+def _normalize_json_keys(obj: Any, _seen: set[int] | None = None) -> Any:
     """Recursively stringify dict keys that orjson will reject.
 
     Walks ``dict``, ``list``, ``tuple`` and ``deque`` so that unsupported keys
@@ -141,8 +141,10 @@ def _normalize_json_keys(obj: Any) -> Any:
     are covered here even though they're only ever *values*: orjson serializes
     them natively (as arrays) and therefore never routes them through the
     ``default`` hook, so a bad-keyed dict nested inside one would otherwise
-    slip past normalization. Cycles are handled downstream by
-    ``_serialize_json`` (which collapses them to ``str``), not here.
+    slip past normalization. A container reachable from itself is collapsed to
+    ``str`` (mirroring how ``_serialize_json`` collapses object cycles) so a
+    plain ``dict``/``list`` cycle does not recurse forever; ``_seen`` tracks the
+    ids of the containers on the current path for that check.
 
     JSON object keys must ultimately be ``str``/``int``/``float``/``bool``/
     ``None``; other key types are stringified via ``_simple_default`` so they
@@ -154,29 +156,45 @@ def _normalize_json_keys(obj: Any) -> Any:
     overwrites the other (last-in-iteration-order wins); the collision is
     logged at debug level so the data loss is traceable.
     """
-    if isinstance(obj, dict):
-        new: dict[Any, Any] = {}
-        for key, value in obj.items():
-            norm_key: Any = (
-                key if isinstance(key, _JSON_KEY_TYPES) else str(_simple_default(key))
-            )
-            if norm_key in new:
-                logger.debug(
-                    "Dict key collision during JSON key normalization; "
-                    "an existing value will be overwritten."
+    if isinstance(obj, (dict, list, tuple, collections.deque)):
+        if _seen is None:
+            _seen = set()
+        obj_id = id(obj)
+        if obj_id in _seen:
+            # A container reachable from itself. Collapse it the same way object
+            # cycles are collapsed, so dumps_json stays non-raising on cyclic data.
+            return str(obj)
+        _seen.add(obj_id)
+        try:
+            if isinstance(obj, dict):
+                new: dict[Any, Any] = {}
+                for key, value in obj.items():
+                    norm_key: Any = (
+                        key
+                        if isinstance(key, _JSON_KEY_TYPES)
+                        else str(_simple_default(key))
+                    )
+                    if norm_key in new:
+                        logger.debug(
+                            "Dict key collision during JSON key normalization; "
+                            "an existing value will be overwritten."
+                        )
+                    new[norm_key] = _normalize_json_keys(value, _seen)
+                return new
+            if isinstance(obj, list):
+                return [_normalize_json_keys(value, _seen) for value in obj]
+            if isinstance(obj, tuple) and not (
+                hasattr(obj, "_asdict") and callable(obj._asdict)
+            ):
+                # Plain tuples recurse; NamedTuples are left for _serialize_json,
+                # which converts them to dicts (preserving field names) first.
+                return tuple(_normalize_json_keys(value, _seen) for value in obj)
+            if isinstance(obj, collections.deque):
+                return collections.deque(
+                    _normalize_json_keys(value, _seen) for value in obj
                 )
-            new[norm_key] = _normalize_json_keys(value)
-        return new
-    if isinstance(obj, list):
-        return [_normalize_json_keys(value) for value in obj]
-    if isinstance(obj, tuple) and not (
-        hasattr(obj, "_asdict") and callable(obj._asdict)
-    ):
-        # Plain tuples recurse; NamedTuples are left for _serialize_json, which
-        # converts them to dicts (preserving field names) before normalization.
-        return tuple(_normalize_json_keys(value) for value in obj)
-    if isinstance(obj, collections.deque):
-        return collections.deque(_normalize_json_keys(value) for value in obj)
+        finally:
+            _seen.discard(obj_id)
     return obj
 
 

--- a/python/tests/unit_tests/test_client.py
+++ b/python/tests/unit_tests/test_client.py
@@ -2383,6 +2383,33 @@ def test_serialize_json(caplog) -> None:
     expected = {"foo": "foo", "bar": 1}
 
 
+def test__dumps_json_plain_container_cycles() -> None:
+    """A cycle built from plain ``dict``/``list``/``deque`` must not raise. It is
+    collapsed to a string like an object cycle, and a subtree shared by two keys
+    (not a cycle) must still be serialized in full rather than mistaken for one.
+    """
+    import collections
+
+    d: dict = {}
+    d["self"] = d
+    assert isinstance(_orjson.loads(_dumps_json({"cyclic": d}))["cyclic"]["self"], str)
+
+    lst: list = []
+    lst.append(lst)
+    assert isinstance(_orjson.loads(_dumps_json({"cyclic": lst}))["cyclic"][0], str)
+
+    dq: collections.deque = collections.deque()
+    dq.append(dq)
+    _orjson.loads(_dumps_json({"cyclic": dq}))  # must not raise
+
+    # a subtree shared by two keys is not a cycle and must be kept intact
+    shared = {"x": 1}
+    assert _orjson.loads(_dumps_json({"a": shared, "b": shared})) == {
+        "a": {"x": 1},
+        "b": {"x": 1},
+    }
+
+
 def test__dumps_json():
     chars = "".join(chr(cp) for cp in range(0, sys.maxunicode + 1))
     trans_table = str.maketrans("", "", "")


### PR DESCRIPTION
Fixes #3393.

`dumps_json` is layered so it never raises on odd user data (an object cycle through `__dict__`-style types is collapsed to a string), but a cycle built out of plain containers slips past all of it:

```python
from langsmith._internal._serde import dumps_json

d = {}; d["self"] = d
dumps_json({"cyclic": d})   # RecursionError

l = []; l.append(l)
dumps_json({"cyclic": l})   # RecursionError
```

orjson rejects the cyclic dict/list (raising `TypeError`), so `dumps_json` drops to its fallback and hands the object to `_normalize_json_keys`, which walks plain containers recursively and therefore recurses forever, letting a `RecursionError` reach the caller. As the issue notes, a dataclass cycle serializes fine, which is why the existing coverage didn't catch this.

This threads a `_seen` set of the container ids on the current path through `_normalize_json_keys` and collapses a container that references itself to `str(obj)`, the same way object cycles are already collapsed. A subtree shared by sibling keys is not a cycle and is still serialized in full, since the ids are tracked per path (added on entry, removed on exit).

Cyclic `dict`/`list`/`deque` now produce valid JSON instead of raising. I added a regression test next to the existing object-cycle one; the serialization tests pass and `ruff` is clean.

One scope note: this addresses the cycle case. The deeply-nested but acyclic case the issue also mentions is a plain Python recursion-depth limit rather than a cycle, so I left it out of this change; happy to follow up if you'd like it handled here too.
