### PR TITLE
feat(sandbox): add generate_download_url to the Python and JS clients

### DIFF
--- a/js/src/sandbox/client.ts
+++ b/js/src/sandbox/client.ts
@@ -481,6 +481,11 @@ export class SandboxClient {
    * Callers can add specific status checks (e.g. 404) before calling this.
    * @internal
    */
+  private _boxUrl(name: string, ...segments: string[]): string {
+    const suffix = segments.length ? `/${segments.join("/")}` : "";
+    return `${this._baseUrl}/boxes/${encodeURIComponent(name)}${suffix}`;
+  }
+
   private async _postJson(
     url: string,
     body: Record<string, unknown>,
@@ -639,7 +644,7 @@ export class SandboxClient {
     name: string,
     options?: { signal?: AbortSignal },
   ): Promise<Sandbox> {
-    const url = `${this._baseUrl}/boxes/${encodeURIComponent(name)}`;
+    const url = this._boxUrl(name);
 
     const response = await this._fetch(url, { signal: options?.signal });
 
@@ -725,7 +730,7 @@ export class SandboxClient {
       return this.getSandbox(name);
     }
 
-    const url = `${this._baseUrl}/boxes/${encodeURIComponent(name)}`;
+    const url = this._boxUrl(name);
     const payload: Record<string, unknown> = {};
     if (newName !== undefined) {
       payload.name = newName;
@@ -772,7 +777,7 @@ export class SandboxClient {
    * @throws LangSmithResourceNotFoundError if sandbox not found.
    */
   async deleteSandbox(name: string): Promise<void> {
-    const url = `${this._baseUrl}/boxes/${encodeURIComponent(name)}`;
+    const url = this._boxUrl(name);
 
     const response = await this._fetch(url, { method: "DELETE" });
 
@@ -801,7 +806,7 @@ export class SandboxClient {
     name: string,
     options?: { signal?: AbortSignal },
   ): Promise<ResourceStatus> {
-    const url = `${this._baseUrl}/boxes/${encodeURIComponent(name)}/status`;
+    const url = this._boxUrl(name, "status");
 
     const response = await this._fetch(url, { signal: options?.signal });
 
@@ -891,7 +896,7 @@ export class SandboxClient {
     options: StartSandboxOptions = {},
   ): Promise<Sandbox> {
     const { timeout = 120, signal } = options;
-    const url = `${this._baseUrl}/boxes/${encodeURIComponent(name)}/start`;
+    const url = this._boxUrl(name, "start");
 
     await this._postJson(url, {}, { signal });
     return this.waitForSandbox(name, { timeout, signal });
@@ -904,6 +909,11 @@ export class SandboxClient {
    * one file without a LangSmith credential. It is pinned to the sandbox and
    * the exact path and cannot be repointed at another file. Fetching wakes a
    * stopped sandbox.
+   *
+   * Do not modify the file after minting a link for it. The link is pinned to
+   * a path, not to a snapshot of the contents, so a later write to that path
+   * may or may not be reflected in what the link serves. Write a new file and
+   * mint a new link when the contents change.
    *
    * @param name - Sandbox name.
    * @param path - File path inside the sandbox.
@@ -930,9 +940,7 @@ export class SandboxClient {
       );
     }
 
-    const url = `${this._baseUrl}/boxes/${encodeURIComponent(
-      name,
-    )}/download-url`;
+    const url = this._boxUrl(name, "download-url");
     const payload: Record<string, unknown> = { path };
     if (expiresInSeconds !== undefined) {
       payload.expires_in_seconds = expiresInSeconds;
@@ -954,7 +962,7 @@ export class SandboxClient {
    * @param name - Sandbox name.
    */
   async stopSandbox(name: string): Promise<void> {
-    const url = `${this._baseUrl}/boxes/${encodeURIComponent(name)}/stop`;
+    const url = this._boxUrl(name, "stop");
     await this._postJson(url, {});
   }
 
@@ -1123,9 +1131,7 @@ export class SandboxClient {
     options: CaptureSnapshotOptions = {},
   ): Promise<Snapshot> {
     const { dockerImage, fsCapacityBytes, timeout = 60, signal } = options;
-    const url = `${this._baseUrl}/boxes/${encodeURIComponent(
-      sandboxName,
-    )}/snapshot`;
+    const url = this._boxUrl(sandboxName, "snapshot");
 
     const payload: Record<string, unknown> = { name };
     if (dockerImage !== undefined) {

--- a/js/src/sandbox/client.ts
+++ b/js/src/sandbox/client.ts
@@ -12,6 +12,8 @@ import type {
   CreateDockerfileSnapshotOptions,
   CreateSandboxOptions,
   CreateSnapshotOptions,
+  DownloadURL,
+  GenerateDownloadURLOptions,
   ListSnapshotsOptions,
   ResourceStatus,
   SandboxClientConfig,
@@ -893,6 +895,57 @@ export class SandboxClient {
 
     await this._postJson(url, {}, { signal });
     return this.waitForSandbox(name, { timeout, signal });
+  }
+
+  /**
+   * Create a link that downloads one file from a sandbox.
+   *
+   * The link carries its own token, so anyone holding the URL can fetch that
+   * one file without a LangSmith credential. It is pinned to the sandbox and
+   * the exact path and cannot be repointed at another file. Fetching wakes a
+   * stopped sandbox.
+   *
+   * @param name - Sandbox name.
+   * @param path - File path inside the sandbox.
+   * @param options - Expiry and response header overrides.
+   * @returns The link and its expiry, if any.
+   *
+   * @example
+   * ```typescript
+   * const link = await client.generateDownloadURL("my-vm", "/tmp/report.pdf");
+   * console.log(link.download_url);
+   * ```
+   */
+  async generateDownloadURL(
+    name: string,
+    path: string,
+    options: GenerateDownloadURLOptions = {},
+  ): Promise<DownloadURL> {
+    const { expiresInSeconds, contentType, contentDisposition, signal } =
+      options;
+    if (expiresInSeconds !== undefined && expiresInSeconds < 1) {
+      throw new LangSmithValidationError(
+        `expiresInSeconds must be greater than 0 (got ${expiresInSeconds}); ` +
+          `omit it for a link that never expires`,
+      );
+    }
+
+    const url = `${this._baseUrl}/boxes/${encodeURIComponent(
+      name,
+    )}/download-url`;
+    const payload: Record<string, unknown> = { path };
+    if (expiresInSeconds !== undefined) {
+      payload.expires_in_seconds = expiresInSeconds;
+    }
+    if (contentType !== undefined) {
+      payload.content_type = contentType;
+    }
+    if (contentDisposition !== undefined) {
+      payload.content_disposition = contentDisposition;
+    }
+
+    const response = await this._postJson(url, payload, { signal });
+    return (await response.json()) as DownloadURL;
   }
 
   /**

--- a/js/src/sandbox/index.ts
+++ b/js/src/sandbox/index.ts
@@ -84,6 +84,7 @@ export type {
   CreateSnapshotOptions,
   CreateDockerfileSnapshotOptions,
   CaptureSnapshotOptions,
+  DownloadContentDisposition,
   DownloadURL,
   GenerateDownloadURLOptions,
   ListSnapshotsOptions,

--- a/js/src/sandbox/index.ts
+++ b/js/src/sandbox/index.ts
@@ -84,6 +84,8 @@ export type {
   CreateSnapshotOptions,
   CreateDockerfileSnapshotOptions,
   CaptureSnapshotOptions,
+  DownloadURL,
+  GenerateDownloadURLOptions,
   ListSnapshotsOptions,
   WaitForSnapshotOptions,
   StartSandboxOptions,

--- a/js/src/sandbox/sandbox.ts
+++ b/js/src/sandbox/sandbox.ts
@@ -496,6 +496,11 @@ export class Sandbox {
    * The link carries its own token, so anyone holding the URL can fetch that
    * one file without a LangSmith credential. Fetching wakes a stopped sandbox.
    *
+   * Do not modify the file after minting a link for it. The link is pinned to
+   * a path, not to a snapshot of the contents, so a later write to that path
+   * may or may not be reflected in what the link serves. Write a new file and
+   * mint a new link when the contents change.
+   *
    * @param path - File path inside the sandbox.
    * @param options - Expiry and response header overrides.
    * @returns The link and its expiry, if any.

--- a/js/src/sandbox/sandbox.ts
+++ b/js/src/sandbox/sandbox.ts
@@ -5,7 +5,9 @@
 import type { SandboxClient } from "./client.js";
 import type {
   CaptureSnapshotOptions,
+  DownloadURL,
   ExecutionResult,
+  GenerateDownloadURLOptions,
   RunOptions,
   SandboxData,
   Snapshot,
@@ -486,6 +488,31 @@ export class Sandbox {
 
     const buffer = await response.arrayBuffer();
     return new Uint8Array(buffer);
+  }
+
+  /**
+   * Create a link that downloads one file from this sandbox.
+   *
+   * The link carries its own token, so anyone holding the URL can fetch that
+   * one file without a LangSmith credential. Fetching wakes a stopped sandbox.
+   *
+   * @param path - File path inside the sandbox.
+   * @param options - Expiry and response header overrides.
+   * @returns The link and its expiry, if any.
+   *
+   * @example
+   * ```typescript
+   * const link = await sandbox.generateDownloadURL("/tmp/report.pdf", {
+   *   expiresInSeconds: 3600,
+   * });
+   * console.log(link.download_url);
+   * ```
+   */
+  async generateDownloadURL(
+    path: string,
+    options: GenerateDownloadURLOptions = {},
+  ): Promise<DownloadURL> {
+    return this._client.generateDownloadURL(this.name, path, options);
   }
 
   /**

--- a/js/src/sandbox/types.ts
+++ b/js/src/sandbox/types.ts
@@ -609,6 +609,37 @@ export interface CaptureSnapshotOptions {
 }
 
 /**
+ * Options for minting a sandbox file download link.
+ */
+export interface GenerateDownloadURLOptions {
+  /**
+   * Link TTL in seconds. Omit for a link that never expires.
+   */
+  expiresInSeconds?: number;
+  /** Content-Type to serve the file as. */
+  contentType?: string;
+  /** Content-Disposition to serve the file with: "attachment" or "inline". */
+  contentDisposition?: string;
+  /** AbortSignal for cancellation. */
+  signal?: AbortSignal;
+}
+
+/**
+ * A link that downloads one sandbox file with no LangSmith credential.
+ *
+ * The link is pinned to the sandbox, the file path, and the response headers,
+ * so it cannot be repointed at another file.
+ */
+export interface DownloadURL {
+  /** The full URL to fetch. Supports GET, HEAD, and Range. */
+  download_url: string;
+  /** The signed token embedded in `download_url`. */
+  token: string;
+  /** Expiry timestamp, or null for a link that never expires. */
+  expires_at: string | null;
+}
+
+/**
  * Options for listing snapshots. All fields are optional and independent.
  *
  * The backend always paginates: when `limit` is omitted the server applies

--- a/js/src/sandbox/types.ts
+++ b/js/src/sandbox/types.ts
@@ -609,6 +609,11 @@ export interface CaptureSnapshotOptions {
 }
 
 /**
+ * How a download link asks the browser to handle the file.
+ */
+export type DownloadContentDisposition = "attachment" | "inline";
+
+/**
  * Options for minting a sandbox file download link.
  */
 export interface GenerateDownloadURLOptions {
@@ -618,8 +623,8 @@ export interface GenerateDownloadURLOptions {
   expiresInSeconds?: number;
   /** Content-Type to serve the file as. */
   contentType?: string;
-  /** Content-Disposition to serve the file with: "attachment" or "inline". */
-  contentDisposition?: string;
+  /** Content-Disposition to serve the file with. */
+  contentDisposition?: DownloadContentDisposition;
   /** AbortSignal for cancellation. */
   signal?: AbortSignal;
 }
@@ -628,7 +633,9 @@ export interface GenerateDownloadURLOptions {
  * A link that downloads one sandbox file with no LangSmith credential.
  *
  * The link is pinned to the sandbox, the file path, and the response headers,
- * so it cannot be repointed at another file.
+ * so it cannot be repointed at another file. It is pinned to the path rather
+ * than to a snapshot of the contents, so the file must not be modified while
+ * the link is in use.
  */
 export interface DownloadURL {
   /** The full URL to fetch. Supports GET, HEAD, and Range. */

--- a/js/src/tests/sandbox.test.ts
+++ b/js/src/tests/sandbox.test.ts
@@ -2509,6 +2509,90 @@ describe("SandboxClient - start/stop", () => {
   });
 });
 
+describe("SandboxClient - generateDownloadURL", () => {
+  const createClientWithMock = (mockFetch: any) => {
+    const client = new SandboxClient({
+      apiEndpoint: "https://api.example.com/v2/sandboxes",
+      apiKey: "test-key",
+    });
+    (client as any)._caller = { call: (fn: any) => fn() };
+    (client as any)._fetchImpl = mockFetch;
+    return client;
+  };
+
+  it("should POST the path and return the link", async () => {
+    const mockFetch = jest.fn<typeof fetch>().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        download_url: "https://uuid--dl.svc.example.com/tok",
+        token: "tok",
+        expires_at: null,
+      }),
+    } as Response);
+
+    const client = createClientWithMock(mockFetch);
+    const link = await client.generateDownloadURL("my-vm", "/tmp/report.pdf");
+
+    expect(link.download_url).toBe("https://uuid--dl.svc.example.com/tok");
+    expect(link.expires_at).toBeNull();
+    const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain("/boxes/my-vm/download-url");
+    expect(JSON.parse(init.body as string)).toEqual({
+      path: "/tmp/report.pdf",
+    });
+  });
+
+  it("should send expiry and response headers when provided", async () => {
+    const mockFetch = jest.fn<typeof fetch>().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        download_url: "https://d/tok",
+        token: "tok",
+        expires_at: "2099-01-01T00:00:00Z",
+      }),
+    } as Response);
+
+    const client = createClientWithMock(mockFetch);
+    await client.generateDownloadURL("my-vm", "/tmp/page.html", {
+      expiresInSeconds: 3600,
+      contentType: "text/html",
+      contentDisposition: "inline",
+    });
+
+    const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(JSON.parse(init.body as string)).toEqual({
+      path: "/tmp/page.html",
+      expires_in_seconds: 3600,
+      content_type: "text/html",
+      content_disposition: "inline",
+    });
+  });
+
+  it("should reject a non-positive expiry", async () => {
+    const mockFetch = jest.fn<typeof fetch>();
+    const client = createClientWithMock(mockFetch);
+
+    await expect(
+      client.generateDownloadURL("my-vm", "/tmp/f", { expiresInSeconds: 0 }),
+    ).rejects.toThrow(LangSmithValidationError);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("should throw ResourceNotFoundError on 404", async () => {
+    const mockFetch = jest.fn<typeof fetch>().mockResolvedValue({
+      ok: false,
+      status: 404,
+      json: async () => ({ detail: "not found" }),
+      text: async () => "not found",
+    } as Response);
+
+    const client = createClientWithMock(mockFetch);
+    await expect(
+      client.generateDownloadURL("nonexistent", "/tmp/f"),
+    ).rejects.toThrow(LangSmithResourceNotFoundError);
+  });
+});
+
 describe("Sandbox - start/stop/captureSnapshot", () => {
   it("start should update status and dataplane_url", async () => {
     const mockClient = createMockClient({

--- a/python/langsmith/sandbox/__init__.py
+++ b/python/langsmith/sandbox/__init__.py
@@ -60,6 +60,7 @@ from langsmith.sandbox._models import (
     AsyncCommandHandle,
     AsyncServiceURL,
     CommandHandle,
+    DownloadURL,
     ExecutionResult,
     OutputChunk,
     ResourceStatus,
@@ -113,6 +114,7 @@ __all__ = [
     "ExecutionResult",
     "Snapshot",
     "ServiceURL",
+    "DownloadURL",
     "AsyncServiceURL",
     # WebSocket streaming models
     "CommandHandle",

--- a/python/langsmith/sandbox/__init__.py
+++ b/python/langsmith/sandbox/__init__.py
@@ -60,6 +60,7 @@ from langsmith.sandbox._models import (
     AsyncCommandHandle,
     AsyncServiceURL,
     CommandHandle,
+    DownloadContentDisposition,
     DownloadURL,
     ExecutionResult,
     OutputChunk,
@@ -115,6 +116,7 @@ __all__ = [
     "Snapshot",
     "ServiceURL",
     "DownloadURL",
+    "DownloadContentDisposition",
     "AsyncServiceURL",
     # WebSocket streaming models
     "CommandHandle",

--- a/python/langsmith/sandbox/_async_client.py
+++ b/python/langsmith/sandbox/_async_client.py
@@ -37,6 +37,7 @@ from langsmith.sandbox._helpers import (
 )
 from langsmith.sandbox._models import (
     AsyncServiceURL,
+    DownloadURL,
     ResourceStatus,
     Snapshot,
 )
@@ -694,6 +695,69 @@ class AsyncSandboxClient:
             )
             response.raise_for_status()
             return AsyncServiceURL.from_dict(response.json(), _refresher=_refresher)
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 404:
+                raise ResourceNotFoundError(
+                    f"Sandbox '{name}' not found", resource_type="sandbox"
+                ) from e
+            handle_client_http_error(e)
+            raise  # pragma: no cover
+
+    async def generate_download_url(
+        self,
+        name: str,
+        path: str,
+        *,
+        expires_in_seconds: Optional[int] = None,
+        content_type: Optional[str] = None,
+        content_disposition: Optional[str] = None,
+        headers: RequestHeaders = None,
+    ) -> DownloadURL:
+        """Create a link that downloads one file from a sandbox.
+
+        The link carries its own token, so anyone holding the URL can fetch
+        that one file without a LangSmith credential. It is pinned to the
+        sandbox and the exact path and cannot be repointed at another file.
+        Fetching wakes a stopped sandbox.
+
+        Args:
+            name: Sandbox name.
+            path: File path inside the sandbox.
+            expires_in_seconds: Link TTL in seconds. Omit for a link that
+                never expires.
+            content_type: Content-Type to serve the file as.
+            content_disposition: Content-Disposition to serve the file with,
+                either ``"attachment"`` or ``"inline"``.
+            headers: Optional per-request header overrides.
+
+        Returns:
+            DownloadURL with the link and its expiry, if any.
+
+        Raises:
+            ResourceNotFoundError: If sandbox not found.
+            ValueError: If expires_in_seconds is not positive.
+            SandboxClientError: For other errors.
+        """
+        if expires_in_seconds is not None and expires_in_seconds < 1:
+            raise ValueError(
+                f"expires_in_seconds must be greater than 0 "
+                f"(got {expires_in_seconds}); omit it for a link that never expires"
+            )
+        url = f"{self._base_url}/boxes/{_quote_path_segment(name)}/download-url"
+        payload: dict[str, Any] = {"path": path}
+        if expires_in_seconds is not None:
+            payload["expires_in_seconds"] = expires_in_seconds
+        if content_type is not None:
+            payload["content_type"] = content_type
+        if content_disposition is not None:
+            payload["content_disposition"] = content_disposition
+
+        try:
+            response = await self._http.post(
+                url, json=payload, headers=self._request_headers(headers)
+            )
+            response.raise_for_status()
+            return DownloadURL.from_dict(response.json())
         except httpx.HTTPStatusError as e:
             if e.response.status_code == 404:
                 raise ResourceNotFoundError(

--- a/python/langsmith/sandbox/_async_client.py
+++ b/python/langsmith/sandbox/_async_client.py
@@ -16,6 +16,7 @@ from langsmith._openapi_client import AsyncLangsmith
 from langsmith.sandbox._async_sandbox import AsyncSandbox
 from langsmith.sandbox._client import (
     SandboxClient,
+    _box_url,
     _make_docker_context_tar,
     _make_dockerfile_build_command,
     _quote_path_segment,
@@ -37,6 +38,7 @@ from langsmith.sandbox._helpers import (
 )
 from langsmith.sandbox._models import (
     AsyncServiceURL,
+    DownloadContentDisposition,
     DownloadURL,
     ResourceStatus,
     Snapshot,
@@ -481,7 +483,7 @@ class AsyncSandboxClient:
             ResourceNotFoundError: If sandbox not found.
             SandboxClientError: For other errors.
         """
-        url = f"{self._base_url}/boxes/{_quote_path_segment(name)}"
+        url = _box_url(self._base_url, name)
 
         try:
             response = await self._http.get(url, headers=self._request_headers(headers))
@@ -558,7 +560,7 @@ class AsyncSandboxClient:
         validate_ttl(idle_ttl_seconds, "idle_ttl_seconds")
         validate_ttl(delete_after_stop_seconds, "delete_after_stop_seconds")
 
-        url = f"{self._base_url}/boxes/{_quote_path_segment(name)}"
+        url = _box_url(self._base_url, name)
         payload: dict[str, Any] = {}
         if new_name is not None:
             payload["name"] = new_name
@@ -600,7 +602,7 @@ class AsyncSandboxClient:
             ResourceNotFoundError: If sandbox not found.
             SandboxClientError: For other errors.
         """
-        url = f"{self._base_url}/boxes/{_quote_path_segment(name)}"
+        url = _box_url(self._base_url, name)
 
         try:
             response = await self._http.delete(
@@ -633,7 +635,7 @@ class AsyncSandboxClient:
             ResourceNotFoundError: If sandbox not found.
             SandboxClientError: For other errors.
         """
-        url = f"{self._base_url}/boxes/{_quote_path_segment(name)}/status"
+        url = _box_url(self._base_url, name, "status")
 
         try:
             response = await self._http.get(url, headers=self._request_headers(headers))
@@ -678,7 +680,7 @@ class AsyncSandboxClient:
             SandboxClientError: For other errors.
         """
         validate_service_params(port, expires_in_seconds)
-        url = f"{self._base_url}/boxes/{_quote_path_segment(name)}/service-url"
+        url = _box_url(self._base_url, name, "service-url")
         payload = {"port": port, "expires_in_seconds": expires_in_seconds}
 
         async def _refresher() -> AsyncServiceURL:
@@ -710,7 +712,7 @@ class AsyncSandboxClient:
         *,
         expires_in_seconds: Optional[int] = None,
         content_type: Optional[str] = None,
-        content_disposition: Optional[str] = None,
+        content_disposition: Optional[DownloadContentDisposition] = None,
         headers: RequestHeaders = None,
     ) -> DownloadURL:
         """Create a link that downloads one file from a sandbox.
@@ -719,6 +721,12 @@ class AsyncSandboxClient:
         that one file without a LangSmith credential. It is pinned to the
         sandbox and the exact path and cannot be repointed at another file.
         Fetching wakes a stopped sandbox.
+
+        Do not modify the file after minting a link for it. The link is
+        pinned to a path, not to a snapshot of the contents, so a later
+        write to that path may or may not be reflected in what the link
+        serves. Write a new file and mint a new link when the contents
+        change.
 
         Args:
             name: Sandbox name.
@@ -743,7 +751,7 @@ class AsyncSandboxClient:
                 f"expires_in_seconds must be greater than 0 "
                 f"(got {expires_in_seconds}); omit it for a link that never expires"
             )
-        url = f"{self._base_url}/boxes/{_quote_path_segment(name)}/download-url"
+        url = _box_url(self._base_url, name, "download-url")
         payload: dict[str, Any] = {"path": path}
         if expires_in_seconds is not None:
             payload["expires_in_seconds"] = expires_in_seconds
@@ -836,7 +844,7 @@ class AsyncSandboxClient:
             ResourceTimeoutError: If sandbox doesn't become ready within timeout.
             SandboxClientError: For other errors.
         """
-        url = f"{self._base_url}/boxes/{_quote_path_segment(name)}/start"
+        url = _box_url(self._base_url, name, "start")
 
         try:
             response = await self._http.post(
@@ -862,7 +870,7 @@ class AsyncSandboxClient:
             ResourceNotFoundError: If sandbox not found.
             SandboxClientError: For other errors.
         """
-        url = f"{self._base_url}/boxes/{_quote_path_segment(name)}/stop"
+        url = _box_url(self._base_url, name, "stop")
 
         try:
             response = await self._http.post(
@@ -1055,7 +1063,7 @@ class AsyncSandboxClient:
             ResourceCreationError: If snapshot capture fails.
             SandboxClientError: For other errors.
         """
-        url = f"{self._base_url}/boxes/{_quote_path_segment(sandbox_name)}/snapshot"
+        url = _box_url(self._base_url, sandbox_name, "snapshot")
 
         payload: dict[str, Any] = {"name": name}
         if docker_image is not None:

--- a/python/langsmith/sandbox/_async_sandbox.py
+++ b/python/langsmith/sandbox/_async_sandbox.py
@@ -19,6 +19,7 @@ from langsmith.sandbox._helpers import handle_sandbox_http_error
 from langsmith.sandbox._models import (
     AsyncCommandHandle,
     AsyncServiceURL,
+    DownloadContentDisposition,
     DownloadURL,
     ExecutionResult,
     Snapshot,
@@ -737,7 +738,7 @@ class AsyncSandbox:
         *,
         expires_in_seconds: Optional[int] = None,
         content_type: Optional[str] = None,
-        content_disposition: Optional[str] = None,
+        content_disposition: Optional[DownloadContentDisposition] = None,
         headers: RequestHeaders = None,
     ) -> DownloadURL:
         """Create a link that downloads one file from this sandbox.
@@ -745,6 +746,12 @@ class AsyncSandbox:
         The link carries its own token, so anyone holding the URL can fetch
         that one file without a LangSmith credential. Fetching wakes a
         stopped sandbox.
+
+        Do not modify the file after minting a link for it. The link is
+        pinned to a path, not to a snapshot of the contents, so a later
+        write to that path may or may not be reflected in what the link
+        serves. Write a new file and mint a new link when the contents
+        change.
 
         Args:
             path: File path inside the sandbox.

--- a/python/langsmith/sandbox/_async_sandbox.py
+++ b/python/langsmith/sandbox/_async_sandbox.py
@@ -19,6 +19,7 @@ from langsmith.sandbox._helpers import handle_sandbox_http_error
 from langsmith.sandbox._models import (
     AsyncCommandHandle,
     AsyncServiceURL,
+    DownloadURL,
     ExecutionResult,
     Snapshot,
     _StreamEndedBeforeStarted,
@@ -727,6 +728,47 @@ class AsyncSandbox:
             self.name,
             port,
             expires_in_seconds=expires_in_seconds,
+            headers=headers,
+        )
+
+    async def generate_download_url(
+        self,
+        path: str,
+        *,
+        expires_in_seconds: Optional[int] = None,
+        content_type: Optional[str] = None,
+        content_disposition: Optional[str] = None,
+        headers: RequestHeaders = None,
+    ) -> DownloadURL:
+        """Create a link that downloads one file from this sandbox.
+
+        The link carries its own token, so anyone holding the URL can fetch
+        that one file without a LangSmith credential. Fetching wakes a
+        stopped sandbox.
+
+        Args:
+            path: File path inside the sandbox.
+            expires_in_seconds: Link TTL in seconds. Omit for a link that
+                never expires.
+            content_type: Content-Type to serve the file as.
+            content_disposition: Content-Disposition to serve the file with,
+                either ``"attachment"`` or ``"inline"``.
+            headers: Optional per-request header overrides.
+
+        Returns:
+            DownloadURL with the link and its expiry, if any.
+
+        Raises:
+            ResourceNotFoundError: If sandbox not found.
+            ValueError: If expires_in_seconds is not positive.
+            SandboxClientError: For other errors.
+        """
+        return await self._client.generate_download_url(
+            self.name,
+            path,
+            expires_in_seconds=expires_in_seconds,
+            content_type=content_type,
+            content_disposition=content_disposition,
             headers=headers,
         )
 

--- a/python/langsmith/sandbox/_client.py
+++ b/python/langsmith/sandbox/_client.py
@@ -32,6 +32,7 @@ from langsmith.sandbox._helpers import (
     validate_ttl,
 )
 from langsmith.sandbox._models import (
+    DownloadContentDisposition,
     DownloadURL,
     ResourceStatus,
     ServiceURL,
@@ -74,6 +75,12 @@ def _quote_path_segment(value: str) -> str:
     if not value:
         raise ValueError("URL path segment must be a non-empty string")
     return quote(value, safe="")
+
+
+def _box_url(base_url: str, name: str, *segments: str) -> str:
+    """Build the URL for a sandbox, optionally with trailing path segments."""
+    suffix = "/" + "/".join(segments) if segments else ""
+    return f"{base_url}/boxes/{_quote_path_segment(name)}{suffix}"
 
 
 def _make_docker_context_tar(context_path: Path) -> bytes:
@@ -580,7 +587,7 @@ class SandboxClient:
             ResourceNotFoundError: If sandbox not found.
             SandboxClientError: For other errors.
         """
-        url = f"{self._base_url}/boxes/{_quote_path_segment(name)}"
+        url = _box_url(self._base_url, name)
 
         try:
             response = self._http.get(url, headers=self._request_headers(headers))
@@ -653,7 +660,7 @@ class SandboxClient:
         validate_ttl(idle_ttl_seconds, "idle_ttl_seconds")
         validate_ttl(delete_after_stop_seconds, "delete_after_stop_seconds")
 
-        url = f"{self._base_url}/boxes/{_quote_path_segment(name)}"
+        url = _box_url(self._base_url, name)
         payload: dict[str, Any] = {}
         if new_name is not None:
             payload["name"] = new_name
@@ -691,7 +698,7 @@ class SandboxClient:
             ResourceNotFoundError: If sandbox not found.
             SandboxClientError: For other errors.
         """
-        url = f"{self._base_url}/boxes/{_quote_path_segment(name)}"
+        url = _box_url(self._base_url, name)
 
         try:
             response = self._http.delete(url, headers=self._request_headers(headers))
@@ -722,7 +729,7 @@ class SandboxClient:
             ResourceNotFoundError: If sandbox not found.
             SandboxClientError: For other errors.
         """
-        url = f"{self._base_url}/boxes/{_quote_path_segment(name)}/status"
+        url = _box_url(self._base_url, name, "status")
 
         try:
             response = self._http.get(url, headers=self._request_headers(headers))
@@ -766,7 +773,7 @@ class SandboxClient:
             SandboxClientError: For other errors.
         """
         validate_service_params(port, expires_in_seconds)
-        url = f"{self._base_url}/boxes/{_quote_path_segment(name)}/service-url"
+        url = _box_url(self._base_url, name, "service-url")
         payload = {"port": port, "expires_in_seconds": expires_in_seconds}
 
         def _refresher() -> ServiceURL:
@@ -798,7 +805,7 @@ class SandboxClient:
         *,
         expires_in_seconds: Optional[int] = None,
         content_type: Optional[str] = None,
-        content_disposition: Optional[str] = None,
+        content_disposition: Optional[DownloadContentDisposition] = None,
         headers: RequestHeaders = None,
     ) -> DownloadURL:
         """Create a link that downloads one file from a sandbox.
@@ -807,6 +814,12 @@ class SandboxClient:
         that one file without a LangSmith credential. It is pinned to the
         sandbox and the exact path and cannot be repointed at another file.
         Fetching wakes a stopped sandbox.
+
+        Do not modify the file after minting a link for it. The link is
+        pinned to a path, not to a snapshot of the contents, so a later
+        write to that path may or may not be reflected in what the link
+        serves. Write a new file and mint a new link when the contents
+        change.
 
         Args:
             name: Sandbox name.
@@ -831,7 +844,7 @@ class SandboxClient:
                 f"expires_in_seconds must be greater than 0 "
                 f"(got {expires_in_seconds}); omit it for a link that never expires"
             )
-        url = f"{self._base_url}/boxes/{_quote_path_segment(name)}/download-url"
+        url = _box_url(self._base_url, name, "download-url")
         payload: dict[str, Any] = {"path": path}
         if expires_in_seconds is not None:
             payload["expires_in_seconds"] = expires_in_seconds
@@ -924,7 +937,7 @@ class SandboxClient:
             ResourceTimeoutError: If sandbox doesn't become ready within timeout.
             SandboxClientError: For other errors.
         """
-        url = f"{self._base_url}/boxes/{_quote_path_segment(name)}/start"
+        url = _box_url(self._base_url, name, "start")
 
         try:
             response = self._http.post(
@@ -950,7 +963,7 @@ class SandboxClient:
             ResourceNotFoundError: If sandbox not found.
             SandboxClientError: For other errors.
         """
-        url = f"{self._base_url}/boxes/{_quote_path_segment(name)}/stop"
+        url = _box_url(self._base_url, name, "stop")
 
         try:
             response = self._http.post(
@@ -1144,7 +1157,7 @@ class SandboxClient:
             ResourceCreationError: If snapshot capture fails.
             SandboxClientError: For other errors.
         """
-        url = f"{self._base_url}/boxes/{_quote_path_segment(sandbox_name)}/snapshot"
+        url = _box_url(self._base_url, sandbox_name, "snapshot")
 
         payload: dict[str, Any] = {"name": name}
         if docker_image is not None:

--- a/python/langsmith/sandbox/_client.py
+++ b/python/langsmith/sandbox/_client.py
@@ -32,6 +32,7 @@ from langsmith.sandbox._helpers import (
     validate_ttl,
 )
 from langsmith.sandbox._models import (
+    DownloadURL,
     ResourceStatus,
     ServiceURL,
     Snapshot,
@@ -782,6 +783,69 @@ class SandboxClient:
             )
             response.raise_for_status()
             return ServiceURL.from_dict(response.json(), _refresher=_refresher)
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 404:
+                raise ResourceNotFoundError(
+                    f"Sandbox '{name}' not found", resource_type="sandbox"
+                ) from e
+            handle_client_http_error(e)
+            raise  # pragma: no cover
+
+    def generate_download_url(
+        self,
+        name: str,
+        path: str,
+        *,
+        expires_in_seconds: Optional[int] = None,
+        content_type: Optional[str] = None,
+        content_disposition: Optional[str] = None,
+        headers: RequestHeaders = None,
+    ) -> DownloadURL:
+        """Create a link that downloads one file from a sandbox.
+
+        The link carries its own token, so anyone holding the URL can fetch
+        that one file without a LangSmith credential. It is pinned to the
+        sandbox and the exact path and cannot be repointed at another file.
+        Fetching wakes a stopped sandbox.
+
+        Args:
+            name: Sandbox name.
+            path: File path inside the sandbox.
+            expires_in_seconds: Link TTL in seconds. Omit for a link that
+                never expires.
+            content_type: Content-Type to serve the file as.
+            content_disposition: Content-Disposition to serve the file with,
+                either ``"attachment"`` or ``"inline"``.
+            headers: Optional per-request header overrides.
+
+        Returns:
+            DownloadURL with the link and its expiry, if any.
+
+        Raises:
+            ResourceNotFoundError: If sandbox not found.
+            ValueError: If expires_in_seconds is not positive.
+            SandboxClientError: For other errors.
+        """
+        if expires_in_seconds is not None and expires_in_seconds < 1:
+            raise ValueError(
+                f"expires_in_seconds must be greater than 0 "
+                f"(got {expires_in_seconds}); omit it for a link that never expires"
+            )
+        url = f"{self._base_url}/boxes/{_quote_path_segment(name)}/download-url"
+        payload: dict[str, Any] = {"path": path}
+        if expires_in_seconds is not None:
+            payload["expires_in_seconds"] = expires_in_seconds
+        if content_type is not None:
+            payload["content_type"] = content_type
+        if content_disposition is not None:
+            payload["content_disposition"] = content_disposition
+
+        try:
+            response = self._http.post(
+                url, json=payload, headers=self._request_headers(headers)
+            )
+            response.raise_for_status()
+            return DownloadURL.from_dict(response.json())
         except httpx.HTTPStatusError as e:
             if e.response.status_code == 404:
                 raise ResourceNotFoundError(

--- a/python/langsmith/sandbox/_models.py
+++ b/python/langsmith/sandbox/_models.py
@@ -6,7 +6,7 @@ import logging
 from collections.abc import AsyncIterator, Awaitable, Callable, Iterator
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any, Literal, Optional
 
 import httpx
 
@@ -464,12 +464,18 @@ class AsyncServiceURL:
 # =============================================================================
 
 
+DownloadContentDisposition = Literal["attachment", "inline"]
+"""How a download link asks the browser to handle the file."""
+
+
 @dataclass
 class DownloadURL:
     """A link that downloads one sandbox file with no LangSmith credential.
 
     The link is pinned to the sandbox, the file path, and the response
-    headers, so it cannot be repointed at another file.
+    headers, so it cannot be repointed at another file. It is pinned to the
+    path rather than to a snapshot of the contents, so the file must not be
+    modified while the link is in use.
 
     Attributes:
         download_url: The full URL to fetch. Supports GET, HEAD, and Range.

--- a/python/langsmith/sandbox/_models.py
+++ b/python/langsmith/sandbox/_models.py
@@ -460,6 +460,38 @@ class AsyncServiceURL:
 
 
 # =============================================================================
+# Download URL Models
+# =============================================================================
+
+
+@dataclass
+class DownloadURL:
+    """A link that downloads one sandbox file with no LangSmith credential.
+
+    The link is pinned to the sandbox, the file path, and the response
+    headers, so it cannot be repointed at another file.
+
+    Attributes:
+        download_url: The full URL to fetch. Supports GET, HEAD, and Range.
+        token: The signed token embedded in ``download_url``.
+        expires_at: Expiry timestamp, or None for a link that never expires.
+    """
+
+    download_url: str
+    token: str
+    expires_at: Optional[str] = None
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> DownloadURL:
+        """Create a DownloadURL from API response dict."""
+        return cls(
+            download_url=data.get("download_url", ""),
+            token=data.get("token", ""),
+            expires_at=data.get("expires_at"),
+        )
+
+
+# =============================================================================
 # WebSocket Command Execution Models
 # =============================================================================
 

--- a/python/langsmith/sandbox/_sandbox.py
+++ b/python/langsmith/sandbox/_sandbox.py
@@ -16,6 +16,7 @@ from langsmith.sandbox._exceptions import (
 from langsmith.sandbox._helpers import handle_sandbox_http_error
 from langsmith.sandbox._models import (
     CommandHandle,
+    DownloadContentDisposition,
     DownloadURL,
     ExecutionResult,
     ServiceURL,
@@ -738,7 +739,7 @@ class Sandbox:
         *,
         expires_in_seconds: Optional[int] = None,
         content_type: Optional[str] = None,
-        content_disposition: Optional[str] = None,
+        content_disposition: Optional[DownloadContentDisposition] = None,
         headers: RequestHeaders = None,
     ) -> DownloadURL:
         """Create a link that downloads one file from this sandbox.
@@ -746,6 +747,12 @@ class Sandbox:
         The link carries its own token, so anyone holding the URL can fetch
         that one file without a LangSmith credential. Fetching wakes a
         stopped sandbox.
+
+        Do not modify the file after minting a link for it. The link is
+        pinned to a path, not to a snapshot of the contents, so a later
+        write to that path may or may not be reflected in what the link
+        serves. Write a new file and mint a new link when the contents
+        change.
 
         Args:
             path: File path inside the sandbox.

--- a/python/langsmith/sandbox/_sandbox.py
+++ b/python/langsmith/sandbox/_sandbox.py
@@ -16,6 +16,7 @@ from langsmith.sandbox._exceptions import (
 from langsmith.sandbox._helpers import handle_sandbox_http_error
 from langsmith.sandbox._models import (
     CommandHandle,
+    DownloadURL,
     ExecutionResult,
     ServiceURL,
     Snapshot,
@@ -728,6 +729,47 @@ class Sandbox:
             self.name,
             port,
             expires_in_seconds=expires_in_seconds,
+            headers=headers,
+        )
+
+    def generate_download_url(
+        self,
+        path: str,
+        *,
+        expires_in_seconds: Optional[int] = None,
+        content_type: Optional[str] = None,
+        content_disposition: Optional[str] = None,
+        headers: RequestHeaders = None,
+    ) -> DownloadURL:
+        """Create a link that downloads one file from this sandbox.
+
+        The link carries its own token, so anyone holding the URL can fetch
+        that one file without a LangSmith credential. Fetching wakes a
+        stopped sandbox.
+
+        Args:
+            path: File path inside the sandbox.
+            expires_in_seconds: Link TTL in seconds. Omit for a link that
+                never expires.
+            content_type: Content-Type to serve the file as.
+            content_disposition: Content-Disposition to serve the file with,
+                either ``"attachment"`` or ``"inline"``.
+            headers: Optional per-request header overrides.
+
+        Returns:
+            DownloadURL with the link and its expiry, if any.
+
+        Raises:
+            ResourceNotFoundError: If sandbox not found.
+            ValueError: If expires_in_seconds is not positive.
+            SandboxClientError: For other errors.
+        """
+        return self._client.generate_download_url(
+            self.name,
+            path,
+            expires_in_seconds=expires_in_seconds,
+            content_type=content_type,
+            content_disposition=content_disposition,
             headers=headers,
         )
 

--- a/python/tests/unit_tests/sandbox/test_async_client.py
+++ b/python/tests/unit_tests/sandbox/test_async_client.py
@@ -1,5 +1,6 @@
 """Tests for AsyncSandboxClient."""
 
+import json
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -8,6 +9,7 @@ from pytest_httpx import HTTPXMock
 from langsmith.sandbox import (
     AsyncSandboxClient,
     AsyncServiceURL,
+    DownloadURL,
     ExecutionResult,
     ResourceCreationError,
     ResourceNameConflictError,
@@ -1090,6 +1092,82 @@ class TestAsyncConnectionErrors:
 
         with pytest.raises(SandboxConnectionError):
             await client.create_sandbox(snapshot_id="snap-1")
+
+
+class TestGenerateDownloadURL:
+    """Tests for AsyncSandboxClient.generate_download_url()."""
+
+    async def test_download_url_happy_path(
+        self, client: AsyncSandboxClient, httpx_mock: HTTPXMock
+    ):
+        """Test minting a download link returns DownloadURL with correct fields."""
+        httpx_mock.add_response(
+            method="POST",
+            url="http://test-server:8080/boxes/my-sandbox/download-url",
+            json={
+                "download_url": "http://uuid--dl.svc.example.com/tok",
+                "token": "tok",
+                "expires_at": None,
+            },
+        )
+
+        link = await client.generate_download_url("my-sandbox", "/tmp/report.pdf")
+
+        assert isinstance(link, DownloadURL)
+        assert link.download_url == "http://uuid--dl.svc.example.com/tok"
+        assert link.expires_at is None
+
+        request = httpx_mock.get_request()
+        assert request is not None
+        assert json.loads(request.content) == {"path": "/tmp/report.pdf"}
+
+    async def test_download_url_optional_fields(
+        self, client: AsyncSandboxClient, httpx_mock: HTTPXMock
+    ):
+        """Test expiry and response headers are sent when provided."""
+        httpx_mock.add_response(
+            method="POST",
+            url="http://test-server:8080/boxes/my-sandbox/download-url",
+            json={"download_url": "http://d/tok", "token": "tok", "expires_at": None},
+        )
+
+        await client.generate_download_url(
+            "my-sandbox",
+            "/tmp/page.html",
+            expires_in_seconds=3600,
+            content_type="text/html",
+            content_disposition="inline",
+        )
+
+        request = httpx_mock.get_request()
+        assert request is not None
+        assert json.loads(request.content) == {
+            "path": "/tmp/page.html",
+            "expires_in_seconds": 3600,
+            "content_type": "text/html",
+            "content_disposition": "inline",
+        }
+
+    async def test_download_url_not_found(
+        self, client: AsyncSandboxClient, httpx_mock: HTTPXMock
+    ):
+        """Test 404 raises ResourceNotFoundError."""
+        httpx_mock.add_response(
+            method="POST",
+            url="http://test-server:8080/boxes/nonexistent/download-url",
+            json={"detail": "Sandbox 'nonexistent' not found"},
+            status_code=404,
+        )
+
+        with pytest.raises(ResourceNotFoundError):
+            await client.generate_download_url("nonexistent", "/tmp/f")
+
+    async def test_download_url_invalid_expiry(self, client: AsyncSandboxClient):
+        """Test non-positive expires_in_seconds raises ValueError."""
+        with pytest.raises(ValueError, match="greater than 0"):
+            await client.generate_download_url(
+                "my-sandbox", "/tmp/f", expires_in_seconds=0
+            )
 
 
 class TestService:

--- a/python/tests/unit_tests/sandbox/test_client.py
+++ b/python/tests/unit_tests/sandbox/test_client.py
@@ -1,11 +1,13 @@
 """Tests for SandboxClient."""
 
+import json
 from unittest.mock import patch
 
 import pytest
 from pytest_httpx import HTTPXMock
 
 from langsmith.sandbox import (
+    DownloadURL,
     ResourceCreationError,
     ResourceNameConflictError,
     ResourceNotFoundError,
@@ -855,6 +857,99 @@ class TestConnectionErrors:
 
         with pytest.raises(SandboxConnectionError):
             client.create_sandbox(snapshot_id="snap-1")
+
+
+class TestGenerateDownloadURL:
+    """Tests for SandboxClient.generate_download_url()."""
+
+    def test_download_url_happy_path(
+        self, client: SandboxClient, httpx_mock: HTTPXMock
+    ):
+        """Test minting a download link returns DownloadURL with correct fields."""
+        httpx_mock.add_response(
+            method="POST",
+            url="http://test-server:8080/boxes/my-sandbox/download-url",
+            json={
+                "download_url": "http://uuid--dl.svc.example.com/tok",
+                "token": "tok",
+                "expires_at": "2099-01-01T00:00:00Z",
+            },
+        )
+
+        link = client.generate_download_url("my-sandbox", "/tmp/report.pdf")
+
+        assert isinstance(link, DownloadURL)
+        assert link.download_url == "http://uuid--dl.svc.example.com/tok"
+        assert link.token == "tok"
+        assert link.expires_at == "2099-01-01T00:00:00Z"
+
+        request = httpx_mock.get_request()
+        assert request is not None
+        body = json.loads(request.content)
+        assert body == {"path": "/tmp/report.pdf"}
+
+    def test_download_url_never_expires(
+        self, client: SandboxClient, httpx_mock: HTTPXMock
+    ):
+        """Test a null expires_at is preserved rather than defaulted."""
+        httpx_mock.add_response(
+            method="POST",
+            url="http://test-server:8080/boxes/my-sandbox/download-url",
+            json={
+                "download_url": "http://d/tok",
+                "token": "tok",
+                "expires_at": None,
+            },
+        )
+
+        link = client.generate_download_url("my-sandbox", "/tmp/report.pdf")
+
+        assert link.expires_at is None
+
+    def test_download_url_optional_fields(
+        self, client: SandboxClient, httpx_mock: HTTPXMock
+    ):
+        """Test expiry and response headers are sent when provided."""
+        httpx_mock.add_response(
+            method="POST",
+            url="http://test-server:8080/boxes/my-sandbox/download-url",
+            json={"download_url": "http://d/tok", "token": "tok", "expires_at": None},
+        )
+
+        client.generate_download_url(
+            "my-sandbox",
+            "/tmp/page.html",
+            expires_in_seconds=3600,
+            content_type="text/html",
+            content_disposition="inline",
+        )
+
+        request = httpx_mock.get_request()
+        assert request is not None
+        body = json.loads(request.content)
+        assert body == {
+            "path": "/tmp/page.html",
+            "expires_in_seconds": 3600,
+            "content_type": "text/html",
+            "content_disposition": "inline",
+        }
+
+    def test_download_url_not_found(self, client: SandboxClient, httpx_mock: HTTPXMock):
+        """Test 404 raises ResourceNotFoundError."""
+        httpx_mock.add_response(
+            method="POST",
+            url="http://test-server:8080/boxes/nonexistent/download-url",
+            json={"detail": "Sandbox 'nonexistent' not found"},
+            status_code=404,
+        )
+
+        with pytest.raises(ResourceNotFoundError):
+            client.generate_download_url("nonexistent", "/tmp/f")
+
+    def test_download_url_invalid_expiry(self, client: SandboxClient):
+        """Test non-positive expires_in_seconds raises ValueError."""
+        with pytest.raises(ValueError, match="greater than 0"):
+            client.generate_download_url("my-sandbox", "/tmp/f", expires_in_seconds=0)
 
 
 class TestService:


### PR DESCRIPTION
## Overview

Exposes sandbox download links in the hand-written Python and JS sandbox clients. A download link serves one sandbox file with no LangSmith credential attached, for a browser tab, an `<a href>`, or a webhook consumer — anything that cannot send an API key the way `read()` requires.

Wraps `POST /api/v2/sandboxes/boxes/{name}/download-url`.

**Python** — `generate_download_url()` on `SandboxClient`, `AsyncSandboxClient`, `Sandbox`, and `AsyncSandbox`, returning a new `DownloadURL` model:

```python
link = sb.generate_download_url("/app/report.csv")
print(link.download_url)

link = sb.generate_download_url(
    "/app/page.html",
    expires_in_seconds=3600,
    content_type="text/html",
    content_disposition="inline",
)
print(link.expires_at)
```

**TypeScript** — `generateDownloadURL()` on `SandboxClient` and `Sandbox`, with `DownloadURL` and `GenerateDownloadURLOptions` types:

```typescript
const link = await sandbox.generateDownloadURL("/app/report.csv", {
  expiresInSeconds: 3600,
});
console.log(link.download_url);
```

Omitting the expiry mints a link that never expires, so `expires_at` is modeled as optional-and-omitted (`None` / `null`) rather than defaulting to a time — defaulting it would silently take the never-expires behavior away from callers. A non-positive expiry is rejected client-side.

Method naming matches `GenerateDownloadURL` / `generateDownloadUrl` in the generated Go and Java SDKs.

## Test plan

- [x] `uv run pytest tests/unit_tests/sandbox` (548 passed), `ruff check`, `ruff format --check`, `mypy langsmith/sandbox`
- [x] `tsc --noEmit`, `jest src/tests/sandbox.test.ts` (145 passed)
- [x] Unit (both languages): request body for the full option set, omission of unset options, `expires_at: null` preserved, 404 mapped to the not-found error, non-positive expiry rejected before any request
