### PR TITLE
feat(js): Avoid redundantly sending inputs up in patch

### DIFF
--- a/js/src/run_trees.ts
+++ b/js/src/run_trees.ts
@@ -266,6 +266,11 @@ class Baggage {
   }
 }
 
+function getExcludeInputsOnPatch(): boolean {
+  const value = getLangSmithEnvironmentVariable("EXCLUDE_INPUTS_ON_PATCH");
+  return value === undefined || value.toLowerCase() === "true" || value === "1";
+}
+
 export class RunTree implements BaseRun {
   private static sharedClient: Client | null = null;
 
@@ -856,7 +861,20 @@ export class RunTree implements BaseRun {
     }
   }
 
+  /**
+   * Patch the run tree to the API.
+   *
+   * @param options.excludeInputs - Whether to exclude inputs from the patch
+   * request. Defaults to the value of `LANGSMITH_EXCLUDE_INPUTS_ON_PATCH`
+   * (or its `LANGCHAIN_` equivalent), which itself defaults to `true`.
+   * An explicit value overrides the environment variable for this call.
+   *
+   * Unless the environment variable is disabled, inputs added after the
+   * initial `postRun()` are not persisted unless this option is explicitly set
+   * to `false`.
+   */
   async patchRun(options?: { excludeInputs?: boolean }): Promise<void> {
+    const excludeInputs = options?.excludeInputs ?? getExcludeInputsOnPatch();
     if (this.replicas && this.replicas.length > 0) {
       for (const {
         projectName,
@@ -901,7 +919,7 @@ export class RunTree implements BaseRun {
         // Important that inputs is not a key in the run update
         // if excluded because it will overwrite the run create if the
         // two operations are merged during batching
-        if (!options?.excludeInputs) {
+        if (!excludeInputs) {
           updatePayload.inputs = runData.inputs;
         }
         const targetClient = replicaClient ?? this.client;
@@ -933,7 +951,7 @@ export class RunTree implements BaseRun {
         // Important that inputs is not a key in the run update
         // if excluded because it will overwrite the run create if the
         // two operations are merged during batching
-        if (!options?.excludeInputs) {
+        if (!excludeInputs) {
           runUpdate.inputs = this.inputs;
         }
         await this.client.updateRun(this.id, runUpdate);

--- a/js/src/tests/openai_agents_sdk.test.ts
+++ b/js/src/tests/openai_agents_sdk.test.ts
@@ -369,6 +369,8 @@ describe("OpenAIAgentsTracingProcessor", () => {
     });
 
     test("derives agent inputs and outputs from child response spans", async () => {
+      const createRunSpy = jest.spyOn(client, "createRun");
+      const updateRunSpy = jest.spyOn(client, "updateRun");
       const trace = createMockTrace("trace-4b", "Test Agent");
       const agentSpan = createMockSpan("trace-4b", "span-agent", null, {
         type: "agent",
@@ -425,8 +427,17 @@ describe("OpenAIAgentsTracingProcessor", () => {
 
       await client.awaitPendingTraceBatches();
 
+      expect(
+        createRunSpy.mock.calls.filter(([run]) => run.name === "WeatherAgent"),
+      ).toHaveLength(1);
+      expect(
+        updateRunSpy.mock.calls.filter(
+          ([, run]) => run.name === "WeatherAgent",
+        ),
+      ).toHaveLength(0);
+
       const tree = await getAssumedTreeFromCalls(callSpy.mock.calls, client);
-      const agentNode = tree.nodes.find((n) => n.includes("WeatherAgent"));
+      const agentNode = tree.nodes.find((n) => n.startsWith("WeatherAgent:"));
       expect(agentNode).toBeDefined();
       if (agentNode) {
         expect(tree.data[agentNode].inputs).toMatchObject({

--- a/js/src/tests/run_trees.test.ts
+++ b/js/src/tests/run_trees.test.ts
@@ -650,3 +650,109 @@ test("fromHeaders drops a non-boolean replica primary value", () => {
   const remapped = (parsed as any)._remapForProject(replica);
   expect(remapped.id).not.toBe(parsed!.id);
 });
+
+describe("LANGSMITH_EXCLUDE_INPUTS_ON_PATCH", () => {
+  const originalLangSmithValue = process.env.LANGSMITH_EXCLUDE_INPUTS_ON_PATCH;
+  const originalLangChainValue = process.env.LANGCHAIN_EXCLUDE_INPUTS_ON_PATCH;
+
+  beforeEach(() => {
+    delete process.env.LANGSMITH_EXCLUDE_INPUTS_ON_PATCH;
+    delete process.env.LANGCHAIN_EXCLUDE_INPUTS_ON_PATCH;
+  });
+
+  afterEach(() => {
+    if (originalLangSmithValue === undefined) {
+      delete process.env.LANGSMITH_EXCLUDE_INPUTS_ON_PATCH;
+    } else {
+      process.env.LANGSMITH_EXCLUDE_INPUTS_ON_PATCH = originalLangSmithValue;
+    }
+    if (originalLangChainValue === undefined) {
+      delete process.env.LANGCHAIN_EXCLUDE_INPUTS_ON_PATCH;
+    } else {
+      process.env.LANGCHAIN_EXCLUDE_INPUTS_ON_PATCH = originalLangChainValue;
+    }
+  });
+
+  test.each([
+    ["env unset", undefined, undefined, undefined, false],
+    ["true", "LANGSMITH_EXCLUDE_INPUTS_ON_PATCH", "true", undefined, false],
+    ["TRUE", "LANGSMITH_EXCLUDE_INPUTS_ON_PATCH", "TRUE", undefined, false],
+    ["1", "LANGSMITH_EXCLUDE_INPUTS_ON_PATCH", "1", undefined, false],
+    ["false", "LANGSMITH_EXCLUDE_INPUTS_ON_PATCH", "false", undefined, true],
+    ["bogus", "LANGSMITH_EXCLUDE_INPUTS_ON_PATCH", "bogus", undefined, true],
+    [
+      "LANGCHAIN namespace",
+      "LANGCHAIN_EXCLUDE_INPUTS_ON_PATCH",
+      "true",
+      undefined,
+      false,
+    ],
+    [
+      "explicit false override",
+      "LANGSMITH_EXCLUDE_INPUTS_ON_PATCH",
+      "true",
+      false,
+      true,
+    ],
+    ["explicit true override", undefined, undefined, true, false],
+  ] as const)(
+    "%s",
+    async (_name, envName, envValue, explicit, expectInputs) => {
+      if (envName !== undefined && envValue !== undefined) {
+        process.env[envName] = envValue;
+      }
+
+      const { client } = mockClient();
+      const updateSpy = jest.spyOn(client, "updateRun");
+      const runTree = new RunTree({
+        name: "test-run",
+        inputs: { a: 1 },
+        client,
+      });
+
+      await runTree.patchRun(
+        explicit === undefined ? undefined : { excludeInputs: explicit },
+      );
+
+      const payload = updateSpy.mock.calls[0][1];
+      expect("inputs" in payload).toBe(expectInputs);
+      if (expectInputs) {
+        expect(payload.inputs).toEqual({ a: 1 });
+      }
+    },
+  );
+
+  test("applies to replica patches", async () => {
+    process.env.LANGSMITH_EXCLUDE_INPUTS_ON_PATCH = "true";
+    const { client } = mockClient();
+    const updateSpy = jest.spyOn(client, "updateRun");
+    const runTree = new RunTree({
+      name: "test-run",
+      inputs: { a: 1 },
+      client,
+      project_name: "test-project",
+      replicas: [{ projectName: "replica-project" }],
+    });
+
+    await runTree.patchRun();
+
+    expect("inputs" in updateSpy.mock.calls[0][1]).toBe(false);
+  });
+
+  test("reads the environment for each implicit patch", async () => {
+    const { client } = mockClient();
+    const updateSpy = jest.spyOn(client, "updateRun");
+    const runTree = new RunTree({
+      name: "test-run",
+      inputs: { a: 1 },
+      client,
+    });
+
+    await runTree.patchRun();
+    expect("inputs" in updateSpy.mock.calls[0][1]).toBe(false);
+
+    process.env.LANGSMITH_EXCLUDE_INPUTS_ON_PATCH = "false";
+    await runTree.patchRun();
+    expect(updateSpy.mock.calls[1][1].inputs).toEqual({ a: 1 });
+  });
+});

--- a/js/src/wrappers/openai_agents.ts
+++ b/js/src/wrappers/openai_agents.ts
@@ -804,6 +804,7 @@ export class OpenAIAgentsTracingProcessor implements TracingProcessor {
       if (
         spanData.type === "generation" ||
         spanData.type === "response" ||
+        spanData.type === "agent" ||
         spanData.type === "function" ||
         spanData.type === "handoff"
       ) {
@@ -917,9 +918,7 @@ export class OpenAIAgentsTracingProcessor implements TracingProcessor {
         this._unpostedSpans.delete(span.spanId);
         await run.postRun();
       } else {
-        await run.patchRun(
-          span.spanData.type === "agent" ? undefined : { excludeInputs: true },
-        );
+        await run.patchRun({ excludeInputs: true });
       }
     } catch (e) {
       console.error("Error updating span run:", e);


### PR DESCRIPTION
Fixes #3415, follow-on from https://github.com/langchain-ai/langsmith-sdk/pull/3350