### PR TITLE
feat(sandbox): support snapshot tags in the Python client

### DIFF
--- a/python/langsmith/sandbox/README.md
+++ b/python/langsmith/sandbox/README.md
@@ -889,9 +889,9 @@ with client.sandbox(snapshot_id=snapshot.id) as sb:
     result = sb.run("python --version")
     print(result.stdout)
 
-# Or resolve by snapshot name. This is optional; omitting both snapshot_id and
-# snapshot_name uses the default runtime.
-with client.sandbox(snapshot_name="my-python-env") as sb:
+# Or resolve by reference: a bare name means `name:latest`. This is optional;
+# omitting the snapshot entirely uses the default runtime.
+with client.sandbox(snapshot="my-python-env") as sb:
     result = sb.run("python --version")
     print(result.stdout)
 ```
@@ -921,6 +921,33 @@ with client.sandbox(snapshot_id=snapshot.id) as sb:
     assert sb.read("/opt/config.yaml") == b"model: gpt-5\n"
 ```
 
+### Snapshot Names and Tags
+
+Snapshots follow Docker's model: the content is immutable and addressed by `id`,
+while `name:tag` is a **mutable pointer** to it. The default tag is `latest`, one
+name can carry several tags, and re-publishing a tag moves it to the new snapshot
+— the old one stays reachable by id. There is no separate retag operation: a tag
+is assigned by the call that creates the snapshot it points at.
+
+```python
+# Publish a new build under an existing name
+snapshot = client.capture_snapshot(sb.name, "my-python-env", tag="v2")
+assert "v2" in snapshot.tags
+
+# Boot from a tag. `snapshot` accepts an id, `name:tag`, or a bare name.
+with client.sandbox(snapshot="my-python-env:v2") as box:
+    box.run("python --version")
+
+# See every tag published under a name, and what each resolves to
+published = client.get_snapshot_name("my-python-env")
+for tag in published.tags:
+    print(tag.tag, tag.snapshot_id)
+```
+
+The first identity to publish under a name owns it; publishing under someone
+else's name needs the `snapshots:update` permission and otherwise fails with
+`403`.
+
 > **Note:** `capture_snapshot` preserves only the **persistent filesystem**.
 > Installed packages (under `/usr/local`, `/root`, `/opt`, the home
 > directory, etc.) and files you wrote to those paths are kept. Running
@@ -942,8 +969,9 @@ snapshots = client.list_snapshots(
     offset=0,
 )
 
-# Get a snapshot by ID
+# Get a snapshot by ID, by `name:tag`, or by a bare name (which means `name:latest`)
 snapshot = client.get_snapshot("550e8400-...")
+snapshot = client.get_snapshot("my-python-env:v2")
 
 # Delete a snapshot
 client.delete_snapshot("550e8400-...")
@@ -1193,8 +1221,8 @@ except SandboxClientError as e:
 
 | Method | Description |
 |--------|-------------|
-| `sandbox(snapshot_id=None, *, snapshot_name=None, mount_config=None, proxy_config=None, ...)` | Create a sandbox with the default runtime (auto-deleted on context exit). Pass `snapshot_id` or `snapshot_name` only to boot from a reusable snapshot. |
-| `create_sandbox(snapshot_id=None, *, snapshot_name=None, mount_config=None, proxy_config=None, wait_for_ready=True, ...)` | Create a sandbox with the default runtime (requires explicit delete). Pass `snapshot_id` or `snapshot_name` only to boot from a reusable snapshot. |
+| `sandbox(snapshot_id=None, *, snapshot=None, mount_config=None, proxy_config=None, ...)` | Create a sandbox with the default runtime (auto-deleted on context exit). Pass `snapshot` (an id, `name:tag`, or a bare name) only to boot from a reusable snapshot. |
+| `create_sandbox(snapshot_id=None, *, snapshot=None, mount_config=None, proxy_config=None, wait_for_ready=True, ...)` | Create a sandbox with the default runtime (requires explicit delete). Pass `snapshot` (an id, `name:tag`, or a bare name) only to boot from a reusable snapshot. |
 | `get_sandbox(name)` | Get an existing sandbox by name |
 | `get_sandbox_status(name)` | Get lightweight provisioning status (`ResourceStatus`) |
 | `wait_for_sandbox(name, *, timeout=120, poll_interval=1.0)` | Poll until sandbox is ready or failed |
@@ -1204,9 +1232,10 @@ except SandboxClientError as e:
 | `delete_sandbox(name)` | Delete a sandbox |
 | `start_sandbox(name, *, timeout=120)` | Start a stopped sandbox, poll until ready |
 | `stop_sandbox(name)` | Stop a running sandbox (preserves sandbox files) |
-| `create_snapshot(name, docker_image, fs_capacity_bytes, *, timeout=60)` | Build a snapshot from a Docker image |
-| `capture_snapshot(sandbox_name, name, *, timeout=60)` | Capture a snapshot from a running sandbox |
-| `get_snapshot(snapshot_id)` | Get a snapshot by ID |
+| `create_snapshot(name, docker_image, fs_capacity_bytes, *, tag=None, timeout=60)` | Build a snapshot from a Docker image, published as `name:tag` (default `latest`) |
+| `capture_snapshot(sandbox_name, name, *, tag=None, timeout=60)` | Capture a snapshot from a running sandbox, published as `name:tag` (default `latest`) |
+| `get_snapshot(snapshot_id)` | Get a snapshot by ID, `name:tag`, or a bare name (means `name:latest`) |
+| `get_snapshot_name(name)` | List every tag published under a snapshot name |
 | `list_snapshots(*, name_contains=None, limit=None, offset=None)` | List a page of snapshots (server paginates, default limit 50, max 500; `name_contains` is a case-insensitive substring match) |
 | `delete_snapshot(snapshot_id)` | Delete a snapshot |
 | `wait_for_snapshot(snapshot_id, *, timeout=300)` | Poll until snapshot is ready or failed |

--- a/python/langsmith/sandbox/README.md
+++ b/python/langsmith/sandbox/README.md
@@ -939,8 +939,7 @@ with client.sandbox(snapshot="my-python-env:v2") as box:
     box.run("python --version")
 
 # See every tag published under a name, and what each resolves to
-published = client.get_snapshot_name("my-python-env")
-for tag in published.tags:
+for tag in client.list_snapshot_tags("my-python-env"):
     print(tag.tag, tag.snapshot_id)
 ```
 
@@ -1235,7 +1234,7 @@ except SandboxClientError as e:
 | `create_snapshot(name, docker_image, fs_capacity_bytes, *, tag=None, timeout=60)` | Build a snapshot from a Docker image, published as `name:tag` (default `latest`) |
 | `capture_snapshot(sandbox_name, name, *, tag=None, timeout=60)` | Capture a snapshot from a running sandbox, published as `name:tag` (default `latest`) |
 | `get_snapshot(snapshot_id)` | Get a snapshot by ID, `name:tag`, or a bare name (means `name:latest`) |
-| `get_snapshot_name(name)` | List every tag published under a snapshot name |
+| `list_snapshot_tags(name)` | List every tag published under a snapshot name, with the snapshot each resolves to |
 | `list_snapshots(*, name_contains=None, limit=None, offset=None)` | List a page of snapshots (server paginates, default limit 50, max 500; `name_contains` is a case-insensitive substring match) |
 | `delete_snapshot(snapshot_id)` | Delete a snapshot |
 | `wait_for_snapshot(snapshot_id, *, timeout=300)` | Poll until snapshot is ready or failed |

--- a/python/langsmith/sandbox/__init__.py
+++ b/python/langsmith/sandbox/__init__.py
@@ -67,6 +67,8 @@ from langsmith.sandbox._models import (
     ResourceStatus,
     ServiceURL,
     Snapshot,
+    SnapshotName,
+    SnapshotNameTag,
 )
 from langsmith.sandbox._mounts import (
     AWSMountAuthConfig,
@@ -114,6 +116,8 @@ __all__ = [
     "ResourceStatus",
     "ExecutionResult",
     "Snapshot",
+    "SnapshotName",
+    "SnapshotNameTag",
     "ServiceURL",
     "DownloadURL",
     "DownloadContentDisposition",

--- a/python/langsmith/sandbox/__init__.py
+++ b/python/langsmith/sandbox/__init__.py
@@ -67,8 +67,7 @@ from langsmith.sandbox._models import (
     ResourceStatus,
     ServiceURL,
     Snapshot,
-    SnapshotName,
-    SnapshotNameTag,
+    SnapshotTag,
 )
 from langsmith.sandbox._mounts import (
     AWSMountAuthConfig,
@@ -116,8 +115,7 @@ __all__ = [
     "ResourceStatus",
     "ExecutionResult",
     "Snapshot",
-    "SnapshotName",
-    "SnapshotNameTag",
+    "SnapshotTag",
     "ServiceURL",
     "DownloadURL",
     "DownloadContentDisposition",

--- a/python/langsmith/sandbox/_async_client.py
+++ b/python/langsmith/sandbox/_async_client.py
@@ -20,6 +20,7 @@ from langsmith.sandbox._client import (
     _make_docker_context_tar,
     _make_dockerfile_build_command,
     _quote_path_segment,
+    _quote_reference_segment,
     _resolve_dockerfile_context,
 )
 from langsmith.sandbox._exceptions import (
@@ -42,6 +43,7 @@ from langsmith.sandbox._models import (
     DownloadURL,
     ResourceStatus,
     Snapshot,
+    SnapshotName,
 )
 from langsmith.sandbox._mounts import (
     SandboxMountConfig,
@@ -252,6 +254,7 @@ class AsyncSandboxClient:
         self,
         snapshot_id: Optional[str] = None,
         *,
+        snapshot: Optional[str] = None,
         snapshot_name: Optional[str] = None,
         name: Optional[str] = None,
         timeout: int = 30,
@@ -281,10 +284,12 @@ class AsyncSandboxClient:
 
         Args:
             snapshot_id: Optional snapshot ID to boot from. Mutually exclusive
-                with ``snapshot_name``.
-            snapshot_name: Snapshot name to boot from. Resolved server-side to a
-                snapshot owned by the caller's tenant. Mutually exclusive with
-                ``snapshot_id``.
+                with ``snapshot`` and ``snapshot_name``.
+            snapshot: Snapshot to boot from, as a UUID, ``name:tag``, or a bare
+                ``name`` (which means ``name:latest``). Prefer this over
+                ``snapshot_id`` and ``snapshot_name``: it covers all three forms.
+            snapshot_name: Deprecated synonym for ``snapshot``, kept for callers
+                that predate it.
             name: Optional sandbox name (auto-generated if not provided).
             timeout: Timeout in seconds when waiting for ready.
             idle_ttl_seconds: Idle timeout in seconds. The launcher
@@ -322,11 +327,12 @@ class AsyncSandboxClient:
             ResourceTimeoutError: If timeout waiting for sandbox to be ready.
             ResourceCreationError: If sandbox creation fails.
             SandboxClientError: For other errors.
-            ValueError: If TTL values are invalid, or if both ``snapshot_id`` and
-                ``snapshot_name`` are provided.
+            ValueError: If TTL values are invalid, or if more than one of
+                ``snapshot_id``, ``snapshot`` and ``snapshot_name`` is provided.
         """
         sb = await self.create_sandbox(
             snapshot_id,
+            snapshot=snapshot,
             snapshot_name=snapshot_name,
             name=name,
             timeout=timeout,
@@ -346,6 +352,7 @@ class AsyncSandboxClient:
         self,
         snapshot_id: Optional[str] = None,
         *,
+        snapshot: Optional[str] = None,
         snapshot_name: Optional[str] = None,
         name: Optional[str] = None,
         timeout: int = 30,
@@ -366,10 +373,12 @@ class AsyncSandboxClient:
 
         Args:
             snapshot_id: Optional snapshot ID to boot from. Mutually exclusive
-                with ``snapshot_name``.
-            snapshot_name: Snapshot name to boot from. Resolved server-side to a
-                snapshot owned by the caller's tenant. Mutually exclusive with
-                ``snapshot_id``.
+                with ``snapshot`` and ``snapshot_name``.
+            snapshot: Snapshot to boot from, as a UUID, ``name:tag``, or a bare
+                ``name`` (which means ``name:latest``). Prefer this over
+                ``snapshot_id`` and ``snapshot_name``: it covers all three forms.
+            snapshot_name: Deprecated synonym for ``snapshot``, kept for callers
+                that predate it.
             name: Optional sandbox name (auto-generated if not provided).
             timeout: Timeout in seconds when waiting for ready (only used when
                 wait_for_ready=True).
@@ -415,8 +424,13 @@ class AsyncSandboxClient:
             ValueError: If TTL values are invalid, or if both ``snapshot_id`` and
                 ``snapshot_name`` are provided.
         """
-        if snapshot_id and snapshot_name:
-            raise ValueError("At most one of snapshot_id or snapshot_name may be set")
+        reference = snapshot or snapshot_name
+        if snapshot and snapshot_name and snapshot != snapshot_name:
+            raise ValueError("snapshot and snapshot_name must not disagree")
+        if snapshot_id and reference:
+            raise ValueError(
+                "At most one of snapshot_id, snapshot or snapshot_name may be set"
+            )
         validate_ttl(idle_ttl_seconds, "idle_ttl_seconds")
         validate_ttl(delete_after_stop_seconds, "delete_after_stop_seconds")
 
@@ -427,7 +441,9 @@ class AsyncSandboxClient:
         }
         if snapshot_id:
             payload["snapshot_id"] = snapshot_id
-        if snapshot_name:
+        if snapshot:
+            payload["snapshot"] = snapshot
+        elif snapshot_name:
             payload["snapshot_name"] = snapshot_name
         if wait_for_ready:
             payload["timeout"] = timeout
@@ -894,6 +910,7 @@ class AsyncSandboxClient:
         docker_image: str,
         fs_capacity_bytes: int,
         *,
+        tag: Optional[str] = None,
         registry_id: Optional[str] = None,
         timeout: int = 60,
         headers: RequestHeaders = None,
@@ -924,6 +941,8 @@ class AsyncSandboxClient:
             "docker_image": docker_image,
             "fs_capacity_bytes": fs_capacity_bytes,
         }
+        if tag is not None:
+            payload["tag"] = tag
         if registry_id is not None:
             payload["registry_id"] = registry_id
 
@@ -1040,6 +1059,7 @@ class AsyncSandboxClient:
         sandbox_name: str,
         name: str,
         *,
+        tag: Optional[str] = None,
         docker_image: Optional[str] = None,
         fs_capacity_bytes: Optional[int] = None,
         timeout: int = 60,
@@ -1052,6 +1072,9 @@ class AsyncSandboxClient:
         Args:
             sandbox_name: Name of the sandbox to capture from.
             name: Snapshot name.
+            tag: Tag to publish the snapshot under, within ``name``. Re-using a
+                tag moves it to the new snapshot, leaving the previous one
+                addressable by id. Defaults server-side to ``latest``.
             timeout: Timeout in seconds when waiting for ready.
 
         Returns:
@@ -1066,6 +1089,8 @@ class AsyncSandboxClient:
         url = _box_url(self._base_url, sandbox_name, "snapshot")
 
         payload: dict[str, Any] = {"name": name}
+        if tag is not None:
+            payload["tag"] = tag
         if docker_image is not None:
             payload["docker_image"] = docker_image
         if fs_capacity_bytes is not None:
@@ -1092,10 +1117,12 @@ class AsyncSandboxClient:
     async def get_snapshot(
         self, snapshot_id: str, *, headers: RequestHeaders = None
     ) -> Snapshot:
-        """Get a snapshot by ID.
+        """Get a snapshot by ID or by a Docker-style reference.
 
         Args:
-            snapshot_id: Snapshot UUID.
+            snapshot_id: Snapshot UUID, ``name:tag``, or a bare ``name``. A bare
+                name means ``name:latest``, falling back to the newest ready
+                untagged snapshot of that name.
 
         Returns:
             Snapshot.
@@ -1104,7 +1131,7 @@ class AsyncSandboxClient:
             ResourceNotFoundError: If snapshot not found.
             SandboxClientError: For other errors.
         """
-        url = f"{self._base_url}/snapshots/{_quote_path_segment(snapshot_id)}"
+        url = f"{self._base_url}/snapshots/{_quote_reference_segment(snapshot_id)}"
 
         try:
             response = await self._http.get(url, headers=self._request_headers(headers))
@@ -1114,6 +1141,36 @@ class AsyncSandboxClient:
             if e.response.status_code == 404:
                 raise ResourceNotFoundError(
                     f"Snapshot '{snapshot_id}' not found", resource_type="snapshot"
+                ) from e
+            handle_client_http_error(e)
+            raise  # pragma: no cover
+
+    async def get_snapshot_name(
+        self, name: str, *, headers: RequestHeaders = None
+    ) -> SnapshotName:
+        """List every tag published under a snapshot name.
+
+        Args:
+            name: Snapshot name, without a tag.
+
+        Returns:
+            The name and each tag under it, with the snapshot the tag resolves
+            to. The tag list is empty when the name carries no tags.
+
+        Raises:
+            ResourceNotFoundError: If nobody has published under the name.
+            SandboxClientError: For other errors, including a name carrying a tag.
+        """
+        url = f"{self._base_url}/snapshots-by-name/{_quote_path_segment(name)}"
+
+        try:
+            response = await self._http.get(url, headers=self._request_headers(headers))
+            response.raise_for_status()
+            return SnapshotName.from_dict(response.json())
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 404:
+                raise ResourceNotFoundError(
+                    f"Snapshot name '{name}' not found", resource_type="snapshot"
                 ) from e
             handle_client_http_error(e)
             raise  # pragma: no cover

--- a/python/langsmith/sandbox/_async_client.py
+++ b/python/langsmith/sandbox/_async_client.py
@@ -43,7 +43,7 @@ from langsmith.sandbox._models import (
     DownloadURL,
     ResourceStatus,
     Snapshot,
-    SnapshotName,
+    SnapshotTag,
 )
 from langsmith.sandbox._mounts import (
     SandboxMountConfig,
@@ -1145,17 +1145,17 @@ class AsyncSandboxClient:
             handle_client_http_error(e)
             raise  # pragma: no cover
 
-    async def get_snapshot_name(
+    async def list_snapshot_tags(
         self, name: str, *, headers: RequestHeaders = None
-    ) -> SnapshotName:
+    ) -> list[SnapshotTag]:
         """List every tag published under a snapshot name.
 
         Args:
             name: Snapshot name, without a tag.
 
         Returns:
-            The name and each tag under it, with the snapshot the tag resolves
-            to. The tag list is empty when the name carries no tags.
+            Each tag under the name with the snapshot it resolves to. Empty when
+            the name exists but currently carries no tags.
 
         Raises:
             ResourceNotFoundError: If nobody has published under the name.
@@ -1166,7 +1166,9 @@ class AsyncSandboxClient:
         try:
             response = await self._http.get(url, headers=self._request_headers(headers))
             response.raise_for_status()
-            return SnapshotName.from_dict(response.json())
+            return [
+                SnapshotTag.from_dict(tag) for tag in response.json().get("tags") or []
+            ]
         except httpx.HTTPStatusError as e:
             if e.response.status_code == 404:
                 raise ResourceNotFoundError(

--- a/python/langsmith/sandbox/_client.py
+++ b/python/langsmith/sandbox/_client.py
@@ -37,6 +37,7 @@ from langsmith.sandbox._models import (
     ResourceStatus,
     ServiceURL,
     Snapshot,
+    SnapshotName,
 )
 from langsmith.sandbox._mounts import (
     SandboxMountConfig,
@@ -75,6 +76,17 @@ def _quote_path_segment(value: str) -> str:
     if not value:
         raise ValueError("URL path segment must be a non-empty string")
     return quote(value, safe="")
+
+
+def _quote_reference_segment(value: str) -> str:
+    """Quote a Docker-style ``name[:tag]`` reference as one URL path segment.
+
+    The colon is left literal: it is a legal path character and the server splits
+    the reference on it, so percent-encoding would hide the tag.
+    """
+    if not value:
+        raise ValueError("URL path segment must be a non-empty string")
+    return quote(value, safe=":")
 
 
 def _box_url(base_url: str, name: str, *segments: str) -> str:
@@ -360,6 +372,7 @@ class SandboxClient:
         self,
         snapshot_id: Optional[str] = None,
         *,
+        snapshot: Optional[str] = None,
         snapshot_name: Optional[str] = None,
         name: Optional[str] = None,
         timeout: int = 30,
@@ -389,10 +402,12 @@ class SandboxClient:
 
         Args:
             snapshot_id: Optional snapshot ID to boot from. Mutually exclusive
-                with ``snapshot_name``.
-            snapshot_name: Snapshot name to boot from. Resolved server-side to a
-                snapshot owned by the caller's tenant. Mutually exclusive with
-                ``snapshot_id``.
+                with ``snapshot`` and ``snapshot_name``.
+            snapshot: Snapshot to boot from, as a UUID, ``name:tag``, or a bare
+                ``name`` (which means ``name:latest``). Prefer this over
+                ``snapshot_id`` and ``snapshot_name``: it covers all three forms.
+            snapshot_name: Deprecated synonym for ``snapshot``, kept for callers
+                that predate it.
             name: Optional sandbox name (auto-generated if not provided).
             timeout: Timeout in seconds when waiting for ready.
             idle_ttl_seconds: Idle timeout in seconds. The launcher
@@ -430,11 +445,12 @@ class SandboxClient:
             ResourceTimeoutError: If timeout waiting for sandbox to be ready.
             ResourceCreationError: If sandbox creation fails.
             SandboxClientError: For other errors.
-            ValueError: If TTL values are invalid, or if both ``snapshot_id`` and
-                ``snapshot_name`` are provided.
+            ValueError: If TTL values are invalid, or if more than one of
+                ``snapshot_id``, ``snapshot`` and ``snapshot_name`` is provided.
         """
         sb = self.create_sandbox(
             snapshot_id,
+            snapshot=snapshot,
             snapshot_name=snapshot_name,
             name=name,
             timeout=timeout,
@@ -454,6 +470,7 @@ class SandboxClient:
         self,
         snapshot_id: Optional[str] = None,
         *,
+        snapshot: Optional[str] = None,
         snapshot_name: Optional[str] = None,
         name: Optional[str] = None,
         timeout: int = 30,
@@ -474,10 +491,12 @@ class SandboxClient:
 
         Args:
             snapshot_id: Optional snapshot ID to boot from. Mutually exclusive
-                with ``snapshot_name``.
-            snapshot_name: Snapshot name to boot from. Resolved server-side to a
-                snapshot owned by the caller's tenant. Mutually exclusive with
-                ``snapshot_id``.
+                with ``snapshot`` and ``snapshot_name``.
+            snapshot: Snapshot to boot from, as a UUID, ``name:tag``, or a bare
+                ``name`` (which means ``name:latest``). Prefer this over
+                ``snapshot_id`` and ``snapshot_name``: it covers all three forms.
+            snapshot_name: Deprecated synonym for ``snapshot``, kept for callers
+                that predate it.
             name: Optional sandbox name (auto-generated if not provided).
             timeout: Timeout in seconds when waiting for ready (only used when
                 wait_for_ready=True).
@@ -520,11 +539,16 @@ class SandboxClient:
             ResourceTimeoutError: If timeout waiting for sandbox to be ready.
             ResourceCreationError: If sandbox creation fails.
             SandboxClientError: For other errors.
-            ValueError: If TTL values are invalid, or if both ``snapshot_id`` and
-                ``snapshot_name`` are provided.
+            ValueError: If TTL values are invalid, or if more than one of
+                ``snapshot_id``, ``snapshot`` and ``snapshot_name`` is provided.
         """
-        if snapshot_id and snapshot_name:
-            raise ValueError("At most one of snapshot_id or snapshot_name may be set")
+        reference = snapshot or snapshot_name
+        if snapshot and snapshot_name and snapshot != snapshot_name:
+            raise ValueError("snapshot and snapshot_name must not disagree")
+        if snapshot_id and reference:
+            raise ValueError(
+                "At most one of snapshot_id, snapshot or snapshot_name may be set"
+            )
         validate_ttl(idle_ttl_seconds, "idle_ttl_seconds")
         validate_ttl(delete_after_stop_seconds, "delete_after_stop_seconds")
 
@@ -535,7 +559,9 @@ class SandboxClient:
         }
         if snapshot_id:
             payload["snapshot_id"] = snapshot_id
-        if snapshot_name:
+        if snapshot:
+            payload["snapshot"] = snapshot
+        elif snapshot_name:
             payload["snapshot_name"] = snapshot_name
         if wait_for_ready:
             payload["timeout"] = timeout
@@ -987,6 +1013,7 @@ class SandboxClient:
         docker_image: str,
         fs_capacity_bytes: int,
         *,
+        tag: Optional[str] = None,
         registry_id: Optional[str] = None,
         timeout: int = 60,
         headers: RequestHeaders = None,
@@ -999,6 +1026,10 @@ class SandboxClient:
             name: Snapshot name.
             docker_image: Docker image to build from (e.g., "python:3.12-slim").
             fs_capacity_bytes: Filesystem capacity in bytes.
+            tag: Tag to publish the snapshot under, within ``name``. Re-using a
+                tag moves it to the new snapshot, leaving the previous one
+                addressable by id. Defaults server-side to the Docker image's
+                own tag, else ``latest``.
             registry_id: Private registry ID.
             timeout: Timeout in seconds when waiting for ready.
 
@@ -1017,6 +1048,8 @@ class SandboxClient:
             "docker_image": docker_image,
             "fs_capacity_bytes": fs_capacity_bytes,
         }
+        if tag is not None:
+            payload["tag"] = tag
         if registry_id is not None:
             payload["registry_id"] = registry_id
 
@@ -1131,6 +1164,7 @@ class SandboxClient:
         sandbox_name: str,
         name: str,
         *,
+        tag: Optional[str] = None,
         docker_image: Optional[str] = None,
         fs_capacity_bytes: Optional[int] = None,
         timeout: int = 60,
@@ -1143,6 +1177,9 @@ class SandboxClient:
         Args:
             sandbox_name: Name of the sandbox to capture from.
             name: Snapshot name.
+            tag: Tag to publish the snapshot under, within ``name``. Re-using a
+                tag moves it to the new snapshot, leaving the previous one
+                addressable by id. Defaults server-side to ``latest``.
             docker_image: Optional Docker image tag inside the sandbox to export
                 into the snapshot instead of capturing the live root filesystem.
             fs_capacity_bytes: Filesystem capacity in bytes for Docker image export.
@@ -1160,6 +1197,8 @@ class SandboxClient:
         url = _box_url(self._base_url, sandbox_name, "snapshot")
 
         payload: dict[str, Any] = {"name": name}
+        if tag is not None:
+            payload["tag"] = tag
         if docker_image is not None:
             payload["docker_image"] = docker_image
         if fs_capacity_bytes is not None:
@@ -1184,10 +1223,12 @@ class SandboxClient:
     def get_snapshot(
         self, snapshot_id: str, *, headers: RequestHeaders = None
     ) -> Snapshot:
-        """Get a snapshot by ID.
+        """Get a snapshot by ID or by a Docker-style reference.
 
         Args:
-            snapshot_id: Snapshot UUID.
+            snapshot_id: Snapshot UUID, ``name:tag``, or a bare ``name``. A bare
+                name means ``name:latest``, falling back to the newest ready
+                untagged snapshot of that name.
 
         Returns:
             Snapshot.
@@ -1196,7 +1237,7 @@ class SandboxClient:
             ResourceNotFoundError: If snapshot not found.
             SandboxClientError: For other errors.
         """
-        url = f"{self._base_url}/snapshots/{_quote_path_segment(snapshot_id)}"
+        url = f"{self._base_url}/snapshots/{_quote_reference_segment(snapshot_id)}"
 
         try:
             response = self._http.get(url, headers=self._request_headers(headers))
@@ -1206,6 +1247,36 @@ class SandboxClient:
             if e.response.status_code == 404:
                 raise ResourceNotFoundError(
                     f"Snapshot '{snapshot_id}' not found", resource_type="snapshot"
+                ) from e
+            handle_client_http_error(e)
+            raise  # pragma: no cover
+
+    def get_snapshot_name(
+        self, name: str, *, headers: RequestHeaders = None
+    ) -> SnapshotName:
+        """List every tag published under a snapshot name.
+
+        Args:
+            name: Snapshot name, without a tag.
+
+        Returns:
+            The name and each tag under it, with the snapshot the tag resolves
+            to. The tag list is empty when the name carries no tags.
+
+        Raises:
+            ResourceNotFoundError: If nobody has published under the name.
+            SandboxClientError: For other errors, including a name carrying a tag.
+        """
+        url = f"{self._base_url}/snapshots-by-name/{_quote_path_segment(name)}"
+
+        try:
+            response = self._http.get(url, headers=self._request_headers(headers))
+            response.raise_for_status()
+            return SnapshotName.from_dict(response.json())
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 404:
+                raise ResourceNotFoundError(
+                    f"Snapshot name '{name}' not found", resource_type="snapshot"
                 ) from e
             handle_client_http_error(e)
             raise  # pragma: no cover

--- a/python/langsmith/sandbox/_client.py
+++ b/python/langsmith/sandbox/_client.py
@@ -37,7 +37,7 @@ from langsmith.sandbox._models import (
     ResourceStatus,
     ServiceURL,
     Snapshot,
-    SnapshotName,
+    SnapshotTag,
 )
 from langsmith.sandbox._mounts import (
     SandboxMountConfig,
@@ -1251,17 +1251,17 @@ class SandboxClient:
             handle_client_http_error(e)
             raise  # pragma: no cover
 
-    def get_snapshot_name(
+    def list_snapshot_tags(
         self, name: str, *, headers: RequestHeaders = None
-    ) -> SnapshotName:
+    ) -> list[SnapshotTag]:
         """List every tag published under a snapshot name.
 
         Args:
             name: Snapshot name, without a tag.
 
         Returns:
-            The name and each tag under it, with the snapshot the tag resolves
-            to. The tag list is empty when the name carries no tags.
+            Each tag under the name with the snapshot it resolves to. Empty when
+            the name exists but currently carries no tags.
 
         Raises:
             ResourceNotFoundError: If nobody has published under the name.
@@ -1272,7 +1272,9 @@ class SandboxClient:
         try:
             response = self._http.get(url, headers=self._request_headers(headers))
             response.raise_for_status()
-            return SnapshotName.from_dict(response.json())
+            return [
+                SnapshotTag.from_dict(tag) for tag in response.json().get("tags") or []
+            ]
         except httpx.HTTPStatusError as e:
             if e.response.status_code == 404:
                 raise ResourceNotFoundError(

--- a/python/langsmith/sandbox/_models.py
+++ b/python/langsmith/sandbox/_models.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import AsyncIterator, Awaitable, Callable, Iterator
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Literal, Optional
 
@@ -113,12 +113,15 @@ class Snapshot:
         registry_id: Private registry ID, if applicable.
         created_at: Timestamp when the snapshot was created.
         updated_at: Timestamp when the snapshot was last updated.
+        tags: Tags currently resolving to this snapshot, under its name. Empty
+            means the snapshot is dangling — reachable only by id.
     """
 
     id: str
     name: str
     status: str
     fs_capacity_bytes: int
+    tags: list[str] = field(default_factory=list)
     docker_image: Optional[str] = None
     image_digest: Optional[str] = None
     source_sandbox_id: Optional[str] = None
@@ -146,6 +149,47 @@ class Snapshot:
             registry_id=data.get("registry_id"),
             created_at=data.get("created_at"),
             updated_at=data.get("updated_at"),
+            tags=list(data.get("tags") or []),
+        )
+
+
+@dataclass
+class SnapshotNameTag:
+    """One tag under a snapshot name and the snapshot it resolves to.
+
+    Attributes:
+        tag: Tag name.
+        snapshot_id: Snapshot the tag currently points at.
+    """
+
+    tag: str
+    snapshot_id: str
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> SnapshotNameTag:
+        """Create a SnapshotNameTag from an API response dict."""
+        return cls(tag=data.get("tag", ""), snapshot_id=data.get("snapshot_id", ""))
+
+
+@dataclass
+class SnapshotName:
+    """A snapshot name and every tag published under it.
+
+    Attributes:
+        name: The snapshot name.
+        tags: Every tag under the name, each with the snapshot it resolves to.
+            Empty when the name exists but currently carries no tags.
+    """
+
+    name: str
+    tags: list[SnapshotNameTag] = field(default_factory=list)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> SnapshotName:
+        """Create a SnapshotName from an API response dict."""
+        return cls(
+            name=data.get("name", ""),
+            tags=[SnapshotNameTag.from_dict(tag) for tag in data.get("tags") or []],
         )
 
 

--- a/python/langsmith/sandbox/_models.py
+++ b/python/langsmith/sandbox/_models.py
@@ -121,7 +121,6 @@ class Snapshot:
     name: str
     status: str
     fs_capacity_bytes: int
-    tags: list[str] = field(default_factory=list)
     docker_image: Optional[str] = None
     image_digest: Optional[str] = None
     source_sandbox_id: Optional[str] = None
@@ -131,6 +130,8 @@ class Snapshot:
     registry_id: Optional[str] = None
     created_at: Optional[str] = None
     updated_at: Optional[str] = None
+    # Appended last so existing positional constructions keep their meaning.
+    tags: list[str] = field(default_factory=list)
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> Snapshot:
@@ -154,8 +155,8 @@ class Snapshot:
 
 
 @dataclass
-class SnapshotNameTag:
-    """One tag under a snapshot name and the snapshot it resolves to.
+class SnapshotTag:
+    """One tag published under a snapshot name, and the snapshot it resolves to.
 
     Attributes:
         tag: Tag name.
@@ -166,31 +167,9 @@ class SnapshotNameTag:
     snapshot_id: str
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> SnapshotNameTag:
-        """Create a SnapshotNameTag from an API response dict."""
+    def from_dict(cls, data: dict[str, Any]) -> SnapshotTag:
+        """Create a SnapshotTag from an API response dict."""
         return cls(tag=data.get("tag", ""), snapshot_id=data.get("snapshot_id", ""))
-
-
-@dataclass
-class SnapshotName:
-    """A snapshot name and every tag published under it.
-
-    Attributes:
-        name: The snapshot name.
-        tags: Every tag under the name, each with the snapshot it resolves to.
-            Empty when the name exists but currently carries no tags.
-    """
-
-    name: str
-    tags: list[SnapshotNameTag] = field(default_factory=list)
-
-    @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> SnapshotName:
-        """Create a SnapshotName from an API response dict."""
-        return cls(
-            name=data.get("name", ""),
-            tags=[SnapshotNameTag.from_dict(tag) for tag in data.get("tags") or []],
-        )
 
 
 # =============================================================================

--- a/python/tests/unit_tests/sandbox/test_async_client.py
+++ b/python/tests/unit_tests/sandbox/test_async_client.py
@@ -881,7 +881,7 @@ class TestAsyncSandboxOperations:
 
         with pytest.raises(
             ValueError,
-            match="At most one of snapshot_id or snapshot_name may be set",
+            match="At most one of snapshot_id, snapshot or snapshot_name may be set",
         ):
             await client.create_sandbox(snapshot_id="snap-1", snapshot_name="my-snap")
 
@@ -1077,6 +1077,83 @@ class TestAsyncSandboxOperations:
 
         assert sandbox_mock.call_args.kwargs["vcpus"] == 2
         assert sandbox_mock.call_args.kwargs["mem_bytes"] == 8589934592
+
+
+class TestAsyncSnapshotTags:
+    """The async client mirrors the sync tag surface."""
+
+    async def test_capture_snapshot_publishes_the_requested_tag(
+        self, client: AsyncSandboxClient, httpx_mock: HTTPXMock
+    ):
+        import json
+
+        httpx_mock.add_response(
+            method="POST",
+            url="http://test-server:8080/boxes/my-vm/snapshot",
+            json={
+                "id": "snap-3",
+                "name": "my-env",
+                "status": "building",
+                "fs_capacity_bytes": 4294967296,
+            },
+            status_code=201,
+        )
+        httpx_mock.add_response(
+            method="GET",
+            url="http://test-server:8080/snapshots/snap-3",
+            json={
+                "id": "snap-3",
+                "name": "my-env",
+                "status": "ready",
+                "fs_capacity_bytes": 4294967296,
+                "tags": ["v2"],
+            },
+        )
+
+        snapshot = await client.capture_snapshot("my-vm", "my-env", tag="v2")
+
+        assert snapshot.tags == ["v2"]
+        assert json.loads(httpx_mock.get_requests()[0].content) == {
+            "name": "my-env",
+            "tag": "v2",
+        }
+
+    async def test_get_snapshot_name_lists_every_tag(
+        self, client: AsyncSandboxClient, httpx_mock: HTTPXMock
+    ):
+        httpx_mock.add_response(
+            method="GET",
+            url="http://test-server:8080/snapshots-by-name/my-env",
+            json={
+                "name": "my-env",
+                "tags": [{"tag": "latest", "snapshot_id": "snap-3"}],
+            },
+        )
+
+        result = await client.get_snapshot_name("my-env")
+
+        assert [(tag.tag, tag.snapshot_id) for tag in result.tags] == [
+            ("latest", "snap-3")
+        ]
+
+    async def test_get_snapshot_by_reference_keeps_the_tag_separator(
+        self, client: AsyncSandboxClient, httpx_mock: HTTPXMock
+    ):
+        httpx_mock.add_response(
+            method="GET",
+            url="http://test-server:8080/snapshots/my-env:v2",
+            json={
+                "id": "snap-5",
+                "name": "my-env",
+                "status": "ready",
+                "fs_capacity_bytes": 1,
+                "tags": ["v2"],
+            },
+        )
+
+        snapshot = await client.get_snapshot("my-env:v2")
+
+        assert snapshot.id == "snap-5"
 
 
 class TestAsyncConnectionErrors:

--- a/python/tests/unit_tests/sandbox/test_async_client.py
+++ b/python/tests/unit_tests/sandbox/test_async_client.py
@@ -1118,7 +1118,7 @@ class TestAsyncSnapshotTags:
             "tag": "v2",
         }
 
-    async def test_get_snapshot_name_lists_every_tag(
+    async def test_list_snapshot_tags_lists_every_tag(
         self, client: AsyncSandboxClient, httpx_mock: HTTPXMock
     ):
         httpx_mock.add_response(
@@ -1130,11 +1130,9 @@ class TestAsyncSnapshotTags:
             },
         )
 
-        result = await client.get_snapshot_name("my-env")
+        tags = await client.list_snapshot_tags("my-env")
 
-        assert [(tag.tag, tag.snapshot_id) for tag in result.tags] == [
-            ("latest", "snap-3")
-        ]
+        assert [(tag.tag, tag.snapshot_id) for tag in tags] == [("latest", "snap-3")]
 
     async def test_get_snapshot_by_reference_keeps_the_tag_separator(
         self, client: AsyncSandboxClient, httpx_mock: HTTPXMock

--- a/python/tests/unit_tests/sandbox/test_client.py
+++ b/python/tests/unit_tests/sandbox/test_client.py
@@ -1144,6 +1144,126 @@ class TestSnapshotOperations:
         assert snapshot.status == "ready"
         assert snapshot.source_sandbox_id == "my-vm"
 
+    def test_capture_snapshot_publishes_the_requested_tag(
+        self, client: SandboxClient, httpx_mock: HTTPXMock
+    ):
+        """A tag is a mutable pointer, so the caller picks which one to move."""
+        import json
+
+        httpx_mock.add_response(
+            method="POST",
+            url="http://test-server:8080/boxes/my-vm/snapshot",
+            json={
+                "id": "snap-3",
+                "name": "my-env",
+                "status": "building",
+                "fs_capacity_bytes": 4294967296,
+            },
+            status_code=201,
+        )
+        httpx_mock.add_response(
+            method="GET",
+            url="http://test-server:8080/snapshots/snap-3",
+            json={
+                "id": "snap-3",
+                "name": "my-env",
+                "status": "ready",
+                "fs_capacity_bytes": 4294967296,
+                "tags": ["v2", "latest"],
+            },
+        )
+
+        snapshot = client.capture_snapshot("my-vm", "my-env", tag="v2")
+
+        assert snapshot.tags == ["v2", "latest"]
+        assert json.loads(httpx_mock.get_requests()[0].content) == {
+            "name": "my-env",
+            "tag": "v2",
+        }
+
+    def test_create_snapshot_publishes_the_requested_tag(
+        self, client: SandboxClient, httpx_mock: HTTPXMock
+    ):
+        import json
+
+        for status in ("building", "ready"):
+            httpx_mock.add_response(
+                method="POST" if status == "building" else "GET",
+                url=(
+                    "http://test-server:8080/snapshots"
+                    if status == "building"
+                    else "http://test-server:8080/snapshots/snap-4"
+                ),
+                json={
+                    "id": "snap-4",
+                    "name": "my-env",
+                    "status": status,
+                    "fs_capacity_bytes": 4294967296,
+                },
+                status_code=201 if status == "building" else 200,
+            )
+
+        client.create_snapshot("my-env", "python:3.12-slim", 4294967296, tag="v2")
+
+        assert json.loads(httpx_mock.get_requests()[0].content)["tag"] == "v2"
+
+    def test_get_snapshot_by_reference_keeps_the_tag_separator(
+        self, client: SandboxClient, httpx_mock: HTTPXMock
+    ):
+        """A percent-encoded colon would hide the tag from the server."""
+        httpx_mock.add_response(
+            method="GET",
+            url="http://test-server:8080/snapshots/my-env:v2",
+            json={
+                "id": "snap-5",
+                "name": "my-env",
+                "status": "ready",
+                "fs_capacity_bytes": 4294967296,
+                "tags": ["v2"],
+            },
+        )
+
+        snapshot = client.get_snapshot("my-env:v2")
+
+        assert snapshot.id == "snap-5"
+        assert str(httpx_mock.get_requests()[0].url).endswith("/snapshots/my-env:v2")
+
+    def test_get_snapshot_name_lists_every_tag(
+        self, client: SandboxClient, httpx_mock: HTTPXMock
+    ):
+        httpx_mock.add_response(
+            method="GET",
+            url="http://test-server:8080/snapshots-by-name/my-env",
+            json={
+                "name": "my-env",
+                "tags": [
+                    {"tag": "latest", "snapshot_id": "snap-5"},
+                    {"tag": "v1", "snapshot_id": "snap-4"},
+                ],
+            },
+        )
+
+        result = client.get_snapshot_name("my-env")
+
+        assert result.name == "my-env"
+        assert [(tag.tag, tag.snapshot_id) for tag in result.tags] == [
+            ("latest", "snap-5"),
+            ("v1", "snap-4"),
+        ]
+
+    def test_get_snapshot_name_raises_when_nobody_published(
+        self, client: SandboxClient, httpx_mock: HTTPXMock
+    ):
+        httpx_mock.add_response(
+            method="GET",
+            url="http://test-server:8080/snapshots-by-name/nope",
+            json={"detail": "not found"},
+            status_code=404,
+        )
+
+        with pytest.raises(ResourceNotFoundError):
+            client.get_snapshot_name("nope")
+
     def test_capture_snapshot_from_docker_image(
         self, client: SandboxClient, httpx_mock: HTTPXMock
     ):
@@ -1620,6 +1740,36 @@ class TestStartStopOperations:
         assert "snapshot_id" not in body
         assert "template_name" not in body
 
+    def test_create_sandbox_boots_from_a_tagged_reference(
+        self, client: SandboxClient, httpx_mock: HTTPXMock
+    ):
+        """`snapshot` carries all three forms: a UUID, `name:tag`, or a bare name."""
+        import json
+
+        httpx_mock.add_response(
+            method="POST",
+            url="http://test-server:8080/boxes",
+            json={
+                "name": "my-vm",
+                "snapshot_id": "snap-1",
+                "status": "ready",
+                "dataplane_url": "https://dp.example.com/my-vm",
+            },
+            status_code=201,
+        )
+
+        client.create_sandbox(snapshot="my-snap:v2", name="my-vm")
+
+        body = json.loads(httpx_mock.get_request().content)
+        assert body["snapshot"] == "my-snap:v2"
+        assert "snapshot_name" not in body
+
+    def test_create_sandbox_rejects_a_disagreeing_snapshot_alias(
+        self, client: SandboxClient
+    ):
+        with pytest.raises(ValueError, match="must not disagree"):
+            client.create_sandbox(snapshot="a:v1", snapshot_name="b")
+
     def test_create_sandbox_omits_snapshot_id_when_absent(
         self, client: SandboxClient, httpx_mock: HTTPXMock
     ):
@@ -1653,7 +1803,7 @@ class TestStartStopOperations:
 
         with pytest.raises(
             ValueError,
-            match="At most one of snapshot_id or snapshot_name may be set",
+            match="At most one of snapshot_id, snapshot or snapshot_name may be set",
         ):
             client.create_sandbox(snapshot_id="snap-1", snapshot_name="my-snap")
 

--- a/python/tests/unit_tests/sandbox/test_client.py
+++ b/python/tests/unit_tests/sandbox/test_client.py
@@ -1228,7 +1228,7 @@ class TestSnapshotOperations:
         assert snapshot.id == "snap-5"
         assert str(httpx_mock.get_requests()[0].url).endswith("/snapshots/my-env:v2")
 
-    def test_get_snapshot_name_lists_every_tag(
+    def test_list_snapshot_tags_lists_every_tag(
         self, client: SandboxClient, httpx_mock: HTTPXMock
     ):
         httpx_mock.add_response(
@@ -1243,15 +1243,14 @@ class TestSnapshotOperations:
             },
         )
 
-        result = client.get_snapshot_name("my-env")
+        tags = client.list_snapshot_tags("my-env")
 
-        assert result.name == "my-env"
-        assert [(tag.tag, tag.snapshot_id) for tag in result.tags] == [
+        assert [(tag.tag, tag.snapshot_id) for tag in tags] == [
             ("latest", "snap-5"),
             ("v1", "snap-4"),
         ]
 
-    def test_get_snapshot_name_raises_when_nobody_published(
+    def test_list_snapshot_tags_raises_when_nobody_published(
         self, client: SandboxClient, httpx_mock: HTTPXMock
     ):
         httpx_mock.add_response(
@@ -1262,7 +1261,7 @@ class TestSnapshotOperations:
         )
 
         with pytest.raises(ResourceNotFoundError):
-            client.get_snapshot_name("nope")
+            client.list_snapshot_tags("nope")
 
     def test_capture_snapshot_from_docker_image(
         self, client: SandboxClient, httpx_mock: HTTPXMock

--- a/python/tests/unit_tests/sandbox/test_models.py
+++ b/python/tests/unit_tests/sandbox/test_models.py
@@ -10,6 +10,7 @@ from langsmith.sandbox import (
     ResourceStatus,
     ServiceURL,
     Snapshot,
+    SnapshotName,
 )
 
 
@@ -83,6 +84,54 @@ _SAMPLE_SERVICE_URL_DATA = {
     "token": "jwt-token-value",
     "expires_at": "2026-04-01T12:10:00Z",
 }
+
+
+class TestSnapshotTags:
+    """Tags are the mutable pointers published under a snapshot's name."""
+
+    def test_from_dict_reads_tags(self):
+        snapshot = Snapshot.from_dict(
+            {
+                "id": "snap-1",
+                "name": "my-env",
+                "status": "ready",
+                "fs_capacity_bytes": 1,
+                "tags": ["latest", "v2"],
+            }
+        )
+        assert snapshot.tags == ["latest", "v2"]
+
+    def test_a_missing_tags_key_means_dangling(self):
+        """The server omits the key entirely rather than sending an empty list."""
+        snapshot = Snapshot.from_dict(
+            {
+                "id": "snap-1",
+                "name": "my-env",
+                "status": "ready",
+                "fs_capacity_bytes": 1,
+            }
+        )
+        assert snapshot.tags == []
+
+    def test_snapshot_name_lists_each_tags_target(self):
+        result = SnapshotName.from_dict(
+            {
+                "name": "my-env",
+                "tags": [
+                    {"tag": "latest", "snapshot_id": "snap-2"},
+                    {"tag": "v1", "snapshot_id": "snap-1"},
+                ],
+            }
+        )
+        assert result.name == "my-env"
+        assert [(tag.tag, tag.snapshot_id) for tag in result.tags] == [
+            ("latest", "snap-2"),
+            ("v1", "snap-1"),
+        ]
+
+    def test_snapshot_name_without_tags(self):
+        """A name that exists but carries no tags is a real, empty result."""
+        assert SnapshotName.from_dict({"name": "my-env"}).tags == []
 
 
 class TestServiceURL:

--- a/python/tests/unit_tests/sandbox/test_models.py
+++ b/python/tests/unit_tests/sandbox/test_models.py
@@ -10,7 +10,7 @@ from langsmith.sandbox import (
     ResourceStatus,
     ServiceURL,
     Snapshot,
-    SnapshotName,
+    SnapshotTag,
 )
 
 
@@ -113,25 +113,15 @@ class TestSnapshotTags:
         )
         assert snapshot.tags == []
 
-    def test_snapshot_name_lists_each_tags_target(self):
-        result = SnapshotName.from_dict(
-            {
-                "name": "my-env",
-                "tags": [
-                    {"tag": "latest", "snapshot_id": "snap-2"},
-                    {"tag": "v1", "snapshot_id": "snap-1"},
-                ],
-            }
-        )
-        assert result.name == "my-env"
-        assert [(tag.tag, tag.snapshot_id) for tag in result.tags] == [
-            ("latest", "snap-2"),
-            ("v1", "snap-1"),
-        ]
+    def test_snapshot_tag_reads_its_target(self):
+        tag = SnapshotTag.from_dict({"tag": "latest", "snapshot_id": "snap-2"})
+        assert (tag.tag, tag.snapshot_id) == ("latest", "snap-2")
 
-    def test_snapshot_name_without_tags(self):
-        """A name that exists but carries no tags is a real, empty result."""
-        assert SnapshotName.from_dict({"name": "my-env"}).tags == []
+    def test_tags_are_appended_last_so_positional_callers_are_unchanged(self):
+        """Inserting it earlier would silently shift every positional arg after it."""
+        snapshot = Snapshot("snap-1", "my-env", "ready", 4096, "python:3.12-slim")
+        assert snapshot.docker_image == "python:3.12-slim"
+        assert snapshot.tags == []
 
 
 class TestServiceURL:


### PR DESCRIPTION
Snapshots went Docker-style server-side (smith-go, API reshaped 2026-08-02): content is immutable and addressed by `id`, while `name:tag` is a **mutable pointer** to it, defaulting to `latest`. Go and Java picked this up through stainless; the hand-written Python and JS clients are still on the pre-tags surface. The server's own checklist tracks it in `smith-go/sandboxes/docs/pending-sdk-changes/2026-06-30-snapshot-tags.md`.

Without a `tag` parameter every capture lands on `name:latest`, so callers who want a stable snapshot name per environment collide with themselves on each rebuild and end up walking a numeric suffix (`-2`, `-3`, …) that reads like a name conflict but is really a missing tag.

This implements the four items that doc lists, for Python:

1. `tag` on `create_snapshot` and `capture_snapshot`, serialized into the request body.
2. `tags` on `Snapshot` (missing key means dangling, not an error), appended last so positional callers are unchanged, plus `list_snapshot_tags(name) -> list[SnapshotTag]` for `GET /v2/sandboxes/snapshots-by-name/{name}`.
3. `get_snapshot()` accepts a reference — a UUID, `name:tag`, or a bare name. The colon is left literal in the path segment (it is a legal path character) so percent-encoding cannot hide the tag from the server.
4. `snapshot` on `create_sandbox()` and `sandbox()`, covering all three reference forms. `snapshot_name` still works and still sends the legacy `snapshot_name` wire field, so existing callers are byte-for-byte unchanged; passing both with different values raises.

JS/TS is untouched and still on the checklist.

## Test Plan

- [x] `make tests TEST=tests/unit_tests/sandbox` — 562 passed
- [x] `uv run ruff check .` and `uv run mypy langsmith` clean
- [x] New unit tests cover: tag in the create and capture bodies, `tags` parsed (and absent) on the response, `Snapshot`'s positional order preserved, `name:tag` surviving path quoting, `list_snapshot_tags` including its 404, booting from a tagged reference, and the disagreeing-alias guard

