### PR TITLE
feat(sandbox): support proxy_config in update_sandbox (Python + JS)

### DIFF
--- a/js/src/sandbox/client.ts
+++ b/js/src/sandbox/client.ts
@@ -36,6 +36,7 @@ import {
 import {
   handleClientHttpError,
   handleSandboxCreationError,
+  throwIfNotReady,
   validateTtl,
 } from "./helpers.js";
 import { validateMountConfigProxyConfig } from "./mounts.js";
@@ -695,8 +696,8 @@ export class SandboxClient {
    */
   async updateSandbox(name: string, newName: string): Promise<Sandbox>;
   /**
-   * Update a sandbox's name and/or retention settings (idle stop and
-   * delete-after-stop).
+   * Update a sandbox's name, retention settings (idle stop and
+   * delete-after-stop), and/or proxy config.
    *
    * @param name - Current sandbox name.
    * @param options - Fields to update. Omit a field to leave it unchanged.
@@ -704,6 +705,8 @@ export class SandboxClient {
    * @throws LangSmithResourceNotFoundError if sandbox not found.
    * @throws LangSmithResourceNameConflictError if newName is already in use.
    * @throws LangSmithValidationError if retention values are invalid.
+   * @throws LangSmithSandboxNotReadyError if proxyConfig was given and the
+   * sandbox is not `ready`.
    */
   async updateSandbox(
     name: string,
@@ -718,14 +721,16 @@ export class SandboxClient {
         ? { newName: newNameOrOptions }
         : newNameOrOptions;
 
-    const { newName, idleTtlSeconds, deleteAfterStopSeconds } = options;
+    const { newName, idleTtlSeconds, deleteAfterStopSeconds, proxyConfig } =
+      options;
     validateTtl(idleTtlSeconds, "idleTtlSeconds");
     validateTtl(deleteAfterStopSeconds, "deleteAfterStopSeconds");
 
     if (
       newName === undefined &&
       idleTtlSeconds === undefined &&
-      deleteAfterStopSeconds === undefined
+      deleteAfterStopSeconds === undefined &&
+      proxyConfig === undefined
     ) {
       return this.getSandbox(name);
     }
@@ -740,6 +745,9 @@ export class SandboxClient {
     }
     if (deleteAfterStopSeconds !== undefined) {
       payload.delete_after_stop_seconds = deleteAfterStopSeconds;
+    }
+    if (proxyConfig !== undefined) {
+      payload.proxy_config = proxyConfig;
     }
 
     const response = await this._fetch(url, {
@@ -762,6 +770,9 @@ export class SandboxClient {
             : "Sandbox update conflict (name may already be in use)",
           "sandbox",
         );
+      }
+      if (proxyConfig !== undefined) {
+        await throwIfNotReady(response, name);
       }
       await handleClientHttpError(response);
     }

--- a/js/src/sandbox/helpers.ts
+++ b/js/src/sandbox/helpers.ts
@@ -208,6 +208,31 @@ export async function handleSandboxCreationError(
 }
 
 /**
+ * Throw `LangSmithSandboxNotReadyError` when the API rejected a proxy-config
+ * update because the sandbox is not `ready`.
+ *
+ * That status check is the sole source of `InvalidRequest` on the update
+ * endpoint for the fields this client sends, so a typed error lets callers
+ * start the sandbox and retry instead of matching on status codes. Reads a
+ * clone so the caller's own error handling can still consume the body.
+ */
+export async function throwIfNotReady(
+  response: Response,
+  name: string,
+): Promise<void> {
+  if (response.status !== 400) {
+    return;
+  }
+  const data = await parseErrorResponse(response.clone());
+  if (data.errorType !== "InvalidRequest") {
+    return;
+  }
+  throw new LangSmithSandboxNotReadyError(
+    data.message || `Sandbox '${name}' is not ready`,
+  );
+}
+
+/**
  * Handle HTTP errors and raise appropriate exceptions (for client operations).
  */
 export async function handleClientHttpError(

--- a/js/src/sandbox/types.ts
+++ b/js/src/sandbox/types.ts
@@ -698,7 +698,7 @@ export interface StartSandboxOptions {
 }
 
 /**
- * Options for updating a sandbox (name and/or retention settings).
+ * Options for updating a sandbox (name, retention settings, proxy config).
  */
 export interface UpdateSandboxOptions {
   /** New display name. */
@@ -715,6 +715,15 @@ export interface UpdateSandboxOptions {
    * `undefined`) to leave the existing value unchanged.
    */
   deleteAfterStopSeconds?: number;
+  /**
+   * Replacement proxy configuration, sent to the server as-is (same shape as
+   * `createSandbox`). Rules replace the existing set rather than merging into
+   * it, so include every rule the sandbox should keep. Opaque header values
+   * carry over from the current config, so rotating one credential does not
+   * mean re-supplying secrets that can no longer be read. The sandbox must be
+   * `ready`; start a stopped one first.
+   */
+  proxyConfig?: SandboxProxyConfig;
 }
 
 /**

--- a/js/src/tests/sandbox.test.ts
+++ b/js/src/tests/sandbox.test.ts
@@ -37,6 +37,7 @@ import {
   LangSmithCommandTimeoutError,
   LangSmithSandboxServerReloadError,
   LangSmithSandboxConnectionError,
+  LangSmithSandboxNotReadyError,
   LangSmithStreamEndedBeforeStartedError,
 } from "../sandbox/errors.js";
 import type {
@@ -1274,6 +1275,57 @@ describe("SandboxClient - updateSandbox", () => {
     expect(url).toContain("/boxes/sb-1");
     expect(init.method).toBeUndefined();
     expect(sb.name).toBe("sb-1");
+  });
+
+  it("should PATCH proxy_config when provided in options", async () => {
+    const mockFetch = jest.fn<typeof fetch>().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        name: "sb-1",
+        status: "ready",
+      }),
+    } as Response);
+
+    const config = proxyConfig({
+      rules: [
+        {
+          name: "github",
+          match_hosts: ["github.com"],
+          headers: [
+            { name: "Authorization", type: "opaque", value: "Basic rotated" },
+          ],
+        },
+      ],
+    });
+
+    const client = createClientWithMock(mockFetch);
+    await client.updateSandbox("sb-1", { proxyConfig: config });
+
+    const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(init.method).toBe("PATCH");
+    expect(JSON.parse(init.body as string)).toEqual({ proxy_config: config });
+  });
+
+  it("should throw NotReady when proxy config is set on a stopped sandbox", async () => {
+    const body = {
+      detail: {
+        error: "InvalidRequest",
+        message:
+          'sandbox "sb-1" is in "stopped" state, must be "ready" to update proxy config',
+      },
+    };
+    const mockFetch = jest.fn<typeof fetch>().mockResolvedValue({
+      ok: false,
+      status: 400,
+      statusText: "Bad Request",
+      json: async () => body,
+      clone: () => ({ status: 400, json: async () => body }),
+    } as unknown as Response);
+
+    const client = createClientWithMock(mockFetch);
+    await expect(
+      client.updateSandbox("sb-1", { proxyConfig: { rules: [] } }),
+    ).rejects.toThrow(LangSmithSandboxNotReadyError);
   });
 });
 

--- a/python/langsmith/sandbox/_async_client.py
+++ b/python/langsmith/sandbox/_async_client.py
@@ -33,6 +33,7 @@ from langsmith.sandbox._helpers import (
     handle_client_http_error,
     handle_sandbox_creation_error,
     merge_headers,
+    raise_if_not_ready,
     validate_service_params,
     validate_ttl,
 )
@@ -533,6 +534,7 @@ class AsyncSandboxClient:
         new_name: Optional[str] = None,
         idle_ttl_seconds: Optional[int] = None,
         delete_after_stop_seconds: Optional[int] = None,
+        proxy_config: Optional[SandboxProxyConfig] = None,
         headers: RequestHeaders = None,
     ) -> AsyncSandbox:
         """Update a sandbox's properties.
@@ -547,6 +549,13 @@ class AsyncSandboxClient:
                 before deletion. Must be a multiple of 60. ``0`` disables
                 stop-anchored deletion. ``None`` leaves the existing value
                 unchanged.
+            proxy_config: Replacement proxy configuration, forwarded to the
+                server as-is (same shape as ``create_sandbox``). Rules replace
+                the existing set rather than merging into it, so include every
+                rule the sandbox should keep. Opaque header values carry over
+                from the current config, so rotating one credential does not
+                mean re-supplying secrets that can no longer be read. The
+                sandbox must be ``ready``; start a stopped one first.
 
         Returns:
             Updated AsyncSandbox.
@@ -554,6 +563,8 @@ class AsyncSandboxClient:
         Raises:
             ResourceNotFoundError: If sandbox not found.
             ResourceNameConflictError: If new_name is already in use.
+            SandboxNotReadyError: If ``proxy_config`` was given and the sandbox
+                is not ``ready``.
             SandboxClientError: For other errors.
             ValueError: If TTL values are invalid.
         """
@@ -568,6 +579,8 @@ class AsyncSandboxClient:
             payload["idle_ttl_seconds"] = idle_ttl_seconds
         if delete_after_stop_seconds is not None:
             payload["delete_after_stop_seconds"] = delete_after_stop_seconds
+        if proxy_config is not None:
+            payload["proxy_config"] = proxy_config
 
         try:
             response = await self._http.patch(
@@ -587,6 +600,8 @@ class AsyncSandboxClient:
                     f"Sandbox name '{new_name}' already in use",
                     resource_type="sandbox",
                 ) from e
+            if proxy_config is not None:
+                raise_if_not_ready(e, name)
             handle_client_http_error(e)
             raise  # pragma: no cover
 

--- a/python/langsmith/sandbox/_client.py
+++ b/python/langsmith/sandbox/_client.py
@@ -28,6 +28,7 @@ from langsmith.sandbox._helpers import (
     handle_client_http_error,
     handle_sandbox_creation_error,
     merge_headers,
+    raise_if_not_ready,
     validate_service_params,
     validate_ttl,
 )
@@ -633,6 +634,7 @@ class SandboxClient:
         new_name: Optional[str] = None,
         idle_ttl_seconds: Optional[int] = None,
         delete_after_stop_seconds: Optional[int] = None,
+        proxy_config: Optional[SandboxProxyConfig] = None,
         headers: RequestHeaders = None,
     ) -> Sandbox:
         """Update a sandbox's properties.
@@ -647,6 +649,13 @@ class SandboxClient:
                 before deletion. Must be a multiple of 60. ``0`` disables
                 stop-anchored deletion. ``None`` leaves the existing value
                 unchanged.
+            proxy_config: Replacement proxy configuration, forwarded to the
+                server as-is (same shape as ``create_sandbox``). Rules replace
+                the existing set rather than merging into it, so include every
+                rule the sandbox should keep. Opaque header values carry over
+                from the current config, so rotating one credential does not
+                mean re-supplying secrets that can no longer be read. The
+                sandbox must be ``ready``; start a stopped one first.
 
         Returns:
             Updated Sandbox.
@@ -654,6 +663,8 @@ class SandboxClient:
         Raises:
             ResourceNotFoundError: If sandbox not found.
             ResourceNameConflictError: If new_name is already in use.
+            SandboxNotReadyError: If ``proxy_config`` was given and the sandbox
+                is not ``ready``.
             SandboxClientError: For other errors.
             ValueError: If TTL values are invalid.
         """
@@ -668,6 +679,8 @@ class SandboxClient:
             payload["idle_ttl_seconds"] = idle_ttl_seconds
         if delete_after_stop_seconds is not None:
             payload["delete_after_stop_seconds"] = delete_after_stop_seconds
+        if proxy_config is not None:
+            payload["proxy_config"] = proxy_config
 
         try:
             response = self._http.patch(
@@ -685,6 +698,8 @@ class SandboxClient:
                     f"Sandbox name '{new_name}' already in use",
                     resource_type="sandbox",
                 ) from e
+            if proxy_config is not None:
+                raise_if_not_ready(e, name)
             handle_client_http_error(e)
             raise  # pragma: no cover
 

--- a/python/langsmith/sandbox/_helpers.py
+++ b/python/langsmith/sandbox/_helpers.py
@@ -265,6 +265,24 @@ def handle_sandbox_creation_error(error: httpx.HTTPStatusError) -> None:
         handle_client_http_error(error)
 
 
+def raise_if_not_ready(error: httpx.HTTPStatusError, name: str) -> None:
+    """Raise ``SandboxNotReadyError`` when the API rejected a proxy-config update.
+
+    A proxy config can only be written to a ``ready`` sandbox, and that status
+    check is the sole source of ``InvalidRequest`` on the update endpoint for the
+    fields this client sends — a typed error lets callers start the sandbox and
+    retry instead of matching on status codes.
+    """
+    if error.response.status_code != 400:
+        return
+    data = parse_error_response(error)
+    if data.get("error_type") != "InvalidRequest":
+        return
+    raise SandboxNotReadyError(
+        data["message"] or f"Sandbox '{name}' is not ready"
+    ) from error
+
+
 def handle_client_http_error(error: httpx.HTTPStatusError) -> None:
     """Handle HTTP errors and raise appropriate exceptions (for client operations)."""
     data = parse_error_response(error)

--- a/python/tests/unit_tests/sandbox/test_async_client.py
+++ b/python/tests/unit_tests/sandbox/test_async_client.py
@@ -17,6 +17,7 @@ from langsmith.sandbox import (
     ResourceStatus,
     ResourceTimeoutError,
     SandboxConnectionError,
+    SandboxNotReadyError,
     Snapshot,
     aws_auth,
     mount_config,
@@ -490,6 +491,62 @@ class TestAsyncSandboxOperations:
             await client.update_sandbox("my-sandbox", new_name="existing-sandbox")
 
         assert exc_info.value.resource_type == "sandbox"
+
+    async def test_update_sandbox_proxy_config(
+        self, client: AsyncSandboxClient, httpx_mock: HTTPXMock
+    ):
+        """Test replacing a sandbox's proxy config."""
+        config = proxy_config(
+            rules=[
+                {
+                    "name": "github",
+                    "match_hosts": ["github.com"],
+                    "headers": [
+                        {
+                            "name": "Authorization",
+                            "type": "opaque",
+                            "value": "Basic rotated",
+                        }
+                    ],
+                }
+            ]
+        )
+        httpx_mock.add_response(
+            method="PATCH",
+            url="http://test-server:8080/boxes/my-sandbox",
+            json={
+                "id": "550e8400-e29b-41d4-a716-446655440003",
+                "name": "my-sandbox",
+                "dataplane_url": "https://sandbox-router.example.com/tenant/sb-123",
+            },
+        )
+
+        await client.update_sandbox("my-sandbox", proxy_config=config)
+
+        request = httpx_mock.get_requests()[-1]
+        assert json.loads(request.content) == {"proxy_config": config}
+
+    async def test_update_sandbox_proxy_config_not_ready(
+        self, client: AsyncSandboxClient, httpx_mock: HTTPXMock
+    ):
+        """A proxy-config update on a stopped sandbox is a typed not-ready error."""
+        httpx_mock.add_response(
+            method="PATCH",
+            url="http://test-server:8080/boxes/my-sandbox",
+            json={
+                "detail": {
+                    "error": "InvalidRequest",
+                    "message": (
+                        'sandbox "my-sandbox" is in "stopped" state, '
+                        'must be "ready" to update proxy config'
+                    ),
+                }
+            },
+            status_code=400,
+        )
+
+        with pytest.raises(SandboxNotReadyError, match="stopped"):
+            await client.update_sandbox("my-sandbox", proxy_config={"rules": []})
 
     async def test_create_sandbox_async_returns_provisioning(
         self, client: AsyncSandboxClient, httpx_mock: HTTPXMock

--- a/python/tests/unit_tests/sandbox/test_client.py
+++ b/python/tests/unit_tests/sandbox/test_client.py
@@ -15,12 +15,14 @@ from langsmith.sandbox import (
     ResourceTimeoutError,
     SandboxClient,
     SandboxConnectionError,
+    SandboxNotReadyError,
     ServiceURL,
     Snapshot,
     aws_auth,
     gcp_auth,
     gcs_mount,
     mount_config,
+    proxy_config,
     s3_mount,
     workspace_secret,
 )
@@ -486,6 +488,62 @@ class TestSandboxOperations:
             client.update_sandbox("my-sandbox", new_name="existing-sandbox")
 
         assert exc_info.value.resource_type == "sandbox"
+
+    def test_update_sandbox_proxy_config(
+        self, client: SandboxClient, httpx_mock: HTTPXMock
+    ):
+        """Test replacing a sandbox's proxy config."""
+        config = proxy_config(
+            rules=[
+                {
+                    "name": "github",
+                    "match_hosts": ["github.com"],
+                    "headers": [
+                        {
+                            "name": "Authorization",
+                            "type": "opaque",
+                            "value": "Basic rotated",
+                        }
+                    ],
+                }
+            ]
+        )
+        httpx_mock.add_response(
+            method="PATCH",
+            url="http://test-server:8080/boxes/my-sandbox",
+            json={
+                "id": "550e8400-e29b-41d4-a716-446655440003",
+                "name": "my-sandbox",
+                "dataplane_url": "https://sandbox-router.example.com/tenant/sb-123",
+            },
+        )
+
+        client.update_sandbox("my-sandbox", proxy_config=config)
+
+        request = httpx_mock.get_requests()[-1]
+        assert json.loads(request.content) == {"proxy_config": config}
+
+    def test_update_sandbox_proxy_config_not_ready(
+        self, client: SandboxClient, httpx_mock: HTTPXMock
+    ):
+        """A proxy-config update on a stopped sandbox is a typed not-ready error."""
+        httpx_mock.add_response(
+            method="PATCH",
+            url="http://test-server:8080/boxes/my-sandbox",
+            json={
+                "detail": {
+                    "error": "InvalidRequest",
+                    "message": (
+                        'sandbox "my-sandbox" is in "stopped" state, '
+                        'must be "ready" to update proxy config'
+                    ),
+                }
+            },
+            status_code=400,
+        )
+
+        with pytest.raises(SandboxNotReadyError, match="stopped"):
+            client.update_sandbox("my-sandbox", proxy_config={"rules": []})
 
     def test_create_sandbox_async_returns_provisioning(
         self, client: SandboxClient, httpx_mock: HTTPXMock


### PR DESCRIPTION
`proxy_config` is settable only at create time. But proxy-injected credentials are short-lived — a GitHub App installation token lasts an hour — while sandboxes are not: idle TTL is measured in hours and stopped retention in days. So any sandbox reused past its first hour needs its proxy config rewritten, and there is no supported client path to do it. Create-time-only configuration makes the feature usable once per sandbox. Same for `aws_auth` and `gcp_auth` rules.

The server has always accepted it — `UpdateSandboxPayload.ProxyConfig` on `PATCH /boxes/{name}` — so callers work around the gap by hand-building a raw PATCH, which gives up the client's URL construction, auth headers, retry transport (429/502/503/504), and all of the typed-error mapping.

Both clients now take it, mirroring the create parameter and forwarding to the server as-is:

- **Python** — `proxy_config` on `SandboxClient.update_sandbox` / `AsyncSandboxClient.update_sandbox`.
- **JS** — `proxyConfig` on `UpdateSandboxOptions`, serialized as `proxy_config`, and added to the guard that short-circuits an all-empty options object to `getSandbox`.

`SandboxResponse` already returns `proxy_config`, so the response models round-trip it with no change.

### Typed not-ready error

The API rejects a proxy-config update on any sandbox that is not `ready` — which is the *common* case for a reused sandbox, because idle boxes are stopped, not deleted. That rejection is a 400 that `handle_client_http_error` / `handleClientHttpError` funnelled into a bare `SandboxClientError` / `LangSmithSandboxError`, leaving callers to match on status codes.

`raise_if_not_ready` (Python) and `throwIfNotReady` (JS) now raise `SandboxNotReadyError` / `LangSmithSandboxNotReadyError` for it. Both exceptions already exist and are exported, and the sandbox-operation handlers already apply the same 400-means-not-ready mapping; this brings the client path in line. Recovery becomes:

```python
try:
    await client.update_sandbox(name, proxy_config=cfg)
except SandboxNotReadyError:
    await client.start_sandbox(name)
    await client.update_sandbox(name, proxy_config=cfg)
```

Gated on the proxy config being present and on `error_type == "InvalidRequest"`, so it can't swallow a future 400 from another field. The JS version reads a clone of the response, so `handleClientHttpError` can still consume the body when the rejection turns out to be something else.

### Deliberately not included

An auto-start flag. Starting a sandbox consumes quota and takes time, and `POST /start` is not idempotent — it 400s on anything not `stopped`/`failed`. Hiding that inside an update call makes the failure modes worse; the typed error gives callers what they need to decide.

`vcpus`, `cpu_millicores`, `mem_bytes`, `fs_capacity_bytes` and `tag_value_ids` are also server-supported and client-absent in both SDKs. Out of scope here.

### Docs

All three docstrings state two behaviors that are not discoverable from the signature and that callers get wrong: rules **replace** rather than merge, and opaque header values carry over from the existing config, so rotating one credential does not require re-supplying secrets you can no longer read.

## Test Plan

- [x] Python: `uv run pytest tests/unit_tests/sandbox/` — 552 pass
- [x] JS: `pnpm test src/tests/sandbox.test.ts` — 147 pass
- [x] New tests on all three clients: payload carries the proxy config; a 400 `InvalidRequest` raises the not-ready error
- [x] Python `make lint` clean (ruff + mypy, 118 files); JS `pnpm lint` clean and `tsc --noEmit` reports 0 errors
