### PR TITLE
fix(py): suppress import-untyped on the optional langsmith_pyo3 import

### DIFF
--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -1487,7 +1487,7 @@ class Client:
         if ls_utils.get_env_var("USE_PYO3_CLIENT") is not None:
             langsmith_pyo3 = None
             try:
-                import langsmith_pyo3  # type: ignore[import-not-found, no-redef]
+                import langsmith_pyo3  # type: ignore[import-not-found, import-untyped, no-redef]
             except ImportError as e:
                 logger.warning(
                     "Failed to import `langsmith_pyo3` when PyO3 client was requested, "


### PR DESCRIPTION
Cherry-pick of @Vissirexa's commit from #3443 / #3444, opened from a branch in this repo so CI can run. Original authorship preserved; closes #3444 in favor of this PR.

Fixes #3443.

`make lint` fails on an unmodified `main` for anyone whose venv has the optional `langsmith_pyo3` extra installed:

```
langsmith/client.py:1491: error: Skipping analyzing "langsmith_pyo3": module is installed, but missing library stubs or py.typed marker  [import-untyped]
langsmith/client.py:1491: note: Error code "import-untyped" not covered by "type: ignore[import-not-found, no-redef]" comment
```

The ignore on that guarded import lists `import-not-found`, which is what mypy emits when the module cannot be resolved at all. `langsmith-pyo3` ships no `py.typed`, so when the extra is actually installed mypy resolves the module, finds no types for it, and emits `import-untyped` instead — a code the list does not cover.

CI does not see this: the lint job installs with `uv sync --group dev --group lint`, and `langsmith_pyo3` is a `[project.optional-dependencies]` extra rather than a dependency group, so it is never present there and mypy takes the `import-not-found` path.

```diff
-import langsmith_pyo3  # type: ignore[import-not-found, no-redef]
+import langsmith_pyo3  # type: ignore[import-not-found, import-untyped, no-redef]
```

Adding the code covers the installed case and is inert in the other — `warn_unused_ignores` is not enabled in `[tool.mypy]`, so an error code in the list that does not fire is not itself an error.

No test accompanies this since it is a type-checker suppression with no runtime behavior. Reproduction is `uv sync --extra langsmith_pyo3 && make lint`, which fails before this change and passes after.
