### PR TITLE
Fix feedback_config silently dropping unknown dict keys

### DIFF
--- a/python/langsmith/evaluation/evaluator.py
+++ b/python/langsmith/evaluation/evaluator.py
@@ -85,7 +85,9 @@ class EvaluationResult(BaseModel):
     """What the correct value should be, if applicable."""
     evaluator_info: dict = Field(default_factory=dict)
     """Additional information about the evaluator."""
-    feedback_config: Optional[Union[FeedbackConfig, dict]] = None
+    feedback_config: Optional[Union[dict, FeedbackConfig]] = Field(
+        default=None, union_mode="left_to_right"
+    )
     """The configuration used to generate this feedback."""
     source_run_id: Optional[Union[uuid.UUID, str]] = None
     """The ID of the trace of the evaluator itself."""


### PR DESCRIPTION
Fixes #31802. FeedbackConfig is a TypedDict with all-optional fields, so under Pydantic v2 smart-union mode, arbitrary dicts passed to feedback_config validated against FeedbackConfig first and silently lost any keys outside its schema. Forces dict to be tried first via union_mode=left_to_right.