### PR TITLE
fix: point migration guide links at their new per-area pages

### DIFF
--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -578,7 +578,7 @@ export type CreateFeedbackLegacyOptions = Omit<CreateFeedbackOptions, "key"> & {
   /**
    * The session (project) ID of the run. Required for run-level feedback;
    * omitting it is deprecated. See
-   * https://docs.langchain.com/langsmith/smithdb-sdk-migration#feedback-create
+   * https://docs.langchain.com/langsmith/smithdb-sdk-migration-feedback#feedback-create
    */
   sessionId?: string;
   /** The project (or experiment) to provide feedback on, for session-level feedback. */
@@ -2443,7 +2443,7 @@ export class Client implements LangSmithTracingClientInterface {
    */
   private async _checkFeedbackSessionId(): Promise<void> {
     const docs =
-      "https://docs.langchain.com/langsmith/smithdb-sdk-migration#feedback-create";
+      "https://docs.langchain.com/langsmith/smithdb-sdk-migration-feedback#feedback-create";
     const serverInfo = await this._ensureServerInfo();
     if (
       getQueryBackend(serverInfo.instance_flags) === QueryBackend.SMITHDB_ONLY
@@ -3178,7 +3178,7 @@ export class Client implements LangSmithTracingClientInterface {
     });
   }
 
-  /** @deprecated Use `client.runs.retrieve()` instead. See https://docs.langchain.com/langsmith/smithdb-sdk-migration#runs-retrieve for the migration guide. Will be removed after Jan 31, 2027. */
+  /** @deprecated Use `client.runs.retrieve()` instead. See https://docs.langchain.com/langsmith/smithdb-sdk-migration-runs#runs-retrieve for the migration guide. Will be removed after Jan 31, 2027. */
   public async readRun(
     runId: string,
     { loadChildRuns }: { loadChildRuns: boolean } = { loadChildRuns: false },
@@ -3186,7 +3186,7 @@ export class Client implements LangSmithTracingClientInterface {
     warnOnce(
       "readRun() is deprecated and will be removed after Jan 31, 2027. " +
         "Use client.runs.retrieve() instead. " +
-        "See https://docs.langchain.com/langsmith/smithdb-sdk-migration#runs-retrieve for the migration guide.",
+        "See https://docs.langchain.com/langsmith/smithdb-sdk-migration-runs#runs-retrieve for the migration guide.",
       { type: "DeprecationWarning", code: "LANGSMITH_DEPRECATED_READ_RUN" },
     );
     return this._readRun(runId, { loadChildRuns });
@@ -3212,7 +3212,7 @@ export class Client implements LangSmithTracingClientInterface {
     return run;
   }
 
-  /** @deprecated Use `client.runs.getURL()` instead. See https://docs.langchain.com/langsmith/smithdb-sdk-migration#runs-get-url for the migration guide. Will be removed after Jan 31, 2027. */
+  /** @deprecated Use `client.runs.getURL()` instead. See https://docs.langchain.com/langsmith/smithdb-sdk-migration-runs#runs-get-url for the migration guide. Will be removed after Jan 31, 2027. */
   public async getRunUrl({
     runId,
     run,
@@ -3225,7 +3225,7 @@ export class Client implements LangSmithTracingClientInterface {
     warnOnce(
       "getRunUrl() is deprecated and will be removed after Jan 31, 2027. " +
         "Use client.runs.getURL() instead. " +
-        "See https://docs.langchain.com/langsmith/smithdb-sdk-migration#runs-get-url for the migration guide.",
+        "See https://docs.langchain.com/langsmith/smithdb-sdk-migration-runs#runs-get-url for the migration guide.",
       { type: "DeprecationWarning", code: "LANGSMITH_DEPRECATED_GET_RUN_URL" },
     );
     if (run !== undefined) {
@@ -3305,7 +3305,7 @@ export class Client implements LangSmithTracingClientInterface {
 
   /**
    * List runs from the LangSmith server.
-   * @deprecated Use `client.runs.query()` instead. See https://docs.langchain.com/langsmith/smithdb-sdk-migration#runs-query for the migration guide. Will be removed after Jan 31, 2027.
+   * @deprecated Use `client.runs.query()` instead. See https://docs.langchain.com/langsmith/smithdb-sdk-migration-query-runs#runs-query for the migration guide. Will be removed after Jan 31, 2027.
    * @param projectId - The ID of the project to filter by.
    * @param projectName - The name of the project to filter by.
    * @param parentRunId - The ID of the parent run to filter by.
@@ -3390,7 +3390,7 @@ export class Client implements LangSmithTracingClientInterface {
     warnOnce(
       "listRuns() is deprecated and will be removed after Jan 31, 2027. " +
         "Use client.runs.query() instead. " +
-        "See https://docs.langchain.com/langsmith/smithdb-sdk-migration#runs-query for the migration guide.",
+        "See https://docs.langchain.com/langsmith/smithdb-sdk-migration-query-runs#runs-query for the migration guide.",
       { type: "DeprecationWarning", code: "LANGSMITH_DEPRECATED_LIST_RUNS" },
     );
     yield* this._listRuns(props);
@@ -3592,12 +3592,12 @@ export class Client implements LangSmithTracingClientInterface {
     }
   }
 
-  /** @deprecated Use `client.threads.listTraces()` instead. See https://docs.langchain.com/langsmith/smithdb-sdk-migration#threads-list-traces for the migration guide. Will be removed after Jan 31, 2027. */
+  /** @deprecated Use `client.threads.listTraces()` instead. See https://docs.langchain.com/langsmith/smithdb-sdk-migration-threads#threads-list-traces for the migration guide. Will be removed after Jan 31, 2027. */
   public async *readThread(props: ReadThreadParams): AsyncIterable<Run> {
     warnOnce(
       "readThread() is deprecated and will be removed after Jan 31, 2027. " +
         "Use client.threads.listTraces() instead. " +
-        "See https://docs.langchain.com/langsmith/smithdb-sdk-migration#threads-list-traces for the migration guide.",
+        "See https://docs.langchain.com/langsmith/smithdb-sdk-migration-threads#threads-list-traces for the migration guide.",
       { type: "DeprecationWarning", code: "LANGSMITH_DEPRECATED_READ_THREAD" },
     );
     const {
@@ -3631,14 +3631,14 @@ export class Client implements LangSmithTracingClientInterface {
     });
   }
 
-  /** @deprecated Use `client.threads.query()` instead. See https://docs.langchain.com/langsmith/smithdb-sdk-migration#threads-query for the migration guide. Will be removed after Jan 31, 2027. */
+  /** @deprecated Use `client.threads.query()` instead. See https://docs.langchain.com/langsmith/smithdb-sdk-migration-threads#threads-query for the migration guide. Will be removed after Jan 31, 2027. */
   public async listThreads(
     props: ListThreadsParams,
   ): Promise<ListThreadsItem[]> {
     warnOnce(
       "listThreads() is deprecated and will be removed after Jan 31, 2027. " +
         "Use client.threads.query() instead. " +
-        "See https://docs.langchain.com/langsmith/smithdb-sdk-migration#threads-query for the migration guide.",
+        "See https://docs.langchain.com/langsmith/smithdb-sdk-migration-threads#threads-query for the migration guide.",
       { type: "DeprecationWarning", code: "LANGSMITH_DEPRECATED_LIST_THREADS" },
     );
     const {
@@ -3864,7 +3864,7 @@ export class Client implements LangSmithTracingClientInterface {
     return result;
   }
 
-  /** @deprecated Use `client.runs.share.create()` instead. See https://docs.langchain.com/langsmith/smithdb-sdk-migration#share-and-read-public-runs for the migration guide. Will be removed after Jan 31, 2027. */
+  /** @deprecated Use `client.runs.share.create()` instead. See https://docs.langchain.com/langsmith/smithdb-sdk-migration-feedback#share-and-read-public-runs for the migration guide. Will be removed after Jan 31, 2027. */
   public async shareRun(
     runId: string,
     { shareId }: { shareId?: string } = {},
@@ -3872,7 +3872,7 @@ export class Client implements LangSmithTracingClientInterface {
     warnOnce(
       "shareRun() is deprecated and will be removed after Jan 31, 2027. " +
         "Use client.runs.share.create() instead. " +
-        "See https://docs.langchain.com/langsmith/smithdb-sdk-migration#share-and-read-public-runs for the migration guide.",
+        "See https://docs.langchain.com/langsmith/smithdb-sdk-migration-feedback#share-and-read-public-runs for the migration guide.",
       { type: "DeprecationWarning", code: "LANGSMITH_DEPRECATED_SHARE_RUN" },
     );
     const data = {
@@ -3899,12 +3899,12 @@ export class Client implements LangSmithTracingClientInterface {
     return `${this.getHostUrl()}/public/${result["share_token"]}/r`;
   }
 
-  /** @deprecated Use `client.runs.share.delete()` instead. See https://docs.langchain.com/langsmith/smithdb-sdk-migration#share-and-read-public-runs for the migration guide. Will be removed after Jan 31, 2027. */
+  /** @deprecated Use `client.runs.share.delete()` instead. See https://docs.langchain.com/langsmith/smithdb-sdk-migration-feedback#share-and-read-public-runs for the migration guide. Will be removed after Jan 31, 2027. */
   public async unshareRun(runId: string): Promise<void> {
     warnOnce(
       "unshareRun() is deprecated and will be removed after Jan 31, 2027. " +
         "Use client.runs.share.delete() instead. " +
-        "See https://docs.langchain.com/langsmith/smithdb-sdk-migration#share-and-read-public-runs for the migration guide.",
+        "See https://docs.langchain.com/langsmith/smithdb-sdk-migration-feedback#share-and-read-public-runs for the migration guide.",
       { type: "DeprecationWarning", code: "LANGSMITH_DEPRECATED_UNSHARE_RUN" },
     );
     assertUuid(runId);
@@ -3920,12 +3920,12 @@ export class Client implements LangSmithTracingClientInterface {
     });
   }
 
-  /** @deprecated Use `client.runs.retrieve({ selects: ["SHARE_URL"] })` instead. See https://docs.langchain.com/langsmith/smithdb-sdk-migration#share-and-read-public-runs for the migration guide. Will be removed after Jan 31, 2027. */
+  /** @deprecated Use `client.runs.retrieve({ selects: ["SHARE_URL"] })` instead. See https://docs.langchain.com/langsmith/smithdb-sdk-migration-feedback#share-and-read-public-runs for the migration guide. Will be removed after Jan 31, 2027. */
   public async readRunSharedLink(runId: string): Promise<string | undefined> {
     warnOnce(
       "readRunSharedLink() is deprecated and will be removed after Jan 31, 2027. " +
         'Use client.runs.retrieve({ selects: ["SHARE_URL"] }) instead. ' +
-        "See https://docs.langchain.com/langsmith/smithdb-sdk-migration#share-and-read-public-runs for the migration guide.",
+        "See https://docs.langchain.com/langsmith/smithdb-sdk-migration-feedback#share-and-read-public-runs for the migration guide.",
       {
         type: "DeprecationWarning",
         code: "LANGSMITH_DEPRECATED_READ_RUN_SHARED_LINK",
@@ -3949,7 +3949,7 @@ export class Client implements LangSmithTracingClientInterface {
     return `${this.getHostUrl()}/public/${result["share_token"]}/r`;
   }
 
-  /** @deprecated Use `client.public.runs.query()` instead. See https://docs.langchain.com/langsmith/smithdb-sdk-migration#share-and-read-public-runs for the migration guide. Will be removed after Jan 31, 2027. */
+  /** @deprecated Use `client.public.runs.query()` instead. See https://docs.langchain.com/langsmith/smithdb-sdk-migration-feedback#share-and-read-public-runs for the migration guide. Will be removed after Jan 31, 2027. */
   public async listSharedRuns(
     shareToken: string,
     {
@@ -3961,7 +3961,7 @@ export class Client implements LangSmithTracingClientInterface {
     warnOnce(
       "listSharedRuns() is deprecated and will be removed after Jan 31, 2027. " +
         "Use client.public.runs.query() instead. " +
-        "See https://docs.langchain.com/langsmith/smithdb-sdk-migration#share-and-read-public-runs for the migration guide.",
+        "See https://docs.langchain.com/langsmith/smithdb-sdk-migration-feedback#share-and-read-public-runs for the migration guide.",
       {
         type: "DeprecationWarning",
         code: "LANGSMITH_DEPRECATED_LIST_SHARED_RUNS",
@@ -6250,7 +6250,7 @@ export class Client implements LangSmithTracingClientInterface {
    *   by SmithDB; routes to `POST /runs/by-key`.
    * - `string[]`: a plain list of run IDs. **Deprecated**: this path will be
    *   removed after Jan 31, 2027; prefer the key form. Routes to `POST /runs`.
-   *   See https://docs.langchain.com/langsmith/smithdb-sdk-migration#annotation-queues-add-runs.
+   *   See https://docs.langchain.com/langsmith/smithdb-sdk-migration-feedback#annotation-queues-add-runs.
    *
    * If every element is a string (or the list is empty) it is treated as run
    * IDs; otherwise the list is treated as `RunKey` objects.
@@ -6299,7 +6299,7 @@ export class Client implements LangSmithTracingClientInterface {
       warnOnce(
         "Passing run IDs as strings to addRunsToAnnotationQueue() is deprecated and will be removed after Jan 31, 2027. " +
           "Use RunKey[] instead. " +
-          "See https://docs.langchain.com/langsmith/smithdb-sdk-migration#annotation-queues-add-runs for the migration guide.",
+          "See https://docs.langchain.com/langsmith/smithdb-sdk-migration-feedback#annotation-queues-add-runs for the migration guide.",
         {
           type: "DeprecationWarning",
           code: "LANGSMITH_DEPRECATED_ADD_RUNS_STRING_IDS",

--- a/js/src/tests/client.test.ts
+++ b/js/src/tests/client.test.ts
@@ -219,7 +219,9 @@ describe("Client", () => {
       );
 
       expect(warn).toHaveBeenCalledWith(
-        expect.stringContaining("smithdb-sdk-migration-feedback#feedback-create"),
+        expect.stringContaining(
+          "smithdb-sdk-migration-feedback#feedback-create",
+        ),
       );
       expect(paths()).toContain("/feedback");
       warn.mockRestore();

--- a/js/src/tests/client.test.ts
+++ b/js/src/tests/client.test.ts
@@ -219,7 +219,7 @@ describe("Client", () => {
       );
 
       expect(warn).toHaveBeenCalledWith(
-        expect.stringContaining("smithdb-sdk-migration#feedback-create"),
+        expect.stringContaining("smithdb-sdk-migration-feedback#feedback-create"),
       );
       expect(paths()).toContain("/feedback");
       warn.mockRestore();

--- a/python/langsmith/async_client.py
+++ b/python/langsmith/async_client.py
@@ -650,7 +650,7 @@ class AsyncClient:
         .. admonition:: Deprecated
 
             Use :meth:`langsmith.AsyncClient.runs.retrieve` instead.
-            See https://docs.langchain.com/langsmith/smithdb-sdk-migration#runs-retrieve for the migration guide.
+            See https://docs.langchain.com/langsmith/smithdb-sdk-migration-runs#runs-retrieve for the migration guide.
             Will be removed after Jan 31, 2027.
 
         Args:
@@ -715,7 +715,7 @@ class AsyncClient:
         .. admonition:: Deprecated
 
             Use :meth:`langsmith.AsyncClient.runs.query` instead.
-            See https://docs.langchain.com/langsmith/smithdb-sdk-migration#runs-query for the migration guide.
+            See https://docs.langchain.com/langsmith/smithdb-sdk-migration-query-runs#runs-query for the migration guide.
             Will be removed after Jan 31, 2027.
 
         Args:
@@ -871,7 +871,7 @@ class AsyncClient:
         .. admonition:: Deprecated
 
             Use :meth:`langsmith.AsyncClient.runs.share.create` instead.
-            See https://docs.langchain.com/langsmith/smithdb-sdk-migration#share-and-read-public-runs for the migration guide.
+            See https://docs.langchain.com/langsmith/smithdb-sdk-migration-feedback#share-and-read-public-runs for the migration guide.
             Will be removed after Jan 31, 2027.
 
         Args:
@@ -918,7 +918,7 @@ class AsyncClient:
         .. admonition:: Deprecated
 
             Use :meth:`langsmith.AsyncClient.runs.retrieve` with ``selects=["SHARE_URL"]`` instead.
-            See https://docs.langchain.com/langsmith/smithdb-sdk-migration#share-and-read-public-runs for the migration guide.
+            See https://docs.langchain.com/langsmith/smithdb-sdk-migration-feedback#share-and-read-public-runs for the migration guide.
             Will be removed after Jan 31, 2027.
 
         Args:
@@ -1159,7 +1159,7 @@ class AsyncClient:
             error: Whether the feedback represents an error.
             session_id: The project ID of the run. Required for run-level feedback;
                 omitting it is deprecated. See
-                https://docs.langchain.com/langsmith/smithdb-sdk-migration#feedback-create
+                https://docs.langchain.com/langsmith/smithdb-sdk-migration-feedback#feedback-create
             start_time: The start time of the run. Better performance if provided.
             comment: A comment about this feedback.
             extend_trace_retention: If false, create the feedback without
@@ -1580,7 +1580,7 @@ class AsyncClient:
           without a scan, and is required for workspaces served by SmithDB.
         - `run_ids`: a plain list of run IDs. This path is deprecated and will
           be removed after Jan 31, 2027; prefer `runs`.
-          See https://docs.langchain.com/langsmith/smithdb-sdk-migration#annotation-queues-add-runs.
+          See https://docs.langchain.com/langsmith/smithdb-sdk-migration-feedback#annotation-queues-add-runs.
 
         Args:
             queue_id (Union[UUID, str]): The ID of the annotation queue.
@@ -1604,7 +1604,7 @@ class AsyncClient:
             warnings.warn(
                 "The run_ids parameter of add_runs_to_annotation_queue() is deprecated and will be removed after Jan 31, 2027. "
                 "Use the runs parameter with RunKey objects instead. "
-                "See https://docs.langchain.com/langsmith/smithdb-sdk-migration#annotation-queues-add-runs for the migration guide.",
+                "See https://docs.langchain.com/langsmith/smithdb-sdk-migration-feedback#annotation-queues-add-runs for the migration guide.",
                 DeprecationWarning,
                 stacklevel=2,
             )

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -758,7 +758,7 @@ def _check_feedback_session_id(info: ls_schemas.LangSmithInfo) -> None:
 
     Call only when run-level feedback has no ``session_id``.
     """
-    docs = "https://docs.langchain.com/langsmith/smithdb-sdk-migration#feedback-create"
+    docs = "https://docs.langchain.com/langsmith/smithdb-sdk-migration-feedback#feedback-create"
     if get_query_backend(info.instance_flags) == QueryBackend.SMITHDB_ONLY:
         raise ValueError(
             "session_id must be provided when creating feedback for a run:"
@@ -4184,7 +4184,7 @@ class Client:
         .. admonition:: Deprecated
 
             Use :meth:`langsmith.Client.runs.retrieve` instead.
-            See https://docs.langchain.com/langsmith/smithdb-sdk-migration#runs-retrieve for the migration guide.
+            See https://docs.langchain.com/langsmith/smithdb-sdk-migration-runs#runs-retrieve for the migration guide.
             Will be removed after Jan 31, 2027.
 
         Args:
@@ -4278,7 +4278,7 @@ class Client:
         .. admonition:: Deprecated
 
             Use :meth:`langsmith.Client.threads.list_traces` instead.
-            See https://docs.langchain.com/langsmith/smithdb-sdk-migration#threads-list-traces for the migration guide.
+            See https://docs.langchain.com/langsmith/smithdb-sdk-migration-threads#threads-list-traces for the migration guide.
             Will be removed after Jan 31, 2027.
 
         Args:
@@ -4357,7 +4357,7 @@ class Client:
         .. admonition:: Deprecated
 
             Use :meth:`langsmith.Client.runs.query` instead.
-            See https://docs.langchain.com/langsmith/smithdb-sdk-migration#runs-query for the migration guide.
+            See https://docs.langchain.com/langsmith/smithdb-sdk-migration-query-runs#runs-query for the migration guide.
             Will be removed after Jan 31, 2027.
 
         Args:
@@ -4552,7 +4552,7 @@ class Client:
         .. admonition:: Deprecated
 
             Use :meth:`langsmith.Client.threads.query` instead.
-            See https://docs.langchain.com/langsmith/smithdb-sdk-migration#threads-query for the migration guide.
+            See https://docs.langchain.com/langsmith/smithdb-sdk-migration-threads#threads-query for the migration guide.
             Will be removed after Jan 31, 2027.
 
         Args:
@@ -4781,7 +4781,7 @@ class Client:
         .. admonition:: Deprecated
 
             Use :meth:`langsmith.Client.runs.get_url` instead.
-            See https://docs.langchain.com/langsmith/smithdb-sdk-migration#runs-get-url for the migration guide.
+            See https://docs.langchain.com/langsmith/smithdb-sdk-migration-runs#runs-get-url for the migration guide.
             Will be removed after Jan 31, 2027.
 
         Args:
@@ -4836,7 +4836,7 @@ class Client:
         .. admonition:: Deprecated
 
             Use :meth:`langsmith.Client.runs.share.create` instead.
-            See https://docs.langchain.com/langsmith/smithdb-sdk-migration#share-and-read-public-runs for the migration guide.
+            See https://docs.langchain.com/langsmith/smithdb-sdk-migration-feedback#share-and-read-public-runs for the migration guide.
             Will be removed after Jan 31, 2027.
 
         Args:
@@ -4874,7 +4874,7 @@ class Client:
         .. admonition:: Deprecated
 
             Use :meth:`langsmith.Client.runs.share.delete` instead.
-            See https://docs.langchain.com/langsmith/smithdb-sdk-migration#share-and-read-public-runs for the migration guide.
+            See https://docs.langchain.com/langsmith/smithdb-sdk-migration-feedback#share-and-read-public-runs for the migration guide.
             Will be removed after Jan 31, 2027.
 
         Args:
@@ -4902,7 +4902,7 @@ class Client:
         .. admonition:: Deprecated
 
             Use :meth:`langsmith.Client.runs.retrieve` with ``selects=["SHARE_URL"]`` instead.
-            See https://docs.langchain.com/langsmith/smithdb-sdk-migration#share-and-read-public-runs for the migration guide.
+            See https://docs.langchain.com/langsmith/smithdb-sdk-migration-feedback#share-and-read-public-runs for the migration guide.
             Will be removed after Jan 31, 2027.
 
         Args:
@@ -4950,7 +4950,7 @@ class Client:
         .. admonition:: Deprecated
 
             Use :meth:`langsmith.Client.public.runs.retrieve` instead.
-            See https://docs.langchain.com/langsmith/smithdb-sdk-migration#share-and-read-public-runs for the migration guide.
+            See https://docs.langchain.com/langsmith/smithdb-sdk-migration-feedback#share-and-read-public-runs for the migration guide.
             Will be removed after Jan 31, 2027.
 
         Args:
@@ -4987,7 +4987,7 @@ class Client:
         .. admonition:: Deprecated
 
             Use :meth:`langsmith.Client.public.runs.query` instead.
-            See https://docs.langchain.com/langsmith/smithdb-sdk-migration#share-and-read-public-runs for the migration guide.
+            See https://docs.langchain.com/langsmith/smithdb-sdk-migration-feedback#share-and-read-public-runs for the migration guide.
             Will be removed after Jan 31, 2027.
 
         Args:
@@ -8241,7 +8241,7 @@ class Client:
             session_id (Optional[Union[UUID, str]]):
                 The session (project) ID of the run. Required for run-level
                 feedback; omitting it is deprecated. See
-                https://docs.langchain.com/langsmith/smithdb-sdk-migration#feedback-create
+                https://docs.langchain.com/langsmith/smithdb-sdk-migration-feedback#feedback-create
             start_time (Optional[datetime]):
                 The start time of the run. Better performance if provided.
             extend_trace_retention (bool, default=True):
@@ -9270,7 +9270,7 @@ class Client:
           without a scan, and is required for workspaces served by SmithDB.
         - `run_ids`: a plain list of run IDs. This path is deprecated and will
           be removed after Jan 31, 2027; prefer `runs`.
-          See https://docs.langchain.com/langsmith/smithdb-sdk-migration#annotation-queues-add-runs.
+          See https://docs.langchain.com/langsmith/smithdb-sdk-migration-feedback#annotation-queues-add-runs.
 
         Args:
             queue_id (Union[UUID, str]): The ID of the annotation queue.
@@ -9294,7 +9294,7 @@ class Client:
             warnings.warn(
                 "The run_ids parameter of add_runs_to_annotation_queue() is deprecated and will be removed after Jan 31, 2027. "
                 "Use the runs parameter with RunKey objects instead. "
-                "See https://docs.langchain.com/langsmith/smithdb-sdk-migration#annotation-queues-add-runs for the migration guide.",
+                "See https://docs.langchain.com/langsmith/smithdb-sdk-migration-feedback#annotation-queues-add-runs for the migration guide.",
                 DeprecationWarning,
                 stacklevel=2,
             )
@@ -11156,7 +11156,7 @@ class Client:
         .. admonition:: Deprecated
 
             Use :meth:`langsmith.Client.datasets.experiment_runs.query` instead.
-            See https://docs.langchain.com/langsmith/smithdb-sdk-migration#dataset-experiment-runs-query for the migration guide.
+            See https://docs.langchain.com/langsmith/smithdb-sdk-migration-experiments#dataset-experiment-runs-query for the migration guide.
             Will be removed after Jan 31, 2027.
 
         Experiment results may not be available immediately after the experiment is created.


### PR DESCRIPTION
## Problem

[docs#5504](https://github.com/langchain-ai/docs/pull/5504) split the SmithDB SDK
migration guide into one page per method area. The anchors moved with their content, so
every `…/smithdb-sdk-migration#<method>` link in this repo now lands on the overview
page with no matching anchor. That is the worst place for it to break: these links are
what a deprecation warning hands the user at the moment they hit the deprecated call,
and they now get the top of an overview instead of the before/after for their method.

## Change

Repointed each deep link at the page that holds its anchor — 45 links across
`python/langsmith/client.py`, `python/langsmith/async_client.py`, `js/src/client.ts`,
and one test expectation. Bare links to the overview page (no anchor) are unchanged;
that page still exists and is still the right target for version/deprecation-date
context.

| fragment | page |
|---|---|
| `runs-query` | `smithdb-sdk-migration-query-runs` |
| `runs-retrieve`, `runs-get-url` | `smithdb-sdk-migration-runs` |
| `threads-query`, `threads-list-traces` | `smithdb-sdk-migration-threads` |
| `dataset-experiment-runs-query` | `smithdb-sdk-migration-experiments` |
| `annotation-queues-add-runs`, `share-and-read-public-runs`, `feedback-create` | `smithdb-sdk-migration-feedback` |

The same fix for the backend's `Link: rel="deprecation"` headers, 501 details, and
generated-SDK deprecation messages is
[langchainplus#34597](https://github.com/langchain-ai/langchainplus/pull/34597).

## Testing

- `python: make lint` — ruff clean; the one mypy error is the pre-existing
  `langsmith/utils.py:792` override on `main`, untouched here.
- `js: pnpm run lint` and `pnpm run build` — clean (no new warnings; build typechecks
  both ESM and CJS).
- Test suites left to CI; the only test change is one expected URL string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
