### PR TITLE
feat(py/js): close sandbox command stdin by default, and expose close_input()

### DIFF
--- a/js/src/sandbox/README.md
+++ b/js/src/sandbox/README.md
@@ -449,11 +449,11 @@ console.log(`Exit code: ${result.exit_code}`);
 ### Sending stdin and killing commands
 
 ```typescript
-// closeStdin: false keeps stdin open; it defaults to true (except with pty),
+// closeInput: false keeps stdin open; it defaults to true (except with pty),
 // so a command that reads stdin sees EOF instead of hanging.
 const handle = await sandbox.run("python -i", {
   wait: false,
-  closeStdin: false,
+  closeInput: false,
 });
 
 // Send input to stdin
@@ -855,7 +855,7 @@ try {
 | `pid` | Process ID on the sandbox |
 | `result` | Final `ExecutionResult` (drains stream if needed) |
 | `kill()` | Send SIGKILL to the running command |
-| `sendInput(data)` | Write string data to the command's stdin. Throws unless the command was run with `closeStdin: false` |
+| `sendInput(data)` | Write string data to the command's stdin. Throws unless the command was run with `closeInput: false` |
 | `closeInput()` | Close stdin so the command reads EOF. Call once done sending input; throws under `pty` |
 | `reconnect()` | Reconnect from the last known offsets |
 | `lastStdoutOffset` | Last stdout byte offset (for manual reconnection) |

--- a/js/src/sandbox/README.md
+++ b/js/src/sandbox/README.md
@@ -459,7 +459,7 @@ const handle = await sandbox.run("python -i", {
 // Send input to stdin
 handle.sendInput("print(2 + 2)\n");
 handle.sendInput("exit()\n");
-handle.closeStdin(); // done sending: the command now reads EOF
+handle.closeInput(); // done sending: the command now reads EOF
 
 for await (const chunk of handle) {
   process.stdout.write(chunk.data);
@@ -856,7 +856,7 @@ try {
 | `result` | Final `ExecutionResult` (drains stream if needed) |
 | `kill()` | Send SIGKILL to the running command |
 | `sendInput(data)` | Write string data to the command's stdin. Throws unless the command was run with `closeStdin: false` |
-| `closeStdin()` | Close stdin so the command reads EOF. Call once done sending input; throws under `pty` |
+| `closeInput()` | Close stdin so the command reads EOF. Call once done sending input; throws under `pty` |
 | `reconnect()` | Reconnect from the last known offsets |
 | `lastStdoutOffset` | Last stdout byte offset (for manual reconnection) |
 | `lastStderrOffset` | Last stderr byte offset (for manual reconnection) |

--- a/js/src/sandbox/README.md
+++ b/js/src/sandbox/README.md
@@ -449,7 +449,12 @@ console.log(`Exit code: ${result.exit_code}`);
 ### Sending stdin and killing commands
 
 ```typescript
-const handle = await sandbox.run("python -i", { wait: false });
+// closeStdin: false keeps stdin open; it defaults to true (except with pty),
+// so a command that reads stdin sees EOF instead of hanging.
+const handle = await sandbox.run("python -i", {
+  wait: false,
+  closeStdin: false,
+});
 
 // Send input to stdin
 handle.sendInput("print(2 + 2)\n");
@@ -849,7 +854,7 @@ try {
 | `pid` | Process ID on the sandbox |
 | `result` | Final `ExecutionResult` (drains stream if needed) |
 | `kill()` | Send SIGKILL to the running command |
-| `sendInput(data)` | Write string data to the command's stdin |
+| `sendInput(data)` | Write string data to the command's stdin. Throws unless the command was run with `closeStdin: false` |
 | `reconnect()` | Reconnect from the last known offsets |
 | `lastStdoutOffset` | Last stdout byte offset (for manual reconnection) |
 | `lastStderrOffset` | Last stderr byte offset (for manual reconnection) |

--- a/js/src/sandbox/README.md
+++ b/js/src/sandbox/README.md
@@ -459,6 +459,7 @@ const handle = await sandbox.run("python -i", {
 // Send input to stdin
 handle.sendInput("print(2 + 2)\n");
 handle.sendInput("exit()\n");
+handle.closeStdin(); // done sending: the command now reads EOF
 
 for await (const chunk of handle) {
   process.stdout.write(chunk.data);
@@ -855,6 +856,7 @@ try {
 | `result` | Final `ExecutionResult` (drains stream if needed) |
 | `kill()` | Send SIGKILL to the running command |
 | `sendInput(data)` | Write string data to the command's stdin. Throws unless the command was run with `closeStdin: false` |
+| `closeStdin()` | Close stdin so the command reads EOF. Call once done sending input; throws under `pty` |
 | `reconnect()` | Reconnect from the last known offsets |
 | `lastStdoutOffset` | Last stdout byte offset (for manual reconnection) |
 | `lastStderrOffset` | Last stderr byte offset (for manual reconnection) |

--- a/js/src/sandbox/command_handle.ts
+++ b/js/src/sandbox/command_handle.ts
@@ -83,6 +83,7 @@ export class CommandHandle {
   private _onStdout?: (data: string) => void;
   private _onStderr?: (data: string) => void;
   private _stdinClosed: boolean;
+  private _pty: boolean;
 
   /** @internal */
   constructor(
@@ -96,6 +97,7 @@ export class CommandHandle {
       onStdout?: (data: string) => void;
       onStderr?: (data: string) => void;
       stdinClosed?: boolean;
+      pty?: boolean;
     },
   ) {
     this._stream = messageStream;
@@ -106,6 +108,7 @@ export class CommandHandle {
     this._onStdout = options?.onStdout;
     this._onStderr = options?.onStderr;
     this._stdinClosed = options?.stdinClosed ?? false;
+    this._pty = options?.pty ?? false;
 
     // New executions (no commandId): _ensureStarted reads "started".
     // Reconnections (commandId set): skip since reconnect streams
@@ -312,6 +315,28 @@ export class CommandHandle {
     }
     if (this._control) {
       this._control.sendInput(data);
+    }
+  }
+
+  /**
+   * Close the command's stdin so a command reading it sees EOF.
+   *
+   * Call this once done sending input. Idempotent. Afterwards `sendInput()`
+   * throws.
+   *
+   * @throws If the command was run with a PTY.
+   */
+  closeStdin(): void {
+    if (this._pty) {
+      throw new Error(
+        "a PTY command has no separate stdin to close. Send an EOT byte " +
+          "(\u0004) with sendInput() to signal EOF instead.",
+      );
+    }
+    if (this._stdinClosed) return;
+    this._stdinClosed = true;
+    if (this._control) {
+      this._control.sendCloseStdin();
     }
   }
 

--- a/js/src/sandbox/command_handle.ts
+++ b/js/src/sandbox/command_handle.ts
@@ -309,7 +309,7 @@ export class CommandHandle {
   sendInput(data: string): void {
     if (this._stdinClosed) {
       throw new Error(
-        "stdin was closed for this command. Pass closeStdin: false to run() " +
+        "stdin was closed for this command. Pass closeInput: false to run() " +
           "to keep it open for sendInput().",
       );
     }

--- a/js/src/sandbox/command_handle.ts
+++ b/js/src/sandbox/command_handle.ts
@@ -82,6 +82,7 @@ export class CommandHandle {
   private _reconnectAttempts = 0;
   private _onStdout?: (data: string) => void;
   private _onStderr?: (data: string) => void;
+  private _stdinClosed: boolean;
 
   /** @internal */
   constructor(
@@ -94,6 +95,7 @@ export class CommandHandle {
       stderrOffset?: number;
       onStdout?: (data: string) => void;
       onStderr?: (data: string) => void;
+      stdinClosed?: boolean;
     },
   ) {
     this._stream = messageStream;
@@ -103,6 +105,7 @@ export class CommandHandle {
     this._lastStderrOffset = options?.stderrOffset ?? 0;
     this._onStdout = options?.onStdout;
     this._onStderr = options?.onStderr;
+    this._stdinClosed = options?.stdinClosed ?? false;
 
     // New executions (no commandId): _ensureStarted reads "started".
     // Reconnections (commandId set): skip since reconnect streams
@@ -297,8 +300,16 @@ export class CommandHandle {
 
   /**
    * Write data to the command's stdin.
+   *
+   * @throws If the command was run with stdin closed.
    */
   sendInput(data: string): void {
+    if (this._stdinClosed) {
+      throw new Error(
+        "stdin was closed for this command. Pass closeStdin: false to run() " +
+          "to keep it open for sendInput().",
+      );
+    }
     if (this._control) {
       this._control.sendInput(data);
     }

--- a/js/src/sandbox/command_handle.ts
+++ b/js/src/sandbox/command_handle.ts
@@ -326,7 +326,7 @@ export class CommandHandle {
    *
    * @throws If the command was run with a PTY.
    */
-  closeStdin(): void {
+  closeInput(): void {
     if (this._pty) {
       throw new Error(
         "a PTY command has no separate stdin to close. Send an EOT byte " +

--- a/js/src/sandbox/command_handle.ts
+++ b/js/src/sandbox/command_handle.ts
@@ -363,9 +363,12 @@ export class CommandHandle {
         "reconnect",
       );
     }
-    return this._sandbox.reconnect(this._commandId, {
+    const handle = await this._sandbox.reconnect(this._commandId, {
       stdoutOffset: this._lastStdoutOffset,
       stderrOffset: this._lastStderrOffset,
     });
+    handle._stdinClosed = this._stdinClosed;
+    handle._pty = this._pty;
+    return handle;
   }
 }

--- a/js/src/sandbox/sandbox.ts
+++ b/js/src/sandbox/sandbox.ts
@@ -188,9 +188,15 @@ export class Sandbox {
       killOnDisconnect,
       ttlSeconds,
       pty,
+      closeStdin,
       ...restOptions
     } = options;
     const hasCallbacks = onStdout !== undefined || onStderr !== undefined;
+
+    // Left open, stdin makes any command that reads it block until the
+    // timeout. Only a PTY needs it open by default; a caller that will
+    // sendInput() on a pipe asks for it with closeStdin: false.
+    const resolvedCloseStdin = closeStdin ?? !pty;
 
     if (!wait || hasCallbacks) {
       // WebSocket required for streaming / non-blocking
@@ -200,6 +206,7 @@ export class Sandbox {
         killOnDisconnect,
         ttlSeconds,
         pty,
+        closeStdin: resolvedCloseStdin,
         onStdout,
         onStderr,
       });
@@ -221,6 +228,7 @@ export class Sandbox {
         killOnDisconnect,
         ttlSeconds,
         pty,
+        closeStdin: resolvedCloseStdin,
       });
       return await handle.result;
     }
@@ -255,6 +263,7 @@ export class Sandbox {
       killOnDisconnect,
       ttlSeconds,
       pty,
+      closeStdin,
     } = options;
     const dataplaneUrl = this.requireDataplaneUrl();
 
@@ -284,6 +293,7 @@ export class Sandbox {
           killOnDisconnect,
           ttlSeconds,
           pty,
+          closeStdin,
           openTimeout: openTimeoutFor(deadline),
           ...(Object.keys(clientHeaders).length > 0
             ? { headers: clientHeaders }
@@ -294,6 +304,7 @@ export class Sandbox {
       const handle = new CommandHandle(stream, control, this, {
         onStdout,
         onStderr,
+        stdinClosed: closeStdin,
       });
       try {
         await handle._ensureStarted();

--- a/js/src/sandbox/sandbox.ts
+++ b/js/src/sandbox/sandbox.ts
@@ -305,6 +305,7 @@ export class Sandbox {
         onStdout,
         onStderr,
         stdinClosed: closeStdin,
+        pty,
       });
       try {
         await handle._ensureStarted();

--- a/js/src/sandbox/sandbox.ts
+++ b/js/src/sandbox/sandbox.ts
@@ -188,15 +188,15 @@ export class Sandbox {
       killOnDisconnect,
       ttlSeconds,
       pty,
-      closeStdin,
+      closeInput,
       ...restOptions
     } = options;
     const hasCallbacks = onStdout !== undefined || onStderr !== undefined;
 
     // Left open, stdin makes any command that reads it block until the
     // timeout. Only a PTY needs it open by default; a caller that will
-    // sendInput() on a pipe asks for it with closeStdin: false.
-    const resolvedCloseStdin = closeStdin ?? !pty;
+    // sendInput() on a pipe asks for it with closeInput: false.
+    const resolvedCloseInput = closeInput ?? !pty;
 
     if (!wait || hasCallbacks) {
       // WebSocket required for streaming / non-blocking
@@ -206,7 +206,7 @@ export class Sandbox {
         killOnDisconnect,
         ttlSeconds,
         pty,
-        closeStdin: resolvedCloseStdin,
+        closeInput: resolvedCloseInput,
         onStdout,
         onStderr,
       });
@@ -228,7 +228,7 @@ export class Sandbox {
         killOnDisconnect,
         ttlSeconds,
         pty,
-        closeStdin: resolvedCloseStdin,
+        closeInput: resolvedCloseInput,
       });
       return await handle.result;
     }
@@ -263,7 +263,7 @@ export class Sandbox {
       killOnDisconnect,
       ttlSeconds,
       pty,
-      closeStdin,
+      closeInput,
     } = options;
     const dataplaneUrl = this.requireDataplaneUrl();
 
@@ -293,7 +293,7 @@ export class Sandbox {
           killOnDisconnect,
           ttlSeconds,
           pty,
-          closeStdin,
+          closeStdin: closeInput,
           openTimeout: openTimeoutFor(deadline),
           ...(Object.keys(clientHeaders).length > 0
             ? { headers: clientHeaders }
@@ -304,7 +304,7 @@ export class Sandbox {
       const handle = new CommandHandle(stream, control, this, {
         onStdout,
         onStderr,
-        stdinClosed: closeStdin,
+        stdinClosed: closeInput,
         pty,
       });
       try {

--- a/js/src/sandbox/types.ts
+++ b/js/src/sandbox/types.ts
@@ -263,7 +263,7 @@ export interface RunOptions {
    * handle whose stdin was closed throws. Ignored by sandboxes older than this
    * option.
    */
-  closeStdin?: boolean;
+  closeInput?: boolean;
 }
 
 /**

--- a/js/src/sandbox/types.ts
+++ b/js/src/sandbox/types.ts
@@ -183,6 +183,8 @@ export interface WsRunOptions {
   ttlSeconds?: number;
   /** Whether to allocate a PTY. */
   pty?: boolean;
+  /** Whether to close the command's stdin so it reads EOF. */
+  closeStdin?: boolean;
   /**
    * Additional headers attached to the WebSocket upgrade request. Merged on
    * top of any default headers the SandboxClient was constructed with.
@@ -254,6 +256,14 @@ export interface RunOptions {
    * commands that use terminal control codes). Defaults to false.
    */
   pty?: boolean;
+  /**
+   * Close the command's stdin so a command that reads it sees EOF instead of
+   * blocking on a pipe nothing writes to. Defaults to true unless `pty` is set.
+   * Pass false to keep stdin open for `sendInput()`; calling `sendInput()` on a
+   * handle whose stdin was closed throws. Ignored by sandboxes older than this
+   * option.
+   */
+  closeStdin?: boolean;
 }
 
 /**

--- a/js/src/sandbox/ws_execute.ts
+++ b/js/src/sandbox/ws_execute.ts
@@ -180,6 +180,13 @@ export class WSStreamControl {
       this._ws.send(JSON.stringify({ type: "input", data }));
     }
   }
+
+  /** Ask the server to close the command's stdin, so it reads EOF. */
+  sendCloseStdin(): void {
+    if (this._ws && !this._closed && this._ws.readyState === 1) {
+      this._ws.send(JSON.stringify({ type: "close_stdin" }));
+    }
+  }
 }
 
 // =============================================================================

--- a/js/src/sandbox/ws_execute.ts
+++ b/js/src/sandbox/ws_execute.ts
@@ -415,6 +415,7 @@ export async function runWsStream(
     killOnDisconnect = false,
     ttlSeconds = 600,
     pty,
+    closeStdin,
     headers: extraHeaders,
     openTimeout = WS_OPEN_TIMEOUT,
   } = options;
@@ -443,6 +444,7 @@ export async function runWsStream(
       if (cwd) payload.cwd = cwd;
       if (commandId) payload.command_id = commandId;
       if (pty) payload.pty = true;
+      if (closeStdin) payload.close_stdin = true;
 
       ws.send(JSON.stringify(payload));
 

--- a/js/src/tests/sandbox.test.ts
+++ b/js/src/tests/sandbox.test.ts
@@ -1933,6 +1933,36 @@ describe("CommandHandle", () => {
       handle.sendInput("test input");
     });
 
+    it("should send close_stdin and then reject further input", () => {
+      const stream = createMockStream([]);
+      const control = new WSStreamControl();
+      const ws = { send: jest.fn(), readyState: 1 };
+      (control as any)._ws = ws;
+      const handle = new CommandHandle(stream, control, createMockSandbox(), {
+        commandId: "cmd-123",
+      });
+
+      handle.sendInput("data\n");
+      handle.closeStdin();
+      handle.closeStdin();
+
+      expect(ws.send.mock.calls.map((c: any) => JSON.parse(c[0]))).toEqual([
+        { type: "input", data: "data\n" },
+        { type: "close_stdin" },
+      ]);
+      expect(() => handle.sendInput("more\n")).toThrow(/closeStdin: false/);
+    });
+
+    it("should throw from closeStdin under a PTY", () => {
+      const stream = createMockStream([]);
+      const handle = new CommandHandle(stream, null, createMockSandbox(), {
+        commandId: "cmd-123",
+        pty: true,
+      });
+
+      expect(() => handle.closeStdin()).toThrow(/EOT/);
+    });
+
     it("should throw when the command was run with stdin closed", () => {
       const stream = createMockStream([]);
       const handle = new CommandHandle(stream, null, createMockSandbox(), {

--- a/js/src/tests/sandbox.test.ts
+++ b/js/src/tests/sandbox.test.ts
@@ -1932,6 +1932,18 @@ describe("CommandHandle", () => {
       // Should not throw
       handle.sendInput("test input");
     });
+
+    it("should throw when the command was run with stdin closed", () => {
+      const stream = createMockStream([]);
+      const handle = new CommandHandle(stream, null, createMockSandbox(), {
+        commandId: "cmd-123",
+        stdinClosed: true,
+      });
+
+      expect(() => handle.sendInput("test input")).toThrow(
+        /closeStdin: false/,
+      );
+    });
   });
 });
 

--- a/js/src/tests/sandbox.test.ts
+++ b/js/src/tests/sandbox.test.ts
@@ -1943,8 +1943,8 @@ describe("CommandHandle", () => {
       });
 
       handle.sendInput("data\n");
-      handle.closeStdin();
-      handle.closeStdin();
+      handle.closeInput();
+      handle.closeInput();
 
       expect(ws.send.mock.calls.map((c: any) => JSON.parse(c[0]))).toEqual([
         { type: "input", data: "data\n" },
@@ -1953,14 +1953,14 @@ describe("CommandHandle", () => {
       expect(() => handle.sendInput("more\n")).toThrow(/closeStdin: false/);
     });
 
-    it("should throw from closeStdin under a PTY", () => {
+    it("should throw from closeInput under a PTY", () => {
       const stream = createMockStream([]);
       const handle = new CommandHandle(stream, null, createMockSandbox(), {
         commandId: "cmd-123",
         pty: true,
       });
 
-      expect(() => handle.closeStdin()).toThrow(/EOT/);
+      expect(() => handle.closeInput()).toThrow(/EOT/);
     });
 
     it("should throw when the command was run with stdin closed", () => {

--- a/js/src/tests/sandbox.test.ts
+++ b/js/src/tests/sandbox.test.ts
@@ -1950,7 +1950,7 @@ describe("CommandHandle", () => {
         { type: "input", data: "data\n" },
         { type: "close_stdin" },
       ]);
-      expect(() => handle.sendInput("more\n")).toThrow(/closeStdin: false/);
+      expect(() => handle.sendInput("more\n")).toThrow(/closeInput: false/);
     });
 
     it("should throw from closeInput under a PTY", () => {
@@ -1971,7 +1971,7 @@ describe("CommandHandle", () => {
       });
 
       expect(() => handle.sendInput("test input")).toThrow(
-        /closeStdin: false/,
+        /closeInput: false/,
       );
     });
   });

--- a/js/src/tests/sandbox.test.ts
+++ b/js/src/tests/sandbox.test.ts
@@ -1963,6 +1963,25 @@ describe("CommandHandle", () => {
       expect(() => handle.closeInput()).toThrow(/EOT/);
     });
 
+    it("should keep stdin closed across a manual reconnect", async () => {
+      const sandbox = createMockSandbox();
+      const handle = new CommandHandle(createMockStream([]), null, sandbox, {
+        commandId: "cmd-123",
+        stdinClosed: true,
+      });
+      (sandbox.reconnect as any).mockResolvedValue(
+        new CommandHandle(createMockStream([]), null, sandbox, {
+          commandId: "cmd-123",
+        }),
+      );
+
+      const reconnected = await handle.reconnect();
+
+      expect(() => reconnected.sendInput("more\n")).toThrow(
+        /closeInput: false/,
+      );
+    });
+
     it("should throw when the command was run with stdin closed", () => {
       const stream = createMockStream([]);
       const handle = new CommandHandle(stream, null, createMockSandbox(), {
@@ -1970,9 +1989,7 @@ describe("CommandHandle", () => {
         stdinClosed: true,
       });
 
-      expect(() => handle.sendInput("test input")).toThrow(
-        /closeInput: false/,
-      );
+      expect(() => handle.sendInput("test input")).toThrow(/closeInput: false/);
     });
   });
 });

--- a/python/langsmith/sandbox/README.md
+++ b/python/langsmith/sandbox/README.md
@@ -460,6 +460,7 @@ with client.sandbox(snapshot_id=snapshot_id) as sb:
     for chunk in handle:
         if "Name:" in chunk.data:
             handle.send_input("World\n")
+            handle.close_stdin()  # done sending: the command now reads EOF
         print(chunk.data, end="")
 
     result = handle.result
@@ -1270,6 +1271,7 @@ Returned by `sb.run(wait=False)`. Iterable, yielding `OutputChunk` objects.
 | `result` | Final `ExecutionResult` (blocks until complete) |
 | `kill()` | Send SIGKILL to the running command |
 | `send_input(data)` | Write string data to the command's stdin. Raises unless the command was run with `close_stdin=False` |
+| `close_stdin()` | Close stdin so the command reads EOF. Call once done sending input; raises under `pty` |
 | `reconnect()` | Reconnect from last known offsets |
 
 ### OutputChunk

--- a/python/langsmith/sandbox/README.md
+++ b/python/langsmith/sandbox/README.md
@@ -448,13 +448,13 @@ with client.sandbox(snapshot_id=snapshot_id) as sb:
 
 ```python
 with client.sandbox(snapshot_id=snapshot_id) as sb:
-    # close_stdin=False keeps stdin open; it defaults to True (except with
+    # close_input=False keeps stdin open; it defaults to True (except with
     # pty), so a command that reads stdin sees EOF instead of hanging.
     handle = sb.run(
         "python -c 'name = input(\"Name: \"); print(f\"Hello {name}\")'",
         timeout=30,
         wait=False,
-        close_stdin=False,
+        close_input=False,
     )
 
     for chunk in handle:
@@ -1270,7 +1270,7 @@ Returned by `sb.run(wait=False)`. Iterable, yielding `OutputChunk` objects.
 | `pid` | Process ID on the sandbox |
 | `result` | Final `ExecutionResult` (blocks until complete) |
 | `kill()` | Send SIGKILL to the running command |
-| `send_input(data)` | Write string data to the command's stdin. Raises unless the command was run with `close_stdin=False` |
+| `send_input(data)` | Write string data to the command's stdin. Raises unless the command was run with `close_input=False` |
 | `close_input()` | Close stdin so the command reads EOF. Call once done sending input; raises under `pty` |
 | `reconnect()` | Reconnect from last known offsets |
 

--- a/python/langsmith/sandbox/README.md
+++ b/python/langsmith/sandbox/README.md
@@ -460,7 +460,7 @@ with client.sandbox(snapshot_id=snapshot_id) as sb:
     for chunk in handle:
         if "Name:" in chunk.data:
             handle.send_input("World\n")
-            handle.close_stdin()  # done sending: the command now reads EOF
+            handle.close_input()  # done sending: the command now reads EOF
         print(chunk.data, end="")
 
     result = handle.result
@@ -1271,7 +1271,7 @@ Returned by `sb.run(wait=False)`. Iterable, yielding `OutputChunk` objects.
 | `result` | Final `ExecutionResult` (blocks until complete) |
 | `kill()` | Send SIGKILL to the running command |
 | `send_input(data)` | Write string data to the command's stdin. Raises unless the command was run with `close_stdin=False` |
-| `close_stdin()` | Close stdin so the command reads EOF. Call once done sending input; raises under `pty` |
+| `close_input()` | Close stdin so the command reads EOF. Call once done sending input; raises under `pty` |
 | `reconnect()` | Reconnect from last known offsets |
 
 ### OutputChunk

--- a/python/langsmith/sandbox/README.md
+++ b/python/langsmith/sandbox/README.md
@@ -448,10 +448,13 @@ with client.sandbox(snapshot_id=snapshot_id) as sb:
 
 ```python
 with client.sandbox(snapshot_id=snapshot_id) as sb:
+    # close_stdin=False keeps stdin open; it defaults to True (except with
+    # pty), so a command that reads stdin sees EOF instead of hanging.
     handle = sb.run(
         "python -c 'name = input(\"Name: \"); print(f\"Hello {name}\")'",
         timeout=30,
         wait=False,
+        close_stdin=False,
     )
 
     for chunk in handle:
@@ -1266,7 +1269,7 @@ Returned by `sb.run(wait=False)`. Iterable, yielding `OutputChunk` objects.
 | `pid` | Process ID on the sandbox |
 | `result` | Final `ExecutionResult` (blocks until complete) |
 | `kill()` | Send SIGKILL to the running command |
-| `send_input(data)` | Write string data to the command's stdin |
+| `send_input(data)` | Write string data to the command's stdin. Raises unless the command was run with `close_stdin=False` |
 | `reconnect()` | Reconnect from last known offsets |
 
 ### OutputChunk

--- a/python/langsmith/sandbox/_async_sandbox.py
+++ b/python/langsmith/sandbox/_async_sandbox.py
@@ -231,6 +231,7 @@ class AsyncSandbox:
         kill_on_disconnect: bool = ...,
         ttl_seconds: int = ...,
         pty: bool = ...,
+        close_stdin: Optional[bool] = ...,
         headers: RequestHeaders = ...,
         wait: Literal[True] = ...,
     ) -> ExecutionResult: ...
@@ -250,6 +251,7 @@ class AsyncSandbox:
         kill_on_disconnect: bool = ...,
         ttl_seconds: int = ...,
         pty: bool = ...,
+        close_stdin: Optional[bool] = ...,
         headers: RequestHeaders = ...,
         wait: Literal[False],
     ) -> AsyncCommandHandle: ...
@@ -268,6 +270,7 @@ class AsyncSandbox:
         kill_on_disconnect: bool = False,
         ttl_seconds: int = 600,
         pty: bool = False,
+        close_stdin: Optional[bool] = None,
         headers: RequestHeaders = None,
         wait: bool = True,
     ) -> Union[ExecutionResult, AsyncCommandHandle]:
@@ -299,6 +302,12 @@ class AsyncSandbox:
                 Useful for commands that require a TTY (e.g., interactive
                 programs, commands that use terminal control codes).
                 Defaults to False.
+            close_stdin: Close the command's stdin so a command that reads it
+                sees EOF instead of blocking on a pipe nothing writes to.
+                Defaults to True unless pty=True. Pass False to keep stdin
+                open for send_input(); calling send_input() on a handle whose
+                stdin was closed raises ValueError. Ignored by sandboxes older
+                than this option.
             wait: If True (default), block until the command completes and
                 return ExecutionResult. If False, return an
                 AsyncCommandHandle immediately for streaming output,
@@ -326,6 +335,11 @@ class AsyncSandbox:
 
         self._require_dataplane_url()
 
+        # Left open, stdin makes any command that reads it block until the
+        # timeout. Only a PTY needs it open by default; a caller that will
+        # send_input() on a pipe asks for it with close_stdin=False.
+        resolved_close_stdin = (not pty) if close_stdin is None else close_stdin
+
         use_ws = not wait or on_stdout or on_stderr
         if use_ws:
             return await self._run_ws(
@@ -341,6 +355,7 @@ class AsyncSandbox:
                 kill_on_disconnect=kill_on_disconnect,
                 ttl_seconds=ttl_seconds,
                 pty=pty,
+                close_stdin=resolved_close_stdin,
                 headers=headers,
             )
 
@@ -360,6 +375,7 @@ class AsyncSandbox:
                 kill_on_disconnect=kill_on_disconnect,
                 ttl_seconds=ttl_seconds,
                 pty=pty,
+                close_stdin=resolved_close_stdin,
                 headers=headers,
             )
         return await self._run_http(
@@ -386,6 +402,7 @@ class AsyncSandbox:
         kill_on_disconnect: bool = False,
         ttl_seconds: int = 600,
         pty: bool = False,
+        close_stdin: bool = False,
         headers: RequestHeaders = None,
     ) -> Union[ExecutionResult, AsyncCommandHandle]:
         """Execute via WebSocket /execute/ws."""
@@ -413,6 +430,7 @@ class AsyncSandbox:
             "kill_on_disconnect": kill_on_disconnect,
             "ttl_seconds": ttl_seconds,
             "pty": pty,
+            "close_stdin": close_stdin,
         }
         merged = self._client._ws_default_headers(headers)
         if merged:
@@ -434,6 +452,7 @@ class AsyncSandbox:
                 self,
                 on_stdout=on_stdout,
                 on_stderr=on_stderr,
+                stdin_closed=close_stdin,
             )
             try:
                 await handle._ensure_started()

--- a/python/langsmith/sandbox/_async_sandbox.py
+++ b/python/langsmith/sandbox/_async_sandbox.py
@@ -453,6 +453,7 @@ class AsyncSandbox:
                 on_stdout=on_stdout,
                 on_stderr=on_stderr,
                 stdin_closed=close_stdin,
+                pty=pty,
             )
             try:
                 await handle._ensure_started()

--- a/python/langsmith/sandbox/_async_sandbox.py
+++ b/python/langsmith/sandbox/_async_sandbox.py
@@ -231,7 +231,7 @@ class AsyncSandbox:
         kill_on_disconnect: bool = ...,
         ttl_seconds: int = ...,
         pty: bool = ...,
-        close_stdin: Optional[bool] = ...,
+        close_input: Optional[bool] = ...,
         headers: RequestHeaders = ...,
         wait: Literal[True] = ...,
     ) -> ExecutionResult: ...
@@ -251,7 +251,7 @@ class AsyncSandbox:
         kill_on_disconnect: bool = ...,
         ttl_seconds: int = ...,
         pty: bool = ...,
-        close_stdin: Optional[bool] = ...,
+        close_input: Optional[bool] = ...,
         headers: RequestHeaders = ...,
         wait: Literal[False],
     ) -> AsyncCommandHandle: ...
@@ -270,7 +270,7 @@ class AsyncSandbox:
         kill_on_disconnect: bool = False,
         ttl_seconds: int = 600,
         pty: bool = False,
-        close_stdin: Optional[bool] = None,
+        close_input: Optional[bool] = None,
         headers: RequestHeaders = None,
         wait: bool = True,
     ) -> Union[ExecutionResult, AsyncCommandHandle]:
@@ -302,7 +302,7 @@ class AsyncSandbox:
                 Useful for commands that require a TTY (e.g., interactive
                 programs, commands that use terminal control codes).
                 Defaults to False.
-            close_stdin: Close the command's stdin so a command that reads it
+            close_input: Close the command's stdin so a command that reads it
                 sees EOF instead of blocking on a pipe nothing writes to.
                 Defaults to True unless pty=True. Pass False to keep stdin
                 open for send_input(); calling send_input() on a handle whose
@@ -337,8 +337,8 @@ class AsyncSandbox:
 
         # Left open, stdin makes any command that reads it block until the
         # timeout. Only a PTY needs it open by default; a caller that will
-        # send_input() on a pipe asks for it with close_stdin=False.
-        resolved_close_stdin = (not pty) if close_stdin is None else close_stdin
+        # send_input() on a pipe asks for it with close_input=False.
+        resolved_close_input = (not pty) if close_input is None else close_input
 
         use_ws = not wait or on_stdout or on_stderr
         if use_ws:
@@ -355,7 +355,7 @@ class AsyncSandbox:
                 kill_on_disconnect=kill_on_disconnect,
                 ttl_seconds=ttl_seconds,
                 pty=pty,
-                close_stdin=resolved_close_stdin,
+                close_input=resolved_close_input,
                 headers=headers,
             )
 
@@ -375,7 +375,7 @@ class AsyncSandbox:
                 kill_on_disconnect=kill_on_disconnect,
                 ttl_seconds=ttl_seconds,
                 pty=pty,
-                close_stdin=resolved_close_stdin,
+                close_input=resolved_close_input,
                 headers=headers,
             )
         return await self._run_http(
@@ -402,7 +402,7 @@ class AsyncSandbox:
         kill_on_disconnect: bool = False,
         ttl_seconds: int = 600,
         pty: bool = False,
-        close_stdin: bool = False,
+        close_input: bool = False,
         headers: RequestHeaders = None,
     ) -> Union[ExecutionResult, AsyncCommandHandle]:
         """Execute via WebSocket /execute/ws."""
@@ -430,7 +430,7 @@ class AsyncSandbox:
             "kill_on_disconnect": kill_on_disconnect,
             "ttl_seconds": ttl_seconds,
             "pty": pty,
-            "close_stdin": close_stdin,
+            "close_stdin": close_input,
         }
         merged = self._client._ws_default_headers(headers)
         if merged:
@@ -452,7 +452,7 @@ class AsyncSandbox:
                 self,
                 on_stdout=on_stdout,
                 on_stderr=on_stderr,
-                stdin_closed=close_stdin,
+                stdin_closed=close_input,
                 pty=pty,
             )
             try:

--- a/python/langsmith/sandbox/_models.py
+++ b/python/langsmith/sandbox/_models.py
@@ -570,12 +570,14 @@ class CommandHandle:
         stderr_offset: int = 0,
         on_stdout: Optional[Callable[[str], Any]] = None,
         on_stderr: Optional[Callable[[str], Any]] = None,
+        stdin_closed: bool = False,
     ) -> None:
         self._stream = message_stream
         self._control = control
         self._sandbox = sandbox
         self._on_stdout = on_stdout
         self._on_stderr = on_stderr
+        self._stdin_closed = stdin_closed
         self._command_id: Optional[str] = None
         self._pid: Optional[int] = None
         self._result: Optional[ExecutionResult] = None
@@ -746,15 +748,26 @@ class CommandHandle:
         if self._control:
             self._control.send_kill()
 
+    def _require_open_stdin(self) -> None:
+        if self._stdin_closed:
+            raise ValueError(
+                "stdin was closed for this command. Pass close_stdin=False to "
+                "run() to keep it open for send_input()."
+            )
+
     def send_input(self, data: str) -> None:
         """Write data to the command's stdin.
 
         Args:
             data: String data to write to stdin.
 
+        Raises:
+            ValueError: If the command was run with stdin closed.
+
         Has no effect if the command has already exited or the
         WebSocket connection is closed.
         """
+        self._require_open_stdin()
         if self._control:
             self._control.send_input(data)
 
@@ -838,12 +851,14 @@ class AsyncCommandHandle:
         stderr_offset: int = 0,
         on_stdout: Optional[Callable[[str], Any]] = None,
         on_stderr: Optional[Callable[[str], Any]] = None,
+        stdin_closed: bool = False,
     ) -> None:
         self._stream = message_stream
         self._control = control
         self._sandbox = sandbox
         self._on_stdout = on_stdout
         self._on_stderr = on_stderr
+        self._stdin_closed = stdin_closed
         self._command_id: Optional[str] = None
         self._pid: Optional[int] = None
         self._result: Optional[ExecutionResult] = None
@@ -996,8 +1011,20 @@ class AsyncCommandHandle:
         if self._control:
             await self._control.send_kill()
 
+    def _require_open_stdin(self) -> None:
+        if self._stdin_closed:
+            raise ValueError(
+                "stdin was closed for this command. Pass close_stdin=False to "
+                "run() to keep it open for send_input()."
+            )
+
     async def send_input(self, data: str) -> None:
-        """Write data to the command's stdin."""
+        """Write data to the command's stdin.
+
+        Raises:
+            ValueError: If the command was run with stdin closed.
+        """
+        self._require_open_stdin()
         if self._control:
             await self._control.send_input(data)
 

--- a/python/langsmith/sandbox/_models.py
+++ b/python/langsmith/sandbox/_models.py
@@ -753,7 +753,7 @@ class CommandHandle:
     def _require_open_stdin(self) -> None:
         if self._stdin_closed:
             raise ValueError(
-                "stdin was closed for this command. Pass close_stdin=False to "
+                "stdin was closed for this command. Pass close_input=False to "
                 "run() to keep it open for send_input()."
             )
 
@@ -1041,7 +1041,7 @@ class AsyncCommandHandle:
     def _require_open_stdin(self) -> None:
         if self._stdin_closed:
             raise ValueError(
-                "stdin was closed for this command. Pass close_stdin=False to "
+                "stdin was closed for this command. Pass close_input=False to "
                 "run() to keep it open for send_input()."
             )
 

--- a/python/langsmith/sandbox/_models.py
+++ b/python/langsmith/sandbox/_models.py
@@ -571,6 +571,7 @@ class CommandHandle:
         on_stdout: Optional[Callable[[str], Any]] = None,
         on_stderr: Optional[Callable[[str], Any]] = None,
         stdin_closed: bool = False,
+        pty: bool = False,
     ) -> None:
         self._stream = message_stream
         self._control = control
@@ -578,6 +579,7 @@ class CommandHandle:
         self._on_stdout = on_stdout
         self._on_stderr = on_stderr
         self._stdin_closed = stdin_closed
+        self._pty = pty
         self._command_id: Optional[str] = None
         self._pid: Optional[int] = None
         self._result: Optional[ExecutionResult] = None
@@ -755,6 +757,13 @@ class CommandHandle:
                 "run() to keep it open for send_input()."
             )
 
+    def _require_closable_stdin(self) -> None:
+        if self._pty:
+            raise ValueError(
+                "a PTY command has no separate stdin to close. Send an EOT "
+                "byte (\\x04) with send_input() to signal EOF instead."
+            )
+
     def send_input(self, data: str) -> None:
         """Write data to the command's stdin.
 
@@ -770,6 +779,22 @@ class CommandHandle:
         self._require_open_stdin()
         if self._control:
             self._control.send_input(data)
+
+    def close_stdin(self) -> None:
+        """Close the command's stdin so a command reading it sees EOF.
+
+        Call this once done sending input. Idempotent. Afterwards send_input()
+        raises.
+
+        Raises:
+            ValueError: If the command was run with a PTY.
+        """
+        self._require_closable_stdin()
+        if self._stdin_closed:
+            return
+        self._stdin_closed = True
+        if self._control:
+            self._control.send_close_stdin()
 
     @property
     def last_stdout_offset(self) -> int:
@@ -852,6 +877,7 @@ class AsyncCommandHandle:
         on_stdout: Optional[Callable[[str], Any]] = None,
         on_stderr: Optional[Callable[[str], Any]] = None,
         stdin_closed: bool = False,
+        pty: bool = False,
     ) -> None:
         self._stream = message_stream
         self._control = control
@@ -859,6 +885,7 @@ class AsyncCommandHandle:
         self._on_stdout = on_stdout
         self._on_stderr = on_stderr
         self._stdin_closed = stdin_closed
+        self._pty = pty
         self._command_id: Optional[str] = None
         self._pid: Optional[int] = None
         self._result: Optional[ExecutionResult] = None
@@ -1018,6 +1045,13 @@ class AsyncCommandHandle:
                 "run() to keep it open for send_input()."
             )
 
+    def _require_closable_stdin(self) -> None:
+        if self._pty:
+            raise ValueError(
+                "a PTY command has no separate stdin to close. Send an EOT "
+                "byte (\\x04) with send_input() to signal EOF instead."
+            )
+
     async def send_input(self, data: str) -> None:
         """Write data to the command's stdin.
 
@@ -1027,6 +1061,22 @@ class AsyncCommandHandle:
         self._require_open_stdin()
         if self._control:
             await self._control.send_input(data)
+
+    async def close_stdin(self) -> None:
+        """Close the command's stdin so a command reading it sees EOF.
+
+        Call this once done sending input. Idempotent. Afterwards send_input()
+        raises.
+
+        Raises:
+            ValueError: If the command was run with a PTY.
+        """
+        self._require_closable_stdin()
+        if self._stdin_closed:
+            return
+        self._stdin_closed = True
+        if self._control:
+            await self._control.send_close_stdin()
 
     @property
     def last_stdout_offset(self) -> int:

--- a/python/langsmith/sandbox/_models.py
+++ b/python/langsmith/sandbox/_models.py
@@ -780,7 +780,7 @@ class CommandHandle:
         if self._control:
             self._control.send_input(data)
 
-    def close_stdin(self) -> None:
+    def close_input(self) -> None:
         """Close the command's stdin so a command reading it sees EOF.
 
         Call this once done sending input. Idempotent. Afterwards send_input()
@@ -1062,7 +1062,7 @@ class AsyncCommandHandle:
         if self._control:
             await self._control.send_input(data)
 
-    async def close_stdin(self) -> None:
+    async def close_input(self) -> None:
         """Close the command's stdin so a command reading it sees EOF.
 
         Call this once done sending input. Idempotent. Afterwards send_input()

--- a/python/langsmith/sandbox/_models.py
+++ b/python/langsmith/sandbox/_models.py
@@ -822,11 +822,14 @@ class CommandHandle:
             SandboxConnectionError: If connection to sandbox fails.
         """
         assert self._command_id is not None
-        return self._sandbox.reconnect(
+        handle = self._sandbox.reconnect(
             self._command_id,
             stdout_offset=self._last_stdout_offset,
             stderr_offset=self._last_stderr_offset,
         )
+        handle._stdin_closed = self._stdin_closed
+        handle._pty = self._pty
+        return handle
 
 
 class AsyncCommandHandle:
@@ -1091,8 +1094,11 @@ class AsyncCommandHandle:
     async def reconnect(self) -> AsyncCommandHandle:
         """Reconnect to this command from the last known offsets."""
         assert self._command_id is not None
-        return await self._sandbox.reconnect(
+        handle = await self._sandbox.reconnect(
             self._command_id,
             stdout_offset=self._last_stdout_offset,
             stderr_offset=self._last_stderr_offset,
         )
+        handle._stdin_closed = self._stdin_closed
+        handle._pty = self._pty
+        return handle

--- a/python/langsmith/sandbox/_sandbox.py
+++ b/python/langsmith/sandbox/_sandbox.py
@@ -227,6 +227,7 @@ class Sandbox:
         kill_on_disconnect: bool = ...,
         ttl_seconds: int = ...,
         pty: bool = ...,
+        close_stdin: Optional[bool] = ...,
         headers: RequestHeaders = ...,
         wait: Literal[True] = ...,
     ) -> ExecutionResult: ...
@@ -246,6 +247,7 @@ class Sandbox:
         kill_on_disconnect: bool = ...,
         ttl_seconds: int = ...,
         pty: bool = ...,
+        close_stdin: Optional[bool] = ...,
         headers: RequestHeaders = ...,
         wait: Literal[False],
     ) -> CommandHandle: ...
@@ -264,6 +266,7 @@ class Sandbox:
         kill_on_disconnect: bool = False,
         ttl_seconds: int = 600,
         pty: bool = False,
+        close_stdin: Optional[bool] = None,
         headers: RequestHeaders = None,
         wait: bool = True,
     ) -> Union[ExecutionResult, CommandHandle]:
@@ -295,6 +298,12 @@ class Sandbox:
                 Useful for commands that require a TTY (e.g., interactive
                 programs, commands that use terminal control codes).
                 Defaults to False.
+            close_stdin: Close the command's stdin so a command that reads it
+                sees EOF instead of blocking on a pipe nothing writes to.
+                Defaults to True unless pty=True. Pass False to keep stdin
+                open for send_input(); calling send_input() on a handle whose
+                stdin was closed raises ValueError. Ignored by sandboxes older
+                than this option.
             wait: If True (default), block until the command completes and
                 return ExecutionResult. If False, return a
                 CommandHandle immediately for streaming output,
@@ -322,6 +331,11 @@ class Sandbox:
 
         self._require_dataplane_url()
 
+        # Left open, stdin makes any command that reads it block until the
+        # timeout. Only a PTY needs it open by default; a caller that will
+        # send_input() on a pipe asks for it with close_stdin=False.
+        resolved_close_stdin = (not pty) if close_stdin is None else close_stdin
+
         # When not waiting or callbacks are requested, WS is required
         use_ws = not wait or on_stdout or on_stderr
         if use_ws:
@@ -338,6 +352,7 @@ class Sandbox:
                 kill_on_disconnect=kill_on_disconnect,
                 ttl_seconds=ttl_seconds,
                 pty=pty,
+                close_stdin=resolved_close_stdin,
                 headers=headers,
             )
 
@@ -357,6 +372,7 @@ class Sandbox:
                 kill_on_disconnect=kill_on_disconnect,
                 ttl_seconds=ttl_seconds,
                 pty=pty,
+                close_stdin=resolved_close_stdin,
                 headers=headers,
             )
         return self._run_http(
@@ -383,6 +399,7 @@ class Sandbox:
         kill_on_disconnect: bool = False,
         ttl_seconds: int = 600,
         pty: bool = False,
+        close_stdin: bool = False,
         headers: RequestHeaders = None,
     ) -> Union[ExecutionResult, CommandHandle]:
         """Execute via WebSocket /execute/ws."""
@@ -410,6 +427,7 @@ class Sandbox:
             "kill_on_disconnect": kill_on_disconnect,
             "ttl_seconds": ttl_seconds,
             "pty": pty,
+            "close_stdin": close_stdin,
         }
         merged = self._client._ws_default_headers(headers)
         if merged:
@@ -432,6 +450,7 @@ class Sandbox:
                     self,
                     on_stdout=on_stdout,
                     on_stderr=on_stderr,
+                    stdin_closed=close_stdin,
                 )
                 break
             except (

--- a/python/langsmith/sandbox/_sandbox.py
+++ b/python/langsmith/sandbox/_sandbox.py
@@ -227,7 +227,7 @@ class Sandbox:
         kill_on_disconnect: bool = ...,
         ttl_seconds: int = ...,
         pty: bool = ...,
-        close_stdin: Optional[bool] = ...,
+        close_input: Optional[bool] = ...,
         headers: RequestHeaders = ...,
         wait: Literal[True] = ...,
     ) -> ExecutionResult: ...
@@ -247,7 +247,7 @@ class Sandbox:
         kill_on_disconnect: bool = ...,
         ttl_seconds: int = ...,
         pty: bool = ...,
-        close_stdin: Optional[bool] = ...,
+        close_input: Optional[bool] = ...,
         headers: RequestHeaders = ...,
         wait: Literal[False],
     ) -> CommandHandle: ...
@@ -266,7 +266,7 @@ class Sandbox:
         kill_on_disconnect: bool = False,
         ttl_seconds: int = 600,
         pty: bool = False,
-        close_stdin: Optional[bool] = None,
+        close_input: Optional[bool] = None,
         headers: RequestHeaders = None,
         wait: bool = True,
     ) -> Union[ExecutionResult, CommandHandle]:
@@ -298,7 +298,7 @@ class Sandbox:
                 Useful for commands that require a TTY (e.g., interactive
                 programs, commands that use terminal control codes).
                 Defaults to False.
-            close_stdin: Close the command's stdin so a command that reads it
+            close_input: Close the command's stdin so a command that reads it
                 sees EOF instead of blocking on a pipe nothing writes to.
                 Defaults to True unless pty=True. Pass False to keep stdin
                 open for send_input(); calling send_input() on a handle whose
@@ -333,8 +333,8 @@ class Sandbox:
 
         # Left open, stdin makes any command that reads it block until the
         # timeout. Only a PTY needs it open by default; a caller that will
-        # send_input() on a pipe asks for it with close_stdin=False.
-        resolved_close_stdin = (not pty) if close_stdin is None else close_stdin
+        # send_input() on a pipe asks for it with close_input=False.
+        resolved_close_input = (not pty) if close_input is None else close_input
 
         # When not waiting or callbacks are requested, WS is required
         use_ws = not wait or on_stdout or on_stderr
@@ -352,7 +352,7 @@ class Sandbox:
                 kill_on_disconnect=kill_on_disconnect,
                 ttl_seconds=ttl_seconds,
                 pty=pty,
-                close_stdin=resolved_close_stdin,
+                close_input=resolved_close_input,
                 headers=headers,
             )
 
@@ -372,7 +372,7 @@ class Sandbox:
                 kill_on_disconnect=kill_on_disconnect,
                 ttl_seconds=ttl_seconds,
                 pty=pty,
-                close_stdin=resolved_close_stdin,
+                close_input=resolved_close_input,
                 headers=headers,
             )
         return self._run_http(
@@ -399,7 +399,7 @@ class Sandbox:
         kill_on_disconnect: bool = False,
         ttl_seconds: int = 600,
         pty: bool = False,
-        close_stdin: bool = False,
+        close_input: bool = False,
         headers: RequestHeaders = None,
     ) -> Union[ExecutionResult, CommandHandle]:
         """Execute via WebSocket /execute/ws."""
@@ -427,7 +427,7 @@ class Sandbox:
             "kill_on_disconnect": kill_on_disconnect,
             "ttl_seconds": ttl_seconds,
             "pty": pty,
-            "close_stdin": close_stdin,
+            "close_stdin": close_input,
         }
         merged = self._client._ws_default_headers(headers)
         if merged:
@@ -450,7 +450,7 @@ class Sandbox:
                     self,
                     on_stdout=on_stdout,
                     on_stderr=on_stderr,
-                    stdin_closed=close_stdin,
+                    stdin_closed=close_input,
                     pty=pty,
                 )
                 break

--- a/python/langsmith/sandbox/_sandbox.py
+++ b/python/langsmith/sandbox/_sandbox.py
@@ -451,6 +451,7 @@ class Sandbox:
                     on_stdout=on_stdout,
                     on_stderr=on_stderr,
                     stdin_closed=close_stdin,
+                    pty=pty,
                 )
                 break
             except (

--- a/python/langsmith/sandbox/_ws_execute.py
+++ b/python/langsmith/sandbox/_ws_execute.py
@@ -322,6 +322,7 @@ def run_ws_stream(
     kill_on_disconnect: bool = False,
     ttl_seconds: int = 600,
     pty: bool = False,
+    close_stdin: bool = False,
     headers: Optional[Mapping[str, str]] = None,
     open_timeout: Optional[float] = WS_OPEN_TIMEOUT,
 ) -> tuple[Iterator[dict], _WSStreamControl]:
@@ -374,6 +375,8 @@ def run_ws_stream(
                     payload["cwd"] = cwd
                 if pty:
                     payload["pty"] = True
+                if close_stdin:
+                    payload["close_stdin"] = True
                 ws.send(json.dumps(payload))
 
                 # Read messages until exit or error
@@ -529,6 +532,7 @@ async def run_ws_stream_async(
     kill_on_disconnect: bool = False,
     ttl_seconds: int = 600,
     pty: bool = False,
+    close_stdin: bool = False,
     headers: Optional[Mapping[str, str]] = None,
     open_timeout: Optional[float] = WS_OPEN_TIMEOUT,
 ) -> tuple[AsyncIterator[dict], _AsyncWSStreamControl]:
@@ -570,6 +574,8 @@ async def run_ws_stream_async(
                     payload["cwd"] = cwd
                 if pty:
                     payload["pty"] = True
+                if close_stdin:
+                    payload["close_stdin"] = True
                 await ws.send(json.dumps(payload))
 
                 async for raw_msg in ws:

--- a/python/langsmith/sandbox/_ws_execute.py
+++ b/python/langsmith/sandbox/_ws_execute.py
@@ -166,6 +166,11 @@ class _WSStreamControl:
         if self._ws and not self._closed:
             self._ws.send(json.dumps({"type": "input", "data": data}))
 
+    def send_close_stdin(self) -> None:
+        """Ask the server to close the command's stdin, so it reads EOF."""
+        if self._ws and not self._closed:
+            self._ws.send(json.dumps({"type": "close_stdin"}))
+
 
 class _AsyncWSStreamControl:
     """Async equivalent of _WSStreamControl."""
@@ -202,6 +207,11 @@ class _AsyncWSStreamControl:
     async def send_input(self, data: str) -> None:
         if self._ws and not self._closed:
             await self._ws.send(json.dumps({"type": "input", "data": data}))
+
+    async def send_close_stdin(self) -> None:
+        """Ask the server to close the command's stdin, so it reads EOF."""
+        if self._ws and not self._closed:
+            await self._ws.send(json.dumps({"type": "close_stdin"}))
 
 
 # =============================================================================

--- a/python/tests/unit_tests/sandbox/test_async_ws_execute.py
+++ b/python/tests/unit_tests/sandbox/test_async_ws_execute.py
@@ -883,6 +883,7 @@ class TestAsyncSandboxRunWs:
             kill_on_disconnect=False,
             ttl_seconds=600,
             pty=False,
+            close_stdin=True,
             open_timeout=ANY,
         )
 

--- a/python/tests/unit_tests/sandbox/test_ws_execute.py
+++ b/python/tests/unit_tests/sandbox/test_ws_execute.py
@@ -841,8 +841,8 @@ class TestSandboxRunWs:
             ({}, True),
             ({"wait": False}, True),
             ({"pty": True}, False),
-            ({"close_stdin": False}, False),
-            ({"pty": True, "close_stdin": True}, True),
+            ({"close_input": False}, False),
+            ({"pty": True, "close_input": True}, True),
         ],
     )
     @patch("langsmith.sandbox._ws_execute.run_ws_stream")
@@ -863,7 +863,7 @@ class TestSandboxRunWs:
             _WSStreamControl(),
         )
         handle = self._make_sandbox().run("cmd", wait=False)
-        with pytest.raises(ValueError, match="close_stdin=False"):
+        with pytest.raises(ValueError, match="close_input=False"):
             handle.send_input("hi\n")
 
     @patch("langsmith.sandbox._ws_execute.run_ws_stream")
@@ -875,7 +875,7 @@ class TestSandboxRunWs:
             _make_stream([_started_msg(), _exit_msg(0)]),
             control,
         )
-        handle = self._make_sandbox().run("cmd", wait=False, close_stdin=False)
+        handle = self._make_sandbox().run("cmd", wait=False, close_input=False)
 
         handle.send_input("data\n")
         handle.close_input()
@@ -888,7 +888,7 @@ class TestSandboxRunWs:
 
         handle.close_input()  # idempotent
         assert control._ws.send.call_count == 2
-        with pytest.raises(ValueError, match="close_stdin=False"):
+        with pytest.raises(ValueError, match="close_input=False"):
             handle.send_input("more\n")
 
     @patch("langsmith.sandbox._ws_execute.run_ws_stream")
@@ -911,7 +911,7 @@ class TestSandboxRunWs:
             _make_stream([_started_msg(), _exit_msg(0)]),
             control,
         )
-        handle = self._make_sandbox().run("cmd", wait=False, close_stdin=False)
+        handle = self._make_sandbox().run("cmd", wait=False, close_input=False)
         handle.send_input("hi\n")
         control._ws.send.assert_called_once()
 

--- a/python/tests/unit_tests/sandbox/test_ws_execute.py
+++ b/python/tests/unit_tests/sandbox/test_ws_execute.py
@@ -831,8 +831,53 @@ class TestSandboxRunWs:
             kill_on_disconnect=False,
             ttl_seconds=600,
             pty=False,
+            close_stdin=True,
             open_timeout=ANY,
         )
+
+    @pytest.mark.parametrize(
+        ("kwargs", "expected"),
+        [
+            ({}, True),
+            ({"wait": False}, True),
+            ({"pty": True}, False),
+            ({"close_stdin": False}, False),
+            ({"pty": True, "close_stdin": True}, True),
+        ],
+    )
+    @patch("langsmith.sandbox._ws_execute.run_ws_stream")
+    def test_close_stdin_default(self, mock_run_ws, kwargs, expected):
+        """stdin is closed unless a PTY is requested or the caller opts out."""
+        mock_run_ws.return_value = (
+            _make_stream([_started_msg(), _exit_msg(0)]),
+            _WSStreamControl(),
+        )
+        self._make_sandbox().run("cmd", **kwargs)
+        assert mock_run_ws.call_args.kwargs["close_stdin"] is expected
+
+    @patch("langsmith.sandbox._ws_execute.run_ws_stream")
+    def test_send_input_rejected_when_stdin_closed(self, mock_run_ws):
+        """send_input() on a closed-stdin handle points at the fix."""
+        mock_run_ws.return_value = (
+            _make_stream([_started_msg(), _exit_msg(0)]),
+            _WSStreamControl(),
+        )
+        handle = self._make_sandbox().run("cmd", wait=False)
+        with pytest.raises(ValueError, match="close_stdin=False"):
+            handle.send_input("hi\n")
+
+    @patch("langsmith.sandbox._ws_execute.run_ws_stream")
+    def test_send_input_allowed_when_stdin_open(self, mock_run_ws):
+        """Opting out keeps send_input() working."""
+        control = _WSStreamControl()
+        control._ws = MagicMock()
+        mock_run_ws.return_value = (
+            _make_stream([_started_msg(), _exit_msg(0)]),
+            control,
+        )
+        handle = self._make_sandbox().run("cmd", wait=False, close_stdin=False)
+        handle.send_input("hi\n")
+        control._ws.send.assert_called_once()
 
     @patch("langsmith.sandbox._ws_execute.run_ws_stream")
     def test_run_forwards_client_default_headers(self, mock_run_ws):

--- a/python/tests/unit_tests/sandbox/test_ws_execute.py
+++ b/python/tests/unit_tests/sandbox/test_ws_execute.py
@@ -867,8 +867,8 @@ class TestSandboxRunWs:
             handle.send_input("hi\n")
 
     @patch("langsmith.sandbox._ws_execute.run_ws_stream")
-    def test_close_stdin_after_sending_input(self, mock_run_ws):
-        """Input then EOF: close_stdin() sends the message and locks the door."""
+    def test_close_input_after_sending_input(self, mock_run_ws):
+        """Input then EOF: close_input() sends the message and locks the door."""
         control = _WSStreamControl()
         control._ws = MagicMock()
         mock_run_ws.return_value = (
@@ -878,7 +878,7 @@ class TestSandboxRunWs:
         handle = self._make_sandbox().run("cmd", wait=False, close_stdin=False)
 
         handle.send_input("data\n")
-        handle.close_stdin()
+        handle.close_input()
 
         sent = [json.loads(c.args[0]) for c in control._ws.send.call_args_list]
         assert sent == [
@@ -886,13 +886,13 @@ class TestSandboxRunWs:
             {"type": "close_stdin"},
         ]
 
-        handle.close_stdin()  # idempotent
+        handle.close_input()  # idempotent
         assert control._ws.send.call_count == 2
         with pytest.raises(ValueError, match="close_stdin=False"):
             handle.send_input("more\n")
 
     @patch("langsmith.sandbox._ws_execute.run_ws_stream")
-    def test_close_stdin_rejected_under_pty(self, mock_run_ws):
+    def test_close_input_rejected_under_pty(self, mock_run_ws):
         """A PTY has no separate stdin; the error says to send EOT."""
         mock_run_ws.return_value = (
             _make_stream([_started_msg(), _exit_msg(0)]),
@@ -900,7 +900,7 @@ class TestSandboxRunWs:
         )
         handle = self._make_sandbox().run("cmd", wait=False, pty=True)
         with pytest.raises(ValueError, match=r"EOT"):
-            handle.close_stdin()
+            handle.close_input()
 
     @patch("langsmith.sandbox._ws_execute.run_ws_stream")
     def test_send_input_allowed_when_stdin_open(self, mock_run_ws):

--- a/python/tests/unit_tests/sandbox/test_ws_execute.py
+++ b/python/tests/unit_tests/sandbox/test_ws_execute.py
@@ -867,6 +867,42 @@ class TestSandboxRunWs:
             handle.send_input("hi\n")
 
     @patch("langsmith.sandbox._ws_execute.run_ws_stream")
+    def test_close_stdin_after_sending_input(self, mock_run_ws):
+        """Input then EOF: close_stdin() sends the message and locks the door."""
+        control = _WSStreamControl()
+        control._ws = MagicMock()
+        mock_run_ws.return_value = (
+            _make_stream([_started_msg(), _exit_msg(0)]),
+            control,
+        )
+        handle = self._make_sandbox().run("cmd", wait=False, close_stdin=False)
+
+        handle.send_input("data\n")
+        handle.close_stdin()
+
+        sent = [json.loads(c.args[0]) for c in control._ws.send.call_args_list]
+        assert sent == [
+            {"type": "input", "data": "data\n"},
+            {"type": "close_stdin"},
+        ]
+
+        handle.close_stdin()  # idempotent
+        assert control._ws.send.call_count == 2
+        with pytest.raises(ValueError, match="close_stdin=False"):
+            handle.send_input("more\n")
+
+    @patch("langsmith.sandbox._ws_execute.run_ws_stream")
+    def test_close_stdin_rejected_under_pty(self, mock_run_ws):
+        """A PTY has no separate stdin; the error says to send EOT."""
+        mock_run_ws.return_value = (
+            _make_stream([_started_msg(), _exit_msg(0)]),
+            _WSStreamControl(),
+        )
+        handle = self._make_sandbox().run("cmd", wait=False, pty=True)
+        with pytest.raises(ValueError, match=r"EOT"):
+            handle.close_stdin()
+
+    @patch("langsmith.sandbox._ws_execute.run_ws_stream")
     def test_send_input_allowed_when_stdin_open(self, mock_run_ws):
         """Opting out keeps send_input() working."""
         control = _WSStreamControl()

--- a/python/tests/unit_tests/sandbox/test_ws_execute.py
+++ b/python/tests/unit_tests/sandbox/test_ws_execute.py
@@ -654,6 +654,24 @@ class TestCommandHandle:
             stderr_offset=handle.last_stderr_offset,
         )
 
+    def test_manual_reconnect_keeps_stdin_closed(self):
+        """A reconnected handle still refuses send_input() once stdin is closed."""
+        sandbox = self._make_sandbox_mock()
+        sandbox.reconnect.return_value = CommandHandle(
+            _make_stream([_exit_msg(0)]), None, sandbox, command_id="cmd-123"
+        )
+        handle = CommandHandle(
+            _make_stream([_started_msg(), _exit_msg(0)]),
+            None,
+            sandbox,
+            stdin_closed=True,
+        )
+        list(handle)
+
+        new_handle = handle.reconnect()
+        with pytest.raises(ValueError, match="close_input=False"):
+            new_handle.send_input("hi\n")
+
     def test_reconnect_with_explicit_command_id(self):
         """Reconnection handle with pre-set command_id."""
         stream = _make_stream(


### PR DESCRIPTION
A sandbox exec session is spawned with a writable stdin pipe that nothing ever closes. A command that reads stdin — `cat`, `grep` with no file argument, an installer that prompts — never sees EOF, so it blocks on a pipe nobody is writing to until the timeout kills it. Callers work around it by prefixing commands with `< /dev/null`.

The dataplane now offers two ways to close it (langchain-ai/langchainplus#35838), and this exposes both, named to pair with `send_input()`.

**1. `close_input` on `run()`** (`closeInput` in JS), for a command that will never be sent input. **It defaults to true unless `pty` is set.** Not reading stdin is overwhelmingly the common case, and hanging until a timeout is a bad default to leave opt-in. A PTY keeps stdin open, since input and output share one fd there and the shape is interactive by definition.

That default is breaking for one pattern: a non-PTY command run with `wait=False` whose handle is then fed `send_input()`. Rather than let that fail silently — input landing on a closed pipe — a handle whose stdin was closed raises from `send_input()` and names the option to pass:

```
ValueError: stdin was closed for this command. Pass close_input=False to run()
to keep it open for send_input().
```

**2. `close_input()` on the command handle** (`closeInput()` in JS), for the send-input-then-EOF flow the spawn-time option can't serve:

```python
handle = sb.run("...", wait=False, close_input=False)
handle.send_input("data\n")
handle.close_input()   # done sending; the command now reads EOF
```

It's idempotent, marks stdin closed locally so a later `send_input()` raises the same way, and refuses under `pty` — where the server would drop the message — pointing at sending an EOT byte (`0x04`) instead.

On the wire both are still `close_stdin` (the execute-message field and the client message); only the SDK surface uses `input`, so the option, the method, and `send_input` share a noun.

Both READMEs' non-PTY `send_input` examples now pass the opt-out explicitly and show the new method; the handle API tables list it. The PTY examples are unaffected. Sandboxes older than the dataplane change ignore both, so behavior there is unchanged.

## Test Plan

- [x] Python: `close_input` resolution parametrized over the default, `wait=False`, `pty=True`, the explicit opt-out, and `pty` plus an explicit opt-in; `send_input()` raising once stdin is closed and working when it is not; and `close_input()` sending exactly `input` then `close_stdin` on the wire, staying idempotent, locking out later input, and refusing under `pty`; and a manual `reconnect()` keeping stdin closed on the handle it returns. `pytest tests/unit_tests/sandbox/` — 558 passed.
- [x] JS: the same handle cases — wire messages, idempotence, the lockout, the PTY refusal, and stdin staying closed across a manual `reconnect()`. `pnpm test:single src/tests/sandbox.test.ts` — 149 passed.
- [x] `ruff format` / `ruff check` clean on the changed Python; `tsc --noEmit` clean on the JS.

