### PR TITLE
fix(py): handle 64bit+ integers without loss of precision

### DIFF
--- a/python/langsmith/_internal/_serde.py
+++ b/python/langsmith/_internal/_serde.py
@@ -227,10 +227,13 @@ def dumps_json(obj: Any) -> bytes:
             default=_serialize_json_with_normalized_keys,
             ensure_ascii=True,
         ).encode("utf-8")
-        try:
-            result = _orjson.dumps(
+        if _SURROGATE_RE.search(result):
+            # orjson.loads serves only to detect lone surrogates here (it
+            # rejects them, triggering the elision below). On success the
+            # stdlib bytes are kept as-is: re-dumping the parsed value through
+            # orjson would silently convert integers >= 2**64 to floats.
+            try:
                 _orjson.loads(result.decode("utf-8", errors="surrogateescape"))
-            )
-        except _orjson.JSONDecodeError:
-            result = _elide_surrogates(result)
+            except _orjson.JSONDecodeError:
+                result = _elide_surrogates(result)
         return result

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -2856,7 +2856,8 @@ class Client:
         if self._hide_inputs is True:
             return {}
         if self._anonymizer:
-            json_inputs = _orjson.loads(_dumps_json(inputs))
+            # stdlib json.loads keeps ints >= 2**64 exact; orjson.loads floats them.
+            json_inputs = json.loads(_dumps_json(inputs))
             return self._anonymizer(json_inputs)
         if self._hide_inputs is False:
             return inputs
@@ -2866,7 +2867,8 @@ class Client:
         if self._hide_outputs is True:
             return {}
         if self._anonymizer:
-            json_outputs = _orjson.loads(_dumps_json(outputs))
+            # stdlib json.loads keeps ints >= 2**64 exact; orjson.loads floats them.
+            json_outputs = json.loads(_dumps_json(outputs))
             return self._anonymizer(json_outputs)
         if self._hide_outputs is False:
             return outputs
@@ -2898,7 +2900,8 @@ class Client:
         if self._hide_metadata is True:
             return {}
         if self._anonymizer:
-            json_metadata = _orjson.loads(_dumps_json(metadata))
+            # stdlib json.loads keeps ints >= 2**64 exact; orjson.loads floats them.
+            json_metadata = json.loads(_dumps_json(metadata))
             return self._anonymizer(json_metadata)
         if self._hide_metadata is False:
             return metadata

--- a/python/tests/integration_tests/test_client.py
+++ b/python/tests/integration_tests/test_client.py
@@ -4,6 +4,7 @@ import asyncio
 import datetime
 import importlib
 import io
+import json
 import logging
 import os
 import queue
@@ -1591,13 +1592,16 @@ def test_fallback_json_serialization():
         (Document(content=item), expected) for item, expected in raw_surrogates
     ]
 
+    # Compare decoded values rather than bytes: which encoder produced the
+    # output is an implementation detail. The stdlib-json fallback keeps
+    # non-BMP characters as escaped surrogate pairs and separates keys with
+    # ": ", where the orjson path emits raw UTF-8 and no space. Both decode
+    # to the same string.
     for item, expected in raw_surrogates:
-        output = dumps_json(item).decode("utf8")
-        assert f'"{expected}"' == output
+        assert json.loads(dumps_json(item)) == expected
 
     for item, expected in pydantic_surrogates:
-        output = dumps_json(item).decode("utf8")
-        assert f'{{"content":"{expected}"}}' == output
+        assert json.loads(dumps_json(item)) == {"content": expected}
 
 
 def test_runs_stats():

--- a/python/tests/unit_tests/test_client.py
+++ b/python/tests/unit_tests/test_client.py
@@ -1865,6 +1865,58 @@ def test_anonymizer_redacts_metadata_on_update() -> None:
     assert SECRET_PLACEHOLDER in metadata
 
 
+def test_anonymizer_preserves_ints_larger_than_64_bits() -> None:
+    """The anonymizer pre-pass must not degrade ints that ``dumps_json`` keeps exact.
+
+    ``_hide_run_*`` round-trip the payload through ``_dumps_json`` so the anonymizer
+    receives plain JSON types. Parsing that back with ``orjson.loads`` turns any int
+    outside the 64-bit range into a float, which would undo the exact stdlib
+    fallback in ``dumps_json`` before the anonymizer ever sees the value.
+    """
+    wei = 19_876_543_210_987_654_321
+    session = mock.MagicMock(spec=requests.Session)
+    client = _client_with_secret_anonymizer(session)
+
+    client.create_run(
+        "my_run",
+        inputs={"balance_wei": wei},
+        outputs={"a": 2**64, "b": 2**64 + 1},
+        run_type="llm",
+        id=uuid.uuid4(),
+        extra={"metadata": {"offset": -(2**80)}},
+    )
+
+    payload = _find_request_payload(session, "POST", "/runs")
+    assert payload["inputs"]["balance_wei"] == wei
+    # Floats would collapse these two to the same value.
+    assert payload["outputs"]["a"] != payload["outputs"]["b"]
+    assert _posted_metadata(session, "POST", "/runs")["offset"] == -(2**80)
+
+
+def test_anonymizer_tolerates_non_finite_floats() -> None:
+    """Configuring an anonymizer must not make a payload unserializable.
+
+    A NaN next to an out-of-range int both force the stdlib fallback in
+    ``dumps_json``, which emits the non-standard ``NaN`` literal. ``orjson.loads``
+    rejects that, so the anonymizer pre-pass used to raise ``JSONDecodeError`` and
+    drop the run; stdlib ``json.loads`` accepts it, matching the behavior of the
+    path with no anonymizer configured.
+    """
+    session = mock.MagicMock(spec=requests.Session)
+    client = _client_with_secret_anonymizer(session)
+
+    client.create_run(
+        "my_run",
+        inputs={"x": float("nan"), "v": 2**70},
+        run_type="llm",
+        id=uuid.uuid4(),
+    )
+
+    payload = _find_request_payload(session, "POST", "/runs")
+    assert math.isnan(payload["inputs"]["x"])
+    assert payload["inputs"]["v"] == 2**70
+
+
 def test_omit_traced_runtime_info() -> None:
     """Test that omit_traced_runtime_info prevents runtime info from being added."""
     session = mock.MagicMock(spec=requests.Session)

--- a/python/tests/unit_tests/test_client.py
+++ b/python/tests/unit_tests/test_client.py
@@ -2395,6 +2395,29 @@ def test__dumps_json():
     assert "\\uDC00" not in serialized_str
 
 
+def test__dumps_json_preserves_ints_larger_than_64_bits():
+    """Integers >= 2**64 must survive the stdlib-json fallback path exactly.
+
+    orjson can't serialize them (TypeError -> stdlib fallback), and orjson.loads
+    parses them as floats, so the fallback's surrogate-detection round-trip must
+    be skipped when no surrogates are present or distinct values collapse to the
+    same float (e.g. 2**64 and 2**64 + 1 both become 1.8446744073709552e+19).
+    """
+    for value in (2**64, 2**64 + 1, 19_876_543_210_987_654_321, -(2**80)):
+        serialized = _dumps_json({"v": value})
+        deserialized = json.loads(serialized)["v"]
+        assert isinstance(deserialized, int)
+        assert deserialized == value
+    assert _dumps_json({"v": 2**64}) != _dumps_json({"v": 2**64 + 1})
+
+    # Non-BMP characters are escaped as valid surrogate pairs by ensure_ascii,
+    # which must not re-trigger the lossy re-encode alongside a big int.
+    serialized = _dumps_json({"emoji": "\U0001f600", "v": 2**70})
+    deserialized = json.loads(serialized)
+    assert deserialized["emoji"] == "\U0001f600"
+    assert deserialized["v"] == 2**70
+
+
 def test__dumps_json_normalizes_unsupported_dict_keys():
     class TupleKeyedDict:
         def to_dict(self) -> Dict:


### PR DESCRIPTION
Includes #3392 (authored by @Vissirexa) and fixes #3391, plus two follow-up commits.

## What's in here

### `5ee503f2` — keep integers exact in the `dumps_json` fallback (#3392)

orjson cannot serialize integers outside the 64-bit range, so `dumps_json` falls back to stdlib `json.dumps`, which produces the exact digits. The fallback then re-dumped that output through `orjson.loads` / `orjson.dumps` to detect lone UTF-16 surrogates — and `orjson.loads` reads an out-of-range integer as a float, so the exact result was discarded. Every int `>= 2**64` lost precision, and neighbouring values collapsed to identical bytes.

Now the surrogate check runs only when escaped surrogates are present, and `orjson.loads` is used only as a detector: on success the stdlib bytes are kept. Lone-surrogate elision is unchanged.

`python/langsmith/_internal/_serde.py` (+8 −5), regression test in `tests/unit_tests/test_client.py`.

### `3ae7621a` — keep integers exact through the anonymizer pre-pass

`_hide_run_inputs`, `_hide_run_outputs` and `_hide_run_metadata` did `_orjson.loads(_dumps_json(...))` to hand the anonymizer plain JSON types. That `_orjson.loads` re-applied the same float conversion, so the fix above had no effect whenever an `anonymizer` was configured.

These three call sites now parse with stdlib `json.loads`. It is ~2x slower per parse (12µs vs 5µs on an 8.5 KiB payload) but ~1% of this path, which is dominated by the anonymizer's own walk over every string node (~1000µs on the same payload).

Side effect: a non-finite float next to an out-of-range int no longer raises `JSONDecodeError` here, so configuring an anonymizer no longer changes whether a payload serializes. This matches the path with no anonymizer, which already sends the bare `NaN` literal — that pre-existing issue is not addressed here.

`python/langsmith/client.py` (+6 −3), two tests.

### `7d03d97c` — `test_fallback_json_serialization` compares decoded values

The test asserted byte-exact `dumps_json` output. Keeping the stdlib bytes changes those bytes without changing the value: non-BMP characters stay escaped as surrogate pairs, and pydantic output gains stdlib's `": "` separator. The test now asserts on the deserialized value.

`python/tests/integration_tests/test_client.py` (+8 −4).

## Notes

- Observable change on the wire, fallback path only: payloads keep `ensure_ascii` escapes and stdlib separators, so bytes are slightly larger. Decoded values are unchanged. The orjson fast path is untouched.
- An exact big-int literal is still read as a float by any double-based parser (`JSON.parse`, `orjson.loads`). This guarantees the exact value leaves the SDK, not that every consumer keeps it.
