### PR TITLE
fix: normalize sandbox websocket URLs

### DIFF
--- a/python/langsmith/sandbox/_ws_execute.py
+++ b/python/langsmith/sandbox/_ws_execute.py
@@ -7,6 +7,7 @@ import logging
 import time
 from collections.abc import AsyncIterator, Iterator, Mapping
 from typing import Any, Callable, Optional
+from urllib.parse import urlsplit, urlunsplit
 
 from langsmith import utils as ls_utils
 from langsmith.sandbox._exceptions import (
@@ -99,8 +100,10 @@ def _ensure_websockets_async():
 
 def _build_ws_url(dataplane_url: str) -> str:
     """Convert dataplane HTTP URL to WebSocket URL for /execute/ws."""
-    ws_url = dataplane_url.replace("https://", "wss://").replace("http://", "ws://")
-    return f"{ws_url}/execute/ws"
+    parsed = urlsplit(dataplane_url)
+    scheme = {"http": "ws", "https": "wss"}.get(parsed.scheme, parsed.scheme)
+    path = f"{parsed.path.rstrip('/')}/execute/ws"
+    return urlunsplit((scheme, parsed.netloc, path, parsed.query, parsed.fragment))
 
 
 def _build_auth_headers(

--- a/python/tests/unit_tests/sandbox/test_ws_execute.py
+++ b/python/tests/unit_tests/sandbox/test_ws_execute.py
@@ -71,6 +71,16 @@ class TestBuildWsUrl:
             "ws://localhost:8080/sb-123/execute/ws"
         )
 
+    def test_strips_trailing_slash(self):
+        assert _build_ws_url("https://example.com/sb-123/") == (
+            "wss://example.com/sb-123/execute/ws"
+        )
+
+    def test_rewrites_only_scheme(self):
+        assert _build_ws_url("https://example.com/sb-123?next=http://x") == (
+            "wss://example.com/sb-123/execute/ws?next=http://x"
+        )
+
 
 class TestBuildAuthHeaders:
     def test_builds_header(self):


### PR DESCRIPTION
## Summary
- Build sandbox WebSocket URLs with URL parsing instead of global string replacement.
- Strip only a trailing dataplane path slash before appending /execute/ws.
- Preserve query strings while rewriting http/https schemes to ws/wss.

## Testing
- Previously verified locally before publication.