### PR TITLE
fix(py): count skipped and errored tests in --langsmith-output pass rate

### DIFF
--- a/python/langsmith/pytest_plugin.py
+++ b/python/langsmith/pytest_plugin.py
@@ -7,11 +7,12 @@ import os
 import time
 from collections import defaultdict
 from threading import Lock
-from typing import Any
+from typing import Any, Optional
 
 import pytest
 
 from langsmith import utils as ls_utils
+from langsmith.testing._internal import _get_test_suite_name
 from langsmith.testing._internal import test as ls_test
 
 logger = logging.getLogger(__name__)
@@ -41,9 +42,11 @@ def pytest_addoption(parser):
 def _handle_output_args(args):
     """Handle output arguments."""
     if any(opt in args for opt in ["--langsmith-output"]):
-        # Only add --quiet if it's not already there
-        if not any(a in args for a in ["-qq"]):
-            args.insert(0, "-qq")
+        # Only add --quiet if it's not already there. Use -q rather than -qq so
+        # pytest still prints its end-of-run counts; the live table only covers
+        # tests that reached a test suite, so it can't stand in for them.
+        if not any(a in args for a in ["-q", "-qq", "--quiet"]):
+            args.insert(0, "-q")
         # Disable built-in output capturing
         if not any(a in args for a in ["-s", "--capture=no"]):
             args.insert(0, "-s")
@@ -98,13 +101,22 @@ def pytest_runtest_call(item):
     yield
 
 
-@pytest.hookimpl
+@pytest.hookimpl(hookwrapper=True)
 def pytest_report_teststatus(report, config):
     """Remove the short test-status character outputs ("./F")."""
-    # The hook normally returns a 3-tuple: (short_letter, verbose_word, color)
-    # By returning empty strings, the progress characters won't show.
-    if config.getoption("--langsmith-output"):
-        return "", "", ""
+    # The hook returns a 3-tuple: (category, short_letter, verbose_word). Blanking
+    # the short letter stops the progress characters from corrupting the live
+    # table. The category has to be left alone: pytest tallies its end-of-run
+    # counts by category, so blanking it files every test under "" and silently
+    # drops passed/failed/skipped/error counts from the summary.
+    outcome = yield
+    if not config.getoption("--langsmith-output"):
+        return
+    status = outcome.get_result()
+    if status is None:
+        return
+    category, _, verbose_word = status
+    outcome.force_result((category, "", verbose_word))
 
 
 class LangSmithPlugin:
@@ -117,6 +129,14 @@ class LangSmithPlugin:
 
         self.test_suites = defaultdict(list)
         self.test_suite_urls = {}
+        # Tests that collection assigned to each suite, including ones that never
+        # run. A test only reaches self.test_suites once its body starts
+        # executing, so anything that errors or skips before then is missing
+        # there and would otherwise vanish from the results table entirely.
+        self.collected_by_suite = defaultdict(set)
+        self.collected_nodeids = set()
+        # Outcomes for tests that never got far enough to report their own status.
+        self.unrun_statuses = {}
 
         self.process_status = {}  # Track process status
         self.status_lock = Lock()  # Thread-safe updates
@@ -133,6 +153,9 @@ class LangSmithPlugin:
         self.collected_nodeids = set()
         for item in session.items:
             self.collected_nodeids.add(item.nodeid)
+            suite_name = _collected_test_suite_name(item)
+            if suite_name is not None:
+                self.collected_by_suite[suite_name].add(item.nodeid)
 
     def add_process_to_test_suite(self, test_suite, process_id):
         """Group a test case with its test suite."""
@@ -157,6 +180,18 @@ class LangSmithPlugin:
         """Initialize live display when first test starts."""
         self.update_process_status(nodeid, {"status": "running"})
 
+    def pytest_runtest_logreport(self, report):
+        """Record outcomes for tests that never reach their suite.
+
+        A test only registers itself with a suite once its body starts running,
+        so one that errors or skips during setup reports nothing of its own.
+        """
+        if report.when in ("setup", "teardown"):
+            if report.outcome == "failed":
+                self.unrun_statuses[report.nodeid] = "error"
+            elif report.outcome == "skipped":
+                self.unrun_statuses[report.nodeid] = "skipped"
+
     def generate_tables(self):
         """Generate a collection of tables—one per suite.
 
@@ -175,7 +210,11 @@ class LangSmithPlugin:
         """Generate results table."""
         from rich.table import Table  # type: ignore[import-not-found]
 
-        process_ids = self.test_suites[suite_name]
+        executed_ids = self.test_suites[suite_name]
+        # Collected tests that never reached the suite: errored in setup, skipped
+        # before the body ran, or not started yet. Without these the pass rate
+        # would be computed over only the tests that got far enough to report.
+        unrun_ids = self.collected_by_suite.get(suite_name, set()) - set(executed_ids)
 
         title = f"""Test Suite: [bold]{suite_name}[/bold]
 LangSmith URL: [bright_cyan]{self.test_suite_urls[suite_name]}[/bright_cyan]"""  # noqa: E501
@@ -195,24 +234,32 @@ LangSmith URL: [bright_cyan]{self.test_suite_urls[suite_name]}[/bright_cyan]""" 
         durations = []
         numeric_feedbacks = defaultdict(list)
         # Gather data only for this suite
-        suite_statuses = {pid: self.process_status[pid] for pid in process_ids}
+        suite_statuses = {pid: self.process_status[pid] for pid in executed_ids}
+        for pid in sorted(unrun_ids):
+            suite_statuses[pid] = {"status": self.unrun_statuses.get(pid, "queued")}
         for pid, status in suite_statuses.items():
-            duration = status.get("end_time", now) - status.get("start_time", now)
-            durations.append(duration)
+            if pid not in unrun_ids:
+                duration = status.get("end_time", now) - status.get("start_time", now)
+                durations.append(duration)
+                max_duration = max(len(f"{duration:.2f}s"), max_duration)
             for k, v in status.get("feedback", {}).items():
                 if isinstance(v, (float, int, bool)):
                     numeric_feedbacks[k].append(v)
-            max_duration = max(len(f"{duration:.2f}s"), max_duration)
             max_status = max(len(status.get("status", "queued")), max_status)
 
+        total_count = len(suite_statuses)
         passed_count = sum(s.get("status") == "passed" for s in suite_statuses.values())
-        failed_count = sum(s.get("status") == "failed" for s in suite_statuses.values())
 
         # You could arrange a row to show the aggregated data—here, in the last column:
-        if passed_count + failed_count:
-            rate = passed_count / (passed_count + failed_count)
-            color = "green" if rate == 1 else "red"
-            aggregate_status = f"[{color}]{rate:.0%}[/{color}]"
+        if total_count:
+            rate = passed_count / total_count
+            # Anything that did not pass — failed, skipped, errored, never
+            # started — keeps this red, so a suite only reads green when every
+            # collected test actually passed.
+            color = "green" if passed_count == total_count else "red"
+            aggregate_status = (
+                f"[{color}]{rate:.0%} ({passed_count}/{total_count})[/{color}]"
+            )
         else:
             aggregate_status = "Passed: --"
         if durations:
@@ -220,8 +267,11 @@ LangSmith URL: [bright_cyan]{self.test_suite_urls[suite_name]}[/bright_cyan]""" 
         else:
             aggregate_duration = "--s"
         if numeric_feedbacks:
+            # Show how many tests each score covers: a mean over 3 of 10 tests
+            # is not the same claim as a mean over all 10.
             aggregate_feedback = "\n".join(
-                f"{k}: {sum(v) / len(v)}" for k, v in numeric_feedbacks.items()
+                f"{k}: {sum(v) / len(v)} ({len(v)}/{total_count})"
+                for k, v in numeric_feedbacks.items()
             )
         else:
             aggregate_feedback = "--"
@@ -235,10 +285,15 @@ LangSmith URL: [bright_cyan]{self.test_suite_urls[suite_name]}[/bright_cyan]""" 
                 "running": "yellow",
                 "passed": "green",
                 "failed": "red",
+                "error": "red",
                 "skipped": "cyan",
             }.get(status.get("status", "queued"), "white")
 
-            duration = status.get("end_time", now) - status.get("start_time", now)
+            if pid in unrun_ids:
+                duration_cell = "--s"
+            else:
+                duration = status.get("end_time", now) - status.get("start_time", now)
+                duration_cell = f"{duration:.2f}s"
             feedback = "\n".join(
                 f"{_abbreviate(k, max_len=max_dynamic_col_width)}: {int(v) if isinstance(v, bool) else v}"  # noqa: E501
                 for k, v in status.get("feedback", {}).items()
@@ -257,7 +312,7 @@ LangSmith URL: [bright_cyan]{self.test_suite_urls[suite_name]}[/bright_cyan]""" 
                 ],
                 f"[{status_color}]{status.get('status', 'queued')}[/{status_color}]",
                 feedback,
-                f"{duration:.2f}s",
+                duration_cell,
             )
 
         # Add a blank row or a section separator if you like:
@@ -287,6 +342,9 @@ LangSmith URL: [bright_cyan]{self.test_suite_urls[suite_name]}[/bright_cyan]""" 
 
     def pytest_sessionfinish(self, session):
         """Stop Rich Live rendering at the end of the session."""
+        # Tests that errored or skipped in setup never trigger a status update,
+        # so render once more to make sure their rows are in the final table.
+        self.live.update(self.generate_tables())
         self.live.stop()
         self.live.console.print("\nFinishing up...")
 
@@ -320,6 +378,24 @@ def pytest_configure(config):
         config.pluginmanager.register(LangSmithPlugin(), "langsmith_output_plugin")
         # Suppress warnings summary
         config.option.showwarnings = False
+
+
+def _collected_test_suite_name(item) -> Optional[str]:
+    """Resolve which suite a collected test belongs to, before it runs.
+
+    Mirrors how the test decorator names a suite so the results table can show a
+    denominator that includes tests which never made it to their suite.
+    """
+    marker = item.get_closest_marker("langsmith")
+    if marker is None:
+        return None
+    if test_suite_name := marker.kwargs.get("test_suite_name"):
+        return test_suite_name
+    try:
+        return _get_test_suite_name(item.obj)
+    except BaseException:
+        logger.debug("Could not determine test suite name for %s.", item.nodeid)
+        return None
 
 
 def _abbreviate(x: str, max_len: int) -> str:

--- a/python/tests/unit_tests/test_pytest_plugin.py
+++ b/python/tests/unit_tests/test_pytest_plugin.py
@@ -1,0 +1,246 @@
+"""Tests for the LangSmith pytest output plugin."""
+
+import os
+from unittest import mock
+
+import pytest
+from pluggy import Result
+
+from langsmith.pytest_plugin import (
+    LangSmithPlugin,
+    _handle_output_args,
+    pytest_report_teststatus,
+)
+
+SUITE = "repo.tests.test_things"
+
+
+def _make_plugin() -> LangSmithPlugin:
+    """Build a plugin with the live display stubbed out."""
+    from rich.console import Console
+
+    with mock.patch("rich.live.Live"):
+        plugin = LangSmithPlugin()
+    # Wide enough that the table renders test names without abbreviating them.
+    plugin.console = Console(record=True, width=200)
+    plugin.test_suite_urls[SUITE] = "https://smith.langchain.com/suite"
+    return plugin
+
+
+def _render(plugin: LangSmithPlugin, suite: str = SUITE) -> str:
+    plugin.console.print(plugin._generate_table(suite))
+    return plugin.console.export_text()
+
+
+def _add_executed(plugin: LangSmithPlugin, nodeid: str, status: str, **extra) -> None:
+    plugin.collected_by_suite[SUITE].add(nodeid)
+    plugin.add_process_to_test_suite(SUITE, nodeid)
+    plugin.process_status[nodeid] = {"status": status, **extra}
+
+
+def test_unrun_tests_count_against_the_pass_rate() -> None:
+    """Skipped and errored tests must not drop out of the denominator."""
+    plugin = _make_plugin()
+    for i in range(3):
+        _add_executed(plugin, f"test_f.py::test_pass{i}", "passed")
+    # Skipped by a marker and errored in a fixture: neither reaches the suite.
+    for i in range(4):
+        plugin.collected_by_suite[SUITE].add(f"test_f.py::test_skip{i}")
+        plugin.unrun_statuses[f"test_f.py::test_skip{i}"] = "skipped"
+    for i in range(3):
+        plugin.collected_by_suite[SUITE].add(f"test_f.py::test_err{i}")
+        plugin.unrun_statuses[f"test_f.py::test_err{i}"] = "error"
+
+    output = _render(plugin)
+
+    assert "30% (3/10)" in output
+    assert "100%" not in output
+
+
+def test_unrun_tests_get_their_own_rows() -> None:
+    """A test that never ran should still be visible in the table."""
+    plugin = _make_plugin()
+    _add_executed(plugin, "test_f.py::test_ok", "passed")
+    plugin.collected_by_suite[SUITE].add("test_f.py::test_broken")
+    plugin.unrun_statuses["test_f.py::test_broken"] = "error"
+    plugin.collected_by_suite[SUITE].add("test_f.py::test_never_started")
+
+    output = _render(plugin)
+
+    assert "test_broken" in output
+    assert "error" in output
+    # Collected but not reported on yet — still owed a result.
+    assert "test_never_started" in output
+    assert "queued" in output
+
+
+def test_all_passing_suite_is_green() -> None:
+    plugin = _make_plugin()
+    for i in range(3):
+        _add_executed(plugin, f"test_f.py::test_pass{i}", "passed")
+
+    table = plugin._generate_table(SUITE)
+    output = _render(plugin)
+
+    assert "100% (3/3)" in output
+    assert any("green" in str(cell) for cell in table.columns[4]._cells)
+
+
+def test_failures_keep_the_suite_red() -> None:
+    plugin = _make_plugin()
+    _add_executed(plugin, "test_f.py::test_pass", "passed")
+    _add_executed(plugin, "test_f.py::test_fail", "failed")
+
+    table = plugin._generate_table(SUITE)
+
+    assert "50% (2" not in str(table.columns[4]._cells)
+    assert any(
+        "red" in str(cell) and "50%" in str(cell) for cell in table.columns[4]._cells
+    )
+
+
+def test_feedback_average_reports_how_many_tests_it_covers() -> None:
+    """A mean over 2 of 5 tests should not read like a mean over all 5."""
+    plugin = _make_plugin()
+    _add_executed(plugin, "test_f.py::test_a", "passed", feedback={"correctness": 1})
+    _add_executed(plugin, "test_f.py::test_b", "passed", feedback={"correctness": 0})
+    for i in range(3):
+        plugin.collected_by_suite[SUITE].add(f"test_f.py::test_skip{i}")
+        plugin.unrun_statuses[f"test_f.py::test_skip{i}"] = "skipped"
+
+    output = _render(plugin)
+
+    assert "correctness: 0.5 (2/5)" in output
+
+
+def test_empty_suite_reports_no_rate() -> None:
+    plugin = _make_plugin()
+    plugin.test_suites[SUITE] = []
+
+    assert "Passed: --" in _render(plugin)
+
+
+@pytest.mark.parametrize(
+    "status",
+    [("error", "E", "ERROR"), ("skipped", "s", "SKIPPED"), ("passed", ".", "PASSED")],
+)
+def test_teststatus_blanks_the_letter_but_keeps_the_category(status) -> None:
+    """Blanking the category would drop these tests from pytest's own counts."""
+    config = mock.Mock()
+    config.getoption.return_value = True
+
+    gen = pytest_report_teststatus(mock.Mock(), config)
+    next(gen)
+    result = Result(status, None)
+    with pytest.raises(StopIteration):
+        gen.send(result)
+
+    category, letter, verbose_word = result.get_result()
+    assert category == status[0]
+    assert letter == ""
+    assert verbose_word == status[2]
+
+
+def test_teststatus_left_alone_without_the_flag() -> None:
+    config = mock.Mock()
+    config.getoption.return_value = False
+
+    gen = pytest_report_teststatus(mock.Mock(), config)
+    next(gen)
+    result = Result(("passed", ".", "PASSED"), None)
+    with pytest.raises(StopIteration):
+        gen.send(result)
+
+    assert result.get_result() == ("passed", ".", "PASSED")
+
+
+def test_output_args_keep_pytest_counts() -> None:
+    """-qq would hide the end-of-run counts the table cannot replace."""
+    args = ["--langsmith-output"]
+    _handle_output_args(args)
+
+    assert "-q" in args
+    assert "-qq" not in args
+
+
+def test_output_args_respect_an_explicit_quiet_flag() -> None:
+    args = ["--langsmith-output", "-qq"]
+    _handle_output_args(args)
+
+    assert args.count("-q") == 0
+
+
+COLLECTION_SAMPLE = """
+import pytest
+
+@pytest.mark.langsmith
+def test_marked(): pass
+
+@pytest.mark.langsmith(test_suite_name="explicit-suite")
+def test_marked_with_suite(): pass
+
+@pytest.mark.langsmith
+@pytest.mark.parametrize("x", [1, 2])
+def test_parametrized(x): pass
+
+def test_unmarked(): pass
+"""
+
+COLLECTION_CONFTEST = """
+import json, os
+from langsmith.pytest_plugin import _collected_test_suite_name
+
+def pytest_collection_finish(session):
+    resolved = {i.nodeid: _collected_test_suite_name(i) for i in session.items}
+    with open(os.environ["RESOLVED_OUT"], "w") as f:
+        json.dump(resolved, f)
+"""
+
+
+def test_collection_resolves_the_suite_for_marked_tests(tmp_path) -> None:
+    """The denominator depends on naming suites the same way the decorator does."""
+    import json
+    import pathlib
+    import subprocess
+    import sys
+
+    import langsmith
+
+    (tmp_path / "test_collect_sample.py").write_text(COLLECTION_SAMPLE)
+    (tmp_path / "conftest.py").write_text(COLLECTION_CONFTEST)
+    out = tmp_path / "resolved.json"
+
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            "--collect-only",
+            "-q",
+            "-p",
+            "no:cacheprovider",
+        ],
+        cwd=tmp_path,
+        env={
+            **os.environ,
+            # Collection runs outside the source tree, so point at the copy of
+            # langsmith under test rather than whatever is installed.
+            "PYTHONPATH": str(pathlib.Path(langsmith.__file__).parents[1]),
+            "RESOLVED_OUT": str(out),
+            "LANGSMITH_TEST_SUITE": "env-suite",
+        },
+        check=True,
+        capture_output=True,
+    )
+    resolved = json.loads(out.read_text())
+
+    # Unmarked tests belong to no suite and must not inflate any denominator.
+    assert resolved["test_collect_sample.py::test_unmarked"] is None
+    assert resolved["test_collect_sample.py::test_marked"] == "env-suite"
+    # An explicit suite on the marker wins, exactly as the decorator resolves it.
+    assert resolved["test_collect_sample.py::test_marked_with_suite"] == (
+        "explicit-suite"
+    )
+    # Parametrized cases are separate rows, keyed by their full node id.
+    assert resolved["test_collect_sample.py::test_parametrized[1]"] == "env-suite"
+    assert resolved["test_collect_sample.py::test_parametrized[2]"] == "env-suite"

--- a/python/tests/unit_tests/test_pytest_plugin.py
+++ b/python/tests/unit_tests/test_pytest_plugin.py
@@ -1,6 +1,5 @@
 """Tests for the LangSmith pytest output plugin."""
 
-import os
 from unittest import mock
 
 import pytest
@@ -8,6 +7,7 @@ from pluggy import Result
 
 from langsmith.pytest_plugin import (
     LangSmithPlugin,
+    _collected_test_suite_name,
     _handle_output_args,
     pytest_report_teststatus,
 )
@@ -38,6 +38,13 @@ def _add_executed(plugin: LangSmithPlugin, nodeid: str, status: str, **extra) ->
     plugin.process_status[nodeid] = {"status": status, **extra}
 
 
+def _add_unrun(plugin: LangSmithPlugin, nodeid: str, status: str = "") -> None:
+    """Collect a test that never reached its suite: skipped, errored, or queued."""
+    plugin.collected_by_suite[SUITE].add(nodeid)
+    if status:
+        plugin.unrun_statuses[nodeid] = status
+
+
 def test_unrun_tests_count_against_the_pass_rate() -> None:
     """Skipped and errored tests must not drop out of the denominator."""
     plugin = _make_plugin()
@@ -45,11 +52,9 @@ def test_unrun_tests_count_against_the_pass_rate() -> None:
         _add_executed(plugin, f"test_f.py::test_pass{i}", "passed")
     # Skipped by a marker and errored in a fixture: neither reaches the suite.
     for i in range(4):
-        plugin.collected_by_suite[SUITE].add(f"test_f.py::test_skip{i}")
-        plugin.unrun_statuses[f"test_f.py::test_skip{i}"] = "skipped"
+        _add_unrun(plugin, f"test_f.py::test_skip{i}", "skipped")
     for i in range(3):
-        plugin.collected_by_suite[SUITE].add(f"test_f.py::test_err{i}")
-        plugin.unrun_statuses[f"test_f.py::test_err{i}"] = "error"
+        _add_unrun(plugin, f"test_f.py::test_err{i}", "error")
 
     output = _render(plugin)
 
@@ -61,9 +66,8 @@ def test_unrun_tests_get_their_own_rows() -> None:
     """A test that never ran should still be visible in the table."""
     plugin = _make_plugin()
     _add_executed(plugin, "test_f.py::test_ok", "passed")
-    plugin.collected_by_suite[SUITE].add("test_f.py::test_broken")
-    plugin.unrun_statuses["test_f.py::test_broken"] = "error"
-    plugin.collected_by_suite[SUITE].add("test_f.py::test_never_started")
+    _add_unrun(plugin, "test_f.py::test_broken", "error")
+    _add_unrun(plugin, "test_f.py::test_never_started")
 
     output = _render(plugin)
 
@@ -74,29 +78,22 @@ def test_unrun_tests_get_their_own_rows() -> None:
     assert "queued" in output
 
 
-def test_all_passing_suite_is_green() -> None:
+@pytest.mark.parametrize(
+    ("statuses", "rate", "color"),
+    [
+        (["passed", "passed"], "100% (2/2)", "green"),
+        (["passed", "failed"], "50% (1/2)", "red"),
+    ],
+)
+def test_suite_reads_green_only_when_every_test_passed(statuses, rate, color) -> None:
     plugin = _make_plugin()
-    for i in range(3):
-        _add_executed(plugin, f"test_f.py::test_pass{i}", "passed")
+    for i, status in enumerate(statuses):
+        _add_executed(plugin, f"test_f.py::test_{i}", status)
 
-    table = plugin._generate_table(SUITE)
-    output = _render(plugin)
+    rate_cells = str(plugin._generate_table(SUITE).columns[4]._cells)
 
-    assert "100% (3/3)" in output
-    assert any("green" in str(cell) for cell in table.columns[4]._cells)
-
-
-def test_failures_keep_the_suite_red() -> None:
-    plugin = _make_plugin()
-    _add_executed(plugin, "test_f.py::test_pass", "passed")
-    _add_executed(plugin, "test_f.py::test_fail", "failed")
-
-    table = plugin._generate_table(SUITE)
-
-    assert "50% (2" not in str(table.columns[4]._cells)
-    assert any(
-        "red" in str(cell) and "50%" in str(cell) for cell in table.columns[4]._cells
-    )
+    assert rate in _render(plugin)
+    assert color in rate_cells
 
 
 def test_feedback_average_reports_how_many_tests_it_covers() -> None:
@@ -105,12 +102,9 @@ def test_feedback_average_reports_how_many_tests_it_covers() -> None:
     _add_executed(plugin, "test_f.py::test_a", "passed", feedback={"correctness": 1})
     _add_executed(plugin, "test_f.py::test_b", "passed", feedback={"correctness": 0})
     for i in range(3):
-        plugin.collected_by_suite[SUITE].add(f"test_f.py::test_skip{i}")
-        plugin.unrun_statuses[f"test_f.py::test_skip{i}"] = "skipped"
+        _add_unrun(plugin, f"test_f.py::test_skip{i}", "skipped")
 
-    output = _render(plugin)
-
-    assert "correctness: 0.5 (2/5)" in output
+    assert "correctness: 0.5 (2/5)" in _render(plugin)
 
 
 def test_empty_suite_reports_no_rate() -> None:
@@ -120,127 +114,62 @@ def test_empty_suite_reports_no_rate() -> None:
     assert "Passed: --" in _render(plugin)
 
 
-@pytest.mark.parametrize(
-    "status",
-    [("error", "E", "ERROR"), ("skipped", "s", "SKIPPED"), ("passed", ".", "PASSED")],
-)
-def test_teststatus_blanks_the_letter_but_keeps_the_category(status) -> None:
+@pytest.mark.parametrize("langsmith_output", [True, False])
+def test_teststatus_blanks_the_letter_but_keeps_the_category(langsmith_output) -> None:
     """Blanking the category would drop these tests from pytest's own counts."""
     config = mock.Mock()
-    config.getoption.return_value = True
+    config.getoption.return_value = langsmith_output
 
     gen = pytest_report_teststatus(mock.Mock(), config)
     next(gen)
-    result = Result(status, None)
+    result = Result(("error", "E", "ERROR"), None)
     with pytest.raises(StopIteration):
         gen.send(result)
 
-    category, letter, verbose_word = result.get_result()
-    assert category == status[0]
-    assert letter == ""
-    assert verbose_word == status[2]
+    letter = "" if langsmith_output else "E"
+    assert result.get_result() == ("error", letter, "ERROR")
 
 
-def test_teststatus_left_alone_without_the_flag() -> None:
-    config = mock.Mock()
-    config.getoption.return_value = False
-
-    gen = pytest_report_teststatus(mock.Mock(), config)
-    next(gen)
-    result = Result(("passed", ".", "PASSED"), None)
-    with pytest.raises(StopIteration):
-        gen.send(result)
-
-    assert result.get_result() == ("passed", ".", "PASSED")
-
-
-def test_output_args_keep_pytest_counts() -> None:
-    """-qq would hide the end-of-run counts the table cannot replace."""
-    args = ["--langsmith-output"]
+@pytest.mark.parametrize(
+    ("args", "quiet_flags"),
+    [
+        # -qq would hide the end-of-run counts the table cannot replace.
+        (["--langsmith-output"], ["-q"]),
+        # An explicit quiet flag is left as the caller set it.
+        (["--langsmith-output", "-qq"], ["-qq"]),
+    ],
+)
+def test_output_args_keep_pytest_counts(args, quiet_flags) -> None:
     _handle_output_args(args)
 
-    assert "-q" in args
-    assert "-qq" not in args
+    assert [a for a in args if a in ("-q", "-qq", "--quiet")] == quiet_flags
 
 
-def test_output_args_respect_an_explicit_quiet_flag() -> None:
-    args = ["--langsmith-output", "-qq"]
-    _handle_output_args(args)
+class _FakeItem:
+    """Minimal stand-in for a collected pytest item."""
 
-    assert args.count("-q") == 0
+    nodeid = "test_f.py::test_x"
 
+    def __init__(self, marker=None):
+        self._marker = marker
 
-COLLECTION_SAMPLE = """
-import pytest
+    def obj(self):
+        pass
 
-@pytest.mark.langsmith
-def test_marked(): pass
-
-@pytest.mark.langsmith(test_suite_name="explicit-suite")
-def test_marked_with_suite(): pass
-
-@pytest.mark.langsmith
-@pytest.mark.parametrize("x", [1, 2])
-def test_parametrized(x): pass
-
-def test_unmarked(): pass
-"""
-
-COLLECTION_CONFTEST = """
-import json, os
-from langsmith.pytest_plugin import _collected_test_suite_name
-
-def pytest_collection_finish(session):
-    resolved = {i.nodeid: _collected_test_suite_name(i) for i in session.items}
-    with open(os.environ["RESOLVED_OUT"], "w") as f:
-        json.dump(resolved, f)
-"""
+    def get_closest_marker(self, name):
+        return self._marker if name == "langsmith" else None
 
 
-def test_collection_resolves_the_suite_for_marked_tests(tmp_path) -> None:
-    """The denominator depends on naming suites the same way the decorator does."""
-    import json
-    import pathlib
-    import subprocess
-    import sys
+def test_unmarked_tests_belong_to_no_suite() -> None:
+    """Unmarked tests must not inflate any suite's denominator."""
+    assert _collected_test_suite_name(_FakeItem()) is None
 
-    import langsmith
 
-    (tmp_path / "test_collect_sample.py").write_text(COLLECTION_SAMPLE)
-    (tmp_path / "conftest.py").write_text(COLLECTION_CONFTEST)
-    out = tmp_path / "resolved.json"
+def test_collection_names_suites_the_way_the_decorator_does(monkeypatch) -> None:
+    """The denominator depends on resolving the same suite the decorator would."""
+    monkeypatch.setenv("LANGSMITH_TEST_SUITE", "env-suite")
 
-    subprocess.run(
-        [
-            sys.executable,
-            "-m",
-            "pytest",
-            "--collect-only",
-            "-q",
-            "-p",
-            "no:cacheprovider",
-        ],
-        cwd=tmp_path,
-        env={
-            **os.environ,
-            # Collection runs outside the source tree, so point at the copy of
-            # langsmith under test rather than whatever is installed.
-            "PYTHONPATH": str(pathlib.Path(langsmith.__file__).parents[1]),
-            "RESOLVED_OUT": str(out),
-            "LANGSMITH_TEST_SUITE": "env-suite",
-        },
-        check=True,
-        capture_output=True,
-    )
-    resolved = json.loads(out.read_text())
-
-    # Unmarked tests belong to no suite and must not inflate any denominator.
-    assert resolved["test_collect_sample.py::test_unmarked"] is None
-    assert resolved["test_collect_sample.py::test_marked"] == "env-suite"
+    assert _collected_test_suite_name(_FakeItem(mock.Mock(kwargs={}))) == "env-suite"
     # An explicit suite on the marker wins, exactly as the decorator resolves it.
-    assert resolved["test_collect_sample.py::test_marked_with_suite"] == (
-        "explicit-suite"
-    )
-    # Parametrized cases are separate rows, keyed by their full node id.
-    assert resolved["test_collect_sample.py::test_parametrized[1]"] == "env-suite"
-    assert resolved["test_collect_sample.py::test_parametrized[2]"] == "env-suite"
+    explicit = _FakeItem(mock.Mock(kwargs={"test_suite_name": "explicit-suite"}))
+    assert _collected_test_suite_name(explicit) == "explicit-suite"


### PR DESCRIPTION
## Description

**The problem**

A test can end in more than two states. It can pass, fail, get skipped, crash before it even starts, or never start at all.

The scoreboard only did the math on passed and failed. Everything else fell out of the fraction entirely. So 3 passed and 7 skipped wasn't "3 out of 10" — it was "3 out of 3." A green 100%.

Then it got worse. A test only checked in to the scoreboard once it actually started running. So a test that crashed during setup never checked in — it wasn't just missing from the math, it was missing from the table. No row. No trace it ever existed.

And the plugin had muted pytest's own summary line at the bottom to keep the display clean. So the one thing that would have contradicted the scoreboard was silenced.

Three things stacked: wrong denominator, invisible tests, no second opinion.

**The fix**

Take attendance before the tests run, not after. pytest already knows the full list of tests the moment it collects them — before a single one executes. The fix grabs that roster up front and uses it as the denominator. Now it's 3 out of 10, because the 10 was known from the start.

Give the missing tests a row. Anything on the roster that never reported back gets listed anyway, labelled with why — skipped, error, or queued. Present instead of vanished.

Green means everyone passed. Not "everyone who bothered to report."

Unmute pytest's summary. This is the backstop for the case the table still can't cover: if every test in a file crashes during setup, no table gets drawn at all. Then pytest's own count is the only thing left telling you something went wrong.

Averages say what they cover. correctness: 0.5 (2/5) — so a score from 2 tests doesn't read like a score from 5.

Solves [LSE-2789](https://linear.app/langchain/issue/LSE-2789/langsmith-pytest-langsmith-output-shows-green-100percent-when-only)

### examples 

<img width="918" height="1138" alt="Screenshot 2026-08-14 at 4 47 56 PM" src="https://github.com/user-attachments/assets/77297b8d-4e68-4c74-9e4a-716746c2826f" />

## Test Plan

Unit tests in `python/tests/unit_tests/test_pytest_plugin.py`.
