### PR TITLE
fix(js): send langsmith-js User-Agent on generated client calls

### DIFF
--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -1621,40 +1621,48 @@ export class Client implements LangSmithTracingClientInterface {
   }
 
   /**
-   * The auth to build the generated client with.
+   * How the generated client should authenticate.
    *
-   * A caller may authenticate by supplying `x-api-key` themselves. The
-   * generated client rejects that as a header (its `validateHeaders` requires
-   * its own `apiKey` to be set), so it is promoted to the `apiKey` option here
-   * and dropped from the headers to avoid sending the same value twice.
+   * `apiKey` is the credential it is constructed with. A caller may instead
+   * authenticate by supplying `x-api-key` themselves; the generated client
+   * rejects that as a header (its `validateHeaders` requires its own `apiKey`
+   * to be set), so it is promoted to the option and named in
+   * `consumedHeaderNames` so the same value is not also sent as a header.
    *
-   * `sendsAPIKeyHeader` is false when this client has no key to offer at all,
-   * leaving the wrapped `fetch` to supply auth: profile auth, an explicit
-   * `Authorization` header, or none.
+   * `headerOverrides` carries what auth needs of the built client's headers:
+   * with no credential to offer, the generated client's own `X-API-Key` is
+   * suppressed so the wrapped `fetch` can supply auth instead — profile auth,
+   * an explicit `Authorization` header, or none at all.
    */
   private get _openAPIAuth(): {
     apiKey: string | undefined;
-    sendsAPIKeyHeader: boolean;
+    consumedHeaderNames: readonly string[];
+    headerOverrides: Record<string, string | null>;
   } {
+    // `_callerHeaders` has already dropped `x-api-key` if this client supplies
+    // its own, so a caller's only survives when there is nothing to override.
     const callerApiKeyName = Object.keys(this._callerHeaders).find(
       (name) => name.toLowerCase() === "x-api-key",
     );
-    // `_callerHeaders` has already dropped `x-api-key` if this client supplies
-    // its own, so a caller's only survives when there is nothing to override.
     const apiKey =
       this.apiKey ??
       (callerApiKeyName === undefined
         ? undefined
         : this._callerHeaders[callerApiKeyName]);
+    const sendsAPIKeyHeader =
+      apiKey !== undefined || this.workspaceId !== undefined;
 
     return {
       apiKey,
-      sendsAPIKeyHeader: apiKey !== undefined || this.workspaceId !== undefined,
+      consumedHeaderNames:
+        callerApiKeyName === undefined ? [] : [callerApiKeyName],
+      headerOverrides: sendsAPIKeyHeader ? {} : { "X-API-Key": null },
     };
   }
 
   /**
-   * The `defaultHeaders` to build the generated client with.
+   * The headers the generated client should send on every request, before auth
+   * is applied.
    *
    * The generated client applies `defaultHeaders` *after* its own auth headers,
    * so the ones this SDK sets are already dropped from `_callerHeaders` to keep
@@ -1666,27 +1674,14 @@ export class Client implements LangSmithTracingClientInterface {
    * which path a call takes. A caller-supplied one still wins, and is matched
    * case-insensitively so we don't send the header twice.
    */
-  private get _openAPIDefaultHeaders():
-    | Record<string, string | null>
-    | undefined {
-    const headers: Record<string, string | null> = {};
-    let hasUserAgent = false;
-    for (const [name, value] of Object.entries(this._callerHeaders)) {
-      const lowerName = name.toLowerCase();
-      // Promoted to the `apiKey` option by `_openAPIAuth`.
-      if (lowerName === "x-api-key") continue;
-      hasUserAgent ||= lowerName === "user-agent";
-      headers[name] = value;
-    }
-
-    if (!hasUserAgent) {
+  private get _openAPIHeaders(): Record<string, string> {
+    const headers = { ...this._callerHeaders };
+    if (
+      !Object.keys(headers).some((name) => name.toLowerCase() === "user-agent")
+    ) {
       headers["User-Agent"] = `langsmith-js/${__version__}`;
     }
-    if (!this._openAPIAuth.sendsAPIKeyHeader) {
-      headers["X-API-Key"] = null;
-    }
-
-    return Object.keys(headers).length > 0 ? headers : undefined;
+    return headers;
   }
 
   /**
@@ -1734,14 +1729,24 @@ export class Client implements LangSmithTracingClientInterface {
     return this._openAPIClient;
   }
 
-  /** The auth and headers the generated client is captured with. */
+  /**
+   * The auth and headers the generated client is captured with: the headers it
+   * should send, less the ones auth consumed, plus the ones auth overrides.
+   */
   private get _openAPIClientOptions(): {
     apiKey: string | undefined;
     defaultHeaders: Record<string, string | null> | undefined;
   } {
+    const auth = this._openAPIAuth;
+    const headers: Record<string, string | null> = this._openAPIHeaders;
+    for (const name of auth.consumedHeaderNames) {
+      delete headers[name];
+    }
+    Object.assign(headers, auth.headerOverrides);
+
     return {
-      apiKey: this._openAPIAuth.apiKey,
-      defaultHeaders: this._openAPIDefaultHeaders,
+      apiKey: auth.apiKey,
+      defaultHeaders: Object.keys(headers).length > 0 ? headers : undefined,
     };
   }
 

--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -1621,67 +1621,53 @@ export class Client implements LangSmithTracingClientInterface {
   }
 
   /**
-   * How the generated client should authenticate.
-   *
-   * `apiKey` is the credential it is constructed with. A caller may instead
-   * authenticate by supplying `x-api-key` themselves; the generated client
-   * rejects that as a header (its `validateHeaders` requires its own `apiKey`
-   * to be set), so it is promoted to the option and named in
-   * `consumedHeaderNames` so the same value is not also sent as a header.
-   *
-   * `headerOverrides` carries what auth needs of the built client's headers:
-   * with no credential to offer, the generated client's own `X-API-Key` is
-   * suppressed so the wrapped `fetch` can supply auth instead — profile auth,
-   * an explicit `Authorization` header, or none at all.
-   */
-  private get _openAPIAuth(): {
-    apiKey: string | undefined;
-    consumedHeaderNames: readonly string[];
-    headerOverrides: Record<string, string | null>;
-  } {
-    // `_callerHeaders` has already dropped `x-api-key` if this client supplies
-    // its own, so a caller's only survives when there is nothing to override.
-    const callerApiKeyName = Object.keys(this._callerHeaders).find(
-      (name) => name.toLowerCase() === "x-api-key",
-    );
-    const apiKey =
-      this.apiKey ??
-      (callerApiKeyName === undefined
-        ? undefined
-        : this._callerHeaders[callerApiKeyName]);
-    const sendsAPIKeyHeader =
-      apiKey !== undefined || this.workspaceId !== undefined;
-
-    return {
-      apiKey,
-      consumedHeaderNames:
-        callerApiKeyName === undefined ? [] : [callerApiKeyName],
-      headerOverrides: sendsAPIKeyHeader ? {} : { "X-API-Key": null },
-    };
-  }
-
-  /**
-   * The headers the generated client should send on every request, before auth
-   * is applied.
+   * The options to build the generated client with: its auth, and the headers
+   * it should send on every request.
    *
    * The generated client applies `defaultHeaders` *after* its own auth headers,
    * so the ones this SDK sets are already dropped from `_callerHeaders` to keep
    * the precedence of `_mergedHeaders`, where required headers win.
-   *
-   * The User-Agent is defaulted to match `_mergedHeaders`: without it the
-   * generated client falls back to its own `Langsmith/JS <generated version>`,
-   * so the same client would identify itself two different ways depending on
-   * which path a call takes. A caller-supplied one still wins, and is matched
-   * case-insensitively so we don't send the header twice.
    */
-  private get _openAPIHeaders(): Record<string, string> {
-    const headers = { ...this._callerHeaders };
+  private get _openAPIClientOptions(): {
+    apiKey: string | undefined;
+    defaultHeaders: Record<string, string | null> | undefined;
+  } {
+    const headers: Record<string, string | null> = { ...this._callerHeaders };
+
+    // Without this the generated client falls back to its own
+    // `Langsmith/JS <generated version>`, so the same client would identify
+    // itself two different ways depending on which path a call takes. A
+    // caller-supplied one still wins, matched case-insensitively so the header
+    // is not sent twice.
     if (
       !Object.keys(headers).some((name) => name.toLowerCase() === "user-agent")
     ) {
       headers["User-Agent"] = `langsmith-js/${__version__}`;
     }
-    return headers;
+
+    // A caller may authenticate by supplying `x-api-key` themselves. The
+    // generated client rejects that as a header (its `validateHeaders` requires
+    // its own `apiKey` to be set), so hand it over as the `apiKey` option and
+    // drop the header to avoid sending the same value twice.
+    const callerApiKeyName = Object.keys(headers).find(
+      (name) => name.toLowerCase() === "x-api-key",
+    );
+    let apiKey = this.apiKey;
+    if (apiKey === undefined && callerApiKeyName !== undefined) {
+      apiKey = headers[callerApiKeyName] ?? undefined;
+      delete headers[callerApiKeyName];
+    }
+
+    if (apiKey === undefined && this.workspaceId === undefined) {
+      // Let the wrapped `fetch` supply auth (profile auth, an explicit
+      // `Authorization` header, or none at all).
+      headers["X-API-Key"] = null;
+    }
+
+    return {
+      apiKey,
+      defaultHeaders: Object.keys(headers).length > 0 ? headers : undefined,
+    };
   }
 
   /**
@@ -1727,27 +1713,6 @@ export class Client implements LangSmithTracingClientInterface {
       this._openAPIClient = this._newOpenAPIClient(options);
     }
     return this._openAPIClient;
-  }
-
-  /**
-   * The auth and headers the generated client is captured with: the headers it
-   * should send, less the ones auth consumed, plus the ones auth overrides.
-   */
-  private get _openAPIClientOptions(): {
-    apiKey: string | undefined;
-    defaultHeaders: Record<string, string | null> | undefined;
-  } {
-    const auth = this._openAPIAuth;
-    const headers: Record<string, string | null> = this._openAPIHeaders;
-    for (const name of auth.consumedHeaderNames) {
-      delete headers[name];
-    }
-    Object.assign(headers, auth.headerOverrides);
-
-    return {
-      apiKey: auth.apiKey,
-      defaultHeaders: Object.keys(headers).length > 0 ? headers : undefined,
-    };
   }
 
   private _newOpenAPIClient(

--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -1621,52 +1621,72 @@ export class Client implements LangSmithTracingClientInterface {
   }
 
   /**
-   * The auth options and caller headers to build the generated client with.
+   * The auth to build the generated client with.
+   *
+   * A caller may authenticate by supplying `x-api-key` themselves. The
+   * generated client rejects that as a header (its `validateHeaders` requires
+   * its own `apiKey` to be set), so it is promoted to the `apiKey` option here
+   * and dropped from the headers to avoid sending the same value twice.
+   *
+   * `sendsAPIKeyHeader` is false when this client has no key to offer at all,
+   * leaving the wrapped `fetch` to supply auth: profile auth, an explicit
+   * `Authorization` header, or none.
+   */
+  private get _openAPIAuth(): {
+    apiKey: string | undefined;
+    sendsAPIKeyHeader: boolean;
+  } {
+    const callerApiKeyName = Object.keys(this._callerHeaders).find(
+      (name) => name.toLowerCase() === "x-api-key",
+    );
+    // `_callerHeaders` has already dropped `x-api-key` if this client supplies
+    // its own, so a caller's only survives when there is nothing to override.
+    const apiKey =
+      this.apiKey ??
+      (callerApiKeyName === undefined
+        ? undefined
+        : this._callerHeaders[callerApiKeyName]);
+
+    return {
+      apiKey,
+      sendsAPIKeyHeader: apiKey !== undefined || this.workspaceId !== undefined,
+    };
+  }
+
+  /**
+   * The `defaultHeaders` to build the generated client with.
    *
    * The generated client applies `defaultHeaders` *after* its own auth headers,
    * so the ones this SDK sets are already dropped from `_callerHeaders` to keep
    * the precedence of `_mergedHeaders`, where required headers win.
    *
-   * The User-Agent is defaulted here to match `_mergedHeaders`: without it the
+   * The User-Agent is defaulted to match `_mergedHeaders`: without it the
    * generated client falls back to its own `Langsmith/JS <generated version>`,
    * so the same client would identify itself two different ways depending on
    * which path a call takes. A caller-supplied one still wins, and is matched
    * case-insensitively so we don't send the header twice.
    */
-  private get _openAPIAuth(): {
-    apiKey: string | undefined;
-    defaultHeaders: Record<string, string | null> | undefined;
-  } {
-    const headers: Record<string, string | null> = { ...this._callerHeaders };
-    if (
-      !Object.keys(headers).some((name) => name.toLowerCase() === "user-agent")
-    ) {
+  private get _openAPIDefaultHeaders():
+    | Record<string, string | null>
+    | undefined {
+    const headers: Record<string, string | null> = {};
+    let hasUserAgent = false;
+    for (const [name, value] of Object.entries(this._callerHeaders)) {
+      const lowerName = name.toLowerCase();
+      // Promoted to the `apiKey` option by `_openAPIAuth`.
+      if (lowerName === "x-api-key") continue;
+      hasUserAgent ||= lowerName === "user-agent";
+      headers[name] = value;
+    }
+
+    if (!hasUserAgent) {
       headers["User-Agent"] = `langsmith-js/${__version__}`;
     }
-
-    // A caller may authenticate by supplying `x-api-key` themselves. The
-    // generated client rejects that as a header (its `validateHeaders` requires
-    // its own `apiKey` to be set), so hand it over as the `apiKey` option and
-    // drop the header to avoid sending the same value twice.
-    const callerApiKeyName = Object.keys(headers).find(
-      (name) => name.toLowerCase() === "x-api-key",
-    );
-    let apiKey = this.apiKey;
-    if (apiKey === undefined && callerApiKeyName !== undefined) {
-      apiKey = headers[callerApiKeyName] ?? undefined;
-      delete headers[callerApiKeyName];
-    }
-
-    if (apiKey === undefined && this.workspaceId === undefined) {
-      // Let the wrapped `fetch` supply auth (profile auth, an explicit
-      // `Authorization` header, or none at all).
+    if (!this._openAPIAuth.sendsAPIKeyHeader) {
       headers["X-API-Key"] = null;
     }
 
-    return {
-      apiKey,
-      defaultHeaders: Object.keys(headers).length > 0 ? headers : undefined,
-    };
+    return Object.keys(headers).length > 0 ? headers : undefined;
   }
 
   /**
@@ -1702,19 +1722,32 @@ export class Client implements LangSmithTracingClientInterface {
    * its token is refreshed.
    */
   private get openAPIClient(): OpenAPILangsmith {
-    const auth = this._openAPIAuth;
-    const signature = JSON.stringify([auth.apiKey, auth.defaultHeaders]);
+    const options = this._openAPIClientOptions;
+    const signature = JSON.stringify([options.apiKey, options.defaultHeaders]);
     if (
       this._openAPIClient === undefined ||
       this._openAPIClientSignature !== signature
     ) {
       this._openAPIClientSignature = signature;
-      this._openAPIClient = this._newOpenAPIClient(auth);
+      this._openAPIClient = this._newOpenAPIClient(options);
     }
     return this._openAPIClient;
   }
 
-  private _newOpenAPIClient(auth = this._openAPIAuth): OpenAPILangsmith {
+  /** The auth and headers the generated client is captured with. */
+  private get _openAPIClientOptions(): {
+    apiKey: string | undefined;
+    defaultHeaders: Record<string, string | null> | undefined;
+  } {
+    return {
+      apiKey: this._openAPIAuth.apiKey,
+      defaultHeaders: this._openAPIDefaultHeaders,
+    };
+  }
+
+  private _newOpenAPIClient(
+    options = this._openAPIClientOptions,
+  ): OpenAPILangsmith {
     const {
       method: _method,
       body: _body,
@@ -1723,13 +1756,13 @@ export class Client implements LangSmithTracingClientInterface {
     } = this.fetchOptions;
 
     return new OpenAPILangsmith({
-      apiKey: auth.apiKey,
+      apiKey: options.apiKey,
       tenantID: this.workspaceId,
       baseURL: this._getOpenAPIBaseUrl(),
       timeout: this.timeout_ms,
       fetch: this._fetch,
       fetchOptions: openAPIFetchOptions,
-      defaultHeaders: auth.defaultHeaders,
+      defaultHeaders: options.defaultHeaders,
     });
   }
 

--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -1626,12 +1626,23 @@ export class Client implements LangSmithTracingClientInterface {
    * The generated client applies `defaultHeaders` *after* its own auth headers,
    * so the ones this SDK sets are already dropped from `_callerHeaders` to keep
    * the precedence of `_mergedHeaders`, where required headers win.
+   *
+   * The User-Agent is defaulted here to match `_mergedHeaders`: without it the
+   * generated client falls back to its own `Langsmith/JS <generated version>`,
+   * so the same client would identify itself two different ways depending on
+   * which path a call takes. A caller-supplied one still wins, and is matched
+   * case-insensitively so we don't send the header twice.
    */
   private get _openAPIAuth(): {
     apiKey: string | undefined;
     defaultHeaders: Record<string, string | null> | undefined;
   } {
     const headers: Record<string, string | null> = { ...this._callerHeaders };
+    if (
+      !Object.keys(headers).some((name) => name.toLowerCase() === "user-agent")
+    ) {
+      headers["User-Agent"] = `langsmith-js/${__version__}`;
+    }
 
     // A caller may authenticate by supplying `x-api-key` themselves. The
     // generated client rejects that as a header (its `validateHeaders` requires

--- a/js/src/tests/client_headers.test.ts
+++ b/js/src/tests/client_headers.test.ts
@@ -11,6 +11,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { Client } from "../client.js";
+import { __version__ } from "../index.js";
 
 describe("caller-supplied headers", () => {
   const mockJsonResponse = () =>
@@ -105,6 +106,64 @@ describe("caller-supplied headers", () => {
       "11111111-1111-1111-1111-111111111111",
     );
   });
+
+  it("sends the SDK User-Agent on the generated OpenAPI client", async () => {
+    const mockFetch = mockJsonResponse();
+    const client = new Client({
+      apiKey: "test-api-key",
+      fetchImplementation: mockFetch as any,
+    });
+
+    await (client as any).openAPIClient.info.list();
+
+    // Not the generated client's own `Langsmith/JS <generated version>`, which
+    // is pinned to a placeholder version and identifies the wrong package.
+    expect(requestHeaders(mockFetch).get("user-agent")).toBe(
+      `langsmith-js/${__version__}`,
+    );
+  });
+
+  it("sends the same User-Agent on handwritten and generated calls", async () => {
+    const generatedFetch = mockJsonResponse();
+    const client = new Client({
+      apiKey: "test-api-key",
+      fetchImplementation: generatedFetch as any,
+    });
+
+    await (client as any).openAPIClient.info.list();
+
+    const handwrittenFetch = mockJsonResponse();
+    (client as any).fetchImplementation = handwrittenFetch;
+    await client.readProject({
+      projectId: "22222222-2222-2222-2222-222222222222",
+    });
+
+    expect(requestHeaders(generatedFetch).get("user-agent")).toBe(
+      requestHeaders(handwrittenFetch).get("user-agent"),
+    );
+  });
+
+  it.each([
+    ["config.headers", { headers: { "User-Agent": "my-app/1.0" } }],
+    [
+      "fetchOptions.headers",
+      { fetchOptions: { headers: { "user-agent": "my-app/1.0" } } },
+    ],
+  ])(
+    "lets %s override the User-Agent on the generated client",
+    async (_name, config) => {
+      const mockFetch = mockJsonResponse();
+      const client = new Client({
+        apiKey: "test-api-key",
+        fetchImplementation: mockFetch as any,
+        ...config,
+      });
+
+      await (client as any).openAPIClient.info.list();
+
+      expect(requestHeaders(mockFetch).get("user-agent")).toBe("my-app/1.0");
+    },
+  );
 
   it("rebuilds the generated client when headers are set after construction", async () => {
     const mockFetch = mockJsonResponse();


### PR DESCRIPTION
## Problem

The JS SDK identifies itself two different ways depending on which code path a call takes:

- Handwritten HTTP path: `langsmith-js/0.8.11` — set in `_mergedHeaders` ([client.ts](https://github.com/langchain-ai/langsmith-sdk/blob/main/js/src/client.ts))
- Generated OpenAPI path (`runs`, `datasets`, `threads`, `sandboxes`, `public`, …): **`Langsmith/JS 0.0.1`**

The generated client is constructed from `_openAPIAuth`, which forwards only `_callerHeaders` (config + fetchOptions headers). The SDK's own User-Agent lives one layer up in `_mergedHeaders` and never reaches `defaultHeaders`, so the generated client falls back to its Stainless default — the wrong package name, and a `0.0.1` placeholder that will never change, since the sync workflow copies the generated source verbatim without rewriting `version.ts`.

For reference, every other LangSmith SDK is consistent:

| SDK | User-Agent |
|---|---|
| langsmith-go | `langsmith-go/<version>` |
| langsmith-api-java | `langsmith-java/<version>` |
| langsmith-sdk Python | `langsmith-py/<version>` (both paths) |
| langsmith-sdk JS | `langsmith-js/<version>` handwritten / `Langsmith/JS 0.0.1` generated |

Python avoids this because `Client` passes its full header dict (which already contains the User-Agent) to the generated client as `default_headers`.

## Fix

Default the User-Agent in `_openAPIAuth` so both paths send the same value. A caller-supplied User-Agent still wins, matched case-insensitively so the header isn't sent under two spellings.

## Tests

Three new cases in `js/src/tests/client_headers.test.ts`, asserting on the actual outgoing request through the generated client:

- generated-client calls send `langsmith-js/<version>`
- handwritten and generated calls send the *same* User-Agent
- a caller-supplied User-Agent (via `config.headers` or `fetchOptions.headers`) still overrides

`client_headers.test.ts` passes in full. `client.test.ts` has one pre-existing failure (`env functions › should return the env variables correctly`) caused by local `LANGSMITH_*` shell vars leaking in — unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)