### PR TITLE
chore(py)!: swtich to httpx2 dependency while keeping httpx as a fallback

### DIFF
--- a/python/Makefile
+++ b/python/Makefile
@@ -44,6 +44,7 @@ tests:
 	 -u LANGSMITH_TRACING \
 	 PYTHONDEVMODE=1 \
 	 PYTHONASYNCIODEBUG=1 \
+	 PYTHONPATH=tests/httpx2_alias \
 	 uv run python -m pytest --disable-socket --allow-unix-socket -n auto --durations=10 ${TEST}
 
 tests_watch:
@@ -90,8 +91,21 @@ test-wheel-imports:
 	uv pip install -r /tmp/langsmith-declared-deps.txt --python /tmp/langsmith-strict-test
 	/tmp/langsmith-strict-test/bin/python -c "\
 from langsmith._openapi_client import Langsmith; \
-from langsmith.client import Client"
-	rm -rf /tmp/langsmith-strict-test /tmp/langsmith-declared-deps.txt
+from langsmith.client import Client; \
+assert __import__('langsmith._openapi_client._httpx', fromlist=['httpx']).httpx.__name__ == 'httpx2'; \
+Langsmith(base_url='https://example.com').close(); \
+Client(api_url='https://example.com', api_key='test', auto_batch_tracing=False, info={}).close()"
+	uv run python3 -c "p='/tmp/langsmith-declared-deps.txt'; lines=open(p).read().splitlines(); open('/tmp/langsmith-httpx-deps.txt','w').write('\n'.join(x for x in lines if not x.startswith('httpx2')) + '\nhttpx>=0.23.0,<1\n')"
+	uv venv /tmp/langsmith-httpx-test
+	uv pip install dist/langsmith-*.whl --no-deps --python /tmp/langsmith-httpx-test
+	uv pip install -r /tmp/langsmith-httpx-deps.txt --python /tmp/langsmith-httpx-test
+	/tmp/langsmith-httpx-test/bin/python -c "\
+from langsmith._openapi_client import Langsmith; \
+from langsmith.client import Client; \
+assert __import__('langsmith._openapi_client._httpx', fromlist=['httpx']).httpx.__name__ == 'httpx'; \
+Langsmith(base_url='https://example.com').close(); \
+Client(api_url='https://example.com', api_key='test', auto_batch_tracing=False, info={}).close()"
+	rm -rf /tmp/langsmith-strict-test /tmp/langsmith-httpx-test /tmp/langsmith-declared-deps.txt /tmp/langsmith-httpx-deps.txt
 
 api_docs_build:
 	uv run python docs/create_api_rst.py

--- a/python/Makefile
+++ b/python/Makefile
@@ -95,17 +95,7 @@ from langsmith.client import Client; \
 assert __import__('langsmith._openapi_client._httpx', fromlist=['httpx']).httpx.__name__ == 'httpx2'; \
 Langsmith(base_url='https://example.com').close(); \
 Client(api_url='https://example.com', api_key='test', auto_batch_tracing=False, info={}).close()"
-	uv run python3 -c "p='/tmp/langsmith-declared-deps.txt'; lines=open(p).read().splitlines(); open('/tmp/langsmith-httpx-deps.txt','w').write('\n'.join(x for x in lines if not x.startswith('httpx2')) + '\nhttpx>=0.23.0,<1\n')"
-	uv venv /tmp/langsmith-httpx-test
-	uv pip install dist/langsmith-*.whl --no-deps --python /tmp/langsmith-httpx-test
-	uv pip install -r /tmp/langsmith-httpx-deps.txt --python /tmp/langsmith-httpx-test
-	/tmp/langsmith-httpx-test/bin/python -c "\
-from langsmith._openapi_client import Langsmith; \
-from langsmith.client import Client; \
-assert __import__('langsmith._openapi_client._httpx', fromlist=['httpx']).httpx.__name__ == 'httpx'; \
-Langsmith(base_url='https://example.com').close(); \
-Client(api_url='https://example.com', api_key='test', auto_batch_tracing=False, info={}).close()"
-	rm -rf /tmp/langsmith-strict-test /tmp/langsmith-httpx-test /tmp/langsmith-declared-deps.txt /tmp/langsmith-httpx-deps.txt
+	rm -rf /tmp/langsmith-strict-test /tmp/langsmith-declared-deps.txt
 
 api_docs_build:
 	uv run python docs/create_api_rst.py

--- a/python/langsmith/async_client.py
+++ b/python/langsmith/async_client.py
@@ -20,13 +20,12 @@ from typing import (
     cast,
 )
 
-import httpx
-
 import langsmith._openapi_client as _langsmith_api_module
 from langsmith._internal._beta_decorator import deprecated as _deprecated
 from langsmith._internal._beta_decorator import (
     suppress_deprecation_warning as _suppress_deprecation_warning,
 )
+from langsmith._openapi_client._httpx import httpx
 from langsmith.client import _get_openapi_base_url
 
 if TYPE_CHECKING:

--- a/python/langsmith/async_client.py
+++ b/python/langsmith/async_client.py
@@ -20,6 +20,7 @@ from typing import (
     cast,
 )
 
+import langsmith
 import langsmith._openapi_client as _langsmith_api_module
 from langsmith._internal._beta_decorator import deprecated as _deprecated
 from langsmith._internal._beta_decorator import (
@@ -108,6 +109,7 @@ class AsyncClient:
         headers = {**self._custom_headers}
         # Required headers that should not be overridden
         headers["Content-Type"] = "application/json"
+        headers["User-Agent"] = f"langsmith-py/{langsmith.__version__}-{httpx.__name__}"
         if self._api_key:
             headers[ls_client.X_API_KEY] = self._api_key
         elif self._profile_auth_headers:

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -1820,7 +1820,8 @@ class Client:
 
     def _compute_headers(self) -> dict[str, str]:
         headers = {
-            "User-Agent": f"langsmith-py/{langsmith.__version__}",
+            # `_httpx.__name__` is `httpx2` or `httpx`; no version, to keep cardinality low.
+            "User-Agent": f"langsmith-py/{langsmith.__version__}-{_httpx.__name__}",
             "Accept": "application/json",
         }
         # Merge custom headers first so they don't override required headers

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -54,7 +54,6 @@ from typing import (
 )
 from urllib import parse as urllib_parse
 
-import httpx as _httpx
 import packaging.version
 import requests
 from pydantic import Field
@@ -126,6 +125,7 @@ from langsmith._openapi_client._base_client import (
 from langsmith._openapi_client._base_client import (
     SyncHttpxClientWrapper as _SyncHttpxClientWrapper,
 )
+from langsmith._openapi_client._httpx import httpx as _httpx
 from langsmith.prompt_cache import PromptCache, prompt_cache_singleton
 from langsmith.schemas import AttachmentInfo, ExampleWithRuns
 

--- a/python/langsmith/sandbox/README.md
+++ b/python/langsmith/sandbox/README.md
@@ -1302,12 +1302,17 @@ service in the sandbox. Properties auto-refresh the token near expiry.
 
 | Method | Description |
 |--------|-------------|
-| `request(method, path="/", **kwargs)` | Make an HTTP request with auth header injected. Returns `httpx.Response`. |
+| `request(method, path="/", **kwargs)` | Make an HTTP request with auth header injected. Returns `httpx2.Response`. |
 | `get(path="/", **kwargs)` | HTTP GET |
 | `post(path="/", **kwargs)` | HTTP POST |
 | `put(path="/", **kwargs)` | HTTP PUT |
 | `patch(path="/", **kwargs)` | HTTP PATCH |
 | `delete(path="/", **kwargs)` | HTTP DELETE |
+
+These return `httpx2.Response`, or `httpx.Response` if `httpx2` is not installed. `httpx2` is a fork
+of `httpx`, not a subclass, so if directly imported `isinstance(resp, httpx.Response)` could be
+`False` and calling `resp.raise_for_status()` yourself could raise `httpx2.HTTPStatusError`, which
+`except httpx.HTTPStatusError` will not catch.
 
 `AsyncServiceURL` is the async variant. Use `await svc.get_token()`,
 `await svc.get_service_url()`, etc. for auto-refreshing access, and

--- a/python/langsmith/sandbox/_async_client.py
+++ b/python/langsmith/sandbox/_async_client.py
@@ -9,10 +9,9 @@ import uuid
 from collections.abc import Callable, Mapping
 from typing import TYPE_CHECKING, Any, Optional, Union
 
-import httpx
-
 from langsmith import utils as ls_utils
 from langsmith._openapi_client import AsyncLangsmith
+from langsmith._openapi_client._httpx import httpx
 from langsmith.sandbox._async_sandbox import AsyncSandbox
 from langsmith.sandbox._client import (
     SandboxClient,

--- a/python/langsmith/sandbox/_async_sandbox.py
+++ b/python/langsmith/sandbox/_async_sandbox.py
@@ -8,8 +8,7 @@ from collections.abc import Mapping
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Callable, Literal, Optional, Union, overload
 
-import httpx
-
+from langsmith._openapi_client._httpx import httpx
 from langsmith.sandbox._exceptions import (
     DataplaneNotConfiguredError,
     ResourceNotFoundError,

--- a/python/langsmith/sandbox/_client.py
+++ b/python/langsmith/sandbox/_client.py
@@ -13,10 +13,9 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional, Union
 from urllib.parse import quote
 
-import httpx
-
 from langsmith import utils as ls_utils
 from langsmith._openapi_client import Langsmith
+from langsmith._openapi_client._httpx import httpx
 from langsmith.sandbox._exceptions import (
     ResourceCreationError,
     ResourceNameConflictError,

--- a/python/langsmith/sandbox/_helpers.py
+++ b/python/langsmith/sandbox/_helpers.py
@@ -9,8 +9,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 from typing import Any, Optional
 
-import httpx
-
+from langsmith._openapi_client._httpx import httpx
 from langsmith.sandbox._exceptions import (
     QuotaExceededError,
     ResourceCreationError,

--- a/python/langsmith/sandbox/_models.py
+++ b/python/langsmith/sandbox/_models.py
@@ -8,8 +8,7 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Literal, Optional
 
-import httpx
-
+from langsmith._openapi_client._httpx import httpx
 from langsmith.sandbox._exceptions import (
     SandboxConnectionError,
     SandboxOperationError,

--- a/python/langsmith/sandbox/_sandbox.py
+++ b/python/langsmith/sandbox/_sandbox.py
@@ -6,8 +6,7 @@ from collections.abc import Mapping
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Callable, Literal, Optional, Union, overload
 
-import httpx
-
+from langsmith._openapi_client._httpx import httpx
 from langsmith.sandbox._exceptions import (
     DataplaneNotConfiguredError,
     ResourceNotFoundError,

--- a/python/langsmith/sandbox/_transport.py
+++ b/python/langsmith/sandbox/_transport.py
@@ -13,8 +13,7 @@ import logging
 import random
 import time
 
-import httpx
-
+from langsmith._openapi_client._httpx import httpx
 from langsmith.sandbox._exceptions import SandboxConnectionError
 
 logger = logging.getLogger(__name__)

--- a/python/langsmith/utils.py
+++ b/python/langsmith/utils.py
@@ -29,12 +29,12 @@ from typing import (
 )
 from urllib import parse as urllib_parse
 
-import httpx
 import requests
 from typing_extensions import ParamSpec
 from urllib3.util import Retry  # type: ignore[import-untyped]
 
 from langsmith import schemas as ls_schemas
+from langsmith._openapi_client._httpx import httpx
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "pydantic>=2,<3",
     "requests>=2.0.0",
     "orjson>=3.9.14; platform_python_implementation != 'PyPy'",
-    "httpx>=0.23.0,<1",
+    "httpx2>=2,<3",
     "requests-toolbelt>=1.0.0",
     "zstandard>=0.23.0",
     "packaging>=23.2",

--- a/python/tests/httpx2_alias/sitecustomize.py
+++ b/python/tests/httpx2_alias/sitecustomize.py
@@ -1,0 +1,5 @@
+"""Use HTTPX2 for tests that import the legacy HTTPX module name."""
+
+import httpx2
+
+httpx2.alias_httpx()

--- a/python/tests/unit_tests/test_httpx_compat.py
+++ b/python/tests/unit_tests/test_httpx_compat.py
@@ -9,6 +9,14 @@ def _info_response(request: httpx.Request) -> httpx.Response:
     return httpx.Response(200, json={"version": "test"})
 
 
+def test_user_agent_names_the_backend() -> None:
+    from langsmith import AsyncClient, Client
+
+    suffix = f"-{httpx.__name__}"
+    assert Client(api_key="test")._compute_headers()["User-Agent"].endswith(suffix)
+    assert AsyncClient(api_key="test")._compute_headers()["User-Agent"].endswith(suffix)
+
+
 def test_prefers_httpx2_for_sync_requests() -> None:
     assert httpx.__name__ == "httpx2"
     with httpx.Client(transport=httpx.MockTransport(_info_response)) as http_client:

--- a/python/tests/unit_tests/test_httpx_compat.py
+++ b/python/tests/unit_tests/test_httpx_compat.py
@@ -1,0 +1,30 @@
+import pytest
+
+from langsmith._openapi_client import AsyncLangsmith, Langsmith
+from langsmith._openapi_client._httpx import httpx
+
+
+def _info_response(request: httpx.Request) -> httpx.Response:
+    assert request.url.path == "/api/v1/info"
+    return httpx.Response(200, json={"version": "test"})
+
+
+def test_prefers_httpx2_for_sync_requests() -> None:
+    assert httpx.__name__ == "httpx2"
+    with httpx.Client(transport=httpx.MockTransport(_info_response)) as http_client:
+        with Langsmith(
+            api_key="test", base_url="https://example.com", http_client=http_client
+        ) as client:
+            assert client.info.list().version == "test"
+
+
+@pytest.mark.asyncio
+async def test_prefers_httpx2_for_async_requests() -> None:
+    assert httpx.__name__ == "httpx2"
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(_info_response)
+    ) as http_client:
+        async with AsyncLangsmith(
+            api_key="test", base_url="https://example.com", http_client=http_client
+        ) as client:
+            assert (await client.info.list()).version == "test"

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -1357,6 +1357,19 @@ wheels = [
 ]
 
 [[package]]
+name = "httpcore2"
+version = "2.10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+    { name = "truststore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a9/83/a896fc59940fc5a6e2aff3a4be1d92fa890112936803b331cae75a993c34/httpcore2-2.10.0.tar.gz", hash = "sha256:13c0cc3d1919d4f28457f60cd2c2abe04113a8af184ccf1142811beba936f9dc", size = 67427, upload-time = "2026-08-09T09:11:32.123Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/4f/d149104195a35e2853a2fc203a8e3477747e58c80e17dda686dace174383/httpcore2-2.10.0-py3-none-any.whl", hash = "sha256:7df06cfb34070cae4f7c89be69dc1095eca138e9704ceffb98d25c1912ab6f01", size = 83000, upload-time = "2026-08-09T09:11:29.555Z" },
+]
+
+[[package]]
 name = "httpx"
 version = "0.28.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1381,12 +1394,38 @@ wheels = [
 ]
 
 [[package]]
-name = "idna"
-version = "3.15"
+name = "httpx2"
+version = "2.10.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc", size = 199245, upload-time = "2026-05-12T22:45:57.011Z" }
+dependencies = [
+    { name = "anyio", marker = "sys_platform != 'emscripten'" },
+    { name = "httpcore2", marker = "sys_platform != 'emscripten'" },
+    { name = "httpx2-jsfetch", marker = "python_full_version >= '3.12' and sys_platform == 'emscripten'" },
+    { name = "idna" },
+    { name = "truststore", marker = "sys_platform != 'emscripten'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bd/3d/f9a8c07a3884f3e5b26205e8436a18b3af61c5d53192c3bea235574dbbec/httpx2-2.10.0.tar.gz", hash = "sha256:8741d7329fe2c7885fc9ceb61c8217acfb87a85f75723714b89ebf7ad7196338", size = 98749, upload-time = "2026-08-09T09:11:33.24Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8", size = 72340, upload-time = "2026-05-12T22:45:55.733Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/6d/a637d52449d98a6892d9a4dc0262587afdb6a66f201871842dce5a97b1c1/httpx2-2.10.0-py3-none-any.whl", hash = "sha256:5e3194a432701e1cc6f69a8b1b2fa199ef907013fede8d9a09a2c5b7b8141a18", size = 94355, upload-time = "2026-08-09T09:11:30.882Z" },
+]
+
+[[package]]
+name = "httpx2-jsfetch"
+version = "1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/c4/0e5636363151a2a1795e0a77617168b9ca438e1748ec05fc9b5687f93d64/httpx2_jsfetch-1.0.tar.gz", hash = "sha256:70a0e3eabfef7cce5ad9c629f7d01ca05e418f586646f4ddf14782e4c1454c60", size = 6872, upload-time = "2026-08-07T00:13:07.492Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/43/832f631d32e4f1211caa2ba368317739fe71f0b8530e4c9d15dc454bac2a/httpx2_jsfetch-1.0-py3-none-any.whl", hash = "sha256:cb916b707601e69a07721aabc8f3f6659be3a6893bc1ff5c6f9e02241df2da32", size = 6382, upload-time = "2026-08-07T00:13:06.567Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.18"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]
@@ -1648,7 +1687,7 @@ source = { editable = "." }
 dependencies = [
     { name = "anyio" },
     { name = "distro" },
-    { name = "httpx" },
+    { name = "httpx2" },
     { name = "orjson", marker = "platform_python_implementation != 'PyPy'" },
     { name = "packaging" },
     { name = "pydantic" },
@@ -1795,7 +1834,7 @@ requires-dist = [
     { name = "google-adk", marker = "extra == 'google-adk'", specifier = ">=1.0.0" },
     { name = "google-adk", marker = "extra == 'google-adk-live'", specifier = ">=2.3.0" },
     { name = "google-genai", marker = "extra == 'gemini-live'", specifier = ">=1.75" },
-    { name = "httpx", specifier = ">=0.23.0,<1" },
+    { name = "httpx2", specifier = ">=2,<3" },
     { name = "langsmith-pyo3", marker = "extra == 'langsmith-pyo3'", specifier = ">=0.1.0rc2" },
     { name = "livekit-agents", marker = "extra == 'livekit'", specifier = ">=1.6" },
     { name = "openai", marker = "extra == 'openai-realtime'", specifier = ">=1.50" },
@@ -4797,6 +4836,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
+]
+
+[[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Moves the Python SDK's runtime HTTP dependency from `httpx` to `httpx2`, Pydantic's maintained fork.

The generated client now emits its own backend-selection shim at `_openapi_client/_httpx.py`. It prefers `httpx2` and falls back to `httpx` if `httpx2` is not installed. Hand-written code imports `httpx` from that same shim instead of
repeating the selection, so the generated and hand-written halves of the SDK are aligned.

`httpx` stays in the dev group only. The shim's `TYPE_CHECKING` branch resolves against it, and the
test suite exercises the fallback path.

Closes LSDK-448. Replaces the prototype in #3341.

### Dependency change

```diff
-    "httpx>=0.23.0,<1",
+    "httpx2>=2,<3",
```

Net effect on an install is one extra package. `httpx` → `httpx2` and `httpcore` → `httpcore2` are
one-for-one swaps. `truststore` is new — it is a hard dependency of `httpcore2`.

### User agent

So we can see which backend clients actually resolve to during the rollout, the `User-Agent` header
now names it: `langsmith-py/<version>-httpx2`, or `langsmith-py/<version>-httpx` when the fallback is
taken. The suffix is the shim's module name, and it carries no backend version, so the header keeps
the same cardinality as before for metrics faceted on it. `langsmith.Client` already sent
`langsmith-py/<version>` on both its `requests` session and the generated clients, so the suffix
covers every request it makes. `langsmith.AsyncClient` set no `User-Agent` at all and leaked httpx's
own default (`python-httpx2/2.10.0`); it now sends the same header as the sync client.

---

## Caveats

All four caveats have the same cause: **`httpx2` is a fork of `httpx`, not a subclass.** The two
packages have classes and exceptions with the same names and the same behaviour, but no shared base
classes. So `isinstance` checks and `except` clauses that cross the boundary do not match. They fail
silently, because the names still resolve.

Examples below can be executed from `python/` after:

```bash
uvx uv@latest sync --all-extras --dev
```

### 1. Test mocks stop intercepting SDK traffic

`pytest-httpx`, `respx`, and `httpx.MockTransport` all patch old httpx's transport layer. The SDK now
speaks httpx2, so these mocks no longer see its requests.

The requests are not blocked and no error is raised. They are sent for real. In a test suite without
socket blocking, that means live calls to the LangSmith API.

**Example**

```python
# /tmp/repro_mock/test_mock.py
from pytest_httpx import HTTPXMock
from langsmith._openapi_client import Langsmith

def test_info_call_is_mocked(httpx_mock: HTTPXMock):
    httpx_mock.add_response(
        url="https://api.smith.invalid.example/api/v1/info",
        json={"version": "1.2.3"},
    )
    client = Langsmith(api_key="fake-key", base_url="https://api.smith.invalid.example")
    assert client.info.list().version == "1.2.3"
    client.close()
```

```bash
.venv/bin/python -m pytest /tmp/repro_mock/test_mock.py -q -p pytest_httpx
```

```
langsmith._openapi_client.APIConnectionError: Connection error.
1 failed, 1 error
```

The mock was skipped and httpcore2 tried to open a real socket to a domain that does not exist.

**Workaround** `httpx2.alias_httpx()` makes `import httpx` return `httpx2` for the whole process.
Add it to a `sitecustomize.py` on the test run's `PYTHONPATH`:

```python
# tests/httpx2_alias/sitecustomize.py
import httpx2

httpx2.alias_httpx()
```

```bash
PYTHONPATH=tests/httpx2_alias .venv/bin/python -m pytest /tmp/repro_mock/test_mock.py -q -p pytest_httpx
```

Existing `pytest-httpx` tests then work unchanged. This PR uses exactly this approach for the SDK's
own test suite — see `python/tests/httpx2_alias/sitecustomize.py` and the `PYTHONPATH` in the
`tests` target of `python/Makefile`. 

### 2. `http_client=` rejects an old-httpx client

Passing an `httpx.Client` to the generated client is rejected. 

This is only reachable by constructing the generated client directly. `langsmith.Client` takes
`session: Optional[requests.Session]`, and `langsmith.AsyncClient` takes no client argument at all.
The message comes from generated code and cannot be changed in this repo.

**Reproduce.**

```bash
.venv/bin/python -c "
import httpx
from langsmith._openapi_client import Langsmith
try:
    Langsmith(api_key='k', base_url='https://example.com', http_client=httpx.Client())
except TypeError as e:
    print(e)"
```

```
Invalid `http_client` argument; Expected an instance of `httpx.Client` but got <class 'httpx.Client'>
```

*Workaround* Import httpx2 directly or from the Langsmith shim (`from langsmith._openapi_client._httpx import httpx`)

### 3. Sandbox request methods now return an `httpx2.Response`

`langsmith/sandbox/README.md` documents the sandbox service `request()` methods as returning
`httpx.Response`. They now return `httpx2.Response`.

This affects user code that:

- checks the result with `isinstance(resp, httpx.Response)`, which is now `False`,
- passes the result to a helper from old httpx,
- calls `.raise_for_status()` on the result. That raises `httpx2.HTTPStatusError`, which
  `except httpx.HTTPStatusError` does not catch.

**Reproduce.**

```bash
.venv/bin/python -c "
import httpx
from langsmith._openapi_client._httpx import httpx as ls_httpx
r = ls_httpx.Response(200, request=ls_httpx.Request('GET', 'https://example.com'))
print('backend:', ls_httpx.__name__)
print('isinstance(response, httpx.Response):', isinstance(r, httpx.Response))"
```

```
backend: httpx2
isinstance(response, httpx.Response): False
```

This PR updates `langsmith/sandbox/README.md` to state the real return type and note the consequences. The type annotations in `langsmith/sandbox/_models.py` needed no change — they annotate `httpx.Response` using the shim's `httpx` name, which already resolves to whichever backend is active.

### 4. TLS trust now comes from the OS, not certifi

`truststore` is not just an extra package. It replaces certifi's role. `httpx2` builds its default
SSL context as `truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT)`, which reads the operating system
trust store. Old httpx used certifi's bundled CA list.

`verify` still defaults to `True`, so certificate verification is not weakened. The source of trust
changes, and that cuts both ways:

- Users behind a corporate TLS-inspecting proxy should start working without an `SSL_CERT_FILE`
  workaround.
- Users on minimal containers with no system CA store, or who depended on certifi's bundle, may see
  new verification failures.

---

## Lower-impact notes

- Mixing a transport from one package with a client from the other is accepted at construction and
  fails later at request time, rather than being rejected up front.
- Importing `langsmith.utils` now loads the generated client eagerly, so first-import time goes from
  roughly 180-200 ms to roughly 300-350 ms. Timings vary by 15-20% between runs.
- `python/langsmith/wrappers/_anthropic.py` keeps its plain `import httpx`. That refers to the
  Anthropic SDK's own response types, not this SDK's backend, so it must not be repointed.

## Testing

- `make tests` — full unit suite with the alias active.
- `make test-wheel-imports` — builds the wheel, installs it into a clean venv with only the declared
  runtime dependencies, and asserts the backend resolves to `httpx2`. The assertion matters because
  the shim falls back silently: without it, the job would pass even if `httpx2` were missing from the
  declared deps and `httpx` arrived transitively. 
- `python/tests/unit_tests/test_httpx_compat.py` — asserts the sync and async clients pick httpx2.

