### PR TITLE
fix: exclude password and email env vars from run metadata

### DIFF
--- a/js/src/tests/client.test.ts
+++ b/js/src/tests/client.test.ts
@@ -878,6 +878,8 @@ describe("Client", () => {
       process.env.LANGCHAIN_ENDPOINT = "https://example.com";
       // eslint-disable-next-line no-process-env
       process.env.SOME_RANDOM_THING = "random";
+      // eslint-disable-next-line no-process-env
+      process.env.LANGSMITH_ADMIN_PASSWORD = "hunter2hunter2";
 
       const envVars = getLangSmithEnvironmentVariables();
       const langchainMetadataEnvVars = getLangSmithEnvVarsMetadata();
@@ -888,6 +890,7 @@ describe("Client", () => {
         LANGCHAIN_OTHER_KEY: "te**********ey",
         LANGCHAIN_ENDPOINT: "https://example.com",
         LANGCHAIN_OTHER_NON_SENSITIVE_METADATA: "test_some_metadata",
+        LANGSMITH_ADMIN_PASSWORD: "hu**********r2",
       });
       expect(envVars).not.toHaveProperty("SOME_RANDOM_THING");
 

--- a/js/src/utils/env.ts
+++ b/js/src/utils/env.ts
@@ -76,6 +76,24 @@ export function getRuntimeEnvironment(): RuntimeEnvironment {
   return runtimeEnvironment;
 }
 
+// Substrings marking a variable as secret-bearing or personal; matched
+// case-insensitively against the variable name.
+const EXCLUDED_SUBSTRINGS = [
+  "key",
+  "secret",
+  "token",
+  "password",
+  "passwd",
+  "pwd",
+  "credential",
+  "email",
+];
+
+function isSensitiveEnvVarName(key: string): boolean {
+  const lowered = key.toLowerCase();
+  return EXCLUDED_SUBSTRINGS.some((sub) => lowered.includes(sub));
+}
+
 /**
  * Retrieves the LangSmith-specific metadata from the current runtime environment.
  *
@@ -103,9 +121,7 @@ export function getLangSmithEnvVarsMetadata(): Record<string, string> {
     if (
       typeof value === "string" &&
       !excluded.includes(key) &&
-      !key.toLowerCase().includes("key") &&
-      !key.toLowerCase().includes("secret") &&
-      !key.toLowerCase().includes("token")
+      !isSensitiveEnvVarName(key)
     ) {
       if (key === "LANGCHAIN_REVISION_ID") {
         envVars["revision_id"] = value;
@@ -138,12 +154,7 @@ export function getLangSmithEnvironmentVariables(): Record<string, string> {
           (key.startsWith("LANGCHAIN_") || key.startsWith("LANGSMITH_")) &&
           value != null
         ) {
-          if (
-            (key.toLowerCase().includes("key") ||
-              key.toLowerCase().includes("secret") ||
-              key.toLowerCase().includes("token")) &&
-            typeof value === "string"
-          ) {
+          if (isSensitiveEnvVarName(key) && typeof value === "string") {
             envVars[key] =
               value.slice(0, 2) +
               "*".repeat(value.length - 4) +

--- a/python/langsmith/env/_runtime_env.py
+++ b/python/langsmith/env/_runtime_env.py
@@ -167,6 +167,20 @@ def get_langchain_env_vars() -> dict:
     return env_vars
 
 
+# Substrings marking a variable as secret-bearing or personal; matched
+# case-insensitively against the variable name.
+_EXCLUDED_SUBSTRINGS = (
+    "key",
+    "secret",
+    "token",
+    "password",
+    "passwd",
+    "pwd",
+    "credential",
+    "email",
+)
+
+
 @functools.lru_cache(maxsize=1)
 def get_langchain_env_var_metadata() -> dict:
     """Retrieve the langchain environment variables."""
@@ -186,9 +200,7 @@ def get_langchain_env_var_metadata() -> dict:
         for k, v in os.environ.items()
         if (k.startswith("LANGCHAIN_") or k.startswith("LANGSMITH_"))
         and k not in excluded
-        and "key" not in k.lower()
-        and "secret" not in k.lower()
-        and "token" not in k.lower()
+        and not any(sub in k.lower() for sub in _EXCLUDED_SUBSTRINGS)
     }
     env_revision_id = langchain_metadata.pop("LANGCHAIN_REVISION_ID", None)
     if env_revision_id:

--- a/python/tests/unit_tests/test_env.py
+++ b/python/tests/unit_tests/test_env.py
@@ -114,7 +114,15 @@ def test_git_info_caches_sanitized_remote_url(monkeypatch: pytest.MonkeyPatch) -
 
 @pytest.mark.parametrize(
     "secret_var",
-    ["LANGSMITH_SIGNING_JWKS", "LANGSMITH_SANDBOX_CALLBACK_SIGNING_JWK"],
+    [
+        "LANGSMITH_SIGNING_JWKS",
+        "LANGSMITH_SANDBOX_CALLBACK_SIGNING_JWK",
+        "LANGSMITH_ADMIN_PASSWORD",
+        "LANGSMITH_ADMIN_EMAIL",
+        "LANGCHAIN_DB_PASSWD",
+        "LANGSMITH_REDIS_PWD",
+        "LANGSMITH_GCP_CREDENTIALS",
+    ],
 )
 def test_env_var_metadata_excludes_signing_secrets(
     monkeypatch: pytest.MonkeyPatch, secret_var: str


### PR DESCRIPTION
Make `get_langchain_env_var_metadata()` (py) and `getLangSmithEnvVarsMetadata()` (js) exclusion list wider.