### PR TITLE
test(evaluation): add regression test for feedback_config dict handling

### DIFF
--- a/python/tests/unit_tests/evaluation/test_evaluator.py
+++ b/python/tests/unit_tests/evaluation/test_evaluator.py
@@ -431,3 +431,29 @@ def test_check_value_non_numeric(caplog):
         "Numeric values should be provided in the 'score' field, not 'value'."
         not in caplog.text
     )
+
+
+def test_feedback_config_arbitrary_dict_is_preserved():
+    """A dict passed as `feedback_config` must keep keys unknown to `FeedbackConfig`.
+
+    Regression test for https://github.com/langchain-ai/langchain/issues/31802:
+    `feedback_config` is typed `Optional[Union[FeedbackConfig, dict]]`, and
+    `FeedbackConfig` is a permissive `TypedDict` where every field is optional.
+    A dict with keys that don't match `FeedbackConfig` at all can still validate
+    against it (all its fields are absent, which `total=False` allows), so a
+    naive union match can silently coerce into `FeedbackConfig` and drop every
+    unrecognized key instead of falling through to the plain `dict` arm.
+    """
+    result = EvaluationResult(
+        key="sentiment", value="positive", feedback_config={"threshold": 1.0}
+    )
+    assert result.feedback_config == {"threshold": 1.0}
+
+    # a dict mixing a real FeedbackConfig key with an unrelated one must also
+    # keep both, not just the recognized one
+    result = EvaluationResult(
+        key="sentiment",
+        value="positive",
+        feedback_config={"type": "continuous", "threshold": 1.0},
+    )
+    assert result.feedback_config == {"type": "continuous", "threshold": 1.0}


### PR DESCRIPTION
This closes the loop on langchain-ai/langchain#31802, which reported that passing
a plain dict to EvaluationResult.feedback_config silently drops keys it doesn't
recognize.

feedback_config is typed as Optional[Union[FeedbackConfig, dict]], and
FeedbackConfig is a permissive TypedDict where every field is optional. That means
a dict with keys that don't match FeedbackConfig at all can still validate against
it (nothing is required), so there was a real risk of the union match silently
coercing into FeedbackConfig and dropping unrecognized keys instead of falling
through to the plain dict.

I could not reproduce the reported behavior against current dependencies. I even
pinned pydantic to the exact version from the report (2.11.1), and it still
worked correctly, because pydantic-core resolves independently and had already
moved past whatever version had this issue. So there's nothing to fix in this
repo's code today.

There was no test covering this case though, so a future pydantic-core regression
(or someone pinning an older version) could bring the bug back with nothing to
catch it. This adds a test that locks in the correct behavior for a fully unknown
dict and for a dict that mixes a real FeedbackConfig key with an unrelated one.

Ran the full evaluation test suite and ruff locally, both clean.