### PR TITLE
release(js): 0.8.12

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langsmith",
-  "version": "0.8.11",
+  "version": "0.8.12",
   "description": "Client library to connect to the LangSmith Observability and Evaluation Platform.",
   "packageManager": "pnpm@10.33.0",
   "files": [

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -54,7 +54,7 @@ export {
 } from "./_openapi_client/core/error.js";
 
 // Update using pnpm bump-version
-export const __version__ = "0.8.11";
+export const __version__ = "0.8.12";
 
 // Metadata key to hide a traced run from LangSmith's Messages View.
 export const LS_MESSAGE_VIEW_EXCLUDE = "ls_message_view_exclude" as const;


### PR DESCRIPTION
## Description
Bumps the JS SDK from 0.8.11 to 0.8.12 so merged fixes and sandbox improvements can be published.

## Test Plan
- [x] `pnpm format`, `pnpm lint`, and `pnpm test` (870 passed, 2 skipped)
- [x] `pnpm run check-version` and `pnpm run check-npm-version`

Made by [Open SWE](https://openswe.vercel.app/agents/27f73bac-85e0-5a00-96cb-be3c867d0a9f)