### PR TITLE
refactor(js): reuse main client for sandbox requests

### DIFF
--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -1135,6 +1135,38 @@ export class Client implements LangSmithTracingClientInterface {
     }) as typeof fetch;
   }
 
+  private async prepareRequestInit(
+    fetchImplementation: typeof fetch,
+    init?: RequestInit,
+  ): Promise<RequestInit | undefined> {
+    let authHeader: ProfileAuthHeader | undefined;
+    const profileManagedAuthorization =
+      this.getProfileManagedAuthorizationHeader(init);
+    if (this.apiKey !== undefined) {
+      authHeader = { name: "x-api-key", value: `${this.apiKey}` };
+    } else if (!this.hasExplicitAuthHeader(init, profileManagedAuthorization)) {
+      authHeader = await this.profileAuth?.getAuthHeader(
+        fetchImplementation,
+        init?.signal,
+      );
+    }
+    return this.applyCurrentAuthHeaders(
+      init,
+      authHeader,
+      profileManagedAuthorization,
+    );
+  }
+
+  /** Resolve the headers used for non-HTTP SDK transports. @internal */
+  public async _getRequestHeaders(): Promise<Record<string, string>> {
+    const fetchImplementation =
+      this.fetchImplementation || _getFetchImplementation(this.debug);
+    const init = await this.prepareRequestInit(fetchImplementation, {
+      headers: this._mergedHeaders,
+    });
+    return Object.fromEntries(new Headers(init?.headers).entries());
+  }
+
   private getProfileManagedAuthorizationHeader(
     init?: RequestInit,
   ): string | undefined {
@@ -1701,6 +1733,11 @@ export class Client implements LangSmithTracingClientInterface {
       this._openAPIClient = this._newOpenAPIClient(auth);
     }
     return this._openAPIClient;
+  }
+
+  /** Return the generated client used by SDK-owned facades. @internal */
+  public _getOpenAPIClient(): OpenAPILangsmith {
+    return this.openAPIClient;
   }
 
   private _newOpenAPIClient(auth = this._openAPIAuth): OpenAPILangsmith {

--- a/js/src/sandbox/client.ts
+++ b/js/src/sandbox/client.ts
@@ -2,11 +2,10 @@
  * Main SandboxClient class for interacting with the sandbox server API.
  */
 
-import { getLangSmithEnvironmentVariable } from "../utils/env.js";
-import { _getFetchImplementation } from "../singletons/fetch.js";
 import { AsyncCaller } from "../utils/async_caller.js";
-import { Langsmith as OpenAPILangsmith } from "../_openapi_client/index.js";
 import { Registries } from "../_openapi_client/resources/sandboxes/registries.js";
+import { APIConnectionError, APIError } from "../_openapi_client/core/error.js";
+import { Client } from "../client.js";
 import type {
   CaptureSnapshotOptions,
   CreateDockerfileSnapshotOptions,
@@ -29,6 +28,7 @@ import {
   LangSmithResourceNotFoundError,
   LangSmithResourceTimeoutError,
   LangSmithSandboxAPIError,
+  LangSmithSandboxConnectionError,
   LangSmithValidationError,
 } from "./errors.js";
 import {
@@ -62,23 +62,32 @@ function sleepWithSignal(ms: number, signal?: AbortSignal): Promise<void> {
   });
 }
 
-/**
- * Get the default sandbox API endpoint from environment.
- *
- * Derives the endpoint from LANGSMITH_ENDPOINT (or LANGCHAIN_ENDPOINT).
- */
-function getDefaultApiEndpoint(): string {
-  const base =
-    getLangSmithEnvironmentVariable("ENDPOINT") ??
-    "https://api.smith.langchain.com";
-  return `${base.replace(/\/$/, "")}/v2/sandboxes`;
+function getLangSmithApiUrl(apiEndpoint: string): string {
+  const endpoint = apiEndpoint.replace(/\/$/, "");
+  for (const suffix of ["/api/v2/sandboxes", "/v2/sandboxes"]) {
+    if (endpoint.endsWith(suffix)) {
+      return endpoint.slice(0, -suffix.length);
+    }
+  }
+  return endpoint;
 }
 
-/**
- * Get the default API key from environment.
- */
-function getDefaultApiKey(): string | undefined {
-  return getLangSmithEnvironmentVariable("API_KEY");
+function getSandboxApiEndpoint(apiRoot: string): string {
+  return `${apiRoot.replace(/\/$/, "")}/api/v2/sandboxes`;
+}
+
+function responseFromAPIError(error: APIError): Response | undefined {
+  if (error.status === undefined || error.headers === undefined) {
+    return undefined;
+  }
+  const body =
+    error.error === undefined
+      ? error.message.replace(new RegExp(`^${error.status}\\s*`), "")
+      : JSON.stringify(error.error);
+  return new Response(body || null, {
+    status: error.status,
+    headers: error.headers,
+  });
 }
 
 function shellQuote(value: string): string {
@@ -361,31 +370,52 @@ function makeDockerfileBuildCommand(args: {
  */
 export class SandboxClient {
   private _baseUrl: string;
-  private _apiKey?: string;
-  private _defaultHeaders: Record<string, string>;
-  private _fetchImpl: typeof fetch;
+  private _langsmithClient: Client;
+  private _maxRetries?: number;
   private _caller: AsyncCaller;
-  private _registriesClient?: OpenAPILangsmith;
 
   constructor(config: SandboxClientConfig = {}) {
-    this._baseUrl = (config.apiEndpoint ?? getDefaultApiEndpoint()).replace(
-      /\/$/,
-      "",
-    );
-    this._apiKey = config.apiKey ?? getDefaultApiKey();
-    this._defaultHeaders = { ...(config.headers ?? {}) };
-    this._fetchImpl = _getFetchImplementation();
+    const ownsClient = config.client === undefined;
+    this._langsmithClient =
+      config.client ??
+      new Client({
+        apiUrl:
+          config.apiEndpoint === undefined
+            ? undefined
+            : getLangSmithApiUrl(config.apiEndpoint),
+        apiKey: config.apiKey,
+        timeout_ms: config.timeoutMs,
+        headers: config.headers,
+        autoBatchTracing: false,
+      });
+    if (ownsClient) {
+      const maxRetries = config.maxRetries ?? 3;
+      if (
+        maxRetries !== Number.POSITIVE_INFINITY &&
+        (!Number.isInteger(maxRetries) || maxRetries < 0)
+      ) {
+        throw new Error(
+          "maxRetries must be a non-negative integer or Infinity",
+        );
+      }
+      this._maxRetries = maxRetries;
+    }
+    const openAPIClient = this._getOpenAPIClient();
+    this._baseUrl = (
+      config.apiEndpoint ?? getSandboxApiEndpoint(openAPIClient.baseURL)
+    ).replace(/\/$/, "");
     this._caller = new AsyncCaller({
-      maxRetries: config.maxRetries ?? 3,
+      maxRetries: 0,
       maxConcurrency: config.maxConcurrency ?? Infinity,
     });
   }
 
-  private _apiRoot(): string {
-    const suffix = "/v2/sandboxes";
-    return this._baseUrl.endsWith(suffix)
-      ? this._baseUrl.slice(0, -suffix.length)
-      : this._baseUrl;
+  private _getOpenAPIClient() {
+    const client = this._langsmithClient._getOpenAPIClient();
+    if (this._maxRetries !== undefined) {
+      client.maxRetries = this._maxRetries;
+    }
+    return client;
   }
 
   /**
@@ -411,47 +441,58 @@ export class SandboxClient {
    * ```
    */
   get registries(): Registries {
-    if (!this._registriesClient) {
-      const defaultHeaders: Record<string, string | null> = {
-        ...this._defaultHeaders,
-      };
-      if (this._apiKey === undefined) {
-        defaultHeaders["X-API-Key"] = null;
-      }
-      this._registriesClient = new OpenAPILangsmith({
-        apiKey: this._apiKey,
-        baseURL: this._apiRoot(),
-        defaultHeaders,
-        fetch: this._fetchImpl,
-      });
-    }
-    return this._registriesClient.sandboxes.registries;
+    return this._getOpenAPIClient().sandboxes.registries;
   }
 
   /**
    * Internal fetch method that adds authentication headers.
    *
-   * Uses AsyncCaller to handle retries for transient failures
-   * (network errors, 5xx, 429).
+   * Uses the main client's generated request pipeline for authentication,
+   * workspace routing, retries, timeouts, and HTTP transport.
    *
    * @internal
    */
   async _fetch(url: string, init: RequestInit = {}): Promise<Response> {
-    const headers = new Headers(init.headers);
-    if (this._apiKey) {
-      headers.set("X-Api-Key", this._apiKey);
-    }
-    for (const [name, value] of Object.entries(this._defaultHeaders)) {
-      if (!headers.has(name)) {
-        headers.set(name, value);
+    const api = this._getOpenAPIClient();
+    const options = {
+      body: init.body,
+      headers: init.headers,
+      signal: init.signal,
+    };
+    const request = () => {
+      switch ((init.method ?? "GET").toUpperCase()) {
+        case "GET":
+          return api.get(url, options).asResponse();
+        case "POST":
+          return api.post(url, options).asResponse();
+        case "PATCH":
+          return api.patch(url, options).asResponse();
+        case "DELETE":
+          return api.delete(url, options).asResponse();
+        default:
+          throw new Error(`Unsupported HTTP method: ${init.method}`);
       }
+    };
+    try {
+      return await this._caller.call(request);
+    } catch (error) {
+      if (error instanceof APIConnectionError) {
+        const cause = (error as Error & { cause?: unknown }).cause;
+        const detail = cause instanceof Error ? cause.message : error.message;
+        const connectionError = new LangSmithSandboxConnectionError(
+          `Failed to connect to the sandbox API: ${detail}`,
+        );
+        (connectionError as Error & { cause?: unknown }).cause = error;
+        throw connectionError;
+      }
+      if (error instanceof APIError) {
+        const response = responseFromAPIError(error);
+        if (response !== undefined) {
+          return response;
+        }
+      }
+      throw error;
     }
-    return this._caller.call(() =>
-      this._fetchImpl(url, {
-        ...init,
-        headers,
-      }),
-    );
   }
 
   /**
@@ -459,7 +500,7 @@ export class SandboxClient {
    * @internal
    */
   getApiKey(): string | undefined {
-    return this._apiKey;
+    return this._getOpenAPIClient().apiKey ?? undefined;
   }
 
   /**
@@ -469,7 +510,12 @@ export class SandboxClient {
    * @internal
    */
   getDefaultHeaders(): Record<string, string> {
-    return { ...this._defaultHeaders };
+    return { ...this._langsmithClient.headers };
+  }
+
+  /** Resolve all current auth, workspace, and custom request headers. @internal */
+  async getRequestHeaders(): Promise<Record<string, string>> {
+    return this._langsmithClient._getRequestHeaders();
   }
 
   /**

--- a/js/src/sandbox/client.ts
+++ b/js/src/sandbox/client.ts
@@ -518,6 +518,11 @@ export class SandboxClient {
     return this._langsmithClient._getRequestHeaders();
   }
 
+  /** Build the control-plane URL for sandbox runtime operations. @internal */
+  getSandboxRuntimeUrl(sandboxIdOrName: string): string {
+    return `${this._baseUrl}/${encodeURIComponent(sandboxIdOrName)}`;
+  }
+
   /**
    * JSON POST helper. Sends JSON body, checks response status,
    * and returns the Response for further processing.

--- a/js/src/sandbox/client.ts
+++ b/js/src/sandbox/client.ts
@@ -518,11 +518,6 @@ export class SandboxClient {
     return this._langsmithClient._getRequestHeaders();
   }
 
-  /** Build the control-plane URL for sandbox runtime operations. @internal */
-  getSandboxRuntimeUrl(sandboxIdOrName: string): string {
-    return `${this._baseUrl}/${encodeURIComponent(sandboxIdOrName)}`;
-  }
-
   /**
    * JSON POST helper. Sends JSON body, checks response status,
    * and returns the Response for further processing.

--- a/js/src/sandbox/sandbox.ts
+++ b/js/src/sandbox/sandbox.ts
@@ -13,7 +13,6 @@ import type {
 } from "./types.js";
 import { uuid7 } from "../uuid.js";
 import {
-  LangSmithDataplaneNotConfiguredError,
   LangSmithSandboxRetryableConnectionError,
   LangSmithStreamEndedBeforeStartedError,
 } from "./errors.js";
@@ -49,7 +48,7 @@ import {
 export class Sandbox {
   /** Display name (can be updated). */
   readonly name: string;
-  /** URL for data plane operations (file I/O, command execution). */
+  /** Server-provided runtime URL retained as response metadata. */
   dataplane_url?: string;
   /** Provisioning status ("provisioning", "ready", "failed", "stopped"). */
   status?: string;
@@ -109,24 +108,9 @@ export class Sandbox {
     this._client = client;
   }
 
-  /**
-   * Return the dataplane URL.
-   *
-   * The client does not gate on lifecycle status: a stopped sandbox is resumed
-   * by the platform when the dataplane request arrives, so only the presence of
-   * a URL is required here. A genuinely not-ready box surfaces the server's
-   * LangSmithSandboxNotReadyError from the request itself.
-   *
-   * @throws LangSmithDataplaneNotConfiguredError if dataplane_url is not configured.
-   */
-  private requireDataplaneUrl(): string {
-    if (!this.dataplane_url) {
-      throw new LangSmithDataplaneNotConfiguredError(
-        `Sandbox '${this.name}' does not have a dataplane_url configured. ` +
-          "Runtime operations require a dataplane URL.",
-      );
-    }
-    return this.dataplane_url;
+  /** Return the main client's control-plane URL for this sandbox. */
+  private runtimeUrl(): string {
+    return this._client.getSandboxRuntimeUrl(this.id ?? this.name);
   }
 
   /**
@@ -254,7 +238,7 @@ export class Sandbox {
       ttlSeconds,
       pty,
     } = options;
-    const dataplaneUrl = this.requireDataplaneUrl();
+    const runtimeUrl = this.runtimeUrl();
 
     const clientHeaders = await this._client.getRequestHeaders();
 
@@ -269,7 +253,7 @@ export class Sandbox {
     // eslint-disable-next-line no-constant-condition
     while (true) {
       const [stream, control] = await runWsStream(
-        dataplaneUrl,
+        runtimeUrl,
         undefined,
         command,
         {
@@ -340,8 +324,7 @@ export class Sandbox {
     options: Omit<RunOptions, "wait" | "onStdout" | "onStderr"> = {},
   ): Promise<ExecutionResult> {
     const { timeout = 60, env, cwd, shell = "/bin/bash" } = options;
-    const dataplaneUrl = this.requireDataplaneUrl();
-    const url = `${dataplaneUrl}/execute`;
+    const url = `${this.runtimeUrl()}/execute`;
 
     const payload: Record<string, unknown> = {
       command,
@@ -393,11 +376,11 @@ export class Sandbox {
     } = {},
   ): Promise<CommandHandle> {
     const { stdoutOffset = 0, stderrOffset = 0 } = options;
-    const dataplaneUrl = this.requireDataplaneUrl();
+    const runtimeUrl = this.runtimeUrl();
 
     const clientHeaders = await this._client.getRequestHeaders();
     const [stream, control] = await reconnectWsStream(
-      dataplaneUrl,
+      runtimeUrl,
       undefined,
       commandId,
       {
@@ -433,8 +416,7 @@ export class Sandbox {
     content: string | Uint8Array,
     timeout = 60,
   ): Promise<void> {
-    const dataplaneUrl = this.requireDataplaneUrl();
-    const url = `${dataplaneUrl}/upload?path=${encodeURIComponent(path)}`;
+    const url = `${this.runtimeUrl()}/upload?path=${encodeURIComponent(path)}`;
 
     // Ensure content is bytes for multipart upload
     const bytes =
@@ -472,8 +454,7 @@ export class Sandbox {
    * ```
    */
   async read(path: string, timeout = 60): Promise<Uint8Array> {
-    const dataplaneUrl = this.requireDataplaneUrl();
-    const url = `${dataplaneUrl}/download?path=${encodeURIComponent(path)}`;
+    const url = `${this.runtimeUrl()}/download?path=${encodeURIComponent(path)}`;
 
     const response = await this._client._fetch(url, {
       method: "GET",
@@ -508,7 +489,7 @@ export class Sandbox {
   /**
    * Start a stopped sandbox and wait until ready.
    *
-   * Updates this sandbox's status and dataplane_url in place.
+   * Updates this sandbox's status and response metadata in place.
    *
    * @param timeout - Timeout in seconds when waiting for ready. Default: 120.
    */
@@ -523,8 +504,6 @@ export class Sandbox {
    */
   async stop(): Promise<void> {
     await this._client.stopSandbox(this.name);
-    // dataplane_url stays set: it is stable across stop/start and a request on
-    // it resumes the sandbox.
     this.status = "stopped";
   }
 

--- a/js/src/sandbox/sandbox.ts
+++ b/js/src/sandbox/sandbox.ts
@@ -256,7 +256,7 @@ export class Sandbox {
     } = options;
     const dataplaneUrl = this.requireDataplaneUrl();
 
-    const clientHeaders = this._client.getDefaultHeaders();
+    const clientHeaders = await this._client.getRequestHeaders();
 
     // A client-supplied command_id makes execute idempotent: the daemon does
     // get-or-create keyed on it, so if the tunnel closes before "started" we
@@ -270,7 +270,7 @@ export class Sandbox {
     while (true) {
       const [stream, control] = await runWsStream(
         dataplaneUrl,
-        this._client.getApiKey(),
+        undefined,
         command,
         {
           timeout,
@@ -395,10 +395,10 @@ export class Sandbox {
     const { stdoutOffset = 0, stderrOffset = 0 } = options;
     const dataplaneUrl = this.requireDataplaneUrl();
 
-    const clientHeaders = this._client.getDefaultHeaders();
+    const clientHeaders = await this._client.getRequestHeaders();
     const [stream, control] = await reconnectWsStream(
       dataplaneUrl,
-      this._client.getApiKey(),
+      undefined,
       commandId,
       {
         stdoutOffset,

--- a/js/src/sandbox/sandbox.ts
+++ b/js/src/sandbox/sandbox.ts
@@ -13,6 +13,7 @@ import type {
 } from "./types.js";
 import { uuid7 } from "../uuid.js";
 import {
+  LangSmithDataplaneNotConfiguredError,
   LangSmithSandboxRetryableConnectionError,
   LangSmithStreamEndedBeforeStartedError,
 } from "./errors.js";
@@ -48,7 +49,7 @@ import {
 export class Sandbox {
   /** Display name (can be updated). */
   readonly name: string;
-  /** Server-provided runtime URL retained as response metadata. */
+  /** URL for data plane operations (file I/O, command execution). */
   dataplane_url?: string;
   /** Provisioning status ("provisioning", "ready", "failed", "stopped"). */
   status?: string;
@@ -108,9 +109,24 @@ export class Sandbox {
     this._client = client;
   }
 
-  /** Return the main client's control-plane URL for this sandbox. */
-  private runtimeUrl(): string {
-    return this._client.getSandboxRuntimeUrl(this.id ?? this.name);
+  /**
+   * Return the dataplane URL.
+   *
+   * The client does not gate on lifecycle status: a stopped sandbox is resumed
+   * by the platform when the dataplane request arrives, so only the presence of
+   * a URL is required here. A genuinely not-ready box surfaces the server's
+   * LangSmithSandboxNotReadyError from the request itself.
+   *
+   * @throws LangSmithDataplaneNotConfiguredError if dataplane_url is not configured.
+   */
+  private requireDataplaneUrl(): string {
+    if (!this.dataplane_url) {
+      throw new LangSmithDataplaneNotConfiguredError(
+        `Sandbox '${this.name}' does not have a dataplane_url configured. ` +
+          "Runtime operations require a dataplane URL.",
+      );
+    }
+    return this.dataplane_url;
   }
 
   /**
@@ -238,7 +254,7 @@ export class Sandbox {
       ttlSeconds,
       pty,
     } = options;
-    const runtimeUrl = this.runtimeUrl();
+    const dataplaneUrl = this.requireDataplaneUrl();
 
     const clientHeaders = await this._client.getRequestHeaders();
 
@@ -253,7 +269,7 @@ export class Sandbox {
     // eslint-disable-next-line no-constant-condition
     while (true) {
       const [stream, control] = await runWsStream(
-        runtimeUrl,
+        dataplaneUrl,
         undefined,
         command,
         {
@@ -324,7 +340,8 @@ export class Sandbox {
     options: Omit<RunOptions, "wait" | "onStdout" | "onStderr"> = {},
   ): Promise<ExecutionResult> {
     const { timeout = 60, env, cwd, shell = "/bin/bash" } = options;
-    const url = `${this.runtimeUrl()}/execute`;
+    const dataplaneUrl = this.requireDataplaneUrl();
+    const url = `${dataplaneUrl}/execute`;
 
     const payload: Record<string, unknown> = {
       command,
@@ -376,11 +393,11 @@ export class Sandbox {
     } = {},
   ): Promise<CommandHandle> {
     const { stdoutOffset = 0, stderrOffset = 0 } = options;
-    const runtimeUrl = this.runtimeUrl();
+    const dataplaneUrl = this.requireDataplaneUrl();
 
     const clientHeaders = await this._client.getRequestHeaders();
     const [stream, control] = await reconnectWsStream(
-      runtimeUrl,
+      dataplaneUrl,
       undefined,
       commandId,
       {
@@ -416,7 +433,8 @@ export class Sandbox {
     content: string | Uint8Array,
     timeout = 60,
   ): Promise<void> {
-    const url = `${this.runtimeUrl()}/upload?path=${encodeURIComponent(path)}`;
+    const dataplaneUrl = this.requireDataplaneUrl();
+    const url = `${dataplaneUrl}/upload?path=${encodeURIComponent(path)}`;
 
     // Ensure content is bytes for multipart upload
     const bytes =
@@ -454,7 +472,8 @@ export class Sandbox {
    * ```
    */
   async read(path: string, timeout = 60): Promise<Uint8Array> {
-    const url = `${this.runtimeUrl()}/download?path=${encodeURIComponent(path)}`;
+    const dataplaneUrl = this.requireDataplaneUrl();
+    const url = `${dataplaneUrl}/download?path=${encodeURIComponent(path)}`;
 
     const response = await this._client._fetch(url, {
       method: "GET",
@@ -489,7 +508,7 @@ export class Sandbox {
   /**
    * Start a stopped sandbox and wait until ready.
    *
-   * Updates this sandbox's status and response metadata in place.
+   * Updates this sandbox's status and dataplane_url in place.
    *
    * @param timeout - Timeout in seconds when waiting for ready. Default: 120.
    */
@@ -504,6 +523,8 @@ export class Sandbox {
    */
   async stop(): Promise<void> {
     await this._client.stopSandbox(this.name);
+    // dataplane_url stays set: it is stable across stop/start and a request on
+    // it resumes the sandbox.
     this.status = "stopped";
   }
 

--- a/js/src/sandbox/types.ts
+++ b/js/src/sandbox/types.ts
@@ -4,6 +4,8 @@
  * Field names use snake_case to match API response format.
  */
 
+import type { Client } from "../client.js";
+
 /**
  * Result of executing a command in a sandbox.
  */
@@ -90,8 +92,14 @@ export interface SandboxData {
  */
 export interface SandboxClientConfig {
   /**
+   * Main LangSmith client whose endpoint, authentication, workspace, headers,
+   * retries, and HTTP transport should be reused. When provided, apiKey,
+   * timeoutMs, maxRetries, and headers are ignored.
+   */
+  client?: Client;
+  /**
    * Full URL of the sandbox API endpoint.
-   * If not provided, derived from LANGSMITH_ENDPOINT environment variable.
+   * If not provided, derived from the main client's API endpoint.
    */
   apiEndpoint?: string;
   /**

--- a/js/src/sandbox/ws_execute.ts
+++ b/js/src/sandbox/ws_execute.ts
@@ -108,10 +108,10 @@ async function ensureWs(): Promise<{
 // =============================================================================
 
 /**
- * Convert a sandbox runtime HTTP URL to a WebSocket URL for /execute/ws.
+ * Convert a dataplane HTTP URL to a WebSocket URL for /execute/ws.
  */
-export function buildWsUrl(runtimeUrl: string): string {
-  const wsUrl = runtimeUrl
+export function buildWsUrl(dataplaneUrl: string): string {
+  const wsUrl = dataplaneUrl
     .replace("https://", "wss://")
     .replace("http://", "ws://");
   return `${wsUrl}/execute/ws`;
@@ -398,7 +398,7 @@ async function* readWsMessages(
  * data arrives in addition to yielding the messages.
  */
 export async function runWsStream(
-  runtimeUrl: string,
+  dataplaneUrl: string,
   apiKey: string | undefined,
   command: string,
   options: WsRunOptions = {},
@@ -419,7 +419,7 @@ export async function runWsStream(
     openTimeout = WS_OPEN_TIMEOUT,
   } = options;
 
-  const wsUrl = buildWsUrl(runtimeUrl);
+  const wsUrl = buildWsUrl(dataplaneUrl);
   const headers = buildAuthHeaders(apiKey, extraHeaders);
   const control = new WSStreamControl();
 
@@ -486,7 +486,7 @@ export async function runWsStream(
  * rather than dropped.
  */
 export async function reconnectWsStream(
-  runtimeUrl: string,
+  dataplaneUrl: string,
   apiKey: string | undefined,
   commandId: string,
   options: {
@@ -497,7 +497,7 @@ export async function reconnectWsStream(
 ): Promise<[AsyncIterableIterator<WsMessage>, WSStreamControl]> {
   const { stdoutOffset = 0, stderrOffset = 0, headers: extraHeaders } = options;
 
-  const wsUrl = buildWsUrl(runtimeUrl);
+  const wsUrl = buildWsUrl(dataplaneUrl);
   const headers = buildAuthHeaders(apiKey, extraHeaders);
   const control = new WSStreamControl();
 

--- a/js/src/sandbox/ws_execute.ts
+++ b/js/src/sandbox/ws_execute.ts
@@ -108,10 +108,10 @@ async function ensureWs(): Promise<{
 // =============================================================================
 
 /**
- * Convert a dataplane HTTP URL to a WebSocket URL for /execute/ws.
+ * Convert a sandbox runtime HTTP URL to a WebSocket URL for /execute/ws.
  */
-export function buildWsUrl(dataplaneUrl: string): string {
-  const wsUrl = dataplaneUrl
+export function buildWsUrl(runtimeUrl: string): string {
+  const wsUrl = runtimeUrl
     .replace("https://", "wss://")
     .replace("http://", "ws://");
   return `${wsUrl}/execute/ws`;
@@ -398,7 +398,7 @@ async function* readWsMessages(
  * data arrives in addition to yielding the messages.
  */
 export async function runWsStream(
-  dataplaneUrl: string,
+  runtimeUrl: string,
   apiKey: string | undefined,
   command: string,
   options: WsRunOptions = {},
@@ -419,7 +419,7 @@ export async function runWsStream(
     openTimeout = WS_OPEN_TIMEOUT,
   } = options;
 
-  const wsUrl = buildWsUrl(dataplaneUrl);
+  const wsUrl = buildWsUrl(runtimeUrl);
   const headers = buildAuthHeaders(apiKey, extraHeaders);
   const control = new WSStreamControl();
 
@@ -486,7 +486,7 @@ export async function runWsStream(
  * rather than dropped.
  */
 export async function reconnectWsStream(
-  dataplaneUrl: string,
+  runtimeUrl: string,
   apiKey: string | undefined,
   commandId: string,
   options: {
@@ -497,7 +497,7 @@ export async function reconnectWsStream(
 ): Promise<[AsyncIterableIterator<WsMessage>, WSStreamControl]> {
   const { stdoutOffset = 0, stderrOffset = 0, headers: extraHeaders } = options;
 
-  const wsUrl = buildWsUrl(dataplaneUrl);
+  const wsUrl = buildWsUrl(runtimeUrl);
   const headers = buildAuthHeaders(apiKey, extraHeaders);
   const control = new WSStreamControl();
 

--- a/js/src/tests/client.test.ts
+++ b/js/src/tests/client.test.ts
@@ -620,6 +620,53 @@ describe("Client", () => {
       expect(updated.profiles.default).not.toHaveProperty("bearer_token");
     });
 
+    it("refreshes expired profile OAuth tokens for non-HTTP request headers", async () => {
+      writeProfileConfig({
+        profiles: {
+          default: {
+            api_url: "https://profile.example.com",
+            oauth: {
+              access_token: "old-access-token",
+              refresh_token: "old-refresh-token",
+              expires_at: new Date(Date.now() - 60_000).toISOString(),
+            },
+          },
+        },
+      });
+      const mockFetch = jest.fn(
+        async (input: RequestInfo | URL, init?: RequestInit) => {
+          if (
+            String(input).includes("/.well-known/oauth-authorization-server")
+          ) {
+            return new Response("", { status: 404 });
+          }
+          if (String(input) === "https://profile.example.com/oauth/token") {
+            expect(init?.method).toBe("POST");
+            return new Response(
+              JSON.stringify({
+                access_token: "new-access-token",
+                refresh_token: "new-refresh-token",
+                expires_in: 300,
+              }),
+              { status: 200 },
+            );
+          }
+          throw new Error(`Unexpected request: ${String(input)}`);
+        },
+      );
+      const client = new Client({ fetchImplementation: mockFetch as any });
+
+      await expect(client._getRequestHeaders()).resolves.toMatchObject({
+        authorization: "Bearer new-access-token",
+      });
+      expect(
+        mockFetch.mock.calls.filter(
+          ([input]) =>
+            String(input) === "https://profile.example.com/oauth/token",
+        ),
+      ).toHaveLength(1);
+    });
+
     it("preserves explicit Authorization headers during profile refresh", async () => {
       writeProfileConfig({
         profiles: {

--- a/js/src/tests/sandbox.test.ts
+++ b/js/src/tests/sandbox.test.ts
@@ -104,10 +104,6 @@ const createMockClient = (overrides: Record<string, any> = {}) =>
     getApiKey: () => "test-key",
     getDefaultHeaders: () => ({}),
     getRequestHeaders: async () => ({ "x-api-key": "test-key" }),
-    getSandboxRuntimeUrl: (sandboxIdOrName: string) =>
-      `https://api.example.com/api/v2/sandboxes/${encodeURIComponent(
-        sandboxIdOrName,
-      )}`,
     deleteSandbox: jest.fn<() => Promise<void>>().mockResolvedValue(undefined),
     ...overrides,
   }) as unknown as SandboxClient;
@@ -762,30 +758,20 @@ describe("SandboxClient", () => {
 
 describe("Sandbox", () => {
   describe("run", () => {
-    it("does not require dataplane_url for runtime operations", async () => {
-      const mockFetch = createMockFetch({
-        ok: true,
-        json: async () => ({ stdout: "ok\n", stderr: "", exit_code: 0 }),
-      });
+    it("should throw DataplaneNotConfiguredError when dataplane_url is missing", async () => {
       const sandbox = new (Sandbox as any)(
         {
           id: "sandbox-123",
           name: "test-sandbox",
+          // No dataplane_url
         },
-        createMockClient({
-          _fetch: mockFetch,
-          getSandboxRuntimeUrl: () =>
-            "https://api.example.com/api/v2/sandboxes/sandbox-123",
-        }),
+        createMockClient(),
         false,
       );
-      forceHttpFallback(sandbox);
 
-      await expect(sandbox.run("echo hello")).resolves.toEqual({
-        stdout: "ok\n",
-        stderr: "",
-        exit_code: 0,
-      });
+      await expect(sandbox.run("echo hello")).rejects.toThrow(
+        LangSmithDataplaneNotConfiguredError,
+      );
     });
 
     it("should execute a command and return result", async () => {
@@ -819,7 +805,7 @@ describe("Sandbox", () => {
       expect(mockFetch).toHaveBeenCalledTimes(1);
     });
 
-    it("routes runtime requests through the main Client control-plane endpoint", async () => {
+    it("keeps an absolute dataplane URL on the main Client transport", async () => {
       let requestUrl: string | undefined;
       let requestHeaders: Headers | undefined;
       const mainClient = new Client({
@@ -838,7 +824,6 @@ describe("Sandbox", () => {
       const client = new SandboxClient({ client: mainClient });
       const sandbox = new Sandbox(
         {
-          id: "sandbox-123",
           name: "test-sandbox",
           dataplane_url: "https://dataplane.example.com/sandbox-123",
         },
@@ -852,7 +837,7 @@ describe("Sandbox", () => {
         exit_code: 0,
       });
       expect(requestUrl).toBe(
-        "https://api.example.com/api/v2/sandboxes/sandbox-123/execute",
+        "https://dataplane.example.com/sandbox-123/execute",
       );
       expect(requestHeaders?.get("x-api-key")).toBe("main-key");
       expect(requestHeaders?.get("x-tenant-id")).toBe("workspace-123");
@@ -1553,7 +1538,7 @@ describe("Sandbox - status fields and not-ready guard", () => {
     expect(sandbox.status_message).toBe("Waiting for resources");
   });
 
-  it("does not gate runtime operations on status", async () => {
+  it("does not gate dataplane ops on status (stopped runs; platform resumes)", async () => {
     const mockFetch = createMockFetch({
       ok: true,
       json: async () => ({ stdout: "ok\n", stderr: "", exit_code: 0 }),

--- a/js/src/tests/sandbox.test.ts
+++ b/js/src/tests/sandbox.test.ts
@@ -4,6 +4,7 @@ import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { inspect } from "node:util";
+import { Client } from "../client.js";
 import { SandboxClient } from "../sandbox/client.js";
 import { Sandbox } from "../sandbox/sandbox.js";
 import { CommandHandle } from "../sandbox/command_handle.js";
@@ -62,12 +63,47 @@ const createMockFetch = (response: any) =>
     .fn<(url: string, init?: RequestInit) => Promise<Response>>()
     .mockResolvedValue(response);
 
+const toResponse = async (response: any): Promise<Response> => {
+  if (response instanceof Response) {
+    return response;
+  }
+  let body: BodyInit | null = null;
+  if (response?.arrayBuffer) {
+    body = await response.arrayBuffer();
+  } else if (response?.json) {
+    body = JSON.stringify(await response.json());
+  } else if (response?.text) {
+    body = await response.text();
+  }
+  const status = response?.status ?? (response?.ok === false ? 500 : 200);
+  return new Response(status === 204 || status === 304 ? null : body, {
+    status,
+    headers: response?.headers,
+  });
+};
+
+const createSandboxClientWithMock = (mockFetch: any): SandboxClient => {
+  const mainClient = new Client({
+    apiUrl: "https://api.example.com",
+    apiKey: "test-key",
+    autoBatchTracing: false,
+    fetchImplementation: async (input, init) =>
+      toResponse(await mockFetch(input, init)),
+  });
+  mainClient._getOpenAPIClient().maxRetries = 0;
+  return new SandboxClient({
+    client: mainClient,
+    apiEndpoint: "https://api.example.com/v2/sandboxes",
+  });
+};
+
 // Helper to create a mock SandboxClient with the required methods
 const createMockClient = (overrides: Record<string, any> = {}) =>
   ({
     _fetch: createMockFetch({}),
     getApiKey: () => "test-key",
     getDefaultHeaders: () => ({}),
+    getRequestHeaders: async () => ({ "x-api-key": "test-key" }),
     deleteSandbox: jest.fn<() => Promise<void>>().mockResolvedValue(undefined),
     ...overrides,
   }) as unknown as SandboxClient;
@@ -540,6 +576,93 @@ describe("sandbox proxy config helpers", () => {
 
 describe("SandboxClient", () => {
   describe("constructor", () => {
+    it("reuses a main Client endpoint and request pipeline", async () => {
+      let requestUrl: string | undefined;
+      let requestHeaders: Headers | undefined;
+      const mainClient = new Client({
+        apiUrl: "https://api.example.com/api/v1",
+        apiKey: "main-key",
+        workspaceId: "workspace-123",
+        headers: { "X-Custom-Header": "custom-value" },
+        fetchImplementation: async (input, init) => {
+          requestUrl = input.toString();
+          requestHeaders = new Headers(init?.headers);
+          return new Response(JSON.stringify({ sandboxes: [] }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          });
+        },
+      });
+
+      const client = new SandboxClient({ client: mainClient });
+      await expect(client.listSandboxes()).resolves.toEqual([]);
+
+      expect(requestUrl).toBe("https://api.example.com/api/v2/sandboxes/boxes");
+      expect(requestHeaders?.get("x-api-key")).toBe("main-key");
+      expect(requestHeaders?.get("x-tenant-id")).toBe("workspace-123");
+      expect(requestHeaders?.get("x-custom-header")).toBe("custom-value");
+    });
+
+    it("exposes the main Client auth and workspace headers for WebSockets", async () => {
+      const mainClient = new Client({
+        apiUrl: "https://api.example.com",
+        apiKey: "main-key",
+        workspaceId: "workspace-123",
+        headers: { "X-Custom-Header": "custom-value" },
+      });
+      const client = new SandboxClient({ client: mainClient });
+
+      await expect(client.getRequestHeaders()).resolves.toEqual(
+        expect.objectContaining({
+          "x-api-key": "main-key",
+          "x-tenant-id": "workspace-123",
+          "x-custom-header": "custom-value",
+        }),
+      );
+    });
+
+    it("maps main Client transport failures to sandbox connection errors", async () => {
+      const mainClient = new Client({
+        apiUrl: "https://api.example.com",
+        apiKey: "main-key",
+        fetchImplementation: async () => {
+          throw new TypeError("network unavailable");
+        },
+      });
+      mainClient._getOpenAPIClient().maxRetries = 0;
+      const client = new SandboxClient({ client: mainClient });
+
+      await expect(client.listSandboxes()).rejects.toThrow(
+        LangSmithSandboxConnectionError,
+      );
+      await expect(client.listSandboxes()).rejects.toThrow(
+        /network unavailable/,
+      );
+    });
+
+    it.each([-1, 1.5, Number.NaN])(
+      "rejects invalid maxRetries values (%s)",
+      (maxRetries) => {
+        expect(
+          () =>
+            new SandboxClient({
+              apiEndpoint: "https://api.example.com/v2/sandboxes",
+              maxRetries,
+            }),
+        ).toThrow(/maxRetries must be a non-negative integer or Infinity/);
+      },
+    );
+
+    it("continues to support infinite retries when explicitly requested", () => {
+      expect(
+        () =>
+          new SandboxClient({
+            apiEndpoint: "https://api.example.com/v2/sandboxes",
+            maxRetries: Number.POSITIVE_INFINITY,
+          }),
+      ).not.toThrow();
+    });
+
     it("should trim trailing slash from endpoint", () => {
       const client = new SandboxClient({
         apiEndpoint: "https://custom.api.com/sandboxes/",
@@ -680,6 +803,44 @@ describe("Sandbox", () => {
       expect(result.stderr).toBe("");
       expect(result.exit_code).toBe(0);
       expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it("keeps an absolute dataplane URL on the main Client transport", async () => {
+      let requestUrl: string | undefined;
+      let requestHeaders: Headers | undefined;
+      const mainClient = new Client({
+        apiUrl: "https://api.example.com",
+        apiKey: "main-key",
+        workspaceId: "workspace-123",
+        fetchImplementation: async (input, init) => {
+          requestUrl = input.toString();
+          requestHeaders = new Headers(init?.headers);
+          return new Response(
+            JSON.stringify({ stdout: "ok\n", stderr: "", exit_code: 0 }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          );
+        },
+      });
+      const client = new SandboxClient({ client: mainClient });
+      const sandbox = new Sandbox(
+        {
+          name: "test-sandbox",
+          dataplane_url: "https://dataplane.example.com/sandbox-123",
+        },
+        client,
+      );
+      forceHttpFallback(sandbox);
+
+      await expect(sandbox.run("echo ok")).resolves.toEqual({
+        stdout: "ok\n",
+        stderr: "",
+        exit_code: 0,
+      });
+      expect(requestUrl).toBe(
+        "https://dataplane.example.com/sandbox-123/execute",
+      );
+      expect(requestHeaders?.get("x-api-key")).toBe("main-key");
+      expect(requestHeaders?.get("x-tenant-id")).toBe("workspace-123");
     });
 
     it("should pass environment variables and cwd to command", async () => {
@@ -848,15 +1009,7 @@ describe("Sandbox", () => {
 
 describe("SandboxClient - createSandbox", () => {
   // Helper to create a SandboxClient with a mocked fetch
-  const createClientWithMock = (mockFetch: any) => {
-    const client = new SandboxClient({
-      apiEndpoint: "https://api.example.com/v2/sandboxes",
-      apiKey: "test-key",
-    });
-    (client as any)._caller = { call: (fn: any) => fn() };
-    (client as any)._fetchImpl = mockFetch;
-    return client;
-  };
+  const createClientWithMock = createSandboxClientWithMock;
 
   it("should send wait_for_ready: true and include timeout by default", async () => {
     const mockFetch = jest.fn<typeof fetch>().mockResolvedValue({
@@ -1205,15 +1358,7 @@ describe("validateTtl", () => {
 });
 
 describe("SandboxClient - updateSandbox", () => {
-  const createClientWithMock = (mockFetch: any) => {
-    const client = new SandboxClient({
-      apiEndpoint: "https://api.example.com/v2/sandboxes",
-      apiKey: "test-key",
-    });
-    (client as any)._caller = { call: (fn: any) => fn() };
-    (client as any)._fetchImpl = mockFetch;
-    return client;
-  };
+  const createClientWithMock = createSandboxClientWithMock;
 
   it("should PATCH retention fields when provided in options", async () => {
     const mockFetch = jest.fn<typeof fetch>().mockResolvedValue({
@@ -1272,21 +1417,13 @@ describe("SandboxClient - updateSandbox", () => {
     expect(mockFetch).toHaveBeenCalledTimes(1);
     const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit];
     expect(url).toContain("/boxes/sb-1");
-    expect(init.method).toBeUndefined();
+    expect(init.method).toBe("GET");
     expect(sb.name).toBe("sb-1");
   });
 });
 
 describe("SandboxClient - getSandboxStatus", () => {
-  const createClientWithMock = (mockFetch: any) => {
-    const client = new SandboxClient({
-      apiEndpoint: "https://api.example.com/v2/sandboxes",
-      apiKey: "test-key",
-    });
-    (client as any)._caller = { call: (fn: any) => fn() };
-    (client as any)._fetchImpl = mockFetch;
-    return client;
-  };
+  const createClientWithMock = createSandboxClientWithMock;
 
   it("should return ResourceStatus", async () => {
     const mockFetch = jest.fn<typeof fetch>().mockResolvedValue({
@@ -1318,15 +1455,7 @@ describe("SandboxClient - getSandboxStatus", () => {
 });
 
 describe("SandboxClient - waitForSandbox", () => {
-  const createClientWithMock = (mockFetch: any) => {
-    const client = new SandboxClient({
-      apiEndpoint: "https://api.example.com/v2/sandboxes",
-      apiKey: "test-key",
-    });
-    (client as any)._caller = { call: (fn: any) => fn() };
-    (client as any)._fetchImpl = mockFetch;
-    return client;
-  };
+  const createClientWithMock = createSandboxClientWithMock;
 
   it("should poll until ready and return sandbox", async () => {
     let callCount = 0;
@@ -1936,15 +2065,7 @@ describe("CommandHandle", () => {
 });
 
 describe("SandboxClient - createSandbox (snapshotId)", () => {
-  const createClientWithMock = (mockFetch: any) => {
-    const client = new SandboxClient({
-      apiEndpoint: "https://api.example.com/v2/sandboxes",
-      apiKey: "test-key",
-    });
-    (client as any)._caller = { call: (fn: any) => fn() };
-    (client as any)._fetchImpl = mockFetch;
-    return client;
-  };
+  const createClientWithMock = createSandboxClientWithMock;
 
   it("should send snapshot_id in the request body", async () => {
     const mockFetch = jest.fn<typeof fetch>().mockResolvedValue({
@@ -2056,15 +2177,7 @@ describe("SandboxClient - createSandbox (snapshotId)", () => {
 });
 
 describe("SandboxClient - snapshot operations", () => {
-  const createClientWithMock = (mockFetch: any) => {
-    const client = new SandboxClient({
-      apiEndpoint: "https://api.example.com/v2/sandboxes",
-      apiKey: "test-key",
-    });
-    (client as any)._caller = { call: (fn: any) => fn() };
-    (client as any)._fetchImpl = mockFetch;
-    return client;
-  };
+  const createClientWithMock = createSandboxClientWithMock;
 
   it("createSnapshot should POST and poll until ready", async () => {
     const mockFetch = jest
@@ -2429,15 +2542,7 @@ describe("SandboxClient - snapshot operations", () => {
 });
 
 describe("SandboxClient - start/stop", () => {
-  const createClientWithMock = (mockFetch: any) => {
-    const client = new SandboxClient({
-      apiEndpoint: "https://api.example.com/v2/sandboxes",
-      apiKey: "test-key",
-    });
-    (client as any)._caller = { call: (fn: any) => fn() };
-    (client as any)._fetchImpl = mockFetch;
-    return client;
-  };
+  const createClientWithMock = createSandboxClientWithMock;
 
   it("startSandbox should POST to /start and poll until ready", async () => {
     const mockFetch = jest

--- a/js/src/tests/sandbox.test.ts
+++ b/js/src/tests/sandbox.test.ts
@@ -104,6 +104,10 @@ const createMockClient = (overrides: Record<string, any> = {}) =>
     getApiKey: () => "test-key",
     getDefaultHeaders: () => ({}),
     getRequestHeaders: async () => ({ "x-api-key": "test-key" }),
+    getSandboxRuntimeUrl: (sandboxIdOrName: string) =>
+      `https://api.example.com/api/v2/sandboxes/${encodeURIComponent(
+        sandboxIdOrName,
+      )}`,
     deleteSandbox: jest.fn<() => Promise<void>>().mockResolvedValue(undefined),
     ...overrides,
   }) as unknown as SandboxClient;
@@ -758,20 +762,30 @@ describe("SandboxClient", () => {
 
 describe("Sandbox", () => {
   describe("run", () => {
-    it("should throw DataplaneNotConfiguredError when dataplane_url is missing", async () => {
+    it("does not require dataplane_url for runtime operations", async () => {
+      const mockFetch = createMockFetch({
+        ok: true,
+        json: async () => ({ stdout: "ok\n", stderr: "", exit_code: 0 }),
+      });
       const sandbox = new (Sandbox as any)(
         {
           id: "sandbox-123",
           name: "test-sandbox",
-          // No dataplane_url
         },
-        createMockClient(),
+        createMockClient({
+          _fetch: mockFetch,
+          getSandboxRuntimeUrl: () =>
+            "https://api.example.com/api/v2/sandboxes/sandbox-123",
+        }),
         false,
       );
+      forceHttpFallback(sandbox);
 
-      await expect(sandbox.run("echo hello")).rejects.toThrow(
-        LangSmithDataplaneNotConfiguredError,
-      );
+      await expect(sandbox.run("echo hello")).resolves.toEqual({
+        stdout: "ok\n",
+        stderr: "",
+        exit_code: 0,
+      });
     });
 
     it("should execute a command and return result", async () => {
@@ -805,7 +819,7 @@ describe("Sandbox", () => {
       expect(mockFetch).toHaveBeenCalledTimes(1);
     });
 
-    it("keeps an absolute dataplane URL on the main Client transport", async () => {
+    it("routes runtime requests through the main Client control-plane endpoint", async () => {
       let requestUrl: string | undefined;
       let requestHeaders: Headers | undefined;
       const mainClient = new Client({
@@ -824,6 +838,7 @@ describe("Sandbox", () => {
       const client = new SandboxClient({ client: mainClient });
       const sandbox = new Sandbox(
         {
+          id: "sandbox-123",
           name: "test-sandbox",
           dataplane_url: "https://dataplane.example.com/sandbox-123",
         },
@@ -837,7 +852,7 @@ describe("Sandbox", () => {
         exit_code: 0,
       });
       expect(requestUrl).toBe(
-        "https://dataplane.example.com/sandbox-123/execute",
+        "https://api.example.com/api/v2/sandboxes/sandbox-123/execute",
       );
       expect(requestHeaders?.get("x-api-key")).toBe("main-key");
       expect(requestHeaders?.get("x-tenant-id")).toBe("workspace-123");
@@ -1538,7 +1553,7 @@ describe("Sandbox - status fields and not-ready guard", () => {
     expect(sandbox.status_message).toBe("Waiting for resources");
   });
 
-  it("does not gate dataplane ops on status (stopped runs; platform resumes)", async () => {
+  it("does not gate runtime operations on status", async () => {
     const mockFetch = createMockFetch({
       ok: true,
       json: async () => ({ stdout: "ok\n", stderr: "", exit_code: 0 }),

--- a/js/src/tests/sandbox_command_id_retry.test.ts
+++ b/js/src/tests/sandbox_command_id_retry.test.ts
@@ -68,7 +68,6 @@ function makeSandbox() {
     getApiKey: () => "test-key",
     getDefaultHeaders: () => ({}),
     getRequestHeaders: async () => ({ "x-api-key": "test-key" }),
-    getSandboxRuntimeUrl: () => "https://api.example.com/api/v2/sandboxes/sb",
   };
   return new Sandbox(
     {

--- a/js/src/tests/sandbox_command_id_retry.test.ts
+++ b/js/src/tests/sandbox_command_id_retry.test.ts
@@ -67,6 +67,7 @@ function makeSandbox() {
   const client = {
     getApiKey: () => "test-key",
     getDefaultHeaders: () => ({}),
+    getRequestHeaders: async () => ({ "x-api-key": "test-key" }),
   };
   return new Sandbox(
     {

--- a/js/src/tests/sandbox_command_id_retry.test.ts
+++ b/js/src/tests/sandbox_command_id_retry.test.ts
@@ -68,6 +68,7 @@ function makeSandbox() {
     getApiKey: () => "test-key",
     getDefaultHeaders: () => ({}),
     getRequestHeaders: async () => ({ "x-api-key": "test-key" }),
+    getSandboxRuntimeUrl: () => "https://api.example.com/api/v2/sandboxes/sb",
   };
   return new Sandbox(
     {

--- a/js/src/tests/sandbox_reconnect_ack.test.ts
+++ b/js/src/tests/sandbox_reconnect_ack.test.ts
@@ -73,6 +73,7 @@ function makeSandbox() {
     getApiKey: () => "test-key",
     getDefaultHeaders: () => ({}),
     getRequestHeaders: async () => ({ "x-api-key": "test-key" }),
+    getSandboxRuntimeUrl: () => "https://api.example.com/api/v2/sandboxes/sb",
   };
   return new Sandbox(
     {

--- a/js/src/tests/sandbox_reconnect_ack.test.ts
+++ b/js/src/tests/sandbox_reconnect_ack.test.ts
@@ -72,6 +72,7 @@ function makeSandbox() {
   const client = {
     getApiKey: () => "test-key",
     getDefaultHeaders: () => ({}),
+    getRequestHeaders: async () => ({ "x-api-key": "test-key" }),
   };
   return new Sandbox(
     {

--- a/js/src/tests/sandbox_reconnect_ack.test.ts
+++ b/js/src/tests/sandbox_reconnect_ack.test.ts
@@ -73,7 +73,6 @@ function makeSandbox() {
     getApiKey: () => "test-key",
     getDefaultHeaders: () => ({}),
     getRequestHeaders: async () => ({ "x-api-key": "test-key" }),
-    getSandboxRuntimeUrl: () => "https://api.example.com/api/v2/sandboxes/sb",
   };
   return new Sandbox(
     {


### PR DESCRIPTION
## Summary

- lets `SandboxClient` reuse an existing LangSmith `Client` endpoint, profile or API-key auth, workspace, headers, timeout and retry policy, and fetch transport
- sends sandbox control-plane and direct dataplane HTTP requests through the main-client transport while preserving sandbox error types and concurrency limits
- resolves the same current credentials for WebSocket upgrades, including OAuth profile refresh, while keeping standalone `SandboxClient` configuration compatible

Python counterpart: https://github.com/langchain-ai/langsmith-sdk/pull/3410

## Test Plan

- [x] Added coverage for main-client routing and headers on control-plane, dataplane HTTP, and WebSocket paths
- [x] Added coverage for expired OAuth profile refresh before non-HTTP requests
- [x] Added coverage for transport error mapping and retry-count validation
