### PR TITLE
release(py): 0.11.2

### DIFF
--- a/python/.bumpversion.cfg
+++ b/python/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.11.1
+current_version = 0.11.2
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
 serialize = {major}.{minor}.{patch}
 search = {current_version}

--- a/python/langsmith/__init__.py
+++ b/python/langsmith/__init__.py
@@ -49,7 +49,7 @@ if TYPE_CHECKING:
 
 # Avoid calling into importlib on every call to __version__
 
-__version__ = "0.11.1"
+__version__ = "0.11.2"
 version = __version__  # for backwards compatibility
 
 # Metadata key to hide a traced run from LangSmith's Messages View.


### PR DESCRIPTION
## Summary

- bump the Python SDK version from 0.11.1 to 0.11.2
- keep the bumpversion config and runtime version declaration synchronized

## Testing

- parsed both version declarations and verified they resolve to 0.11.2
- `git diff --check`