### PR TITLE
release(py): 0.11.0

### DIFF
--- a/python/.bumpversion.cfg
+++ b/python/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.10.18
+current_version = 0.11.0
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
 serialize = {major}.{minor}.{patch}
 search = {current_version}

--- a/python/langsmith/__init__.py
+++ b/python/langsmith/__init__.py
@@ -49,7 +49,7 @@ if TYPE_CHECKING:
 
 # Avoid calling into importlib on every call to __version__
 
-__version__ = "0.10.18"
+__version__ = "0.11.0"
 version = __version__  # for backwards compatibility
 
 # Metadata key to hide a traced run from LangSmith's Messages View.


### PR DESCRIPTION
0.10.18 → 0.11.0. Minor rather than patch because two tracing defaults change behaviour for existing users.

## Potential Breaking Changes

- #3396 — `perf(py): stop re-sending run inputs on patch by default`. `LANGSMITH_EXCLUDE_INPUTS_ON_PATCH` now defaults to true, so `RunTree.patch()` no longer re-uploads inputs. Inputs first set *after* `post()` (e.g. `add_inputs()` inside a `with trace(...)` block) are no longer persisted unless you pass `patch(exclude_inputs=False)` or set the variable to `false`. Does not affect `langchain`/`langgraph` traces, which pass `exclude_inputs` explicitly.
- #3395 — `perf(py): default zstd compression to a single worker thread`. `LANGSMITH_RUN_COMPRESSION_THREADS` defaults to 1 instead of -1 (one worker per logical CPU), cutting peak RSS in the ingest path. An explicit `0` is now honoured (previously coerced to the default).

## Other Python changes

- #3367 — `perf(py): call pydantic core serializer directly, skip orjson key checks`
- #3394 — `feat(sandbox): support proxy rule env vars in the Python and JS helpers`
- #3351 — `feat(sandbox): add Context Hub mount helpers`
- #3383 — `fix: default Dockerfile snapshot capacity`
- #3375 — `fix(py): stop recording mcp_servers in Anthropic run metadata`
- #3371 — `fix(py): mask MCP server credentials in Anthropic wrapper traces`
- #3365 — `security(python): update aiohttp and cryptography`