### PR TITLE
fix(py): exclude replica config from the serialized run body

### DIFF
--- a/python/langsmith/run_trees.py
+++ b/python/langsmith/run_trees.py
@@ -355,6 +355,8 @@ class RunTree(ls_schemas.RunBase):
     )
     replicas: Optional[Sequence[WriteReplica]] = Field(
         default=None,
+        # Routing config, not run data: keep it out of the serialized run.
+        exclude=True,
         description="Projects to replicate this run to with optional updates.",
     )
 

--- a/python/tests/unit_tests/test_replica_serialization.py
+++ b/python/tests/unit_tests/test_replica_serialization.py
@@ -1,0 +1,62 @@
+"""`RunTree.replicas` is routing config, not run data: it must not be serialized.
+
+`serialize_run_dict` dumps whatever is left in the payload with no allow-list,
+so the guard has to live on the model field.
+"""
+
+import queue
+import uuid
+from unittest.mock import MagicMock
+
+import orjson
+
+from langsmith import Client
+from langsmith.run_trees import AuthHeaders, RunTree, WriteReplica
+
+SECRET = "replica-secret"
+OTHER_URL = "https://other.example.com"
+
+
+def _client(api_url="https://main.example.com", api_key="main-key"):
+    client = Client(
+        api_url=api_url,
+        api_key=api_key,
+        session=MagicMock(),
+        auto_batch_tracing=False,
+    )
+    client.tracing_queue = queue.PriorityQueue(maxsize=100)
+    client.compressed_traces = None
+    return client
+
+
+def test_replica_config_is_not_serialized():
+    """The fan-out sends one body per replica, so anything left in the body
+    reaches every destination -- including the other replicas' credentials."""
+    client = _client()
+    rt = RunTree(
+        name="r",
+        run_type="chain",
+        id=uuid.uuid4(),
+        inputs={"a": 1},
+        ls_client=client,
+        project_name="p",
+        replicas=[
+            WriteReplica(project_name="p", primary=True),
+            WriteReplica(
+                project_name="q",
+                api_url=OTHER_URL,
+                auth=AuthHeaders(api_key=SECRET),
+                client=_client(OTHER_URL, "other-key"),
+            ),
+        ],
+    )
+    rt.post()
+    rt.end(outputs={"b": 2})
+    rt.patch()
+
+    ops = [item.item for item in list(client.tracing_queue.queue)]
+    assert ops, "nothing was queued"
+    for op in ops:
+        assert "replicas" not in orjson.loads(op._none)
+        assert SECRET.encode() not in op._none
+        assert OTHER_URL.encode() not in op._none


### PR DESCRIPTION
## Description

`RunTree.replicas` is routing config, not run data, but it sat on the same model and so was picked up by `_get_dicts_safe`'s `model_dump`. `serialize_run_dict` dumps whatever is left in the payload with no allow-list, so the whole list — every replica's `auth` block, and any per-replica `client` — was serialized into the run body.

The fan-out sends one body per replica, so **each destination received every other destination's credentials**. Confirmed on a live deployment. Backends discard the unknown field rather than persisting it, so the exposure is in transmission, not storage — plaintext past TLS termination, and replicas can target arbitrary URLs.

`exclude=True` keeps the field out of serialization. `create_child`, `to_headers` and the `before` validator read the attribute directly rather than from a dumped dict, so routing is unchanged.

## Release Note

Replica configuration, including per-replica API keys, is no longer serialized into the run body.

## Test Plan

- [x] `python/tests/unit_tests/test_replica_serialization.py` (new) — fails without the fix
- [x] Replica / run-tree unit suites: 101 passed
- [x] Live deployment: credentials absent from request bodies, ingestion unaffected
