### PR TITLE
ci: enable CodSpeed flame graphs and pin the benchmarks to one CPU

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -34,7 +34,11 @@ jobs:
     name: "Python Benchmarks (${{ matrix.mode }})"
     # Same-repo PRs only: forks would pollute the baseline and reach the self-hosted runner.
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
-    runs-on: ${{ matrix.runner }}
+    # CodSpeed's bare-metal ARM64 runners, in the org's `oss-runners` group.
+    # Every instrument runs here: GitHub swaps the CPU model between hosted
+    # runs (Intel Xeon to AMD EPYC), which moves simulated cache behaviour and
+    # so the cycle counts, and shows up as phantom regressions.
+    runs-on: codspeed-macro
     # CPU simulation is far slower than a bare run, so the job timeout is what
     # bounds a hung benchmark (see --timeout=0 below).
     timeout-minutes: 30
@@ -44,20 +48,10 @@ jobs:
       # runner hung installing Valgrind for simulation, memory never ran at all.
       fail-fast: false
       matrix:
-        include:
-          # Models the CPU rather than timing it, so shared runners are fine.
-          - mode: simulation
-            runner: ubuntu-latest
-          # Heap allocations; also instrument-based, so shared runners are fine.
-          - mode: memory
-            runner: ubuntu-latest
-          # Real elapsed time, including syscalls, I/O and thread parallelism,
-          # which matters for the create_*_run_trees cases (they drive tracing
-          # threads). Needs CodSpeed's bare-metal ARM64 runners to be low-noise;
-          # they are registered into the org's `oss-runners` group, which
-          # langsmith-sdk has access to.
-          - mode: walltime
-            runner: codspeed-macro
+        # simulation models the CPU, memory tracks heap allocations, and
+        # walltime measures real elapsed time - the last of which matters for
+        # the create_*_run_trees cases, since they drive tracing threads.
+        mode: [simulation, memory, walltime]
     permissions:
       contents: read # required for actions/checkout
       id-token: write # required for OIDC authentication with CodSpeed
@@ -67,12 +61,14 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      # No cache-suffix needed for the ARM64 runner: setup-uv already embeds the
-      # arch in its cache key, so x86 and ARM64 entries cannot collide.
+      # 3.12 is the floor for flame graphs: pytest-codspeed reads CPython's
+      # PY_HAVE_PERF_TRAMPOLINE, which does not exist before then, and without
+      # it the run logs "callgraph: not supported" and the profiling pane is
+      # empty. No cache-suffix needed - setup-uv embeds the arch in its key.
       - name: Install uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
-          python-version: 3.11
+          python-version: "3.12"
           enable-cache: true
 
       - name: Install dependencies

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -68,14 +68,14 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      # 3.12 is the floor for flame graphs: pytest-codspeed reads CPython's
-      # PY_HAVE_PERF_TRAMPOLINE, which does not exist before then, and without
-      # it the run logs "callgraph: not supported" and the profiling pane is
-      # empty. No cache-suffix needed - setup-uv embeds the arch in its key.
+      # Flame graphs need CPython's perf trampoline: pytest-codspeed reads
+      # PY_HAVE_PERF_TRAMPOLINE, absent before 3.12, and without it the run logs
+      # "callgraph: not supported" and the profiling pane is empty. 3.12 is the
+      # floor; we pin 3.13. No cache-suffix needed - setup-uv embeds the arch.
       - name: Install uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
-          python-version: "3.12"
+          python-version: "3.13"
           enable-cache: true
 
       - name: Install dependencies

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -51,7 +51,17 @@ jobs:
         # simulation models the CPU, memory tracks heap allocations, and
         # walltime measures real elapsed time - the last of which matters for
         # the create_*_run_trees cases, since they drive tracing threads.
-        mode: [simulation, memory, walltime]
+        include:
+          # PROBE, revert once attributed: on 3.12 this leg completed zero of 9
+          # benchmarks in 27 minutes and hit the job timeout (run 33004187688),
+          # where the same cases took 6m12s on x86. 3.11 has no perf trampoline,
+          # so callgraph is off here, isolating it from the runner change.
+          - mode: simulation
+            python: "3.11"
+          - mode: memory
+            python: "3.12"
+          - mode: walltime
+            python: "3.12"
     permissions:
       contents: read # required for actions/checkout
       id-token: write # required for OIDC authentication with CodSpeed
@@ -68,7 +78,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
-          python-version: "3.12"
+          python-version: ${{ matrix.python }}
           enable-cache: true
 
       - name: Install dependencies

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -35,12 +35,10 @@ jobs:
     # Same-repo PRs only: forks would pollute the baseline and reach the self-hosted runner.
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
     # CodSpeed's bare-metal ARM64 runners, in the org's `oss-runners` group.
-    # Every instrument runs here: GitHub swaps the CPU model between hosted
-    # runs (Intel Xeon to AMD EPYC), which moves simulated cache behaviour and
-    # so the cycle counts, and shows up as phantom regressions.
+    # Hosted runners swap the CPU model between runs (Intel Xeon to AMD EPYC),
+    # which moves simulated cache behaviour and surfaces as phantom regressions.
     runs-on: codspeed-macro
-    # CPU simulation is far slower than a bare run, so the job timeout is what
-    # bounds a hung benchmark (see --timeout=0 below).
+    # Backstop only: `--timeout=0` below disables pytest's own timeout.
     timeout-minutes: 30
     strategy:
       # One job per instrument, so a failure in one cannot stop the others.
@@ -48,22 +46,19 @@ jobs:
       # runner hung installing Valgrind for simulation, memory never ran at all.
       fail-fast: false
       matrix:
-        # simulation models the CPU, memory tracks heap allocations, and
-        # walltime measures real elapsed time - the last of which matters for
-        # the create_*_run_trees cases, since they drive tracing threads.
+        # memory tracks heap allocations; walltime measures real elapsed time,
+        # which matters for the create_*_run_trees cases since they drive
+        # tracing threads.
         include:
-          # PROBE, revert once attributed. This leg completes zero of 9
-          # benchmarks in 27 minutes on ARM and hits the job timeout, on 3.12
-          # with callgraph (run 33004187688) and on 3.11 without it (run
-          # 33008357502) alike - so callgraph is not the cost, ARM Valgrind is.
-          # The same cases take 6m12s on x86. Trying 3.13 in case the
-          # interpreter build behaves differently under simulation.
-          - mode: simulation
-            python: "3.13"
+          # Disabled: Valgrind is too slow on the ARM64 macro runners. This leg
+          # completed zero of 9 benchmarks in 27 minutes and hit the job
+          # timeout, identically on 3.11, 3.12 and 3.13 (runs 33004187688,
+          # 33008357502, 33066038098), so neither the interpreter nor callgraph
+          # is the cause. The same cases take 6m12s on x86. Re-enable once
+          # CodSpeed offers x86_64 runners.
+          # - mode: simulation
           - mode: memory
-            python: "3.12"
           - mode: walltime
-            python: "3.12"
     permissions:
       contents: read # required for actions/checkout
       id-token: write # required for OIDC authentication with CodSpeed
@@ -80,7 +75,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
-          python-version: ${{ matrix.python }}
+          python-version: "3.12"
           enable-cache: true
 
       - name: Install dependencies

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -52,12 +52,14 @@ jobs:
         # walltime measures real elapsed time - the last of which matters for
         # the create_*_run_trees cases, since they drive tracing threads.
         include:
-          # PROBE, revert once attributed: on 3.12 this leg completed zero of 9
-          # benchmarks in 27 minutes and hit the job timeout (run 33004187688),
-          # where the same cases took 6m12s on x86. 3.11 has no perf trampoline,
-          # so callgraph is off here, isolating it from the runner change.
+          # PROBE, revert once attributed. This leg completes zero of 9
+          # benchmarks in 27 minutes on ARM and hits the job timeout, on 3.12
+          # with callgraph (run 33004187688) and on 3.11 without it (run
+          # 33008357502) alike - so callgraph is not the cost, ARM Valgrind is.
+          # The same cases take 6m12s on x86. Trying 3.13 in case the
+          # interpreter build behaves differently under simulation.
           - mode: simulation
-            python: "3.11"
+            python: "3.13"
           - mode: memory
             python: "3.12"
           - mode: walltime

--- a/.github/workflows/py-bench-datadog.yml
+++ b/.github/workflows/py-bench-datadog.yml
@@ -40,7 +40,8 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
-          python-version: 3.11
+          # Matches codspeed.yml, so both systems benchmark one interpreter.
+          python-version: "3.12"
           enable-cache: true
 
       - name: Install dependencies

--- a/.github/workflows/py-bench-datadog.yml
+++ b/.github/workflows/py-bench-datadog.yml
@@ -41,7 +41,7 @@ jobs:
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           # Matches codspeed.yml, so both systems benchmark one interpreter.
-          python-version: "3.12"
+          python-version: "3.13"
           enable-cache: true
 
       - name: Install dependencies


### PR DESCRIPTION
Two fixes suggested by the CodSpeed team.

**Empty profiling pane.** Flame graphs need CPython's perf trampoline: pytest-codspeed gates them on `sysconfig.get_config_var("PY_HAVE_PERF_TRAMPOLINE")`, which does not exist before 3.12, so every job logged `callgraph: not supported`. Both benchmark workflows now pin `"3.13"` — quoted, since an unquoted `3.10` would parse as the float `3.1` — keeping one interpreter across CodSpeed and Datadog. Confirmed: the legs now log `callgraph: enabled`.

**Phantom regressions.** The `memory` and `walltime` legs now run on `codspeed-macro`, CodSpeed's bare-metal ARM64 runners, instead of `ubuntu-latest` where GitHub swapped the CPU between runs (Intel Xeon 6973P-C → AMD EPYC 9V74) and shifted the numbers. Both reproduce to within a second across four runs (1m47–1m49s and 2m16–2m19s), so the stability is real.

**`simulation` is commented out**, not moved. Valgrind is too slow on those ARM runners: the leg completed zero of 9 benchmarks in 27 minutes and hit the job timeout on 3.12 with callgraph (33004187688), 3.11 without it (33008357502) and 3.13 (33066038098) alike, so neither the interpreter nor callgraph explains it — the same cases take 6m12s on x86. It is a one-line uncomment to restore once CodSpeed offers x86_64 runners. Until then, regression detection rests on walltime and memory, and CodSpeed receives no cycle counts.
