### PR TITLE
feat(livekit): align trace audio with the span timeline

### DIFF
--- a/python/langsmith/integrations/livekit/__init__.py
+++ b/python/langsmith/integrations/livekit/__init__.py
@@ -3,13 +3,15 @@
 from __future__ import annotations
 
 import logging
-from pathlib import Path
-from typing import Any, Callable, Optional
+from typing import Any, Optional
 
 from langsmith._internal._beta_decorator import warn_beta
 from langsmith._internal.voice import set_thread_id
 
-from .processor import LiveKitLangSmithSpanProcessor
+from .processor import (
+    DEFAULT_RECORDING_TIMEOUT_SECONDS,
+    LiveKitLangSmithSpanProcessor,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -23,10 +25,11 @@ __all__ = [
 @warn_beta
 def configure_livekit(
     *,
-    audio_path_provider: Optional[Callable[[], Optional[Path]]] = None,
     api_key: Optional[str] = None,
     project: Optional[str] = None,
     endpoint: Optional[str] = None,
+    await_recording: bool = True,
+    recording_timeout_seconds: float = DEFAULT_RECORDING_TIMEOUT_SECONDS,
     **kwargs: Any,
 ) -> Optional[LiveKitLangSmithSpanProcessor]:
     """Enable LangSmith tracing for a LiveKit Agents worker.
@@ -53,13 +56,36 @@ def configure_livekit(
     processor: the user transcript arrives as a session event rather than on a
     span, so without it the trace shows only the agent's turns.
 
+    Each conversation's root span is held open until its recording arrives, so
+    the recording can be attached and its time origin stamped on the trace.
+    Deliver it from an ``on_session_end`` callback::
+
+        processor = configure_livekit()
+
+
+        async def on_session_end(ctx: JobContext) -> None:
+            processor.attach_session_report(
+                ctx.make_session_report(), thread_id=ctx.room.name
+            )
+
+
+        server = AgentServer()
+
+
+        @server.rtc_session(on_session_end=on_session_end)
+        async def entrypoint(ctx: JobContext) -> None: ...
+
+    With LiveKit Egress (or your own capture), call
+    :meth:`LiveKitLangSmithSpanProcessor.complete_recording` with the bytes and
+    the recording's ``started_at`` instead.
+
     Args:
-        audio_path_provider: zero-arg callable returning a local recording path
-            whose bytes are embedded in the root span (console/dev only). For
-            production, attach a LiveKit Egress recording via the returned
-            processor's ``expect_recording`` / ``complete_recording`` methods.
         api_key / project / endpoint: LangSmith exporter config; default to the
             standard ``LANGSMITH_*`` resolution.
+        await_recording: hold each root span until a recording is delivered.
+            Pass ``False`` when tracing a session with no audio.
+        recording_timeout_seconds: how long that hold lasts before the trace is
+            exported without audio.
 
     Returns:
         The processor, or ``None`` if LiveKit / OpenTelemetry aren't installed.
@@ -74,10 +100,11 @@ def configure_livekit(
         return None
 
     processor = LiveKitLangSmithSpanProcessor(
-        audio_path_provider=audio_path_provider,
         api_key=api_key,
         project=project,
         endpoint=endpoint,
+        await_recording=await_recording,
+        recording_timeout_seconds=recording_timeout_seconds,
         **kwargs,
     )
     provider = TracerProvider()

--- a/python/langsmith/integrations/livekit/__init__.py
+++ b/python/langsmith/integrations/livekit/__init__.py
@@ -58,9 +58,8 @@ def configure_livekit(
     processor: the user transcript arrives as a session event rather than on a
     span, so without it the trace shows only the agent's turns.
 
-    In ``session_report`` mode, each conversation's root span is held until its
-    complete report arrives, so the transcript, recording, and time origin are
-    attached atomically. Deliver it from an ``on_session_end`` callback::
+    Each conversation's root span is held until its session report arrives.
+    Deliver it from an ``on_session_end`` callback::
 
         processor = configure_livekit()
 
@@ -79,17 +78,27 @@ def configure_livekit(
             set_thread_id(ctx.room.name)
             ...
 
-    With LiveKit Egress (or your own capture), configure ``recording_mode="egress"``
-    and pass the completed bytes to that same ``attach_session_report`` call.
-    Use ``recording_mode="none"`` for sessions that should export immediately at
-    session end without a report.
+    In ``session_report`` mode the report's recording is attached with its chat
+    history. With LiveKit Egress (or your own capture), configure
+    ``recording_mode="egress"`` and deliver the audio independently when it is
+    available::
+
+        processor.complete_recording(
+            thread_id,
+            audio_bytes,
+            started_at=egress_started_at,
+        )
+
+    The report and recording may arrive in either order. The root is released
+    after both, or after ``recording_timeout_seconds``. Use
+    ``recording_mode="none"`` to attach report data without audio.
 
     Args:
         api_key / project / endpoint: LangSmith exporter config; default to the
             standard ``LANGSMITH_*`` resolution.
         recording_mode: ``"session_report"``, ``"egress"``, or ``"none"``.
-        recording_timeout_seconds: how long that hold lasts before the trace is
-            exported without audio.
+        recording_timeout_seconds: how long the root waits for required session
+            data before it is exported with whatever is available.
 
     Returns:
         The processor, or ``None`` if LiveKit / OpenTelemetry aren't installed.

--- a/python/langsmith/integrations/livekit/__init__.py
+++ b/python/langsmith/integrations/livekit/__init__.py
@@ -11,12 +11,14 @@ from langsmith._internal.voice import set_thread_id
 from .processor import (
     DEFAULT_RECORDING_TIMEOUT_SECONDS,
     LiveKitLangSmithSpanProcessor,
+    RecordingMode,
 )
 
 logger = logging.getLogger(__name__)
 
 __all__ = [
     "LiveKitLangSmithSpanProcessor",
+    "RecordingMode",
     "configure_livekit",
     "set_thread_id",
 ]
@@ -28,7 +30,7 @@ def configure_livekit(
     api_key: Optional[str] = None,
     project: Optional[str] = None,
     endpoint: Optional[str] = None,
-    await_recording: bool = True,
+    recording_mode: RecordingMode = "session_report",
     recording_timeout_seconds: float = DEFAULT_RECORDING_TIMEOUT_SECONDS,
     **kwargs: Any,
 ) -> Optional[LiveKitLangSmithSpanProcessor]:
@@ -56,9 +58,9 @@ def configure_livekit(
     processor: the user transcript arrives as a session event rather than on a
     span, so without it the trace shows only the agent's turns.
 
-    Each conversation's root span is held open until its recording arrives, so
-    the recording can be attached and its time origin stamped on the trace.
-    Deliver it from an ``on_session_end`` callback::
+    In ``session_report`` mode, each conversation's root span is held until its
+    complete report arrives, so the transcript, recording, and time origin are
+    attached atomically. Deliver it from an ``on_session_end`` callback::
 
         processor = configure_livekit()
 
@@ -73,17 +75,19 @@ def configure_livekit(
 
 
         @server.rtc_session(on_session_end=on_session_end)
-        async def entrypoint(ctx: JobContext) -> None: ...
+        async def entrypoint(ctx: JobContext) -> None:
+            set_thread_id(ctx.room.name)
+            ...
 
-    With LiveKit Egress (or your own capture), call
-    :meth:`LiveKitLangSmithSpanProcessor.complete_recording` with the bytes and
-    the recording's ``started_at`` instead.
+    With LiveKit Egress (or your own capture), configure ``recording_mode="egress"``
+    and pass the completed bytes to that same ``attach_session_report`` call.
+    Use ``recording_mode="none"`` for sessions that should export immediately at
+    session end without a report.
 
     Args:
         api_key / project / endpoint: LangSmith exporter config; default to the
             standard ``LANGSMITH_*`` resolution.
-        await_recording: hold each root span until a recording is delivered.
-            Pass ``False`` when tracing a session with no audio.
+        recording_mode: ``"session_report"``, ``"egress"``, or ``"none"``.
         recording_timeout_seconds: how long that hold lasts before the trace is
             exported without audio.
 
@@ -103,7 +107,7 @@ def configure_livekit(
         api_key=api_key,
         project=project,
         endpoint=endpoint,
-        await_recording=await_recording,
+        recording_mode=recording_mode,
         recording_timeout_seconds=recording_timeout_seconds,
         **kwargs,
     )

--- a/python/langsmith/integrations/livekit/__init__.py
+++ b/python/langsmith/integrations/livekit/__init__.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 import logging
+import warnings
+from collections.abc import Callable
+from pathlib import Path
 from typing import Any, Optional
 
 from langsmith._internal._beta_decorator import warn_beta
@@ -30,6 +33,7 @@ def configure_livekit(
     api_key: Optional[str] = None,
     project: Optional[str] = None,
     endpoint: Optional[str] = None,
+    audio_path_provider: Optional[Callable[[], Optional[Path]]] = None,
     recording_mode: RecordingMode = "session_report",
     recording_timeout_seconds: float = DEFAULT_RECORDING_TIMEOUT_SECONDS,
     **kwargs: Any,
@@ -58,29 +62,14 @@ def configure_livekit(
     processor: the user transcript arrives as a session event rather than on a
     span, so without it the trace shows only the agent's turns.
 
-    Each conversation's root span is held until its session report arrives.
-    Deliver it from an ``on_session_end`` callback::
+    Each conversation's root span is held until its session report arrives. The
+    processor registers an additive ``AgentSession`` close listener and captures
+    that report automatically; no ``on_session_end`` callback is required. In
+    ``session_report`` mode the report's recording is attached with its chat
+    history.
 
-        processor = configure_livekit()
-
-
-        async def on_session_end(ctx: JobContext) -> None:
-            processor.attach_session_report(
-                ctx.make_session_report(), thread_id=ctx.room.name
-            )
-
-
-        server = AgentServer()
-
-
-        @server.rtc_session(on_session_end=on_session_end)
-        async def entrypoint(ctx: JobContext) -> None:
-            set_thread_id(ctx.room.name)
-            ...
-
-    In ``session_report`` mode the report's recording is attached with its chat
-    history. With LiveKit Egress (or your own capture), configure
-    ``recording_mode="egress"`` and deliver the audio independently when it is
+    With LiveKit Egress (or your own capture), configure
+    ``recording_mode="egress"`` and deliver each conversation's audio when it is
     available::
 
         processor.complete_recording(
@@ -89,13 +78,18 @@ def configure_livekit(
             started_at=egress_started_at,
         )
 
-    The report and recording may arrive in either order. The root is released
-    after both, or after ``recording_timeout_seconds``. Use
+    Existing code may instead call ``processor.expect_recording(thread_id)`` at
+    conversation start. That marks only that conversation as egress, even when
+    the processor's default mode is ``session_report`` or ``none``. It may be
+    called before the conversation's spans start. The automatic report and
+    recording may arrive in either order; an egress root is released after both,
+    or after ``recording_timeout_seconds`` as failure protection. Use
     ``recording_mode="none"`` to attach report data without audio.
 
     Args:
         api_key / project / endpoint: LangSmith exporter config; default to the
             standard ``LANGSMITH_*`` resolution.
+        audio_path_provider: Deprecated compatibility parameter. It is ignored.
         recording_mode: ``"session_report"``, ``"egress"``, or ``"none"``.
         recording_timeout_seconds: how long the root waits for required session
             data before it is exported with whatever is available.
@@ -103,6 +97,13 @@ def configure_livekit(
     Returns:
         The processor, or ``None`` if LiveKit / OpenTelemetry aren't installed.
     """
+    if audio_path_provider is not None:
+        warnings.warn(
+            "audio_path_provider is deprecated and ignored.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
     try:
         from opentelemetry import trace as otel_trace
         from opentelemetry.sdk.trace import TracerProvider

--- a/python/langsmith/integrations/livekit/_helpers.py
+++ b/python/langsmith/integrations/livekit/_helpers.py
@@ -7,10 +7,14 @@ span detection, and the tiny chat-message builders the handlers reuse.
 
 from __future__ import annotations
 
+import inspect
 import json
+import logging
 from typing import Any, Optional
 
 from langsmith._internal.voice._helpers import try_parse_json_object
+
+logger = logging.getLogger(__name__)
 
 # The instrumentation scope LiveKit's tracer is created under
 # (``get_tracer("livekit-agents")``). Every span LiveKit emits carries it, so it
@@ -220,3 +224,103 @@ def build_message_from_event(role: str, event: Any) -> dict:
     if tool_calls:
         msg["tool_calls"] = tool_calls
     return msg
+
+
+# ``system``/``developer`` items carry the agent's instructions, not conversation.
+_TRANSCRIPT_SKIP_ROLES = {"system", "developer"}
+
+
+def _content_to_text(content: Any) -> str:
+    """Flatten a ``ChatMessage.content`` list to text, dropping non-text parts."""
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, (list, tuple)):
+        return ""
+    return "\n".join(part for part in content if isinstance(part, str))
+
+
+def build_messages_from_chat_history(chat_history: Any) -> list[dict]:
+    """Convert a LiveKit ``ChatContext`` into LangSmith chat messages.
+
+    Keeps the conversation in ``created_at`` order — turns plus tool calls and
+    their outputs — and drops the instructions and items with no message form.
+    Returns ``[]`` for anything it can't read, so a malformed history degrades to
+    the span-derived transcript rather than failing the export.
+    """
+    # ``to_dict`` has gained keywords over time (``strip_markup`` is newer than
+    # our floor), so pass only the ones this version actually accepts rather
+    # than risking a TypeError that would cost us the whole transcript.
+    wanted = {
+        "exclude_timestamp": False,  # we need created_at; the default drops it
+        "exclude_function_call": False,  # tool calls belong in the transcript
+        "exclude_metrics": True,
+        "exclude_config_update": True,
+        "strip_markup": True,
+    }
+    try:
+        accepted = inspect.signature(chat_history.to_dict).parameters
+        if any(p.kind is inspect.Parameter.VAR_KEYWORD for p in accepted.values()):
+            kwargs = dict(wanted)  # **kwargs absorbs whatever it doesn't name
+        else:
+            kwargs = {k: v for k, v in wanted.items() if k in accepted}
+    except (TypeError, ValueError):  # pragma: no cover - exotic to_dict
+        kwargs = {}
+
+    try:
+        payload = chat_history.to_dict(**kwargs)
+    except Exception:
+        logger.warning(
+            "langsmith voice: could not read the session report's chat history; "
+            "falling back to the transcript built from spans.",
+            exc_info=True,
+        )
+        return []
+
+    items = payload.get("items") if isinstance(payload, dict) else None
+    if not isinstance(items, list):
+        logger.warning(
+            "langsmith voice: session report chat history had no 'items'; "
+            "falling back to the transcript built from spans."
+        )
+        return []
+
+    ordered = sorted(items, key=lambda i: i.get("created_at") or 0.0)
+    messages: list[dict] = []
+    for item in ordered:
+        if not isinstance(item, dict):
+            continue
+        kind = item.get("type")
+        if kind == "message":
+            role = item.get("role")
+            if role in _TRANSCRIPT_SKIP_ROLES:
+                continue
+            text = _content_to_text(item.get("content"))
+            if text:
+                messages.append({"role": str(role or "user"), "content": text})
+        elif kind == "function_call":
+            messages.append(
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": str(item.get("call_id") or ""),
+                            "type": "function",
+                            "function": {
+                                "name": str(item.get("name") or ""),
+                                "arguments": str(item.get("arguments") or ""),
+                            },
+                        }
+                    ],
+                }
+            )
+        elif kind == "function_call_output":
+            messages.append(
+                build_tool_message(
+                    str(item.get("output") or ""),
+                    tool_call_id=item.get("call_id"),
+                    name=item.get("name"),
+                )
+            )
+        # agent_handoff has no message equivalent; config updates are excluded.
+    return messages

--- a/python/langsmith/integrations/livekit/_helpers.py
+++ b/python/langsmith/integrations/livekit/_helpers.py
@@ -259,7 +259,7 @@ def build_messages_from_chat_history(chat_history: Any) -> list[dict]:
         return []
 
     messages: list[dict] = []
-    for item in sorted(items, key=lambda item: item["created_at"]):
+    for item in items:
         kind = item["type"]
         if kind == "message":
             role = item["role"]

--- a/python/langsmith/integrations/livekit/_helpers.py
+++ b/python/langsmith/integrations/livekit/_helpers.py
@@ -196,6 +196,21 @@ def build_tool_message(
     return msg
 
 
+def build_assistant_tool_call_message(call_id: str, name: str, arguments: str) -> dict:
+    """Build an assistant message containing one tool call."""
+    return {
+        "role": "assistant",
+        "content": "",
+        "tool_calls": [
+            {
+                "id": call_id,
+                "type": "function",
+                "function": {"name": name, "arguments": arguments},
+            }
+        ],
+    }
+
+
 def build_message_from_event(role: str, event: Any) -> dict:
     """Build a chat message dict from a LiveKit ``gen_ai.*`` span event.
 
@@ -253,20 +268,9 @@ def build_messages_from_chat_history(chat_history: Any) -> list[dict]:
                 messages.append({"role": role, "content": text})
         elif kind == "function_call":
             messages.append(
-                {
-                    "role": "assistant",
-                    "content": "",
-                    "tool_calls": [
-                        {
-                            "id": item["call_id"],
-                            "type": "function",
-                            "function": {
-                                "name": item["name"],
-                                "arguments": item["arguments"],
-                            },
-                        }
-                    ],
-                }
+                build_assistant_tool_call_message(
+                    item["call_id"], item["name"], item["arguments"]
+                )
             )
         elif kind == "function_call_output":
             messages.append(

--- a/python/langsmith/integrations/livekit/_helpers.py
+++ b/python/langsmith/integrations/livekit/_helpers.py
@@ -7,7 +7,6 @@ span detection, and the tiny chat-message builders the handlers reuse.
 
 from __future__ import annotations
 
-import inspect
 import json
 import logging
 from typing import Any, Optional
@@ -16,17 +15,8 @@ from langsmith._internal.voice._helpers import try_parse_json_object
 
 logger = logging.getLogger(__name__)
 
-# The instrumentation scope LiveKit's tracer is created under
-# (``get_tracer("livekit-agents")``). Every span LiveKit emits carries it, so it
-# is how we tell a LiveKit span apart from a non-LiveKit run riding the same OTel
-# provider (e.g. a LangChain/LangGraph trace under ``LANGSMITH_TRACING_MODE=otel``).
 _LIVEKIT_INSTRUMENTATION_SCOPE = "livekit-agents"
 
-# LiveKit reports some providers as the API base-URL host (e.g. its OpenAI
-# plugin → ``api.openai.com``), but LangSmith's cost engine keys on provider
-# *slugs* (``openai`` / ``deepgram`` / …), so a hostname never matches a price.
-# We recover the slug by substring — so ``beta.anthropic.com`` still → ``anthropic``
-# — mirroring how LangSmith itself infers the provider from a model name.
 _PROVIDER_ALIASES = (
     "openai",
     "anthropic",
@@ -226,48 +216,25 @@ def build_message_from_event(role: str, event: Any) -> dict:
     return msg
 
 
-# ``system``/``developer`` items carry the agent's instructions, not conversation.
-_TRANSCRIPT_SKIP_ROLES = {"system", "developer"}
-
-
-def _content_to_text(content: Any) -> str:
+def _content_to_text(content: list[Any]) -> str:
     """Flatten a ``ChatMessage.content`` list to text, dropping non-text parts."""
-    if isinstance(content, str):
-        return content
-    if not isinstance(content, (list, tuple)):
-        return ""
     return "\n".join(part for part in content if isinstance(part, str))
 
 
 def build_messages_from_chat_history(chat_history: Any) -> list[dict]:
     """Convert a LiveKit ``ChatContext`` into LangSmith chat messages.
 
-    Keeps the conversation in ``created_at`` order — turns plus tool calls and
-    their outputs — and drops the instructions and items with no message form.
-    Returns ``[]`` for anything it can't read, so a malformed history degrades to
-    the span-derived transcript rather than failing the export.
+    Keeps LiveKit's conversation order, including instructions, tool calls, and
+    tool outputs. Returns ``[]`` if LiveKit cannot serialize the history, so
+    export falls back to the span-derived transcript.
     """
-    # ``to_dict`` has gained keywords over time (``strip_markup`` is newer than
-    # our floor), so pass only the ones this version actually accepts rather
-    # than risking a TypeError that would cost us the whole transcript.
-    wanted = {
-        "exclude_timestamp": False,  # we need created_at; the default drops it
-        "exclude_function_call": False,  # tool calls belong in the transcript
-        "exclude_metrics": True,
-        "exclude_config_update": True,
-        "strip_markup": True,
-    }
     try:
-        accepted = inspect.signature(chat_history.to_dict).parameters
-        if any(p.kind is inspect.Parameter.VAR_KEYWORD for p in accepted.values()):
-            kwargs = dict(wanted)  # **kwargs absorbs whatever it doesn't name
-        else:
-            kwargs = {k: v for k, v in wanted.items() if k in accepted}
-    except (TypeError, ValueError):  # pragma: no cover - exotic to_dict
-        kwargs = {}
-
-    try:
-        payload = chat_history.to_dict(**kwargs)
+        items = chat_history.to_dict(
+            exclude_timestamp=False,
+            exclude_function_call=False,
+            exclude_metrics=True,
+            exclude_config_update=True,
+        )["items"]
     except Exception:
         logger.warning(
             "langsmith voice: could not read the session report's chat history; "
@@ -276,27 +243,14 @@ def build_messages_from_chat_history(chat_history: Any) -> list[dict]:
         )
         return []
 
-    items = payload.get("items") if isinstance(payload, dict) else None
-    if not isinstance(items, list):
-        logger.warning(
-            "langsmith voice: session report chat history had no 'items'; "
-            "falling back to the transcript built from spans."
-        )
-        return []
-
-    ordered = sorted(items, key=lambda i: i.get("created_at") or 0.0)
     messages: list[dict] = []
-    for item in ordered:
-        if not isinstance(item, dict):
-            continue
-        kind = item.get("type")
+    for item in sorted(items, key=lambda item: item["created_at"]):
+        kind = item["type"]
         if kind == "message":
-            role = item.get("role")
-            if role in _TRANSCRIPT_SKIP_ROLES:
-                continue
-            text = _content_to_text(item.get("content"))
+            role = item["role"]
+            text = _content_to_text(item["content"])
             if text:
-                messages.append({"role": str(role or "user"), "content": text})
+                messages.append({"role": role, "content": text})
         elif kind == "function_call":
             messages.append(
                 {
@@ -304,11 +258,11 @@ def build_messages_from_chat_history(chat_history: Any) -> list[dict]:
                     "content": "",
                     "tool_calls": [
                         {
-                            "id": str(item.get("call_id") or ""),
+                            "id": item["call_id"],
                             "type": "function",
                             "function": {
-                                "name": str(item.get("name") or ""),
-                                "arguments": str(item.get("arguments") or ""),
+                                "name": item["name"],
+                                "arguments": item["arguments"],
                             },
                         }
                     ],
@@ -317,10 +271,9 @@ def build_messages_from_chat_history(chat_history: Any) -> list[dict]:
         elif kind == "function_call_output":
             messages.append(
                 build_tool_message(
-                    str(item.get("output") or ""),
-                    tool_call_id=item.get("call_id"),
-                    name=item.get("name"),
+                    item["output"],
+                    tool_call_id=item["call_id"],
+                    name=item["name"],
                 )
             )
-        # agent_handoff has no message equivalent; config updates are excluded.
     return messages

--- a/python/langsmith/integrations/livekit/_state.py
+++ b/python/langsmith/integrations/livekit/_state.py
@@ -17,8 +17,20 @@ class _PendingAudio:
 
 
 @dataclass
+class _PendingThreadState:
+    """Lifecycle data delivered before a thread is associated with a trace."""
+
+    recording_mode: Optional[str] = None
+    pending_audio: Optional[_PendingAudio] = None
+    recording_started_at: Optional[float] = None
+    audio_status: Optional[str] = None
+    recording_received: bool = False
+
+
+@dataclass
 class _ConversationState:
     trace_id: int
+    recording_mode: str = "session_report"
     thread_id: Optional[str] = None
     root: Optional[TranslatedSpan] = None
     session_ended: bool = False
@@ -29,6 +41,7 @@ class _ConversationState:
     audio_status: Optional[str] = None
     report_received: bool = False
     recording_received: bool = False
+    report_hook_session_id: Optional[int] = None
     release_timer: Optional[threading.Timer] = None
     spans_waiting_for_transcript: list[TranslatedSpan] = field(default_factory=list)
     transcripts_waiting_for_span: list[str] = field(default_factory=list)

--- a/python/langsmith/integrations/livekit/_state.py
+++ b/python/langsmith/integrations/livekit/_state.py
@@ -27,8 +27,8 @@ class _ConversationState:
     pending_audio: Optional[_PendingAudio] = None
     recording_started_at: Optional[float] = None
     audio_status: Optional[str] = None
-    delivery_complete: bool = False
-    delivery_in_progress: bool = False
+    report_received: bool = False
+    recording_received: bool = False
     release_timer: Optional[threading.Timer] = None
     spans_waiting_for_transcript: list[TranslatedSpan] = field(default_factory=list)
     transcripts_waiting_for_span: list[str] = field(default_factory=list)

--- a/python/langsmith/integrations/livekit/_state.py
+++ b/python/langsmith/integrations/livekit/_state.py
@@ -30,5 +30,5 @@ class _ConversationState:
     delivery_complete: bool = False
     delivery_in_progress: bool = False
     release_timer: Optional[threading.Timer] = None
-    deferred_user_speaking: list[TranslatedSpan] = field(default_factory=list)
+    spans_waiting_for_transcript: list[TranslatedSpan] = field(default_factory=list)
     transcripts_waiting_for_span: list[str] = field(default_factory=list)

--- a/python/langsmith/integrations/livekit/_state.py
+++ b/python/langsmith/integrations/livekit/_state.py
@@ -31,4 +31,4 @@ class _ConversationState:
     delivery_in_progress: bool = False
     release_timer: Optional[threading.Timer] = None
     deferred_user_speaking: list[TranslatedSpan] = field(default_factory=list)
-    pending_user_transcripts: list[str] = field(default_factory=list)
+    transcripts_waiting_for_span: list[str] = field(default_factory=list)

--- a/python/langsmith/integrations/livekit/_state.py
+++ b/python/langsmith/integrations/livekit/_state.py
@@ -1,0 +1,34 @@
+"""Mutable lifecycle state for the LiveKit span processor."""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+from langsmith._internal.voice.base_span_processor import TranslatedSpan
+
+
+@dataclass
+class _PendingAudio:
+    name: str
+    data: bytes
+    mime_type: str
+
+
+@dataclass
+class _ConversationState:
+    trace_id: int
+    thread_id: Optional[str] = None
+    root: Optional[TranslatedSpan] = None
+    session_ended: bool = False
+    transcript: list[tuple[Any, dict]] = field(default_factory=list)
+    report_transcript: Optional[list[dict]] = None
+    pending_audio: Optional[_PendingAudio] = None
+    recording_started_at: Optional[float] = None
+    audio_status: Optional[str] = None
+    delivery_complete: bool = False
+    delivery_in_progress: bool = False
+    release_timer: Optional[threading.Timer] = None
+    deferred_user_speaking: list[TranslatedSpan] = field(default_factory=list)
+    pending_user_transcripts: list[str] = field(default_factory=list)

--- a/python/langsmith/integrations/livekit/processor.py
+++ b/python/langsmith/integrations/livekit/processor.py
@@ -4,22 +4,24 @@ Rewrites LiveKit's ``lk.*`` span data into the ``gen_ai.*`` / ``langsmith.*``
 namespaces LangSmith ingests; non-LiveKit spans on the same provider pass
 through untouched.
 
-The root span is held until its session report arrives. LiveKit's recorder
-supplies audio on that report; egress audio arrives separately through
-:meth:`complete_recording`. Shared export / ``thread_id`` / message plumbing
-lives in :class:`BaseLangSmithSpanProcessor`.
+The root span is held until the processor's AgentSession close hook captures
+its session report. LiveKit's recorder supplies audio on that report; egress
+audio arrives separately through :meth:`complete_recording`. Shared export /
+``thread_id`` / message plumbing lives in :class:`BaseLangSmithSpanProcessor`.
 """
 
 from __future__ import annotations
 
 import logging
 import threading
-from collections.abc import MutableMapping
+import warnings
+from collections.abc import Callable, MutableMapping
 from pathlib import Path
 from typing import Any, Literal, Optional, get_args
 
 from cachetools import TTLCache
-from opentelemetry.sdk.trace import SpanProcessor
+from opentelemetry.context import Context
+from opentelemetry.sdk.trace import Span, SpanProcessor
 
 from langsmith._internal._package_version import get_package_version
 from langsmith._internal.voice._helpers import (
@@ -43,7 +45,7 @@ from ._helpers import (
     is_livekit_span,
     normalize_provider,
 )
-from ._state import _ConversationState, _PendingAudio
+from ._state import _ConversationState, _PendingAudio, _PendingThreadState
 
 # Lifetime / cap for per-conversation state; bounds memory for calls that never end.
 DEFAULT_STATE_TTL_SECONDS = 3600.0
@@ -87,6 +89,7 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         api_key: Optional[str] = None,
         project: Optional[str] = None,
         endpoint: Optional[str] = None,
+        audio_path_provider: Optional[Callable[[], Optional[Path]]] = None,
         audio_mime_type: str = "audio/ogg",
         recording_mode: RecordingMode = "session_report",
         recording_timeout_seconds: float = DEFAULT_RECORDING_TIMEOUT_SECONDS,
@@ -96,15 +99,24 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         """Create the processor.
 
         Args:
+            audio_path_provider: Deprecated compatibility parameter. It is ignored.
             audio_mime_type: default MIME type for embedded recordings.
             recording_mode: where recordings come from: ``"session_report"``
                 for LiveKit's recorder, ``"egress"`` for bytes supplied with
                 :meth:`complete_recording`, or ``"none"`` for report data
-                without audio.
+                without audio. This is the default for every conversation;
+                :meth:`expect_recording` can override one thread to egress.
             recording_timeout_seconds: how long the root waits for required
                 session data before it is exported.
             state_ttl_seconds: lifetime for per-conversation state.
         """
+        if audio_path_provider is not None:
+            warnings.warn(
+                "audio_path_provider is deprecated and ignored.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
         super().__init__(
             downstream_processor,
             api_key=api_key,
@@ -130,6 +142,15 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
 
         self._state_by_trace: MutableMapping[int, _ConversationState] = _cache()
         self._trace_by_thread: MutableMapping[str, int] = _cache()
+        # ``expect_recording`` and ``complete_recording`` are legacy APIs that
+        # may be called before LiveKit starts the first span for a conversation.
+        self._thread_state_waiting_for_trace: MutableMapping[
+            str, _PendingThreadState
+        ] = _cache()
+        # Distinguish a genuinely early legacy delivery from one that arrived
+        # after its trace was already exported (which must not leak into a later
+        # conversation that reuses the same thread id).
+        self._completed_threads: MutableMapping[str, bool] = _cache()
         # A transcript event may arrive after instrument_session() but before a
         # LiveKit span has given us that thread's trace id.
         self._transcripts_waiting_for_trace: MutableMapping[str, list[str]] = _cache()
@@ -140,26 +161,57 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
     def _get_or_create_state(self, trace_id: int) -> _ConversationState:
         state = self._get_state(trace_id)
         if state is not None:
+            self._associate_thread_with_state(
+                state, self._thread_id_by_trace.get(trace_id)
+            )
             return state
 
-        state = _ConversationState(trace_id=trace_id)
-        thread_id = self._thread_id_by_trace.get(trace_id)
-        if thread_id is not None:
-            existing_state = self._get_state_by_thread(thread_id)
-            if existing_state is not None:
-                logger.warning(
-                    "langsmith voice: thread id %s is already bound to an active "
-                    "LiveKit trace; recordings require one active trace per thread.",
-                    thread_id,
-                )
-            else:
-                state.thread_id = thread_id
-                self._trace_by_thread[thread_id] = trace_id
-                waiting = self._transcripts_waiting_for_trace.pop(thread_id, None)
-                if waiting:
-                    state.transcripts_waiting_for_span.extend(waiting)
+        state = _ConversationState(
+            trace_id=trace_id, recording_mode=self._recording_mode
+        )
+        self._associate_thread_with_state(state, self._thread_id_by_trace.get(trace_id))
         self._state_by_trace[trace_id] = state
         return state
+
+    def _associate_thread_with_state(
+        self, state: _ConversationState, thread_id: Optional[str]
+    ) -> None:
+        if thread_id is None or state.thread_id == thread_id:
+            return
+        if state.thread_id is not None:
+            logger.warning(
+                "langsmith voice: trace %x is already bound to thread %s; "
+                "ignoring a second thread id %s.",
+                state.trace_id,
+                state.thread_id,
+                thread_id,
+            )
+            return
+
+        existing_state = self._get_state_by_thread(thread_id)
+        if existing_state is not None and existing_state is not state:
+            logger.warning(
+                "langsmith voice: thread id %s is already bound to an active "
+                "LiveKit trace; recordings require one active trace per thread.",
+                thread_id,
+            )
+            return
+
+        state.thread_id = thread_id
+        self._completed_threads.pop(thread_id, None)
+        self._trace_by_thread[thread_id] = state.trace_id
+        waiting = self._transcripts_waiting_for_trace.pop(thread_id, None)
+        if waiting:
+            state.transcripts_waiting_for_span.extend(waiting)
+        pending = self._thread_state_waiting_for_trace.pop(thread_id, None)
+        if pending is not None:
+            if pending.recording_mode is not None:
+                state.recording_mode = pending.recording_mode
+            if pending.recording_received:
+                state.pending_audio = pending.pending_audio
+                state.recording_started_at = pending.recording_started_at
+                state.audio_status = pending.audio_status
+                state.recording_received = True
 
     def _get_state_by_thread(self, thread_id: str) -> Optional[_ConversationState]:
         trace_id = self._trace_by_thread.get(thread_id)
@@ -173,6 +225,79 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
 
     def _refresh_state(self, state: _ConversationState) -> None:
         self._state_by_trace[state.trace_id] = state
+
+    def _remember_thread_id(self, trace_id: int, thread_id: str) -> None:
+        """Capture a late thread id and merge any pre-trace lifecycle data."""
+        super()._remember_thread_id(trace_id, thread_id)
+        with self._state_lock:
+            state = self._get_state(trace_id)
+            if state is not None:
+                self._associate_thread_with_state(state, thread_id)
+                self._refresh_state(state)
+
+    def on_start(self, span: Span, parent_context: Optional[Context] = None) -> None:
+        """Capture thread context and install the session-report close hook."""
+        super().on_start(span, parent_context)
+        if span.name != _SESSION_SPAN:
+            return
+        try:
+            self._install_session_report_hook(span.context.trace_id)
+        except Exception:
+            # Lifecycle instrumentation must never prevent a LiveKit session
+            # from starting. The release timeout remains the failure fallback.
+            logger.warning(
+                "langsmith voice: failed installing the automatic LiveKit "
+                "session-report callback.",
+                exc_info=True,
+            )
+
+    def _install_session_report_hook(self, trace_id: int) -> None:
+        """Attach one additive close listener to the active AgentSession."""
+        try:
+            from livekit.agents import get_job_context  # type: ignore[import-not-found]
+        except ImportError:
+            return
+
+        job_ctx = get_job_context(required=False)
+        if job_ctx is None:
+            return
+        session = getattr(job_ctx, "_primary_agent_session", None)
+        if session is None:
+            try:
+                session = job_ctx.primary_session
+            except (AttributeError, RuntimeError):
+                return
+
+        session_id = id(session)
+        with self._state_lock:
+            state = self._get_or_create_state(trace_id)
+            if state.report_hook_session_id == session_id:
+                return
+            state.report_hook_session_id = session_id
+            self._refresh_state(state)
+
+        def _capture_report(*_: Any) -> None:
+            try:
+                report = job_ctx.make_session_report(session)
+                self._attach_session_report_to_trace(
+                    report, trace_id=trace_id, expected_state=state
+                )
+            except Exception:
+                logger.warning(
+                    "langsmith voice: failed capturing the automatic LiveKit "
+                    "session report.",
+                    exc_info=True,
+                )
+
+        try:
+            session.once("close", _capture_report)
+        except Exception:
+            with self._state_lock:
+                current = self._get_state(trace_id)
+                if current is state and current.report_hook_session_id == session_id:
+                    current.report_hook_session_id = None
+                    self._refresh_state(current)
+            raise
 
     def instrument_session(self, session: Any, thread_id: str) -> None:
         """Subscribe this processor to a LiveKit ``AgentSession``'s events.
@@ -220,26 +345,83 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
                 imports it, so it stays importable without ``livekit-agents``).
             thread_id: the conversation id, matching :func:`set_thread_id`.
         """
-        messages = build_messages_from_chat_history(report.chat_history)
-        report_audio = self._audio_from_session_report(report)
-
         thread = str(thread_id)
         with self._state_lock:
             state = self._get_state_by_thread(thread)
             if state is None:
+                if self._completed_threads.get(thread):
+                    # An older user callback may deliver the same report after
+                    # the automatic close hook has already exported the trace.
+                    return
                 self._warn_missing_conversation(thread, "session report")
+                return
+            trace_id = state.trace_id
+        self._attach_session_report_to_trace(
+            report, trace_id=trace_id, expected_state=state
+        )
+
+    def _attach_session_report_to_trace(
+        self,
+        report: Any,
+        *,
+        trace_id: int,
+        expected_state: _ConversationState,
+    ) -> None:
+        """Commit a report to the exact state captured by a lifecycle hook."""
+        with self._state_lock:
+            state = self._get_state(trace_id)
+            if state is not expected_state or state.report_received:
+                return
+            read_report_audio = state.recording_mode == "session_report"
+
+        history = getattr(report, "chat_history", None)
+        messages = build_messages_from_chat_history(history) if history else []
+        report_audio = (
+            self._audio_from_session_report(report)
+            if read_report_audio
+            else (None, None, None)
+        )
+
+        with self._state_lock:
+            state = self._get_state(trace_id)
+            if state is not expected_state or state.report_received:
                 return
             state.report_transcript = messages
             state.report_received = True
-            if report_audio is not None:
+            if state.recording_mode == "session_report":
                 (
                     state.pending_audio,
                     state.recording_started_at,
                     state.audio_status,
                 ) = report_audio
             self._refresh_state(state)
-            trace_id = state.trace_id
         self._export_conversation_if_ready(trace_id)
+
+    def expect_recording(self, thread_id: str) -> None:
+        """Mark one conversation as awaiting :meth:`complete_recording`.
+
+        This legacy API overrides the processor's default recording mode for
+        only ``thread_id``. It may be called before LiveKit starts any spans.
+        """
+        thread = str(thread_id)
+        with self._state_lock:
+            state = self._get_state_by_thread(thread)
+            if state is None:
+                self._completed_threads.pop(thread, None)
+                pending = self._thread_state_waiting_for_trace.get(thread)
+                if pending is None:
+                    pending = _PendingThreadState()
+                pending.recording_mode = "egress"
+                self._thread_state_waiting_for_trace[thread] = pending
+                return
+            state.recording_mode = "egress"
+            if state.report_received and not state.recording_received:
+                # A report may have arrived before this override. Its audio is
+                # no longer authoritative; preserve only its transcript.
+                state.pending_audio = None
+                state.recording_started_at = None
+                state.audio_status = None
+            self._refresh_state(state)
 
     def complete_recording(
         self,
@@ -257,9 +439,6 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         audio MIME type. ``started_at`` is the epoch time of the recording's first
         sample and enables waterfall alignment.
         """
-        if self._recording_mode != "egress":
-            raise RuntimeError("complete_recording() requires recording_mode='egress'")
-
         pending_audio = None
         status: Optional[str] = "none"
         if data:
@@ -280,8 +459,23 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         with self._state_lock:
             state = self._get_state_by_thread(thread)
             if state is None:
-                self._warn_missing_conversation(thread, "recording")
+                if self._completed_threads.get(thread):
+                    self._warn_missing_conversation(thread, "recording")
+                    return
+                pending = self._thread_state_waiting_for_trace.get(thread)
+                if pending is None:
+                    pending = _PendingThreadState()
+                # A completed external recording is itself sufficient to
+                # identify this thread's source as egress. ``expect_recording``
+                # is still needed when the processor must wait before it arrives.
+                pending.recording_mode = "egress"
+                pending.pending_audio = pending_audio
+                pending.recording_started_at = started_at
+                pending.audio_status = status
+                pending.recording_received = True
+                self._thread_state_waiting_for_trace[thread] = pending
                 return
+            state.recording_mode = "egress"
             state.pending_audio = pending_audio
             state.recording_started_at = started_at
             state.audio_status = status
@@ -300,13 +494,12 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
 
     def _audio_from_session_report(
         self, report: Any
-    ) -> Optional[tuple[Optional[_PendingAudio], Optional[float], Optional[str]]]:
-        if self._recording_mode != "session_report":
-            return None
-        audio_path = report.audio_recording_path
-        started_at = report.audio_recording_started_at
+    ) -> tuple[Optional[_PendingAudio], Optional[float], Optional[str]]:
+        audio_path = getattr(report, "audio_recording_path", None)
+        started_at = getattr(report, "audio_recording_started_at", None)
         if audio_path is None:
             return None, started_at, "none"
+        audio_path = Path(audio_path)
         data, status = self._read_audio_file(audio_path)
         if data is None:
             return None, started_at, status
@@ -601,6 +794,7 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         self._cancel_release_timer(state)
         self._state_by_trace.pop(trace_id, None)
         if state.thread_id is not None:
+            self._completed_threads[state.thread_id] = True
             self._trace_by_thread.pop(state.thread_id, None)
             self._transcripts_waiting_for_trace.pop(state.thread_id, None)
         self._forget_thread_id(trace_id)
@@ -608,7 +802,7 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
 
     def _has_required_session_data(self, state: _ConversationState) -> bool:
         return state.report_received and (
-            self._recording_mode != "egress" or state.recording_received
+            state.recording_mode != "egress" or state.recording_received
         )
 
     def _export_completed_conversation(
@@ -644,7 +838,7 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
             if self._has_required_session_data(state):
                 return
             missing = ["session report"] if not state.report_received else []
-            if self._recording_mode == "egress" and not state.recording_received:
+            if state.recording_mode == "egress" and not state.recording_received:
                 missing.append("egress recording")
             logger.warning(
                 "langsmith voice: timed out waiting for %s for thread %s after "
@@ -653,7 +847,7 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
                 state.thread_id,
                 self._recording_timeout_seconds,
             )
-            if self._recording_mode != "none" and state.pending_audio is None:
+            if state.recording_mode != "none" and state.pending_audio is None:
                 state.audio_status = "timeout"
             self._refresh_state(state)
         self._export_conversation_if_ready(trace_id, force=True)
@@ -723,6 +917,8 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
             remaining = list(self._state_by_trace.values())
             self._state_by_trace.clear()
             self._trace_by_thread.clear()
+            self._thread_state_waiting_for_trace.clear()
+            self._completed_threads.clear()
             self._transcripts_waiting_for_trace.clear()
         for state in remaining:
             for speaking_span in state.spans_waiting_for_transcript:

--- a/python/langsmith/integrations/livekit/processor.py
+++ b/python/langsmith/integrations/livekit/processor.py
@@ -165,7 +165,7 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
     def _refresh_state_locked(self, state: _ConversationState) -> None:
         self._state_by_trace[state.trace_id] = state
 
-    def _bind_thread_locked(
+    def _associate_thread_with_state_locked(
         self, state: _ConversationState, thread_id: Optional[str]
     ) -> None:
         if thread_id is None:
@@ -405,7 +405,9 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         tspan.set_kind("chain")
         with self._state_lock:
             state = self._get_or_create_state_locked(trace_id)
-            self._bind_thread_locked(state, self._thread_id_by_trace.get(trace_id))
+            self._associate_thread_with_state_locked(
+                state, self._thread_id_by_trace.get(trace_id)
+            )
             state.session_ended = True
             held = state.deferred_user_speaking
             state.deferred_user_speaking = []
@@ -531,7 +533,7 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
 
         with self._state_lock:
             state = self._get_or_create_state_locked(tspan.span.context.trace_id)
-            self._bind_thread_locked(state, thread)
+            self._associate_thread_with_state_locked(state, thread)
             has_transcript = bool(state.pending_user_transcripts)
             transcript = state.pending_user_transcripts.pop(0) if has_transcript else ""
             if not has_transcript:
@@ -606,10 +608,19 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
             "ls_integration_version", (get_package_version("livekit-agents") or "")
         )
         thread = tspan.attributes.get("langsmith.metadata.thread_id")
+        if thread is None and self._recording_mode != "none":
+            logger.warning(
+                "langsmith voice: trace %x has no thread id; its session report "
+                "and recording cannot be attached. Call set_thread_id() before "
+                "the conversation starts, or configure recording_mode='none'.",
+                trace_id,
+            )
         with self._state_lock:
             state = self._get_or_create_state_locked(trace_id)
             state.root = tspan
-            self._bind_thread_locked(state, str(thread) if thread is not None else None)
+            self._associate_thread_with_state_locked(
+                state, str(thread) if thread is not None else None
+            )
             self._refresh_state_locked(state)
         self._export_conversation_if_ready(trace_id)
 

--- a/python/langsmith/integrations/livekit/processor.py
+++ b/python/langsmith/integrations/livekit/processor.py
@@ -136,6 +136,11 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         # The timeout fires on a timer thread; every conversation-state mutation
         # uses this lock, including the framework's normal span callbacks.
         self._state_lock = threading.RLock()
+        # Serialize the full claim-and-export operation with downstream shutdown.
+        # This is separate from ``_state_lock`` so exporter I/O does not block
+        # unrelated conversation-state updates. When both are needed, acquire
+        # this lock first.
+        self._export_lock = threading.RLock()
 
         def _cache() -> Any:
             return TTLCache(maxsize=DEFAULT_STATE_MAXSIZE, ttl=state_ttl_seconds)
@@ -752,12 +757,14 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
             state = self._get_or_create_state(trace_id)
             state.root = tspan
             self._refresh_state(state)
-            has_thread_id = state.thread_id is not None
-        if not has_thread_id:
+            missing_egress_thread = (
+                state.recording_mode == "egress" and state.thread_id is None
+            )
+        if missing_egress_thread:
             logger.warning(
-                "langsmith voice: trace %x has no thread id; its session report "
-                "cannot be attached. Call set_thread_id() before the conversation "
-                "starts.",
+                "langsmith voice: egress trace %x has no thread id; its recording "
+                "cannot be delivered. Call set_thread_id() before the conversation "
+                "starts, or choose a different recording mode.",
                 trace_id,
             )
         self._export_conversation_if_ready(trace_id)
@@ -770,12 +777,13 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         Every mode waits for the report. Egress additionally waits for
         :meth:`complete_recording`. ``force`` skips those gates at shutdown.
         """
-        with self._state_lock:
-            claimed = self._claim_conversation_for_export(trace_id, force=force)
-        if claimed is None:
-            return
-        state, root = claimed
-        self._export_completed_conversation(state, root)
+        with self._export_lock:
+            with self._state_lock:
+                claimed = self._claim_conversation_for_export(trace_id, force=force)
+            if claimed is None:
+                return
+            state, root = claimed
+            self._export_completed_conversation(state, root)
 
     def _claim_conversation_for_export(
         self, trace_id: int, *, force: bool
@@ -785,7 +793,7 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
             return None
         if not force and not state.session_ended:
             return None
-        expects_session_data = not force and state.thread_id is not None
+        expects_session_data = not force and self._expects_session_data(state)
         if expects_session_data and not self._has_required_session_data(state):
             self._schedule_release_timeout(state)
             return None
@@ -799,6 +807,16 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
             self._transcripts_waiting_for_trace.pop(state.thread_id, None)
         self._forget_thread_id(trace_id)
         return state, root
+
+    def _expects_session_data(self, state: _ConversationState) -> bool:
+        """Whether this conversation has a viable session-data delivery route."""
+        if state.recording_mode == "egress":
+            # External recordings are routed by ``complete_recording(thread_id)``.
+            return state.thread_id is not None
+        # The automatic close hook captures this state's exact OTel trace id, so
+        # session-report and no-audio modes do not require a LangSmith thread id.
+        # A thread id also permits manual delivery through attach_session_report.
+        return state.report_hook_session_id is not None or state.thread_id is not None
 
     def _has_required_session_data(self, state: _ConversationState) -> bool:
         return state.report_received and (
@@ -907,23 +925,24 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         ``force_flush`` deliberately does not — a still-held root there is
         legitimately in progress, not a buffered export waiting to drain.
         """
-        with self._state_lock:
-            trace_ids = list(self._state_by_trace)
-            for state in list(self._state_by_trace.values()):
-                self._cancel_release_timer(state)
-        for trace_id in trace_ids:
-            self._export_conversation_if_ready(trace_id, force=True)
-        with self._state_lock:
-            remaining = list(self._state_by_trace.values())
-            self._state_by_trace.clear()
-            self._trace_by_thread.clear()
-            self._thread_state_waiting_for_trace.clear()
-            self._completed_threads.clear()
-            self._transcripts_waiting_for_trace.clear()
-        for state in remaining:
-            for speaking_span in state.spans_waiting_for_transcript:
-                self._export(speaking_span)
-        super().shutdown()
+        with self._export_lock:
+            with self._state_lock:
+                trace_ids = list(self._state_by_trace)
+                for state in list(self._state_by_trace.values()):
+                    self._cancel_release_timer(state)
+            for trace_id in trace_ids:
+                self._export_conversation_if_ready(trace_id, force=True)
+            with self._state_lock:
+                remaining = list(self._state_by_trace.values())
+                self._state_by_trace.clear()
+                self._trace_by_thread.clear()
+                self._thread_state_waiting_for_trace.clear()
+                self._completed_threads.clear()
+                self._transcripts_waiting_for_trace.clear()
+            for state in remaining:
+                for speaking_span in state.spans_waiting_for_transcript:
+                    self._export(speaking_span)
+            super().shutdown()
 
     def force_flush(self, timeout_millis: int = 30000) -> bool:
         """Force-flush the downstream — deferred root spans are NOT finalized."""

--- a/python/langsmith/integrations/livekit/processor.py
+++ b/python/langsmith/integrations/livekit/processor.py
@@ -244,7 +244,7 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
     def complete_recording(
         self,
         thread_id: str,
-        recording: Optional[bytes],
+        data: Optional[bytes],
         *,
         name: str = "recording.ogg",
         mime_type: Optional[str] = None,
@@ -252,25 +252,26 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
     ) -> None:
         """Attach completed egress audio, or ``None`` for a terminal failure.
 
-        ``name`` defaults to ``recording.ogg`` and ``mime_type`` defaults to the
-        processor's configured audio MIME type. ``started_at`` is the epoch time
-        of the recording's first sample and enables waterfall alignment.
+        ``data`` contains the completed recording bytes. ``name`` defaults to
+        ``recording.ogg`` and ``mime_type`` defaults to the processor's configured
+        audio MIME type. ``started_at`` is the epoch time of the recording's first
+        sample and enables waterfall alignment.
         """
         if self._recording_mode != "egress":
             raise RuntimeError("complete_recording() requires recording_mode='egress'")
 
         pending_audio = None
         status: Optional[str] = "none"
-        if recording:
+        if data:
             if (
                 self.audio_size_limit_bytes is not None
-                and len(recording) > self.audio_size_limit_bytes
+                and len(data) > self.audio_size_limit_bytes
             ):
                 status = "too_large"
             else:
                 pending_audio = _PendingAudio(
                     name=name,
-                    data=bytes(recording),
+                    data=bytes(data),
                     mime_type=mime_type or self._audio_mime_type,
                 )
                 status = None

--- a/python/langsmith/integrations/livekit/processor.py
+++ b/python/langsmith/integrations/livekit/processor.py
@@ -407,8 +407,8 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
                 state, self._thread_id_by_trace.get(trace_id)
             )
             state.session_ended = True
-            held = state.deferred_user_speaking
-            state.deferred_user_speaking = []
+            held = state.spans_waiting_for_transcript
+            state.spans_waiting_for_transcript = []
             state.transcripts_waiting_for_span = []
             self._refresh_state(state)
         for speaking_span in held:
@@ -537,7 +537,7 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
                 state.transcripts_waiting_for_span.pop(0) if has_transcript else ""
             )
             if not has_transcript:
-                state.deferred_user_speaking.append(tspan)
+                state.spans_waiting_for_transcript.append(tspan)
             self._refresh_state(state)
         if has_transcript:
             self._apply_user_transcript(tspan, transcript)
@@ -560,8 +560,8 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
                 self._transcripts_waiting_for_trace[tid] = waiting
                 return
             tspan = (
-                state.deferred_user_speaking.pop(0)
-                if state.deferred_user_speaking
+                state.spans_waiting_for_transcript.pop(0)
+                if state.spans_waiting_for_transcript
                 else None
             )
             if tspan is None:
@@ -668,7 +668,7 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
     def _export_completed_conversation(
         self, state: _ConversationState, root: TranslatedSpan
     ) -> None:
-        for speaking_span in state.deferred_user_speaking:
+        for speaking_span in state.spans_waiting_for_transcript:
             self._export(speaking_span)
         self._render_conversation(root, state)
         attached = self._attach_pending_audio(root, state)
@@ -776,7 +776,7 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
             self._trace_by_thread.clear()
             self._transcripts_waiting_for_trace.clear()
         for state in remaining:
-            for speaking_span in state.deferred_user_speaking:
+            for speaking_span in state.spans_waiting_for_transcript:
                 self._export(speaking_span)
         super().shutdown()
 

--- a/python/langsmith/integrations/livekit/processor.py
+++ b/python/langsmith/integrations/livekit/processor.py
@@ -2,17 +2,23 @@
 
 Rewrites LiveKit's ``lk.*`` span data into the ``gen_ai.*`` / ``langsmith.*``
 namespaces LangSmith ingests; non-LiveKit spans on the same provider pass
-through untouched. The call recording is attached to the root span, either from
-a local file (``audio_path_provider``, dev) or via :meth:`expect_recording` /
-:meth:`complete_recording` (LiveKit Egress, production). Shared export /
-``thread_id`` / message plumbing lives in :class:`BaseLangSmithSpanProcessor`.
+through untouched.
+
+The root span is held open until the call recording arrives, then released with
+the recording attached and its time origin stamped on it. A recording is
+delivered one of two ways: :meth:`attach_session_report` (LiveKit's in-process
+recorder, via ``ctx.make_session_report()`` in an ``on_session_end`` callback) or
+:meth:`complete_recording` (LiveKit Egress, or any capture of your own). Shared
+export / ``thread_id`` / message plumbing lives in
+:class:`BaseLangSmithSpanProcessor`.
 """
 
 from __future__ import annotations
 
+import logging
+import threading
 from collections.abc import MutableMapping
-from pathlib import Path
-from typing import Any, Callable, Optional
+from typing import Any, Optional
 
 from cachetools import TTLCache
 from opentelemetry.sdk.trace import SpanProcessor
@@ -30,6 +36,7 @@ from langsmith._internal.voice.base_span_processor import (
 
 from ._helpers import (
     build_message_from_event,
+    build_messages_from_chat_history,
     extract_llm_usage,
     extract_model_from_lk_metrics,
     extract_provider_from_lk_metrics,
@@ -42,6 +49,11 @@ from ._helpers import (
 # Lifetime / cap for per-conversation state; bounds memory for calls that never end.
 DEFAULT_STATE_TTL_SECONDS = 3600.0
 DEFAULT_STATE_MAXSIZE = 100_000
+
+# How long a root span waits for its recording before being exported without
+# one. Bounds the hold so a crashed job — or an ``on_session_end`` that never
+# runs — yields a trace with no audio rather than no trace at all.
+DEFAULT_RECORDING_TIMEOUT_SECONDS = 30.0
 
 # LiveKit span names. Inference calls are ``llm``-kind; framework wrappers ``chain``.
 _STT_SPAN = "user_turn"  # audio → transcript (inference)
@@ -65,6 +77,8 @@ _LLM_EVENT_ROLES = {
 }
 _LLM_CHOICE_EVENT = "gen_ai.choice"
 
+logger = logging.getLogger(__name__)
+
 
 class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
     """Enriches LiveKit Agents' OTel spans with LangSmith-compatible attributes."""
@@ -76,18 +90,22 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         api_key: Optional[str] = None,
         project: Optional[str] = None,
         endpoint: Optional[str] = None,
-        audio_path_provider: Optional[Callable[[], Optional[Path]]] = None,
         audio_mime_type: str = "audio/ogg",
+        await_recording: bool = True,
+        recording_timeout_seconds: float = DEFAULT_RECORDING_TIMEOUT_SECONDS,
         state_ttl_seconds: float = DEFAULT_STATE_TTL_SECONDS,
         **kwargs: Any,
     ) -> None:
         """Create the processor.
 
         Args:
-            audio_path_provider: returns a local recording path to embed on the
-                root (dev only); for production use :meth:`expect_recording` /
-                :meth:`complete_recording`.
             audio_mime_type: default MIME type for embedded recordings.
+            await_recording: hold each root span until a recording is delivered
+                by :meth:`attach_session_report` or :meth:`complete_recording`.
+                Pass ``False`` when tracing a session with no audio, so its
+                traces export immediately instead of waiting out the timeout.
+            recording_timeout_seconds: how long that hold lasts before the root
+                is exported without audio.
             state_ttl_seconds: lifetime for per-conversation state.
         """
         super().__init__(
@@ -97,8 +115,12 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
             endpoint=endpoint,
             **kwargs,
         )
-        self.audio_path_provider = audio_path_provider
         self._audio_mime_type = audio_mime_type
+        self._await_recording = await_recording
+        self._recording_timeout_seconds = recording_timeout_seconds
+        # Guards release: the timeout fires on a timer thread, while spans end
+        # on the framework's asyncio loop, so both can reach _maybe_release.
+        self._release_lock = threading.RLock()
 
         def _cache() -> Any:
             return TTLCache(maxsize=DEFAULT_STATE_MAXSIZE, ttl=state_ttl_seconds)
@@ -121,11 +143,26 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
             _cache()
         )
         self._pending_user_transcripts: MutableMapping[str, list[str]] = _cache()
+        # thread id -> recording start (epoch seconds), the audio's time origin.
+        self._recording_started_at_by_thread: MutableMapping[str, float] = _cache()
+        # thread id -> transcript built from a session report's chat history.
+        self._chat_transcript_by_thread: MutableMapping[str, list[dict]] = _cache()
+        # thread id -> why the recording did or didn't attach.
+        self._audio_status_by_thread: MutableMapping[str, str] = _cache()
+        # trace_id -> the timer that force-releases a root that waited too long.
+        self._release_timers: dict[int, threading.Timer] = {}
 
     def _remember_thread_id(self, trace_id: int, thread_id: str) -> None:
-        """Also index thread→trace (so ``complete_recording`` can find the trace)."""
+        """Index thread→trace, and start awaiting this conversation's recording.
+
+        Marking the thread here is what removes the old per-conversation
+        ``expect_recording`` call: every traced conversation awaits a recording
+        from the moment its first span starts.
+        """
         super()._remember_thread_id(trace_id, thread_id)
         self._trace_by_thread[thread_id] = trace_id
+        if self._await_recording and thread_id not in self._audio_status_by_thread:
+            self._threads_awaiting_recording[thread_id] = True
 
     # -- realtime session instrumentation ------------------------------------
 
@@ -133,10 +170,9 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         """Subscribe this processor to a LiveKit ``AgentSession``'s events.
 
         A realtime (speech-to-speech) model's user transcript arrives via the
-        ``user_input_transcribed`` session event — never on a span — so the
-        processor can't see it from spans alone, and the trace ends up with only
-        the agent's turns. Call this once after creating the session to wire the
-        transcript in::
+        ``user_input_transcribed`` session event — never on a span — so without
+        this the ``user_speaking`` spans render bare. Call it once after
+        creating the session to wire the transcript in::
 
             processor = configure_livekit(...)
             session = AgentSession(llm=...)
@@ -147,6 +183,12 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         that has no transcript yet (we have no id to match a transcript to its
         exact span). No-op for the cascade pipeline, where the transcript already
         rides the STT ``user_turn`` span.
+
+        This is about the *spans*. The root's transcript comes from the session
+        report's chat history when one is supplied
+        (:meth:`attach_session_report`), which already includes the realtime
+        user's turns — so without a report, this is also the only way those
+        turns reach the root.
 
         Args:
             session: the LiveKit ``AgentSession`` to subscribe to.
@@ -160,15 +202,91 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
                     str(thread_id), getattr(ev, "transcript", "") or ""
                 )
 
-    # -- production recording (egress) ---------------------------------------
+    # -- recording delivery ---------------------------------------------------
 
-    def expect_recording(self, thread_id: str) -> None:
-        """Hold the root span open until :meth:`complete_recording` supplies the audio.
+    def attach_session_report(
+        self,
+        report: Any,
+        thread_id: str,
+    ) -> None:
+        """Attach a LiveKit ``SessionReport`` and release the held root.
 
-        Call at conversation start (with egress); always pair with a
-        ``complete_recording`` call. ``thread_id`` must match ``set_thread_id``.
+        Call once per conversation from an ``on_session_end`` callback, where
+        the recorder has closed and the report is complete::
+
+            processor = configure_livekit()
+
+
+            async def on_session_end(ctx: JobContext) -> None:
+                processor.attach_session_report(
+                    ctx.make_session_report(), thread_id=ctx.room.name
+                )
+
+
+            server = AgentServer()
+
+
+            @server.rtc_session(on_session_end=on_session_end)
+            async def entrypoint(ctx: JobContext) -> None: ...
+
+        Reads the recording's time origin (so the trace audio player lines up
+        with the waterfall), embeds the recording itself, and rolls the report's
+        chat history up as the root's transcript.
+
+        A report always carries the chat history, but only carries a recording
+        when LiveKit's own recorder made one. If it has no recording, the root
+        stays held for a :meth:`complete_recording` call — so recording with
+        egress means calling *both*: this for the transcript, then
+        ``complete_recording`` with the audio, which releases the trace with
+        both. Pass ``await_recording=False`` to :func:`configure_livekit` when
+        the conversation has no audio at all.
+
+        Args:
+            report: LiveKit's ``SessionReport`` (duck-typed — the module never
+                imports it, so it stays importable without ``livekit-agents``).
+            thread_id: the conversation id, matching :func:`set_thread_id`.
         """
-        self._threads_awaiting_recording[str(thread_id)] = True
+        thread = str(thread_id)
+
+        started_at = getattr(report, "audio_recording_started_at", None)
+        audio_path = getattr(report, "audio_recording_path", None)
+        history = getattr(report, "chat_history", None)
+
+        status = "none"
+        data = None
+        if audio_path is not None:
+            # Read the file before taking the lock — it is the slow part, and it
+            # touches none of the shared state.
+            data, status = self._read_audio_file(audio_path)
+        messages = build_messages_from_chat_history(history) if history else []
+
+        # Everything this delivery contributes lands as one atomic unit, so a
+        # concurrent delivery can never release a root halfway through it.
+        with self._release_lock:
+            if isinstance(started_at, (int, float)):
+                self._recording_started_at_by_thread[thread] = float(started_at)
+            if data:
+                self._pending_audio_by_thread[thread] = {
+                    "name": getattr(audio_path, "name", "recording.ogg"),
+                    "data": data,
+                    "mime_type": self._audio_mime_type,
+                }
+            if messages:
+                self._chat_transcript_by_thread[thread] = messages
+            return self._finish_report(thread, status, audio_path)
+
+    def _finish_report(self, thread: str, status: str, audio_path: Any) -> None:
+        """Release for a session report, unless its audio is coming separately."""
+        if audio_path is None and self._await_recording:
+            # The report carried no recording, so LiveKit's own recorder was not
+            # the capture: the audio is arriving separately, from an egress
+            # upload handed to ``complete_recording``. Keep the root held for it
+            # — everything above is already stored, so that later call releases
+            # a trace with both the recording and this transcript. The timeout
+            # still bounds the wait, and ``await_recording=False`` says up front
+            # that no audio is coming.
+            return
+        self._finish_recording(thread, status)
 
     def complete_recording(
         self,
@@ -177,23 +295,48 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         *,
         name: str = "recording.ogg",
         mime_type: Optional[str] = None,
+        started_at: Optional[float] = None,
     ) -> None:
-        """Attach an egress recording and release the held root.
+        """Attach a recording supplied as bytes and release the held root.
 
-        ``data`` is the recording bytes (embedded as an attachment), or ``None``
-        to release without audio. ``thread_id`` must match :meth:`expect_recording`.
-        Safe to call before or after the session ends.
+        For LiveKit Egress, or any capture of your own. ``data`` is the
+        recording bytes, or ``None`` to release without audio. ``thread_id``
+        must match :func:`set_thread_id`. Safe to call before or after the
+        session ends.
+
+        ``started_at`` is when the recording's first sample was captured (epoch
+        seconds). Without it the trace audio player has to assume the recording
+        starts when the trace does, which it generally does not.
         """
-        if data:
-            self._pending_audio_by_thread[str(thread_id)] = {
-                "name": name,
-                "data": bytes(data),
-                "mime_type": mime_type or self._audio_mime_type,
-            }
-        self._threads_awaiting_recording.pop(str(thread_id), None)
-        trace_id = self._trace_by_thread.get(str(thread_id))
-        if trace_id is not None:
-            self._maybe_release(trace_id)
+        thread = str(thread_id)
+        with self._release_lock:
+            if isinstance(started_at, (int, float)):
+                self._recording_started_at_by_thread[thread] = float(started_at)
+            status = "none"
+            if data:
+                self._pending_audio_by_thread[thread] = {
+                    "name": name,
+                    "data": bytes(data),
+                    "mime_type": mime_type or self._audio_mime_type,
+                }
+                status = "attached"
+            self._finish_recording(thread, status)
+
+    def _finish_recording(self, thread: str, status: str) -> None:
+        """Stop awaiting this thread's recording and release its root."""
+        self._audio_status_by_thread[thread] = status
+        self._threads_awaiting_recording.pop(thread, None)
+        trace_id = self._trace_by_thread.get(thread)
+        if trace_id is None:
+            logger.warning(
+                "langsmith voice: nothing to attach a recording to for thread "
+                "%s — its trace was already exported, or this thread id never "
+                "matched one. Deliver the recording before the trace is "
+                "released, and check the id matches set_thread_id().",
+                thread,
+            )
+            return
+        self._maybe_release(trace_id)
 
     # -- dispatch -------------------------------------------------------------
 
@@ -404,6 +547,10 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
             tspan.attributes["lk.user_transcript"] = transcript
             msg = build_user_message(transcript)
             tspan.set_messages(prompt=[msg])
+            # Also feed the span-derived rollup. That rollup is only read when
+            # no session report was supplied (see ``_render_conversation``), so
+            # this line does nothing on the report path and is the realtime
+            # user's only route into the root transcript on the egress path.
             self._append_transcript(
                 tspan.span.context.trace_id, msg, tspan.span.start_time
             )
@@ -449,34 +596,116 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         """Export the deferred root once the session ended and audio is ready.
 
         Requires the root seen, the session ended, and no awaited recording.
-        ``force`` skips the last two gates — the last-resort path at
-        :meth:`shutdown` for a root that never completed.
+        While a recording is still awaited this arms the timeout that releases
+        the root without one. ``force`` skips both gates — the last-resort path
+        at :meth:`shutdown` for a root that never completed.
         """
-        tspan = self._deferred_root_by_trace.get(trace_id)
-        if tspan is None:
-            return
-        thread = self._thread_id_by_trace.get(trace_id)
-        if not force:
-            if trace_id not in self._ended_session_traces:
+        with self._release_lock:
+            tspan = self._deferred_root_by_trace.get(trace_id)
+            if tspan is None:
                 return
-            if thread is not None and thread in self._threads_awaiting_recording:
-                return  # still waiting for complete_recording()
+            thread = self._thread_id_by_trace.get(trace_id)
+            if not force:
+                if trace_id not in self._ended_session_traces:
+                    return
+                if thread is not None and thread in self._threads_awaiting_recording:
+                    self._schedule_release_timeout(trace_id)
+                    return  # still waiting for a recording
 
-        self._deferred_root_by_trace.pop(trace_id, None)
-        self._render_conversation(tspan)
-        self._attach_audio_recording(tspan)
+            self._cancel_release_timer(trace_id)
+            self._deferred_root_by_trace.pop(trace_id, None)
+            self._render_conversation(tspan, thread)
+            if thread is not None:
+                self._attach_pending_audio(tspan, thread)
+                self._stamp_recording_origin(tspan, thread)
+            self._export(tspan)
+            self._cleanup_trace(trace_id)
+
+    def _schedule_release_timeout(self, trace_id: int) -> None:
+        """Arm the one-shot timer that releases a root whose audio never came."""
+        if trace_id in self._release_timers or self._recording_timeout_seconds <= 0:
+            return
+        timer = threading.Timer(
+            self._recording_timeout_seconds, self._on_recording_timeout, (trace_id,)
+        )
+        timer.daemon = True
+        self._release_timers[trace_id] = timer
+        timer.start()
+
+    def _on_recording_timeout(self, trace_id: int) -> None:
+        """Give up waiting for a recording and export the root without one."""
+        with self._release_lock:
+            self._release_timers.pop(trace_id, None)
+            thread = self._thread_id_by_trace.get(trace_id)
+            if thread is not None:
+                if thread not in self._threads_awaiting_recording:
+                    return  # a recording landed just as the timer fired
+                logger.warning(
+                    "langsmith voice: no recording for thread %s after %.1fs; "
+                    "exporting the trace without audio. Call "
+                    "attach_session_report() or complete_recording() at session "
+                    "end, or pass await_recording=False if this session has no "
+                    "audio.",
+                    thread,
+                    self._recording_timeout_seconds,
+                )
+                self._audio_status_by_thread[thread] = "timeout"
+                self._threads_awaiting_recording.pop(thread, None)
+            self._maybe_release(trace_id)
+
+    def _cancel_release_timer(self, trace_id: int) -> None:
+        """Cancel a pending timeout (the recording arrived, or we're shutting down)."""
+        timer = self._release_timers.pop(trace_id, None)
+        if timer is not None:
+            timer.cancel()
+
+    def _stamp_recording_origin(self, tspan: TranslatedSpan, thread: str) -> None:
+        """Stamp where the recording sits on the trace's timeline, and why.
+
+        LiveKit's recorder starts inside ``session.start()`` — after room
+        connect and agent setup — so the recording's first sample is seconds
+        later than the root span's start. Without the offset the trace audio
+        player has to assume they coincide, and playback runs ahead of the
+        waterfall by that gap.
+        """
+        status = self._audio_status_by_thread.get(thread)
+        if status:
+            tspan.set_metadata("ls_audio_attach_status", status)
+        started_at = self._recording_started_at_by_thread.get(thread)
+        root_start_ns = tspan.span.start_time
+        if started_at is None or root_start_ns is None:
+            return
+        # Both values come from ``time.time()`` in the agent process and the
+        # root's start_time is from that same process and clock, so the
+        # difference holds even under wall-clock skew. Never turn this into a
+        # cross-host comparison.
+        root_start_s = root_start_ns / 1e9
+        tspan.set_metadata("ls_audio_recording_started_at", started_at)
+        tspan.set_metadata(
+            "ls_audio_recording_start_offset_ms",
+            round((started_at - root_start_s) * 1000),
+        )
+
+    def _render_conversation(
+        self, tspan: TranslatedSpan, thread: Optional[str] = None
+    ) -> bool:
+        """Set the conversation transcript as the root's input.
+
+        Prefers a session report's chat history — it is ordered by the messages'
+        own timestamps and carries the tool calls — and falls back to the
+        transcript assembled from spans when no report was supplied.
+        """
         if thread is not None:
-            self._attach_pending_audio(tspan, thread)
-        self._export(tspan)
-        self._cleanup_trace(trace_id)
-
-    def _render_conversation(self, tspan: TranslatedSpan) -> bool:
-        """Set the whole transcript (ordered by span start_time) as the root's input."""
+            messages = self._chat_transcript_by_thread.get(thread)
+            if messages:
+                tspan.set_messages(prompt=messages)
+                return True
         entries = self._transcript_by_trace.get(tspan.span.context.trace_id, [])
         if not entries:
             return False
-        messages = [msg for _, msg in sorted(entries, key=lambda e: e[0])]
-        tspan.set_messages(prompt=messages)
+        tspan.set_messages(
+            prompt=[msg for _, msg in sorted(entries, key=lambda e: e[0])]
+        )
         return True
 
     def _cleanup_trace(self, trace_id: int) -> None:
@@ -485,10 +714,14 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         self._transcript_by_trace.pop(trace_id, None)
         self._forget_thread_id(trace_id)
         self._ended_session_traces.pop(trace_id, None)
+        self._cancel_release_timer(trace_id)
         if thread is not None:
             self._trace_by_thread.pop(thread, None)
             self._threads_awaiting_recording.pop(thread, None)
             self._pending_audio_by_thread.pop(thread, None)
+            self._recording_started_at_by_thread.pop(thread, None)
+            self._chat_transcript_by_thread.pop(thread, None)
+            self._audio_status_by_thread.pop(thread, None)
             self._flush_user_speaking(thread)
 
     def shutdown(self) -> None:
@@ -497,6 +730,8 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         ``force_flush`` deliberately does not — a still-held root there is
         legitimately in progress, not a buffered export waiting to drain.
         """
+        for trace_id in list(self._release_timers):
+            self._cancel_release_timer(trace_id)
         for trace_id in list(self._deferred_root_by_trace):
             self._maybe_release(trace_id, force=True)
         for thread in list(self._deferred_user_speaking.keys()):
@@ -509,26 +744,45 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
 
     # -- audio attachment -----------------------------------------------------
 
-    def _attach_audio_recording(self, tspan: TranslatedSpan) -> None:
-        """Embed audio from the local ``audio_path_provider`` file (dev)."""
-        if self.audio_path_provider is None:
-            return
-        audio_path = self.audio_path_provider()
-        if audio_path is None or not audio_path.exists():
-            return
+    def _read_audio_file(self, path: Any) -> tuple[Optional[bytes], str]:
+        """Read a recording from disk, size-checked *before* it is loaded.
+
+        Returns ``(bytes, "attached")`` or ``(None, reason)``. The size is
+        checked with ``stat()`` first so an oversize recording is never read
+        into memory. Callers inline the returned bytes — the path itself must
+        never reach the LangSmith client, which rejects filesystem-referencing
+        attachments unless ``dangerously_allow_filesystem=True``
+        (see ``_reject_filesystem_attachments`` / GHSA-f4xh-w4cj-qxq8).
+        """
         try:
-            audio_bytes = audio_path.read_bytes()
-        except Exception:  # pragma: no cover
-            return
-        self._attach_audio(
-            tspan,
-            name=audio_path.name,
-            data=audio_bytes,
-            mime_type=self._audio_mime_type,
-        )
+            size = path.stat().st_size
+        except Exception:
+            logger.warning("langsmith voice: no readable recording at %s.", path)
+            return None, "unreadable"
+        if (
+            self.audio_size_limit_bytes is not None
+            and size > self.audio_size_limit_bytes
+        ):
+            logger.warning(
+                "langsmith voice: recording at %s is %d bytes, over the "
+                "%d-byte limit; skipping the attachment.",
+                path,
+                size,
+                self.audio_size_limit_bytes,
+            )
+            return None, "too_large"
+        try:
+            return path.read_bytes(), "attached"
+        except Exception:
+            logger.warning(
+                "langsmith voice: failed reading the recording at %s.",
+                path,
+                exc_info=True,
+            )
+            return None, "unreadable"
 
     def _attach_pending_audio(self, tspan: TranslatedSpan, thread: str) -> None:
-        """Embed a recording supplied via :meth:`complete_recording` (egress)."""
+        """Embed the recording delivered for this conversation, if any."""
         pending = self._pending_audio_by_thread.pop(thread, None)
         if not pending or not pending.get("data"):
             return

--- a/python/langsmith/integrations/livekit/processor.py
+++ b/python/langsmith/integrations/livekit/processor.py
@@ -4,12 +4,10 @@ Rewrites LiveKit's ``lk.*`` span data into the ``gen_ai.*`` / ``langsmith.*``
 namespaces LangSmith ingests; non-LiveKit spans on the same provider pass
 through untouched.
 
-The root span is held open until the call recording arrives, then released with
-the recording attached and its time origin stamped on it. A recording is
-delivered one of two ways: :meth:`attach_session_report` (LiveKit's in-process
-recorder, via ``ctx.make_session_report()`` in an ``on_session_end`` callback) or
-:meth:`complete_recording` (LiveKit Egress, or any capture of your own). Shared
-export / ``thread_id`` / message plumbing lives in
+In recorded modes the root span is held until :meth:`attach_session_report`
+delivers the complete transcript, recording, and time origin as one atomic unit.
+LiveKit's recorder supplies a path on the report; egress supplies bytes in the
+same call. Shared export / ``thread_id`` / message plumbing lives in
 :class:`BaseLangSmithSpanProcessor`.
 """
 
@@ -18,7 +16,8 @@ from __future__ import annotations
 import logging
 import threading
 from collections.abc import MutableMapping
-from typing import Any, Optional
+from pathlib import Path
+from typing import Any, Literal, Optional, get_args
 
 from cachetools import TTLCache
 from opentelemetry.sdk.trace import SpanProcessor
@@ -45,6 +44,7 @@ from ._helpers import (
     is_livekit_span,
     normalize_provider,
 )
+from ._state import _ConversationState, _PendingAudio
 
 # Lifetime / cap for per-conversation state; bounds memory for calls that never end.
 DEFAULT_STATE_TTL_SECONDS = 3600.0
@@ -55,7 +55,6 @@ DEFAULT_STATE_MAXSIZE = 100_000
 # runs — yields a trace with no audio rather than no trace at all.
 DEFAULT_RECORDING_TIMEOUT_SECONDS = 30.0
 
-# LiveKit span names. Inference calls are ``llm``-kind; framework wrappers ``chain``.
 _STT_SPAN = "user_turn"  # audio → transcript (inference)
 _LLM_INFERENCE_SPAN = "llm_request"  # chat completion (inference)
 _LLM_WRAPPER_SPANS = {"llm_node", "llm_request_run"}
@@ -67,8 +66,6 @@ _TOOL_SPAN = "function_tool"
 _REALTIME_METRICS_SPAN = "realtime_metrics"
 _USER_SPEAKING_SPAN = "user_speaking"
 
-# ``llm_request`` emits one ``gen_ai.<role>.message`` event per chat item, plus a
-# ``gen_ai.choice`` for the reply.
 _LLM_EVENT_ROLES = {
     "gen_ai.system.message": "system",
     "gen_ai.user.message": "user",
@@ -78,6 +75,9 @@ _LLM_EVENT_ROLES = {
 _LLM_CHOICE_EVENT = "gen_ai.choice"
 
 logger = logging.getLogger(__name__)
+
+RecordingMode = Literal["session_report", "egress", "none"]
+_RECORDING_MODES = frozenset(get_args(RecordingMode))
 
 
 class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
@@ -91,7 +91,7 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         project: Optional[str] = None,
         endpoint: Optional[str] = None,
         audio_mime_type: str = "audio/ogg",
-        await_recording: bool = True,
+        recording_mode: RecordingMode = "session_report",
         recording_timeout_seconds: float = DEFAULT_RECORDING_TIMEOUT_SECONDS,
         state_ttl_seconds: float = DEFAULT_STATE_TTL_SECONDS,
         **kwargs: Any,
@@ -100,10 +100,10 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
 
         Args:
             audio_mime_type: default MIME type for embedded recordings.
-            await_recording: hold each root span until a recording is delivered
-                by :meth:`attach_session_report` or :meth:`complete_recording`.
-                Pass ``False`` when tracing a session with no audio, so its
-                traces export immediately instead of waiting out the timeout.
+            recording_mode: where recordings come from: ``"session_report"``
+                for LiveKit's recorder, ``"egress"`` for bytes supplied with
+                :meth:`attach_session_report`, or ``"none"`` to export without
+                waiting for a report.
             recording_timeout_seconds: how long that hold lasts before the root
                 is exported without audio.
             state_ttl_seconds: lifetime for per-conversation state.
@@ -115,56 +115,85 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
             endpoint=endpoint,
             **kwargs,
         )
+        if recording_mode not in _RECORDING_MODES:
+            raise ValueError(
+                f"recording_mode must be one of {sorted(_RECORDING_MODES)!r}"
+            )
+        if recording_mode != "none" and recording_timeout_seconds <= 0:
+            raise ValueError(
+                "recording_timeout_seconds must be greater than zero when a "
+                "recording is expected"
+            )
         self._audio_mime_type = audio_mime_type
-        self._await_recording = await_recording
+        self._recording_mode = recording_mode
         self._recording_timeout_seconds = recording_timeout_seconds
-        # Guards release: the timeout fires on a timer thread, while spans end
-        # on the framework's asyncio loop, so both can reach _maybe_release.
-        self._release_lock = threading.RLock()
+        # The timeout fires on a timer thread; every conversation-state mutation
+        # uses this lock, including the framework's normal span callbacks.
+        self._state_lock = threading.RLock()
 
         def _cache() -> Any:
             return TTLCache(maxsize=DEFAULT_STATE_MAXSIZE, ttl=state_ttl_seconds)
 
-        # trace_id -> running transcript, rolled up onto the root at session end.
-        self._transcript_by_trace: MutableMapping[int, list[tuple[Any, dict]]] = (
-            _cache()
-        )
-        # trace_id -> root span held open until the session (and any egress) ends.
-        self._deferred_root_by_trace: MutableMapping[int, TranslatedSpan] = _cache()
-        # trace_ids whose ``agent_session`` end span has arrived (used as a set).
-        self._ended_session_traces: MutableMapping[int, bool] = _cache()
-        # thread ids awaiting an egress recording (used as a set).
-        self._threads_awaiting_recording: MutableMapping[str, bool] = _cache()
-        # thread id -> pending egress audio bytes.
-        self._pending_audio_by_thread: MutableMapping[str, dict] = _cache()
-        # thread id -> trace_id, so ``complete_recording`` can find the trace.
+        self._state_by_trace: MutableMapping[int, _ConversationState] = _cache()
         self._trace_by_thread: MutableMapping[str, int] = _cache()
-        self._deferred_user_speaking: MutableMapping[str, list[TranslatedSpan]] = (
-            _cache()
-        )
-        self._pending_user_transcripts: MutableMapping[str, list[str]] = _cache()
-        # thread id -> recording start (epoch seconds), the audio's time origin.
-        self._recording_started_at_by_thread: MutableMapping[str, float] = _cache()
-        # thread id -> transcript built from a session report's chat history.
-        self._chat_transcript_by_thread: MutableMapping[str, list[dict]] = _cache()
-        # thread id -> why the recording did or didn't attach.
-        self._audio_status_by_thread: MutableMapping[str, str] = _cache()
-        # trace_id -> the timer that force-releases a root that waited too long.
-        self._release_timers: dict[int, threading.Timer] = {}
+        # A transcript event may arrive after instrument_session() but before a
+        # LiveKit span has given us that thread's trace id.
+        self._unmatched_user_transcripts: MutableMapping[str, list[str]] = _cache()
 
-    def _remember_thread_id(self, trace_id: int, thread_id: str) -> None:
-        """Index thread→trace, and start awaiting this conversation's recording.
+    def _get_state_locked(self, trace_id: int) -> Optional[_ConversationState]:
+        return self._state_by_trace.get(trace_id)
 
-        Marking the thread here is what removes the old per-conversation
-        ``expect_recording`` call: every traced conversation awaits a recording
-        from the moment its first span starts.
-        """
-        super()._remember_thread_id(trace_id, thread_id)
-        self._trace_by_thread[thread_id] = trace_id
-        if self._await_recording and thread_id not in self._audio_status_by_thread:
-            self._threads_awaiting_recording[thread_id] = True
+    def _get_or_create_state_locked(self, trace_id: int) -> _ConversationState:
+        state = self._get_state_locked(trace_id)
+        if state is None:
+            state = _ConversationState(trace_id=trace_id)
+            self._state_by_trace[trace_id] = state
+        return state
 
-    # -- realtime session instrumentation ------------------------------------
+    def _get_state_by_thread_locked(
+        self, thread_id: str
+    ) -> Optional[_ConversationState]:
+        trace_id = self._trace_by_thread.get(thread_id)
+        if trace_id is None:
+            return None
+        state = self._state_by_trace.get(trace_id)
+        if state is None or state.thread_id != thread_id:
+            self._trace_by_thread.pop(thread_id, None)
+            return None
+        return state
+
+    def _refresh_state_locked(self, state: _ConversationState) -> None:
+        self._state_by_trace[state.trace_id] = state
+
+    def _bind_thread_locked(
+        self, state: _ConversationState, thread_id: Optional[str]
+    ) -> None:
+        if thread_id is None:
+            return
+        thread = str(thread_id)
+        if state.thread_id is not None and state.thread_id != thread:
+            logger.warning(
+                "langsmith voice: trace %x already uses thread id %s; ignoring "
+                "conflicting id %s.",
+                state.trace_id,
+                state.thread_id,
+                thread,
+            )
+            return
+        existing_state = self._get_state_by_thread_locked(thread)
+        if existing_state is not None and existing_state.trace_id != state.trace_id:
+            logger.warning(
+                "langsmith voice: thread id %s is already bound to an active "
+                "LiveKit trace; recordings require one active trace per thread.",
+                thread,
+            )
+            return
+        state.thread_id = thread
+        self._trace_by_thread[thread] = state.trace_id
+        unmatched = self._unmatched_user_transcripts.pop(thread, None)
+        if unmatched:
+            state.pending_user_transcripts.extend(unmatched)
+        self._refresh_state_locked(state)
 
     def instrument_session(self, session: Any, thread_id: str) -> None:
         """Subscribe this processor to a LiveKit ``AgentSession``'s events.
@@ -184,12 +213,6 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         exact span). No-op for the cascade pipeline, where the transcript already
         rides the STT ``user_turn`` span.
 
-        This is about the *spans*. The root's transcript comes from the session
-        report's chat history when one is supplied
-        (:meth:`attach_session_report`), which already includes the realtime
-        user's turns — so without a report, this is also the only way those
-        turns reach the root.
-
         Args:
             session: the LiveKit ``AgentSession`` to subscribe to.
             thread_id: the conversation id, matching :func:`set_thread_id`.
@@ -202,143 +225,147 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
                     str(thread_id), getattr(ev, "transcript", "") or ""
                 )
 
-    # -- recording delivery ---------------------------------------------------
-
     def attach_session_report(
         self,
         report: Any,
         thread_id: str,
+        *,
+        recording: Optional[bytes] = None,
+        recording_name: str = "recording.ogg",
+        recording_mime_type: Optional[str] = None,
+        recording_started_at: Optional[float] = None,
     ) -> None:
-        """Attach a LiveKit ``SessionReport`` and release the held root.
+        """Attach a complete LiveKit session report and release the held root.
 
-        Call once per conversation from an ``on_session_end`` callback, where
-        the recorder has closed and the report is complete::
-
-            processor = configure_livekit()
-
-
-            async def on_session_end(ctx: JobContext) -> None:
-                processor.attach_session_report(
-                    ctx.make_session_report(), thread_id=ctx.room.name
-                )
-
-
-            server = AgentServer()
-
-
-            @server.rtc_session(on_session_end=on_session_end)
-            async def entrypoint(ctx: JobContext) -> None: ...
-
-        Reads the recording's time origin (so the trace audio player lines up
-        with the waterfall), embeds the recording itself, and rolls the report's
-        chat history up as the root's transcript.
-
-        A report always carries the chat history, but only carries a recording
-        when LiveKit's own recorder made one. If it has no recording, the root
-        stays held for a :meth:`complete_recording` call — so recording with
-        egress means calling *both*: this for the transcript, then
-        ``complete_recording`` with the audio, which releases the trace with
-        both. Pass ``await_recording=False`` to :func:`configure_livekit` when
-        the conversation has no audio at all.
+        This is the single terminal delivery for a recorded conversation. In
+        ``session_report`` mode it reads LiveKit's recording path and origin. In
+        ``egress`` mode pass the external recording bytes and origin in this same
+        call, so the root can never export with only half the delivery. In
+        ``none`` mode roots export at session end and reports are not accepted.
 
         Args:
             report: LiveKit's ``SessionReport`` (duck-typed — the module never
                 imports it, so it stays importable without ``livekit-agents``).
             thread_id: the conversation id, matching :func:`set_thread_id`.
+            recording: external audio bytes in ``egress`` mode.
+            recording_name: attachment name for external audio.
+            recording_mime_type: MIME type for external audio.
+            recording_started_at: external recording's first-sample epoch time.
         """
         thread = str(thread_id)
+        with self._state_lock:
+            if not self._claim_report_delivery_locked(thread):
+                return
 
-        started_at = getattr(report, "audio_recording_started_at", None)
-        audio_path = getattr(report, "audio_recording_path", None)
-        history = getattr(report, "chat_history", None)
+        messages = build_messages_from_chat_history(report.chat_history)
+        pending_audio, started_at, status = self._prepare_report_audio(
+            report,
+            recording=recording,
+            recording_name=recording_name,
+            recording_mime_type=recording_mime_type,
+            recording_started_at=recording_started_at,
+        )
 
-        status = "none"
-        data = None
-        if audio_path is not None:
-            # Read the file before taking the lock — it is the slow part, and it
-            # touches none of the shared state.
+        with self._state_lock:
+            trace_id = self._complete_report_delivery_locked(
+                thread,
+                transcript=messages,
+                pending_audio=pending_audio,
+                recording_started_at=started_at,
+                audio_status=status,
+            )
+        if trace_id is not None:
+            self._export_conversation_if_ready(trace_id)
+
+    def _claim_report_delivery_locked(self, thread_id: str) -> bool:
+        state = self._get_state_by_thread_locked(thread_id)
+        if state is None:
+            logger.warning(
+                "langsmith voice: no active LiveKit trace for thread %s; "
+                "the report arrived after export, or the id did not match "
+                "set_thread_id().",
+                thread_id,
+            )
+            return False
+        if self._recording_mode == "none":
+            logger.warning(
+                "langsmith voice: ignoring a session report for thread %s "
+                "because recording_mode='none' exports at session end.",
+                thread_id,
+            )
+            return False
+        if state.delivery_complete or state.delivery_in_progress:
+            logger.warning(
+                "langsmith voice: ignoring a duplicate session report for thread %s.",
+                thread_id,
+            )
+            return False
+        # Claim delivery and cancel the timeout before file I/O. A timer that
+        # fires after this point observes delivery_in_progress and cannot
+        # export a partial root.
+        state.delivery_in_progress = True
+        self._cancel_release_timer_locked(state)
+        self._refresh_state_locked(state)
+        return True
+
+    def _prepare_report_audio(
+        self,
+        report: Any,
+        *,
+        recording: Optional[bytes],
+        recording_name: str,
+        recording_mime_type: Optional[str],
+        recording_started_at: Optional[float],
+    ) -> tuple[Optional[_PendingAudio], Optional[float], Optional[str]]:
+        if self._recording_mode == "session_report":
+            audio_path = report.audio_recording_path
+            started_at = report.audio_recording_started_at
+            if audio_path is None:
+                return None, started_at, "none"
             data, status = self._read_audio_file(audio_path)
-        messages = build_messages_from_chat_history(history) if history else []
+            if data is None:
+                return None, started_at, status
+            return (
+                _PendingAudio(
+                    name=audio_path.name,
+                    data=data,
+                    mime_type=self._audio_mime_type,
+                ),
+                started_at,
+                status,
+            )
+        if not recording:
+            return None, recording_started_at, "none"
+        return (
+            _PendingAudio(
+                name=recording_name,
+                data=bytes(recording),
+                mime_type=recording_mime_type or self._audio_mime_type,
+            ),
+            recording_started_at,
+            None,
+        )
 
-        # Everything this delivery contributes lands as one atomic unit, so a
-        # concurrent delivery can never release a root halfway through it.
-        with self._release_lock:
-            if isinstance(started_at, (int, float)):
-                self._recording_started_at_by_thread[thread] = float(started_at)
-            if data:
-                self._pending_audio_by_thread[thread] = {
-                    "name": getattr(audio_path, "name", "recording.ogg"),
-                    "data": data,
-                    "mime_type": self._audio_mime_type,
-                }
-            if messages:
-                self._chat_transcript_by_thread[thread] = messages
-            return self._finish_report(thread, status, audio_path)
-
-    def _finish_report(self, thread: str, status: str, audio_path: Any) -> None:
-        """Release for a session report, unless its audio is coming separately."""
-        if audio_path is None and self._await_recording:
-            # The report carried no recording, so LiveKit's own recorder was not
-            # the capture: the audio is arriving separately, from an egress
-            # upload handed to ``complete_recording``. Keep the root held for it
-            # — everything above is already stored, so that later call releases
-            # a trace with both the recording and this transcript. The timeout
-            # still bounds the wait, and ``await_recording=False`` says up front
-            # that no audio is coming.
-            return
-        self._finish_recording(thread, status)
-
-    def complete_recording(
+    def _complete_report_delivery_locked(
         self,
         thread_id: str,
-        data: Optional[bytes],
         *,
-        name: str = "recording.ogg",
-        mime_type: Optional[str] = None,
-        started_at: Optional[float] = None,
-    ) -> None:
-        """Attach a recording supplied as bytes and release the held root.
-
-        For LiveKit Egress, or any capture of your own. ``data`` is the
-        recording bytes, or ``None`` to release without audio. ``thread_id``
-        must match :func:`set_thread_id`. Safe to call before or after the
-        session ends.
-
-        ``started_at`` is when the recording's first sample was captured (epoch
-        seconds). Without it the trace audio player has to assume the recording
-        starts when the trace does, which it generally does not.
-        """
-        thread = str(thread_id)
-        with self._release_lock:
-            if isinstance(started_at, (int, float)):
-                self._recording_started_at_by_thread[thread] = float(started_at)
-            status = "none"
-            if data:
-                self._pending_audio_by_thread[thread] = {
-                    "name": name,
-                    "data": bytes(data),
-                    "mime_type": mime_type or self._audio_mime_type,
-                }
-                status = "attached"
-            self._finish_recording(thread, status)
-
-    def _finish_recording(self, thread: str, status: str) -> None:
-        """Stop awaiting this thread's recording and release its root."""
-        self._audio_status_by_thread[thread] = status
-        self._threads_awaiting_recording.pop(thread, None)
-        trace_id = self._trace_by_thread.get(thread)
-        if trace_id is None:
-            logger.warning(
-                "langsmith voice: nothing to attach a recording to for thread "
-                "%s — its trace was already exported, or this thread id never "
-                "matched one. Deliver the recording before the trace is "
-                "released, and check the id matches set_thread_id().",
-                thread,
-            )
-            return
-        self._maybe_release(trace_id)
-
-    # -- dispatch -------------------------------------------------------------
+        transcript: list[dict],
+        pending_audio: Optional[_PendingAudio],
+        recording_started_at: Optional[float],
+        audio_status: Optional[str],
+    ) -> Optional[int]:
+        state = self._get_state_by_thread_locked(thread_id)
+        if state is None:
+            return None
+        state.report_transcript = transcript
+        state.pending_audio = pending_audio
+        state.recording_started_at = recording_started_at
+        state.audio_status = audio_status
+        state.delivery_in_progress = False
+        state.delivery_complete = True
+        self._refresh_state_locked(state)
+        return state.trace_id
 
     def _dispatch(self, tspan: TranslatedSpan) -> bool:
         trace_id = tspan.span.context.trace_id
@@ -349,38 +376,46 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         elif name == _LLM_INFERENCE_SPAN:
             self._handle_llm_request(tspan)
         elif name in _LLM_WRAPPER_SPANS:
-            tspan.set_kind("chain")  # wrappers: no fabricated I/O
+            tspan.set_kind("chain")
         elif name == _TTS_INFERENCE_SPAN:
             self._handle_tts(tspan)
         elif name in _TTS_WRAPPER_SPANS:
-            tspan.set_kind("chain")  # wrappers: no fabricated I/O
+            tspan.set_kind("chain")
         elif name == _TURN_SPAN:
             self._handle_turn(tspan)
         elif name == _USER_SPEAKING_SPAN:
             return self._handle_user_speaking(tspan)
         elif name == _SESSION_SPAN:
-            # Session end: release the deferred root, then export this span.
-            tspan.set_kind("chain")
-            self._ended_session_traces[trace_id] = True
-            self._flush_user_speaking(self._thread_id_by_trace.get(trace_id))
-            self._maybe_release(trace_id)
+            self._handle_session_end(tspan)
         elif name == "eou_detection":
-            tspan.set_kind("chain")  # framework step
+            tspan.set_kind("chain")
         elif name == _TOOL_SPAN:
             self._handle_tool(tspan)
         elif name == _REALTIME_METRICS_SPAN:
             tspan.set_kind("llm")
         elif tspan.span.parent is None and is_livekit_span(tspan.span):
-            # Conversation root — _handle_root owns its export (False). Gated on
-            # the LiveKit scope so a non-LiveKit parentless span isn't hijacked.
+            # Only LiveKit parentless spans are conversation roots; other OTel
+            # integrations may share this provider.
             self._handle_root(tspan, trace_id)
             return False
-        return True  # non-LiveKit span: export untouched
+        return True
 
-    # -- per-span-type handlers ----------------------------------------------
+    def _handle_session_end(self, tspan: TranslatedSpan) -> None:
+        trace_id = tspan.span.context.trace_id
+        tspan.set_kind("chain")
+        with self._state_lock:
+            state = self._get_or_create_state_locked(trace_id)
+            self._bind_thread_locked(state, self._thread_id_by_trace.get(trace_id))
+            state.session_ended = True
+            held = state.deferred_user_speaking
+            state.deferred_user_speaking = []
+            state.pending_user_transcripts = []
+            self._refresh_state_locked(state)
+        for speaking_span in held:
+            self._export(speaking_span)
+        self._export_conversation_if_ready(trace_id)
 
     def _handle_stt(self, tspan: TranslatedSpan) -> None:
-        """STT (``user_turn``): audio input → transcribed text."""
         tspan.set_kind("llm")
         tspan.set_model(tspan.attributes.get("gen_ai.request.model"))
         tspan.set_provider(
@@ -417,7 +452,6 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         )
         tspan.set_provider(normalize_provider(provider))
 
-        # Lift the token usage (counts + cache_read detail) from the metrics blob.
         usage = extract_llm_usage(tspan.attributes.get("lk.llm_metrics"))
         if usage:
             tspan.set_usage(**usage)
@@ -429,7 +463,6 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         ]
 
     def _handle_tts(self, tspan: TranslatedSpan) -> None:
-        """``tts_request``: synthesize text → audio (an ``llm`` inference)."""
         tspan.set_kind("llm")
         tspan.exclude_from_message_view()
 
@@ -478,12 +511,10 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
 
     def _append_transcript(self, trace_id: int, message: dict, sort_key: Any) -> None:
         """Append a message to the transcript the root rolls up, keyed for ordering."""
-        conversation = self._transcript_by_trace.get(trace_id) or []
-        conversation.append((sort_key, message))
-        # Re-assign (not just mutate) so each turn refreshes the cache TTL.
-        self._transcript_by_trace[trace_id] = conversation
-
-    # -- realtime user transcript (speech-to-speech) --------------------------
+        with self._state_lock:
+            state = self._get_or_create_state_locked(trace_id)
+            state.transcript.append((sort_key, message))
+            self._refresh_state_locked(state)
 
     def _handle_user_speaking(self, tspan: TranslatedSpan) -> bool:
         """Handle a ``user_speaking`` span — the realtime user turn.
@@ -498,20 +529,18 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
             return True
         thread = str(thread)
 
-        pending = self._pending_user_transcripts.get(thread)
-        if pending:
-            transcript = pending.pop(0)
-            if pending:
-                self._pending_user_transcripts[thread] = pending
-            else:
-                self._pending_user_transcripts.pop(thread, None)
+        with self._state_lock:
+            state = self._get_or_create_state_locked(tspan.span.context.trace_id)
+            self._bind_thread_locked(state, thread)
+            has_transcript = bool(state.pending_user_transcripts)
+            transcript = state.pending_user_transcripts.pop(0) if has_transcript else ""
+            if not has_transcript:
+                state.deferred_user_speaking.append(tspan)
+            self._refresh_state_locked(state)
+        if has_transcript:
             self._apply_user_transcript(tspan, transcript)
             self._export(tspan)
             return False
-
-        held = self._deferred_user_speaking.get(thread) or []
-        held.append(tspan)
-        self._deferred_user_speaking[thread] = held
         return False
 
     def _record_user_transcript(self, thread_id: str, transcript: str) -> None:
@@ -521,19 +550,24 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         buffers it if that span hasn't ended yet.
         """
         tid = str(thread_id)
-        held = self._deferred_user_speaking.get(tid)
-        if held:
-            tspan = held.pop(0)
-            if held:
-                self._deferred_user_speaking[tid] = held
-            else:
-                self._deferred_user_speaking.pop(tid, None)
+        with self._state_lock:
+            state = self._get_state_by_thread_locked(tid)
+            if state is None:
+                pending = self._unmatched_user_transcripts.get(tid) or []
+                pending.append(transcript)
+                self._unmatched_user_transcripts[tid] = pending
+                return
+            tspan = (
+                state.deferred_user_speaking.pop(0)
+                if state.deferred_user_speaking
+                else None
+            )
+            if tspan is None:
+                state.pending_user_transcripts.append(transcript)
+            self._refresh_state_locked(state)
+        if tspan is not None:
             self._apply_user_transcript(tspan, transcript)
             self._export(tspan)
-            return
-        pending = self._pending_user_transcripts.get(tid) or []
-        pending.append(transcript)
-        self._pending_user_transcripts[tid] = pending
 
     def _apply_user_transcript(self, tspan: TranslatedSpan, transcript: str) -> None:
         """Render a fed transcript onto a ``user_speaking`` span as the user's turn.
@@ -547,25 +581,11 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
             tspan.attributes["lk.user_transcript"] = transcript
             msg = build_user_message(transcript)
             tspan.set_messages(prompt=[msg])
-            # Also feed the span-derived rollup. That rollup is only read when
-            # no session report was supplied (see ``_render_conversation``), so
-            # this line does nothing on the report path and is the realtime
-            # user's only route into the root transcript on the egress path.
             self._append_transcript(
                 tspan.span.context.trace_id, msg, tspan.span.start_time
             )
 
-    def _flush_user_speaking(self, thread_id: Optional[str]) -> None:
-        """Export held ``user_speaking`` spans untranscribed (no transcript arrived)."""
-        if thread_id is None:
-            return
-        tid = str(thread_id)
-        for tspan in self._deferred_user_speaking.pop(tid, None) or []:
-            self._export(tspan)
-        self._pending_user_transcripts.pop(tid, None)
-
     def _handle_tool(self, tspan: TranslatedSpan) -> None:
-        """``function_tool``: render as a proper ``tool`` run with its I/O."""
         tspan.set_kind("tool")
         tool_name = tspan.attributes.get("lk.function_tool.name")
         if tool_name:
@@ -577,10 +597,7 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         if output is not None:
             tspan.set_tool_output(output)
 
-    # -- deferred root release ------------------------------------------------
-
     def _handle_root(self, tspan: TranslatedSpan, trace_id: int) -> None:
-        """Mark the conversation root and defer it until the session ends."""
         tspan.set_kind("chain")
         tspan.set_root_span(True)
         tspan.set_metadata("ls_modality", "audio")
@@ -588,78 +605,108 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         tspan.set_metadata(
             "ls_integration_version", (get_package_version("livekit-agents") or "")
         )
+        thread = tspan.attributes.get("langsmith.metadata.thread_id")
+        with self._state_lock:
+            state = self._get_or_create_state_locked(trace_id)
+            state.root = tspan
+            self._bind_thread_locked(state, str(thread) if thread is not None else None)
+            self._refresh_state_locked(state)
+        self._export_conversation_if_ready(trace_id)
 
-        self._deferred_root_by_trace[trace_id] = tspan
-        self._maybe_release(trace_id)
-
-    def _maybe_release(self, trace_id: int, *, force: bool = False) -> None:
+    def _export_conversation_if_ready(
+        self, trace_id: int, *, force: bool = False
+    ) -> None:
         """Export the deferred root once the session ended and audio is ready.
 
-        Requires the root seen, the session ended, and no awaited recording.
-        While a recording is still awaited this arms the timeout that releases
-        the root without one. ``force`` skips both gates — the last-resort path
-        at :meth:`shutdown` for a root that never completed.
+        Requires the root and session end. Recorded modes additionally require
+        one complete :meth:`attach_session_report` delivery; while waiting, this
+        arms the bounded fallback timer. ``force`` skips the gates at shutdown.
         """
-        with self._release_lock:
-            tspan = self._deferred_root_by_trace.get(trace_id)
-            if tspan is None:
-                return
-            thread = self._thread_id_by_trace.get(trace_id)
-            if not force:
-                if trace_id not in self._ended_session_traces:
-                    return
-                if thread is not None and thread in self._threads_awaiting_recording:
-                    self._schedule_release_timeout(trace_id)
-                    return  # still waiting for a recording
+        with self._state_lock:
+            claimed = self._claim_conversation_for_export_locked(trace_id, force=force)
+        if claimed is None:
+            return
+        state, root = claimed
+        self._export_completed_conversation(state, root)
 
-            self._cancel_release_timer(trace_id)
-            self._deferred_root_by_trace.pop(trace_id, None)
-            self._render_conversation(tspan, thread)
-            if thread is not None:
-                self._attach_pending_audio(tspan, thread)
-                self._stamp_recording_origin(tspan, thread)
-            self._export(tspan)
-            self._cleanup_trace(trace_id)
+    def _claim_conversation_for_export_locked(
+        self, trace_id: int, *, force: bool
+    ) -> Optional[tuple[_ConversationState, TranslatedSpan]]:
+        state = self._get_state_locked(trace_id)
+        if state is None or state.root is None:
+            return None
+        if not force and not state.session_ended:
+            return None
+        expects_delivery = (
+            not force and self._recording_mode != "none" and state.thread_id is not None
+        )
+        if expects_delivery and not state.delivery_complete:
+            if not state.delivery_in_progress:
+                self._schedule_release_timeout_locked(state)
+            return None
 
-    def _schedule_release_timeout(self, trace_id: int) -> None:
-        """Arm the one-shot timer that releases a root whose audio never came."""
-        if trace_id in self._release_timers or self._recording_timeout_seconds <= 0:
+        root = state.root
+        self._cancel_release_timer_locked(state)
+        self._state_by_trace.pop(trace_id, None)
+        if state.thread_id is not None:
+            self._trace_by_thread.pop(state.thread_id, None)
+            self._unmatched_user_transcripts.pop(state.thread_id, None)
+        self._forget_thread_id(trace_id)
+        return state, root
+
+    def _export_completed_conversation(
+        self, state: _ConversationState, root: TranslatedSpan
+    ) -> None:
+        for speaking_span in state.deferred_user_speaking:
+            self._export(speaking_span)
+        self._render_conversation(root, state)
+        attached = self._attach_pending_audio(root, state)
+        if attached:
+            self._stamp_recording_origin(root, state.recording_started_at)
+        self._export(root)
+
+    def _schedule_release_timeout_locked(self, state: _ConversationState) -> None:
+        if state.release_timer is not None:
             return
         timer = threading.Timer(
-            self._recording_timeout_seconds, self._on_recording_timeout, (trace_id,)
+            self._recording_timeout_seconds,
+            self._on_recording_timeout,
+            (state.trace_id,),
         )
         timer.daemon = True
-        self._release_timers[trace_id] = timer
+        state.release_timer = timer
+        self._refresh_state_locked(state)
         timer.start()
 
     def _on_recording_timeout(self, trace_id: int) -> None:
-        """Give up waiting for a recording and export the root without one."""
-        with self._release_lock:
-            self._release_timers.pop(trace_id, None)
-            thread = self._thread_id_by_trace.get(trace_id)
-            if thread is not None:
-                if thread not in self._threads_awaiting_recording:
-                    return  # a recording landed just as the timer fired
-                logger.warning(
-                    "langsmith voice: no recording for thread %s after %.1fs; "
-                    "exporting the trace without audio. Call "
-                    "attach_session_report() or complete_recording() at session "
-                    "end, or pass await_recording=False if this session has no "
-                    "audio.",
-                    thread,
-                    self._recording_timeout_seconds,
-                )
-                self._audio_status_by_thread[thread] = "timeout"
-                self._threads_awaiting_recording.pop(thread, None)
-            self._maybe_release(trace_id)
+        with self._state_lock:
+            state = self._get_state_locked(trace_id)
+            if state is None:
+                return
+            state.release_timer = None
+            if state.delivery_complete or state.delivery_in_progress:
+                return
+            logger.warning(
+                "langsmith voice: no session report for thread %s after %.1fs; "
+                "exporting the trace without audio. Call attach_session_report() "
+                "at session end, or configure recording_mode='none'.",
+                state.thread_id,
+                self._recording_timeout_seconds,
+            )
+            state.audio_status = "timeout"
+            state.delivery_complete = True
+            self._refresh_state_locked(state)
+        self._export_conversation_if_ready(trace_id)
 
-    def _cancel_release_timer(self, trace_id: int) -> None:
-        """Cancel a pending timeout (the recording arrived, or we're shutting down)."""
-        timer = self._release_timers.pop(trace_id, None)
+    def _cancel_release_timer_locked(self, state: _ConversationState) -> None:
+        timer = state.release_timer
+        state.release_timer = None
         if timer is not None:
             timer.cancel()
 
-    def _stamp_recording_origin(self, tspan: TranslatedSpan, thread: str) -> None:
+    def _stamp_recording_origin(
+        self, tspan: TranslatedSpan, started_at: Optional[float]
+    ) -> None:
         """Stamp where the recording sits on the trace's timeline, and why.
 
         LiveKit's recorder starts inside ``session.start()`` — after room
@@ -668,10 +715,6 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         player has to assume they coincide, and playback runs ahead of the
         waterfall by that gap.
         """
-        status = self._audio_status_by_thread.get(thread)
-        if status:
-            tspan.set_metadata("ls_audio_attach_status", status)
-        started_at = self._recording_started_at_by_thread.get(thread)
         root_start_ns = tspan.span.start_time
         if started_at is None or root_start_ns is None:
             return
@@ -687,42 +730,22 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         )
 
     def _render_conversation(
-        self, tspan: TranslatedSpan, thread: Optional[str] = None
-    ) -> bool:
+        self, tspan: TranslatedSpan, state: _ConversationState
+    ) -> None:
         """Set the conversation transcript as the root's input.
 
         Prefers a session report's chat history — it is ordered by the messages'
         own timestamps and carries the tool calls — and falls back to the
         transcript assembled from spans when no report was supplied.
         """
-        if thread is not None:
-            messages = self._chat_transcript_by_thread.get(thread)
-            if messages:
-                tspan.set_messages(prompt=messages)
-                return True
-        entries = self._transcript_by_trace.get(tspan.span.context.trace_id, [])
-        if not entries:
-            return False
+        if state.report_transcript:
+            tspan.set_messages(prompt=state.report_transcript)
+            return
+        if not state.transcript:
+            return
         tspan.set_messages(
-            prompt=[msg for _, msg in sorted(entries, key=lambda e: e[0])]
+            prompt=[msg for _, msg in sorted(state.transcript, key=lambda e: e[0])]
         )
-        return True
-
-    def _cleanup_trace(self, trace_id: int) -> None:
-        # Read the thread id before ``_forget_thread_id`` drops it from the base map.
-        thread = self._thread_id_by_trace.get(trace_id)
-        self._transcript_by_trace.pop(trace_id, None)
-        self._forget_thread_id(trace_id)
-        self._ended_session_traces.pop(trace_id, None)
-        self._cancel_release_timer(trace_id)
-        if thread is not None:
-            self._trace_by_thread.pop(thread, None)
-            self._threads_awaiting_recording.pop(thread, None)
-            self._pending_audio_by_thread.pop(thread, None)
-            self._recording_started_at_by_thread.pop(thread, None)
-            self._chat_transcript_by_thread.pop(thread, None)
-            self._audio_status_by_thread.pop(thread, None)
-            self._flush_user_speaking(thread)
 
     def shutdown(self) -> None:
         """Force-export any still-held roots and user_speaking spans, then shut down.
@@ -730,24 +753,30 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         ``force_flush`` deliberately does not — a still-held root there is
         legitimately in progress, not a buffered export waiting to drain.
         """
-        for trace_id in list(self._release_timers):
-            self._cancel_release_timer(trace_id)
-        for trace_id in list(self._deferred_root_by_trace):
-            self._maybe_release(trace_id, force=True)
-        for thread in list(self._deferred_user_speaking.keys()):
-            self._flush_user_speaking(thread)
+        with self._state_lock:
+            trace_ids = list(self._state_by_trace)
+            for state in list(self._state_by_trace.values()):
+                self._cancel_release_timer_locked(state)
+        for trace_id in trace_ids:
+            self._export_conversation_if_ready(trace_id, force=True)
+        with self._state_lock:
+            remaining = list(self._state_by_trace.values())
+            self._state_by_trace.clear()
+            self._trace_by_thread.clear()
+            self._unmatched_user_transcripts.clear()
+        for state in remaining:
+            for speaking_span in state.deferred_user_speaking:
+                self._export(speaking_span)
         super().shutdown()
 
     def force_flush(self, timeout_millis: int = 30000) -> bool:
         """Force-flush the downstream — deferred root spans are NOT finalized."""
         return super().force_flush(timeout_millis)
 
-    # -- audio attachment -----------------------------------------------------
-
-    def _read_audio_file(self, path: Any) -> tuple[Optional[bytes], str]:
+    def _read_audio_file(self, path: Path) -> tuple[Optional[bytes], Optional[str]]:
         """Read a recording from disk, size-checked *before* it is loaded.
 
-        Returns ``(bytes, "attached")`` or ``(None, reason)``. The size is
+        Returns ``(bytes, None)`` or ``(None, reason)``. The size is
         checked with ``stat()`` first so an oversize recording is never read
         into memory. Callers inline the returned bytes — the path itself must
         never reach the LangSmith client, which rejects filesystem-referencing
@@ -772,7 +801,7 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
             )
             return None, "too_large"
         try:
-            return path.read_bytes(), "attached"
+            return path.read_bytes(), None
         except Exception:
             logger.warning(
                 "langsmith voice: failed reading the recording at %s.",
@@ -781,17 +810,31 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
             )
             return None, "unreadable"
 
-    def _attach_pending_audio(self, tspan: TranslatedSpan, thread: str) -> None:
-        """Embed the recording delivered for this conversation, if any."""
-        pending = self._pending_audio_by_thread.pop(thread, None)
-        if not pending or not pending.get("data"):
-            return
-        self._attach_audio(
-            tspan,
-            name=pending["name"],
-            data=pending["data"],
-            mime_type=pending["mime_type"],
-        )
+    def _attach_pending_audio(
+        self, tspan: TranslatedSpan, state: _ConversationState
+    ) -> bool:
+        pending = state.pending_audio
+        attached = False
+        status = state.audio_status
+        if pending is not None:
+            if not pending.data:
+                status = "none"
+            elif (
+                self.audio_size_limit_bytes is not None
+                and len(pending.data) > self.audio_size_limit_bytes
+            ):
+                status = "too_large"
+            else:
+                attached = self._attach_audio(
+                    tspan,
+                    name=pending.name,
+                    data=pending.data,
+                    mime_type=pending.mime_type,
+                )
+                status = "attached" if attached else "none"
+        if status is not None:
+            tspan.set_metadata("ls_audio_attach_status", status)
+        return attached
 
     def _pre_export(self, tspan: TranslatedSpan) -> None:
         """Forward ``lk.*`` to ``langsmith.metadata.lk_*`` and normalize the provider.
@@ -809,21 +852,18 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
                 for name, val in flatten_lk_attributes_to_ls_metadata(
                     parsed, flat_key
                 ).items():
-                    if name not in tspan.attributes:  # don't clobber what a branch set
+                    if name not in tspan.attributes:
                         tspan.attributes[name] = val
                 continue
-            if flat_key in tspan.attributes:  # don't clobber what a branch set
+            if flat_key in tspan.attributes:
                 continue
             tspan.attributes[flat_key] = value
 
-        # Normalize + cross-fill both provider keys from whichever LiveKit set.
         provider = normalize_provider(
             tspan.attributes.get("gen_ai.provider.name")
         ) or normalize_provider(tspan.attributes.get("gen_ai.system"))
         tspan.set_provider(provider)
 
-        # Lift realtime usage wherever LiveKit stamps the blob (agent_turn, or an
-        # orphaned realtime_metrics span). Idempotent: skipped once usage is set.
         if (
             "lk.realtime_model_metrics" in tspan.attributes
             and "langsmith.usage_metadata" not in tspan.attributes

--- a/python/langsmith/integrations/livekit/processor.py
+++ b/python/langsmith/integrations/livekit/processor.py
@@ -4,11 +4,10 @@ Rewrites LiveKit's ``lk.*`` span data into the ``gen_ai.*`` / ``langsmith.*``
 namespaces LangSmith ingests; non-LiveKit spans on the same provider pass
 through untouched.
 
-In recorded modes the root span is held until :meth:`attach_session_report`
-delivers the complete transcript, recording, and time origin as one atomic unit.
-LiveKit's recorder supplies a path on the report; egress supplies bytes in the
-same call. Shared export / ``thread_id`` / message plumbing lives in
-:class:`BaseLangSmithSpanProcessor`.
+The root span is held until its session report arrives. LiveKit's recorder
+supplies audio on that report; egress audio arrives separately through
+:meth:`complete_recording`. Shared export / ``thread_id`` / message plumbing
+lives in :class:`BaseLangSmithSpanProcessor`.
 """
 
 from __future__ import annotations
@@ -50,9 +49,7 @@ from ._state import _ConversationState, _PendingAudio
 DEFAULT_STATE_TTL_SECONDS = 3600.0
 DEFAULT_STATE_MAXSIZE = 100_000
 
-# How long a root span waits for its recording before being exported without
-# one. Bounds the hold so a crashed job — or an ``on_session_end`` that never
-# runs — yields a trace with no audio rather than no trace at all.
+# How long a root span waits for its session data before being exported.
 DEFAULT_RECORDING_TIMEOUT_SECONDS = 30.0
 
 _STT_SPAN = "user_turn"  # audio → transcript (inference)
@@ -102,10 +99,10 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
             audio_mime_type: default MIME type for embedded recordings.
             recording_mode: where recordings come from: ``"session_report"``
                 for LiveKit's recorder, ``"egress"`` for bytes supplied with
-                :meth:`attach_session_report`, or ``"none"`` to export without
-                waiting for a report.
-            recording_timeout_seconds: how long that hold lasts before the root
-                is exported without audio.
+                :meth:`complete_recording`, or ``"none"`` for report data
+                without audio.
+            recording_timeout_seconds: how long the root waits for required
+                session data before it is exported.
             state_ttl_seconds: lifetime for per-conversation state.
         """
         super().__init__(
@@ -119,11 +116,8 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
             raise ValueError(
                 f"recording_mode must be one of {sorted(_RECORDING_MODES)!r}"
             )
-        if recording_mode != "none" and recording_timeout_seconds <= 0:
-            raise ValueError(
-                "recording_timeout_seconds must be greater than zero when a "
-                "recording is expected"
-            )
+        if recording_timeout_seconds <= 0:
+            raise ValueError("recording_timeout_seconds must be greater than zero")
         self._audio_mime_type = audio_mime_type
         self._recording_mode = recording_mode
         self._recording_timeout_seconds = recording_timeout_seconds
@@ -145,9 +139,26 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
 
     def _get_or_create_state(self, trace_id: int) -> _ConversationState:
         state = self._get_state(trace_id)
-        if state is None:
-            state = _ConversationState(trace_id=trace_id)
-            self._state_by_trace[trace_id] = state
+        if state is not None:
+            return state
+
+        state = _ConversationState(trace_id=trace_id)
+        thread_id = self._thread_id_by_trace.get(trace_id)
+        if thread_id is not None:
+            existing_state = self._get_state_by_thread(thread_id)
+            if existing_state is not None:
+                logger.warning(
+                    "langsmith voice: thread id %s is already bound to an active "
+                    "LiveKit trace; recordings require one active trace per thread.",
+                    thread_id,
+                )
+            else:
+                state.thread_id = thread_id
+                self._trace_by_thread[thread_id] = trace_id
+                waiting = self._transcripts_waiting_for_trace.pop(thread_id, None)
+                if waiting:
+                    state.transcripts_waiting_for_span.extend(waiting)
+        self._state_by_trace[trace_id] = state
         return state
 
     def _get_state_by_thread(self, thread_id: str) -> Optional[_ConversationState]:
@@ -162,36 +173,6 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
 
     def _refresh_state(self, state: _ConversationState) -> None:
         self._state_by_trace[state.trace_id] = state
-
-    def _associate_thread_with_state(
-        self, state: _ConversationState, thread_id: Optional[str]
-    ) -> None:
-        if thread_id is None:
-            return
-        thread = str(thread_id)
-        if state.thread_id is not None and state.thread_id != thread:
-            logger.warning(
-                "langsmith voice: trace %x already uses thread id %s; ignoring "
-                "conflicting id %s.",
-                state.trace_id,
-                state.thread_id,
-                thread,
-            )
-            return
-        existing_state = self._get_state_by_thread(thread)
-        if existing_state is not None and existing_state.trace_id != state.trace_id:
-            logger.warning(
-                "langsmith voice: thread id %s is already bound to an active "
-                "LiveKit trace; recordings require one active trace per thread.",
-                thread,
-            )
-            return
-        state.thread_id = thread
-        self._trace_by_thread[thread] = state.trace_id
-        waiting = self._transcripts_waiting_for_trace.pop(thread, None)
-        if waiting:
-            state.transcripts_waiting_for_span.extend(waiting)
-        self._refresh_state(state)
 
     def instrument_session(self, session: Any, thread_id: str) -> None:
         """Subscribe this processor to a LiveKit ``AgentSession``'s events.
@@ -227,143 +208,116 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         self,
         report: Any,
         thread_id: str,
-        *,
-        recording: Optional[bytes] = None,
-        recording_name: str = "recording.ogg",
-        recording_mime_type: Optional[str] = None,
-        recording_started_at: Optional[float] = None,
     ) -> None:
-        """Attach a complete LiveKit session report and release the held root.
+        """Attach a LiveKit session report to the held conversation root.
 
-        This is the single terminal delivery for a recorded conversation. In
-        ``session_report`` mode it reads LiveKit's recording path and origin. In
-        ``egress`` mode pass the external recording bytes and origin in this same
-        call, so the root can never export with only half the delivery. In
-        ``none`` mode roots export at session end and reports are not accepted.
+        The report supplies chat history in every recording mode. In
+        ``session_report`` mode it also supplies the recording; egress audio is
+        delivered separately through :meth:`complete_recording`.
 
         Args:
             report: LiveKit's ``SessionReport`` (duck-typed — the module never
                 imports it, so it stays importable without ``livekit-agents``).
             thread_id: the conversation id, matching :func:`set_thread_id`.
-            recording: external audio bytes in ``egress`` mode.
-            recording_name: attachment name for external audio.
-            recording_mime_type: MIME type for external audio.
-            recording_started_at: external recording's first-sample epoch time.
         """
+        messages = build_messages_from_chat_history(report.chat_history)
+        report_audio = self._audio_from_session_report(report)
+
         thread = str(thread_id)
         with self._state_lock:
-            if not self._claim_report_delivery(thread):
+            state = self._get_state_by_thread(thread)
+            if state is None:
+                self._warn_missing_conversation(thread, "session report")
                 return
+            state.report_transcript = messages
+            state.report_received = True
+            if report_audio is not None:
+                (
+                    state.pending_audio,
+                    state.recording_started_at,
+                    state.audio_status,
+                ) = report_audio
+            self._refresh_state(state)
+            trace_id = state.trace_id
+        self._export_conversation_if_ready(trace_id)
 
-        messages = build_messages_from_chat_history(report.chat_history)
-        pending_audio, started_at, status = self._prepare_report_audio(
-            report,
-            recording=recording,
-            recording_name=recording_name,
-            recording_mime_type=recording_mime_type,
-            recording_started_at=recording_started_at,
-        )
-
-        with self._state_lock:
-            trace_id = self._complete_report_delivery(
-                thread,
-                transcript=messages,
-                pending_audio=pending_audio,
-                recording_started_at=started_at,
-                audio_status=status,
-            )
-        if trace_id is not None:
-            self._export_conversation_if_ready(trace_id)
-
-    def _claim_report_delivery(self, thread_id: str) -> bool:
-        state = self._get_state_by_thread(thread_id)
-        if state is None:
-            logger.warning(
-                "langsmith voice: no active LiveKit trace for thread %s; "
-                "the report arrived after export, or the id did not match "
-                "set_thread_id().",
-                thread_id,
-            )
-            return False
-        if self._recording_mode == "none":
-            logger.warning(
-                "langsmith voice: ignoring a session report for thread %s "
-                "because recording_mode='none' exports at session end.",
-                thread_id,
-            )
-            return False
-        if state.delivery_complete or state.delivery_in_progress:
-            logger.warning(
-                "langsmith voice: ignoring a duplicate session report for thread %s.",
-                thread_id,
-            )
-            return False
-        # Claim delivery and cancel the timeout before file I/O. A timer that
-        # fires after this point observes delivery_in_progress and cannot
-        # export a partial root.
-        state.delivery_in_progress = True
-        self._cancel_release_timer(state)
-        self._refresh_state(state)
-        return True
-
-    def _prepare_report_audio(
-        self,
-        report: Any,
-        *,
-        recording: Optional[bytes],
-        recording_name: str,
-        recording_mime_type: Optional[str],
-        recording_started_at: Optional[float],
-    ) -> tuple[Optional[_PendingAudio], Optional[float], Optional[str]]:
-        if self._recording_mode == "session_report":
-            audio_path = report.audio_recording_path
-            started_at = report.audio_recording_started_at
-            if audio_path is None:
-                return None, started_at, "none"
-            data, status = self._read_audio_file(audio_path)
-            if data is None:
-                return None, started_at, status
-            return (
-                _PendingAudio(
-                    name=audio_path.name,
-                    data=data,
-                    mime_type=self._audio_mime_type,
-                ),
-                started_at,
-                status,
-            )
-        if not recording:
-            return None, recording_started_at, "none"
-        return (
-            _PendingAudio(
-                name=recording_name,
-                data=bytes(recording),
-                mime_type=recording_mime_type or self._audio_mime_type,
-            ),
-            recording_started_at,
-            None,
-        )
-
-    def _complete_report_delivery(
+    def complete_recording(
         self,
         thread_id: str,
+        recording: Optional[bytes],
         *,
-        transcript: list[dict],
-        pending_audio: Optional[_PendingAudio],
-        recording_started_at: Optional[float],
-        audio_status: Optional[str],
-    ) -> Optional[int]:
-        state = self._get_state_by_thread(thread_id)
-        if state is None:
+        name: str = "recording.ogg",
+        mime_type: Optional[str] = None,
+        started_at: Optional[float] = None,
+    ) -> None:
+        """Attach completed egress audio, or ``None`` for a terminal failure.
+
+        ``name`` defaults to ``recording.ogg`` and ``mime_type`` defaults to the
+        processor's configured audio MIME type. ``started_at`` is the epoch time
+        of the recording's first sample and enables waterfall alignment.
+        """
+        if self._recording_mode != "egress":
+            raise RuntimeError("complete_recording() requires recording_mode='egress'")
+
+        pending_audio = None
+        status: Optional[str] = "none"
+        if recording:
+            if (
+                self.audio_size_limit_bytes is not None
+                and len(recording) > self.audio_size_limit_bytes
+            ):
+                status = "too_large"
+            else:
+                pending_audio = _PendingAudio(
+                    name=name,
+                    data=bytes(recording),
+                    mime_type=mime_type or self._audio_mime_type,
+                )
+                status = None
+
+        thread = str(thread_id)
+        with self._state_lock:
+            state = self._get_state_by_thread(thread)
+            if state is None:
+                self._warn_missing_conversation(thread, "recording")
+                return
+            state.pending_audio = pending_audio
+            state.recording_started_at = started_at
+            state.audio_status = status
+            state.recording_received = True
+            self._refresh_state(state)
+            trace_id = state.trace_id
+        self._export_conversation_if_ready(trace_id)
+
+    def _warn_missing_conversation(self, thread_id: str, delivery: str) -> None:
+        logger.warning(
+            "langsmith voice: no active LiveKit trace for thread %s; the %s "
+            "arrived after export, or the id did not match set_thread_id().",
+            thread_id,
+            delivery,
+        )
+
+    def _audio_from_session_report(
+        self, report: Any
+    ) -> Optional[tuple[Optional[_PendingAudio], Optional[float], Optional[str]]]:
+        if self._recording_mode != "session_report":
             return None
-        state.report_transcript = transcript
-        state.pending_audio = pending_audio
-        state.recording_started_at = recording_started_at
-        state.audio_status = audio_status
-        state.delivery_in_progress = False
-        state.delivery_complete = True
-        self._refresh_state(state)
-        return state.trace_id
+        audio_path = report.audio_recording_path
+        started_at = report.audio_recording_started_at
+        if audio_path is None:
+            return None, started_at, "none"
+        data, status = self._read_audio_file(audio_path)
+        if data is None:
+            return None, started_at, status
+        return (
+            _PendingAudio(
+                name=audio_path.name,
+                data=data,
+                mime_type=self._audio_mime_type,
+            ),
+            started_at,
+            status,
+        )
 
     def _dispatch(self, tspan: TranslatedSpan) -> bool:
         trace_id = tspan.span.context.trace_id
@@ -403,9 +357,6 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         tspan.set_kind("chain")
         with self._state_lock:
             state = self._get_or_create_state(trace_id)
-            self._associate_thread_with_state(
-                state, self._thread_id_by_trace.get(trace_id)
-            )
             state.session_ended = True
             held = state.spans_waiting_for_transcript
             state.spans_waiting_for_transcript = []
@@ -524,14 +475,10 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         end). Exported as-is (``True``) when there's no thread id to pair against.
         """
         tspan.set_kind("chain")
-        thread = tspan.attributes.get("langsmith.metadata.thread_id")
-        if thread is None:
-            return True
-        thread = str(thread)
-
         with self._state_lock:
             state = self._get_or_create_state(tspan.span.context.trace_id)
-            self._associate_thread_with_state(state, thread)
+            if state.thread_id is None:
+                return True
             has_transcript = bool(state.transcripts_waiting_for_span)
             transcript = (
                 state.transcripts_waiting_for_span.pop(0) if has_transcript else ""
@@ -607,31 +554,27 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         tspan.set_metadata(
             "ls_integration_version", (get_package_version("livekit-agents") or "")
         )
-        thread = tspan.attributes.get("langsmith.metadata.thread_id")
-        if thread is None and self._recording_mode != "none":
-            logger.warning(
-                "langsmith voice: trace %x has no thread id; its session report "
-                "and recording cannot be attached. Call set_thread_id() before "
-                "the conversation starts, or configure recording_mode='none'.",
-                trace_id,
-            )
         with self._state_lock:
             state = self._get_or_create_state(trace_id)
             state.root = tspan
-            self._associate_thread_with_state(
-                state, str(thread) if thread is not None else None
-            )
             self._refresh_state(state)
+            has_thread_id = state.thread_id is not None
+        if not has_thread_id:
+            logger.warning(
+                "langsmith voice: trace %x has no thread id; its session report "
+                "cannot be attached. Call set_thread_id() before the conversation "
+                "starts.",
+                trace_id,
+            )
         self._export_conversation_if_ready(trace_id)
 
     def _export_conversation_if_ready(
         self, trace_id: int, *, force: bool = False
     ) -> None:
-        """Export the deferred root once the session ended and audio is ready.
+        """Export the deferred root once the required session data is ready.
 
-        Requires the root and session end. Recorded modes additionally require
-        one complete :meth:`attach_session_report` delivery; while waiting, this
-        arms the bounded fallback timer. ``force`` skips the gates at shutdown.
+        Every mode waits for the report. Egress additionally waits for
+        :meth:`complete_recording`. ``force`` skips those gates at shutdown.
         """
         with self._state_lock:
             claimed = self._claim_conversation_for_export(trace_id, force=force)
@@ -648,12 +591,9 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
             return None
         if not force and not state.session_ended:
             return None
-        expects_delivery = (
-            not force and self._recording_mode != "none" and state.thread_id is not None
-        )
-        if expects_delivery and not state.delivery_complete:
-            if not state.delivery_in_progress:
-                self._schedule_release_timeout(state)
+        expects_session_data = not force and state.thread_id is not None
+        if expects_session_data and not self._has_required_session_data(state):
+            self._schedule_release_timeout(state)
             return None
 
         root = state.root
@@ -664,6 +604,11 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
             self._transcripts_waiting_for_trace.pop(state.thread_id, None)
         self._forget_thread_id(trace_id)
         return state, root
+
+    def _has_required_session_data(self, state: _ConversationState) -> bool:
+        return state.report_received and (
+            self._recording_mode != "egress" or state.recording_received
+        )
 
     def _export_completed_conversation(
         self, state: _ConversationState, root: TranslatedSpan
@@ -695,19 +640,22 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
             if state is None:
                 return
             state.release_timer = None
-            if state.delivery_complete or state.delivery_in_progress:
+            if self._has_required_session_data(state):
                 return
+            missing = ["session report"] if not state.report_received else []
+            if self._recording_mode == "egress" and not state.recording_received:
+                missing.append("egress recording")
             logger.warning(
-                "langsmith voice: no session report for thread %s after %.1fs; "
-                "exporting the trace without audio. Call attach_session_report() "
-                "at session end, or configure recording_mode='none'.",
+                "langsmith voice: timed out waiting for %s for thread %s after "
+                "%.1fs; exporting the trace with available session data.",
+                " and ".join(missing),
                 state.thread_id,
                 self._recording_timeout_seconds,
             )
-            state.audio_status = "timeout"
-            state.delivery_complete = True
+            if self._recording_mode != "none" and state.pending_audio is None:
+                state.audio_status = "timeout"
             self._refresh_state(state)
-        self._export_conversation_if_ready(trace_id)
+        self._export_conversation_if_ready(trace_id, force=True)
 
     def _cancel_release_timer(self, state: _ConversationState) -> None:
         timer = state.release_timer

--- a/python/langsmith/integrations/livekit/processor.py
+++ b/python/langsmith/integrations/livekit/processor.py
@@ -138,21 +138,19 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         self._trace_by_thread: MutableMapping[str, int] = _cache()
         # A transcript event may arrive after instrument_session() but before a
         # LiveKit span has given us that thread's trace id.
-        self._unmatched_user_transcripts: MutableMapping[str, list[str]] = _cache()
+        self._transcripts_waiting_for_trace: MutableMapping[str, list[str]] = _cache()
 
-    def _get_state_locked(self, trace_id: int) -> Optional[_ConversationState]:
+    def _get_state(self, trace_id: int) -> Optional[_ConversationState]:
         return self._state_by_trace.get(trace_id)
 
-    def _get_or_create_state_locked(self, trace_id: int) -> _ConversationState:
-        state = self._get_state_locked(trace_id)
+    def _get_or_create_state(self, trace_id: int) -> _ConversationState:
+        state = self._get_state(trace_id)
         if state is None:
             state = _ConversationState(trace_id=trace_id)
             self._state_by_trace[trace_id] = state
         return state
 
-    def _get_state_by_thread_locked(
-        self, thread_id: str
-    ) -> Optional[_ConversationState]:
+    def _get_state_by_thread(self, thread_id: str) -> Optional[_ConversationState]:
         trace_id = self._trace_by_thread.get(thread_id)
         if trace_id is None:
             return None
@@ -162,10 +160,10 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
             return None
         return state
 
-    def _refresh_state_locked(self, state: _ConversationState) -> None:
+    def _refresh_state(self, state: _ConversationState) -> None:
         self._state_by_trace[state.trace_id] = state
 
-    def _associate_thread_with_state_locked(
+    def _associate_thread_with_state(
         self, state: _ConversationState, thread_id: Optional[str]
     ) -> None:
         if thread_id is None:
@@ -180,7 +178,7 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
                 thread,
             )
             return
-        existing_state = self._get_state_by_thread_locked(thread)
+        existing_state = self._get_state_by_thread(thread)
         if existing_state is not None and existing_state.trace_id != state.trace_id:
             logger.warning(
                 "langsmith voice: thread id %s is already bound to an active "
@@ -190,10 +188,10 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
             return
         state.thread_id = thread
         self._trace_by_thread[thread] = state.trace_id
-        unmatched = self._unmatched_user_transcripts.pop(thread, None)
-        if unmatched:
-            state.pending_user_transcripts.extend(unmatched)
-        self._refresh_state_locked(state)
+        waiting = self._transcripts_waiting_for_trace.pop(thread, None)
+        if waiting:
+            state.transcripts_waiting_for_span.extend(waiting)
+        self._refresh_state(state)
 
     def instrument_session(self, session: Any, thread_id: str) -> None:
         """Subscribe this processor to a LiveKit ``AgentSession``'s events.
@@ -254,7 +252,7 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         """
         thread = str(thread_id)
         with self._state_lock:
-            if not self._claim_report_delivery_locked(thread):
+            if not self._claim_report_delivery(thread):
                 return
 
         messages = build_messages_from_chat_history(report.chat_history)
@@ -267,7 +265,7 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         )
 
         with self._state_lock:
-            trace_id = self._complete_report_delivery_locked(
+            trace_id = self._complete_report_delivery(
                 thread,
                 transcript=messages,
                 pending_audio=pending_audio,
@@ -277,8 +275,8 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         if trace_id is not None:
             self._export_conversation_if_ready(trace_id)
 
-    def _claim_report_delivery_locked(self, thread_id: str) -> bool:
-        state = self._get_state_by_thread_locked(thread_id)
+    def _claim_report_delivery(self, thread_id: str) -> bool:
+        state = self._get_state_by_thread(thread_id)
         if state is None:
             logger.warning(
                 "langsmith voice: no active LiveKit trace for thread %s; "
@@ -304,8 +302,8 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         # fires after this point observes delivery_in_progress and cannot
         # export a partial root.
         state.delivery_in_progress = True
-        self._cancel_release_timer_locked(state)
-        self._refresh_state_locked(state)
+        self._cancel_release_timer(state)
+        self._refresh_state(state)
         return True
 
     def _prepare_report_audio(
@@ -346,7 +344,7 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
             None,
         )
 
-    def _complete_report_delivery_locked(
+    def _complete_report_delivery(
         self,
         thread_id: str,
         *,
@@ -355,7 +353,7 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         recording_started_at: Optional[float],
         audio_status: Optional[str],
     ) -> Optional[int]:
-        state = self._get_state_by_thread_locked(thread_id)
+        state = self._get_state_by_thread(thread_id)
         if state is None:
             return None
         state.report_transcript = transcript
@@ -364,7 +362,7 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         state.audio_status = audio_status
         state.delivery_in_progress = False
         state.delivery_complete = True
-        self._refresh_state_locked(state)
+        self._refresh_state(state)
         return state.trace_id
 
     def _dispatch(self, tspan: TranslatedSpan) -> bool:
@@ -404,15 +402,15 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         trace_id = tspan.span.context.trace_id
         tspan.set_kind("chain")
         with self._state_lock:
-            state = self._get_or_create_state_locked(trace_id)
-            self._associate_thread_with_state_locked(
+            state = self._get_or_create_state(trace_id)
+            self._associate_thread_with_state(
                 state, self._thread_id_by_trace.get(trace_id)
             )
             state.session_ended = True
             held = state.deferred_user_speaking
             state.deferred_user_speaking = []
-            state.pending_user_transcripts = []
-            self._refresh_state_locked(state)
+            state.transcripts_waiting_for_span = []
+            self._refresh_state(state)
         for speaking_span in held:
             self._export(speaking_span)
         self._export_conversation_if_ready(trace_id)
@@ -514,9 +512,9 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
     def _append_transcript(self, trace_id: int, message: dict, sort_key: Any) -> None:
         """Append a message to the transcript the root rolls up, keyed for ordering."""
         with self._state_lock:
-            state = self._get_or_create_state_locked(trace_id)
+            state = self._get_or_create_state(trace_id)
             state.transcript.append((sort_key, message))
-            self._refresh_state_locked(state)
+            self._refresh_state(state)
 
     def _handle_user_speaking(self, tspan: TranslatedSpan) -> bool:
         """Handle a ``user_speaking`` span — the realtime user turn.
@@ -532,13 +530,15 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         thread = str(thread)
 
         with self._state_lock:
-            state = self._get_or_create_state_locked(tspan.span.context.trace_id)
-            self._associate_thread_with_state_locked(state, thread)
-            has_transcript = bool(state.pending_user_transcripts)
-            transcript = state.pending_user_transcripts.pop(0) if has_transcript else ""
+            state = self._get_or_create_state(tspan.span.context.trace_id)
+            self._associate_thread_with_state(state, thread)
+            has_transcript = bool(state.transcripts_waiting_for_span)
+            transcript = (
+                state.transcripts_waiting_for_span.pop(0) if has_transcript else ""
+            )
             if not has_transcript:
                 state.deferred_user_speaking.append(tspan)
-            self._refresh_state_locked(state)
+            self._refresh_state(state)
         if has_transcript:
             self._apply_user_transcript(tspan, transcript)
             self._export(tspan)
@@ -553,11 +553,11 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         """
         tid = str(thread_id)
         with self._state_lock:
-            state = self._get_state_by_thread_locked(tid)
+            state = self._get_state_by_thread(tid)
             if state is None:
-                pending = self._unmatched_user_transcripts.get(tid) or []
-                pending.append(transcript)
-                self._unmatched_user_transcripts[tid] = pending
+                waiting = self._transcripts_waiting_for_trace.get(tid) or []
+                waiting.append(transcript)
+                self._transcripts_waiting_for_trace[tid] = waiting
                 return
             tspan = (
                 state.deferred_user_speaking.pop(0)
@@ -565,8 +565,8 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
                 else None
             )
             if tspan is None:
-                state.pending_user_transcripts.append(transcript)
-            self._refresh_state_locked(state)
+                state.transcripts_waiting_for_span.append(transcript)
+            self._refresh_state(state)
         if tspan is not None:
             self._apply_user_transcript(tspan, transcript)
             self._export(tspan)
@@ -616,12 +616,12 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
                 trace_id,
             )
         with self._state_lock:
-            state = self._get_or_create_state_locked(trace_id)
+            state = self._get_or_create_state(trace_id)
             state.root = tspan
-            self._associate_thread_with_state_locked(
+            self._associate_thread_with_state(
                 state, str(thread) if thread is not None else None
             )
-            self._refresh_state_locked(state)
+            self._refresh_state(state)
         self._export_conversation_if_ready(trace_id)
 
     def _export_conversation_if_ready(
@@ -634,16 +634,16 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         arms the bounded fallback timer. ``force`` skips the gates at shutdown.
         """
         with self._state_lock:
-            claimed = self._claim_conversation_for_export_locked(trace_id, force=force)
+            claimed = self._claim_conversation_for_export(trace_id, force=force)
         if claimed is None:
             return
         state, root = claimed
         self._export_completed_conversation(state, root)
 
-    def _claim_conversation_for_export_locked(
+    def _claim_conversation_for_export(
         self, trace_id: int, *, force: bool
     ) -> Optional[tuple[_ConversationState, TranslatedSpan]]:
-        state = self._get_state_locked(trace_id)
+        state = self._get_state(trace_id)
         if state is None or state.root is None:
             return None
         if not force and not state.session_ended:
@@ -653,15 +653,15 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         )
         if expects_delivery and not state.delivery_complete:
             if not state.delivery_in_progress:
-                self._schedule_release_timeout_locked(state)
+                self._schedule_release_timeout(state)
             return None
 
         root = state.root
-        self._cancel_release_timer_locked(state)
+        self._cancel_release_timer(state)
         self._state_by_trace.pop(trace_id, None)
         if state.thread_id is not None:
             self._trace_by_thread.pop(state.thread_id, None)
-            self._unmatched_user_transcripts.pop(state.thread_id, None)
+            self._transcripts_waiting_for_trace.pop(state.thread_id, None)
         self._forget_thread_id(trace_id)
         return state, root
 
@@ -676,7 +676,7 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
             self._stamp_recording_origin(root, state.recording_started_at)
         self._export(root)
 
-    def _schedule_release_timeout_locked(self, state: _ConversationState) -> None:
+    def _schedule_release_timeout(self, state: _ConversationState) -> None:
         if state.release_timer is not None:
             return
         timer = threading.Timer(
@@ -686,12 +686,12 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         )
         timer.daemon = True
         state.release_timer = timer
-        self._refresh_state_locked(state)
+        self._refresh_state(state)
         timer.start()
 
     def _on_recording_timeout(self, trace_id: int) -> None:
         with self._state_lock:
-            state = self._get_state_locked(trace_id)
+            state = self._get_state(trace_id)
             if state is None:
                 return
             state.release_timer = None
@@ -706,10 +706,10 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
             )
             state.audio_status = "timeout"
             state.delivery_complete = True
-            self._refresh_state_locked(state)
+            self._refresh_state(state)
         self._export_conversation_if_ready(trace_id)
 
-    def _cancel_release_timer_locked(self, state: _ConversationState) -> None:
+    def _cancel_release_timer(self, state: _ConversationState) -> None:
         timer = state.release_timer
         state.release_timer = None
         if timer is not None:
@@ -767,14 +767,14 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         with self._state_lock:
             trace_ids = list(self._state_by_trace)
             for state in list(self._state_by_trace.values()):
-                self._cancel_release_timer_locked(state)
+                self._cancel_release_timer(state)
         for trace_id in trace_ids:
             self._export_conversation_if_ready(trace_id, force=True)
         with self._state_lock:
             remaining = list(self._state_by_trace.values())
             self._state_by_trace.clear()
             self._trace_by_thread.clear()
-            self._unmatched_user_transcripts.clear()
+            self._transcripts_waiting_for_trace.clear()
         for state in remaining:
             for speaking_span in state.deferred_user_speaking:
                 self._export(speaking_span)

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -71,7 +71,7 @@ pipecat = [
 
 # Enabled via `pip install langsmith[livekit]`
 livekit = [
-    "livekit-agents>=1.0",
+    "livekit-agents>=1.3",
     "opentelemetry-sdk>=1.30.0",
     "opentelemetry-api>=1.30.0",
     "opentelemetry-exporter-otlp-proto-http>=1.30.0",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -71,7 +71,7 @@ pipecat = [
 
 # Enabled via `pip install langsmith[livekit]`
 livekit = [
-    "livekit-agents>=1.3",
+    "livekit-agents>=1.6",
     "opentelemetry-sdk>=1.30.0",
     "opentelemetry-api>=1.30.0",
     "opentelemetry-exporter-otlp-proto-http>=1.30.0",

--- a/python/tests/unit_tests/wrappers/test_livekit.py
+++ b/python/tests/unit_tests/wrappers/test_livekit.py
@@ -147,8 +147,8 @@ class TestDispatchDisposition:
 
         assert proc._trace_by_thread["call-1"] == 0xABC
 
-    def test_recorded_root_without_thread_warns_once(self, caplog):
-        proc = _processor()
+    def test_egress_root_without_thread_warns_once(self, caplog):
+        proc = _processor(recording_mode="egress")
         proc.on_end(_make_span("job_entrypoint", parent=None))
         proc.on_end(_make_span("agent_session", span_id=0x2))
 
@@ -661,6 +661,43 @@ class _RecordingHarness:
 
 
 class TestAutomaticSessionReport(_RecordingHarness):
+    def test_report_hook_correlates_unthreaded_trace_by_trace_id(
+        self, monkeypatch, tmp_path
+    ):
+        audio = tmp_path / "unthreaded.ogg"
+        audio.write_bytes(b"unthreaded-audio")
+        session = _FakeLifecycleSession()
+        ctx = _FakeJobContext(session, _report(path=audio))
+        current_context = {"value": ctx}
+        _install_fake_livekit(monkeypatch, current_context)
+        proc = _processor()
+
+        self._start_conversation(proc, thread_id=None)
+        self._start_session(proc, thread_id=None)
+        self._end_session(proc)
+        assert self._root(proc) is None
+
+        session.close()
+
+        root = self._root(proc)
+        payload = json.loads(root._attributes["langsmith.attachments"])
+        assert base64.b64decode(payload[0]["content"]) == b"unthreaded-audio"
+        assert "langsmith.metadata.thread_id" not in root._attributes
+        assert ctx.make_report_calls == [session]
+
+    def test_unthreaded_egress_does_not_wait_for_report(self, monkeypatch):
+        session = _FakeLifecycleSession()
+        ctx = _FakeJobContext(session, _report())
+        current_context = {"value": ctx}
+        _install_fake_livekit(monkeypatch, current_context)
+        proc = _processor(recording_mode="egress")
+
+        self._start_conversation(proc, thread_id=None)
+        self._start_session(proc, thread_id=None)
+        self._end_session(proc)
+
+        assert self._root(proc) is not None
+
     def test_direct_processor_captures_report_on_session_close(
         self, monkeypatch, tmp_path
     ):
@@ -1129,6 +1166,53 @@ class TestEgressDeliveryRace(_RecordingHarness):
 
 class TestRecordingTimeout(_RecordingHarness):
     """A recording that never arrives yields a trace without audio, not no trace."""
+
+    def test_shutdown_waits_for_in_flight_timeout_export(self):
+        proc = _processor(recording_timeout_seconds=60.0)
+        self._start_conversation(proc)
+        self._end_session(proc)
+        state = proc._get_state_by_thread("call-1")
+        assert state is not None
+        assert state.release_timer is not None
+        state.release_timer.cancel()
+
+        export_started = threading.Event()
+        allow_export = threading.Event()
+        shutdown_started = threading.Event()
+        shutdown_finished = threading.Event()
+        original_export = proc._export_completed_conversation
+
+        def blocking_export(state, root):
+            export_started.set()
+            assert allow_export.wait(timeout=5)
+            original_export(state, root)
+
+        def shut_down():
+            shutdown_started.set()
+            proc.shutdown()
+            shutdown_finished.set()
+
+        proc._export_completed_conversation = blocking_export
+        timeout_thread = threading.Thread(
+            target=proc._on_recording_timeout, args=(0xABC,)
+        )
+        timeout_thread.start()
+        assert export_started.wait(timeout=5)
+
+        shutdown_thread = threading.Thread(target=shut_down)
+        shutdown_thread.start()
+        assert shutdown_started.wait(timeout=5)
+        assert not shutdown_finished.wait(timeout=0.05)
+
+        allow_export.set()
+        timeout_thread.join(timeout=5)
+        shutdown_thread.join(timeout=5)
+
+        assert not timeout_thread.is_alive()
+        assert not shutdown_thread.is_alive()
+        assert shutdown_finished.is_set()
+        assert self._root(proc) is not None
+        proc.downstream.shutdown.assert_called_once()
 
     def test_timeout_releases_the_root(self):
         proc = _processor(recording_timeout_seconds=0.05)

--- a/python/tests/unit_tests/wrappers/test_livekit.py
+++ b/python/tests/unit_tests/wrappers/test_livekit.py
@@ -66,6 +66,13 @@ def _processor(**kwargs):
     return LiveKitLangSmithSpanProcessor(downstream_processor=MagicMock(), **kwargs)
 
 
+def _start_span(proc, span, thread_id):
+    set_thread_id(thread_id)
+    proc.on_start(span)
+    set_thread_id(None)
+    return span
+
+
 class TestDispatchDisposition:
     """``_dispatch`` decides whether the base exports each span."""
 
@@ -181,10 +188,9 @@ class TestRealtimeUserTranscript:
     def teardown_method(self):
         set_thread_id(None)
 
-    def _speaking(self, *, thread="call-1", trace_id=0xABC, span_id=0x2):
+    def _speaking(self, *, trace_id=0xABC, span_id=0x2):
         return _make_span(
             "user_speaking",
-            {"langsmith.metadata.thread_id": thread},
             trace_id=trace_id,
             span_id=span_id,
         )
@@ -199,7 +205,7 @@ class TestRealtimeUserTranscript:
     def test_transcript_after_span_stamps_and_exports(self):
         # Span ends empty first (held), then the transcript arrives.
         proc = _processor()
-        proc.on_end(self._speaking())
+        proc.on_end(_start_span(proc, self._speaking(), "call-1"))
         # Held — nothing exported yet.
         assert self._exported(proc, "user_speaking") == []
 
@@ -228,7 +234,7 @@ class TestRealtimeUserTranscript:
         proc._record_user_transcript("call-1", "hello there")
         assert self._exported(proc, "user_speaking") == []
 
-        proc.on_end(self._speaking())
+        proc.on_end(_start_span(proc, self._speaking(), "call-1"))
 
         exported = self._exported(proc, "user_speaking")
         assert len(exported) == 1
@@ -238,8 +244,8 @@ class TestRealtimeUserTranscript:
     def test_fifo_pairing_within_conversation(self):
         # Two utterances, two transcripts — paired in order.
         proc = _processor()
-        proc.on_end(self._speaking(span_id=0x2))
-        proc.on_end(self._speaking(span_id=0x3))
+        proc.on_end(_start_span(proc, self._speaking(span_id=0x2), "call-1"))
+        proc.on_end(_start_span(proc, self._speaking(span_id=0x3), "call-1"))
         proc._record_user_transcript("call-1", "first")
         proc._record_user_transcript("call-1", "second")
 
@@ -262,7 +268,7 @@ class TestRealtimeUserTranscript:
         # A final-but-empty transcript still pairs (keeping FIFO aligned) but
         # renders no fabricated I/O.
         proc = _processor()
-        proc.on_end(self._speaking())
+        proc.on_end(_start_span(proc, self._speaking(), "call-1"))
         proc._record_user_transcript("call-1", "")
 
         exported = self._exported(proc, "user_speaking")
@@ -281,7 +287,7 @@ class TestRealtimeUserTranscript:
         proc.on_start(_make_span("job_entrypoint", parent=None, trace_id=tid))
         set_thread_id(None)
         proc.on_end(_make_span("job_entrypoint", parent=None, trace_id=tid))
-        proc.on_end(self._speaking(trace_id=tid))
+        proc.on_end(_start_span(proc, self._speaking(trace_id=tid), "call-1"))
         assert self._exported(proc, "user_speaking") == []  # held
 
         proc.on_end(_make_span("agent_session", trace_id=tid, span_id=0x3))
@@ -291,7 +297,7 @@ class TestRealtimeUserTranscript:
 
     def test_shutdown_flushes_untranscribed_span(self):
         proc = _processor(recording_mode="none")
-        proc.on_end(self._speaking())
+        proc.on_end(_start_span(proc, self._speaking(), "call-1"))
         proc.shutdown()
         assert len(self._exported(proc, "user_speaking")) == 1
 
@@ -315,18 +321,20 @@ class TestRealtimeRootRollup:
         proc = _processor(recording_mode="none")
         tid = 0xABC
         proc.on_end(
-            _make_span(
-                "job_entrypoint",
-                {"langsmith.metadata.thread_id": "call-1"},
-                parent=None,
-                trace_id=tid,
+            _start_span(
+                proc,
+                _make_span(
+                    "job_entrypoint",
+                    parent=None,
+                    trace_id=tid,
+                ),
+                "call-1",
             )
         )
         # User speaks (early span), then the reply turn lands and is recorded...
         proc.on_end(
             _make_span(
                 "user_speaking",
-                {"langsmith.metadata.thread_id": "call-1"},
                 trace_id=tid,
                 span_id=0x2,
                 start_time=10,
@@ -344,6 +352,7 @@ class TestRealtimeRootRollup:
         # ...only *then* does the transcript arrive (out of order).
         proc._record_user_transcript("call-1", "weather?")
         proc.on_end(_make_span("agent_session", trace_id=tid, span_id=0x4))
+        proc.attach_session_report(_report(), thread_id="call-1")
 
         root = self._root(proc)
         prompt = json.loads(root._attributes["gen_ai.prompt"])["messages"]
@@ -356,11 +365,14 @@ class TestRealtimeRootRollup:
         proc = _processor(recording_mode="none")
         tid = 0xABC
         proc.on_end(
-            _make_span(
-                "job_entrypoint",
-                {"langsmith.metadata.thread_id": "call-1"},
-                parent=None,
-                trace_id=tid,
+            _start_span(
+                proc,
+                _make_span(
+                    "job_entrypoint",
+                    parent=None,
+                    trace_id=tid,
+                ),
+                "call-1",
             )
         )
         proc.on_end(
@@ -375,7 +387,6 @@ class TestRealtimeRootRollup:
         proc.on_end(
             _make_span(
                 "user_speaking",
-                {"langsmith.metadata.thread_id": "call-1"},
                 trace_id=tid,
                 span_id=0x3,
                 start_time=10,
@@ -392,6 +403,7 @@ class TestRealtimeRootRollup:
         )
         proc._record_user_transcript("call-1", "weather?")
         proc.on_end(_make_span("agent_session", trace_id=tid, span_id=0x5))
+        proc.attach_session_report(_report(), thread_id="call-1")
 
         root = self._root(proc)
         contents = [
@@ -429,13 +441,8 @@ class TestInstrumentSession:
         session = self._FakeSession()
         proc.instrument_session(session, "call-1")
 
-        proc.on_end(
-            _make_span(
-                "user_speaking",
-                {"langsmith.metadata.thread_id": "call-1"},
-                span_id=0x2,
-            )
-        )
+        span = _make_span("user_speaking", span_id=0x2)
+        proc.on_end(_start_span(proc, span, "call-1"))
         session.handlers["user_input_transcribed"](
             self._event(is_final=True, transcript="hello there")
         )
@@ -587,34 +594,58 @@ class _RecordingHarness:
 
 
 class TestEgressRecording(_RecordingHarness):
-    """An egress report delivers transcript and external audio atomically."""
+    """Egress report data and external audio may arrive in either order."""
 
-    def test_holds_until_complete_with_audio(self):
-        proc = _processor(recording_mode="egress")
-        self._start_conversation(proc)
-        self._end_session(proc)
-        # Session ended but recording still awaited → root NOT exported.
-        assert self._root(proc) is None
-
-        proc.attach_session_report(
-            _report(),
-            thread_id="call-1",
-            recording=b"OggS-bytes",
-            recording_name="call.ogg",
-        )
-
-        root = self._root(proc)
-        payload = json.loads(root._attributes["langsmith.attachments"])
-        assert base64.b64decode(payload[0]["content"]) == b"OggS-bytes"
-        assert (
-            root._attributes["langsmith.metadata.ls_audio_attach_status"] == "attached"
-        )
-
-    def test_complete_with_none_releases_without_audio(self):
+    def test_report_then_recording(self):
         proc = _processor(recording_mode="egress")
         self._start_conversation(proc)
         self._end_session(proc)
         proc.attach_session_report(_report(), thread_id="call-1")
+        assert self._root(proc) is None
+
+        proc.complete_recording("call-1", b"OggS-bytes", name="call.ogg")
+
+        root = self._root(proc)
+        payload = json.loads(root._attributes["langsmith.attachments"])
+        assert base64.b64decode(payload[0]["content"]) == b"OggS-bytes"
+        assert payload[0]["name"] == "call.ogg"
+        assert payload[0]["mime_type"] == "audio/ogg"
+        assert (
+            root._attributes["langsmith.metadata.ls_audio_attach_status"] == "attached"
+        )
+
+    def test_recording_then_report(self):
+        proc = _processor(recording_mode="egress")
+        self._start_conversation(proc)
+        self._end_session(proc)
+        proc.complete_recording("call-1", b"OggS-bytes")
+        assert self._root(proc) is None
+
+        proc.attach_session_report(_report(), thread_id="call-1")
+
+        assert "langsmith.attachments" in self._root(proc)._attributes
+
+    def test_report_audio_is_ignored(self, tmp_path):
+        report_audio = tmp_path / "report.ogg"
+        report_audio.write_bytes(b"wrong audio")
+        proc = _processor(recording_mode="egress")
+        self._start_conversation(proc)
+        self._end_session(proc)
+
+        proc.attach_session_report(_report(path=report_audio), thread_id="call-1")
+        proc.complete_recording("call-1", b"egress audio")
+
+        payload = json.loads(self._root(proc)._attributes["langsmith.attachments"])
+        assert base64.b64decode(payload[0]["content"]) == b"egress audio"
+
+    def test_terminal_recording_failure_releases_without_audio(self):
+        proc = _processor(recording_mode="egress")
+        self._start_conversation(proc)
+        self._end_session(proc)
+        proc.attach_session_report(_report(), thread_id="call-1")
+        assert self._root(proc) is None
+
+        proc.complete_recording("call-1", None)
 
         root = self._root(proc)
         assert "langsmith.attachments" not in root._attributes
@@ -624,16 +655,30 @@ class TestEgressRecording(_RecordingHarness):
         proc = _processor(recording_mode="egress")
         self._start_conversation(proc)
         self._end_session(proc)
-        # Egress began 4.25s after the trace did.
-        proc.attach_session_report(
-            _report(),
-            thread_id="call-1",
-            recording=b"x",
-            recording_started_at=(_ROOT_START_NS / 1e9) + 4.25,
+        proc.attach_session_report(_report(), thread_id="call-1")
+        proc.complete_recording(
+            "call-1",
+            b"x",
+            started_at=(_ROOT_START_NS / 1e9) + 4.25,
         )
 
         md = self._root(proc)._attributes
         assert md["langsmith.metadata.ls_audio_recording_start_offset_ms"] == 4250
+
+    def test_complete_recording_requires_egress_mode(self):
+        proc = _processor()
+        with pytest.raises(RuntimeError, match="recording_mode='egress'"):
+            proc.complete_recording("call-1", b"x")
+
+    def test_oversize_recording_is_not_buffered(self):
+        proc = _processor(recording_mode="egress", audio_size_limit_bytes=3)
+        self._start_conversation(proc)
+        proc.complete_recording("call-1", b"large")
+
+        state = proc._get_state_by_thread("call-1")
+        assert state.recording_received is True
+        assert state.pending_audio is None
+        assert state.audio_status == "too_large"
 
 
 class TestSessionReport(_RecordingHarness):
@@ -733,10 +778,10 @@ class TestSessionReport(_RecordingHarness):
         assert md["langsmith.metadata.ls_audio_attach_status"] == "none"
 
 
-class TestAtomicDelivery(_RecordingHarness):
-    """One terminal delivery always exports one complete trace."""
+class TestEgressDeliveryRace(_RecordingHarness):
+    """The report/recording race exports exactly one complete root."""
 
-    def test_duplicate_deliveries_export_once(self):
+    def test_concurrent_report_and_recording_export_once(self):
         for attempt in range(40):
             proc = _processor(recording_mode="egress", recording_timeout_seconds=5.0)
             self._start_conversation(proc, tid=0xABC + attempt)
@@ -754,18 +799,17 @@ class TestAtomicDelivery(_RecordingHarness):
             )
             start = threading.Barrier(2)
 
-            def deliver():
+            def deliver_report():
                 start.wait()
-                proc.attach_session_report(
-                    report,
-                    thread_id="call-1",
-                    recording=b"OggS-egress",
-                    recording_started_at=1.0,
-                )
+                proc.attach_session_report(report, thread_id="call-1")
+
+            def deliver_recording():
+                start.wait()
+                proc.complete_recording("call-1", b"OggS-egress", started_at=1.0)
 
             threads = [
-                threading.Thread(target=deliver),
-                threading.Thread(target=deliver),
+                threading.Thread(target=deliver_report),
+                threading.Thread(target=deliver_recording),
             ]
             for t in threads:
                 t.start()
@@ -777,39 +821,10 @@ class TestAtomicDelivery(_RecordingHarness):
                 for c in proc.downstream.on_end.call_args_list
                 if c.args[0]._attributes.get("langsmith.root_span")
             ]
-            # Exactly one root, and its single delivery carries both pieces.
             assert len(roots) == 1, f"attempt {attempt}: {len(roots)} roots"
             assert "langsmith.attachments" in roots[0]._attributes, attempt
             messages = json.loads(roots[0]._attributes["gen_ai.prompt"])["messages"]
             assert messages == [{"role": "user", "content": "Hello"}]
-
-    def test_delivery_claim_cancels_timeout_before_file_read(self, tmp_path):
-        audio = tmp_path / "audio.ogg"
-        audio.write_bytes(b"OggS")
-        proc = _processor(recording_timeout_seconds=0.05)
-        self._start_conversation(proc)
-        self._end_session(proc)
-        entered = threading.Event()
-        resume = threading.Event()
-        read_audio = proc._read_audio_file
-
-        def slow_read(path):
-            entered.set()
-            assert resume.wait(timeout=2)
-            return read_audio(path)
-
-        proc._read_audio_file = slow_read
-        delivery = threading.Thread(
-            target=proc.attach_session_report,
-            args=(_report(path=audio), "call-1"),
-        )
-        delivery.start()
-        assert entered.wait(timeout=2)
-        time.sleep(0.1)
-        assert self._root(proc) is None
-        resume.set()
-        delivery.join(timeout=2)
-        assert "langsmith.attachments" in self._root(proc)._attributes
 
 
 class TestRecordingTimeout(_RecordingHarness):
@@ -832,20 +847,36 @@ class TestRecordingTimeout(_RecordingHarness):
             root._attributes["langsmith.metadata.ls_audio_attach_status"] == "timeout"
         )
 
-    def test_none_mode_releases_immediately(self):
+    def test_egress_timeout_releases_when_recording_never_arrives(self):
+        proc = _processor(recording_mode="egress", recording_timeout_seconds=0.05)
+        self._start_conversation(proc)
+        self._end_session(proc)
+        proc.attach_session_report(_report(), thread_id="call-1")
+
+        deadline = time.monotonic() + 2.0
+        while self._root(proc) is None and time.monotonic() < deadline:
+            time.sleep(0.01)
+
+        root = self._root(proc)
+        assert root is not None
+        assert (
+            root._attributes["langsmith.metadata.ls_audio_attach_status"] == "timeout"
+        )
+
+    def test_none_mode_waits_for_report(self):
         proc = _processor(recording_mode="none")
         self._start_conversation(proc)
         self._end_session(proc)
-        # Nothing to wait for — the trace exports as soon as the session ends.
+        assert self._root(proc) is None
+
+        proc.attach_session_report(_report(), thread_id="call-1")
+
         assert self._root(proc) is not None
 
     @pytest.mark.parametrize("timeout", [0, -1])
     def test_nonpositive_timeout_is_rejected(self, timeout):
         with pytest.raises(ValueError, match="greater than zero"):
             _processor(recording_timeout_seconds=timeout)
-
-    def test_nonpositive_timeout_is_irrelevant_without_recording(self):
-        _processor(recording_mode="none", recording_timeout_seconds=0)
 
     def test_unknown_recording_mode_is_rejected(self):
         with pytest.raises(ValueError, match="recording_mode"):
@@ -967,7 +998,7 @@ class TestChatHistoryTranscript(_RecordingHarness):
             "name": "get_weather",
         }
 
-    def test_egress_report_and_audio_are_one_delivery(self):
+    def test_egress_report_and_audio_are_combined(self):
         proc = _processor(recording_mode="egress")
         self._start_conversation(proc)
         self._end_session(proc)
@@ -984,11 +1015,13 @@ class TestChatHistoryTranscript(_RecordingHarness):
                 ]
             ),
             thread_id="call-1",
-            recording=b"OggS-egress",
-            recording_started_at=(_ROOT_START_NS / 1e9) + 3.0,
+        )
+        proc.complete_recording(
+            "call-1",
+            b"OggS-egress",
+            started_at=(_ROOT_START_NS / 1e9) + 3.0,
         )
 
-        # The root is released once, carrying both pieces from the same call.
         root = self._root(proc)
         md = root._attributes
         payload = json.loads(md["langsmith.attachments"])
@@ -996,7 +1029,7 @@ class TestChatHistoryTranscript(_RecordingHarness):
         assert md["langsmith.metadata.ls_audio_recording_start_offset_ms"] == 3000
         assert self._messages(root) == [{"role": "user", "content": "Hello"}]
 
-    def test_none_mode_does_not_claim_late_report_transcript(self):
+    def test_none_mode_uses_report_transcript(self):
         proc = _processor(recording_mode="none")
         self._start_conversation(proc)
         self._end_session(proc)
@@ -1014,7 +1047,7 @@ class TestChatHistoryTranscript(_RecordingHarness):
             thread_id="call-1",
         )
         root = self._root(proc)
-        assert "gen_ai.prompt" not in root._attributes
+        assert self._messages(root) == [{"role": "user", "content": "Hello"}]
 
     def test_egress_path_falls_back_to_span_rollup(self):
         proc = _processor(recording_mode="egress")
@@ -1029,7 +1062,8 @@ class TestChatHistoryTranscript(_RecordingHarness):
         )
         self._end_session(proc)
         # An empty report transcript falls back to the conversation's spans.
-        proc.attach_session_report(_report(), thread_id="call-1", recording=b"x")
+        proc.attach_session_report(_report(), thread_id="call-1")
+        proc.complete_recording("call-1", b"x")
 
         messages = self._messages(self._root(proc))
         assert [m["content"] for m in messages] == ["Hello", "Hi there"]
@@ -1072,6 +1106,29 @@ class TestThreadId:
 
     def teardown_method(self):
         set_thread_id(None)
+
+    def test_state_uses_captured_thread_id(self):
+        proc = _processor()
+        proc._remember_thread_id(0xABC, "call-1")
+
+        with proc._state_lock:
+            state = proc._get_or_create_state(0xABC)
+
+        assert state.thread_id == "call-1"
+        assert proc._trace_by_thread == {"call-1": 0xABC}
+
+    def test_thread_cannot_route_to_two_active_traces(self):
+        proc = _processor()
+        proc._remember_thread_id(0xABC, "call-1")
+        proc._remember_thread_id(0xDEF, "call-1")
+
+        with proc._state_lock:
+            first = proc._get_or_create_state(0xABC)
+            second = proc._get_or_create_state(0xDEF)
+
+        assert first.thread_id == "call-1"
+        assert second.thread_id is None
+        assert proc._trace_by_thread["call-1"] == 0xABC
 
     def test_set_thread_id_injected(self):
         proc = _processor()

--- a/python/tests/unit_tests/wrappers/test_livekit.py
+++ b/python/tests/unit_tests/wrappers/test_livekit.py
@@ -220,7 +220,7 @@ class TestRealtimeUserTranscript:
         # No state left behind.
         state = proc._state_by_trace[0xABC]
         assert state.deferred_user_speaking == []
-        assert state.pending_user_transcripts == []
+        assert state.transcripts_waiting_for_span == []
 
     def test_transcript_before_span_is_buffered(self):
         # Transcript can race ahead of the span's on_end — buffer, then apply.
@@ -233,7 +233,7 @@ class TestRealtimeUserTranscript:
         exported = self._exported(proc, "user_speaking")
         assert len(exported) == 1
         assert exported[0]._attributes["lk.user_transcript"] == "hello there"
-        assert len(proc._unmatched_user_transcripts) == 0
+        assert len(proc._transcripts_waiting_for_trace) == 0
 
     def test_fifo_pairing_within_conversation(self):
         # Two utterances, two transcripts — paired in order.
@@ -457,7 +457,7 @@ class TestInstrumentSession:
             self._event(is_final=False, transcript="partial")
         )
         # Interim result buffered nothing; a later span has no transcript to pair.
-        assert len(proc._unmatched_user_transcripts) == 0
+        assert len(proc._transcripts_waiting_for_trace) == 0
 
 
 class TestForceFlush:

--- a/python/tests/unit_tests/wrappers/test_livekit.py
+++ b/python/tests/unit_tests/wrappers/test_livekit.py
@@ -16,6 +16,7 @@ import pytest
 
 from langsmith._internal.voice import set_thread_id
 from langsmith.integrations.livekit._helpers import (
+    build_assistant_tool_call_message,
     build_message_from_event,
     normalize_provider,
 )
@@ -118,6 +119,16 @@ class TestDispatchDisposition:
         set_thread_id(None)
 
         assert proc._trace_by_thread["call-1"] == 0xABC
+
+    def test_recorded_root_without_thread_warns_once(self, caplog):
+        proc = _processor()
+        proc.on_end(_make_span("job_entrypoint", parent=None))
+        proc.on_end(_make_span("agent_session", span_id=0x2))
+
+        warnings = [
+            message for message in caplog.messages if "has no thread id" in message
+        ]
+        assert len(warnings) == 1
 
 
 class TestDeferredRootRelease:
@@ -1095,6 +1106,22 @@ class TestMessageFromEvent:
         event = MagicMock()
         event.attributes = attributes
         return event
+
+    def test_build_assistant_tool_call_message(self):
+        assert build_assistant_tool_call_message("call_1", "lookup", '{"q": "x"}') == {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {
+                        "name": "lookup",
+                        "arguments": '{"q": "x"}',
+                    },
+                }
+            ],
+        }
 
     def test_tool_calls_forwarded_unchanged(self):
         call = {

--- a/python/tests/unit_tests/wrappers/test_livekit.py
+++ b/python/tests/unit_tests/wrappers/test_livekit.py
@@ -7,7 +7,12 @@ mocked and no framework install is needed.
 
 import base64
 import json
+import threading
+import time
+from types import SimpleNamespace
 from unittest.mock import MagicMock
+
+import pytest
 
 from langsmith._internal.voice import set_thread_id
 from langsmith.integrations.livekit._helpers import (
@@ -476,56 +481,529 @@ class TestForceFlush:
         )
 
 
-class TestEgressRecording:
-    """expect_recording / complete_recording hold the root for late egress audio."""
+class _FakeChatHistory:
+    """Stands in for LiveKit's ``ChatContext``; only ``to_dict`` is read.
+
+    The keyword list mirrors a real ``ChatContext.to_dict`` — deliberately
+    *without* ``strip_markup``, which only exists on newer livekit-agents than
+    the floor. Passing an unsupported keyword must not cost us the transcript.
+    """
+
+    def __init__(self, items):
+        self._items = items
+
+    def to_dict(
+        self,
+        *,
+        exclude_image=True,
+        exclude_audio=True,
+        exclude_timestamp=True,
+        exclude_function_call=False,
+        exclude_metrics=False,
+        exclude_config_update=False,
+    ):
+        # The processor must ask for timestamps and keep function calls — the
+        # transcript is ordered by created_at and shows the tool calls.
+        assert exclude_timestamp is False
+        assert exclude_function_call is False
+        return {"items": self._items}
+
+
+class _NewerChatHistory(_FakeChatHistory):
+    """A newer ``ChatContext`` that also accepts ``strip_markup``."""
+
+    def __init__(self, items):
+        super().__init__(items)
+        self.strip_markup_seen = None
+
+    def to_dict(
+        self,
+        *,
+        exclude_image=True,
+        exclude_audio=True,
+        exclude_timestamp=True,
+        exclude_function_call=False,
+        exclude_metrics=False,
+        exclude_config_update=False,
+        strip_markup=False,
+    ):
+        self.strip_markup_seen = strip_markup
+        return super().to_dict(
+            exclude_image=exclude_image,
+            exclude_audio=exclude_audio,
+            exclude_timestamp=exclude_timestamp,
+            exclude_function_call=exclude_function_call,
+            exclude_metrics=exclude_metrics,
+            exclude_config_update=exclude_config_update,
+        )
+
+
+def _report(*, path=None, started_at=None, items=None):
+    """A duck-typed LiveKit ``SessionReport``."""
+    return SimpleNamespace(
+        audio_recording_path=path,
+        audio_recording_started_at=started_at,
+        chat_history=_FakeChatHistory(items or []),
+    )
+
+
+# One second in nanoseconds — root start times are OTel ns, origins are epoch s.
+_NS = 1_000_000_000
+_ROOT_START_NS = 1_700_000_000 * _NS
+
+
+class _RecordingHarness:
+    """Drives one conversation through the processor: start, spans, session end."""
 
     def teardown_method(self):
         set_thread_id(None)
 
-    def _start_conversation(self, proc, tid):
+    def _start_conversation(self, proc, tid=0xABC, start_time=_ROOT_START_NS):
         # The root's thread id comes from set_thread_id (captured at on_start),
         # exactly as in production; clearing it after simulates the detached end.
         set_thread_id("call-1")
-        proc.on_start(_make_span("job_entrypoint", parent=None, trace_id=tid))
-        set_thread_id(None)
-        proc.on_end(_make_span("job_entrypoint", parent=None, trace_id=tid))
-
-    def test_expect_holds_until_complete_with_audio(self):
-        proc = _processor()
-        tid = 0xABC
-        proc.expect_recording("call-1")
-        self._start_conversation(proc, tid)
-        proc.on_end(_make_span("agent_session", trace_id=tid, span_id=0x3))
-        # Session ended but recording still awaited → root NOT exported.
-        assert not any(
-            c.args[0]._attributes.get("langsmith.root_span")
-            for c in proc.downstream.on_end.call_args_list
+        proc.on_start(
+            _make_span(
+                "job_entrypoint", parent=None, trace_id=tid, start_time=start_time
+            )
         )
+        set_thread_id(None)
+        proc.on_end(
+            _make_span(
+                "job_entrypoint", parent=None, trace_id=tid, start_time=start_time
+            )
+        )
+
+    def _end_session(self, proc, tid=0xABC):
+        proc.on_end(_make_span("agent_session", trace_id=tid, span_id=0x3))
+
+    def _root(self, proc):
+        return next(
+            (
+                c.args[0]
+                for c in proc.downstream.on_end.call_args_list
+                if c.args[0]._attributes.get("langsmith.root_span")
+            ),
+            None,
+        )
+
+
+class TestEgressRecording(_RecordingHarness):
+    """complete_recording holds the root for a late egress recording."""
+
+    def test_holds_until_complete_with_audio(self):
+        proc = _processor()
+        self._start_conversation(proc)
+        self._end_session(proc)
+        # Session ended but recording still awaited → root NOT exported.
+        assert self._root(proc) is None
 
         proc.complete_recording("call-1", b"OggS-bytes", name="call.ogg")
 
-        root = next(
-            c.args[0]
-            for c in proc.downstream.on_end.call_args_list
-            if c.args[0]._attributes.get("langsmith.root_span")
-        )
+        root = self._root(proc)
         payload = json.loads(root._attributes["langsmith.attachments"])
         assert base64.b64decode(payload[0]["content"]) == b"OggS-bytes"
+        assert (
+            root._attributes["langsmith.metadata.ls_audio_attach_status"] == "attached"
+        )
 
     def test_complete_with_none_releases_without_audio(self):
         proc = _processor()
-        tid = 0xABC
-        proc.expect_recording("call-1")
-        self._start_conversation(proc, tid)
-        proc.on_end(_make_span("agent_session", trace_id=tid, span_id=0x3))
+        self._start_conversation(proc)
+        self._end_session(proc)
         proc.complete_recording("call-1", None)
 
-        root = next(
-            c.args[0]
-            for c in proc.downstream.on_end.call_args_list
-            if c.args[0]._attributes.get("langsmith.root_span")
-        )
+        root = self._root(proc)
         assert "langsmith.attachments" not in root._attributes
+        assert root._attributes["langsmith.metadata.ls_audio_attach_status"] == "none"
+
+    def test_started_at_stamps_the_offset(self):
+        proc = _processor()
+        self._start_conversation(proc)
+        self._end_session(proc)
+        # Egress began 4.25s after the trace did.
+        proc.complete_recording(
+            "call-1", b"x", started_at=(_ROOT_START_NS / 1e9) + 4.25
+        )
+
+        md = self._root(proc)._attributes
+        assert md["langsmith.metadata.ls_audio_recording_start_offset_ms"] == 4250
+
+
+class TestSessionReport(_RecordingHarness):
+    """attach_session_report delivers audio, origin, and transcript in one call."""
+
+    def test_attaches_audio_and_offset(self, tmp_path):
+        audio = tmp_path / "audio.ogg"
+        audio.write_bytes(b"OggS-session")
+        proc = _processor()
+        self._start_conversation(proc)
+        self._end_session(proc)
+        assert self._root(proc) is None
+
+        proc.attach_session_report(
+            _report(path=audio, started_at=(_ROOT_START_NS / 1e9) + 2.8),
+            thread_id="call-1",
+        )
+
+        root = self._root(proc)
+        md = root._attributes
+        payload = json.loads(md["langsmith.attachments"])
+        assert base64.b64decode(payload[0]["content"]) == b"OggS-session"
+        assert payload[0]["name"] == "audio.ogg"
+        assert md["langsmith.metadata.ls_audio_recording_start_offset_ms"] == 2800
+        assert md["langsmith.metadata.ls_audio_recording_started_at"] == pytest.approx(
+            (_ROOT_START_NS / 1e9) + 2.8
+        )
+        assert md["langsmith.metadata.ls_audio_attach_status"] == "attached"
+
+    def test_offset_can_be_negative(self, tmp_path):
+        audio = tmp_path / "audio.ogg"
+        audio.write_bytes(b"x")
+        proc = _processor()
+        self._start_conversation(proc)
+        self._end_session(proc)
+        # A recording that predates the trace must not be clamped to zero.
+        proc.attach_session_report(
+            _report(path=audio, started_at=(_ROOT_START_NS / 1e9) - 1.5),
+            thread_id="call-1",
+        )
+
+        offset = self._root(proc)._attributes[
+            "langsmith.metadata.ls_audio_recording_start_offset_ms"
+        ]
+        assert offset == -1500
+
+    def test_absent_origin_stamps_neither_key(self, tmp_path):
+        audio = tmp_path / "audio.ogg"
+        audio.write_bytes(b"x")
+        proc = _processor()
+        self._start_conversation(proc)
+        self._end_session(proc)
+        proc.attach_session_report(
+            _report(path=audio, started_at=None), thread_id="call-1"
+        )
+
+        md = self._root(proc)._attributes
+        assert "langsmith.metadata.ls_audio_recording_started_at" not in md
+        assert "langsmith.metadata.ls_audio_recording_start_offset_ms" not in md
+        # The audio still attaches; only the alignment is unknown.
+        assert "langsmith.attachments" in md
+
+    def test_oversize_recording_is_never_read(self, tmp_path):
+        audio = tmp_path / "audio.ogg"
+        audio.write_bytes(b"x" * 500)
+        proc = _processor(audio_size_limit_bytes=100)
+        self._start_conversation(proc)
+        self._end_session(proc)
+        proc.attach_session_report(_report(path=audio), thread_id="call-1")
+
+        md = self._root(proc)._attributes
+        assert "langsmith.attachments" not in md
+        assert md["langsmith.metadata.ls_audio_attach_status"] == "too_large"
+
+    def test_missing_file_reports_unreadable(self, tmp_path):
+        proc = _processor()
+        self._start_conversation(proc)
+        self._end_session(proc)
+        proc.attach_session_report(
+            _report(path=tmp_path / "gone.ogg"), thread_id="call-1"
+        )
+
+        md = self._root(proc)._attributes
+        assert "langsmith.attachments" not in md
+        assert md["langsmith.metadata.ls_audio_attach_status"] == "unreadable"
+
+
+class TestConcurrentDelivery(_RecordingHarness):
+    """Two deliveries racing must still export exactly one complete trace."""
+
+    def test_report_and_recording_arriving_together(self, tmp_path):
+        for attempt in range(40):
+            proc = _processor(recording_timeout_seconds=5.0)
+            self._start_conversation(proc, tid=0xABC + attempt)
+            self._end_session(proc, tid=0xABC + attempt)
+
+            report = _report(
+                items=[
+                    {
+                        "type": "message",
+                        "role": "user",
+                        "content": ["Hello"],
+                        "created_at": 1.0,
+                    }
+                ]
+            )
+            start = threading.Barrier(2)
+
+            def deliver_report():
+                start.wait()
+                proc.attach_session_report(report, thread_id="call-1")
+
+            def deliver_audio():
+                start.wait()
+                proc.complete_recording("call-1", b"OggS-egress", started_at=1.0)
+
+            threads = [
+                threading.Thread(target=deliver_report),
+                threading.Thread(target=deliver_audio),
+            ]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join(timeout=5)
+
+            roots = [
+                c.args[0]
+                for c in proc.downstream.on_end.call_args_list
+                if c.args[0]._attributes.get("langsmith.root_span")
+            ]
+            # Exactly one root, and it always carries the audio — whichever
+            # delivery lands second is the one that releases.
+            assert len(roots) == 1, f"attempt {attempt}: {len(roots)} roots"
+            assert "langsmith.attachments" in roots[0]._attributes, attempt
+
+    def test_two_audioless_reports_still_release_on_timeout(self):
+        """Both take the early return, so only the timeout can release."""
+        proc = _processor(recording_timeout_seconds=0.05)
+        self._start_conversation(proc)
+        self._end_session(proc)
+        proc.attach_session_report(_report(), thread_id="call-1")
+        proc.attach_session_report(_report(), thread_id="call-1")
+        assert self._root(proc) is None
+
+        deadline = time.monotonic() + 2.0
+        while self._root(proc) is None and time.monotonic() < deadline:
+            time.sleep(0.01)
+        assert self._root(proc) is not None
+
+
+class TestRecordingTimeout(_RecordingHarness):
+    """A recording that never arrives yields a trace without audio, not no trace."""
+
+    def test_timeout_releases_the_root(self):
+        proc = _processor(recording_timeout_seconds=0.05)
+        self._start_conversation(proc)
+        self._end_session(proc)
+        assert self._root(proc) is None
+
+        deadline = time.monotonic() + 2.0
+        while self._root(proc) is None and time.monotonic() < deadline:
+            time.sleep(0.01)
+
+        root = self._root(proc)
+        assert root is not None
+        assert "langsmith.attachments" not in root._attributes
+        assert (
+            root._attributes["langsmith.metadata.ls_audio_attach_status"] == "timeout"
+        )
+
+    def test_await_disabled_releases_immediately(self):
+        proc = _processor(await_recording=False)
+        self._start_conversation(proc)
+        self._end_session(proc)
+        # Nothing to wait for — the trace exports as soon as the session ends.
+        assert self._root(proc) is not None
+
+
+class TestChatHistoryTranscript(_RecordingHarness):
+    """The root transcript comes from the report's chat history when present."""
+
+    def _messages(self, root):
+        return json.loads(root._attributes["gen_ai.prompt"])["messages"]
+
+    def _audio(self, tmp_path):
+        """A recording on the report, so it releases the root on arrival."""
+        f = tmp_path / "audio.ogg"
+        f.write_bytes(b"OggS")
+        return f
+
+    def test_orders_by_created_at_and_drops_instructions(self, tmp_path):
+        proc = _processor()
+        self._start_conversation(proc)
+        self._end_session(proc)
+        proc.attach_session_report(
+            _report(
+                path=self._audio(tmp_path),
+                items=[
+                    {
+                        "type": "message",
+                        "role": "assistant",
+                        "content": ["Hi there"],
+                        "created_at": 20.0,
+                    },
+                    {
+                        "type": "message",
+                        "role": "system",
+                        "content": ["You are a bot"],
+                        "created_at": 0.0,
+                    },
+                    {
+                        "type": "message",
+                        "role": "user",
+                        "content": ["Hello"],
+                        "created_at": 10.0,
+                    },
+                ],
+            ),
+            thread_id="call-1",
+        )
+
+        messages = self._messages(self._root(proc))
+        assert messages == [
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi there"},
+        ]
+
+    def test_keeps_function_calls_and_outputs(self, tmp_path):
+        proc = _processor()
+        self._start_conversation(proc)
+        self._end_session(proc)
+        proc.attach_session_report(
+            _report(
+                path=self._audio(tmp_path),
+                items=[
+                    {
+                        "type": "message",
+                        "role": "user",
+                        "content": ["Weather in Paris?"],
+                        "created_at": 1.0,
+                    },
+                    {
+                        "type": "function_call",
+                        "call_id": "c1",
+                        "name": "get_weather",
+                        "arguments": '{"city": "Paris"}',
+                        "created_at": 2.0,
+                    },
+                    {
+                        "type": "function_call_output",
+                        "call_id": "c1",
+                        "name": "get_weather",
+                        "output": "18C",
+                        "is_error": False,
+                        "created_at": 3.0,
+                    },
+                    {
+                        "type": "message",
+                        "role": "assistant",
+                        "content": ["It's 18 degrees."],
+                        "created_at": 4.0,
+                    },
+                ],
+            ),
+            thread_id="call-1",
+        )
+
+        messages = self._messages(self._root(proc))
+        assert [m["role"] for m in messages] == [
+            "user",
+            "assistant",
+            "tool",
+            "assistant",
+        ]
+        call = messages[1]["tool_calls"][0]
+        assert call["id"] == "c1"
+        assert call["function"]["name"] == "get_weather"
+        assert json.loads(call["function"]["arguments"]) == {"city": "Paris"}
+        assert messages[2] == {
+            "role": "tool",
+            "content": "18C",
+            "tool_call_id": "c1",
+            "name": "get_weather",
+        }
+
+    def test_uses_strip_markup_only_where_supported(self, tmp_path):
+        """Newer livekit-agents gets strip_markup; the floor version must not."""
+        proc = _processor()
+        self._start_conversation(proc)
+        self._end_session(proc)
+        history = _NewerChatHistory(
+            [{"type": "message", "role": "user", "content": ["Hi"], "created_at": 1.0}]
+        )
+        report = SimpleNamespace(
+            audio_recording_path=self._audio(tmp_path),
+            audio_recording_started_at=None,
+            chat_history=history,
+        )
+        proc.attach_session_report(report, thread_id="call-1")
+
+        assert history.strip_markup_seen is True
+        assert self._messages(self._root(proc)) == [{"role": "user", "content": "Hi"}]
+
+    def test_report_without_audio_waits_for_egress(self):
+        """A report with no recording is the egress case: hold for the audio."""
+        proc = _processor()
+        self._start_conversation(proc)
+        self._end_session(proc)
+
+        # Transcript arrives first, from the report. No recording on it, so the
+        # root must NOT export yet — the egress audio is still coming.
+        proc.attach_session_report(
+            _report(
+                items=[
+                    {
+                        "type": "message",
+                        "role": "user",
+                        "content": ["Hello"],
+                        "created_at": 1.0,
+                    }
+                ]
+            ),
+            thread_id="call-1",
+        )
+        assert self._root(proc) is None
+
+        proc.complete_recording(
+            "call-1", b"OggS-egress", started_at=(_ROOT_START_NS / 1e9) + 3.0
+        )
+
+        # One trace carrying BOTH the egress audio and the report's transcript.
+        root = self._root(proc)
+        md = root._attributes
+        payload = json.loads(md["langsmith.attachments"])
+        assert base64.b64decode(payload[0]["content"]) == b"OggS-egress"
+        assert md["langsmith.metadata.ls_audio_recording_start_offset_ms"] == 3000
+        assert self._messages(root) == [{"role": "user", "content": "Hello"}]
+
+    def test_report_without_audio_releases_when_not_awaiting(self):
+        """With await_recording=False there is no audio coming; do not stall."""
+        proc = _processor(await_recording=False)
+        self._start_conversation(proc)
+        self._end_session(proc)
+        proc.attach_session_report(
+            _report(
+                items=[
+                    {
+                        "type": "message",
+                        "role": "user",
+                        "content": ["Hello"],
+                        "created_at": 1.0,
+                    }
+                ]
+            ),
+            thread_id="call-1",
+        )
+        # Already exported at session end; the transcript still lands on it.
+        assert self._root(proc) is not None
+
+    def test_egress_path_falls_back_to_span_rollup(self):
+        proc = _processor()
+        self._start_conversation(proc)
+        proc.on_end(
+            _make_span(
+                "agent_turn",
+                {"lk.user_input": "Hello", "lk.response.text": "Hi there"},
+                trace_id=0xABC,
+                span_id=0x2,
+            )
+        )
+        self._end_session(proc)
+        # No report — the transcript still comes from the conversation's spans.
+        proc.complete_recording("call-1", b"x")
+
+        messages = self._messages(self._root(proc))
+        assert [m["content"] for m in messages] == ["Hello", "Hi there"]
 
 
 class TestStateTTL:

--- a/python/tests/unit_tests/wrappers/test_livekit.py
+++ b/python/tests/unit_tests/wrappers/test_livekit.py
@@ -219,7 +219,7 @@ class TestRealtimeUserTranscript:
         assert "gen_ai.completion" not in span._attributes
         # No state left behind.
         state = proc._state_by_trace[0xABC]
-        assert state.deferred_user_speaking == []
+        assert state.spans_waiting_for_transcript == []
         assert state.transcripts_waiting_for_span == []
 
     def test_transcript_before_span_is_buffered(self):
@@ -287,7 +287,7 @@ class TestRealtimeUserTranscript:
         proc.on_end(_make_span("agent_session", trace_id=tid, span_id=0x3))
 
         assert len(self._exported(proc, "user_speaking")) == 1
-        assert proc._state_by_trace[tid].deferred_user_speaking == []
+        assert proc._state_by_trace[tid].spans_waiting_for_transcript == []
 
     def test_shutdown_flushes_untranscribed_span(self):
         proc = _processor(recording_mode="none")

--- a/python/tests/unit_tests/wrappers/test_livekit.py
+++ b/python/tests/unit_tests/wrappers/test_livekit.py
@@ -603,7 +603,7 @@ class TestEgressRecording(_RecordingHarness):
         proc.attach_session_report(_report(), thread_id="call-1")
         assert self._root(proc) is None
 
-        proc.complete_recording("call-1", b"OggS-bytes", name="call.ogg")
+        proc.complete_recording("call-1", data=b"OggS-bytes", name="call.ogg")
 
         root = self._root(proc)
         payload = json.loads(root._attributes["langsmith.attachments"])

--- a/python/tests/unit_tests/wrappers/test_livekit.py
+++ b/python/tests/unit_tests/wrappers/test_livekit.py
@@ -1195,7 +1195,7 @@ class TestChatHistoryTranscript(_RecordingHarness):
         f.write_bytes(b"OggS")
         return f
 
-    def test_orders_by_created_at_and_keeps_instructions(self, tmp_path):
+    def test_preserves_livekit_item_order_and_keeps_instructions(self, tmp_path):
         proc = _processor()
         self._start_conversation(proc)
         self._end_session(proc)
@@ -1205,27 +1205,27 @@ class TestChatHistoryTranscript(_RecordingHarness):
                 items=[
                     {
                         "type": "message",
-                        "role": "assistant",
-                        "content": ["Hi there"],
-                        "created_at": 20.0,
-                    },
-                    {
-                        "type": "message",
                         "role": "system",
                         "content": ["You are a bot"],
-                        "created_at": 0.0,
+                        "created_at": 20.0,
                     },
                     {
                         "type": "message",
                         "role": "developer",
                         "content": ["Be concise"],
-                        "created_at": 5.0,
+                        "created_at": 0.0,
                     },
                     {
                         "type": "message",
                         "role": "user",
                         "content": ["Hello"],
                         "created_at": 10.0,
+                    },
+                    {
+                        "type": "message",
+                        "role": "assistant",
+                        "content": ["Hi there"],
+                        "created_at": 5.0,
                     },
                 ],
             ),
@@ -1259,7 +1259,7 @@ class TestChatHistoryTranscript(_RecordingHarness):
                         "call_id": "c1",
                         "name": "get_weather",
                         "arguments": '{"city": "Paris"}',
-                        "created_at": 2.0,
+                        "created_at": 3.0,
                     },
                     {
                         "type": "function_call_output",
@@ -1267,13 +1267,13 @@ class TestChatHistoryTranscript(_RecordingHarness):
                         "name": "get_weather",
                         "output": "18C",
                         "is_error": False,
-                        "created_at": 3.0,
+                        "created_at": 4.0,
                     },
                     {
                         "type": "message",
                         "role": "assistant",
                         "content": ["It's 18 degrees."],
-                        "created_at": 4.0,
+                        "created_at": 2.0,
                     },
                 ],
             ),

--- a/python/tests/unit_tests/wrappers/test_livekit.py
+++ b/python/tests/unit_tests/wrappers/test_livekit.py
@@ -99,7 +99,25 @@ class TestDispatchDisposition:
         exported = proc.downstream.on_end.call_args.args[0]
         assert "langsmith.root_span" not in exported._attributes
         assert "langsmith.metadata.ls_modality" not in exported._attributes
-        assert len(proc._deferred_root_by_trace) == 0
+        assert len(proc._state_by_trace) == 0
+
+    def test_non_livekit_trace_cannot_hijack_recording_route(self):
+        proc = _processor()
+        set_thread_id("call-1")
+        proc.on_start(_make_span("job_entrypoint", parent=None, trace_id=0xABC))
+        proc.on_end(_make_span("job_entrypoint", parent=None, trace_id=0xABC))
+
+        proc.on_start(
+            _make_span(
+                "ChatOpenAI",
+                parent=None,
+                scope="langsmith",
+                trace_id=0xDEF,
+            )
+        )
+        set_thread_id(None)
+
+        assert proc._trace_by_thread["call-1"] == 0xABC
 
 
 class TestDeferredRootRelease:
@@ -137,8 +155,7 @@ class TestDeferredRootRelease:
         assert [m["content"] for m in prompt] == ["weather?", "sunny"]
         assert "gen_ai.completion" not in root._attributes
         # Per-conversation state freed after release.
-        assert len(proc._deferred_root_by_trace) == 0
-        assert len(proc._transcript_by_trace) == 0
+        assert len(proc._state_by_trace) == 0
 
 
 class TestRealtimeUserTranscript:
@@ -190,8 +207,9 @@ class TestRealtimeUserTranscript:
         }
         assert "gen_ai.completion" not in span._attributes
         # No state left behind.
-        assert len(proc._deferred_user_speaking) == 0
-        assert len(proc._pending_user_transcripts) == 0
+        state = proc._state_by_trace[0xABC]
+        assert state.deferred_user_speaking == []
+        assert state.pending_user_transcripts == []
 
     def test_transcript_before_span_is_buffered(self):
         # Transcript can race ahead of the span's on_end — buffer, then apply.
@@ -204,7 +222,7 @@ class TestRealtimeUserTranscript:
         exported = self._exported(proc, "user_speaking")
         assert len(exported) == 1
         assert exported[0]._attributes["lk.user_transcript"] == "hello there"
-        assert len(proc._pending_user_transcripts) == 0
+        assert len(proc._unmatched_user_transcripts) == 0
 
     def test_fifo_pairing_within_conversation(self):
         # Two utterances, two transcripts — paired in order.
@@ -258,10 +276,10 @@ class TestRealtimeUserTranscript:
         proc.on_end(_make_span("agent_session", trace_id=tid, span_id=0x3))
 
         assert len(self._exported(proc, "user_speaking")) == 1
-        assert len(proc._deferred_user_speaking) == 0
+        assert proc._state_by_trace[tid].deferred_user_speaking == []
 
     def test_shutdown_flushes_untranscribed_span(self):
-        proc = _processor()
+        proc = _processor(recording_mode="none")
         proc.on_end(self._speaking())
         proc.shutdown()
         assert len(self._exported(proc, "user_speaking")) == 1
@@ -283,7 +301,7 @@ class TestRealtimeRootRollup:
         )
 
     def test_user_sorts_before_reply_despite_late_arrival(self):
-        proc = _processor()
+        proc = _processor(recording_mode="none")
         tid = 0xABC
         proc.on_end(
             _make_span(
@@ -324,7 +342,7 @@ class TestRealtimeRootRollup:
     def test_greeting_then_user_turn_ordered(self):
         # Agent greets first (agent_turn, no user_speaking), then a user turn.
         # The greeting must not steal the user's transcript, and order holds.
-        proc = _processor()
+        proc = _processor(recording_mode="none")
         tid = 0xABC
         proc.on_end(
             _make_span(
@@ -428,7 +446,7 @@ class TestInstrumentSession:
             self._event(is_final=False, transcript="partial")
         )
         # Interim result buffered nothing; a later span has no transcript to pair.
-        assert len(proc._pending_user_transcripts) == 0
+        assert len(proc._unmatched_user_transcripts) == 0
 
 
 class TestForceFlush:
@@ -457,7 +475,7 @@ class TestForceFlush:
             c.args[0]._attributes.get("langsmith.root_span")
             for c in proc.downstream.on_end.call_args_list
         )
-        assert tid in proc._deferred_root_by_trace
+        assert proc._state_by_trace[tid].root is not None
 
         # When the session finally ends, the complete root is exported once.
         proc.on_end(_make_span("agent_session", trace_id=tid, span_id=0x3))
@@ -484,9 +502,7 @@ class TestForceFlush:
 class _FakeChatHistory:
     """Stands in for LiveKit's ``ChatContext``; only ``to_dict`` is read.
 
-    The keyword list mirrors a real ``ChatContext.to_dict`` — deliberately
-    *without* ``strip_markup``, which only exists on newer livekit-agents than
-    the floor. Passing an unsupported keyword must not cost us the transcript.
+    The keyword list mirrors the public ``livekit-agents>=1.3`` contract.
     """
 
     def __init__(self, items):
@@ -507,35 +523,6 @@ class _FakeChatHistory:
         assert exclude_timestamp is False
         assert exclude_function_call is False
         return {"items": self._items}
-
-
-class _NewerChatHistory(_FakeChatHistory):
-    """A newer ``ChatContext`` that also accepts ``strip_markup``."""
-
-    def __init__(self, items):
-        super().__init__(items)
-        self.strip_markup_seen = None
-
-    def to_dict(
-        self,
-        *,
-        exclude_image=True,
-        exclude_audio=True,
-        exclude_timestamp=True,
-        exclude_function_call=False,
-        exclude_metrics=False,
-        exclude_config_update=False,
-        strip_markup=False,
-    ):
-        self.strip_markup_seen = strip_markup
-        return super().to_dict(
-            exclude_image=exclude_image,
-            exclude_audio=exclude_audio,
-            exclude_timestamp=exclude_timestamp,
-            exclude_function_call=exclude_function_call,
-            exclude_metrics=exclude_metrics,
-            exclude_config_update=exclude_config_update,
-        )
 
 
 def _report(*, path=None, started_at=None, items=None):
@@ -589,16 +576,21 @@ class _RecordingHarness:
 
 
 class TestEgressRecording(_RecordingHarness):
-    """complete_recording holds the root for a late egress recording."""
+    """An egress report delivers transcript and external audio atomically."""
 
     def test_holds_until_complete_with_audio(self):
-        proc = _processor()
+        proc = _processor(recording_mode="egress")
         self._start_conversation(proc)
         self._end_session(proc)
         # Session ended but recording still awaited → root NOT exported.
         assert self._root(proc) is None
 
-        proc.complete_recording("call-1", b"OggS-bytes", name="call.ogg")
+        proc.attach_session_report(
+            _report(),
+            thread_id="call-1",
+            recording=b"OggS-bytes",
+            recording_name="call.ogg",
+        )
 
         root = self._root(proc)
         payload = json.loads(root._attributes["langsmith.attachments"])
@@ -608,22 +600,25 @@ class TestEgressRecording(_RecordingHarness):
         )
 
     def test_complete_with_none_releases_without_audio(self):
-        proc = _processor()
+        proc = _processor(recording_mode="egress")
         self._start_conversation(proc)
         self._end_session(proc)
-        proc.complete_recording("call-1", None)
+        proc.attach_session_report(_report(), thread_id="call-1")
 
         root = self._root(proc)
         assert "langsmith.attachments" not in root._attributes
         assert root._attributes["langsmith.metadata.ls_audio_attach_status"] == "none"
 
     def test_started_at_stamps_the_offset(self):
-        proc = _processor()
+        proc = _processor(recording_mode="egress")
         self._start_conversation(proc)
         self._end_session(proc)
         # Egress began 4.25s after the trace did.
-        proc.complete_recording(
-            "call-1", b"x", started_at=(_ROOT_START_NS / 1e9) + 4.25
+        proc.attach_session_report(
+            _report(),
+            thread_id="call-1",
+            recording=b"x",
+            recording_started_at=(_ROOT_START_NS / 1e9) + 4.25,
         )
 
         md = self._root(proc)._attributes
@@ -714,13 +709,25 @@ class TestSessionReport(_RecordingHarness):
         assert "langsmith.attachments" not in md
         assert md["langsmith.metadata.ls_audio_attach_status"] == "unreadable"
 
+    def test_empty_file_reports_none(self, tmp_path):
+        audio = tmp_path / "empty.ogg"
+        audio.write_bytes(b"")
+        proc = _processor()
+        self._start_conversation(proc)
+        self._end_session(proc)
+        proc.attach_session_report(_report(path=audio), thread_id="call-1")
 
-class TestConcurrentDelivery(_RecordingHarness):
-    """Two deliveries racing must still export exactly one complete trace."""
+        md = self._root(proc)._attributes
+        assert "langsmith.attachments" not in md
+        assert md["langsmith.metadata.ls_audio_attach_status"] == "none"
 
-    def test_report_and_recording_arriving_together(self, tmp_path):
+
+class TestAtomicDelivery(_RecordingHarness):
+    """One terminal delivery always exports one complete trace."""
+
+    def test_duplicate_deliveries_export_once(self):
         for attempt in range(40):
-            proc = _processor(recording_timeout_seconds=5.0)
+            proc = _processor(recording_mode="egress", recording_timeout_seconds=5.0)
             self._start_conversation(proc, tid=0xABC + attempt)
             self._end_session(proc, tid=0xABC + attempt)
 
@@ -736,17 +743,18 @@ class TestConcurrentDelivery(_RecordingHarness):
             )
             start = threading.Barrier(2)
 
-            def deliver_report():
+            def deliver():
                 start.wait()
-                proc.attach_session_report(report, thread_id="call-1")
-
-            def deliver_audio():
-                start.wait()
-                proc.complete_recording("call-1", b"OggS-egress", started_at=1.0)
+                proc.attach_session_report(
+                    report,
+                    thread_id="call-1",
+                    recording=b"OggS-egress",
+                    recording_started_at=1.0,
+                )
 
             threads = [
-                threading.Thread(target=deliver_report),
-                threading.Thread(target=deliver_audio),
+                threading.Thread(target=deliver),
+                threading.Thread(target=deliver),
             ]
             for t in threads:
                 t.start()
@@ -758,24 +766,39 @@ class TestConcurrentDelivery(_RecordingHarness):
                 for c in proc.downstream.on_end.call_args_list
                 if c.args[0]._attributes.get("langsmith.root_span")
             ]
-            # Exactly one root, and it always carries the audio — whichever
-            # delivery lands second is the one that releases.
+            # Exactly one root, and its single delivery carries both pieces.
             assert len(roots) == 1, f"attempt {attempt}: {len(roots)} roots"
             assert "langsmith.attachments" in roots[0]._attributes, attempt
+            messages = json.loads(roots[0]._attributes["gen_ai.prompt"])["messages"]
+            assert messages == [{"role": "user", "content": "Hello"}]
 
-    def test_two_audioless_reports_still_release_on_timeout(self):
-        """Both take the early return, so only the timeout can release."""
+    def test_delivery_claim_cancels_timeout_before_file_read(self, tmp_path):
+        audio = tmp_path / "audio.ogg"
+        audio.write_bytes(b"OggS")
         proc = _processor(recording_timeout_seconds=0.05)
         self._start_conversation(proc)
         self._end_session(proc)
-        proc.attach_session_report(_report(), thread_id="call-1")
-        proc.attach_session_report(_report(), thread_id="call-1")
-        assert self._root(proc) is None
+        entered = threading.Event()
+        resume = threading.Event()
+        read_audio = proc._read_audio_file
 
-        deadline = time.monotonic() + 2.0
-        while self._root(proc) is None and time.monotonic() < deadline:
-            time.sleep(0.01)
-        assert self._root(proc) is not None
+        def slow_read(path):
+            entered.set()
+            assert resume.wait(timeout=2)
+            return read_audio(path)
+
+        proc._read_audio_file = slow_read
+        delivery = threading.Thread(
+            target=proc.attach_session_report,
+            args=(_report(path=audio), "call-1"),
+        )
+        delivery.start()
+        assert entered.wait(timeout=2)
+        time.sleep(0.1)
+        assert self._root(proc) is None
+        resume.set()
+        delivery.join(timeout=2)
+        assert "langsmith.attachments" in self._root(proc)._attributes
 
 
 class TestRecordingTimeout(_RecordingHarness):
@@ -798,12 +821,24 @@ class TestRecordingTimeout(_RecordingHarness):
             root._attributes["langsmith.metadata.ls_audio_attach_status"] == "timeout"
         )
 
-    def test_await_disabled_releases_immediately(self):
-        proc = _processor(await_recording=False)
+    def test_none_mode_releases_immediately(self):
+        proc = _processor(recording_mode="none")
         self._start_conversation(proc)
         self._end_session(proc)
         # Nothing to wait for — the trace exports as soon as the session ends.
         assert self._root(proc) is not None
+
+    @pytest.mark.parametrize("timeout", [0, -1])
+    def test_nonpositive_timeout_is_rejected(self, timeout):
+        with pytest.raises(ValueError, match="greater than zero"):
+            _processor(recording_timeout_seconds=timeout)
+
+    def test_nonpositive_timeout_is_irrelevant_without_recording(self):
+        _processor(recording_mode="none", recording_timeout_seconds=0)
+
+    def test_unknown_recording_mode_is_rejected(self):
+        with pytest.raises(ValueError, match="recording_mode"):
+            _processor(recording_mode="automatic")
 
 
 class TestChatHistoryTranscript(_RecordingHarness):
@@ -818,7 +853,7 @@ class TestChatHistoryTranscript(_RecordingHarness):
         f.write_bytes(b"OggS")
         return f
 
-    def test_orders_by_created_at_and_drops_instructions(self, tmp_path):
+    def test_orders_by_created_at_and_keeps_instructions(self, tmp_path):
         proc = _processor()
         self._start_conversation(proc)
         self._end_session(proc)
@@ -840,6 +875,12 @@ class TestChatHistoryTranscript(_RecordingHarness):
                     },
                     {
                         "type": "message",
+                        "role": "developer",
+                        "content": ["Be concise"],
+                        "created_at": 5.0,
+                    },
+                    {
+                        "type": "message",
                         "role": "user",
                         "content": ["Hello"],
                         "created_at": 10.0,
@@ -851,6 +892,8 @@ class TestChatHistoryTranscript(_RecordingHarness):
 
         messages = self._messages(self._root(proc))
         assert messages == [
+            {"role": "system", "content": "You are a bot"},
+            {"role": "developer", "content": "Be concise"},
             {"role": "user", "content": "Hello"},
             {"role": "assistant", "content": "Hi there"},
         ]
@@ -913,32 +956,11 @@ class TestChatHistoryTranscript(_RecordingHarness):
             "name": "get_weather",
         }
 
-    def test_uses_strip_markup_only_where_supported(self, tmp_path):
-        """Newer livekit-agents gets strip_markup; the floor version must not."""
-        proc = _processor()
-        self._start_conversation(proc)
-        self._end_session(proc)
-        history = _NewerChatHistory(
-            [{"type": "message", "role": "user", "content": ["Hi"], "created_at": 1.0}]
-        )
-        report = SimpleNamespace(
-            audio_recording_path=self._audio(tmp_path),
-            audio_recording_started_at=None,
-            chat_history=history,
-        )
-        proc.attach_session_report(report, thread_id="call-1")
-
-        assert history.strip_markup_seen is True
-        assert self._messages(self._root(proc)) == [{"role": "user", "content": "Hi"}]
-
-    def test_report_without_audio_waits_for_egress(self):
-        """A report with no recording is the egress case: hold for the audio."""
-        proc = _processor()
+    def test_egress_report_and_audio_are_one_delivery(self):
+        proc = _processor(recording_mode="egress")
         self._start_conversation(proc)
         self._end_session(proc)
 
-        # Transcript arrives first, from the report. No recording on it, so the
-        # root must NOT export yet — the egress audio is still coming.
         proc.attach_session_report(
             _report(
                 items=[
@@ -951,14 +973,11 @@ class TestChatHistoryTranscript(_RecordingHarness):
                 ]
             ),
             thread_id="call-1",
-        )
-        assert self._root(proc) is None
-
-        proc.complete_recording(
-            "call-1", b"OggS-egress", started_at=(_ROOT_START_NS / 1e9) + 3.0
+            recording=b"OggS-egress",
+            recording_started_at=(_ROOT_START_NS / 1e9) + 3.0,
         )
 
-        # One trace carrying BOTH the egress audio and the report's transcript.
+        # The root is released once, carrying both pieces from the same call.
         root = self._root(proc)
         md = root._attributes
         payload = json.loads(md["langsmith.attachments"])
@@ -966,9 +985,8 @@ class TestChatHistoryTranscript(_RecordingHarness):
         assert md["langsmith.metadata.ls_audio_recording_start_offset_ms"] == 3000
         assert self._messages(root) == [{"role": "user", "content": "Hello"}]
 
-    def test_report_without_audio_releases_when_not_awaiting(self):
-        """With await_recording=False there is no audio coming; do not stall."""
-        proc = _processor(await_recording=False)
+    def test_none_mode_does_not_claim_late_report_transcript(self):
+        proc = _processor(recording_mode="none")
         self._start_conversation(proc)
         self._end_session(proc)
         proc.attach_session_report(
@@ -984,11 +1002,11 @@ class TestChatHistoryTranscript(_RecordingHarness):
             ),
             thread_id="call-1",
         )
-        # Already exported at session end; the transcript still lands on it.
-        assert self._root(proc) is not None
+        root = self._root(proc)
+        assert "gen_ai.prompt" not in root._attributes
 
     def test_egress_path_falls_back_to_span_rollup(self):
-        proc = _processor()
+        proc = _processor(recording_mode="egress")
         self._start_conversation(proc)
         proc.on_end(
             _make_span(
@@ -999,8 +1017,8 @@ class TestChatHistoryTranscript(_RecordingHarness):
             )
         )
         self._end_session(proc)
-        # No report — the transcript still comes from the conversation's spans.
-        proc.complete_recording("call-1", b"x")
+        # An empty report transcript falls back to the conversation's spans.
+        proc.attach_session_report(_report(), thread_id="call-1", recording=b"x")
 
         messages = self._messages(self._root(proc))
         assert [m["content"] for m in messages] == ["Hello", "Hi there"]
@@ -1016,7 +1034,7 @@ class TestStateTTL:
         proc.on_end(_make_span("job_entrypoint", parent=None, trace_id=0xAAA))
         # A later, different conversation's root triggers eviction of the first.
         proc.on_end(_make_span("job_entrypoint", parent=None, trace_id=0xBBB))
-        assert 0xAAA not in proc._deferred_root_by_trace
+        assert 0xAAA not in proc._state_by_trace
 
     def test_active_call_refreshes_transcript_ttl(self):
         proc = _processor(state_ttl_seconds=60)
@@ -1031,8 +1049,8 @@ class TestStateTTL:
                 "agent_turn", {"lk.response.text": "two"}, trace_id=tid, span_id=0x3
             )
         )
-        # The store holds (sort_key, message) tuples.
-        assert [m["content"] for _, m in proc._transcript_by_trace[tid]] == [
+        # One state object owns the ordered transcript.
+        assert [m["content"] for _, m in proc._state_by_trace[tid].transcript] == [
             "one",
             "two",
         ]

--- a/python/tests/unit_tests/wrappers/test_livekit.py
+++ b/python/tests/unit_tests/wrappers/test_livekit.py
@@ -7,14 +7,17 @@ mocked and no framework install is needed.
 
 import base64
 import json
+import sys
 import threading
 import time
-from types import SimpleNamespace
+import warnings
+from types import ModuleType, SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
 
 from langsmith._internal.voice import set_thread_id
+from langsmith.integrations.livekit import configure_livekit
 from langsmith.integrations.livekit._helpers import (
     build_assistant_tool_call_message,
     build_message_from_event,
@@ -71,6 +74,23 @@ def _start_span(proc, span, thread_id):
     proc.on_start(span)
     set_thread_id(None)
     return span
+
+
+class TestDeprecatedAudioPathProvider:
+    def test_is_accepted_but_not_called(self):
+        provider = MagicMock()
+
+        with pytest.warns(
+            DeprecationWarning, match="audio_path_provider is deprecated and ignored"
+        ):
+            _processor(audio_path_provider=provider)
+
+        provider.assert_not_called()
+
+    def test_none_does_not_warn(self):
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            _processor(audio_path_provider=None)
 
 
 class TestDispatchDisposition:
@@ -552,6 +572,46 @@ def _report(*, path=None, started_at=None, items=None):
     )
 
 
+class _FakeLifecycleSession:
+    """Minimal additive/one-shot LiveKit session event emitter."""
+
+    def __init__(self):
+        self.listeners = {}
+
+    def once(self, name, callback):
+        self.listeners.setdefault(name, []).append(callback)
+
+    def close(self):
+        callbacks = self.listeners.pop("close", [])
+        for callback in callbacks:
+            callback(SimpleNamespace())
+
+
+class _FakeJobContext:
+    def __init__(self, session, report):
+        self._primary_agent_session = session
+        self.report = report
+        self.make_report_calls = []
+
+    def make_session_report(self, session):
+        self.make_report_calls.append(session)
+        return self.report
+
+
+def _install_fake_livekit(monkeypatch, current_context, telemetry=None):
+    """Install the tiny optional LiveKit surface the processor/configure use."""
+    agents_module = ModuleType("livekit.agents")
+    agents_module.get_job_context = lambda required=False: current_context["value"]
+    agents_module.telemetry = telemetry or SimpleNamespace(
+        set_tracer_provider=MagicMock()
+    )
+    livekit_module = ModuleType("livekit")
+    livekit_module.agents = agents_module
+    monkeypatch.setitem(sys.modules, "livekit", livekit_module)
+    monkeypatch.setitem(sys.modules, "livekit.agents", agents_module)
+    return agents_module
+
+
 # One second in nanoseconds — root start times are OTel ns, origins are epoch s.
 _NS = 1_000_000_000
 _ROOT_START_NS = 1_700_000_000 * _NS
@@ -563,10 +623,12 @@ class _RecordingHarness:
     def teardown_method(self):
         set_thread_id(None)
 
-    def _start_conversation(self, proc, tid=0xABC, start_time=_ROOT_START_NS):
+    def _start_conversation(
+        self, proc, tid=0xABC, start_time=_ROOT_START_NS, thread_id="call-1"
+    ):
         # The root's thread id comes from set_thread_id (captured at on_start),
         # exactly as in production; clearing it after simulates the detached end.
-        set_thread_id("call-1")
+        set_thread_id(thread_id)
         proc.on_start(
             _make_span(
                 "job_entrypoint", parent=None, trace_id=tid, start_time=start_time
@@ -582,6 +644,11 @@ class _RecordingHarness:
     def _end_session(self, proc, tid=0xABC):
         proc.on_end(_make_span("agent_session", trace_id=tid, span_id=0x3))
 
+    def _start_session(self, proc, thread_id="call-1", tid=0xABC):
+        set_thread_id(thread_id)
+        proc.on_start(_make_span("agent_session", trace_id=tid, span_id=0x2))
+        set_thread_id(None)
+
     def _root(self, proc):
         return next(
             (
@@ -591,6 +658,165 @@ class _RecordingHarness:
             ),
             None,
         )
+
+
+class TestAutomaticSessionReport(_RecordingHarness):
+    def test_direct_processor_captures_report_on_session_close(
+        self, monkeypatch, tmp_path
+    ):
+        audio = tmp_path / "automatic.ogg"
+        audio.write_bytes(b"automatic-audio")
+        session = _FakeLifecycleSession()
+        ctx = _FakeJobContext(session, _report(path=audio, items=[]))
+        current_context = {"value": ctx}
+        _install_fake_livekit(monkeypatch, current_context)
+        proc = _processor()
+
+        self._start_conversation(proc)
+        self._start_session(proc)
+        self._end_session(proc)
+        assert self._root(proc) is None
+
+        session.close()
+
+        root = self._root(proc)
+        payload = json.loads(root._attributes["langsmith.attachments"])
+        assert base64.b64decode(payload[0]["content"]) == b"automatic-audio"
+        assert ctx.make_report_calls == [session]
+
+    def test_configured_processor_installs_the_same_automatic_hook(self, monkeypatch):
+        from opentelemetry import trace as otel_trace
+
+        session = _FakeLifecycleSession()
+        ctx = _FakeJobContext(session, _report())
+        current_context = {"value": ctx}
+        telemetry = SimpleNamespace(set_tracer_provider=MagicMock())
+        _install_fake_livekit(monkeypatch, current_context, telemetry=telemetry)
+        monkeypatch.setattr(otel_trace, "set_tracer_provider", MagicMock())
+
+        proc = configure_livekit(downstream_processor=MagicMock())
+        assert proc is not None
+        self._start_conversation(proc)
+        self._start_session(proc)
+        self._end_session(proc)
+        session.close()
+
+        assert self._root(proc) is not None
+        telemetry.set_tracer_provider.assert_called_once()
+
+    def test_existing_close_listener_is_preserved(self, monkeypatch):
+        session = _FakeLifecycleSession()
+        existing = MagicMock()
+        session.once("close", existing)
+        ctx = _FakeJobContext(session, _report())
+        current_context = {"value": ctx}
+        _install_fake_livekit(monkeypatch, current_context)
+        proc = _processor(recording_mode="none")
+
+        self._start_conversation(proc)
+        self._start_session(proc)
+        self._end_session(proc)
+        session.close()
+
+        existing.assert_called_once()
+        assert self._root(proc) is not None
+
+    def test_egress_waits_for_automatic_report_and_completion(self, monkeypatch):
+        session = _FakeLifecycleSession()
+        report = _report()
+        ctx = _FakeJobContext(session, report)
+        current_context = {"value": ctx}
+        _install_fake_livekit(monkeypatch, current_context)
+        proc = _processor(recording_mode="egress")
+
+        self._start_conversation(proc)
+        self._start_session(proc)
+        self._end_session(proc)
+        session.close()
+        assert self._root(proc) is None
+
+        # A duplicate manual delivery is harmless while the egress root is held.
+        proc.attach_session_report(report, thread_id="call-1")
+        proc.complete_recording("call-1", b"egress")
+
+        roots = [
+            call.args[0]
+            for call in proc.downstream.on_end.call_args_list
+            if call.args[0]._attributes.get("langsmith.root_span")
+        ]
+        assert len(roots) == 1
+        assert "langsmith.attachments" in roots[0]._attributes
+
+    def test_hook_registration_is_idempotent(self, monkeypatch):
+        session = _FakeLifecycleSession()
+        ctx = _FakeJobContext(session, _report())
+        current_context = {"value": ctx}
+        _install_fake_livekit(monkeypatch, current_context)
+        proc = _processor()
+
+        self._start_conversation(proc)
+        self._start_session(proc)
+        self._start_session(proc)
+
+        assert len(session.listeners["close"]) == 1
+        self._end_session(proc)
+        session.close()
+        assert ctx.make_report_calls == [session]
+        assert self._root(proc) is not None
+
+    def test_reports_route_to_the_captured_trace(self, monkeypatch):
+        session_a = _FakeLifecycleSession()
+        session_b = _FakeLifecycleSession()
+        ctx_a = _FakeJobContext(
+            session_a,
+            _report(
+                items=[
+                    {
+                        "type": "message",
+                        "role": "user",
+                        "content": ["A"],
+                        "created_at": 1,
+                    }
+                ]
+            ),
+        )
+        ctx_b = _FakeJobContext(
+            session_b,
+            _report(
+                items=[
+                    {
+                        "type": "message",
+                        "role": "user",
+                        "content": ["B"],
+                        "created_at": 1,
+                    }
+                ]
+            ),
+        )
+        current_context = {"value": ctx_a}
+        _install_fake_livekit(monkeypatch, current_context)
+        proc = _processor(recording_mode="none")
+
+        self._start_conversation(proc, tid=0xAAA, thread_id="thread-a")
+        self._start_session(proc, tid=0xAAA, thread_id="thread-a")
+        current_context["value"] = ctx_b
+        self._start_conversation(proc, tid=0xBBB, thread_id="thread-b")
+        self._start_session(proc, tid=0xBBB, thread_id="thread-b")
+        self._end_session(proc, tid=0xAAA)
+        self._end_session(proc, tid=0xBBB)
+
+        session_b.close()
+        session_a.close()
+
+        roots = {
+            call.args[0].context.trace_id: call.args[0]
+            for call in proc.downstream.on_end.call_args_list
+            if call.args[0]._attributes.get("langsmith.root_span")
+        }
+        prompt_a = json.loads(roots[0xAAA]._attributes["gen_ai.prompt"])
+        prompt_b = json.loads(roots[0xBBB]._attributes["gen_ai.prompt"])
+        assert prompt_a["messages"][0]["content"] == "A"
+        assert prompt_b["messages"][0]["content"] == "B"
 
 
 class TestEgressRecording(_RecordingHarness):
@@ -665,10 +891,84 @@ class TestEgressRecording(_RecordingHarness):
         md = self._root(proc)._attributes
         assert md["langsmith.metadata.ls_audio_recording_start_offset_ms"] == 4250
 
-    def test_complete_recording_requires_egress_mode(self):
+    def test_complete_recording_before_spans_selects_egress_for_that_thread(self):
         proc = _processor()
-        with pytest.raises(RuntimeError, match="recording_mode='egress'"):
-            proc.complete_recording("call-1", b"x")
+        proc.complete_recording("call-1", b"x")
+        self._start_conversation(proc)
+        state = proc._get_state_by_thread("call-1")
+        assert state.recording_mode == "egress"
+        assert state.recording_received is True
+        self._end_session(proc)
+        proc.attach_session_report(_report(), thread_id="call-1")
+        assert "langsmith.attachments" in self._root(proc)._attributes
+
+    def test_expect_recording_before_spans_overrides_only_that_thread(self):
+        proc = _processor()
+        proc.expect_recording("call-1")
+        self._start_conversation(proc)
+
+        state = proc._get_state_by_thread("call-1")
+        assert state.recording_mode == "egress"
+        self._end_session(proc)
+        proc.attach_session_report(_report(), thread_id="call-1")
+        assert self._root(proc) is None
+
+        proc.complete_recording("call-1", b"x")
+        assert "langsmith.attachments" in self._root(proc)._attributes
+
+    def test_expect_recording_can_override_after_spans_arrive(self):
+        proc = _processor()
+        self._start_conversation(proc)
+        proc.expect_recording("call-1")
+
+        assert proc._get_state_by_thread("call-1").recording_mode == "egress"
+
+    def test_expect_recording_does_not_change_other_conversations(self):
+        proc = _processor()
+        proc.expect_recording("egress-call")
+        self._start_conversation(proc, tid=0xAAA, thread_id="egress-call")
+        self._start_conversation(proc, tid=0xBBB, thread_id="report-call")
+        self._end_session(proc, tid=0xAAA)
+        self._end_session(proc, tid=0xBBB)
+
+        proc.attach_session_report(_report(), thread_id="egress-call")
+        proc.attach_session_report(_report(), thread_id="report-call")
+        exported_trace_ids = {
+            call.args[0].context.trace_id
+            for call in proc.downstream.on_end.call_args_list
+            if call.args[0]._attributes.get("langsmith.root_span")
+        }
+        assert exported_trace_ids == {0xBBB}
+
+        proc.complete_recording("egress-call", b"x")
+        exported_trace_ids = {
+            call.args[0].context.trace_id
+            for call in proc.downstream.on_end.call_args_list
+            if call.args[0]._attributes.get("langsmith.root_span")
+        }
+        assert exported_trace_ids == {0xAAA, 0xBBB}
+
+    def test_processor_egress_default_does_not_require_expect_recording(self):
+        proc = _processor(recording_mode="egress")
+        self._start_conversation(proc)
+        self._end_session(proc)
+        proc.attach_session_report(_report(), thread_id="call-1")
+        assert self._root(proc) is None
+
+        proc.complete_recording("call-1", b"x")
+        assert self._root(proc) is not None
+
+    def test_late_recording_is_not_reused_by_a_future_trace(self, caplog):
+        proc = _processor(recording_mode="egress")
+        self._start_conversation(proc)
+        self._end_session(proc)
+        proc.attach_session_report(_report(), thread_id="call-1")
+        proc.complete_recording("call-1", b"first")
+
+        proc.complete_recording("call-1", b"late")
+
+        assert "call-1" not in proc._thread_state_waiting_for_trace
+        assert any("no active LiveKit trace" in message for message in caplog.messages)
 
     def test_oversize_recording_is_not_buffered(self):
         proc = _processor(recording_mode="egress", audio_size_limit_bytes=3)

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -1790,7 +1790,7 @@ requires-dist = [
     { name = "google-adk", marker = "extra == 'google-adk-live'", specifier = ">=2.3.0" },
     { name = "httpx", specifier = ">=0.23.0,<1" },
     { name = "langsmith-pyo3", marker = "extra == 'langsmith-pyo3'", specifier = ">=0.1.0rc2" },
-    { name = "livekit-agents", marker = "extra == 'livekit'", specifier = ">=1.3" },
+    { name = "livekit-agents", marker = "extra == 'livekit'", specifier = ">=1.6" },
     { name = "openai", marker = "extra == 'openai-realtime'", specifier = ">=1.50" },
     { name = "openai-agents", marker = "extra == 'openai-agents'", specifier = ">=0.0.3" },
     { name = "openai-agents", marker = "extra == 'openai-realtime'", specifier = ">=0.0.3" },

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -11,7 +11,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer = "2026-08-25T23:14:58.29605Z"
 exclude-newer-span = "P1D"
 
 [manifest]
@@ -1790,7 +1790,7 @@ requires-dist = [
     { name = "google-adk", marker = "extra == 'google-adk-live'", specifier = ">=2.3.0" },
     { name = "httpx", specifier = ">=0.23.0,<1" },
     { name = "langsmith-pyo3", marker = "extra == 'langsmith-pyo3'", specifier = ">=0.1.0rc2" },
-    { name = "livekit-agents", marker = "extra == 'livekit'", specifier = ">=1.0" },
+    { name = "livekit-agents", marker = "extra == 'livekit'", specifier = ">=1.3" },
     { name = "openai", marker = "extra == 'openai-realtime'", specifier = ">=1.50" },
     { name = "openai-agents", marker = "extra == 'openai-agents'", specifier = ">=0.0.3" },
     { name = "openai-agents", marker = "extra == 'openai-realtime'", specifier = ">=0.0.3" },


### PR DESCRIPTION
## Summary

Fixes LiveKit recording alignment and supports both session-report and Egress recording workflows.

- Adds `ls_audio_recording_started_at` and `ls_audio_recording_start_offset_ms` to the root run metadata to account for the offset between when the audio starts recording and when the trace starts (trace starts first). This will allow us to align the player with the spans in the audio player UI.
- Adds `attach_session_report()` to attach chat history and, when available, session-recorded audio.
- Adds three recording modes:
  - `session_report` (default): Use audio from the report when present; reports without audio still export normally.
  - `egress`: Receive report data through `attach_session_report()` and audio through `complete_recording()`. Either can arrive first; the trace exports after both arrive or the timeout expires.
  - `none`: Attach report data without audio.
- Adds `started_at` to `complete_recording()` for Egress alignment. Recording name and MIME type remain optional overrides.
- Builds the root transcript from LiveKit chat history, including tool calls and tool results.
- Reports attachment outcomes through `ls_audio_attach_status` and checks file size before reading audio into memory.

## Breaking changes

- Removes `audio_path_provider`, `expect_recording()`, and `await_recording`.
- Requires `livekit-agents>=1.3` for `make_session_report()`.

## Test plan

- [x] Session-report mode with audio, without audio, and with unreadable or oversized files
- [x] Egress report and recording delivery in either order, including failure and timeout paths
- [x] Positive, negative, and absent recording offsets
- [x] Chat-history transcripts, tool calls, realtime transcripts, and concurrent session correlation
- [x] LiveKit wrapper unit tests, Ruff, and mypy

#### PR Dependency Tree

* **PR #3452** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)
