### PR TITLE
perf(py): serialize identical replicas once, into one frame

### DIFF
--- a/python/langsmith/_internal/_background_thread.py
+++ b/python/langsmith/_internal/_background_thread.py
@@ -242,7 +242,7 @@ def _tracing_thread_drain_compressed_buffer(
 
 def _process_buffered_run_ops_batch(
     client: Client,
-    batch_to_process: list[tuple[str, dict, dict[str, Optional[str]]]],
+    batch_to_process: list[tuple[str, dict, dict[str, Any]]],
 ) -> None:
     """Process a batch of run operations asynchronously."""
     try:

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -2781,21 +2781,21 @@ class Client:
         cookie: Optional[str] = None,
         _replica_auths: Optional[Sequence[ReplicaAuth]] = None,
     ) -> None:
+        auths = _replica_auths or [
+            ReplicaAuth(
+                api_url=api_url,
+                api_key=api_key,
+                service_key=service_key,
+                tenant_id=tenant_id,
+                authorization=authorization,
+                cookie=cookie,
+            )
+        ]
         if (
             # batch ingest requires trace_id and dotted_order to be set
             run_create.get("trace_id") is not None
             and run_create.get("dotted_order") is not None
         ):
-            auths = _replica_auths or [
-                ReplicaAuth(
-                    api_url=api_url,
-                    api_key=api_key,
-                    service_key=service_key,
-                    tenant_id=tenant_id,
-                    authorization=authorization,
-                    cookie=cookie,
-                )
-            ]
             destinations = (
                 self._resolve_destinations(*auths)
                 if self.compressed_traces is not None
@@ -2838,25 +2838,11 @@ class Client:
             else:
                 # Neither Rust nor Python batch ingestion is configured,
                 # fall back to the non-batch approach.
-                self._create_run_non_batch(
-                    run_create,
-                    api_key=api_key,
-                    api_url=api_url,
-                    service_key=service_key,
-                    tenant_id=tenant_id,
-                    authorization=authorization,
-                    cookie=cookie,
-                )
+                for auth in auths:
+                    self._create_run_non_batch(run_create, **auth._asdict())
         else:
-            self._create_run_non_batch(
-                run_create,
-                api_key=api_key,
-                api_url=api_url,
-                service_key=service_key,
-                tenant_id=tenant_id,
-                authorization=authorization,
-                cookie=cookie,
-            )
+            for auth in auths:
+                self._create_run_non_batch(run_create, **auth._asdict())
 
     def _create_run_non_batch(
         self,
@@ -3967,6 +3953,16 @@ class Client:
         cookie: Optional[str] = None,
         _replica_auths: Optional[Sequence[ReplicaAuth]] = None,
     ):
+        auths = _replica_auths or [
+            ReplicaAuth(
+                api_url=api_url,
+                api_key=api_key,
+                service_key=service_key,
+                tenant_id=tenant_id,
+                authorization=authorization,
+                cookie=cookie,
+            )
+        ]
         use_multipart = (
             (self.tracing_queue is not None or self.compressed_traces is not None)
             # batch ingest requires trace_id and dotted_order to be set
@@ -3977,16 +3973,6 @@ class Client:
             self._pyo3_client.update_run(run_update)
         elif use_multipart:
             serialized_op = serialize_run_dict(operation="patch", payload=run_update)
-            auths = _replica_auths or [
-                ReplicaAuth(
-                    api_url=api_url,
-                    api_key=api_key,
-                    service_key=service_key,
-                    tenant_id=tenant_id,
-                    authorization=authorization,
-                    cookie=cookie,
-                )
-            ]
             destinations = (
                 self._resolve_destinations(*auths)
                 if self.compressed_traces is not None
@@ -4023,15 +4009,8 @@ class Client:
                 )
                 self._enqueue_op(run_update["dotted_order"], serialized_op, auths)
         else:
-            self._update_run_non_batch(
-                run_update,
-                api_key=api_key,
-                api_url=api_url,
-                service_key=service_key,
-                tenant_id=tenant_id,
-                authorization=authorization,
-                cookie=cookie,
-            )
+            for auth in auths:
+                self._update_run_non_batch(run_update, **auth._asdict())
 
     def _update_run_non_batch(
         self,

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -18,6 +18,7 @@ import collections
 import concurrent.futures as cf
 import contextlib
 import contextvars
+import copy
 import datetime
 import functools
 import importlib
@@ -1355,7 +1356,7 @@ class Client:
         self.compressed_traces: Optional[CompressedTraces] = None
         self._data_available_event: Optional[threading.Event] = None
         self._futures: Optional[weakref.WeakSet[cf.Future]] = None
-        self._run_ops_buffer: list[tuple[str, dict, dict[str, Optional[str]]]] = []
+        self._run_ops_buffer: list[tuple[str, dict, dict[str, Any]]] = []
         self._run_ops_buffer_lock = threading.Lock()
         self.otel_exporter: Optional[OTELExporter] = None
         self._max_batch_size_bytes = max_batch_size_bytes
@@ -2611,6 +2612,10 @@ class Client:
             ```
         """
         service_key: str | None = kwargs.pop("service_key", None)
+        # Popped before run_create is built, or it would become a run field.
+        replica_auths: Optional[Sequence[ReplicaAuth]] = kwargs.pop(
+            "_replica_auths", None
+        )
         tenant_id: str | None = kwargs.pop("tenant_id", None)
         authorization: str | None = kwargs.pop("authorization", None)
         cookie: str | None = kwargs.pop("cookie", None)
@@ -2650,6 +2655,7 @@ class Client:
                             "tenant_id": tenant_id,
                             "authorization": authorization,
                             "cookie": cookie,
+                            "_replica_auths": replica_auths,
                         },
                     )
                 )
@@ -2666,27 +2672,36 @@ class Client:
                 tenant_id=tenant_id,
                 authorization=authorization,
                 cookie=cookie,
+                _replica_auths=replica_auths,
             )
 
     def _enqueue_op(
         self,
         priority: str,
         op: Union[SerializedRunOperation, SerializedFeedbackOperation],
-        auth: ReplicaAuth,
+        auths: Sequence[ReplicaAuth],
     ) -> None:
-        """Put one op on the uncompressed queue, carrying its destination's auth."""
-        self._put_tracing_queue(
-            TracingQueueItem(
-                priority,
-                op,
-                **auth._asdict(),
-                otel_context=(
-                    self._set_span_in_context(self._otel_trace.get_current_span())
-                    if self.otel_exporter is not None
-                    else None
-                ),
-            )
+        """Put one queue item per destination.
+
+        A queue item carries one auth tuple, so a multi-destination op becomes
+        several items. They share the payload's bytes but need separate objects:
+        combine_serialized_queue_operations mutates the post op in place, per
+        auth group.
+        """
+        otel_context = (
+            self._set_span_in_context(self._otel_trace.get_current_span())
+            if self.otel_exporter is not None
+            else None
         )
+        for index, auth in enumerate(auths):
+            self._put_tracing_queue(
+                TracingQueueItem(
+                    priority,
+                    op if index == 0 else _duplicate_op(op),
+                    **auth._asdict(),
+                    otel_context=otel_context,
+                )
+            )
 
     def _compress_admitted(
         self, multipart_form: MultipartPartsAndContext, destinations: frozenset
@@ -2731,24 +2746,28 @@ class Client:
             _destination_urls(destinations) if destinations else "another endpoint",
         )
 
-    def _resolve_destinations(self, auth: ReplicaAuth) -> frozenset[ReplicaAuth]:
+    def _resolve_destinations(self, *auths: ReplicaAuth) -> frozenset[ReplicaAuth]:
         """Where a frame carrying this op must be POSTed.
 
         Pre-resolve the URL + auth for each destination the compressed frame committed to
         """
-        if not any(auth):
-            return frozenset(
-                ReplicaAuth(api_url=url, api_key=key)
-                for url, key in self._write_api_urls.items()
+        resolved: set[ReplicaAuth] = set()
+        for auth in auths:
+            if not any(auth):
+                resolved.update(
+                    ReplicaAuth(api_url=url, api_key=key)
+                    for url, key in self._write_api_urls.items()
+                )
+                continue
+            api_key = auth.api_key
+            if api_key is None and not any(
+                [auth.service_key, auth.authorization, auth.cookie]
+            ):
+                api_key = self.api_key
+            resolved.add(
+                auth._replace(api_url=auth.api_url or self.api_url, api_key=api_key)
             )
-        api_key = auth.api_key
-        if api_key is None and not any(
-            [auth.service_key, auth.authorization, auth.cookie]
-        ):
-            api_key = self.api_key
-        return frozenset(
-            {auth._replace(api_url=auth.api_url or self.api_url, api_key=api_key)}
-        )
+        return frozenset(resolved)
 
     def _create_run(
         self,
@@ -2760,22 +2779,25 @@ class Client:
         tenant_id: Optional[str] = None,
         authorization: Optional[str] = None,
         cookie: Optional[str] = None,
+        _replica_auths: Optional[Sequence[ReplicaAuth]] = None,
     ) -> None:
         if (
             # batch ingest requires trace_id and dotted_order to be set
             run_create.get("trace_id") is not None
             and run_create.get("dotted_order") is not None
         ):
-            auth = ReplicaAuth(
-                api_url=api_url,
-                api_key=api_key,
-                service_key=service_key,
-                tenant_id=tenant_id,
-                authorization=authorization,
-                cookie=cookie,
-            )
+            auths = _replica_auths or [
+                ReplicaAuth(
+                    api_url=api_url,
+                    api_key=api_key,
+                    service_key=service_key,
+                    tenant_id=tenant_id,
+                    authorization=authorization,
+                    cookie=cookie,
+                )
+            ]
             destinations = (
-                self._resolve_destinations(auth)
+                self._resolve_destinations(*auths)
                 if self.compressed_traces is not None
                 else None
             )
@@ -2802,7 +2824,7 @@ class Client:
                 admitted = self._compress_admitted(multipart_form, destinations)
                 _close_files(list(opened_files.values()))
                 if not admitted and self.tracing_queue is not None:
-                    self._enqueue_op(run_create["dotted_order"], serialized_op, auth)
+                    self._enqueue_op(run_create["dotted_order"], serialized_op, auths)
             elif self.tracing_queue is not None:
                 self._warn_compression_downgrade(destinations)
                 serialized_op = serialize_run_dict("post", run_create)
@@ -2812,7 +2834,7 @@ class Client:
                     serialized_op.trace_id,
                     serialized_op.id,
                 )
-                self._enqueue_op(run_create["dotted_order"], serialized_op, auth)
+                self._enqueue_op(run_create["dotted_order"], serialized_op, auths)
             else:
                 # Neither Rust nor Python batch ingestion is configured,
                 # fall back to the non-batch approach.
@@ -3850,6 +3872,9 @@ class Client:
             client.update_run(run["id"], **run)
             ```
         """
+        replica_auths: Optional[Sequence[ReplicaAuth]] = kwargs.pop(
+            "_replica_auths", None
+        )
         data: dict[str, Any] = {
             "id": _as_uuid(run_id, "run_id"),
             "name": name,
@@ -3910,6 +3935,7 @@ class Client:
                             "tenant_id": tenant_id,
                             "authorization": authorization,
                             "cookie": cookie,
+                            "_replica_auths": replica_auths,
                         },
                     )
                 )
@@ -3926,6 +3952,7 @@ class Client:
                 tenant_id=tenant_id,
                 authorization=authorization,
                 cookie=cookie,
+                _replica_auths=replica_auths,
             )
 
     def _update_run(
@@ -3938,6 +3965,7 @@ class Client:
         tenant_id: Optional[str] = None,
         authorization: Optional[str] = None,
         cookie: Optional[str] = None,
+        _replica_auths: Optional[Sequence[ReplicaAuth]] = None,
     ):
         use_multipart = (
             (self.tracing_queue is not None or self.compressed_traces is not None)
@@ -3949,16 +3977,18 @@ class Client:
             self._pyo3_client.update_run(run_update)
         elif use_multipart:
             serialized_op = serialize_run_dict(operation="patch", payload=run_update)
-            auth = ReplicaAuth(
-                api_url=api_url,
-                api_key=api_key,
-                service_key=service_key,
-                tenant_id=tenant_id,
-                authorization=authorization,
-                cookie=cookie,
-            )
+            auths = _replica_auths or [
+                ReplicaAuth(
+                    api_url=api_url,
+                    api_key=api_key,
+                    service_key=service_key,
+                    tenant_id=tenant_id,
+                    authorization=authorization,
+                    cookie=cookie,
+                )
+            ]
             destinations = (
-                self._resolve_destinations(auth)
+                self._resolve_destinations(*auths)
                 if self.compressed_traces is not None
                 else None
             )
@@ -3982,7 +4012,7 @@ class Client:
                 admitted = self._compress_admitted(multipart_form, destinations)
                 _close_files(list(opened_files.values()))
                 if not admitted and self.tracing_queue is not None:
-                    self._enqueue_op(run_update["dotted_order"], serialized_op, auth)
+                    self._enqueue_op(run_update["dotted_order"], serialized_op, auths)
             elif self.tracing_queue is not None:
                 self._warn_compression_downgrade(destinations)
                 logger.log(
@@ -3991,7 +4021,7 @@ class Client:
                     serialized_op.trace_id,
                     serialized_op.id,
                 )
-                self._enqueue_op(run_update["dotted_order"], serialized_op, auth)
+                self._enqueue_op(run_update["dotted_order"], serialized_op, auths)
         else:
             self._update_run_non_batch(
                 run_update,
@@ -11875,6 +11905,18 @@ def prep_obj_for_push(obj: Any) -> Any:
 
 
 _COMPRESSION_DOWNGRADE_WARNED = False
+
+
+def _duplicate_op(
+    op: Union[SerializedRunOperation, SerializedFeedbackOperation],
+) -> Union[SerializedRunOperation, SerializedFeedbackOperation]:
+    """Copy an op for another destination, sharing its immutable bytes."""
+    duplicate = copy.copy(op)
+    # attachments is a dict, and combine_serialized_queue_operations updates it
+    # in place.
+    if isinstance(duplicate, SerializedRunOperation) and duplicate.attachments:
+        duplicate.attachments = dict(duplicate.attachments)
+    return duplicate
 
 
 def _destination_urls(destinations: frozenset) -> list[str]:

--- a/python/langsmith/run_trees.py
+++ b/python/langsmith/run_trees.py
@@ -11,7 +11,7 @@ import threading
 import urllib.parse
 from collections.abc import Mapping, Sequence
 from datetime import datetime, timezone
-from typing import Any, Optional, Union, cast
+from typing import Any, NamedTuple, Optional, Union, cast
 from uuid import UUID
 
 from pydantic import ConfigDict, Field, PrivateAttr, model_validator
@@ -83,6 +83,26 @@ class WriteReplica(TypedDict, total=False):
     The field is **not** propagated in distributed-tracing baggage (each service
     must construct its own clients).
     """
+
+
+class _PayloadKey(NamedTuple):
+    """The four things that decide whether two replicas serialize to the same bytes.
+
+    Credentials are absent on purpose: they do not affect the bytes, which is what
+    lets one group of replicas span several destinations.
+    """
+
+    client: Client
+    project_name: str
+    updates: Optional[dict]
+    primary: Optional[bool]
+
+
+class _ReplicaGroup(NamedTuple):
+    """Replicas that serialize alike, so they can share one payload."""
+
+    key: _PayloadKey
+    members: list[WriteReplica]
 
 
 _HEADER_SAFE_REPLICA_FIELDS: frozenset[str] = frozenset(
@@ -806,43 +826,36 @@ class RunTree(ls_schemas.RunBase):
             dup.update(updates)
         return dup
 
-    def _replica_groups(
-        self,
-    ) -> list[tuple[Client, str, Optional[dict], Optional[bool], list[WriteReplica]]]:
-        """Group replicas that would serialize to the same bytes.
+    def _replica_groups(self) -> list[_ReplicaGroup]:
+        """Bucket replicas by the payload each one would produce.
 
-        Credentials do not affect the bytes, so one group can span destinations.
+        `post()` and `patch()` remap UUIDs and serialize once per group - byte-identical
+        payloads make up a single group, even when authentication differs.
         """
-        groups: list[
-            tuple[Client, str, Optional[dict], Optional[bool], list[WriteReplica]]
-        ] = []
+        groups: list[_ReplicaGroup] = []
         for replica in self.replicas or ():
-            key = (
-                replica.get("client") or self.client,
-                replica.get("project_name") or self.session_name,
-                replica.get("updates"),
-                replica.get("primary"),
+            # Identity key - if those match across replicas, then payload can be reused.
+            key = _PayloadKey(
+                client=replica.get("client") or self.client,
+                project_name=replica.get("project_name") or self.session_name,
+                updates=replica.get("updates"),
+                primary=replica.get("primary"),
             )
-            # ponytail: O(n^2) over a handful of replicas, and `updates` compares by
-            # value without needing a hashable freeze. Use a key if that changes.
+            # Join the first group that matches, or start a new group
             for group in groups:
-                if group[:4] == key:
-                    group[4].append(replica)
+                if group.key == key:
+                    group.members.append(replica)
                     break
             else:
-                groups.append((*key, [replica]))
+                groups.append(_ReplicaGroup(key, [replica]))
         return groups
 
     def post(self, exclude_child_runs: bool = True) -> None:
         """Post the run tree to the API asynchronously."""
         if self.replicas:
-            for (
-                replica_client,
-                project_name,
-                updates,
-                primary,
-                members,
-            ) in self._replica_groups():
+            for group in self._replica_groups():
+                replica_client, project_name, updates, primary = group.key
+                members = group.members
                 if not hasattr(replica_client, "create_run"):
                     raise TypeError(
                         f"WriteReplica 'client' must be a langsmith.Client, "
@@ -908,13 +921,9 @@ class RunTree(ls_schemas.RunBase):
         except Exception as e:
             logger.warning(f"Error filtering attachments to upload: {e}")
         if self.replicas:
-            for (
-                replica_client,
-                project_name,
-                updates,
-                primary,
-                members,
-            ) in self._replica_groups():
+            for group in self._replica_groups():
+                replica_client, project_name, updates, primary = group.key
+                members = group.members
                 if not hasattr(replica_client, "update_run"):
                     raise TypeError(
                         f"WriteReplica 'client' must be a langsmith.Client, "

--- a/python/langsmith/run_trees.py
+++ b/python/langsmith/run_trees.py
@@ -806,32 +806,54 @@ class RunTree(ls_schemas.RunBase):
             dup.update(updates)
         return dup
 
+    def _replica_groups(
+        self,
+    ) -> list[tuple[Client, str, Optional[dict], Optional[bool], list[WriteReplica]]]:
+        """Group replicas that would serialize to the same bytes.
+
+        Credentials do not affect the bytes, so one group can span destinations.
+        """
+        groups: list[
+            tuple[Client, str, Optional[dict], Optional[bool], list[WriteReplica]]
+        ] = []
+        for replica in self.replicas or ():
+            key = (
+                replica.get("client") or self.client,
+                replica.get("project_name") or self.session_name,
+                replica.get("updates"),
+                replica.get("primary"),
+            )
+            # ponytail: O(n^2) over a handful of replicas, and `updates` compares by
+            # value without needing a hashable freeze. Use a key if that changes.
+            for group in groups:
+                if group[:4] == key:
+                    group[4].append(replica)
+                    break
+            else:
+                groups.append((*key, [replica]))
+        return groups
+
     def post(self, exclude_child_runs: bool = True) -> None:
         """Post the run tree to the API asynchronously."""
         if self.replicas:
-            for replica in self.replicas:
-                project_name = replica.get("project_name") or self.session_name
-                updates = replica.get("updates")
-                run_dict = self._remap_for_project(
-                    project_name, updates, primary=replica.get("primary")
-                )
-                api_url, api_key, service_key, tenant_id, authorization, cookie = (
-                    _extract_replica_auth(replica)
-                )
-                replica_client = replica.get("client") or self.client
+            for (
+                replica_client,
+                project_name,
+                updates,
+                primary,
+                members,
+            ) in self._replica_groups():
                 if not hasattr(replica_client, "create_run"):
                     raise TypeError(
                         f"WriteReplica 'client' must be a langsmith.Client, "
                         f"got {type(replica_client).__name__}"
                     )
+                run_dict = self._remap_for_project(
+                    project_name, updates, primary=primary
+                )
                 replica_client.create_run(
                     **run_dict,
-                    api_key=api_key,
-                    api_url=api_url,
-                    service_key=service_key,
-                    tenant_id=tenant_id,
-                    authorization=authorization,
-                    cookie=cookie,
+                    _replica_auths=[_extract_replica_auth(r) for r in members],
                 )
         else:
             kwargs = self._get_dicts_safe()
@@ -886,21 +908,21 @@ class RunTree(ls_schemas.RunBase):
         except Exception as e:
             logger.warning(f"Error filtering attachments to upload: {e}")
         if self.replicas:
-            for replica in self.replicas:
-                project_name = replica.get("project_name") or self.session_name
-                updates = replica.get("updates")
-                run_dict = self._remap_for_project(
-                    project_name, updates, primary=replica.get("primary")
-                )
-                api_url, api_key, service_key, tenant_id, authorization, cookie = (
-                    _extract_replica_auth(replica)
-                )
-                replica_client = replica.get("client") or self.client
+            for (
+                replica_client,
+                project_name,
+                updates,
+                primary,
+                members,
+            ) in self._replica_groups():
                 if not hasattr(replica_client, "update_run"):
                     raise TypeError(
                         f"WriteReplica 'client' must be a langsmith.Client, "
                         f"got {type(replica_client).__name__}"
                     )
+                run_dict = self._remap_for_project(
+                    project_name, updates, primary=primary
+                )
                 replica_client.update_run(
                     name=run_dict["name"],
                     run_id=run_dict["id"],
@@ -919,12 +941,7 @@ class RunTree(ls_schemas.RunBase):
                     tags=run_dict.get("tags"),
                     extra=run_dict.get("extra"),
                     attachments=attachments,
-                    api_key=api_key,
-                    api_url=api_url,
-                    service_key=service_key,
-                    tenant_id=tenant_id,
-                    authorization=authorization,
-                    cookie=cookie,
+                    _replica_auths=[_extract_replica_auth(r) for r in members],
                 )
         else:
             self.client.update_run(

--- a/python/tests/unit_tests/test_multiple_endpoints.py
+++ b/python/tests/unit_tests/test_multiple_endpoints.py
@@ -161,14 +161,20 @@ class TestLangsmithRunsEndpoints:
 
         # First replica call
         first_call = calls[0]
-        assert first_call.kwargs["api_key"] == "replica_key1"
-        assert first_call.kwargs["api_url"] == "https://replica1.example.com"
+        assert first_call.kwargs["_replica_auths"][0].api_key == "replica_key1"
+        assert (
+            first_call.kwargs["_replica_auths"][0].api_url
+            == "https://replica1.example.com"
+        )
         assert first_call.kwargs["session_name"] == "project1"
 
         # Second replica call
         second_call = calls[1]
-        assert second_call.kwargs["api_key"] == "replica_key2"
-        assert second_call.kwargs["api_url"] == "https://replica2.example.com"
+        assert second_call.kwargs["_replica_auths"][0].api_key == "replica_key2"
+        assert (
+            second_call.kwargs["_replica_auths"][0].api_url
+            == "https://replica2.example.com"
+        )
         assert second_call.kwargs["session_name"] == "project2"
 
     def test_background_threading_with_different_endpoints(self):

--- a/python/tests/unit_tests/test_replica_compression.py
+++ b/python/tests/unit_tests/test_replica_compression.py
@@ -6,6 +6,7 @@ credential resolution behind it, and that nothing crosses between destinations.
 """
 
 import threading
+import uuid
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -14,7 +15,16 @@ import zstandard
 from langsmith import schemas as ls_schemas
 from langsmith._internal import _background_thread as bt
 from langsmith._internal._compressed_traces import CompressedTraces
-from langsmith.client import Client, ReplicaAuth, _apply_auth_overrides
+from langsmith._internal._operations import (
+    SerializedFeedbackOperation,
+    SerializedRunOperation,
+)
+from langsmith.client import (
+    Client,
+    ReplicaAuth,
+    _apply_auth_overrides,
+    _duplicate_op,
+)
 from langsmith.run_trees import RunTree
 
 _INFO = ls_schemas.LangSmithInfo(
@@ -163,7 +173,9 @@ def test_nothing_crosses_between_destinations():
 
 def test_post_and_patch_for_one_destination_take_the_same_transport():
     with Harness() as h:
-        run = h.post([_replica("https://b", "kb"), _replica("https://d", "kd")])
+        run = h.post(
+            [_replica("https://b", "kb", "p1"), _replica("https://d", "kd", "p2")]
+        )
         run.end(outputs={"b": 2})
         run.patch()
         assert h.client.compressed_traces.trace_count == 2  # B's post and patch
@@ -182,12 +194,13 @@ def test_a_fixed_replica_list_keeps_a_stable_outcome():
     claims every new frame and the other consistently uses the queue. A run's post
     and patch therefore stay on one transport.
     """
+    pair = [_replica("https://b", "kb", "p1"), _replica("https://d", "kd", "p2")]
     with Harness() as h:
-        h.post([_replica("https://b", "kb"), _replica("https://d", "kd")])
+        h.post(pair)
         h.flush()
         assert len(h.queued) == 1
         for _ in range(3):
-            h.post([_replica("https://b", "kb"), _replica("https://d", "kd")])
+            h.post(pair)
             h.flush()
     assert {u for u, _, _ in h.sent} == {"https://b/runs/multipart"}
     assert [i.api_url for i in h.queued] == ["https://d"] * 4
@@ -367,12 +380,20 @@ def test_service_key_replica_sends_no_api_key():
 
 
 def test_two_keys_for_one_host_stay_distinct_destinations():
-    """§13.2: identical payloads, different tenants -- the merge would be invisible."""
+    """Identical payloads, different tenants: one frame, one send per key.
+
+    Destinations come from resolved auth, so the two keys are never merged into
+    one destination. A merge would be invisible here -- the payloads do match.
+    """
     with Harness() as h:
         h.post([_replica("https://same", "key-1"), _replica("https://same", "key-2")])
+        assert h.client.compressed_traces.trace_count == 1
         h.flush()
-    assert h.routes == [("https://same/runs/multipart", "key-1")]
-    assert [(i.api_url, i.api_key) for i in h.queued] == [("https://same", "key-2")]
+    assert h.routes == [
+        ("https://same/runs/multipart", "key-1"),
+        ("https://same/runs/multipart", "key-2"),
+    ]
+    assert not h.queued
 
 
 # --- non-regression ----------------------------------------------------------
@@ -488,3 +509,153 @@ def test_admission_under_concurrency_never_mixes_destinations():
         assert urls == {"https://b"}, urls
         body = zstandard.ZstdDecompressor().decompressobj().decompress(raw)
         assert b"theirs" not in body
+
+
+# --- payload grouping (step 2) ------------------------------------------------
+
+
+class _CountSerializations:
+    """Count serialize_run_dict calls inside the block."""
+
+    def __enter__(self):
+        from langsmith import client as client_module
+
+        self.calls: list = []
+        original = client_module.serialize_run_dict
+
+        def spy(*args, **kwargs):
+            self.calls.append(1)
+            return original(*args, **kwargs)
+
+        self._patch = patch.object(client_module, "serialize_run_dict", spy)
+        self._patch.start()
+        return self
+
+    def __exit__(self, *exc):
+        self._patch.stop()
+
+    def __len__(self):
+        return len(self.calls)
+
+
+def test_identical_replicas_are_serialized_once():
+    with Harness() as h, _CountSerializations() as count:
+        h.post([_replica("https://a", "ka"), _replica("https://b", "kb")])
+    assert len(count) == 1
+
+
+def test_one_frame_reaches_every_destination_with_its_own_key():
+    with Harness() as h:
+        h.post([_replica("https://a", "ka"), _replica("https://b", "kb")])
+        assert h.client.compressed_traces.trace_count == 1
+        h.flush()
+    assert h.routes == [
+        ("https://a/runs/multipart", "ka"),
+        ("https://b/runs/multipart", "kb"),
+    ]
+    assert h.sent[0][2] == h.sent[1][2] and h.sent[0][2]
+    assert not h.queued
+
+
+def test_grouped_ops_share_bytes_but_are_distinct_objects():
+    with Harness() as h:
+        h.post([_replica("https://x", "kx")])  # takes the frame
+        h.post([_replica("https://a", "ka"), _replica("https://b", "kb")])
+    assert len(h.queued) == 2
+    first, second = (item.item for item in h.queued)
+    assert first is not second
+    assert first._none is second._none
+    assert first.inputs is second.inputs
+
+
+def test_duplicating_an_op_shares_bytes_but_not_the_attachments_dict():
+    op = SerializedRunOperation(
+        "post",
+        uuid.uuid4(),
+        uuid.uuid4(),
+        b"none-blob",
+        inputs=b"in-blob",
+        attachments={"a": ("text/plain", b"x")},
+    )
+    duplicate = _duplicate_op(op)
+
+    assert duplicate is not op
+    assert duplicate._none is op._none
+    assert duplicate.inputs is op.inputs
+    assert duplicate.attachments is not op.attachments
+    assert duplicate.attachments == op.attachments
+
+    # combine_serialized_queue_operations does exactly this, per auth group.
+    duplicate.attachments.update({"b": ("text/plain", b"y")})
+    assert "b" not in op.attachments
+
+
+def test_duplicating_an_op_without_attachments_is_safe():
+    op = SerializedFeedbackOperation(uuid.uuid4(), uuid.uuid4(), b"f")
+    duplicate = _duplicate_op(op)
+    assert duplicate is not op
+    assert duplicate.feedback is op.feedback
+
+
+def test_a_rejected_group_reaches_every_destination_by_queue():
+    with Harness() as h:
+        h.post([_replica("https://x", "kx")])
+        h.post([_replica("https://a", "ka"), _replica("https://b", "kb")])
+    assert [(i.api_url, i.api_key) for i in h.queued] == [
+        ("https://a", "ka"),
+        ("https://b", "kb"),
+    ]
+
+
+# One test per field of the grouping key: each must NOT group.
+
+
+def test_replicas_with_different_projects_are_not_grouped():
+    with Harness() as h, _CountSerializations() as count:
+        h.post([_replica("https://a", "ka", "p1"), _replica("https://b", "kb", "p2")])
+    assert len(count) == 2
+
+
+def test_replicas_with_different_updates_are_not_grouped():
+    with Harness() as h, _CountSerializations() as count:
+        h.post(
+            [
+                {
+                    "api_url": "https://a",
+                    "auth": {"api_key": "ka"},
+                    "updates": {"tags": ["x"]},
+                },
+                {"api_url": "https://b", "auth": {"api_key": "kb"}},
+            ]
+        )
+    assert len(count) == 2
+
+
+def test_primary_false_is_not_the_same_as_primary_absent():
+    with Harness() as h, _CountSerializations() as count:
+        h.post(
+            [
+                {"api_url": "https://a", "auth": {"api_key": "ka"}, "primary": False},
+                {"api_url": "https://b", "auth": {"api_key": "kb"}},
+            ]
+        )
+    assert len(count) == 2
+
+
+def test_replicas_on_different_clients_are_not_grouped():
+    with Harness() as h, _CountSerializations() as count:
+        other = Client(
+            api_url="https://own",
+            api_key="own-key",
+            session=MagicMock(),
+            auto_batch_tracing=False,
+            info=_INFO,
+        )
+        other.tracing_queue = MagicMock()  # so it serializes instead of POSTing
+        h.post(
+            [
+                {"api_url": "https://a", "auth": {"api_key": "ka"}},
+                {"api_url": "https://b", "auth": {"api_key": "kb"}, "client": other},
+            ]
+        )
+    assert len(count) == 2

--- a/python/tests/unit_tests/test_replica_compression.py
+++ b/python/tests/unit_tests/test_replica_compression.py
@@ -659,3 +659,66 @@ def test_replicas_on_different_clients_are_not_grouped():
             ]
         )
     assert len(count) == 2
+
+
+# --- the non-batch path (no compression, no queue) -----------------------------
+
+
+def _non_batch_client():
+    client = Client(
+        api_url="https://own",
+        api_key="own-key",
+        session=MagicMock(),
+        auto_batch_tracing=False,
+    )
+    assert client.tracing_queue is None and client.compressed_traces is None
+    return client
+
+
+def test_non_batch_writes_reach_the_replica_destination():
+    client = _non_batch_client()
+    sent: list = []
+    with patch.object(
+        Client,
+        "request_with_retries",
+        lambda _s, _m, url, **kw: sent.append(
+            (url, kw["request_kwargs"]["headers"].get("x-api-key"))
+        ),
+    ):
+        run = RunTree(
+            name="r",
+            run_type="chain",
+            inputs={"a": 1},
+            ls_client=client,
+            project_name="proj",
+            replicas=[_replica("https://b", "kb")],
+        )
+        run.post()
+        run.end(outputs={"b": 2})
+        run.patch()
+    assert [key for _, key in sent] == ["kb", "kb"]
+    assert all(url.startswith("https://b/") for url, _ in sent), sent
+
+
+def test_non_batch_writes_reach_every_destination_of_a_group():
+    client = _non_batch_client()
+    sent: list = []
+    with patch.object(
+        Client,
+        "request_with_retries",
+        lambda _s, _m, url, **kw: sent.append(
+            (url, kw["request_kwargs"]["headers"].get("x-api-key"))
+        ),
+    ):
+        RunTree(
+            name="r",
+            run_type="chain",
+            inputs={"a": 1},
+            ls_client=client,
+            project_name="proj",
+            replicas=[_replica("https://a", "ka"), _replica("https://b", "kb")],
+        ).post()
+    assert sorted(sent) == [
+        ("https://a/runs", "ka"),
+        ("https://b/runs", "kb"),
+    ]

--- a/python/tests/unit_tests/test_replica_endpoints.py
+++ b/python/tests/unit_tests/test_replica_endpoints.py
@@ -730,12 +730,12 @@ class TestRunTreeReplicas:
         # Verify client.create_run was called with replica parameters
         assert client.create_run.call_count == 1
         call_args = client.create_run.call_args
-        assert call_args[1]["api_key"] is None
-        assert call_args[1]["api_url"] is None
-        assert call_args[1]["service_key"] is None
-        assert call_args[1]["tenant_id"] is None
-        assert call_args[1]["authorization"] is None
-        assert call_args[1]["cookie"] is None
+        assert call_args[1]["_replica_auths"][0].api_key is None
+        assert call_args[1]["_replica_auths"][0].api_url is None
+        assert call_args[1]["_replica_auths"][0].service_key is None
+        assert call_args[1]["_replica_auths"][0].tenant_id is None
+        assert call_args[1]["_replica_auths"][0].authorization is None
+        assert call_args[1]["_replica_auths"][0].cookie is None
 
     def test_run_tree_with_authorization_and_cookie(self):
         client = Mock()
@@ -762,9 +762,9 @@ class TestRunTreeReplicas:
         run_tree.post()
 
         call_args = client.create_run.call_args
-        assert call_args[1]["authorization"] == "Bearer token-123"
-        assert call_args[1]["cookie"] == "session=abc"
-        assert call_args[1]["api_key"] is None
+        assert call_args[1]["_replica_auths"][0].authorization == "Bearer token-123"
+        assert call_args[1]["_replica_auths"][0].cookie == "session=abc"
+        assert call_args[1]["_replica_auths"][0].api_key is None
 
     def test_run_tree_with_new_replicas(self):
         """Test RunTree with WriteReplica format."""
@@ -798,10 +798,14 @@ class TestRunTreeReplicas:
         assert client.create_run.call_count == 2
 
         calls = client.create_run.call_args_list
-        assert calls[0][1]["api_key"] == "replica1-key"
-        assert calls[0][1]["api_url"] == "https://replica1.example.com"
-        assert calls[1][1]["api_key"] == "replica2-key"
-        assert calls[1][1]["api_url"] == "https://replica2.example.com"
+        assert calls[0][1]["_replica_auths"][0].api_key == "replica1-key"
+        assert (
+            calls[0][1]["_replica_auths"][0].api_url == "https://replica1.example.com"
+        )
+        assert calls[1][1]["_replica_auths"][0].api_key == "replica2-key"
+        assert (
+            calls[1][1]["_replica_auths"][0].api_url == "https://replica2.example.com"
+        )
         assert calls[0][1]["id"] == run_tree.id
         assert calls[1][1]["id"] == compute_run_id_for_secondary_replica(
             run_tree.id, "replica2-project"
@@ -832,10 +836,12 @@ class TestRunTreeReplicas:
         # Verify client.create_run was called with service auth parameters
         assert client.create_run.call_count == 1
         call_args = client.create_run.call_args
-        assert call_args[1]["api_key"] is None
-        assert call_args[1]["api_url"] == "https://internal.example.com"
-        assert call_args[1]["service_key"] == "jwt-token-123"
-        assert call_args[1]["tenant_id"] == "tenant-abc"
+        assert call_args[1]["_replica_auths"][0].api_key is None
+        assert (
+            call_args[1]["_replica_auths"][0].api_url == "https://internal.example.com"
+        )
+        assert call_args[1]["_replica_auths"][0].service_key == "jwt-token-123"
+        assert call_args[1]["_replica_auths"][0].tenant_id == "tenant-abc"
 
     def test_run_tree_patch_with_replicas(self):
         """Test RunTree patch method with replicas."""
@@ -863,8 +869,10 @@ class TestRunTreeReplicas:
         # Verify client.update_run was called with replica parameters
         assert client.update_run.call_count == 1
         call_args = client.update_run.call_args
-        assert call_args[1]["api_key"] == "replica-key"
-        assert call_args[1]["api_url"] == "https://replica.example.com"
+        assert call_args[1]["_replica_auths"][0].api_key == "replica-key"
+        assert (
+            call_args[1]["_replica_auths"][0].api_url == "https://replica.example.com"
+        )
         assert call_args[1]["run_id"] == compute_run_id_for_secondary_replica(
             run_tree.id, "replica-project"
         )


### PR DESCRIPTION
## Description

Stacked on #3448. That change let a compressed frame record where it must be sent, but
nothing ever produced an operation bound for more than one place — so every replica with its
own credentials still got its own serialized copy, and only one could use the frame.

Replicas that would produce the same bytes are now serialized once, and the single operation
is marked as belonging to all of their destinations. One frame carries one copy and is sent
to each destination with that destination's own credentials. This is what
`LANGSMITH_RUNS_ENDPOINTS` with several endpoints needs.

Credentials do not affect the bytes, which is what lets a group span destinations. Project
does not affect the destination, so multi-project replicas that share credentials keep
sharing one frame.

Replicas whose projects **and** destinations both differ still need one Zstd frame each, so one
is compressed and the rest use the non-compressed queue. That would be the next optimization.

## Release Note

Replicas that write the same run to several endpoints, as `LANGSMITH_RUNS_ENDPOINTS` does,
are now serialized once and compressed into a single frame instead of once per endpoint.

## Test Plan

- [x] 9 new tests in `test_replica_compression.py`: one serialization for identical replicas, one frame reaching every destination with its own key, and one test per field of the grouping key asserting that replicas which differ are not grouped
- [x] Three existing fixtures updated — same-project credentialed replicas are now one group
- [x] 23 assertions retargeted in `test_replica_endpoints.py` / `test_multiple_endpoints.py`
- [x] Full unit suite: 2056 passed