### PR TITLE
fix(client): clamp list_runs page-size to 100 to avoid HTTP 400 for limit>100

### DIFF
--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -4517,7 +4517,11 @@ class Client:
             "id": run_ids,
             "trace": trace_id,
             "select": select,
-            "limit": limit,
+            # /runs/query enforces a server-side page-size cap of 100.
+            # Clamp to 100 so callers who pass limit>100 don't get HTTP 400.
+            # The total-count cap below (i+1 >= limit) still honours the
+            # caller's intent across pages.
+            "limit": min(limit, 100) if limit is not None else 100,
             **kwargs,
         }
         body_query = {k: v for k, v in body_query.items() if v is not None}

--- a/python/tests/unit_tests/test_client.py
+++ b/python/tests/unit_tests/test_client.py
@@ -8051,3 +8051,57 @@ def test_compression_threads_default(monkeypatch: pytest.MonkeyPatch) -> None:
     finally:
         monkeypatch.undo()
         _reload()
+
+
+@mock.patch("langsmith.client.requests.Session")
+def test_list_runs_clamps_limit_to_100(mock_session_cls: mock.Mock) -> None:
+    """list_runs(limit=N) must not pass N > 100 as the page size to /runs/query.
+
+    The server enforces a hard cap of 100 on the ``limit`` field.  Passing a
+    larger value results in HTTP 400.  The client should clamp the page size
+    while still honouring the caller's total-count cap via the client-side
+    break condition (i + 1 >= limit).
+    """
+    import json
+
+    mock_session = mock.Mock()
+    mock_session_cls.return_value = mock_session
+    # Return an empty run list to stop pagination immediately.
+    mock_session.request.return_value.json.return_value = {"runs": []}
+    mock_session.request.return_value.raise_for_status.return_value = None
+
+    client = Client(api_key="test-key", api_url="http://localhost")
+
+    with pytest.warns(DeprecationWarning):
+        list(client.list_runs(project_id=uuid.uuid4(), limit=200))
+
+    # Inspect the POST body sent to /runs/query.
+    call_args = mock_session.request.call_args
+    sent_data = call_args.kwargs.get("data") or call_args[1].get("data") or b""
+    body = json.loads(sent_data)
+    assert body["limit"] == 100, (
+        f"Expected page-size limit=100 to be sent to server, got {body['limit']}"
+    )
+
+
+@mock.patch("langsmith.client.requests.Session")
+def test_list_runs_passes_small_limit_unchanged(mock_session_cls: mock.Mock) -> None:
+    """list_runs(limit=N) for N <= 100 should pass N as-is to the server."""
+    import json
+
+    mock_session = mock.Mock()
+    mock_session_cls.return_value = mock_session
+    mock_session.request.return_value.json.return_value = {"runs": []}
+    mock_session.request.return_value.raise_for_status.return_value = None
+
+    client = Client(api_key="test-key", api_url="http://localhost")
+
+    with pytest.warns(DeprecationWarning):
+        list(client.list_runs(project_id=uuid.uuid4(), limit=42))
+
+    call_args = mock_session.request.call_args
+    sent_data = call_args.kwargs.get("data") or call_args[1].get("data") or b""
+    body = json.loads(sent_data)
+    assert body["limit"] == 42, (
+        f"Expected page-size limit=42 to be sent to server, got {body['limit']}"
+    )


### PR DESCRIPTION
## Summary

`Client.list_runs(limit=N)` fails with HTTP 400 for any `N` above 100. The
`/runs/query` endpoint enforces a server-side page-size cap of 100.

**Root cause**: `list_runs` passes the caller's `limit` directly to the
request body as the page-size field. About ten sibling methods (`list_threads`,
`list_examples`, `list_feedback`, and others) already clamp this value with
`min(limit, 100) if limit is not None else 100`; `list_runs` was the odd one
out.

**Fix**: apply the same clamp. The client-side break condition
(`i + 1 >= limit`) is preserved, so callers who pass `limit > 100` still
receive up to `limit` results across multiple pages instead of getting a 400
on the first request.

Fixes #3455.

## Changes

- `python/langsmith/client.py`: clamp the page-size `"limit"` in the
  `list_runs` request body to `min(limit, 100) if limit is not None else 100`,
  matching every other cursor-paginated method in the file.
- `python/tests/unit_tests/test_client.py`: two new unit tests verifying the
  correct page-size is sent to the server for both small (<=100) and large
  (>100) caller limits.

## Test plan

- `pytest python/tests/unit_tests/test_client.py -k "list_runs_clamps or list_runs_passes_small"` passes.
- Existing `test_list_runs_child_run_ids_deprecation_warning` continues to pass.