### PR TITLE
feat(js): respect dockerignore when building from Dockerfile

### DIFF
--- a/js/src/sandbox/client.ts
+++ b/js/src/sandbox/client.ts
@@ -173,6 +173,7 @@ async function makeDockerContextTar(
 
   const contextRoot = path.resolve(contextPath);
   const chunks: Buffer[] = [];
+
   let dockerIgnore = "";
   let dockerIgnoreRel: string | undefined;
   for (const candidate of [`${dockerfileRel}.dockerignore`, ".dockerignore"]) {
@@ -189,13 +190,7 @@ async function makeDockerContextTar(
       }
     }
   }
-  let ignore = DockerIgnoreMatcher.parse("");
-  try {
-    ignore = DockerIgnoreMatcher.parse(dockerIgnore);
-  } catch {
-    // Match Docker's fail-open behavior: an unusable ignore file must not
-    // remove files from the uploaded build context.
-  }
+  const ignore = DockerIgnoreMatcher.parse(dockerIgnore);
 
   async function addEntry(absPath: string): Promise<void> {
     const rel = path.relative(contextRoot, absPath);

--- a/js/src/sandbox/client.ts
+++ b/js/src/sandbox/client.ts
@@ -174,25 +174,27 @@ async function makeDockerContextTar(
   const contextRoot = path.resolve(contextPath);
   const chunks: Buffer[] = [];
   let dockerIgnore = "";
-  try {
-    dockerIgnore = await fs.readFile(
-      path.join(contextRoot, ".dockerignore"),
-      "utf8",
-    );
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
-      throw error;
+  let dockerIgnoreRel: string | undefined;
+  for (const candidate of [`${dockerfileRel}.dockerignore`, ".dockerignore"]) {
+    try {
+      dockerIgnore = await fs.readFile(
+        path.join(contextRoot, candidate),
+        "utf8",
+      );
+      dockerIgnoreRel = candidate;
+      break;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+        throw error;
+      }
     }
   }
-  let ignore: ReturnType<(typeof DockerIgnoreMatcher)["parse"]>;
+  let ignore = DockerIgnoreMatcher.parse("");
   try {
     ignore = DockerIgnoreMatcher.parse(dockerIgnore);
-  } catch (error) {
-    throw new Error(
-      `Invalid .dockerignore: ${
-        error instanceof Error ? error.message : String(error)
-      }`,
-    );
+  } catch {
+    // Match Docker's fail-open behavior: an unusable ignore file must not
+    // remove files from the uploaded build context.
   }
 
   async function addEntry(absPath: string): Promise<void> {
@@ -205,7 +207,7 @@ async function makeDockerContextTar(
 
     const ignored =
       !(
-        tarPath === ".dockerignore" ||
+        tarPath === dockerIgnoreRel ||
         tarPath === dockerfileRel ||
         (stat.isDirectory() && dockerfileRel.startsWith(`${tarPath}/`))
       ) && ignore.isIgnored(tarPath);

--- a/js/src/sandbox/client.ts
+++ b/js/src/sandbox/client.ts
@@ -163,11 +163,37 @@ function makeTarHeader(args: {
   return header;
 }
 
-async function makeDockerContextTar(contextPath: string): Promise<Uint8Array> {
+async function makeDockerContextTar(
+  contextPath: string,
+  dockerfileRel: string,
+): Promise<Uint8Array> {
   const fs = await import("node:fs/promises");
   const path = await import("node:path");
+  const { DockerIgnoreMatcher } = await import("./dockerignore.js");
+
   const contextRoot = path.resolve(contextPath);
   const chunks: Buffer[] = [];
+  let dockerIgnore = "";
+  try {
+    dockerIgnore = await fs.readFile(
+      path.join(contextRoot, ".dockerignore"),
+      "utf8",
+    );
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+      throw error;
+    }
+  }
+  let ignore: ReturnType<(typeof DockerIgnoreMatcher)["parse"]>;
+  try {
+    ignore = DockerIgnoreMatcher.parse(dockerIgnore);
+  } catch (error) {
+    throw new Error(
+      `Invalid .dockerignore: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
 
   async function addEntry(absPath: string): Promise<void> {
     const rel = path.relative(contextRoot, absPath);
@@ -176,22 +202,36 @@ async function makeDockerContextTar(contextPath: string): Promise<Uint8Array> {
     }
     const tarPath = rel.split(path.sep).join("/");
     const stat = await fs.lstat(absPath);
+
+    const ignored =
+      !(
+        tarPath === ".dockerignore" ||
+        tarPath === dockerfileRel ||
+        (stat.isDirectory() && dockerfileRel.startsWith(`${tarPath}/`))
+      ) && ignore.isIgnored(tarPath);
+
     if (stat.isDirectory()) {
-      chunks.push(
-        makeTarHeader({
-          name: tarPath.endsWith("/") ? tarPath : `${tarPath}/`,
-          mode: stat.mode & 0o777,
-          size: 0,
-          type: "directory",
-          mtimeMs: stat.mtimeMs,
-        }),
-      );
+      if (!ignored) {
+        chunks.push(
+          makeTarHeader({
+            name: tarPath.endsWith("/") ? tarPath : `${tarPath}/`,
+            mode: stat.mode & 0o777,
+            size: 0,
+            type: "directory",
+            mtimeMs: stat.mtimeMs,
+          }),
+        );
+      }
+
+      // Skip traversal if the directory is ignored and cannot contain any included descendants.
+      if (ignored && !ignore.couldIncludeDescendant(tarPath)) return;
       const entries = await fs.readdir(absPath);
       for (const entry of entries.sort()) {
         await addEntry(path.join(absPath, entry));
       }
       return;
     }
+    if (ignored) return;
     if (stat.isSymbolicLink()) {
       chunks.push(
         makeTarHeader({
@@ -1071,7 +1111,7 @@ export class SandboxClient {
     try {
       await builder.write(
         remoteTar,
-        await makeDockerContextTar(contextPath),
+        await makeDockerContextTar(contextPath, dockerfileRel),
         timeout,
       );
       await builder.run(

--- a/js/src/sandbox/client.ts
+++ b/js/src/sandbox/client.ts
@@ -40,6 +40,7 @@ import {
 } from "./helpers.js";
 import { validateMountConfigProxyConfig } from "./mounts.js";
 import { v4 as uuidv4 } from "../utils/uuid/src/index.js";
+import { DockerIgnoreMatcher } from "./dockerignore.js";
 
 /**
  * Sleep that can be interrupted by an AbortSignal.
@@ -169,28 +170,34 @@ async function makeDockerContextTar(
 ): Promise<Uint8Array> {
   const fs = await import("node:fs/promises");
   const path = await import("node:path");
-  const { DockerIgnoreMatcher } = await import("./dockerignore.js");
 
   const contextRoot = path.resolve(contextPath);
   const chunks: Buffer[] = [];
 
-  let dockerIgnore = "";
-  let dockerIgnoreRel: string | undefined;
-  for (const candidate of [`${dockerfileRel}.dockerignore`, ".dockerignore"]) {
-    try {
-      dockerIgnore = await fs.readFile(
-        path.join(contextRoot, candidate),
-        "utf8",
-      );
-      dockerIgnoreRel = candidate;
-      break;
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
-        throw error;
+  const dockerIgnore = await (async () => {
+    for (const rel of [`${dockerfileRel}.dockerignore`, ".dockerignore"]) {
+      try {
+        const file = await fs.readFile(path.join(contextRoot, rel), "utf8");
+        return { rel, file };
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+          throw error;
+        }
       }
     }
-  }
-  const ignore = DockerIgnoreMatcher.parse(dockerIgnore);
+
+    return { file: "", rel: undefined };
+  })();
+
+  const ignore = (() => {
+    try {
+      return DockerIgnoreMatcher.parse(dockerIgnore.file);
+    } catch {
+      // Match Docker's fail-open behavior: an unusable ignore file must not
+      // remove files from the uploaded build context.
+      return DockerIgnoreMatcher.parse("");
+    }
+  })();
 
   async function addEntry(absPath: string): Promise<void> {
     const rel = path.relative(contextRoot, absPath);
@@ -202,7 +209,7 @@ async function makeDockerContextTar(
 
     const ignored =
       !(
-        tarPath === dockerIgnoreRel ||
+        tarPath === dockerIgnore.rel ||
         tarPath === dockerfileRel ||
         (stat.isDirectory() && dockerfileRel.startsWith(`${tarPath}/`))
       ) && ignore.isIgnored(tarPath);

--- a/js/src/sandbox/dockerignore.ts
+++ b/js/src/sandbox/dockerignore.ts
@@ -1,203 +1,211 @@
-import { posix as path } from "node:path";
+type CharacterRange = [start: number, end: number];
+
+type GlobToken =
+  | { type: "literal"; value: string }
+  | { type: "star" }
+  | { type: "globstar" }
+  | { type: "globstarSegments" }
+  | { type: "any" }
+  | { type: "class"; negated: boolean; ranges: CharacterRange[] };
 
 type DockerIgnoreRule = {
   exclusion: boolean;
   pattern: string;
+  tokens: GlobToken[];
   staticPrefix: string;
   hasSlash: boolean;
   hasGlob: boolean;
 };
 
-function normalizePattern(pattern: string): string {
-  let normalized = path.normalize(pattern);
-  while (normalized.startsWith("/")) {
-    normalized = normalized.slice(1);
-  }
-  while (normalized.endsWith("/")) {
-    normalized = normalized.slice(0, -1);
-  }
-  return normalized;
-}
-
 function firstGlobIndex(pattern: string): number {
   for (let i = 0; i < pattern.length; i += 1) {
     if (pattern[i] === "\\") {
       i += 1;
-    } else if (
-      pattern[i] === "*" ||
-      pattern[i] === "?" ||
-      pattern[i] === "[" ||
-      pattern[i] === "{" ||
-      ((pattern[i] === "@" || pattern[i] === "+" || pattern[i] === "!") &&
-        pattern[i + 1] === "(")
-    ) {
+    } else if (pattern[i] === "*" || pattern[i] === "?" || pattern[i] === "[") {
       return i;
     }
   }
   return -1;
 }
 
-function validatePattern(pattern: string): void {
-  for (let i = 0; i < pattern.length; i += 1) {
-    if (pattern[i] === "\\") {
-      if (i + 1 === pattern.length) {
-        throw new Error(`invalid trailing escape in pattern ${pattern}`);
-      }
-      i += 1;
-      continue;
+class DockerGlobParser {
+  private readonly characters: string[];
+
+  private cursor = 0;
+
+  constructor(private readonly pattern: string) {
+    this.characters = Array.from(pattern);
+  }
+
+  parse(): GlobToken[] {
+    const tokens: GlobToken[] = [];
+    while (!this.atEnd()) {
+      tokens.push(this.parseToken());
     }
-    if (pattern[i] !== "[") {
-      continue;
+    return tokens;
+  }
+
+  private parseToken(): GlobToken {
+    const character = this.consume();
+    if (character === "\\") {
+      return this.parseEscapedLiteral();
+    }
+    if (character === "*") {
+      return this.parseStar();
+    }
+    if (character === "?") {
+      return { type: "any" };
+    }
+    if (character === "[") {
+      return this.parseCharacterClass();
+    }
+    return { type: "literal", value: character };
+  }
+
+  private parseEscapedLiteral(): GlobToken {
+    if (this.atEnd()) {
+      throw new Error(`invalid trailing escape in pattern ${this.pattern}`);
+    }
+    return { type: "literal", value: this.consume() };
+  }
+
+  private parseStar(): GlobToken {
+    if (this.peek() !== "*") {
+      return { type: "star" };
+    }
+    this.consume();
+    if (this.peek() === "/") {
+      this.consume();
+      return { type: "globstarSegments" };
+    }
+    return { type: "globstar" };
+  }
+
+  private parseCharacterClass(): GlobToken {
+    const negated = this.peek() === "^";
+    if (negated) {
+      this.consume();
     }
 
-    i += 1;
-    if (pattern[i] === "^") {
-      i += 1;
+    const ranges: CharacterRange[] = [];
+    while (!this.atEnd() && this.peek() !== "]") {
+      ranges.push(this.parseCharacterRange());
     }
-    let members = 0;
-    while (i < pattern.length && pattern[i] !== "]") {
-      if (pattern[i] === "-") {
-        throw new Error(`invalid character class in pattern ${pattern}`);
+    if (ranges.length === 0 || this.atEnd()) {
+      this.invalidCharacterClass();
+    }
+    this.consume();
+    return { type: "class", negated, ranges };
+  }
+
+  private parseCharacterRange(): CharacterRange {
+    if (this.peek() === "-") {
+      this.invalidCharacterClass();
+    }
+    const start = this.parseClassCharacter();
+    if (this.peek() !== "-") {
+      return [start, start];
+    }
+
+    this.consume();
+    if (this.atEnd() || this.peek() === "]" || this.peek() === "-") {
+      this.invalidCharacterClass();
+    }
+    const end = this.parseClassCharacter();
+    if (end < start) {
+      this.invalidCharacterClass();
+    }
+    return [start, end];
+  }
+
+  private parseClassCharacter(): number {
+    if (this.peek() === "\\") {
+      this.consume();
+      if (this.atEnd()) {
+        this.invalidCharacterClass();
       }
-      let rangeStart = pattern.codePointAt(i) ?? 0;
-      if (pattern[i] === "\\") {
-        i += 1;
-        if (i === pattern.length) {
-          throw new Error(`invalid character class in pattern ${pattern}`);
+    }
+    return this.consume().codePointAt(0) ?? 0;
+  }
+
+  private peek(): string | undefined {
+    return this.characters[this.cursor];
+  }
+
+  private consume(): string {
+    return this.characters[this.cursor++];
+  }
+
+  private atEnd(): boolean {
+    return this.cursor >= this.characters.length;
+  }
+
+  private invalidCharacterClass(): never {
+    throw new Error(`invalid character class in pattern ${this.pattern}`);
+  }
+}
+
+function matchesDockerGlob(value: string, tokens: GlobToken[]): boolean {
+  const characters = Array.from(value);
+  const memo = new Map<string, boolean>();
+
+  const match = (tokenIndex: number, characterIndex: number): boolean => {
+    const key = `${tokenIndex}:${characterIndex}`;
+    const cached = memo.get(key);
+    if (cached !== undefined) {
+      return cached;
+    }
+
+    const token = tokens[tokenIndex];
+    let matched: boolean;
+    if (token === undefined) {
+      matched = characterIndex === characters.length;
+    } else if (token.type === "literal") {
+      matched =
+        characters[characterIndex] === token.value &&
+        match(tokenIndex + 1, characterIndex + 1);
+    } else if (token.type === "any") {
+      matched =
+        characters[characterIndex] !== undefined &&
+        characters[characterIndex] !== "/" &&
+        match(tokenIndex + 1, characterIndex + 1);
+    } else if (token.type === "star") {
+      matched =
+        match(tokenIndex + 1, characterIndex) ||
+        (characters[characterIndex] !== undefined &&
+          characters[characterIndex] !== "/" &&
+          match(tokenIndex, characterIndex + 1));
+    } else if (token.type === "globstar") {
+      matched =
+        match(tokenIndex + 1, characterIndex) ||
+        (characterIndex < characters.length &&
+          match(tokenIndex, characterIndex + 1));
+    } else if (token.type === "globstarSegments") {
+      matched = match(tokenIndex + 1, characterIndex);
+      for (let i = characterIndex; !matched && i < characters.length; i += 1) {
+        if (characters[i] === "/") {
+          matched = match(tokenIndex + 1, i + 1);
         }
-        rangeStart = pattern.codePointAt(i) ?? 0;
       }
-      members += 1;
-      i += 1;
-      if (pattern[i] === "-") {
-        i += 1;
-        if (i === pattern.length || pattern[i] === "]" || pattern[i] === "-") {
-          throw new Error(`invalid character class in pattern ${pattern}`);
-        }
-        if (pattern[i] === "\\") {
-          i += 1;
-          if (i === pattern.length) {
-            throw new Error(`invalid character class in pattern ${pattern}`);
-          }
-        }
-        const rangeEnd = pattern.codePointAt(i) ?? 0;
-        if (rangeEnd < rangeStart) {
-          throw new Error(`invalid character class in pattern ${pattern}`);
-        }
-        i += 1;
-      }
+    } else {
+      const codePoint = characters[characterIndex]?.codePointAt(0);
+      const inClass =
+        codePoint !== undefined &&
+        token.ranges.some(
+          ([start, end]) => codePoint >= start && codePoint <= end,
+        );
+      matched =
+        codePoint !== undefined &&
+        characters[characterIndex] !== "/" &&
+        (token.negated ? !inClass : inClass) &&
+        match(tokenIndex + 1, characterIndex + 1);
     }
-    if (members === 0 || i === pattern.length) {
-      throw new Error(`invalid character class in pattern ${pattern}`);
-    }
-  }
-}
 
-function prepareNativeGlob(
-  value: string,
-  pattern: string,
-): { value: string; pattern: string } {
-  // Adapt Go-style literal escapes and mid-segment globstars before handing
-  // matching to the native implementation.
-  const escaped = new Map<string, string>();
-  let nativePattern = "";
-  for (let i = 0; i < pattern.length; i += 1) {
-    if (pattern[i] === "\\") {
-      const literal = pattern[(i += 1)];
-      let replacement = escaped.get(literal);
-      if (replacement === undefined) {
-        replacement = String.fromCodePoint(0xe000 + escaped.size);
-        escaped.set(literal, replacement);
-      }
-      nativePattern += replacement;
-      continue;
-    }
-    if (
-      pattern[i] === "*" &&
-      pattern[i + 1] === "*" &&
-      pattern[i + 2] === "/" &&
-      i > 0 &&
-      pattern[i - 1] !== "/"
-    ) {
-      nativePattern += "*/**/";
-      i += 2;
-      continue;
-    }
-    nativePattern += pattern[i];
-  }
-  let nativeValue = value;
-  for (const [literal, replacement] of escaped) {
-    nativeValue = nativeValue.split(literal).join(replacement);
-  }
-  return { value: nativeValue, pattern: nativePattern };
-}
+    memo.set(key, matched);
+    return matched;
+  };
 
-function expandCaseFoldedRanges(pattern: string): string[] {
-  // On case-insensitive hosts, matchesGlob case-folds magic patterns. Split a
-  // lower-case-to-Unicode range before masking ASCII case below.
-  for (let i = 0; i + 4 < pattern.length; i += 1) {
-    const start = pattern.charCodeAt(i + 1);
-    const end = pattern.charCodeAt(i + 3);
-    if (
-      pattern[i] === "[" &&
-      pattern[i + 2] === "-" &&
-      pattern[i + 4] === "]" &&
-      start >= 0x61 &&
-      start <= 0x7a &&
-      end > 0x7a
-    ) {
-      const variants: string[] = [];
-      const prefix = pattern.slice(0, i);
-      const suffix = pattern.slice(i + 5);
-      for (let codePoint = start; codePoint <= 0x7a; codePoint += 1) {
-        variants.push(`${prefix}${String.fromCodePoint(codePoint)}${suffix}`);
-      }
-      variants.push(`${prefix}[{-${pattern[i + 3]}]${suffix}`);
-      return variants;
-    }
-  }
-  return [pattern];
-}
-
-function makeAsciiCaseSensitive(value: string): string {
-  // Docker matching is case-sensitive even when the host filesystem is not.
-  // Separate private-use ranges keep native wildcard matching case-sensitive.
-  return Array.from(value, (character) => {
-    const codePoint = character.codePointAt(0) ?? 0;
-    if (codePoint >= 0x61 && codePoint <= 0x7a) {
-      return String.fromCodePoint(0xe100 + codePoint - 0x61);
-    }
-    if (codePoint >= 0x41 && codePoint <= 0x5a) {
-      return String.fromCodePoint(0xe200 + codePoint - 0x41);
-    }
-    return character;
-  }).join("");
-}
-
-function makeDotfilesVisible(value: string, pattern: boolean): string {
-  // matchesGlob hides dotfiles from wildcards. Prefix each path segment so
-  // Docker patterns such as `**/*` still include them.
-  return value
-    .split("/")
-    .map((part) => (pattern && part === "**" ? part : `_${part}`))
-    .join("/");
-}
-
-function matchesDockerGlob(value: string, pattern: string): boolean {
-  if (typeof path.matchesGlob !== "function") {
-    throw new Error(".dockerignore requires Node.js path.matchesGlob support");
-  }
-  const native = prepareNativeGlob(value, pattern);
-  const nativeValue = makeDotfilesVisible(
-    makeAsciiCaseSensitive(native.value),
-    false,
-  );
-  return expandCaseFoldedRanges(native.pattern).some((nativePattern) =>
-    path.matchesGlob(
-      nativeValue,
-      makeDotfilesVisible(makeAsciiCaseSensitive(nativePattern), true),
-    ),
-  );
+  return match(0, 0);
 }
 
 function ruleMatches(rule: DockerIgnoreRule, path: string): boolean {
@@ -206,7 +214,7 @@ function ruleMatches(rule: DockerIgnoreRule, path: string): boolean {
     const value = rule.hasSlash
       ? candidate
       : candidate.slice(candidate.lastIndexOf("/") + 1);
-    if (matchesDockerGlob(value, rule.pattern)) {
+    if (matchesDockerGlob(value, rule.tokens)) {
       return true;
     }
     const separator = candidate.lastIndexOf("/");
@@ -239,11 +247,28 @@ export class DockerIgnoreMatcher {
           throw new Error("invalid empty exclusion pattern");
         }
       }
-      pattern = normalizePattern(pattern);
+
+      const absolute = pattern.startsWith("/");
+      const segments: string[] = [];
+      for (const segment of pattern.split("/")) {
+        if (!segment || segment === ".") {
+          continue;
+        }
+        if (segment === "..") {
+          if (segments.length > 0 && segments.at(-1) !== "..") {
+            segments.pop();
+          } else if (!absolute) {
+            segments.push(segment);
+          }
+        } else {
+          segments.push(segment);
+        }
+      }
+      pattern = segments.join("/");
       if (!pattern || pattern === ".") {
         continue;
       }
-      validatePattern(pattern);
+      const tokens = new DockerGlobParser(pattern).parse();
       const globIndex = firstGlobIndex(pattern);
       const hasGlob = globIndex !== -1;
       const prefixBeforeGlob = hasGlob ? pattern.slice(0, globIndex) : pattern;
@@ -251,17 +276,13 @@ export class DockerIgnoreMatcher {
       rules.push({
         exclusion,
         pattern,
+        tokens,
         staticPrefix: hasGlob
           ? prefixBeforeGlob.slice(0, Math.max(0, prefixEnd))
           : pattern,
         hasSlash: pattern.includes("/"),
         hasGlob,
       });
-    }
-    if (rules.length > 0 && typeof path.matchesGlob !== "function") {
-      throw new Error(
-        ".dockerignore requires Node.js path.matchesGlob support",
-      );
     }
     return new DockerIgnoreMatcher(rules);
   }

--- a/js/src/sandbox/dockerignore.ts
+++ b/js/src/sandbox/dockerignore.ts
@@ -23,7 +23,14 @@ function firstGlobIndex(pattern: string): number {
   for (let i = 0; i < pattern.length; i += 1) {
     if (pattern[i] === "\\") {
       i += 1;
-    } else if (pattern[i] === "*" || pattern[i] === "?" || pattern[i] === "[") {
+    } else if (
+      pattern[i] === "*" ||
+      pattern[i] === "?" ||
+      pattern[i] === "[" ||
+      pattern[i] === "{" ||
+      ((pattern[i] === "@" || pattern[i] === "+" || pattern[i] === "!") &&
+        pattern[i + 1] === "(")
+    ) {
       return i;
     }
   }
@@ -31,19 +38,140 @@ function firstGlobIndex(pattern: string): number {
 }
 
 function validatePattern(pattern: string): void {
-  let inCharacterClass = false;
   for (let i = 0; i < pattern.length; i += 1) {
     if (pattern[i] === "\\") {
+      if (i + 1 === pattern.length) {
+        throw new Error(`invalid trailing escape in pattern ${pattern}`);
+      }
       i += 1;
-    } else if (pattern[i] === "[") {
-      inCharacterClass = true;
-    } else if (pattern[i] === "]") {
-      inCharacterClass = false;
+      continue;
+    }
+    if (pattern[i] !== "[") {
+      continue;
+    }
+
+    i += 1;
+    if (pattern[i] === "^") {
+      i += 1;
+    }
+    let members = 0;
+    while (i < pattern.length && pattern[i] !== "]") {
+      if (pattern[i] === "-") {
+        throw new Error(`invalid character class in pattern ${pattern}`);
+      }
+      let rangeStart = pattern.codePointAt(i) ?? 0;
+      if (pattern[i] === "\\") {
+        i += 1;
+        if (i === pattern.length) {
+          throw new Error(`invalid character class in pattern ${pattern}`);
+        }
+        rangeStart = pattern.codePointAt(i) ?? 0;
+      }
+      members += 1;
+      i += 1;
+      if (pattern[i] === "-") {
+        i += 1;
+        if (i === pattern.length || pattern[i] === "]" || pattern[i] === "-") {
+          throw new Error(`invalid character class in pattern ${pattern}`);
+        }
+        if (pattern[i] === "\\") {
+          i += 1;
+          if (i === pattern.length) {
+            throw new Error(`invalid character class in pattern ${pattern}`);
+          }
+        }
+        const rangeEnd = pattern.codePointAt(i) ?? 0;
+        if (rangeEnd < rangeStart) {
+          throw new Error(`invalid character class in pattern ${pattern}`);
+        }
+        i += 1;
+      }
+    }
+    if (members === 0 || i === pattern.length) {
+      throw new Error(`invalid character class in pattern ${pattern}`);
     }
   }
-  if (inCharacterClass) {
-    throw new Error(`invalid character class in pattern ${pattern}`);
+}
+
+function prepareNativeGlob(
+  value: string,
+  pattern: string,
+): { value: string; pattern: string } {
+  // Adapt Go-style literal escapes and mid-segment globstars before handing
+  // matching to the native implementation.
+  const escaped = new Map<string, string>();
+  let nativePattern = "";
+  for (let i = 0; i < pattern.length; i += 1) {
+    if (pattern[i] === "\\") {
+      const literal = pattern[(i += 1)];
+      let replacement = escaped.get(literal);
+      if (replacement === undefined) {
+        replacement = String.fromCodePoint(0xe000 + escaped.size);
+        escaped.set(literal, replacement);
+      }
+      nativePattern += replacement;
+      continue;
+    }
+    if (
+      pattern[i] === "*" &&
+      pattern[i + 1] === "*" &&
+      pattern[i + 2] === "/" &&
+      i > 0 &&
+      pattern[i - 1] !== "/"
+    ) {
+      nativePattern += "*/**/";
+      i += 2;
+      continue;
+    }
+    nativePattern += pattern[i];
   }
+  let nativeValue = value;
+  for (const [literal, replacement] of escaped) {
+    nativeValue = nativeValue.split(literal).join(replacement);
+  }
+  return { value: nativeValue, pattern: nativePattern };
+}
+
+function expandCaseFoldedRanges(pattern: string): string[] {
+  // On case-insensitive hosts, matchesGlob case-folds magic patterns. Split a
+  // lower-case-to-Unicode range before masking ASCII case below.
+  for (let i = 0; i + 4 < pattern.length; i += 1) {
+    const start = pattern.charCodeAt(i + 1);
+    const end = pattern.charCodeAt(i + 3);
+    if (
+      pattern[i] === "[" &&
+      pattern[i + 2] === "-" &&
+      pattern[i + 4] === "]" &&
+      start >= 0x61 &&
+      start <= 0x7a &&
+      end > 0x7a
+    ) {
+      const variants: string[] = [];
+      const prefix = pattern.slice(0, i);
+      const suffix = pattern.slice(i + 5);
+      for (let codePoint = start; codePoint <= 0x7a; codePoint += 1) {
+        variants.push(`${prefix}${String.fromCodePoint(codePoint)}${suffix}`);
+      }
+      variants.push(`${prefix}[{-${pattern[i + 3]}]${suffix}`);
+      return variants;
+    }
+  }
+  return [pattern];
+}
+
+function makeAsciiCaseSensitive(value: string): string {
+  // Docker matching is case-sensitive even when the host filesystem is not.
+  // Separate private-use ranges keep native wildcard matching case-sensitive.
+  return Array.from(value, (character) => {
+    const codePoint = character.codePointAt(0) ?? 0;
+    if (codePoint >= 0x61 && codePoint <= 0x7a) {
+      return String.fromCodePoint(0xe100 + codePoint - 0x61);
+    }
+    if (codePoint >= 0x41 && codePoint <= 0x5a) {
+      return String.fromCodePoint(0xe200 + codePoint - 0x41);
+    }
+    return character;
+  }).join("");
 }
 
 function makeDotfilesVisible(value: string, pattern: boolean): string {
@@ -59,16 +187,26 @@ function matchesDockerGlob(value: string, pattern: string): boolean {
   if (typeof path.matchesGlob !== "function") {
     throw new Error(".dockerignore requires Node.js path.matchesGlob support");
   }
-  return path.matchesGlob(
-    makeDotfilesVisible(value, false),
-    makeDotfilesVisible(pattern, true),
+  const native = prepareNativeGlob(value, pattern);
+  const nativeValue = makeDotfilesVisible(
+    makeAsciiCaseSensitive(native.value),
+    false,
+  );
+  return expandCaseFoldedRanges(native.pattern).some((nativePattern) =>
+    path.matchesGlob(
+      nativeValue,
+      makeDotfilesVisible(makeAsciiCaseSensitive(nativePattern), true),
+    ),
   );
 }
 
 function ruleMatches(rule: DockerIgnoreRule, path: string): boolean {
   let candidate = path;
   while (candidate) {
-    if (matchesDockerGlob(candidate, rule.pattern)) {
+    const value = rule.hasSlash
+      ? candidate
+      : candidate.slice(candidate.lastIndexOf("/") + 1);
+    if (matchesDockerGlob(value, rule.pattern)) {
       return true;
     }
     const separator = candidate.lastIndexOf("/");
@@ -119,6 +257,11 @@ export class DockerIgnoreMatcher {
         hasSlash: pattern.includes("/"),
         hasGlob,
       });
+    }
+    if (rules.length > 0 && typeof path.matchesGlob !== "function") {
+      throw new Error(
+        ".dockerignore requires Node.js path.matchesGlob support",
+      );
     }
     return new DockerIgnoreMatcher(rules);
   }

--- a/js/src/sandbox/dockerignore.ts
+++ b/js/src/sandbox/dockerignore.ts
@@ -1,0 +1,154 @@
+import { posix as path } from "node:path";
+
+type DockerIgnoreRule = {
+  exclusion: boolean;
+  pattern: string;
+  staticPrefix: string;
+  hasSlash: boolean;
+  hasGlob: boolean;
+};
+
+function normalizePattern(pattern: string): string {
+  let normalized = path.normalize(pattern);
+  while (normalized.startsWith("/")) {
+    normalized = normalized.slice(1);
+  }
+  while (normalized.endsWith("/")) {
+    normalized = normalized.slice(0, -1);
+  }
+  return normalized;
+}
+
+function firstGlobIndex(pattern: string): number {
+  for (let i = 0; i < pattern.length; i += 1) {
+    if (pattern[i] === "\\") {
+      i += 1;
+    } else if (pattern[i] === "*" || pattern[i] === "?" || pattern[i] === "[") {
+      return i;
+    }
+  }
+  return -1;
+}
+
+function validatePattern(pattern: string): void {
+  let inCharacterClass = false;
+  for (let i = 0; i < pattern.length; i += 1) {
+    if (pattern[i] === "\\") {
+      i += 1;
+    } else if (pattern[i] === "[") {
+      inCharacterClass = true;
+    } else if (pattern[i] === "]") {
+      inCharacterClass = false;
+    }
+  }
+  if (inCharacterClass) {
+    throw new Error(`invalid character class in pattern ${pattern}`);
+  }
+}
+
+function makeDotfilesVisible(value: string, pattern: boolean): string {
+  // matchesGlob hides dotfiles from wildcards. Prefix each path segment so
+  // Docker patterns such as `**/*` still include them.
+  return value
+    .split("/")
+    .map((part) => (pattern && part === "**" ? part : `_${part}`))
+    .join("/");
+}
+
+function matchesDockerGlob(value: string, pattern: string): boolean {
+  if (typeof path.matchesGlob !== "function") {
+    throw new Error(".dockerignore requires Node.js path.matchesGlob support");
+  }
+  return path.matchesGlob(
+    makeDotfilesVisible(value, false),
+    makeDotfilesVisible(pattern, true),
+  );
+}
+
+function ruleMatches(rule: DockerIgnoreRule, path: string): boolean {
+  let candidate = path;
+  while (candidate) {
+    if (matchesDockerGlob(candidate, rule.pattern)) {
+      return true;
+    }
+    const separator = candidate.lastIndexOf("/");
+    if (separator === -1) {
+      break;
+    }
+    candidate = candidate.slice(0, separator);
+  }
+  return false;
+}
+
+/** Parsed `.dockerignore` patterns for paths relative to a build context. */
+export class DockerIgnoreMatcher {
+  private constructor(private readonly rules: DockerIgnoreRule[]) {}
+
+  static parse(contents: string): DockerIgnoreMatcher {
+    const rules: DockerIgnoreRule[] = [];
+    for (const rawLine of contents.replace(/^\uFEFF/, "").split(/\r?\n/)) {
+      if (rawLine.startsWith("#")) {
+        continue;
+      }
+      let pattern = rawLine.trim();
+      if (!pattern) {
+        continue;
+      }
+      const exclusion = pattern.startsWith("!");
+      if (exclusion) {
+        pattern = pattern.slice(1).trim();
+        if (!pattern) {
+          throw new Error("invalid empty exclusion pattern");
+        }
+      }
+      pattern = normalizePattern(pattern);
+      if (!pattern || pattern === ".") {
+        continue;
+      }
+      validatePattern(pattern);
+      const globIndex = firstGlobIndex(pattern);
+      const hasGlob = globIndex !== -1;
+      const prefixBeforeGlob = hasGlob ? pattern.slice(0, globIndex) : pattern;
+      const prefixEnd = prefixBeforeGlob.lastIndexOf("/");
+      rules.push({
+        exclusion,
+        pattern,
+        staticPrefix: hasGlob
+          ? prefixBeforeGlob.slice(0, Math.max(0, prefixEnd))
+          : pattern,
+        hasSlash: pattern.includes("/"),
+        hasGlob,
+      });
+    }
+    return new DockerIgnoreMatcher(rules);
+  }
+
+  isIgnored(path: string): boolean {
+    let ignored = false;
+    for (const rule of this.rules) {
+      if (ruleMatches(rule, path)) {
+        ignored = !rule.exclusion;
+      }
+    }
+    return ignored;
+  }
+
+  couldIncludeDescendant(path: string): boolean {
+    return this.rules.some((rule) => {
+      if (!rule.exclusion || !rule.hasSlash) {
+        return false;
+      }
+      if (!rule.hasGlob) {
+        return rule.pattern.startsWith(`${path}/`);
+      }
+      if (!rule.staticPrefix) {
+        return true;
+      }
+      return (
+        rule.staticPrefix === path ||
+        rule.staticPrefix.startsWith(`${path}/`) ||
+        path.startsWith(`${rule.staticPrefix}/`)
+      );
+    });
+  }
+}

--- a/js/src/tests/dockerignore.test.ts
+++ b/js/src/tests/dockerignore.test.ts
@@ -4,7 +4,7 @@ import { DockerIgnoreMatcher } from "../sandbox/dockerignore.js";
 // Observable compatibility cases from moby/patternmatcher at
 // 5a6d8429a19bb6948a372ff19e86fe83599a04b7. Compile-type and generated-regexp
 // assertions are implementation details of the Go matcher and do not apply to
-// this implementation, which delegates matching to path.matchesGlob.
+// this implementation, which matches parsed glob tokens directly.
 const mobyMatchCases: [pattern: string, path: string, ignored: boolean][] = [
   ["**", "file", true],
   ["**", "file/", true],
@@ -147,7 +147,7 @@ describe("DockerIgnoreMatcher", () => {
 
   it("supports Docker wildcards", () => {
     const matcher = DockerIgnoreMatcher.parse(
-      ["**/*.tmp", "logs/**/debug-?.[0-9].log", "assets/icon[!0-3].png"].join(
+      ["**/*.tmp", "logs/**/debug-?.[0-9].log", "assets/icon[^0-3].png"].join(
         "\n",
       ),
     );
@@ -162,17 +162,13 @@ describe("DockerIgnoreMatcher", () => {
     expect(DockerIgnoreMatcher.parse("*.go").isIgnored("FILE.GO")).toBe(false);
   });
 
-  it("uses native matchesGlob syntax", () => {
-    const matcher = DockerIgnoreMatcher.parse(
-      "*.{js,ts}\n@(foo|bar)\n*\n!@(foo|bar)/keep.txt",
-    );
+  it("treats non-Docker glob extensions literally", () => {
+    const matcher = DockerIgnoreMatcher.parse("*.{js,ts}\n@(foo|bar)");
 
-    expect(matcher.isIgnored("file.js")).toBe(true);
-    expect(matcher.isIgnored("file.ts")).toBe(true);
-    expect(matcher.isIgnored("foo")).toBe(true);
-    expect(matcher.isIgnored("bar")).toBe(true);
-    expect(matcher.isIgnored("foo/keep.txt")).toBe(false);
-    expect(matcher.couldIncludeDescendant("foo")).toBe(true);
+    expect(matcher.isIgnored("file.js")).toBe(false);
+    expect(matcher.isIgnored("file.ts")).toBe(false);
+    expect(matcher.isIgnored("file.{js,ts}")).toBe(true);
+    expect(matcher.isIgnored("@(foo|bar)")).toBe(true);
   });
 
   it("matches dotfiles", () => {

--- a/js/src/tests/dockerignore.test.ts
+++ b/js/src/tests/dockerignore.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "@jest/globals";
+import { DockerIgnoreMatcher } from "../sandbox/dockerignore.js";
+
+describe("DockerIgnoreMatcher", () => {
+  it("parses comments, blank lines, and normalized paths", () => {
+    const matcher = DockerIgnoreMatcher.parse(
+      "\uFEFF# comment\r\n\r\n/root.txt\r\ndirectory/\r\na/../other.txt\r\n../outside.txt\r\n",
+    );
+
+    expect(matcher.isIgnored("root.txt")).toBe(true);
+    expect(matcher.isIgnored("nested/root.txt")).toBe(false);
+    expect(matcher.isIgnored("directory/file.txt")).toBe(true);
+    expect(matcher.isIgnored("other.txt")).toBe(true);
+    expect(matcher.isIgnored("outside.txt")).toBe(false);
+    expect(matcher.isIgnored("included.txt")).toBe(false);
+  });
+
+  it("supports Docker wildcards", () => {
+    const matcher = DockerIgnoreMatcher.parse(
+      ["**/*.tmp", "logs/**/debug-?.[0-9].log", "assets/icon[!0-3].png"].join(
+        "\n",
+      ),
+    );
+
+    expect(matcher.isIgnored("root.tmp")).toBe(true);
+    expect(matcher.isIgnored("nested/root.tmp")).toBe(true);
+    expect(matcher.isIgnored("logs/debug-a.4.log")).toBe(true);
+    expect(matcher.isIgnored("logs/archive/debug-b.7.log")).toBe(true);
+    expect(matcher.isIgnored("logs/archive/debug-long.7.log")).toBe(false);
+    expect(matcher.isIgnored("assets/icon8.png")).toBe(true);
+    expect(matcher.isIgnored("assets/icon2.png")).toBe(false);
+  });
+
+  it("matches dotfiles", () => {
+    const matcher = DockerIgnoreMatcher.parse("**/*\n!visible.txt");
+
+    expect(matcher.isIgnored(".env")).toBe(true);
+    expect(matcher.isIgnored("nested/.env")).toBe(true);
+    expect(matcher.isIgnored("visible.txt")).toBe(false);
+  });
+
+  it("applies ordered exclusions to ignored directories and their children", () => {
+    const matcher = DockerIgnoreMatcher.parse(
+      ["vendor", "!vendor/keep.txt", "vendor/private.txt"].join("\n"),
+    );
+
+    expect(matcher.isIgnored("vendor")).toBe(true);
+    expect(matcher.isIgnored("vendor/drop.txt")).toBe(true);
+    expect(matcher.isIgnored("vendor/keep.txt")).toBe(false);
+    expect(matcher.isIgnored("vendor/keep.txt/child")).toBe(false);
+    expect(matcher.isIgnored("vendor/private.txt")).toBe(true);
+    expect(matcher.couldIncludeDescendant("vendor")).toBe(true);
+    expect(matcher.couldIncludeDescendant("node_modules")).toBe(false);
+  });
+
+  it("uses the last matching pattern", () => {
+    const matcher = DockerIgnoreMatcher.parse(
+      ["*.md", "!README*.md", "README-secret.md"].join("\n"),
+    );
+
+    expect(matcher.isIgnored("guide.md")).toBe(true);
+    expect(matcher.isIgnored("README.md")).toBe(false);
+    expect(matcher.isIgnored("README-secret.md")).toBe(true);
+  });
+
+  it("rejects malformed patterns", () => {
+    expect(() => DockerIgnoreMatcher.parse("!")).toThrow(
+      "invalid empty exclusion pattern",
+    );
+    expect(() => DockerIgnoreMatcher.parse("file[abc")).toThrow(
+      "invalid character class",
+    );
+  });
+});

--- a/js/src/tests/dockerignore.test.ts
+++ b/js/src/tests/dockerignore.test.ts
@@ -1,6 +1,135 @@
 import { describe, expect, it } from "@jest/globals";
 import { DockerIgnoreMatcher } from "../sandbox/dockerignore.js";
 
+// Observable compatibility cases from moby/patternmatcher at
+// 5a6d8429a19bb6948a372ff19e86fe83599a04b7. Compile-type and generated-regexp
+// assertions are implementation details of the Go matcher and do not apply to
+// this implementation, which delegates matching to path.matchesGlob.
+const mobyMatchCases: [pattern: string, path: string, ignored: boolean][] = [
+  ["**", "file", true],
+  ["**", "file/", true],
+  ["**/", "file", true],
+  ["**/", "file/", true],
+  ["**", "/", true],
+  ["**/", "/", true],
+  ["**", "dir/file", true],
+  ["**/", "dir/file", true],
+  ["**", "dir/file/", true],
+  ["**/", "dir/file/", true],
+  ["**/**", "dir/file", true],
+  ["**/**", "dir/file/", true],
+  ["dir/**", "dir/file", true],
+  ["dir/**", "dir/file/", true],
+  ["dir/**", "dir/dir2/file", true],
+  ["dir/**", "dir/dir2/file/", true],
+  ["**/dir", "dir", true],
+  ["**/dir", "dir/file", true],
+  ["**/dir2/*", "dir/dir2/file", true],
+  ["**/dir2/*", "dir/dir2/file/", true],
+  ["**/dir2/**", "dir/dir2/dir3/file", true],
+  ["**/dir2/**", "dir/dir2/dir3/file/", true],
+  ["**file", "file", true],
+  ["**file", "dir/file", true],
+  ["**/file", "dir/file", true],
+  ["**file", "dir/dir/file", true],
+  ["**/file", "dir/dir/file", true],
+  ["**/file*", "dir/dir/file", true],
+  ["**/file*", "dir/dir/file.txt", true],
+  ["**/file*txt", "dir/dir/file.txt", true],
+  ["**/file*.txt", "dir/dir/file.txt", true],
+  ["**/file*.txt*", "dir/dir/file.txt", true],
+  ["**/**/*.txt", "dir/dir/file.txt", true],
+  ["**/**/*.txt2", "dir/dir/file.txt", false],
+  ["**/*.txt", "file.txt", true],
+  ["**/**/*.txt", "file.txt", true],
+  ["a**/*.txt", "a/file.txt", true],
+  ["a**/*.txt", "a/dir/file.txt", true],
+  ["a**/*.txt", "a/dir/dir/file.txt", true],
+  ["a/*.txt", "a/dir/file.txt", false],
+  ["a/*.txt", "a/file.txt", true],
+  ["a/*.txt**", "a/file.txt", true],
+  ["a[b-d]e", "ae", false],
+  ["a[b-d]e", "ace", true],
+  ["a[b-d]e", "aae", false],
+  ["a[^b-d]e", "aze", true],
+  [".*", ".foo", true],
+  [".*", "foo", false],
+  ["abc.def", "abcdef", false],
+  ["abc.def", "abc.def", true],
+  ["abc.def", "abcZdef", false],
+  ["abc?def", "abcZdef", true],
+  ["abc?def", "abcdef", false],
+  ["a\\\\", "a\\", true],
+  ["**/foo/bar", "foo/bar", true],
+  ["**/foo/bar", "dir/foo/bar", true],
+  ["**/foo/bar", "dir/dir2/foo/bar", true],
+  ["abc/**", "abc", false],
+  ["abc/**", "abc/def", true],
+  ["abc/**", "abc/def/ghi", true],
+  ["**/.foo", ".foo", true],
+  ["**/.foo", "bar.foo", false],
+  ["a(b)c/def", "a(b)c/def", true],
+  ["a(b)c/def", "a(b)c/xyz", false],
+  ["a.|)$(}+{bc", "a.|)$(}+{bc", true],
+  [
+    "dist/proxy.py-2.4.0rc3.dev36+g08acad9-py3-none-any.whl",
+    "dist/proxy.py-2.4.0rc3.dev36+g08acad9-py3-none-any.whl",
+    true,
+  ],
+  [
+    "dist/*.whl",
+    "dist/proxy.py-2.4.0rc3.dev36+g08acad9-py3-none-any.whl",
+    true,
+  ],
+  ["a\\*b", "a*b", true],
+];
+
+const mobyFilepathMatchCases: [
+  pattern: string,
+  path: string,
+  ignored: boolean,
+][] = [
+  ["abc", "abc", true],
+  ["*", "abc", true],
+  ["*c", "abc", true],
+  ["a*", "a", true],
+  ["a*", "abc", true],
+  ["a*", "ab/c", true],
+  ["a*/b", "abc/b", true],
+  ["a*/b", "a/c/b", false],
+  ["a*b*c*d*e*/f", "axbxcxdxe/f", true],
+  ["a*b*c*d*e*/f", "axbxcxdxexxx/f", true],
+  ["a*b*c*d*e*/f", "axbxcxdxe/xxx/f", false],
+  ["a*b*c*d*e*/f", "axbxcxdxexxx/fff", false],
+  ["a*b?c*x", "abxbbxdbxebxczzx", true],
+  ["a*b?c*x", "abxbbxdbxebxczzy", false],
+  ["ab[c]", "abc", true],
+  ["ab[b-d]", "abc", true],
+  ["ab[e-g]", "abc", false],
+  ["ab[^c]", "abc", false],
+  ["ab[^b-d]", "abc", false],
+  ["ab[^e-g]", "abc", true],
+  ["a\\*b", "a*b", true],
+  ["a\\*b", "ab", false],
+  ["a?b", "a☺b", true],
+  ["a[^a]b", "a☺b", true],
+  ["a???b", "a☺b", false],
+  ["a[^a][^a][^a]b", "a☺b", false],
+  ["[a-ζ]*", "α", true],
+  ["*[a-ζ]", "A", false],
+  ["a?b", "a/b", false],
+  ["a*b", "a/b", false],
+  ["[\\]a]", "]", true],
+  ["[\\-]", "-", true],
+  ["[x\\-]", "x", true],
+  ["[x\\-]", "-", true],
+  ["[x\\-]", "z", false],
+  ["[\\-x]", "x", true],
+  ["[\\-x]", "-", true],
+  ["[\\-x]", "a", false],
+  ["*x", "xxx", true],
+];
+
 describe("DockerIgnoreMatcher", () => {
   it("parses comments, blank lines, and normalized paths", () => {
     const matcher = DockerIgnoreMatcher.parse(
@@ -8,8 +137,9 @@ describe("DockerIgnoreMatcher", () => {
     );
 
     expect(matcher.isIgnored("root.txt")).toBe(true);
-    expect(matcher.isIgnored("nested/root.txt")).toBe(false);
+    expect(matcher.isIgnored("nested/root.txt")).toBe(true);
     expect(matcher.isIgnored("directory/file.txt")).toBe(true);
+    expect(matcher.isIgnored("nested/directory/file.txt")).toBe(true);
     expect(matcher.isIgnored("other.txt")).toBe(true);
     expect(matcher.isIgnored("outside.txt")).toBe(false);
     expect(matcher.isIgnored("included.txt")).toBe(false);
@@ -29,6 +159,20 @@ describe("DockerIgnoreMatcher", () => {
     expect(matcher.isIgnored("logs/archive/debug-long.7.log")).toBe(false);
     expect(matcher.isIgnored("assets/icon8.png")).toBe(true);
     expect(matcher.isIgnored("assets/icon2.png")).toBe(false);
+    expect(DockerIgnoreMatcher.parse("*.go").isIgnored("FILE.GO")).toBe(false);
+  });
+
+  it("uses native matchesGlob syntax", () => {
+    const matcher = DockerIgnoreMatcher.parse(
+      "*.{js,ts}\n@(foo|bar)\n*\n!@(foo|bar)/keep.txt",
+    );
+
+    expect(matcher.isIgnored("file.js")).toBe(true);
+    expect(matcher.isIgnored("file.ts")).toBe(true);
+    expect(matcher.isIgnored("foo")).toBe(true);
+    expect(matcher.isIgnored("bar")).toBe(true);
+    expect(matcher.isIgnored("foo/keep.txt")).toBe(false);
+    expect(matcher.couldIncludeDescendant("foo")).toBe(true);
   });
 
   it("matches dotfiles", () => {
@@ -69,6 +213,103 @@ describe("DockerIgnoreMatcher", () => {
     );
     expect(() => DockerIgnoreMatcher.parse("file[abc")).toThrow(
       "invalid character class",
+    );
+  });
+
+  describe("moby/patternmatcher compatibility", () => {
+    it.each([...mobyMatchCases, ...mobyFilepathMatchCases])(
+      "matches pattern %j against %j",
+      (pattern, path, ignored) => {
+        expect(DockerIgnoreMatcher.parse(pattern).isIgnored(path)).toBe(
+          ignored,
+        );
+      },
+    );
+
+    it.each([
+      [["!fileutils.go", "*.go"], "fileutils.go", true],
+      [["docs", "!docs/README.md"], "docs/README.md", false],
+      [["docs/", "!docs/README.md"], "docs/README.md", false],
+      [["docs/*", "!docs/README.md"], "docs/README.md", false],
+      [["*.go", "!fileutils.go"], "fileutils.go", false],
+      [["**", "!util/docker/web"], "util/docker/web/foo", false],
+      [
+        ["**", "!util/docker/web", "util/docker/web/foo"],
+        "util/docker/web/foo",
+        true,
+      ],
+      [
+        ["**", "!dist/proxy.py-2.4.0rc3.dev36+g08acad9-py3-none-any.whl"],
+        "dist/proxy.py-2.4.0rc3.dev36+g08acad9-py3-none-any.whl",
+        false,
+      ],
+      [
+        ["**", "!dist/*.whl"],
+        "dist/proxy.py-2.4.0rc3.dev36+g08acad9-py3-none-any.whl",
+        false,
+      ],
+    ] as [patterns: string[], path: string, ignored: boolean][])(
+      "applies ordered patterns %j to %j",
+      (patterns, path, ignored) => {
+        expect(
+          DockerIgnoreMatcher.parse(patterns.join("\n")).isIgnored(path),
+        ).toBe(ignored);
+      },
+    );
+
+    it("preprocesses ignore-file lines like moby/ignorefile", () => {
+      const matcher = DockerIgnoreMatcher.parse(`test1
+/test2
+/a/file/here
+
+lastfile
+# this is a comment
+! /inverted/abs/path`);
+
+      expect(matcher.isIgnored("test1")).toBe(true);
+      expect(matcher.isIgnored("test2")).toBe(true);
+      expect(matcher.isIgnored("a/file/here")).toBe(true);
+      expect(matcher.isIgnored("lastfile")).toBe(true);
+      expect(matcher.isIgnored("inverted/abs/path")).toBe(false);
+      const inverseMatcher = DockerIgnoreMatcher.parse(
+        "**\n! /inverted/abs/path",
+      );
+      expect(inverseMatcher.isIgnored("other/path")).toBe(true);
+      expect(inverseMatcher.isIgnored("inverted/abs/path")).toBe(false);
+      expect(DockerIgnoreMatcher.parse("").isIgnored("any/path")).toBe(false);
+      expect(DockerIgnoreMatcher.parse("*.go").isIgnored(".")).toBe(false);
+      expect(
+        DockerIgnoreMatcher.parse("docs\nconfig\n\n").isIgnored("docs"),
+      ).toBe(true);
+      expect(
+        DockerIgnoreMatcher.parse("docs\n  !docs/README.md  ").isIgnored(
+          "docs/README.md",
+        ),
+      ).toBe(false);
+    });
+
+    it.each([
+      "[]a]",
+      "[-]",
+      "[x-]",
+      "[-x]",
+      "\\",
+      "[a-b-c]",
+      "[",
+      "[^",
+      "[^bc",
+      "a[",
+      "[Local-Only]/",
+    ])("rejects malformed upstream pattern %j", (pattern) => {
+      expect(() => DockerIgnoreMatcher.parse(pattern)).toThrow();
+      expect(() => DockerIgnoreMatcher.parse(pattern)).toThrow();
+    });
+
+    it.each(["!", "! "])(
+      "rejects the empty exclusion pattern %j",
+      (pattern) => {
+        expect(() => DockerIgnoreMatcher.parse(pattern)).toThrow();
+      },
     );
   });
 });

--- a/js/src/tests/sandbox.test.ts
+++ b/js/src/tests/sandbox.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { jest, describe, it, expect } from "@jest/globals";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { inspect } from "node:util";
@@ -77,6 +77,29 @@ const createMockClient = (overrides: Record<string, any> = {}) =>
 // the HTTP fallback path's request/response shaping.
 const forceHttpFallback = (sandbox: any) =>
   jest.spyOn(sandbox, "_wsAvailable").mockResolvedValue(false);
+
+const readTarEntryNames = (tar: Uint8Array): string[] => {
+  const buffer = Buffer.from(tar);
+  const names: string[] = [];
+  let offset = 0;
+  while (offset + 512 <= buffer.byteLength) {
+    const header = buffer.subarray(offset, offset + 512);
+    if (header.every((byte) => byte === 0)) {
+      break;
+    }
+    const readString = (start: number, length: number) => {
+      const value = header.subarray(start, start + length).toString("utf8");
+      const end = value.indexOf("\0");
+      return end === -1 ? value : value.slice(0, end);
+    };
+    const name = readString(0, 100);
+    const prefix = readString(345, 155);
+    names.push(prefix ? `${prefix}/${name}` : name);
+    const size = Number.parseInt(readString(124, 12).trim() || "0", 8);
+    offset += 512 + Math.ceil(size / 512) * 512;
+  }
+  return names;
+};
 
 describe("sandbox proxy config helpers", () => {
   it("workspaceSecret wraps names and preserves references", () => {
@@ -2189,6 +2212,99 @@ describe("SandboxClient - snapshot operations", () => {
         }),
       );
       expect(fakeSandbox.delete).toHaveBeenCalledTimes(1);
+    } finally {
+      await rm(context, { recursive: true, force: true });
+    }
+  });
+
+  it("createSnapshotFromDockerfile should respect .dockerignore", async () => {
+    const context = await mkdtemp(join(tmpdir(), "langsmith-docker-context-"));
+    const client = createClientWithMock(jest.fn<typeof fetch>());
+    let contextTar: Uint8Array | undefined;
+    const fakeSandbox = {
+      name: "builder",
+      write: jest
+        .fn<(path: string, content: string | Uint8Array) => Promise<void>>()
+        .mockImplementation(async (_path, content) => {
+          if (content instanceof Uint8Array) {
+            contextTar = content;
+          }
+        }),
+      run: jest
+        .fn<
+          (
+            command: string,
+          ) => Promise<{ stdout: string; stderr: string; exit_code: number }>
+        >()
+        .mockResolvedValue({ stdout: "", stderr: "", exit_code: 0 }),
+      delete: jest.fn<() => Promise<void>>().mockResolvedValue(undefined),
+    };
+    jest.spyOn(client, "createSandbox").mockResolvedValue(fakeSandbox as any);
+    jest.spyOn(client, "captureSnapshot").mockResolvedValue({
+      id: "snap-1",
+      name: "snap",
+      status: "ready",
+      fs_capacity_bytes: 4294967296,
+    });
+
+    try {
+      await mkdir(join(context, "docker"));
+      await mkdir(join(context, "ignored-dir"));
+      await mkdir(join(context, "logs"));
+      await mkdir(join(context, "node_modules"));
+      await Promise.all([
+        writeFile(join(context, "docker", "Dockerfile"), "FROM scratch\n"),
+        writeFile(join(context, "included.txt"), "included\n"),
+        writeFile(join(context, "excluded.txt"), "excluded\n"),
+        writeFile(join(context, "root-only.txt"), "excluded\n"),
+        writeFile(join(context, "ignored-dir", "drop.txt"), "excluded\n"),
+        writeFile(join(context, "ignored-dir", "keep.txt"), "included\n"),
+        writeFile(join(context, "logs", "debug.log"), "excluded\n"),
+        writeFile(join(context, "node_modules", "package.js"), "excluded\n"),
+        writeFile(
+          join(context, ".dockerignore"),
+          [
+            "# Ignore generated and local files",
+            "excluded.txt",
+            "/root-only.txt",
+            "node_modules",
+            "**/*.log",
+            "ignored-dir",
+            "!ignored-dir/keep.txt",
+            "docker",
+            ".dockerignore",
+            "",
+          ].join("\n"),
+        ),
+      ]);
+
+      await client.createSnapshotFromDockerfile("snap", "docker/Dockerfile", {
+        context,
+      });
+
+      expect(contextTar).toBeDefined();
+      const names = readTarEntryNames(contextTar as Uint8Array);
+      expect(names).toEqual(
+        expect.arrayContaining([
+          ".dockerignore",
+          "docker/",
+          "docker/Dockerfile",
+          "ignored-dir/keep.txt",
+          "included.txt",
+          "logs/",
+        ]),
+      );
+      expect(names).not.toEqual(
+        expect.arrayContaining([
+          "excluded.txt",
+          "root-only.txt",
+          "ignored-dir/",
+          "ignored-dir/drop.txt",
+          "logs/debug.log",
+          "node_modules/",
+          "node_modules/package.js",
+        ]),
+      );
     } finally {
       await rm(context, { recursive: true, force: true });
     }

--- a/js/src/tests/sandbox.test.ts
+++ b/js/src/tests/sandbox.test.ts
@@ -2217,7 +2217,7 @@ describe("SandboxClient - snapshot operations", () => {
     }
   });
 
-  it("createSnapshotFromDockerfile should respect .dockerignore", async () => {
+  it("createSnapshotFromDockerfile should respect a valid .dockerignore", async () => {
     const context = await mkdtemp(join(tmpdir(), "langsmith-docker-context-"));
     const client = createClientWithMock(jest.fn<typeof fetch>());
     let contextTar: Uint8Array | undefined;
@@ -2305,6 +2305,41 @@ describe("SandboxClient - snapshot operations", () => {
           "node_modules/package.js",
         ]),
       );
+
+      await writeFile(join(context, ".dockerignore"), "invalid[");
+      await client.createSnapshotFromDockerfile("snap", "docker/Dockerfile", {
+        context,
+      });
+
+      const fallbackNames = readTarEntryNames(contextTar as Uint8Array);
+      expect(fallbackNames).toEqual(
+        expect.arrayContaining([
+          "excluded.txt",
+          "ignored-dir/drop.txt",
+          "logs/debug.log",
+          "node_modules/package.js",
+        ]),
+      );
+
+      await Promise.all([
+        writeFile(join(context, ".dockerignore"), "excluded.txt\n"),
+        writeFile(
+          join(context, "docker", "Dockerfile.dockerignore"),
+          "included.txt\ndocker/Dockerfile.dockerignore\n",
+        ),
+      ]);
+      await client.createSnapshotFromDockerfile("snap", "docker/Dockerfile", {
+        context,
+      });
+
+      const dockerfileIgnoreNames = readTarEntryNames(contextTar as Uint8Array);
+      expect(dockerfileIgnoreNames).toEqual(
+        expect.arrayContaining([
+          "excluded.txt",
+          "docker/Dockerfile.dockerignore",
+        ]),
+      );
+      expect(dockerfileIgnoreNames).not.toContain("included.txt");
     } finally {
       await rm(context, { recursive: true, force: true });
     }


### PR DESCRIPTION
Running `createSnapshotFromDockerfile` ignores `.dockerignore` and can potentially pull in huge folders (like `node_modules`).
