### PR TITLE
feat(py): add strip_binary option to list_runs to drop inline base64 content

### DIFF
--- a/python/langsmith/async_client.py
+++ b/python/langsmith/async_client.py
@@ -708,6 +708,7 @@ class AsyncClient:
         run_ids: Optional[Sequence[ls_client.ID_TYPE]] = None,
         select: Optional[Sequence[str]] = None,
         limit: Optional[int] = None,
+        strip_binary: bool = False,
         **kwargs: Any,
     ) -> AsyncIterator[ls_schemas.Run]:
         """List runs from the LangSmith API.
@@ -744,6 +745,11 @@ class AsyncClient:
             run_ids: The IDs of the runs to filter by.
             select: The fields to select.
             limit: The maximum number of runs to return.
+            strip_binary: If True, replace large base64-encoded binary content
+                (images, audio, video) in ``inputs`` and ``outputs`` with a small
+                placeholder reference before yielding the run. This happens
+                client-side, so it reduces memory and disk usage but not network
+                transfer. Defaults to False.
             **kwargs: Additional keyword arguments.
 
         Yields:
@@ -852,6 +858,10 @@ class AsyncClient:
         body = {k: v for k, v in body_query.items() if v is not None}
         ix = 0
         async for run in self._aget_cursor_paginated_list("/runs/query", body=body):
+            if strip_binary:
+                for field in ("inputs", "outputs"):
+                    if isinstance(run.get(field), dict):
+                        run[field] = ls_client._strip_binary_content(run[field])
             yield ls_schemas.Run(**run)
             ix += 1
             if limit is not None and ix >= limit:

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -4353,6 +4353,7 @@ class Client:
         run_ids: Optional[Sequence[ID_TYPE]] = None,
         select: Optional[Sequence[str]] = None,
         limit: Optional[int] = None,
+        strip_binary: bool = False,
         **kwargs: Any,
     ) -> Iterator[ls_schemas.Run]:
         """List runs from the LangSmith API.
@@ -4389,6 +4390,11 @@ class Client:
             run_ids: The IDs of the runs to filter by.
             select: The fields to select.
             limit: The maximum number of runs to return.
+            strip_binary: If True, replace large base64-encoded binary content
+                (images, audio, video) in ``inputs`` and ``outputs`` with a small
+                placeholder reference before yielding the run. This happens
+                client-side, so it reduces memory and disk usage but not network
+                transfer. Defaults to False.
             **kwargs: Additional keyword arguments.
 
         Yields:
@@ -4413,6 +4419,12 @@ class Client:
             correct_runs = client.list_runs(project_name="<your_project>", error=False)
 
             # List runs and only return their inputs/outputs (to speed up the query)
+
+            # List runs while stripping large inline binary content from
+            # inputs/outputs (e.g. base64 images) to save memory
+            text_only_runs = client.list_runs(
+                project_name="<your_project>", strip_binary=True
+            )
             input_output_runs = client.list_runs(
                 project_name="<your_project>", select=["inputs", "outputs"]
             )
@@ -4528,6 +4540,10 @@ class Client:
             attachments = _convert_stored_attachments_to_attachments_dict(
                 run, attachments_key="s3_urls", api_url=self.api_url
             )
+            if strip_binary:
+                for field in ("inputs", "outputs"):
+                    if isinstance(run.get(field), dict):
+                        run[field] = _strip_binary_content(run[field])
             yield ls_schemas.Run(
                 attachments=attachments, **run, _host_url=self._host_url
             )
@@ -11714,6 +11730,39 @@ def _convert_stored_attachments_to_attachments_dict(
                 }
             )
     return attachments_dict
+
+
+_BASE64_MIN_LENGTH = 10_000
+_BASE64_CHARSET = frozenset(
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/="
+)
+_BASE64_DATA_URI_PREFIX = ";base64,"
+
+
+def _is_likely_base64(value: str, min_length: int = _BASE64_MIN_LENGTH) -> bool:
+    """Heuristically detect large base64-encoded payloads (e.g. inline media)."""
+    if len(value) < min_length:
+        return False
+    # Tolerate data URIs like "data:image/png;base64,<payload>".
+    if value.startswith("data:"):
+        payload = value.partition(_BASE64_DATA_URI_PREFIX)[2]
+    else:
+        payload = value
+    return len(payload) >= min_length and not set(payload) - _BASE64_CHARSET
+
+
+def _strip_binary_content(obj: Any) -> Any:
+    """Recursively replace large base64 strings with lightweight references."""
+    if isinstance(obj, dict):
+        return {k: _strip_binary_content(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_strip_binary_content(item) for item in obj]
+    if isinstance(obj, str) and _is_likely_base64(obj):
+        return {
+            "type": "binary_reference",
+            "size_bytes": len(obj),
+        }
+    return obj
 
 
 def _close_files(files: list[io.BufferedReader]) -> None:

--- a/python/tests/unit_tests/test_client.py
+++ b/python/tests/unit_tests/test_client.py
@@ -6599,6 +6599,72 @@ def test_run_ops_buffer_preserves_service_auth_overrides():
 
 
 @mock.patch("langsmith.client.requests.Session")
+def test_list_runs_strip_binary(mock_session_cls: mock.Mock) -> None:
+    """strip_binary=True replaces large base64 content with a placeholder."""
+    big_b64 = "QUJD" * 10_000  # 40k chars of valid base64
+    run = {
+        "id": str(uuid.uuid4()),
+        "name": "run",
+        "run_type": "llm",
+        "start_time": "2026-01-01T00:00:00Z",
+        "inputs": {"messages": [{"content": [{"type": "image", "data": big_b64}]}]},
+        "outputs": {"text": "small"},
+        "extra": {"note": big_b64},
+    }
+    mock_session = mock.Mock()
+    mock_session_cls.return_value = mock_session
+    mock_session.request.return_value.json.return_value = {"runs": [dict(run)]}
+
+    client = Client()
+    runs = list(client.list_runs(project_id=uuid.uuid4(), strip_binary=True))
+
+    stripped_input = runs[0].inputs["messages"][0]["content"][0]["data"]
+    assert stripped_input == {
+        "type": "binary_reference",
+        "size_bytes": len(big_b64),
+    }
+    assert runs[0].outputs == {"text": "small"}
+    # Only inputs/outputs are stripped.
+    assert runs[0].extra["note"] == big_b64
+
+
+@mock.patch("langsmith.client.requests.Session")
+def test_list_runs_strip_binary_default_keeps_content(
+    mock_session_cls: mock.Mock,
+) -> None:
+    """Without strip_binary, binary content is returned untouched."""
+    big_b64 = "QUJD" * 10_000
+    run = {
+        "id": str(uuid.uuid4()),
+        "name": "run",
+        "run_type": "llm",
+        "start_time": "2026-01-01T00:00:00Z",
+        "inputs": {"data": big_b64},
+        "outputs": {},
+    }
+    mock_session = mock.Mock()
+    mock_session_cls.return_value = mock_session
+    mock_session.request.return_value.json.return_value = {"runs": [dict(run)]}
+
+    client = Client()
+    runs = list(client.list_runs(project_id=uuid.uuid4()))
+
+    assert runs[0].inputs["data"] == big_b64
+
+
+def test_is_likely_base64() -> None:
+    """The base64 heuristic rejects long non-base64 text and short payloads."""
+    from langsmith.client import _is_likely_base64
+
+    assert _is_likely_base64("QUJD" * 10_000)
+    assert _is_likely_base64("data:image/png;base64," + "QUJD" * 10_000)
+    # Long but not base64 (contains spaces/punctuation).
+    assert not _is_likely_base64("hello world, this is plain text. " * 500)
+    # Valid base64 but under the size threshold.
+    assert not _is_likely_base64("QUJDREVG")
+
+
+@mock.patch("langsmith.client.requests.Session")
 def test_list_runs_child_run_ids_deprecation_warning(
     mock_session_cls: mock.Mock,
 ) -> None:


### PR DESCRIPTION
## Description
Adds a `strip_binary: bool = False` option to `Client.list_runs()` and `AsyncClient.list_runs()`. When enabled, large base64-encoded strings (images, audio, video) found in `inputs`/`outputs` are recursively replaced with a small placeholder before the run is yielded:

```python
runs = client.list_runs(project_name="my-project", strip_binary=True)
# inputs.messages[0].content[1].data ->
# {"type": "binary_reference", "size_bytes": 955000}
```

Closes #2553 (implements its Option A, client-side).

## Motivation
Runs from vision/video/audio services can carry ~1 MB of inline base64 per run; bulk-fetching thousands of runs is dominated by binary payload (96% of bytes in the reporter's workload). This flag removes that cost for local caching/analysis without any server change.

## Scope note
This is applied **client-side**, so it saves memory/disk but not network transfer — full bandwidth savings would require server-side support in the LangSmith API, which is out of scope for this SDK repo. The docstrings state this explicitly.

Detection heuristic (`_is_likely_base64`): strings >= 10,000 chars consisting only of base64 charset, with data-URI prefix tolerance. Only `inputs` and `outputs` are touched.

## Testing
- New unit tests in `tests/unit_tests/test_client.py`: stripping behavior, default-off passthrough, and heuristic edge cases (data URIs, plain text, short payloads).
- Full `test_client.py` suite passes except pre-existing failures from missing optional deps (`langchain_anthropic`/`langchain_openai`) in the local environment; `test_async_client.py`: 26 passed.
- `ruff check` and `ruff format --check` clean on changed files.