### PR TITLE
fix(py): compress replica writes that carry their own credentials

### DIFF
--- a/python/langsmith/_internal/_background_thread.py
+++ b/python/langsmith/_internal/_background_thread.py
@@ -183,10 +183,11 @@ def _tracing_thread_drain_queue(
 
 def _tracing_thread_drain_compressed_buffer(
     client: Client, size_limit: int = 100, size_limit_bytes: int | None = 20_971_520
-) -> tuple[Optional[io.BytesIO], Optional[tuple[int, int]]]:
+) -> tuple[Optional[io.BytesIO], Optional[tuple[int, int]], Optional[frozenset]]:
+    """Take the filled frame, plus the destination set it committed to."""
     try:
         if client.compressed_traces is None:
-            return None, None
+            return None, None, None
         with client.compressed_traces.lock:
             pre_compressed_size = client.compressed_traces.uncompressed_size
 
@@ -204,7 +205,7 @@ def _tracing_thread_drain_compressed_buffer(
             ) and (
                 size_limit is None or client.compressed_traces.trace_count < size_limit
             ):
-                return None, None
+                return None, None, None
 
             # Write final boundary and close compression stream
             client.compressed_traces.compressor_writer.write(
@@ -221,11 +222,12 @@ def _tracing_thread_drain_compressed_buffer(
             )
 
             compressed_traces_info = (pre_compressed_size, current_size)
+            destinations = client.compressed_traces.destinations
 
             client.compressed_traces.reset()
 
         filled_buffer.seek(0)
-        return (filled_buffer, compressed_traces_info)
+        return (filled_buffer, compressed_traces_info, destinations)
     except Exception:
         logger.error(
             "LangSmith tracing error: Failed to submit trace data.\n"
@@ -235,7 +237,7 @@ def _tracing_thread_drain_compressed_buffer(
         )
         # exceptions are logged elsewhere, but we need to make sure the
         # background thread continues to run
-        return None, None
+        return None, None, None
 
 
 def _process_buffered_run_ops_batch(
@@ -789,7 +791,7 @@ def tracing_control_thread_func_compress_parallel(
         if triggered:
             client._data_available_event.clear()
 
-            data_stream, compressed_traces_info = (
+            data_stream, compressed_traces_info, destinations = (
                 _tracing_thread_drain_compressed_buffer
             )(client, size_limit, size_limit_bytes)
             # If we have data, submit the send request
@@ -799,12 +801,14 @@ def tracing_control_thread_func_compress_parallel(
                         client._send_compressed_multipart_req,
                         data_stream,
                         compressed_traces_info,
+                        destinations=destinations,
                     )
                     client._futures.add(future)
                 except RuntimeError:
                     client._send_compressed_multipart_req(
                         data_stream,
                         compressed_traces_info,
+                        destinations=destinations,
                     )
             last_flush_time = time.monotonic()
 
@@ -813,6 +817,7 @@ def tracing_control_thread_func_compress_parallel(
                 (
                     data_stream,
                     compressed_traces_info,
+                    destinations,
                 ) = _tracing_thread_drain_compressed_buffer(
                     client, size_limit=1, size_limit_bytes=1
                 )
@@ -824,6 +829,7 @@ def tracing_control_thread_func_compress_parallel(
                                     client._send_compressed_multipart_req,
                                     data_stream,
                                     compressed_traces_info,
+                                    destinations=destinations,
                                 )
                             ]
                         )
@@ -831,6 +837,7 @@ def tracing_control_thread_func_compress_parallel(
                         client._send_compressed_multipart_req(
                             data_stream,
                             compressed_traces_info,
+                            destinations=destinations,
                         )
                 last_flush_time = time.monotonic()
 
@@ -848,6 +855,7 @@ def tracing_control_thread_func_compress_parallel(
         (
             final_data_stream,
             compressed_traces_info,
+            destinations,
         ) = _tracing_thread_drain_compressed_buffer(
             client, size_limit=1, size_limit_bytes=1
         )
@@ -863,6 +871,7 @@ def tracing_control_thread_func_compress_parallel(
                             client._send_compressed_multipart_req,
                             final_data_stream,
                             compressed_traces_info,
+                            destinations=destinations,
                         )
                     ]
                 )
@@ -875,6 +884,7 @@ def tracing_control_thread_func_compress_parallel(
                 client._send_compressed_multipart_req(
                     final_data_stream,
                     compressed_traces_info,
+                    destinations=destinations,
                 )
                 logger.debug("Compression thread final flush: sync send completed")
         else:

--- a/python/langsmith/_internal/_compressed_traces.py
+++ b/python/langsmith/_internal/_compressed_traces.py
@@ -49,12 +49,23 @@ class CompressedTraces:
         self.lock = threading.Lock()
         self.uncompressed_size: int = 0
         self._context: list[str] = []
+        # Frame's destinations. Sent verbatim to each, so all ops in one frame
+        # must match. Set once, kept across resets.
+        self.destinations: Optional[frozenset] = None
 
         self.compressor_writer = ZstdCompressor(
             level=compression_level, threads=compression_threads
         ).stream_writer(self.buffer, closefd=False)
 
+    def accepts(self, destinations: frozenset) -> bool:
+        """Report whether an op for `destinations` may join this frame.
+
+        Hold self.lock; commit and write in the same hold.
+        """
+        return self.destinations in (None, destinations)
+
     def reset(self) -> None:
+        # destinations survives: a new frame inherits it, so ownership is decided once.
         self.buffer = io.BytesIO()
         self.trace_count = 0
         self.uncompressed_size = 0

--- a/python/langsmith/_internal/_compressed_traces.py
+++ b/python/langsmith/_internal/_compressed_traces.py
@@ -49,8 +49,9 @@ class CompressedTraces:
         self.lock = threading.Lock()
         self.uncompressed_size: int = 0
         self._context: list[str] = []
-        # Frame's destinations. Sent verbatim to each, so all ops in one frame
-        # must match. Set once, kept across resets.
+        # Where this frame goes. Sent verbatim to each, so all ops in one frame
+        # must share it. Claimed by the first op written, released when the frame
+        # is sent, so a client whose replicas change is not stuck on the first set.
         self.destinations: Optional[frozenset] = None
 
         self.compressor_writer = ZstdCompressor(
@@ -65,7 +66,8 @@ class CompressedTraces:
         return self.destinations is None or self.destinations == destinations
 
     def reset(self) -> None:
-        # destinations survives: a new frame inherits it, so ownership is decided once.
+        # The next op claims the new frame, whatever its destinations.
+        self.destinations = None
         self.buffer = io.BytesIO()
         self.trace_count = 0
         self.uncompressed_size = 0

--- a/python/langsmith/_internal/_compressed_traces.py
+++ b/python/langsmith/_internal/_compressed_traces.py
@@ -62,7 +62,7 @@ class CompressedTraces:
 
         Hold self.lock; commit and write in the same hold.
         """
-        return self.destinations in (None, destinations)
+        return self.destinations is None or self.destinations == destinations
 
     def reset(self) -> None:
         # destinations survives: a new frame inherits it, so ownership is decided once.

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -46,6 +46,7 @@ from typing import (
     Any,
     Callable,
     Literal,
+    NamedTuple,
     Optional,
     TypedDict,
     Union,
@@ -2667,6 +2668,90 @@ class Client:
                 cookie=cookie,
             )
 
+    def _enqueue_op(
+        self,
+        priority: str,
+        op: Union[SerializedRunOperation, SerializedFeedbackOperation],
+        auth: ReplicaAuth,
+    ) -> None:
+        """Put one op on the uncompressed queue, carrying its destination's auth."""
+        self._put_tracing_queue(
+            TracingQueueItem(
+                priority,
+                op,
+                **auth._asdict(),
+                otel_context=(
+                    self._set_span_in_context(self._otel_trace.get_current_span())
+                    if self.otel_exporter is not None
+                    else None
+                ),
+            )
+        )
+
+    def _compress_admitted(
+        self, multipart_form: MultipartPartsAndContext, destinations: frozenset
+    ) -> bool:
+        """Write one op into the frame if the frame goes where it does.
+
+        Check, commit and write in one lock hold, or two threads adopt an
+        uncommitted frame and the loser's bytes go to the winner. True also covers
+        a full frame dropping the op, as before.
+        """
+        ct = self.compressed_traces
+        if ct is None:
+            return False
+        if self._data_available_event is None:
+            raise ValueError(
+                "Run compression is enabled but threading event is not configured"
+            )
+        with ct.lock:
+            if not ct.accepts(destinations):
+                return False
+            if ct.destinations is None:
+                ct.destinations = destinations
+                logger.debug(
+                    "Compressed frame committed to %s", _destination_urls(destinations)
+                )
+            if compress_multipart_parts_and_context(multipart_form, ct, _BOUNDARY):
+                ct.trace_count += 1
+                self._data_available_event.set()
+        return True
+
+    def _warn_compression_downgrade(self, destinations: Optional[frozenset]) -> None:
+        """Warn once when compression is on but this op cannot use it."""
+        global _COMPRESSION_DOWNGRADE_WARNED
+        if self.compressed_traces is None or _COMPRESSION_DOWNGRADE_WARNED:
+            return
+        _COMPRESSION_DOWNGRADE_WARNED = True
+        logger.warning(
+            "Run compression is enabled, but this client's compressed buffer already "
+            "belongs to a different destination, so writes to %s are sent "
+            "uncompressed. Use one set of tracing credentials per Client to avoid "
+            "this.",
+            _destination_urls(destinations) if destinations else "another endpoint",
+        )
+
+    def _resolve_destinations(self, auth: ReplicaAuth) -> frozenset[ReplicaAuth]:
+        """Where a frame carrying this op must be POSTed.
+
+        No per-call auth: every write endpoint, verbatim -- a None key must stay
+        None, it strips X-API-KEY. Otherwise the named endpoint, api_key resolved
+        as _apply_auth_overrides does: no fallback beside a service key.
+        """
+        if not any(auth):
+            return frozenset(
+                ReplicaAuth(url, key, None, None, None, None)
+                for url, key in self._write_api_urls.items()
+            )
+        api_key = auth.api_key
+        if api_key is None and not any(
+            [auth.service_key, auth.authorization, auth.cookie]
+        ):
+            api_key = self.api_key
+        return frozenset(
+            {auth._replace(api_url=auth.api_url or self.api_url, api_key=api_key)}
+        )
+
     def _create_run(
         self,
         run_create: dict,
@@ -2683,21 +2768,22 @@ class Client:
             run_create.get("trace_id") is not None
             and run_create.get("dotted_order") is not None
         ):
+            auth = ReplicaAuth(
+                api_url, api_key, service_key, tenant_id, authorization, cookie
+            )
+            destinations = (
+                self._resolve_destinations(auth)
+                if self.compressed_traces is not None
+                else None
+            )
             if self._pyo3_client is not None:
                 self._pyo3_client.create_run(run_create)
             elif (
                 self.compressed_traces is not None
-                and api_key is None
-                and api_url is None
-                and service_key is None
-                and tenant_id is None
-                and authorization is None
-                and cookie is None
+                and destinations is not None
+                # Cheap reject; the real check is inside the lock.
+                and self.compressed_traces.accepts(destinations)
             ):
-                if self._data_available_event is None:
-                    raise ValueError(
-                        "Run compression is enabled but threading event is not configured"
-                    )
                 serialized_op = serialize_run_dict("post", run_create)
                 (
                     multipart_form,
@@ -2710,18 +2796,12 @@ class Client:
                     "Adding compressed multipart to queue with context: %s",
                     multipart_form.context,
                 )
-                with self.compressed_traces.lock:
-                    enqueued = compress_multipart_parts_and_context(
-                        multipart_form,
-                        self.compressed_traces,
-                        _BOUNDARY,
-                    )
-                    if enqueued:
-                        self.compressed_traces.trace_count += 1
-                        self._data_available_event.set()
-
+                admitted = self._compress_admitted(multipart_form, destinations)
                 _close_files(list(opened_files.values()))
+                if not admitted and self.tracing_queue is not None:
+                    self._enqueue_op(run_create["dotted_order"], serialized_op, auth)
             elif self.tracing_queue is not None:
+                self._warn_compression_downgrade(destinations)
                 serialized_op = serialize_run_dict("post", run_create)
                 logger.log(
                     5,
@@ -2729,35 +2809,7 @@ class Client:
                     serialized_op.trace_id,
                     serialized_op.id,
                 )
-                if self.otel_exporter is not None:
-                    self._put_tracing_queue(
-                        TracingQueueItem(
-                            run_create["dotted_order"],
-                            serialized_op,
-                            api_key=api_key,
-                            api_url=api_url,
-                            service_key=service_key,
-                            tenant_id=tenant_id,
-                            authorization=authorization,
-                            cookie=cookie,
-                            otel_context=self._set_span_in_context(
-                                self._otel_trace.get_current_span()
-                            ),
-                        )
-                    )
-                else:
-                    self._put_tracing_queue(
-                        TracingQueueItem(
-                            run_create["dotted_order"],
-                            serialized_op,
-                            api_key=api_key,
-                            api_url=api_url,
-                            service_key=service_key,
-                            tenant_id=tenant_id,
-                            authorization=authorization,
-                            cookie=cookie,
-                        )
-                    )
+                self._enqueue_op(run_create["dotted_order"], serialized_op, auth)
             else:
                 # Neither Rust nor Python batch ingestion is configured,
                 # fall back to the non-batch approach.
@@ -3619,23 +3671,32 @@ class Client:
         data_stream: io.BytesIO,
         compressed_traces_info: Optional[tuple[int, int]],
         *,
+        destinations: Optional[frozenset] = None,
         attempts: int = 3,
     ):
-        """Send a zstd-compressed multipart form data stream to the backend."""
-        _context: str = "; ".join(getattr(data_stream, "context", []))
+        """Send a zstd-compressed multipart stream to each of `destinations`.
 
-        for api_url, api_key in self._write_api_urls.items():
+        None means the client's default set: every _write_api_urls entry.
+        """
+        _context: str = "; ".join(getattr(data_stream, "context", []))
+        if destinations is None:
+            destinations = self._resolve_destinations(
+                ReplicaAuth(None, None, None, None, None, None)
+            )
+
+        for dest in sorted(destinations, key=lambda d: d.api_url or ""):
+            api_url = dest.api_url
             data_stream.seek(0)
 
             for idx in range(1, attempts + 1):
                 try:
                     headers = _apply_auth_overrides(
                         self._headers,
-                        api_key=api_key,
-                        service_key=None,
-                        tenant_id=None,
-                        authorization=None,
-                        cookie=None,
+                        api_key=dest.api_key,
+                        service_key=dest.service_key,
+                        tenant_id=dest.tenant_id,
+                        authorization=dest.authorization,
+                        cookie=dest.cookie,
                         fallback_api_key=None,
                     )
                     headers["Content-Type"] = (
@@ -3887,14 +3948,19 @@ class Client:
             self._pyo3_client.update_run(run_update)
         elif use_multipart:
             serialized_op = serialize_run_dict(operation="patch", payload=run_update)
+            auth = ReplicaAuth(
+                api_url, api_key, service_key, tenant_id, authorization, cookie
+            )
+            destinations = (
+                self._resolve_destinations(auth)
+                if self.compressed_traces is not None
+                else None
+            )
             if (
                 self.compressed_traces is not None
-                and api_key is None
-                and api_url is None
-                and service_key is None
-                and tenant_id is None
-                and authorization is None
-                and cookie is None
+                and destinations is not None
+                # Cheap reject; the real check is inside the lock.
+                and self.compressed_traces.accepts(destinations)
             ):
                 (
                     multipart_form,
@@ -3907,56 +3973,19 @@ class Client:
                     "Adding compressed multipart to queue with context: %s",
                     multipart_form.context,
                 )
-                with self.compressed_traces.lock:
-                    if self._data_available_event is None:
-                        raise ValueError(
-                            "Run compression is enabled but threading event is not configured"
-                        )
-                    enqueued = compress_multipart_parts_and_context(
-                        multipart_form,
-                        self.compressed_traces,
-                        _BOUNDARY,
-                    )
-                    if enqueued:
-                        self.compressed_traces.trace_count += 1
-                        self._data_available_event.set()
+                admitted = self._compress_admitted(multipart_form, destinations)
                 _close_files(list(opened_files.values()))
+                if not admitted and self.tracing_queue is not None:
+                    self._enqueue_op(run_update["dotted_order"], serialized_op, auth)
             elif self.tracing_queue is not None:
+                self._warn_compression_downgrade(destinations)
                 logger.log(
                     5,
                     "Adding to tracing queue: trace_id=%s, run_id=%s",
                     serialized_op.trace_id,
                     serialized_op.id,
                 )
-                if self.otel_exporter is not None:
-                    self._put_tracing_queue(
-                        TracingQueueItem(
-                            run_update["dotted_order"],
-                            serialized_op,
-                            api_key=api_key,
-                            api_url=api_url,
-                            service_key=service_key,
-                            tenant_id=tenant_id,
-                            authorization=authorization,
-                            cookie=cookie,
-                            otel_context=self._set_span_in_context(
-                                self._otel_trace.get_current_span()
-                            ),
-                        )
-                    )
-                else:
-                    self._put_tracing_queue(
-                        TracingQueueItem(
-                            run_update["dotted_order"],
-                            serialized_op,
-                            api_key=api_key,
-                            api_url=api_url,
-                            service_key=service_key,
-                            tenant_id=tenant_id,
-                            authorization=authorization,
-                            cookie=cookie,
-                        )
-                    )
+                self._enqueue_op(run_update["dotted_order"], serialized_op, auth)
         else:
             self._update_run_non_batch(
                 run_update,
@@ -4052,6 +4081,7 @@ class Client:
         (
             final_data_stream,
             compressed_traces_info,
+            destinations,
         ) = _tracing_thread_drain_compressed_buffer(
             self, size_limit=1, size_limit_bytes=1
         )
@@ -4064,13 +4094,17 @@ class Client:
                     self._send_compressed_multipart_req,
                     final_data_stream,
                     compressed_traces_info,
+                    destinations=destinations,
                     attempts=attempts,
                 )
                 self._futures.add(future)
             except RuntimeError:
                 # In case the ThreadPoolExecutor is already shutdown
                 self._send_compressed_multipart_req(
-                    final_data_stream, compressed_traces_info, attempts=attempts
+                    final_data_stream,
+                    compressed_traces_info,
+                    destinations=destinations,
+                    attempts=attempts,
                 )
 
         # If we got a future, wait for it to complete
@@ -8395,23 +8429,25 @@ class Client:
                 and self.otel_exporter is None
             ):
                 serialized_op = serialize_feedback_dict(feedback)
-                if self.compressed_traces is not None:
+                # No per-call auth, so: the default destinations. Needs the same
+                # check as runs, or its bytes ride a replica's frame.
+                destinations = (
+                    self._resolve_destinations(
+                        ReplicaAuth(None, None, None, None, None, None)
+                    )
+                    if self.compressed_traces is not None
+                    else None
+                )
+                admitted = False
+                if destinations is not None:
                     multipart_form = (
                         serialized_feedback_operation_to_multipart_parts_and_context(
                             serialized_op
                         )
                     )
-                    with self.compressed_traces.lock:
-                        enqueued = compress_multipart_parts_and_context(
-                            multipart_form,
-                            self.compressed_traces,
-                            _BOUNDARY,
-                        )
-                        if enqueued:
-                            self.compressed_traces.trace_count += 1
-                            if self._data_available_event:
-                                self._data_available_event.set()
-                elif self.tracing_queue is not None:
+                    admitted = self._compress_admitted(multipart_form, destinations)
+                if not admitted and self.tracing_queue is not None:
+                    self._warn_compression_downgrade(destinations)
                     self._put_tracing_queue(
                         TracingQueueItem(str(feedback.id), serialized_op)
                     )
@@ -11832,6 +11868,30 @@ def prep_obj_for_push(obj: Any) -> Any:
             # called.
             chain_to_push = RunnableSequence(prompt, bound_model)
     return chain_to_push
+
+
+_COMPRESSION_DOWNGRADE_WARNED = False
+
+
+def _destination_urls(destinations: frozenset) -> list[str]:
+    """Log-safe rendering of a destination set: URLs only, never credentials."""
+    return sorted({d.api_url or "" for d in destinations})
+
+
+class ReplicaAuth(NamedTuple):
+    """One write destination: a server plus the credentials to reach it."""
+
+    api_url: str | None
+    api_key: str | None
+    service_key: str | None
+    tenant_id: str | None
+    authorization: str | None
+    cookie: str | None
+
+    def __repr__(self) -> str:
+        """Redact credentials: this reaches logs and tracebacks."""
+        set_fields = [f for f in self._fields[1:] if getattr(self, f) is not None]
+        return f"ReplicaAuth(api_url={self.api_url!r}, set={set_fields})"
 
 
 def _apply_auth_overrides(

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -2734,13 +2734,11 @@ class Client:
     def _resolve_destinations(self, auth: ReplicaAuth) -> frozenset[ReplicaAuth]:
         """Where a frame carrying this op must be POSTed.
 
-        No per-call auth: every write endpoint, verbatim -- a None key must stay
-        None, it strips X-API-KEY. Otherwise the named endpoint, api_key resolved
-        as _apply_auth_overrides does: no fallback beside a service key.
+        Pre-resolve the URL + auth for each destination the compressed frame committed to
         """
         if not any(auth):
             return frozenset(
-                ReplicaAuth(url, key, None, None, None, None)
+                ReplicaAuth(api_url=url, api_key=key)
                 for url, key in self._write_api_urls.items()
             )
         api_key = auth.api_key
@@ -2769,7 +2767,12 @@ class Client:
             and run_create.get("dotted_order") is not None
         ):
             auth = ReplicaAuth(
-                api_url, api_key, service_key, tenant_id, authorization, cookie
+                api_url=api_url,
+                api_key=api_key,
+                service_key=service_key,
+                tenant_id=tenant_id,
+                authorization=authorization,
+                cookie=cookie,
             )
             destinations = (
                 self._resolve_destinations(auth)
@@ -3680,9 +3683,7 @@ class Client:
         """
         _context: str = "; ".join(getattr(data_stream, "context", []))
         if destinations is None:
-            destinations = self._resolve_destinations(
-                ReplicaAuth(None, None, None, None, None, None)
-            )
+            destinations = self._resolve_destinations(ReplicaAuth())
 
         for dest in sorted(destinations, key=lambda d: d.api_url or ""):
             api_url = dest.api_url
@@ -3949,7 +3950,12 @@ class Client:
         elif use_multipart:
             serialized_op = serialize_run_dict(operation="patch", payload=run_update)
             auth = ReplicaAuth(
-                api_url, api_key, service_key, tenant_id, authorization, cookie
+                api_url=api_url,
+                api_key=api_key,
+                service_key=service_key,
+                tenant_id=tenant_id,
+                authorization=authorization,
+                cookie=cookie,
             )
             destinations = (
                 self._resolve_destinations(auth)
@@ -8432,9 +8438,7 @@ class Client:
                 # No per-call auth, so: the default destinations. Needs the same
                 # check as runs, or its bytes ride a replica's frame.
                 destinations = (
-                    self._resolve_destinations(
-                        ReplicaAuth(None, None, None, None, None, None)
-                    )
+                    self._resolve_destinations(ReplicaAuth())
                     if self.compressed_traces is not None
                     else None
                 )
@@ -11881,12 +11885,12 @@ def _destination_urls(destinations: frozenset) -> list[str]:
 class ReplicaAuth(NamedTuple):
     """One write destination: a server plus the credentials to reach it."""
 
-    api_url: str | None
-    api_key: str | None
-    service_key: str | None
-    tenant_id: str | None
-    authorization: str | None
-    cookie: str | None
+    api_url: str | None = None
+    api_key: str | None = None
+    service_key: str | None = None
+    tenant_id: str | None = None
+    authorization: str | None = None
+    cookie: str | None = None
 
     def __repr__(self) -> str:
         """Redact credentials: this reaches logs and tracebacks."""

--- a/python/langsmith/run_trees.py
+++ b/python/langsmith/run_trees.py
@@ -11,7 +11,7 @@ import threading
 import urllib.parse
 from collections.abc import Mapping, Sequence
 from datetime import datetime, timezone
-from typing import Any, NamedTuple, Optional, Union, cast
+from typing import Any, Optional, Union, cast
 from uuid import UUID
 
 from pydantic import ConfigDict, Field, PrivateAttr, model_validator
@@ -22,7 +22,14 @@ from langsmith import schemas as ls_schemas
 from langsmith import utils
 from langsmith._internal import _v2_migration_utils
 from langsmith._internal._uuid import uuid7, uuid7_deterministic
-from langsmith.client import ID_TYPE, RUN_TYPE_T, Client, _dumps_json, _ensure_uuid
+from langsmith.client import (
+    ID_TYPE,
+    RUN_TYPE_T,
+    Client,
+    ReplicaAuth,
+    _dumps_json,
+    _ensure_uuid,
+)
 from langsmith.uuid import uuid7_from_datetime
 
 logger = logging.getLogger(__name__)
@@ -1418,15 +1425,6 @@ def _create_current_dotted_order(
     st = start_time or datetime.now(timezone.utc)
     id_ = run_id or uuid7_from_datetime(st)
     return st.strftime("%Y%m%dT%H%M%S%fZ") + str(id_)
-
-
-class ReplicaAuth(NamedTuple):
-    api_url: str | None
-    api_key: str | None
-    service_key: str | None
-    tenant_id: str | None
-    authorization: str | None
-    cookie: str | None
 
 
 def _extract_replica_auth(

--- a/python/tests/unit_tests/test_replica_compression.py
+++ b/python/tests/unit_tests/test_replica_compression.py
@@ -1,0 +1,453 @@
+"""Compressed ingestion for replicas that carry their own credentials (R2).
+
+A zstd frame is POSTed verbatim to each of its destinations, so every op inside one
+frame must share the same destination set. These tests pin that invariant, the
+credential resolution behind it, and that nothing crosses between destinations.
+"""
+
+import threading
+from unittest.mock import MagicMock, patch
+
+import pytest
+import zstandard
+
+from langsmith import schemas as ls_schemas
+from langsmith._internal import _background_thread as bt
+from langsmith._internal._compressed_traces import CompressedTraces
+from langsmith.client import Client, ReplicaAuth, _apply_auth_overrides
+from langsmith.run_trees import RunTree
+
+_INFO = ls_schemas.LangSmithInfo(
+    version="0.8.11",
+    batch_ingest_config=ls_schemas.BatchIngestConfig(use_multipart_endpoint=True),
+)
+
+
+def _replica(api_url, api_key, project_name=None):
+    replica = {"api_url": api_url, "auth": {"api_key": api_key}}
+    if project_name:
+        replica["project_name"] = project_name
+    return replica
+
+
+class Harness:
+    """A client whose frame is real but whose queue and network are captured.
+
+    The background threads are off, so nothing drains concurrently and the
+    assertions are deterministic.
+    """
+
+    def __init__(self, **client_kwargs):
+        client_kwargs.setdefault("api_url", "https://own")
+        client_kwargs.setdefault("api_key", "own-key")
+        self.client = Client(
+            session=MagicMock(), auto_batch_tracing=False, info=_INFO, **client_kwargs
+        )
+        self.client.compressed_traces = CompressedTraces()
+        self.client._data_available_event = threading.Event()
+        self.client.tracing_queue = MagicMock()  # exists, so the fallback is live
+        self.queued: list = []
+        self.sent: list = []
+        # Patched with lambdas, not bound methods: a bound method assigned to a
+        # class attribute is not a descriptor, so `self` would not be passed and
+        # every argument would shift by one.
+        self._patches = [
+            patch.object(
+                Client,
+                "request_with_retries",
+                lambda _self, _method, url, **kwargs: self._record(url, kwargs),
+            ),
+            patch.object(
+                Client,
+                "_put_tracing_queue",
+                lambda _self, item: self.queued.append(item),
+            ),
+        ]
+
+    def _record(self, url, kwargs):
+        body = kwargs["request_kwargs"].get("data")
+        if isinstance(body, bytes):
+            raw = body
+        elif hasattr(body, "getvalue"):
+            raw = body.getvalue()
+        else:
+            raw = b""
+        headers = kwargs["request_kwargs"].get("headers", {})
+        self.sent.append((url, headers.get("x-api-key"), raw))
+
+    def __enter__(self):
+        for p in self._patches:
+            p.start()
+        return self
+
+    def __exit__(self, *exc):
+        for p in self._patches:
+            p.stop()
+
+    def post(self, replicas=None, project_name="proj", inputs=None):
+        run = RunTree(
+            name="r",
+            run_type="chain",
+            inputs=inputs if inputs is not None else {"a": 1},
+            ls_client=self.client,
+            project_name=project_name,
+            replicas=replicas,
+        )
+        run.post()
+        return run
+
+    def flush(self):
+        stream, info, destinations = bt._tracing_thread_drain_compressed_buffer(
+            self.client, size_limit=1, size_limit_bytes=1
+        )
+        if stream is not None:
+            self.client._send_compressed_multipart_req(
+                stream, info, destinations=destinations
+            )
+
+    @property
+    def routes(self):
+        return sorted((url, key) for url, key, _ in self.sent)
+
+    def frame_for(self, url_prefix):
+        """The decompressed body of the frame sent to a destination."""
+        raw = next(r for u, _, r in self.sent if u.startswith(url_prefix))
+        return zstandard.ZstdDecompressor().decompressobj().decompress(raw)
+
+
+# --- routing -----------------------------------------------------------------
+
+
+def test_credentialed_replica_is_compressed_to_its_own_destination():
+    with Harness() as h:
+        h.post([_replica("https://b", "kb")])
+        h.flush()
+    assert h.routes == [("https://b/runs/multipart", "kb")]
+    assert not h.queued
+
+
+def test_replicas_sharing_auth_share_one_frame():
+    with Harness() as h:
+        h.post([_replica("https://b", "kb", "p1"), _replica("https://b", "kb", "p2")])
+        assert h.client.compressed_traces.trace_count == 2
+        h.flush()
+    assert h.routes == [("https://b/runs/multipart", "kb")]
+    assert not h.queued
+
+
+def test_replica_naming_the_clients_own_credentials_shares_the_frame():
+    with Harness() as h:
+        h.post([{"project_name": "p1"}, _replica("https://own", "own-key", "p2")])
+        assert h.client.compressed_traces.trace_count == 2
+        h.flush()
+    assert h.routes == [("https://own/runs/multipart", "own-key")]
+    assert not h.queued
+
+
+def test_nothing_crosses_between_destinations():
+    """The assertion that would have caught #2013."""
+    with Harness() as h:
+        h.post(
+            [_replica("https://b", "kb", "mine"), _replica("https://d", "kd", "theirs")]
+        )
+        h.flush()
+
+    assert {u: k for u, k, _ in h.sent} == {"https://b/runs/multipart": "kb"}
+    assert [(i.api_url, i.api_key) for i in h.queued] == [("https://d", "kd")]
+
+    body = h.frame_for("https://b")
+    assert b"mine" in body
+    assert b"theirs" not in body
+    assert b"kd" not in body and b"https://d" not in body
+
+
+def test_post_and_patch_for_one_destination_take_the_same_transport():
+    with Harness() as h:
+        run = h.post([_replica("https://b", "kb"), _replica("https://d", "kd")])
+        run.end(outputs={"b": 2})
+        run.patch()
+        assert h.client.compressed_traces.trace_count == 2  # B's post and patch
+        h.flush()
+    assert h.routes == [("https://b/runs/multipart", "kb")]
+    assert [(i.api_url, i.api_key) for i in h.queued] == [("https://d", "kd")] * 2
+
+
+# --- ownership ---------------------------------------------------------------
+
+
+def test_ownership_is_stable_across_flushes():
+    """reset() must not clear `destinations`, or the loser would alternate paths."""
+    with Harness() as h:
+        h.post([_replica("https://b", "kb"), _replica("https://d", "kd")])
+        h.flush()
+        assert len(h.queued) == 1
+        for _ in range(3):
+            h.post([_replica("https://b", "kb"), _replica("https://d", "kd")])
+            h.flush()
+    assert {u for u, _, _ in h.sent} == {"https://b/runs/multipart"}
+    assert [i.api_url for i in h.queued] == ["https://d"] * 4
+
+
+def test_a_replica_only_client_is_never_challenged():
+    with Harness() as h:
+        for _ in range(3):
+            h.post([_replica("https://b", "kb")])
+        h.flush()
+    assert h.routes == [("https://b/runs/multipart", "kb")]
+    assert not h.queued
+
+
+def test_the_frame_never_changes_owner():
+    dest_b = frozenset({ReplicaAuth("https://b", "kb", None, None, None, None)})
+    dest_d = frozenset({ReplicaAuth("https://d", "kd", None, None, None, None)})
+    traces = CompressedTraces()
+    assert traces.accepts(dest_b) and traces.accepts(dest_d)
+    traces.destinations = dest_b
+    traces.reset()
+    assert traces.destinations == dest_b
+    assert traces.accepts(dest_b)
+    assert not traces.accepts(dest_d)
+
+
+# --- feedback ----------------------------------------------------------------
+
+
+def test_feedback_is_kept_out_of_a_replica_owned_frame():
+    with Harness() as h:
+        run = h.post([_replica("https://b", "kb")])
+        h.client.create_feedback(run.id, key="score", score=1.0, trace_id=run.trace_id)
+        assert h.client.compressed_traces.trace_count == 1  # the run only
+        h.flush()
+    assert h.routes == [("https://b/runs/multipart", "kb")]
+    assert [type(i.item).__name__ for i in h.queued] == ["SerializedFeedbackOperation"]
+    assert b"feedback" not in h.frame_for("https://b")
+
+
+def test_feedback_shares_the_frame_when_no_replica_owns_it():
+    with Harness() as h:
+        run = h.post()
+        h.client.create_feedback(run.id, key="score", score=1.0, trace_id=run.trace_id)
+        assert h.client.compressed_traces.trace_count == 2
+        h.flush()
+    assert h.routes == [("https://own/runs/multipart", "own-key")]
+    assert not h.queued
+
+
+# --- credential resolution ---------------------------------------------------
+
+
+def _headers_for(client, destinations):
+    return sorted(
+        (
+            d.api_url,
+            tuple(
+                sorted(
+                    _apply_auth_overrides(
+                        {**client._headers},
+                        api_key=d.api_key,
+                        service_key=d.service_key,
+                        tenant_id=d.tenant_id,
+                        authorization=d.authorization,
+                        cookie=d.cookie,
+                        fallback_api_key=None,
+                    ).items()
+                )
+            ),
+        )
+        for d in destinations
+    )
+
+
+@pytest.mark.parametrize(
+    "auth",
+    [
+        ReplicaAuth(None, None, None, None, None, None),
+        ReplicaAuth(None, "replica-key", None, None, None, None),
+        ReplicaAuth("https://b", None, None, None, None, None),
+        ReplicaAuth(None, None, "svc", None, None, None),
+        ReplicaAuth(None, None, None, None, "Bearer t", None),
+        ReplicaAuth(None, None, None, None, None, "c=1"),
+        ReplicaAuth("https://b", "kb", None, None, None, None),
+    ],
+    ids=[
+        "none",
+        "api_key",
+        "api_url",
+        "service_key",
+        "authorization",
+        "cookie",
+        "both",
+    ],
+)
+def test_resolution_matches_the_headers_the_old_paths_would_have_sent(auth):
+    client = Client(
+        api_url="https://own",
+        api_key="own-key",
+        session=MagicMock(),
+        auto_batch_tracing=False,
+    )
+    if not any(auth):
+        expected = [
+            (url, key, None, None, None, None)
+            for url, key in client._write_api_urls.items()
+        ]
+        fallback = None
+    else:
+        expected = [auth]
+        fallback = client.api_key
+    want = sorted(
+        (
+            a[0] or client.api_url,
+            tuple(
+                sorted(
+                    _apply_auth_overrides(
+                        {**client._headers},
+                        api_key=a[1],
+                        service_key=a[2],
+                        tenant_id=a[3],
+                        authorization=a[4],
+                        cookie=a[5],
+                        fallback_api_key=fallback,
+                    ).items()
+                )
+            ),
+        )
+        for a in expected
+    )
+    assert _headers_for(client, client._resolve_destinations(auth)) == want
+
+
+def test_a_null_write_api_url_key_still_strips_the_api_key_header():
+    client = Client(
+        api_urls={"https://a": ""}, session=MagicMock(), auto_batch_tracing=False
+    )
+    destinations = client._resolve_destinations(
+        ReplicaAuth(None, None, None, None, None, None)
+    )
+    assert [d.api_key for d in destinations] == [""]
+
+
+def test_service_key_replica_sends_no_api_key():
+    with Harness() as h:
+        h.post([{"api_url": "https://b", "auth": {"service_key": "svc"}}])
+        h.flush()
+    assert h.routes == [("https://b/runs/multipart", None)]
+
+
+def test_two_keys_for_one_host_stay_distinct_destinations():
+    """§13.2: identical payloads, different tenants -- the merge would be invisible."""
+    with Harness() as h:
+        h.post([_replica("https://same", "key-1"), _replica("https://same", "key-2")])
+        h.flush()
+    assert h.routes == [("https://same/runs/multipart", "key-1")]
+    assert [(i.api_url, i.api_key) for i in h.queued] == [("https://same", "key-2")]
+
+
+# --- non-regression ----------------------------------------------------------
+
+
+def test_multiple_write_api_urls_still_replay_one_frame():
+    with Harness(api_url=None, api_urls={"https://a": "ka", "https://b": "kb"}) as h:
+        h.post()
+        h.flush()
+    assert h.routes == [
+        ("https://a/runs/multipart", "ka"),
+        ("https://b/runs/multipart", "kb"),
+    ]
+    assert h.sent[0][2] == h.sent[1][2] and h.sent[0][2]
+    assert not h.queued
+
+
+def test_project_only_replicas_are_unchanged():
+    with Harness() as h:
+        h.post([{"project_name": "p1"}, {"project_name": "p2"}])
+        assert h.client.compressed_traces.trace_count == 2
+        h.flush()
+    assert h.routes == [("https://own/runs/multipart", "own-key")]
+    assert not h.queued
+
+
+# --- resources and security --------------------------------------------------
+
+
+def test_multipart_files_are_closed_whether_or_not_the_op_is_admitted():
+    """The close must not sit on the accept path only -- that would leak fds."""
+    from langsmith import client as client_module
+
+    closed: list = []
+    with (
+        Harness() as h,
+        patch.object(client_module, "_close_files", lambda files: closed.append(files)),
+    ):
+        h.post([_replica("https://b", "kb")])  # admitted
+        assert len(closed) == 1
+        h.post([_replica("https://d", "kd")])  # rejected -> queue
+        assert len(closed) == 1, "rejected op never reached the compressed path"
+        h.post([_replica("https://b", "kb")])  # admitted again
+    assert len(closed) == 2
+
+
+def test_replica_auth_never_renders_a_credential():
+    auth = ReplicaAuth(
+        "https://x", "sk-secret", "svc-secret", "tenant-1", "Bearer tok", "c=v"
+    )
+    secrets = ["sk-secret", "svc-secret", "Bearer tok", "c=v"]
+    for rendered in (
+        repr(auth),
+        str(auth),
+        f"{auth}",
+        "%s" % (auth,),
+        "%r" % (auth,),
+        repr(frozenset({auth})),
+        repr({"dest": auth}),
+    ):
+        for secret in secrets:
+            assert secret not in rendered, rendered
+    assert "https://x" in repr(auth)
+    assert "api_key" in repr(auth)  # which fields are set is still visible
+
+
+def test_admission_under_concurrency_never_mixes_destinations():
+    with Harness() as h:
+        stop = threading.Event()
+        drains: list = []
+
+        def drain_loop():
+            while not stop.is_set():
+                stream, info, destinations = bt._tracing_thread_drain_compressed_buffer(
+                    h.client, size_limit=1, size_limit_bytes=1
+                )
+                if stream is not None:
+                    drains.append((destinations, stream.getvalue()))
+
+        drainer = threading.Thread(target=drain_loop)
+        drainer.start()
+        writers = [
+            threading.Thread(
+                target=lambda i=i: [
+                    h.post(
+                        [
+                            _replica("https://b", "kb", "mine"),
+                            _replica("https://d", "kd", "theirs"),
+                        ],
+                        inputs={"n": i},
+                    )
+                    for _ in range(10)
+                ]
+            )
+            for i in range(4)
+        ]
+        for w in writers:
+            w.start()
+        for w in writers:
+            w.join()
+        stop.set()
+        drainer.join()
+        h.flush()
+
+    assert drains, "expected at least one frame to be drained mid-flight"
+    for destinations, raw in drains:
+        urls = {d.api_url for d in destinations}
+        assert urls == {"https://b"}, urls
+        body = zstandard.ZstdDecompressor().decompressobj().decompress(raw)
+        assert b"theirs" not in body

--- a/python/tests/unit_tests/test_replica_compression.py
+++ b/python/tests/unit_tests/test_replica_compression.py
@@ -198,8 +198,8 @@ def test_a_replica_only_client_is_never_challenged():
 
 
 def test_the_frame_never_changes_owner():
-    dest_b = frozenset({ReplicaAuth("https://b", "kb", None, None, None, None)})
-    dest_d = frozenset({ReplicaAuth("https://d", "kd", None, None, None, None)})
+    dest_b = frozenset({ReplicaAuth(api_url="https://b", api_key="kb")})
+    dest_d = frozenset({ReplicaAuth(api_url="https://d", api_key="kd")})
     traces = CompressedTraces()
     assert traces.accepts(dest_b) and traces.accepts(dest_d)
     traces.destinations = dest_b
@@ -261,13 +261,13 @@ def _headers_for(client, destinations):
 @pytest.mark.parametrize(
     "auth",
     [
-        ReplicaAuth(None, None, None, None, None, None),
-        ReplicaAuth(None, "replica-key", None, None, None, None),
-        ReplicaAuth("https://b", None, None, None, None, None),
-        ReplicaAuth(None, None, "svc", None, None, None),
-        ReplicaAuth(None, None, None, None, "Bearer t", None),
-        ReplicaAuth(None, None, None, None, None, "c=1"),
-        ReplicaAuth("https://b", "kb", None, None, None, None),
+        ReplicaAuth(),
+        ReplicaAuth(api_key="replica-key"),
+        ReplicaAuth(api_url="https://b"),
+        ReplicaAuth(service_key="svc"),
+        ReplicaAuth(authorization="Bearer t"),
+        ReplicaAuth(cookie="c=1"),
+        ReplicaAuth(api_url="https://b", api_key="kb"),
     ],
     ids=[
         "none",
@@ -321,9 +321,7 @@ def test_a_null_write_api_url_key_still_strips_the_api_key_header():
     client = Client(
         api_urls={"https://a": ""}, session=MagicMock(), auto_batch_tracing=False
     )
-    destinations = client._resolve_destinations(
-        ReplicaAuth(None, None, None, None, None, None)
-    )
+    destinations = client._resolve_destinations(ReplicaAuth())
     assert [d.api_key for d in destinations] == [""]
 
 
@@ -389,7 +387,12 @@ def test_multipart_files_are_closed_whether_or_not_the_op_is_admitted():
 
 def test_replica_auth_never_renders_a_credential():
     auth = ReplicaAuth(
-        "https://x", "sk-secret", "svc-secret", "tenant-1", "Bearer tok", "c=v"
+        api_url="https://x",
+        api_key="sk-secret",
+        service_key="svc-secret",
+        tenant_id="tenant-1",
+        authorization="Bearer tok",
+        cookie="c=v",
     )
     secrets = ["sk-secret", "svc-secret", "Bearer tok", "c=v"]
     for rendered in (

--- a/python/tests/unit_tests/test_replica_compression.py
+++ b/python/tests/unit_tests/test_replica_compression.py
@@ -175,8 +175,13 @@ def test_post_and_patch_for_one_destination_take_the_same_transport():
 # --- ownership ---------------------------------------------------------------
 
 
-def test_ownership_is_stable_across_flushes():
-    """reset() must not clear `destinations`, or the loser would alternate paths."""
+def test_a_fixed_replica_list_keeps_a_stable_outcome():
+    """Frames release their destinations when sent, but the result must not churn.
+
+    `post()` writes in replica-list order, so with an unchanged list the same set
+    claims every new frame and the other consistently uses the queue. A run's post
+    and patch therefore stay on one transport.
+    """
     with Harness() as h:
         h.post([_replica("https://b", "kb"), _replica("https://d", "kd")])
         h.flush()
@@ -192,21 +197,50 @@ def test_a_replica_only_client_is_never_challenged():
     with Harness() as h:
         for _ in range(3):
             h.post([_replica("https://b", "kb")])
+        assert h.client.compressed_traces.trace_count == 3
         h.flush()
     assert h.routes == [("https://b/runs/multipart", "kb")]
     assert not h.queued
 
 
-def test_the_frame_never_changes_owner():
+def test_an_open_frame_holds_its_destinations_and_a_sent_one_releases_them():
     dest_b = frozenset({ReplicaAuth(api_url="https://b", api_key="kb")})
     dest_d = frozenset({ReplicaAuth(api_url="https://d", api_key="kd")})
     traces = CompressedTraces()
+
+    # unclaimed: anything may enter
     assert traces.accepts(dest_b) and traces.accepts(dest_d)
+
+    # claimed: only its own destinations, or the frame would be mis-delivered
     traces.destinations = dest_b
-    traces.reset()
-    assert traces.destinations == dest_b
     assert traces.accepts(dest_b)
     assert not traces.accepts(dest_d)
+
+    # sent: released, so a client whose replicas changed is not stuck on dest_b
+    traces.reset()
+    assert traces.destinations is None
+    assert traces.accepts(dest_d)
+
+
+def test_replicas_that_change_can_claim_the_next_frame():
+    with Harness() as h:
+        h.post([_replica("https://b", "kb")])
+        h.flush()
+        h.post([_replica("https://d", "kd")])
+        assert h.client.compressed_traces.trace_count == 1
+        h.flush()
+    assert h.routes == [
+        ("https://b/runs/multipart", "kb"),
+        ("https://d/runs/multipart", "kd"),
+    ]
+    assert not h.queued
+
+
+def test_a_second_destination_set_still_waits_for_the_next_frame():
+    with Harness() as h:
+        h.post([_replica("https://b", "kb", "p1"), _replica("https://d", "kd", "p2")])
+        assert h.client.compressed_traces.trace_count == 1
+        assert [i.api_url for i in h.queued] == ["https://d"]
 
 
 # --- feedback ----------------------------------------------------------------


### PR DESCRIPTION
## Description

`_create_run` and `_update_run` took the compressed (zstd) path only when **all six**
per-call auth arguments were `None`. Any replica carrying e.g. `api_url`/`auth` fell through to
the uncompressed `tracing_queue`, silently. Using `LANGSMITH_RUNS_ENDPOINTS`
always produces that shape, so the whole documented multi-endpoint configuration paid the
uncompressed cost.

This was no accident - a zstd frame had nowhere to record where it should be POSTed.

With this PR the frame now carries the missing field. `CompressedTraces.destinations` records where a
frame goes, `accepts()` admits only ops bound for the same place, and the sender routes by
it (`None` keeps the old `_write_api_urls` behaviour). The check, the commit and the write
happen in **one hold** of the existing lock.

There is _still_ one frame per client, so when a client has several destination sets only one is
compressed: the first to write owns it, and `reset()` deliberately does not clear
`destinations`, so ownership is decided once instead of re-raced after every flush. The
rest use the plaintext queue, exactly as today - nothing is worse than before. A one-time warning
replaces the silence.

`create_feedback` is the third writer into that frame and gets the same check.

## Release Note

Replicas hitting the **same destination** URL now use compressed trace ingestion instead of silently falling back to plaintext. Payloads sent to different projects are bundled in the same zstd Multipart frame, greatly reducing the memory footprint (e.g 8 replicas go from ~90MB -> ~2MB)

## Test Plan

- [x] `python/tests/unit_tests/test_replica_compression.py` (new, 25 tests): no cross-destination bleed with decompressed frame bodies, stable ownership across flushes, feedback kept out of a replica-owned frame, concurrent admission vs. drain
- [x] Credential resolution produces byte-identical headers to the previous paths on all 7 auth shapes, including the `None`-key and `service_key`-only cases
- [x] Non-regression: `api_urls={A,B}` still replays one frame to both; project-only replicas unchanged; existing `test_multiple_endpoints.py` / `test_replica_endpoints.py` untouched and passing
- [x] Full unit suite: 2047 passed (one pre-existing failure from a locally-set `LANGSMITH_ENDPOINT`; passes when cleared)
