### PR TITLE
release(py/js): 0.11.1 / 0.8.12

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langsmith",
-  "version": "0.8.11",
+  "version": "0.8.12",
   "description": "Client library to connect to the LangSmith Observability and Evaluation Platform.",
   "packageManager": "pnpm@10.33.0",
   "files": [

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -54,7 +54,7 @@ export {
 } from "./_openapi_client/core/error.js";
 
 // Update using pnpm bump-version
-export const __version__ = "0.8.11";
+export const __version__ = "0.8.12";
 
 // Metadata key to hide a traced run from LangSmith's Messages View.
 export const LS_MESSAGE_VIEW_EXCLUDE = "ls_message_view_exclude" as const;

--- a/python/.bumpversion.cfg
+++ b/python/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.11.0
+current_version = 0.11.1
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
 serialize = {major}.{minor}.{patch}
 search = {current_version}

--- a/python/langsmith/__init__.py
+++ b/python/langsmith/__init__.py
@@ -49,7 +49,7 @@ if TYPE_CHECKING:
 
 # Avoid calling into importlib on every call to __version__
 
-__version__ = "0.11.0"
+__version__ = "0.11.1"
 version = __version__  # for backwards compatibility
 
 # Metadata key to hide a traced run from LangSmith's Messages View.


### PR DESCRIPTION
## Description
Bumps Python from 0.11.0 to 0.11.1 and JS from 0.8.11 to 0.8.12 in one release PR.

## Test Plan
- [x] Python `make format`, `make lint`, and `make tests` (1,983 passed, 6 skipped)
- [x] JS `pnpm format`, `pnpm lint`, and `pnpm test` (870 passed, 2 skipped)
- [x] JS version and npm publication checks

Made by [Open SWE](https://openswe.vercel.app/agents/27f73bac-85e0-5a00-96cb-be3c867d0a9f)