### PR TITLE
fix(sandbox): resolve the workspace id in the Python sandbox clients

### DIFF
--- a/python/langsmith/sandbox/_async_client.py
+++ b/python/langsmith/sandbox/_async_client.py
@@ -90,6 +90,7 @@ class AsyncSandboxClient:
         api_endpoint: Optional[str] = None,
         timeout: float = 10.0,
         api_key: Optional[str] = None,
+        workspace_id: Optional[str] = None,
         max_retries: int = 3,
         headers: Optional[Mapping[str, str]] = None,
     ):
@@ -101,6 +102,10 @@ class AsyncSandboxClient:
             timeout: Default HTTP timeout in seconds.
             api_key: API key for authentication. If not provided, uses
                      LANGSMITH_API_KEY environment variable.
+            workspace_id: Workspace the requests act on, sent as ``X-Tenant-Id``.
+                          If not provided, uses the LANGSMITH_WORKSPACE_ID
+                          environment variable. Required for org-scoped API keys,
+                          which the server rejects when no workspace is named.
             max_retries: Maximum number of retries for transient errors (502, 503,
                          504), rate limits (429), and connection failures. Set to 0
                          to disable retries. Default: 3.
@@ -112,9 +117,16 @@ class AsyncSandboxClient:
         self._base_url = (api_endpoint or _get_default_api_endpoint()).rstrip("/")
         resolved_api_key = api_key or _get_default_api_key()
         self._api_key = resolved_api_key
+        self._workspace_id = ls_utils.get_workspace_id(workspace_id)
         self._timeout = timeout
         self._max_retries = max_retries
         self._default_headers: dict[str, str] = dict(headers) if headers else {}
+        # Carried on _default_headers rather than the httpx client so the
+        # WebSocket upgrade and the registries client are scoped the same way.
+        if self._workspace_id and not any(
+            name.lower() == "x-tenant-id" for name in self._default_headers
+        ):
+            self._default_headers["X-Tenant-Id"] = self._workspace_id
         client_headers: dict[str, str] = {}
         if resolved_api_key:
             client_headers["X-Api-Key"] = resolved_api_key
@@ -192,6 +204,7 @@ class AsyncSandboxClient:
             api_endpoint=self._base_url,
             timeout=self._timeout,
             api_key=self._api_key,
+            workspace_id=self._workspace_id,
             max_retries=self._max_retries,
             headers=self._default_headers or None,
         )

--- a/python/langsmith/sandbox/_client.py
+++ b/python/langsmith/sandbox/_client.py
@@ -199,6 +199,7 @@ class SandboxClient:
         api_endpoint: Optional[str] = None,
         timeout: float = 10.0,
         api_key: Optional[str] = None,
+        workspace_id: Optional[str] = None,
         max_retries: int = 3,
         headers: Optional[RequestHeaders] = None,
     ):
@@ -210,6 +211,10 @@ class SandboxClient:
             timeout: Default HTTP timeout in seconds.
             api_key: API key for authentication. If not provided, uses
                      LANGSMITH_API_KEY environment variable.
+            workspace_id: Workspace the requests act on, sent as ``X-Tenant-Id``.
+                          If not provided, uses the LANGSMITH_WORKSPACE_ID
+                          environment variable. Required for org-scoped API keys,
+                          which the server rejects when no workspace is named.
             max_retries: Maximum number of retries for transient errors (502, 503,
                          504), rate limits (429), and connection failures. Set to 0
                          to disable retries. Default: 3.
@@ -221,9 +226,16 @@ class SandboxClient:
         self._base_url = (api_endpoint or _get_default_api_endpoint()).rstrip("/")
         resolved_api_key = api_key or _get_default_api_key()
         self._api_key = resolved_api_key
+        self._workspace_id = ls_utils.get_workspace_id(workspace_id)
         self._timeout = timeout
         self._max_retries = max_retries
         self._default_headers: dict[str, str] = dict(headers) if headers else {}
+        # Carried on _default_headers rather than the httpx client so the
+        # WebSocket upgrade and the registries client are scoped the same way.
+        if self._workspace_id and not any(
+            name.lower() == "x-tenant-id" for name in self._default_headers
+        ):
+            self._default_headers["X-Tenant-Id"] = self._workspace_id
         client_headers: dict[str, str] = {}
         if resolved_api_key:
             client_headers["X-Api-Key"] = resolved_api_key
@@ -303,6 +315,7 @@ class SandboxClient:
             api_endpoint=self._base_url,
             timeout=self._timeout,
             api_key=self._api_key,
+            workspace_id=self._workspace_id,
             max_retries=self._max_retries,
             headers=self._default_headers or None,
         )

--- a/python/tests/unit_tests/sandbox/test_async_client.py
+++ b/python/tests/unit_tests/sandbox/test_async_client.py
@@ -1,10 +1,12 @@
 """Tests for AsyncSandboxClient."""
 
+import os
 from unittest.mock import AsyncMock, patch
 
 import pytest
 from pytest_httpx import HTTPXMock
 
+from langsmith import utils as ls_utils
 from langsmith.sandbox import (
     AsyncSandboxClient,
     AsyncServiceURL,
@@ -119,6 +121,40 @@ class TestAsyncSandboxClientInit:
             # merge_headers normalizes names to lowercase.
             assert client._ws_default_headers(None) == {"x-service-key": "svc-jwt"}
             await client.aclose()
+
+    async def test_workspace_id_from_env_sets_tenant_header(self):
+        """An org-scoped key is rejected unless the request names a workspace."""
+        with patch.dict(os.environ, {"LANGSMITH_WORKSPACE_ID": "env-ws"}):
+            ls_utils.get_env_var.cache_clear()
+            client = AsyncSandboxClient(
+                api_endpoint="http://localhost:8080", api_key="api-key"
+            )
+        ls_utils.get_env_var.cache_clear()
+        assert client._http.headers.get("X-Tenant-Id") == "env-ws"
+        assert client._default_headers == {"X-Tenant-Id": "env-ws"}
+        await client.aclose()
+
+    async def test_tenant_header_overrides_workspace_id(self):
+        """An explicitly passed header wins, whatever its casing."""
+        client = AsyncSandboxClient(
+            api_endpoint="http://localhost:8080",
+            api_key="api-key",
+            workspace_id="ws-from-arg",
+            headers={"x-tenant-id": "header-ws"},
+        )
+        assert client._http.headers.get("X-Tenant-Id") == "header-ws"
+        await client.aclose()
+
+    async def test_to_sync_carries_workspace_id(self):
+        client = AsyncSandboxClient(
+            api_endpoint="http://localhost:8080",
+            api_key="api-key",
+            workspace_id="ws-1",
+        )
+        sync_client = client.to_sync()
+        assert sync_client._http.headers.get("X-Tenant-Id") == "ws-1"
+        sync_client.close()
+        await client.aclose()
 
     async def test_max_retries_default(self):
         """Test default max_retries is 3."""

--- a/python/tests/unit_tests/sandbox/test_client.py
+++ b/python/tests/unit_tests/sandbox/test_client.py
@@ -1,10 +1,12 @@
 """Tests for SandboxClient."""
 
+import os
 from unittest.mock import patch
 
 import pytest
 from pytest_httpx import HTTPXMock
 
+from langsmith import utils as ls_utils
 from langsmith.sandbox import (
     ResourceCreationError,
     ResourceNameConflictError,
@@ -124,6 +126,64 @@ class TestSandboxClientInit:
         assert client._http.headers.get("X-Service-Key") == "svc-jwt"
         assert client._http.headers.get("X-Api-Key") == "api-key"
         assert client._default_headers == {"X-Service-Key": "svc-jwt"}
+        client.close()
+
+    def test_workspace_id_from_env_sets_tenant_header(self):
+        """An org-scoped key is rejected unless the request names a workspace."""
+        with patch.dict(os.environ, {"LANGSMITH_WORKSPACE_ID": "env-ws"}):
+            ls_utils.get_env_var.cache_clear()
+            client = SandboxClient(
+                api_endpoint="http://localhost:8080", api_key="api-key"
+            )
+        ls_utils.get_env_var.cache_clear()
+        assert client._http.headers.get("X-Tenant-Id") == "env-ws"
+        # The WS upgrade and the registries client read _default_headers.
+        assert client._default_headers == {"X-Tenant-Id": "env-ws"}
+        client.close()
+
+    def test_explicit_workspace_id_overrides_env(self):
+        with patch.dict(os.environ, {"LANGSMITH_WORKSPACE_ID": "env-ws"}):
+            ls_utils.get_env_var.cache_clear()
+            client = SandboxClient(
+                api_endpoint="http://localhost:8080",
+                api_key="api-key",
+                workspace_id="explicit-ws",
+            )
+        ls_utils.get_env_var.cache_clear()
+        assert client._http.headers.get("X-Tenant-Id") == "explicit-ws"
+        client.close()
+
+    def test_tenant_header_overrides_workspace_id(self):
+        """An explicitly passed header wins, whatever its casing."""
+        client = SandboxClient(
+            api_endpoint="http://localhost:8080",
+            api_key="api-key",
+            workspace_id="ws-from-arg",
+            headers={"x-tenant-id": "header-ws"},
+        )
+        assert client._http.headers.get("X-Tenant-Id") == "header-ws"
+        assert client._default_headers == {"x-tenant-id": "header-ws"}
+        client.close()
+
+    def test_no_workspace_id_sends_no_tenant_header(self):
+        with patch.dict(os.environ, {}, clear=True):
+            ls_utils.get_env_var.cache_clear()
+            client = SandboxClient(
+                api_endpoint="http://localhost:8080", api_key="api-key"
+            )
+        ls_utils.get_env_var.cache_clear()
+        assert client._http.headers.get("X-Tenant-Id") is None
+        assert client._default_headers == {}
+        client.close()
+
+    def test_to_async_carries_workspace_id(self):
+        client = SandboxClient(
+            api_endpoint="http://localhost:8080",
+            api_key="api-key",
+            workspace_id="ws-1",
+        )
+        async_client = client.to_async()
+        assert async_client._http.headers.get("X-Tenant-Id") == "ws-1"
         client.close()
 
     def test_ws_default_headers_merges_per_request(self):


### PR DESCRIPTION
`SandboxClient` and `AsyncSandboxClient` attach only `X-Api-Key`, so a request never names a workspace. An org-scoped API key is rejected server-side in that case, and the caller sees a bare `403 Forbidden` with no indication that a workspace was the missing piece.

`langsmith.Client` has resolved this since forever — it reads `LANGSMITH_WORKSPACE_ID` via `ls_utils.get_workspace_id()` and sends `X-Tenant-Id`. The sandbox clients hand-roll their own env resolution (`_get_default_api_endpoint`, `_get_default_api_key`) and simply never picked up the workspace, so they are the odd ones out.

Both clients now resolve the workspace the same way and accept an explicit `workspace_id=`. The header is stored on `_default_headers` rather than only on the httpx client, so the `/execute/ws` WebSocket upgrade and the nested registries client are scoped identically to ordinary HTTP requests, and `to_async()` / `to_sync()` carry it across. An explicitly supplied `X-Tenant-Id` header still wins, at any casing, and callers that pass no workspace are unaffected.

Found while debugging LangSmith's sandbox E2E suite: the Python and Java lanes returned 403 on every create against an environment whose key is org-scoped, while the Go lane passed because the Go SDK resolves the workspace on its own.

Follow-up, not in this PR: `js/src/sandbox/client.ts` has the same gap. The generated `_openapi_client` supports `tenantID`, but the hand-written sandbox client does not.

## Test Plan

- [x] `pytest tests/unit_tests/sandbox` — 547 passed, including new cases for env resolution, explicit `workspace_id`, header precedence and casing, absent workspace, and `to_async`/`to_sync` propagation
- [x] `ruff format --check` and `ruff check` clean on the touched packages
- [x] Full `tests/unit_tests` run: the only failures are 5 pre-existing ones that fail identically on the base commit (local `LANGSMITH_*` env leaking into endpoint/api-key tests)