### PR TITLE
fix: use reference outputs for example creation [closes LSE-2783]

### DIFF
--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -4868,27 +4868,30 @@ export class Client implements LangSmithTracingClientInterface {
    */
   public async createExample(
     inputs: KVMap,
-    outputs: KVMap,
+    referenceOutputs: KVMap,
     options: CreateExampleOptions,
   ): Promise<Example>;
 
   public async createExample(
     inputsOrUpdate: KVMap | ExampleCreate,
-    outputs?: KVMap,
+    referenceOutputs?: KVMap,
     options?: CreateExampleOptions,
   ): Promise<Example> {
-    if (isExampleCreate(inputsOrUpdate)) {
-      if (outputs !== undefined || options !== undefined) {
+    const usesCreateModel = isExampleCreate(inputsOrUpdate);
+    if (usesCreateModel) {
+      if (referenceOutputs !== undefined || options !== undefined) {
         throw new Error(
-          "Cannot provide outputs or options when using ExampleCreate object",
+          "Cannot provide referenceOutputs or options when using ExampleCreate object",
         );
       }
     }
 
-    let datasetId_ = outputs ? options?.datasetId : inputsOrUpdate.dataset_id;
-    const datasetName_ = outputs
-      ? options?.datasetName
-      : inputsOrUpdate.dataset_name;
+    let datasetId_ = usesCreateModel
+      ? inputsOrUpdate.dataset_id
+      : options?.datasetId;
+    const datasetName_ = usesCreateModel
+      ? inputsOrUpdate.dataset_name
+      : options?.datasetName;
     if (datasetId_ === undefined && datasetName_ === undefined) {
       throw new Error("Must provide either datasetName or datasetId");
     } else if (datasetId_ !== undefined && datasetName_ !== undefined) {
@@ -4898,14 +4901,12 @@ export class Client implements LangSmithTracingClientInterface {
       datasetId_ = dataset.id;
     }
 
-    const createdAt_ =
-      (outputs ? options?.createdAt : inputsOrUpdate.created_at) || new Date();
     let data: ExampleCreate;
-    if (!isExampleCreate(inputsOrUpdate)) {
+    if (!usesCreateModel) {
       data = {
         inputs: inputsOrUpdate,
-        outputs,
-        created_at: createdAt_?.toISOString(),
+        reference_outputs: referenceOutputs,
+        created_at: (options?.createdAt ?? new Date()).toISOString(),
         id: options?.exampleId,
         metadata: options?.metadata,
         split: options?.split,
@@ -4929,6 +4930,8 @@ export class Client implements LangSmithTracingClientInterface {
   /** @deprecated Use the uploads-only overload instead */
   public async createExamples(props: {
     inputs?: Array<KVMap>;
+    referenceOutputs?: Array<KVMap>;
+    /** @deprecated Use referenceOutputs instead. */
     outputs?: Array<KVMap>;
     metadata?: Array<KVMap>;
     splits?: Array<string | Array<string>>;
@@ -4945,6 +4948,8 @@ export class Client implements LangSmithTracingClientInterface {
       | ExampleCreate[]
       | {
           inputs?: Array<KVMap>;
+          referenceOutputs?: Array<KVMap>;
+          /** @deprecated Use referenceOutputs instead. */
           outputs?: Array<KVMap>;
           metadata?: Array<KVMap>;
           splits?: Array<string | Array<string>>;
@@ -4986,6 +4991,7 @@ export class Client implements LangSmithTracingClientInterface {
 
     const {
       inputs,
+      referenceOutputs,
       outputs,
       metadata,
       splits,
@@ -4998,6 +5004,9 @@ export class Client implements LangSmithTracingClientInterface {
       datasetName,
     } = propsOrUploads;
 
+    if (referenceOutputs !== undefined && outputs !== undefined) {
+      throw new Error("Cannot specify both referenceOutputs and outputs");
+    }
     if (inputs === undefined) {
       throw new Error("Must provide inputs when using legacy parameters");
     }
@@ -5018,7 +5027,7 @@ export class Client implements LangSmithTracingClientInterface {
       return {
         dataset_id: datasetId_,
         inputs: input,
-        outputs: outputs?.[idx],
+        reference_outputs: (referenceOutputs ?? outputs)?.[idx],
         metadata: metadata?.[idx],
         split: splits?.[idx],
         id: exampleIds?.[idx],
@@ -7071,6 +7080,7 @@ export class Client implements LangSmithTracingClientInterface {
     datasetId: string,
     uploads: ExampleCreate[] = [],
   ): Promise<UploadExamplesResponse> {
+    uploads.forEach(getExampleReferenceOutputs);
     if (!(await this._getDatasetExamplesMultiPartSupport())) {
       throw new Error(
         "Your LangSmith deployment does not allow using the multipart examples endpoint, please upgrade your deployment to the latest version.",
@@ -7080,6 +7090,7 @@ export class Client implements LangSmithTracingClientInterface {
 
     for (const example of uploads) {
       const exampleId = (example.id ?? uuid.v4()).toString();
+      const referenceOutputs = getExampleReferenceOutputs(example);
 
       // Prepare the main example body
       const exampleBody = {
@@ -7118,10 +7129,10 @@ export class Client implements LangSmithTracingClientInterface {
       }
 
       // Add outputs if present
-      if (example.outputs) {
+      if (referenceOutputs) {
         const stringifiedOutputs = serializePayloadForTracing(
-          example.outputs,
-          `Serializing outputs for uploaded example with id: ${exampleId}`,
+          referenceOutputs,
+          `Serializing reference outputs for uploaded example with id: ${exampleId}`,
         );
         const outputsBlob = new Blob([stringifiedOutputs], {
           type: "application/json",
@@ -8033,6 +8044,16 @@ export interface LangSmithTracingClientInterface {
   createRun: (run: CreateRunParams) => Promise<void>;
 
   updateRun: (runId: string, run: RunUpdate) => Promise<void>;
+}
+
+function getExampleReferenceOutputs(example: ExampleCreate): KVMap | undefined {
+  if (
+    example.reference_outputs !== undefined &&
+    example.outputs !== undefined
+  ) {
+    throw new Error("Cannot specify both reference_outputs and outputs");
+  }
+  return example.reference_outputs ?? example.outputs;
 }
 
 function isExampleCreate(input: KVMap | ExampleCreate): input is ExampleCreate {

--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -4881,7 +4881,7 @@ export class Client implements LangSmithTracingClientInterface {
     if (usesCreateModel) {
       if (referenceOutputs !== undefined || options !== undefined) {
         throw new Error(
-          "Cannot provide referenceOutputs or options when using ExampleCreate object",
+          "Cannot provide outputs or options when using ExampleCreate object",
         );
       }
     }

--- a/js/src/schemas.ts
+++ b/js/src/schemas.ts
@@ -263,6 +263,8 @@ export interface RunUpdate {
 export interface ExampleCreate {
   id?: string;
   inputs: KVMap;
+  reference_outputs?: KVMap;
+  /** @deprecated Use reference_outputs instead. */
   outputs?: KVMap;
   metadata?: KVMap;
   split?: string | string[];

--- a/js/src/tests/client.test.ts
+++ b/js/src/tests/client.test.ts
@@ -19,6 +19,7 @@ import {
 } from "../utils/env.js";
 import { parseHubIdentifier } from "../utils/prompts.js";
 import { _resetWarnedMessages } from "../utils/warn.js";
+import { ExampleCreate } from "../schemas.js";
 
 describe("Client", () => {
   describe("resource tags on create", () => {
@@ -67,6 +68,119 @@ describe("Client", () => {
       expect(JSON.parse(init?.body as string).tag_value_ids).toEqual(
         tagValueIds,
       );
+    });
+  });
+
+  describe("example reference outputs", () => {
+    it.each(["reference_outputs", "outputs"] as const)(
+      "serializes %s to the existing multipart outputs part",
+      async (field) => {
+        const exampleId = uuid();
+        const referenceOutputs = { answer: 42 };
+        let formData: FormData | undefined;
+        const mockFetch = jest
+          .fn<typeof fetch>()
+          .mockImplementation(async (input, init) => {
+            const url = String(input);
+            if (url.endsWith("/info")) {
+              return new Response(
+                JSON.stringify({
+                  instance_flags: {
+                    dataset_examples_multipart_enabled: true,
+                  },
+                }),
+                { status: 200 },
+              );
+            }
+            formData = init?.body as FormData;
+            return new Response(
+              JSON.stringify({ count: 1, example_ids: [exampleId] }),
+              { status: 200 },
+            );
+          });
+        const client = new Client({
+          apiUrl: "http://localhost:1984",
+          apiKey: "test-api-key",
+          fetchImplementation: mockFetch,
+        });
+        const datasetId = uuid();
+        const example = {
+          id: exampleId,
+          dataset_id: datasetId,
+          inputs: { question: "meaning" },
+          [field]: referenceOutputs,
+        } as ExampleCreate;
+
+        await client.uploadExamplesMultipart(datasetId, [example]);
+
+        const part = formData?.get(`${exampleId}.outputs`) as Blob;
+        expect(await part.text()).toBe(JSON.stringify(referenceOutputs));
+        expect(formData?.has(`${exampleId}.reference_outputs`)).toBe(false);
+      },
+    );
+
+    it("rejects reference_outputs and outputs together", async () => {
+      const mockFetch = jest.fn<typeof fetch>();
+      const client = new Client({
+        apiUrl: "http://localhost:1984",
+        apiKey: "test-api-key",
+        fetchImplementation: mockFetch,
+      });
+
+      await expect(
+        client.uploadExamplesMultipart(uuid(), [
+          {
+            inputs: { question: "meaning" },
+            reference_outputs: { answer: 42 },
+            outputs: { answer: 43 },
+          },
+        ]),
+      ).rejects.toThrow("Cannot specify both reference_outputs and outputs");
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it.each(["referenceOutputs", "outputs"] as const)(
+      "normalizes createExamples %s to reference_outputs",
+      async (field) => {
+        const client = new Client({
+          apiUrl: "http://localhost:1984",
+          apiKey: "test-api-key",
+        });
+        const upload = jest
+          .spyOn(client as any, "_uploadExamplesMultipart")
+          .mockResolvedValue({ count: 0, example_ids: [] });
+        const referenceOutputs = [{ answer: 42 }];
+
+        await client.createExamples({
+          inputs: [{ question: "meaning" }],
+          datasetId: uuid(),
+          [field]: referenceOutputs,
+        });
+
+        const uploadedExamples = upload.mock.calls[0][1] as ExampleCreate[];
+        expect(uploadedExamples[0]).toEqual(
+          expect.objectContaining({
+            reference_outputs: referenceOutputs[0],
+          }),
+        );
+        expect(uploadedExamples[0].outputs).toBeUndefined();
+      },
+    );
+
+    it("rejects createExamples referenceOutputs and outputs together", async () => {
+      const client = new Client({
+        apiUrl: "http://localhost:1984",
+        apiKey: "test-api-key",
+      });
+
+      await expect(
+        client.createExamples({
+          inputs: [{ question: "meaning" }],
+          datasetId: uuid(),
+          referenceOutputs: [{ answer: 42 }],
+          outputs: [{ answer: 43 }],
+        }),
+      ).rejects.toThrow("Cannot specify both referenceOutputs and outputs");
     });
   });
 

--- a/python/langsmith/async_client.py
+++ b/python/langsmith/async_client.py
@@ -1075,17 +1075,20 @@ class AsyncClient:
         """
         if reference_outputs is not None and outputs is not None:
             raise ValueError("Cannot specify both 'reference_outputs' and 'outputs'.")
-        if reference_outputs is None:
-            reference_outputs = outputs
         if dataset_id is None and dataset_name is None:
             raise ValueError("Either dataset_id or dataset_name must be provided")
         if dataset_id is None:
             dataset = await self.read_dataset(dataset_name=dataset_name)
             dataset_id = dataset.id
 
+        outputs_data = (
+            {"reference_outputs": reference_outputs}
+            if reference_outputs is not None
+            else {"outputs": outputs}
+        )
         data = {
             "inputs": inputs,
-            "reference_outputs": reference_outputs,
+            **outputs_data,
             "dataset_id": str(dataset_id),
             **kwargs,
         }

--- a/python/langsmith/async_client.py
+++ b/python/langsmith/async_client.py
@@ -1056,12 +1056,27 @@ class AsyncClient:
     async def create_example(
         self,
         inputs: dict[str, Any],
-        outputs: Optional[dict[str, Any]] = None,
+        reference_outputs: Optional[dict[str, Any]] = None,
         dataset_id: Optional[ls_client.ID_TYPE] = None,
         dataset_name: Optional[str] = None,
+        *,
+        outputs: Optional[dict[str, Any]] = None,
         **kwargs: Any,
     ) -> ls_schemas.Example:
-        """Create an example."""
+        """Create an example with optional reference outputs.
+
+        Args:
+            inputs: The input values for the example.
+            reference_outputs: The reference output values for the example.
+            dataset_id: The ID of the dataset.
+            dataset_name: The name of the dataset.
+            outputs: Deprecated alias for reference_outputs.
+            **kwargs: Additional example fields.
+        """
+        if reference_outputs is not None and outputs is not None:
+            raise ValueError("Cannot specify both 'reference_outputs' and 'outputs'.")
+        if reference_outputs is None:
+            reference_outputs = outputs
         if dataset_id is None and dataset_name is None:
             raise ValueError("Either dataset_id or dataset_name must be provided")
         if dataset_id is None:
@@ -1070,7 +1085,7 @@ class AsyncClient:
 
         data = {
             "inputs": inputs,
-            "outputs": outputs,
+            "reference_outputs": reference_outputs,
             "dataset_id": str(dataset_id),
             **kwargs,
         }

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -6263,7 +6263,7 @@ class Client:
         """
         return self.create_example(
             inputs={"input": prompt},
-            outputs={"output": generation},
+            reference_outputs={"output": generation},
             dataset_id=dataset_id,
             dataset_name=dataset_name,
             created_at=created_at,
@@ -6317,7 +6317,7 @@ class Client:
                 final_generations = cast(dict, generations)
         return self.create_example(
             inputs={"input": final_input},
-            outputs=(
+            reference_outputs=(
                 {"output": final_generations} if final_generations is not None else None
             ),
             dataset_id=dataset_id,
@@ -6408,7 +6408,7 @@ class Client:
             raise ValueError(f"Dataset type {dataset_type} not recognized.")
         return self.create_example(
             inputs=inputs,
-            outputs=outputs,
+            reference_outputs=outputs,
             dataset_id=dataset_id,
             dataset_name=dataset_name,
             created_at=created_at,
@@ -6513,8 +6513,13 @@ class Client:
                     )
                 )
 
-            if example.outputs is not None:
-                outputsb = _dumps_json(example.outputs)
+            outputs = (
+                example.reference_outputs
+                if isinstance(example, ls_schemas.ExampleCreate)
+                else example.outputs
+            )
+            if outputs is not None:
+                outputsb = _dumps_json(outputs)
                 parts.append(
                     (
                         f"{example_id}.outputs",
@@ -6697,8 +6702,8 @@ class Client:
 
         if example.inputs:
             size += len(_dumps_json(example.inputs))
-        if example.outputs:
-            size += len(_dumps_json(example.outputs))
+        if example.reference_outputs:
+            size += len(_dumps_json(example.reference_outputs))
         if example.metadata:
             size += len(_dumps_json(example.metadata))
 
@@ -6889,7 +6894,8 @@ class Client:
             **kwargs (Any): Legacy keyword args. Should not be specified if 'examples' is specified.
 
                 - inputs (Sequence[Mapping[str, Any]]): The input values for the examples.
-                - outputs (Optional[Sequence[Optional[Mapping[str, Any]]]]): The output values for the examples.
+                - reference_outputs (Optional[Sequence[Optional[Mapping[str, Any]]]]): The reference output values for the examples.
+                - outputs (Optional[Sequence[Optional[Mapping[str, Any]]]]): Deprecated alias for reference_outputs.
                 - metadata (Optional[Sequence[Optional[Mapping[str, Any]]]]): The metadata for the examples.
                 - splits (Optional[Sequence[Optional[str | List[str]]]]): The splits for the examples, which are divisions of your dataset such as 'train', 'test', or 'validation'.
                 - source_run_ids (Optional[Sequence[Optional[Union[UUID, str]]]]): The IDs of the source runs associated with the examples.
@@ -6905,8 +6911,8 @@ class Client:
 
             Updated to take argument 'examples', a single list where each
             element is the full example to create. This should be used instead of the
-            legacy 'inputs', 'outputs', etc. arguments which split each examples
-            attributes across arguments.
+            legacy 'inputs', 'reference_outputs', etc. arguments which split each
+            example's attributes across arguments.
 
             Updated to support creating examples with attachments.
 
@@ -6921,14 +6927,14 @@ class Client:
             examples = [
                 {
                     "inputs": {"question": "what's an agent"},
-                    "outputs": {"answer": "an agent is..."},
+                    "reference_outputs": {"answer": "an agent is..."},
                     "metadata": {"difficulty": "easy"},
                 },
                 {
                     "inputs": {
                         "question": "can you explain the agent architecture in this diagram?"
                     },
-                    "outputs": {"answer": "this diagram shows..."},
+                    "reference_outputs": {"answer": "this diagram shows..."},
                     "attachments": {"diagram": {"mime_type": "image/png", "data": b"..."}},
                     "metadata": {"difficulty": "medium"},
                 },
@@ -6950,6 +6956,7 @@ class Client:
 
         supported_kwargs = {
             "inputs",
+            "reference_outputs",
             "outputs",
             "metadata",
             "splits",
@@ -6960,6 +6967,9 @@ class Client:
             raise ValueError(
                 f"Received unsupported keyword arguments: {tuple(unsupported)}."
             )
+
+        if "reference_outputs" in kwargs and "outputs" in kwargs:
+            raise ValueError("Cannot specify both 'reference_outputs' and 'outputs'.")
 
         if not (dataset_id or dataset_name):
             raise ValueError("Either dataset_id or dataset_name must be provided.")
@@ -6989,16 +6999,17 @@ class Client:
                 ls_schemas.ExampleCreate(
                     **{
                         "inputs": in_,
-                        "outputs": out_,
+                        "reference_outputs": reference_outputs_,
                         "metadata": metadata_,
                         "split": split_,
                         "id": id_ or str(uuid.uuid4()),
                         "source_run_id": source_run_id_,
                     }
                 )
-                for in_, out_, metadata_, split_, id_, source_run_id_ in zip(
+                for in_, reference_outputs_, metadata_, split_, id_, source_run_id_ in zip(
                     inputs,
-                    kwargs.get("outputs") or (None for _ in range(input_len)),
+                    (kwargs.get("reference_outputs") or kwargs.get("outputs"))
+                    or (None for _ in range(input_len)),
                     kwargs.get("metadata") or (None for _ in range(input_len)),
                     kwargs.get("splits") or (None for _ in range(input_len)),
                     kwargs.get("ids") or (None for _ in range(input_len)),
@@ -7103,7 +7114,7 @@ class Client:
         dataset_id: Optional[ID_TYPE] = None,
         dataset_name: Optional[str] = None,
         created_at: Optional[datetime.datetime] = None,
-        outputs: Optional[Mapping[str, Any]] = None,
+        reference_outputs: Optional[Mapping[str, Any]] = None,
         metadata: Optional[Mapping[str, Any]] = None,
         split: Optional[str | list[str]] = None,
         example_id: Optional[ID_TYPE] = None,
@@ -7111,6 +7122,8 @@ class Client:
         use_source_run_io: bool = False,
         use_source_run_attachments: Optional[list[str]] = None,
         attachments: Optional[ls_schemas.Attachments] = None,
+        *,
+        outputs: Optional[Mapping[str, Any]] = None,
     ) -> ls_schemas.Example:
         """Create a dataset example in the LangSmith API.
 
@@ -7127,8 +7140,8 @@ class Client:
                 The name of the dataset to create the example in.
             created_at (Optional[datetime.datetime]):
                 The creation timestamp of the example.
-            outputs (Optional[Mapping[str, Any]]):
-                The output values for the example.
+            reference_outputs (Optional[Mapping[str, Any]]):
+                The reference output values for the example.
             metadata (Optional[Mapping[str, Any]]):
                 The metadata for the example.
             split (Optional[str | List[str]]):
@@ -7146,10 +7159,17 @@ class Client:
                 is True, all attachments will be used regardless of this param.
             attachments (Optional[Attachments]):
                 The attachments for the example.
+            outputs (Optional[Mapping[str, Any]]):
+                Deprecated alias for reference_outputs.
 
         Returns:
             Example: The created example.
         """
+        if reference_outputs is not None and outputs is not None:
+            raise ValueError("Cannot specify both 'reference_outputs' and 'outputs'.")
+        if reference_outputs is None:
+            reference_outputs = outputs
+
         if inputs is None and not use_source_run_io:
             raise ValueError("Must provide either inputs or use_source_run_io")
 
@@ -7159,7 +7179,7 @@ class Client:
         data = ls_schemas.ExampleCreate(
             **{
                 "inputs": inputs,
-                "outputs": outputs,
+                "reference_outputs": reference_outputs,
                 "metadata": metadata,
                 "split": split,
                 "source_run_id": source_run_id,
@@ -7506,14 +7526,14 @@ class Client:
             examples = [
                 {
                     "inputs": {"question": "what's an agent"},
-                    "outputs": {"answer": "an agent is..."},
+                    "reference_outputs": {"answer": "an agent is..."},
                     "metadata": {"difficulty": "easy"},
                 },
                 {
                     "inputs": {
                         "question": "can you explain the agent architecture in this diagram?"
                     },
-                    "outputs": {"answer": "this diagram shows..."},
+                    "reference_outputs": {"answer": "this diagram shows..."},
                     "attachments": {"diagram": {"mime_type": "image/png", "data": b"..."}},
                     "metadata": {"difficulty": "medium"},
                 },

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -6513,11 +6513,12 @@ class Client:
                     )
                 )
 
-            outputs = (
-                example.reference_outputs
-                if isinstance(example, ls_schemas.ExampleCreate)
-                else example.outputs
-            )
+            outputs = example.outputs
+            if (
+                isinstance(example, ls_schemas.ExampleCreate)
+                and example.reference_outputs is not None
+            ):
+                outputs = example.reference_outputs
             if outputs is not None:
                 outputsb = _dumps_json(outputs)
                 parts.append(
@@ -6702,8 +6703,13 @@ class Client:
 
         if example.inputs:
             size += len(_dumps_json(example.inputs))
-        if example.reference_outputs:
-            size += len(_dumps_json(example.reference_outputs))
+        outputs = (
+            example.reference_outputs
+            if example.reference_outputs is not None
+            else example.outputs
+        )
+        if outputs:
+            size += len(_dumps_json(outputs))
         if example.metadata:
             size += len(_dumps_json(example.metadata))
 
@@ -6995,21 +7001,23 @@ class Client:
                         f"Length of {arg_name} ({len(arg_value)}) does not match"
                         f" length of inputs ({input_len})"
                     )
+            outputs_field = (
+                "reference_outputs" if "reference_outputs" in kwargs else "outputs"
+            )
             uploads = [
                 ls_schemas.ExampleCreate(
                     **{
                         "inputs": in_,
-                        "reference_outputs": reference_outputs_,
+                        outputs_field: outputs_,
                         "metadata": metadata_,
                         "split": split_,
                         "id": id_ or str(uuid.uuid4()),
                         "source_run_id": source_run_id_,
                     }
                 )
-                for in_, reference_outputs_, metadata_, split_, id_, source_run_id_ in zip(
+                for in_, outputs_, metadata_, split_, id_, source_run_id_ in zip(
                     inputs,
-                    (kwargs.get("reference_outputs") or kwargs.get("outputs"))
-                    or (None for _ in range(input_len)),
+                    kwargs.get(outputs_field) or (None for _ in range(input_len)),
                     kwargs.get("metadata") or (None for _ in range(input_len)),
                     kwargs.get("splits") or (None for _ in range(input_len)),
                     kwargs.get("ids") or (None for _ in range(input_len)),
@@ -7167,8 +7175,6 @@ class Client:
         """
         if reference_outputs is not None and outputs is not None:
             raise ValueError("Cannot specify both 'reference_outputs' and 'outputs'.")
-        if reference_outputs is None:
-            reference_outputs = outputs
 
         if inputs is None and not use_source_run_io:
             raise ValueError("Must provide either inputs or use_source_run_io")
@@ -7176,10 +7182,15 @@ class Client:
         if dataset_id is None:
             dataset_id = self.read_dataset(dataset_name=dataset_name).id
 
+        outputs_data = (
+            {"reference_outputs": reference_outputs}
+            if reference_outputs is not None
+            else {"outputs": outputs}
+        )
         data = ls_schemas.ExampleCreate(
             **{
                 "inputs": inputs,
-                "reference_outputs": reference_outputs,
+                **outputs_data,
                 "metadata": metadata,
                 "split": split,
                 "source_run_id": source_run_id,

--- a/python/langsmith/evaluation/_arunner.py
+++ b/python/langsmith/evaluation/_arunner.py
@@ -402,7 +402,7 @@ async def aevaluate_existing(
         >>> dataset = client.create_dataset(dataset_name)
         >>> example = client.create_example(
         ...     inputs={"question": "What is 2+2?"},
-        ...     outputs={"answer": "4"},
+        ...     reference_outputs={"answer": "4"},
         ...     dataset_id=dataset.id,
         ... )
         >>> async def apredict(inputs: dict) -> dict:

--- a/python/langsmith/evaluation/_runner.py
+++ b/python/langsmith/evaluation/_runner.py
@@ -483,7 +483,7 @@ def evaluate_existing(
         >>> dataset = client.create_dataset(dataset_name)
         >>> example = client.create_example(
         ...     inputs={"question": "What is 2+2?"},
-        ...     outputs={"answer": "4"},
+        ...     reference_outputs={"answer": "4"},
         ...     dataset_id=dataset.id,
         ... )
         >>> def predict(inputs: dict) -> dict:

--- a/python/langsmith/schemas.py
+++ b/python/langsmith/schemas.py
@@ -106,7 +106,7 @@ class ExampleCreate(BaseModel):
     id: Optional[UUID] = None
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     inputs: Optional[dict[str, Any]] = Field(default=None)
-    outputs: Optional[dict[str, Any]] = Field(default=None)
+    reference_outputs: Optional[dict[str, Any]] = Field(default=None)
     metadata: Optional[dict[str, Any]] = Field(default=None)
     split: Optional[Union[str, list[str]]] = None
     attachments: Optional[dict[str, _AttachmentLike]] = None
@@ -116,7 +116,20 @@ class ExampleCreate(BaseModel):
 
     def __init__(self, **data):
         """Initialize from dict."""
+        if "reference_outputs" in data and "outputs" in data:
+            raise ValueError("Cannot specify both 'reference_outputs' and 'outputs'.")
+        if "outputs" in data:
+            data["reference_outputs"] = data.pop("outputs")
         super().__init__(**data)
+
+    @property
+    def outputs(self) -> Optional[dict[str, Any]]:
+        """Deprecated alias for reference_outputs."""
+        return self.reference_outputs
+
+    @outputs.setter
+    def outputs(self, value: Optional[dict[str, Any]]) -> None:
+        self.reference_outputs = value
 
 
 ExampleUploadWithAttachments = ExampleCreate

--- a/python/langsmith/schemas.py
+++ b/python/langsmith/schemas.py
@@ -107,6 +107,9 @@ class ExampleCreate(BaseModel):
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     inputs: Optional[dict[str, Any]] = Field(default=None)
     reference_outputs: Optional[dict[str, Any]] = Field(default=None)
+    outputs: Optional[dict[str, Any]] = Field(
+        default=None, description="Deprecated: use reference_outputs instead."
+    )
     metadata: Optional[dict[str, Any]] = Field(default=None)
     split: Optional[Union[str, list[str]]] = None
     attachments: Optional[dict[str, _AttachmentLike]] = None
@@ -118,18 +121,7 @@ class ExampleCreate(BaseModel):
         """Initialize from dict."""
         if "reference_outputs" in data and "outputs" in data:
             raise ValueError("Cannot specify both 'reference_outputs' and 'outputs'.")
-        if "outputs" in data:
-            data["reference_outputs"] = data.pop("outputs")
         super().__init__(**data)
-
-    @property
-    def outputs(self) -> Optional[dict[str, Any]]:
-        """Deprecated alias for reference_outputs."""
-        return self.reference_outputs
-
-    @outputs.setter
-    def outputs(self, value: Optional[dict[str, Any]]) -> None:
-        self.reference_outputs = value
 
 
 ExampleUploadWithAttachments = ExampleCreate

--- a/python/langsmith/testing/_internal.py
+++ b/python/langsmith/testing/_internal.py
@@ -690,7 +690,7 @@ class _LangSmithTestSuite:
                 example = self.client.create_example(
                     example_id=example_id,
                     inputs=inputs,
-                    outputs=outputs,
+                    reference_outputs=outputs,
                     dataset_id=self.id,
                     metadata=metadata,
                     split=split,

--- a/python/tests/unit_tests/test_async_client.py
+++ b/python/tests/unit_tests/test_async_client.py
@@ -1011,8 +1011,11 @@ async def test_create_example_reference_outputs_alias(argument_name: str) -> Non
         )
 
     payload = json.loads(request.call_args.kwargs["content"])
-    assert payload["reference_outputs"] == reference_outputs
-    assert "outputs" not in payload
+    assert payload[argument_name] == reference_outputs
+    other_name = (
+        "outputs" if argument_name == "reference_outputs" else "reference_outputs"
+    )
+    assert other_name not in payload
     await client.aclose()
 
 

--- a/python/tests/unit_tests/test_async_client.py
+++ b/python/tests/unit_tests/test_async_client.py
@@ -982,3 +982,50 @@ async def test_async_client_resource_version_check(
 
     version_warnings = [r for r in caplog.records if r.name == _VERSION_LOGGER]
     assert bool(version_warnings) is expect_warning
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("argument_name", ["reference_outputs", "outputs"])
+async def test_create_example_reference_outputs_alias(argument_name: str) -> None:
+    client = AsyncClient(api_url="http://localhost:1984", api_key="test")
+    dataset_id = uuid.uuid4()
+    reference_outputs = {"answer": 42}
+    response = MagicMock()
+    response.json.return_value = {
+        "id": str(uuid.uuid4()),
+        "dataset_id": str(dataset_id),
+        "inputs": {"question": "meaning"},
+        "outputs": reference_outputs,
+    }
+
+    with mock.patch.object(
+        AsyncClient,
+        "_arequest_with_retries",
+        new_callable=AsyncMock,
+        return_value=response,
+    ) as request:
+        await client.create_example(
+            inputs={"question": "meaning"},
+            dataset_id=dataset_id,
+            **{argument_name: reference_outputs},
+        )
+
+    payload = json.loads(request.call_args.kwargs["content"])
+    assert payload["reference_outputs"] == reference_outputs
+    assert "outputs" not in payload
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_create_example_rejects_reference_outputs_conflict() -> None:
+    client = AsyncClient(api_url="http://localhost:1984", api_key="test")
+
+    with pytest.raises(ValueError, match="both 'reference_outputs' and 'outputs'"):
+        await client.create_example(
+            inputs={"question": "meaning"},
+            dataset_id=uuid.uuid4(),
+            reference_outputs={"answer": 42},
+            outputs={"answer": 43},
+        )
+
+    await client.aclose()

--- a/python/tests/unit_tests/test_client.py
+++ b/python/tests/unit_tests/test_client.py
@@ -1200,7 +1200,7 @@ def test_upsert_examples_multipart(mock_session_cls: mock.Mock) -> None:
         dataset_id=dataset_id,
         created_at=created_at,
         inputs={"input": "test input"},
-        outputs={"output": "test output"},
+        reference_outputs={"output": "test output"},
         metadata={"meta": "data"},
         split="train",
         attachments={
@@ -1270,6 +1270,130 @@ def test_upsert_examples_multipart(mock_session_cls: mock.Mock) -> None:
             value = json.loads(part.value)
             assert value == expected_parts[name]
             assert part.headers["Content-Type"] == "application/json"
+
+
+def test_example_create_reference_outputs_aliases() -> None:
+    reference_outputs = {"answer": 42}
+
+    canonical = ls_schemas.ExampleCreate(reference_outputs=reference_outputs)
+    assert (
+        canonical.model_dump(exclude_none=True)["reference_outputs"]
+        == reference_outputs
+    )
+    assert "outputs" not in canonical.model_dump(exclude_none=True)
+
+    legacy = ls_schemas.ExampleCreate(outputs=reference_outputs)
+    assert legacy.reference_outputs == reference_outputs
+    assert legacy.outputs == reference_outputs
+    assert (
+        legacy.model_dump(exclude_none=True)["reference_outputs"] == reference_outputs
+    )
+
+    with pytest.raises(ValueError, match="both 'reference_outputs' and 'outputs'"):
+        ls_schemas.ExampleCreate(
+            reference_outputs=reference_outputs,
+            outputs=reference_outputs,
+        )
+
+
+@pytest.mark.parametrize("argument_name", ["reference_outputs", "outputs"])
+@mock.patch("langsmith.client.requests.Session")
+def test_create_example_legacy_json_reference_outputs(
+    mock_session_cls: mock.Mock, argument_name: str
+) -> None:
+    example_id = uuid.uuid4()
+    dataset_id = uuid.uuid4()
+    reference_outputs = {"answer": 42}
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "id": str(example_id),
+        "dataset_id": str(dataset_id),
+        "inputs": {"question": "meaning"},
+        "outputs": reference_outputs,
+    }
+    mock_session = MagicMock()
+    mock_session.request.return_value = mock_response
+    mock_session_cls.return_value = mock_session
+    client = Client(
+        api_url="http://localhost:1984",
+        api_key="123",
+        info={},
+        auto_batch_tracing=False,
+    )
+
+    client.create_example(
+        inputs={"question": "meaning"},
+        dataset_id=dataset_id,
+        **{argument_name: reference_outputs},
+    )
+
+    request = next(
+        call for call in mock_session.request.call_args_list if call.args[0] == "POST"
+    )
+    payload = json.loads(request.kwargs["data"])
+    assert payload["reference_outputs"] == reference_outputs
+    assert "outputs" not in payload
+
+
+@pytest.mark.parametrize("argument_name", ["reference_outputs", "outputs"])
+def test_create_examples_reference_outputs_alias(argument_name: str) -> None:
+    client = Client(
+        api_url="http://localhost:1984",
+        api_key="123",
+        info={},
+        auto_batch_tracing=False,
+    )
+    reference_outputs = [{"answer": 42}]
+
+    with mock.patch.object(
+        Client,
+        "_upload_examples_batches_parallel",
+        return_value=ls_schemas.UpsertExamplesResponse(
+            example_ids=[], count=1, as_of=None
+        ),
+    ) as upload:
+        client.create_examples(
+            dataset_id=uuid.uuid4(),
+            inputs=[{"question": "meaning"}],
+            **{argument_name: reference_outputs},
+        )
+
+    example = upload.call_args.args[0][0][0]
+    assert example.reference_outputs == reference_outputs[0]
+    assert (
+        example.model_dump(exclude_none=True)["reference_outputs"]
+        == reference_outputs[0]
+    )
+
+
+def test_create_examples_rejects_reference_outputs_conflict() -> None:
+    client = Client(api_url="http://localhost:1984", api_key="123", info={})
+
+    with pytest.raises(ValueError, match="both 'reference_outputs' and 'outputs'"):
+        client.create_examples(
+            dataset_id=uuid.uuid4(),
+            inputs=[{"question": "meaning"}],
+            reference_outputs=[{"answer": 42}],
+            outputs=[{"answer": 43}],
+        )
+
+
+@mock.patch("langsmith.client.requests.Session")
+def test_create_example_rejects_reference_outputs_conflict(
+    mock_session_cls: mock.Mock,
+) -> None:
+    client = Client(api_url="http://localhost:1984", api_key="123", info={})
+
+    with pytest.raises(ValueError, match="both 'reference_outputs' and 'outputs'"):
+        client.create_example(
+            inputs={"question": "meaning"},
+            dataset_id=uuid.uuid4(),
+            reference_outputs={"answer": 42},
+            outputs={"answer": 43},
+        )
+
+    mock_session_cls.return_value.request.assert_not_called()
 
 
 @mock.patch("langsmith.client.requests.Session")

--- a/python/tests/unit_tests/test_client.py
+++ b/python/tests/unit_tests/test_client.py
@@ -1283,11 +1283,9 @@ def test_example_create_reference_outputs_aliases() -> None:
     assert "outputs" not in canonical.model_dump(exclude_none=True)
 
     legacy = ls_schemas.ExampleCreate(outputs=reference_outputs)
-    assert legacy.reference_outputs == reference_outputs
+    assert legacy.reference_outputs is None
     assert legacy.outputs == reference_outputs
-    assert (
-        legacy.model_dump(exclude_none=True)["reference_outputs"] == reference_outputs
-    )
+    assert legacy.model_dump(exclude_none=True)["outputs"] == reference_outputs
 
     with pytest.raises(ValueError, match="both 'reference_outputs' and 'outputs'"):
         ls_schemas.ExampleCreate(
@@ -1332,8 +1330,11 @@ def test_create_example_legacy_json_reference_outputs(
         call for call in mock_session.request.call_args_list if call.args[0] == "POST"
     )
     payload = json.loads(request.kwargs["data"])
-    assert payload["reference_outputs"] == reference_outputs
-    assert "outputs" not in payload
+    assert payload[argument_name] == reference_outputs
+    other_name = (
+        "outputs" if argument_name == "reference_outputs" else "reference_outputs"
+    )
+    assert other_name not in payload
 
 
 @pytest.mark.parametrize("argument_name", ["reference_outputs", "outputs"])
@@ -1360,11 +1361,12 @@ def test_create_examples_reference_outputs_alias(argument_name: str) -> None:
         )
 
     example = upload.call_args.args[0][0][0]
-    assert example.reference_outputs == reference_outputs[0]
-    assert (
-        example.model_dump(exclude_none=True)["reference_outputs"]
-        == reference_outputs[0]
+    assert getattr(example, argument_name) == reference_outputs[0]
+    other_name = (
+        "outputs" if argument_name == "reference_outputs" else "reference_outputs"
     )
+    assert getattr(example, other_name) is None
+    assert example.model_dump(exclude_none=True)[argument_name] == reference_outputs[0]
 
 
 def test_create_examples_rejects_reference_outputs_conflict() -> None:


### PR DESCRIPTION
## Description
Python and TypeScript example creation APIs now prefer reference-output terminology while retaining deprecated `outputs` aliases. Canonical JSON payloads use `reference_outputs`; multipart storage names remain unchanged. Merge and deploy the API compatibility PR before releasing this change.

Linear: https://linear.app/langchain/issue/LSE-2783/update-dataset-api-and-sdk-to-use-reference-outputs-instead-of-outputs
Depends on: https://github.com/langchain-ai/langchainplus/pull/34107 · UI: https://github.com/langchain-ai/langchainplus/pull/34106

## Test Plan
- [x] Verify canonical, legacy, and conflicting values in Python and TypeScript client tests.
- [x] Run both SDK unit suites.

Made by [Open SWE](https://openswe.vercel.app/agents/243f5382-7daa-7334-5e10-86ac30feb40e)
