### PR TITLE
release(js): 0.8.11

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langsmith",
-  "version": "0.8.10",
+  "version": "0.8.11",
   "description": "Client library to connect to the LangSmith Observability and Evaluation Platform.",
   "packageManager": "pnpm@10.33.0",
   "files": [

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -54,7 +54,7 @@ export {
 } from "./_openapi_client/core/error.js";
 
 // Update using pnpm bump-version
-export const __version__ = "0.8.10";
+export const __version__ = "0.8.11";
 
 // Metadata key to hide a traced run from LangSmith's Messages View.
 export const LS_MESSAGE_VIEW_EXCLUDE = "ls_message_view_exclude" as const;


### PR DESCRIPTION
0.8.10 → 0.8.11. Patch: nothing here is breaking, and this matches recent practice (0.8.8 and 0.8.10 both shipped features as patches).

## What's in it

- #3351 — `feat(sandbox): add Context Hub mount helpers`. New exports: `contextHubMount`, `ContextHubMountConfig`, `ContextHubMountSpec`; `SandboxMount` gains a variant.
- #3394 — `feat(sandbox): support proxy rule env vars in the Python and JS helpers`. Adds optional `env_vars` to the proxy rule types.
- #3383 — `fix: default Dockerfile snapshot capacity`. `createDockerfileSnapshot`'s third argument becomes optional (`number | CreateDockerfileSnapshotOptions`); omitting it defers to the server's default capacity. Existing calls that pass a number are unaffected.
- #3372 — `fix(js): mask MCP server credentials in Anthropic wrapper traces`.
- #3292, #3272 — security/dependency updates. No consumer-facing change: both are `pnpm.overrides` on transitive **dev** dependencies (runtime `dependencies` is unchanged).
