### PR TITLE
feat(py,js): generate Insights over an existing tracing project

### DIFF
--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -58,6 +58,8 @@ import {
   Entry,
   DirectoryCommitResponse,
   HubRepoType,
+  InsightsReport,
+  InsightsReportResult,
 } from "./schemas.js";
 import {
   convertLangChainMessageToExample,
@@ -823,6 +825,38 @@ const SERVER_INFO_REQUEST_TIMEOUT_MS = 10000;
 
 /** Maximum number of operations to batch in a single request. */
 const DEFAULT_BATCH_SIZE_LIMIT = 100;
+
+const OPENAI_API_KEY = "OPENAI_API_KEY";
+const ANTHROPIC_API_KEY = "ANTHROPIC_API_KEY";
+const DEFAULT_INSIGHTS_INSTRUCTIONS =
+  "How are people using my agent? What are they asking about?";
+const UPLOADED_TRACE_STRUCTURE =
+  "The run.outputs.messages field contains a chat history between the user and the" +
+  " agent. This is all the context you need.";
+const DEFAULT_TRACE_STRUCTURE =
+  "Each trace is a single interaction with the agent. The root run's inputs and" +
+  " outputs are the primary context.";
+const MAX_INSIGHTS_CHAT_HISTORIES = 1000;
+
+/** Resolve an Insights job id and project id from either form of the args. */
+function _resolveInsightsIds(
+  report: InsightsReport | undefined,
+  id: string | undefined,
+  projectId: string | undefined,
+): [string, string] {
+  if (report !== undefined) {
+    if (id !== undefined || projectId !== undefined) {
+      throw new Error(
+        "Must provide either report or id and projectId, not both",
+      );
+    }
+    return [report.id, report.project_id];
+  }
+  if (id === undefined || projectId === undefined) {
+    throw new Error("Must provide either report or both id and projectId");
+  }
+  return [id, projectId];
+}
 
 /**
  * Reject header names or values that could alter a request's framing.
@@ -4369,6 +4403,366 @@ export class Client implements LangSmithTracingClientInterface {
       return projects[0].tenant_id;
     }
     throw new Error("No projects found to resolve tenant.");
+  }
+
+  /**
+   * Generate Insights over an existing tracing project or over chat histories
+   * you upload.
+   *
+   * Specify exactly one of `chatHistories`, `projectName`, or `projectId`. The
+   * first uploads the histories as traces to a new project, the latter two run
+   * over runs already traced to that project.
+   *
+   * Only available to Plus and higher tier LangSmith users. The Insights agent
+   * uses your own model API key; if you pass one it is stored as a workspace
+   * secret, meaning it is also used for evaluators and the playground.
+   *
+   * @example
+   * ```ts
+   * const report = await client.generateInsights({
+   *   projectName: "my-agent",
+   *   instructions: "What do users ask about?",
+   *   lastNHours: 24 * 7,
+   *   sample: 0.1,
+   * });
+   * await client.pollInsights({ report });
+   * ```
+   */
+  public async generateInsights({
+    chatHistories,
+    projectName,
+    projectId,
+    instructions = DEFAULT_INSIGHTS_INSTRUCTIONS,
+    traceStructure,
+    name,
+    lastNHours,
+    startTime,
+    endTime,
+    filter,
+    sample,
+    model,
+    openaiApiKey,
+    anthropicApiKey,
+  }: {
+    chatHistories?: KVMap[][];
+    projectName?: string;
+    projectId?: string;
+    instructions?: string;
+    traceStructure?: string;
+    name?: string;
+    lastNHours?: number;
+    startTime?: Date | string;
+    endTime?: Date | string;
+    filter?: string;
+    sample?: number;
+    model?: "openai" | "anthropic";
+    openaiApiKey?: string;
+    anthropicApiKey?: string;
+  }): Promise<InsightsReport> {
+    const sources = [chatHistories, projectName, projectId].filter(
+      (source) => source !== undefined,
+    );
+    if (sources.length !== 1) {
+      throw new Error(
+        "Must provide exactly one of chatHistories, projectName, or projectId",
+      );
+    }
+
+    let runSelection: RecordStringAny = {
+      last_n_hours: lastNHours,
+      start_time:
+        startTime instanceof Date ? startTime.toISOString() : startTime,
+      end_time: endTime instanceof Date ? endTime.toISOString() : endTime,
+      filter,
+      sample,
+    };
+    if (
+      chatHistories !== undefined &&
+      Object.values(runSelection).some((value) => value !== undefined)
+    ) {
+      throw new Error(
+        "lastNHours, startTime, endTime, filter, and sample select runs from an" +
+          " existing project and cannot be used with chatHistories",
+      );
+    }
+
+    const resolvedModel = await this._ensureInsightsApiKey({
+      openaiApiKey,
+      anthropicApiKey,
+      model,
+    });
+
+    let sessionId: string;
+    let defaultTraceStructure: string;
+    if (chatHistories !== undefined) {
+      sessionId = await this._ingestInsightsRuns(chatHistories, name);
+      // The runs were just ingested, so only the last hour can match.
+      runSelection = { last_n_hours: 1 };
+      defaultTraceStructure = UPLOADED_TRACE_STRUCTURE;
+    } else {
+      sessionId = projectId ?? (await this.readProject({ projectName })).id;
+      defaultTraceStructure = DEFAULT_TRACE_STRUCTURE;
+    }
+
+    const body: RecordStringAny = {
+      name: name ?? null,
+      user_context: {
+        "How are your agent traces structured?":
+          traceStructure ?? defaultTraceStructure,
+        "What would you like to learn about your agent?": instructions,
+      },
+      model: resolvedModel,
+    };
+    // Omit unset keys so the server applies its own defaults.
+    for (const [key, value] of Object.entries(runSelection)) {
+      if (value !== undefined) {
+        body[key] = value;
+      }
+    }
+
+    const serializedBody = JSON.stringify(body);
+    const response = await this.caller.call(async () => {
+      const res = await this._fetch(
+        `${this.apiUrl}/sessions/${sessionId}/insights`,
+        {
+          method: "POST",
+          headers: {
+            ...this._mergedHeaders,
+            "Content-Type": "application/json",
+          },
+          signal: AbortSignal.timeout(this.timeout_ms),
+          ...this.fetchOptions,
+          body: serializedBody,
+        },
+      );
+      await raiseForStatus(res, "generate insights");
+      return res;
+    });
+    return this._toInsightsReport(await response.json(), sessionId);
+  }
+
+  /**
+   * Poll an Insights report until it completes.
+   *
+   * Provide either `report` or both `id` and `projectId`. `rate` and `timeout`
+   * are in seconds.
+   */
+  public async pollInsights({
+    report,
+    id,
+    projectId,
+    rate = 30,
+    timeout = 30 * 60,
+  }: {
+    report?: InsightsReport;
+    id?: string;
+    projectId?: string;
+    rate?: number;
+    timeout?: number;
+  }): Promise<InsightsReport> {
+    const [jobId, sessionId] = _resolveInsightsIds(report, id, projectId);
+    const deadline = Date.now() + timeout * 1000;
+    do {
+      const job = await this._get<RecordStringAny>(
+        `/sessions/${sessionId}/insights/${jobId}`,
+      );
+      if (job.status === "success") {
+        return this._toInsightsReport(job, sessionId);
+      }
+      if (job.status === "error") {
+        throw new Error(`Failed to generate insights: ${job.error}`);
+      }
+      const delay = Math.min(rate * 1000, deadline - Date.now());
+      if (delay <= 0) {
+        break;
+      }
+      await new Promise((resolve) => setTimeout(resolve, delay));
+    } while (Date.now() < deadline);
+    throw new Error("Insights still pending");
+  }
+
+  /**
+   * Fetch a completed Insights report, by default including its runs.
+   *
+   * Provide either `report` or both `id` and `projectId`.
+   */
+  public async getInsightsReport({
+    id,
+    report,
+    projectId,
+    includeRuns = true,
+  }: {
+    id?: string;
+    report?: InsightsReport;
+    projectId?: string;
+    includeRuns?: boolean;
+  }): Promise<InsightsReportResult> {
+    const [jobId, sessionId] = _resolveInsightsIds(report, id, projectId);
+    const result = await this._get<InsightsReportResult>(
+      `/sessions/${sessionId}/insights/${jobId}`,
+    );
+    result.clusters = result.clusters ?? [];
+    result.runs = includeRuns
+      ? await this.fetchInsightsRuns({ id: jobId, projectId: sessionId })
+      : [];
+    return result;
+  }
+
+  /**
+   * Fetch the runs analyzed by an Insights report, optionally narrowed to one
+   * cluster.
+   */
+  public async fetchInsightsRuns({
+    id,
+    projectId,
+    clusterId,
+  }: {
+    id: string;
+    projectId: string;
+    clusterId?: string;
+  }): Promise<KVMap[]> {
+    const params = new URLSearchParams();
+    if (clusterId !== undefined) {
+      params.append("cluster_id", clusterId);
+    }
+    const runs: KVMap[] = [];
+    for await (const batch of this._getPaginated<KVMap, { runs?: KVMap[] }>(
+      `/sessions/${projectId}/insights/${id}/runs`,
+      params,
+      (data) => data.runs ?? [],
+    )) {
+      runs.push(...batch);
+    }
+    return runs;
+  }
+
+  private async _toInsightsReport(
+    job: RecordStringAny,
+    projectId: string,
+  ): Promise<InsightsReport> {
+    const tenantId = await this._getTenantId();
+    const hostUrl = this.getHostUrl();
+    return {
+      id: job.id,
+      name: job.name,
+      status: job.status,
+      error: job.error ?? null,
+      project_id: projectId,
+      tenant_id: tenantId,
+      host_url: hostUrl,
+      link:
+        `${hostUrl}/o/${tenantId}/projects/p/${projectId}` +
+        `?tab=3&clusterJobId=${job.id}`,
+    };
+  }
+
+  private async _ensureInsightsApiKey({
+    openaiApiKey,
+    anthropicApiKey,
+    model,
+  }: {
+    openaiApiKey?: string;
+    anthropicApiKey?: string;
+    model?: "openai" | "anthropic";
+  }): Promise<"openai" | "anthropic"> {
+    const secrets = await this._get<{ key?: string }[]>(
+      "/workspaces/current/secrets",
+    );
+    const workspaceKeys = new Set((secrets ?? []).map((secret) => secret.key));
+    const targetKeys: string[] = [];
+    if (model !== "anthropic") {
+      targetKeys.push(OPENAI_API_KEY);
+    }
+    if (model !== "openai") {
+      targetKeys.push(ANTHROPIC_API_KEY);
+    }
+
+    const existing = targetKeys.filter((key) => workspaceKeys.has(key));
+    if (existing.length > 0) {
+      return existing.includes(OPENAI_API_KEY) ? "openai" : "anthropic";
+    }
+
+    let apiKey: string | undefined;
+    let apiVar: string;
+    if (model === "openai") {
+      apiKey = openaiApiKey;
+      apiVar = OPENAI_API_KEY;
+    } else if (model === "anthropic") {
+      apiKey = anthropicApiKey;
+      apiVar = ANTHROPIC_API_KEY;
+    } else if (openaiApiKey || anthropicApiKey) {
+      apiKey = openaiApiKey ?? anthropicApiKey;
+      apiVar = openaiApiKey ? OPENAI_API_KEY : ANTHROPIC_API_KEY;
+    } else {
+      throw new Error("Must specify openaiApiKey or anthropicApiKey.");
+    }
+    if (!apiKey) {
+      const expected =
+        apiVar === OPENAI_API_KEY ? "openaiApiKey" : "anthropicApiKey";
+      throw new Error(`Must specify ${expected}.`);
+    }
+
+    const serializedBody = JSON.stringify([{ key: apiVar, value: apiKey }]);
+    await this.caller.call(async () => {
+      const res = await this._fetch(
+        `${this.apiUrl}/workspaces/current/secrets`,
+        {
+          method: "POST",
+          headers: {
+            ...this._mergedHeaders,
+            "Content-Type": "application/json",
+          },
+          signal: AbortSignal.timeout(this.timeout_ms),
+          ...this.fetchOptions,
+          body: serializedBody,
+        },
+      );
+      await raiseForStatus(res, "store workspace secret", true);
+      return res;
+    });
+    return apiVar === OPENAI_API_KEY ? "openai" : "anthropic";
+  }
+
+  private async _ingestInsightsRuns(
+    chatHistories: KVMap[][],
+    name?: string,
+  ): Promise<string> {
+    let histories = chatHistories;
+    if (histories.length > MAX_INSIGHTS_CHAT_HISTORIES) {
+      warnOnce(
+        `Can only generate insights over ${MAX_INSIGHTS_CHAT_HISTORIES} chat` +
+          ` histories. Truncating to the first ${MAX_INSIGHTS_CHAT_HISTORIES}.`,
+      );
+      histories = histories.slice(0, MAX_INSIGHTS_CHAT_HISTORIES);
+    }
+    const projectName =
+      name ??
+      `insights ${new Date().toISOString().replace("T", " ").slice(0, 19)}`;
+    const project = await this.createProject({ projectName });
+    const endTime = new Date();
+    const startTime = new Date(endTime.getTime() - 1000);
+    const runCreates: RunCreate[] = histories.map((history) => {
+      const runId = uuid.v7();
+      return {
+        id: runId,
+        trace_id: runId,
+        dotted_order:
+          `${startTime.toISOString().slice(0, -1)}001Z`.replace(
+            /[^a-zA-Z0-9]/g,
+            "",
+          ) + runId,
+        name: "trace",
+        run_type: "chain",
+        inputs: { messages: history.slice(0, 1) },
+        outputs: { messages: history },
+        start_time: startTime.toISOString(),
+        end_time: endTime.toISOString(),
+        session_name: projectName,
+      };
+    });
+    await this.batchIngestRuns({ runCreates });
+    await this.flush();
+    return project.id;
   }
 
   public async *listProjects({

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -12,6 +12,11 @@ export type {
   Feedback,
   FeedbackConfigSchema,
   RetrieverOutput,
+  InsightsReport,
+  InsightsReportResult,
+  InsightsCluster,
+  InsightsSummaryReport,
+  InsightsHighlightedTrace,
 } from "./schemas.js";
 
 export { RunTree, type RunTreeConfig, type WriteReplica } from "./run_trees.js";

--- a/js/src/schemas.ts
+++ b/js/src/schemas.ts
@@ -812,3 +812,66 @@ export type UsageMetadata = {
 };
 
 export type ExtractedUsageMetadata = Partial<UsageMetadata>;
+
+/**
+ * A running or completed Insights report (also called a clustering job).
+ */
+export interface InsightsReport {
+  id: string;
+  name: string;
+  status: string;
+  error?: string | null;
+  project_id: string;
+  tenant_id: string;
+  host_url: string;
+  /** Link to the report in the LangSmith UI. */
+  link: string;
+}
+
+/** A trace highlighted in an Insights report summary. */
+export interface InsightsHighlightedTrace {
+  run_id: string;
+  rank: number;
+  highlight_reason: string;
+  cluster_id?: string | null;
+  cluster_name?: string | null;
+  summary?: string | null;
+}
+
+/** High level summary of an Insights report. */
+export interface InsightsSummaryReport {
+  title?: string | null;
+  key_points?: string[];
+  highlighted_traces?: InsightsHighlightedTrace[];
+  created_at?: string | null;
+}
+
+/** One cluster of runs within an Insights report. */
+export interface InsightsCluster {
+  id: string;
+  level: number;
+  name: string;
+  description: string;
+  num_runs: number;
+  parent_id?: string | null;
+  parent_name?: string | null;
+  stats?: KVMap | null;
+}
+
+/** The full result of a completed Insights report. */
+export interface InsightsReportResult {
+  id: string;
+  name: string;
+  status: string;
+  start_time?: string | null;
+  end_time?: string | null;
+  created_at?: string | null;
+  metadata?: KVMap | null;
+  shape?: Record<string, number> | null;
+  error?: string | null;
+  config_id?: string | null;
+  clusters: InsightsCluster[];
+  report?: InsightsSummaryReport | null;
+  /** Populated when `includeRuns` is true. */
+  runs: KVMap[];
+}

--- a/js/src/tests/insights.test.ts
+++ b/js/src/tests/insights.test.ts
@@ -1,0 +1,253 @@
+import { jest } from "@jest/globals";
+
+import { Client } from "../client.js";
+
+const PROJECT_ID = "55555555-5555-5555-5555-555555555555";
+const TENANT_ID = "44444444-4444-4444-4444-444444444444";
+const JOB_ID = "11111111-1111-1111-1111-111111111111";
+
+function jsonResponse(payload: unknown): Response {
+  return new Response(JSON.stringify(payload), {
+    status: 200,
+    statusText: "OK",
+    headers: { "content-type": "application/json" },
+  });
+}
+
+const secretsPayload = [{ key: "OPENAI_API_KEY" }];
+const jobPayload = {
+  id: JOB_ID,
+  name: "test-report",
+  status: "queued",
+  error: null,
+};
+const projectPayload = {
+  id: PROJECT_ID,
+  name: "my-agent",
+  tenant_id: TENANT_ID,
+  start_time: "2026-02-12T22:14:48.648851Z",
+  reference_dataset_id: null,
+};
+
+function makeClient(responses: unknown[]) {
+  const mockFetch = jest.fn<typeof fetch>();
+  for (const payload of responses) {
+    mockFetch.mockResolvedValueOnce(jsonResponse(payload));
+  }
+  const client = new Client({
+    apiUrl: "http://localhost:1984",
+    apiKey: "test-api-key",
+    fetchImplementation: mockFetch,
+  });
+  return { client, mockFetch };
+}
+
+describe("generateInsights", () => {
+  it("posts to an existing project and omits unset run selection", async () => {
+    // secrets -> create job -> resolve tenant
+    const { client, mockFetch } = makeClient([
+      secretsPayload,
+      jobPayload,
+      [projectPayload],
+    ]);
+
+    const report = await client.generateInsights({
+      projectId: PROJECT_ID,
+      name: "Conversation Topics",
+      instructions: "What do users ask about?",
+      lastNHours: 24,
+      filter: "eq(is_root, true)",
+      sample: 0.1,
+    });
+
+    const [url, init] = mockFetch.mock.calls[1];
+    expect(url).toBe(`http://localhost:1984/sessions/${PROJECT_ID}/insights`);
+    expect(init?.method).toBe("POST");
+
+    const body = JSON.parse(init?.body as string);
+    expect(body.last_n_hours).toBe(24);
+    expect(body.filter).toBe("eq(is_root, true)");
+    expect(body.sample).toBe(0.1);
+    expect(body).not.toHaveProperty("start_time");
+    expect(body).not.toHaveProperty("end_time");
+    expect(
+      body.user_context["What would you like to learn about your agent?"],
+    ).toBe("What do users ask about?");
+
+    expect(report.id).toBe(JOB_ID);
+    expect(report.project_id).toBe(PROJECT_ID);
+    expect(report.link).toBe(
+      `http://localhost:3000/o/${TENANT_ID}/projects/p/${PROJECT_ID}` +
+        `?tab=3&clusterJobId=${JOB_ID}`,
+    );
+  });
+
+  it("resolves projectName to a project id", async () => {
+    // secrets -> read project -> create job -> resolve tenant
+    const { client, mockFetch } = makeClient([
+      secretsPayload,
+      [projectPayload],
+      jobPayload,
+      [projectPayload],
+    ]);
+
+    await client.generateInsights({ projectName: "my-agent" });
+
+    expect(mockFetch.mock.calls[1][0]).toBe(
+      "http://localhost:1984/sessions?name=my-agent",
+    );
+    expect(mockFetch.mock.calls[2][0]).toBe(
+      `http://localhost:1984/sessions/${PROJECT_ID}/insights`,
+    );
+  });
+
+  it("serializes Date run selection bounds", async () => {
+    const { client, mockFetch } = makeClient([
+      secretsPayload,
+      jobPayload,
+      [projectPayload],
+    ]);
+
+    await client.generateInsights({
+      projectId: PROJECT_ID,
+      startTime: new Date("2026-01-01T00:00:00.000Z"),
+      endTime: "2026-01-02T00:00:00.000Z",
+    });
+
+    const body = JSON.parse(mockFetch.mock.calls[1][1]?.body as string);
+    expect(body.start_time).toBe("2026-01-01T00:00:00.000Z");
+    expect(body.end_time).toBe("2026-01-02T00:00:00.000Z");
+  });
+
+  it("uses the supplied trace structure", async () => {
+    const { client, mockFetch } = makeClient([
+      secretsPayload,
+      jobPayload,
+      [projectPayload],
+    ]);
+
+    await client.generateInsights({
+      projectId: PROJECT_ID,
+      traceStructure: "Look at outputs.answer.",
+    });
+
+    const body = JSON.parse(mockFetch.mock.calls[1][1]?.body as string);
+    expect(body.user_context["How are your agent traces structured?"]).toBe(
+      "Look at outputs.answer.",
+    );
+  });
+
+  it.each([
+    [{}],
+    [{ projectId: PROJECT_ID, projectName: "my-agent" }],
+    [{ chatHistories: [], projectName: "my-agent" }],
+  ])("requires exactly one source (%j)", async (args) => {
+    const { client, mockFetch } = makeClient([]);
+
+    await expect(client.generateInsights(args)).rejects.toThrow(
+      "Must provide exactly one of chatHistories, projectName, or projectId",
+    );
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("rejects run selection alongside chatHistories", async () => {
+    const { client, mockFetch } = makeClient([]);
+
+    await expect(
+      client.generateInsights({ chatHistories: [], lastNHours: 24 }),
+    ).rejects.toThrow("cannot be used with chatHistories");
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+});
+
+describe("pollInsights", () => {
+  it("polls until the job succeeds", async () => {
+    const { client, mockFetch } = makeClient([
+      { ...jobPayload, status: "running" },
+      { ...jobPayload, status: "success" },
+      [projectPayload],
+    ]);
+
+    const report = await client.pollInsights({
+      id: JOB_ID,
+      projectId: PROJECT_ID,
+      rate: 0.01,
+    });
+
+    expect(report.status).toBe("success");
+    expect(mockFetch.mock.calls[0][0]).toBe(
+      `http://localhost:1984/sessions/${PROJECT_ID}/insights/${JOB_ID}?`,
+    );
+    expect(mockFetch.mock.calls[1][1]?.method).toBe("GET");
+  });
+
+  it("throws the job error", async () => {
+    const { client } = makeClient([
+      { ...jobPayload, status: "error", error: "boom" },
+    ]);
+
+    await expect(
+      client.pollInsights({ id: JOB_ID, projectId: PROJECT_ID, rate: 0.01 }),
+    ).rejects.toThrow("Failed to generate insights: boom");
+  });
+
+  it("requires report or both id and projectId", async () => {
+    const { client } = makeClient([]);
+
+    await expect(client.pollInsights({ id: JOB_ID })).rejects.toThrow(
+      "Must provide either report or both id and projectId",
+    );
+  });
+});
+
+describe("getInsightsReport", () => {
+  it("skips run fetching when includeRuns is false", async () => {
+    const { client, mockFetch } = makeClient([
+      {
+        id: JOB_ID,
+        name: "test-report",
+        status: "success",
+        clusters: [
+          {
+            id: "33333333-3333-3333-3333-333333333333",
+            level: 0,
+            name: "cluster-a",
+            description: "Cluster A",
+            num_runs: 2,
+          },
+        ],
+      },
+    ]);
+
+    const result = await client.getInsightsReport({
+      id: JOB_ID,
+      projectId: PROJECT_ID,
+      includeRuns: false,
+    });
+
+    expect(result.clusters).toHaveLength(1);
+    expect(result.runs).toEqual([]);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("paginates runs when includeRuns is true", async () => {
+    const page = (n: number) => ({
+      runs: [{ id: `run-${n}-1` }, { id: `run-${n}-2` }],
+    });
+    const { client, mockFetch } = makeClient([
+      { id: JOB_ID, name: "test-report", status: "success", clusters: [] },
+      page(1),
+    ]);
+
+    const result = await client.getInsightsReport({
+      id: JOB_ID,
+      projectId: PROJECT_ID,
+    });
+
+    // Short page ends pagination, so exactly one runs request is made.
+    expect(result.runs).toHaveLength(2);
+    expect(mockFetch.mock.calls[1][0]).toContain(
+      `/sessions/${PROJECT_ID}/insights/${JOB_ID}/runs`,
+    );
+  });
+});

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -393,6 +393,14 @@ EMPTY_SEQ: tuple[dict, ...] = ()
 _UNSET = object()
 URLLIB3_SUPPORTS_BLOCKSIZE = "key_blocksize" in signature(PoolKey).parameters
 DEFAULT_INSTRUCTIONS = "How are people using my agent? What are they asking about?"
+_UPLOADED_TRACE_STRUCTURE = (
+    "The run.outputs.messages field contains a chat history between the user and the"
+    " agent. This is all the context you need."
+)
+_DEFAULT_TRACE_STRUCTURE = (
+    "Each trace is a single interaction with the agent. The root run's inputs and"
+    " outputs are the primary context."
+)
 
 _fallback_dirs_created: set[str] = set()
 
@@ -11236,36 +11244,64 @@ class Client:
         )
 
     @warn_beta
+    @ls_utils.xor_args(("chat_histories", "project_name", "project_id"))
     def generate_insights(
         self,
         *,
-        chat_histories: list[list[dict]],
+        chat_histories: list[list[dict]] | None = None,
+        project_name: str | None = None,
+        project_id: ID_TYPE | None = None,
         instructions: str = DEFAULT_INSTRUCTIONS,
+        trace_structure: str | None = None,
         name: str | None = None,
+        last_n_hours: int | None = None,
+        start_time: datetime.datetime | None = None,
+        end_time: datetime.datetime | None = None,
+        filter: str | None = None,
+        sample: float | int | None = None,
         model: Literal["openai", "anthropic"] | None = None,
         openai_api_key: str | None = None,
         anthropic_api_key: str | None = None,
     ) -> ls_schemas.InsightsReport:
-        """Generate Insights over your agent chat histories.
+        """Generate Insights over an existing tracing project or your chat histories.
+
+        Specify exactly one of 'chat_histories', 'project_name', or 'project_id'. The
+        first uploads the histories as traces to a new project, the latter two run
+        over runs already traced to that project.
 
         !!! note
 
             - Only available to Plus and higher tier LangSmith users.
             - Insights Agent uses user's model API key. The cost of the report
-                grows linearly with the number of chat histories you upload and the
-                size of each history. For more see [insights](https://docs.langchain.com/langsmith/insights).
-            - This method will upload your chat histories as traces to LangSmith.
+                grows linearly with the number of traces analyzed and the
+                size of each one. For more see [insights](https://docs.langchain.com/langsmith/insights).
             - If you pass in a model API key this will be set as a workspace secret
                 meaning it will be usedin for evaluators and the playground.
 
         Args:
-            chat_histories: A list of chat histories. Each chat history should be a
-                list of messages. We recommend formatting these as OpenAI messages with
-                a "role" and "content" key. Max length 1000 items.
+            chat_histories: A list of chat histories to upload as a new project. Each
+                chat history should be a list of messages. We recommend formatting
+                these as OpenAI messages with a "role" and "content" key. Max length
+                1000 items.
+            project_name: Name of an existing tracing project to analyze.
+            project_id: ID of an existing tracing project to analyze.
             instructions: Instructions for the Insights agent. Should focus on what
                 your agent does and what types of insights you
                 want to generate.
+            trace_structure: Description of how your traces are structured and where
+                the Insights agent should look for the agent's conversation. Defaults
+                to a generic description of a root run.
             name: Name for the generated Insights report.
+            last_n_hours: Analyze runs from the last N hours. Defaults to 168 (7 days)
+                server-side. Only for an existing project, and mutually exclusive with
+                'start_time'.
+            start_time: Analyze runs starting at this time. Only for an existing
+                project.
+            end_time: Analyze runs up until this time. Only for an existing project.
+            filter: LangSmith filter query narrowing which runs are analyzed. Defaults
+                to "eq(is_root, true)" server-side. Only for an existing project.
+            sample: Sample size (e.g. 200) or sampling rate (e.g. 0.1) of matching
+                runs. Only for an existing project.
             model: Whether to use OpenAI or Anthropic models. This will impact the
                 cost of generating the Insights Report.
             openai_api_key: OpenAI API key to use. Only needed if you have not already
@@ -11278,8 +11314,19 @@ class Client:
             import os
             from langsmith import Client
 
-            client = client()
+            client = Client()
 
+            # Over a project you are already tracing to.
+            report = client.generate_insights(
+                project_name="my-agent",
+                name="Conversation Topics",
+                instructions="What are the high-level topics of conversations users are having with the assistant?",
+                last_n_hours=24 * 7,
+                sample=0.1,
+                openai_api_key=os.environ["OPENAI_API_KEY"],
+            )
+
+            # Or over chat histories you upload.
             chat_histories = [
                 [
                     {"role": "user", "content": "how are you"},
@@ -11290,40 +11337,68 @@ class Client:
                     {"role": "assistant", "content": "only Tarkovsky"},
                 ],
             ]
-
             report = client.generate_insights(
                 chat_histories=chat_histories,
                 name="Conversation Topics",
-                instructions="What are the high-level topics of conversations users are having with the assistant?",
                 openai_api_key=os.environ["OPENAI_API_KEY"],
             )
 
             # client.poll_insights(report=report)
             ```
         """
+        run_selection: dict[str, Any] = {
+            "last_n_hours": last_n_hours,
+            "start_time": start_time.isoformat() if start_time else None,
+            "end_time": end_time.isoformat() if end_time else None,
+            "filter": filter,
+            "sample": sample,
+        }
+        if chat_histories is not None and any(
+            v is not None for v in run_selection.values()
+        ):
+            raise ValueError(
+                f"{sorted(run_selection)} select runs from an existing project and"
+                " cannot be used with 'chat_histories'."
+            )
+
         model = self._ensure_insights_api_key(
             openai_api_key=openai_api_key,
             anthropic_api_key=anthropic_api_key,
             model=model,
         )
-        project = self._ingest_insights_runs(chat_histories, name)
+        if chat_histories is not None:
+            session_id: ID_TYPE = self._ingest_insights_runs(chat_histories, name).id
+            # The runs were just ingested, so only the last hour can match.
+            run_selection = {"last_n_hours": 1}
+            default_trace_structure = _UPLOADED_TRACE_STRUCTURE
+        else:
+            session_id = (
+                _as_uuid(project_id, "project_id")
+                if project_id is not None
+                else self.read_project(project_name=project_name).id
+            )
+            default_trace_structure = _DEFAULT_TRACE_STRUCTURE
+
         config = {
             "name": name,
             "user_context": {
-                "How are your agent traces structured?": "The run.outputs.messages field contains a chat history between the user and the agent. This is all the context you need.",
+                "How are your agent traces structured?": (
+                    trace_structure or default_trace_structure
+                ),
                 "What would you like to learn about your agent?": instructions,
             },
-            "last_n_hours": 1,
             "model": model,
+            # Omit unset keys so the server applies its own defaults.
+            **{k: v for k, v in run_selection.items() if v is not None},
         }
         response = self.request_with_retries(
-            "POST", f"/sessions/{project.id}/insights", json=config
+            "POST", f"/sessions/{session_id}/insights", json=config
         )
         ls_utils.raise_for_status_with_text(response)
         res = response.json()
         report = ls_schemas.InsightsReport(
             **res,
-            project_id=project.id,
+            project_id=session_id,
             tenant_id=self._get_tenant_id(),
             host_url=self._host_url,
         )
@@ -11377,8 +11452,7 @@ class Client:
                     host_url=self._host_url,
                 )
                 print(  # noqa: T201
-                    "Insights report completed! View the results at %s",
-                    job.link,
+                    f"Insights report completed! View the results at {job.link}"
                 )
                 return job
             elif resp_json["status"] == "error":

--- a/python/tests/unit_tests/test_insights_report.py
+++ b/python/tests/unit_tests/test_insights_report.py
@@ -5,15 +5,17 @@ from __future__ import annotations
 from typing import Any, Dict, List
 from uuid import UUID
 
+import pytest
+
 from langsmith import schemas as ls_schemas
 from langsmith.client import Client
 
 
 class _DummyResponse:
-    def __init__(self, payload: Dict[str, Any]) -> None:
+    def __init__(self, payload: Any) -> None:
         self._payload = payload
 
-    def json(self) -> Dict[str, Any]:
+    def json(self) -> Any:
         return self._payload
 
     def raise_for_status(self) -> None:
@@ -22,7 +24,7 @@ class _DummyResponse:
 
 
 class _DummyClient(Client):
-    def __init__(self, responses: List[Dict[str, Any]]) -> None:  # type: ignore[no-untyped-def]
+    def __init__(self, responses: List[Any]) -> None:  # type: ignore[no-untyped-def]
         self._responses = responses
         self._calls: List[Dict[str, Any]] = []
 
@@ -179,3 +181,131 @@ def test_get_insights_report_with_runs_and_cluster_load_traces() -> None:
     for call in run_calls_with_cluster:
         assert "/insights/job-id/runs" in call["path"]
         assert call["kwargs"]["params"]["cluster_id"] == str(cluster.id)
+
+
+class _GenerateInsightsClient(_DummyClient):
+    """_DummyClient plus the attributes generate_insights reads off a real Client."""
+
+    _TENANT_ID = "44444444-4444-4444-4444-444444444444"
+
+    def _get_tenant_id(self) -> str:  # type: ignore[override]
+        return self._TENANT_ID
+
+    @property
+    def _host_url(self) -> str:  # type: ignore[override]
+        return "https://smith.langchain.com"
+
+
+def _make_secrets_payload() -> List[Dict[str, str]]:
+    return [{"key": "OPENAI_API_KEY"}]
+
+
+def _make_job_payload() -> Dict[str, Any]:
+    return {
+        "id": "11111111-1111-1111-1111-111111111111",
+        "name": "test-report",
+        "status": "queued",
+        "error": None,
+    }
+
+
+def _make_project_payload(project_id: str) -> Dict[str, Any]:
+    return {
+        "id": project_id,
+        "name": "my-agent",
+        "tenant_id": _GenerateInsightsClient._TENANT_ID,
+        "reference_dataset_id": None,
+    }
+
+
+def test_generate_insights_over_existing_project_id() -> None:
+    project_id = "55555555-5555-5555-5555-555555555555"
+    client = _GenerateInsightsClient([_make_secrets_payload(), _make_job_payload()])
+
+    report = client.generate_insights(
+        project_id=project_id,
+        name="Conversation Topics",
+        instructions="What do users ask about?",
+        last_n_hours=24,
+        filter="eq(is_root, true)",
+        sample=0.1,
+    )
+
+    assert isinstance(report, ls_schemas.InsightsReport)
+    assert str(report.project_id) == project_id
+    assert f"clusterJobId={report.id}" in report.link
+
+    create_call = client._calls[1]
+    assert create_call["method"] == "POST"
+    assert create_call["path"] == f"/sessions/{project_id}/insights"
+
+    body = create_call["kwargs"]["json"]
+    assert body["last_n_hours"] == 24
+    assert body["filter"] == "eq(is_root, true)"
+    assert body["sample"] == 0.1
+    # Unset run-selection keys are omitted so the server applies its defaults.
+    assert "start_time" not in body
+    assert "end_time" not in body
+    assert (
+        body["user_context"]["What would you like to learn about your agent?"]
+        == "What do users ask about?"
+    )
+
+
+def test_generate_insights_resolves_project_name() -> None:
+    project_id = "55555555-5555-5555-5555-555555555555"
+    client = _GenerateInsightsClient(
+        [
+            _make_secrets_payload(),
+            [_make_project_payload(project_id)],
+            _make_job_payload(),
+        ]
+    )
+
+    client.generate_insights(project_name="my-agent")
+
+    read_call = client._calls[1]
+    assert read_call["path"] == "/sessions"
+    assert read_call["kwargs"]["params"]["name"] == "my-agent"
+    assert client._calls[2]["path"] == f"/sessions/{project_id}/insights"
+
+
+def test_generate_insights_passes_trace_structure() -> None:
+    client = _GenerateInsightsClient([_make_secrets_payload(), _make_job_payload()])
+
+    client.generate_insights(
+        project_id="55555555-5555-5555-5555-555555555555",
+        trace_structure="Look at outputs.answer.",
+    )
+
+    body = client._calls[1]["kwargs"]["json"]
+    assert (
+        body["user_context"]["How are your agent traces structured?"]
+        == "Look at outputs.answer."
+    )
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {},
+        {"project_id": "p", "project_name": "my-agent"},
+        {"chat_histories": [], "project_name": "my-agent"},
+    ],
+)
+def test_generate_insights_requires_exactly_one_source(kwargs: Dict[str, Any]) -> None:
+    client = _GenerateInsightsClient([])
+
+    with pytest.raises(ValueError, match="Exactly one argument"):
+        client.generate_insights(**kwargs)
+
+    assert client._calls == []
+
+
+def test_generate_insights_rejects_run_selection_with_chat_histories() -> None:
+    client = _GenerateInsightsClient([])
+
+    with pytest.raises(ValueError, match="cannot be used with 'chat_histories'"):
+        client.generate_insights(chat_histories=[], last_n_hours=24)
+
+    assert client._calls == []


### PR DESCRIPTION
## Why

`POST /sessions/{session_id}/insights` can run an Insights report over any tracing project, but neither hand-written SDK exposed that:

- **Python** — `generate_insights` always called `_ingest_insights_runs`, which creates a *new* project and uploads chat histories into it. Pointing Insights at a project you already trace to meant dropping to `client.request_with_retries(...)` by hand.
- **JS** — no Insights surface at all.

The generated Go/Java SDKs already ship the raw endpoint; the generated Python/TS clients skip the whole `sessions` resource by design, so this is hand-written SDK work.

## Python

`generate_insights` now accepts `project_name` / `project_id` alongside `chat_histories` — exactly one, enforced with the existing `ls_utils.xor_args` — plus the run-selection args the endpoint supports:

```python
report = client.generate_insights(
    project_name="my-agent",
    instructions="What do users ask about?",
    last_n_hours=24 * 7,
    filter="eq(is_root, true)",
    sample=0.1,
)
client.poll_insights(report=report)
```

Unset run-selection keys are omitted from the request body so the server applies its own defaults (`last_n_hours=168`, `filter="eq(is_root, true)"`). The existing `chat_histories` call is unchanged and still pins `last_n_hours=1`. `poll_insights` and `get_insights_report` already accepted `id` + `project_id`, so they needed no changes.

Two judgment calls worth a look in review:

1. The hardcoded `"How are your agent traces structured?"` answer described the *synthetic uploaded* run shape (`run.outputs.messages`), which is wrong for an arbitrary existing project. It is now a `trace_structure` param, defaulting per path.
2. Passing a run-selection arg together with `chat_histories` raises `ValueError` rather than being silently ignored.

Also fixes an adjacent `print("... %s", job.link)` in `poll_insights` that printed a literal `%s`.

## JS

New surface at parity with Python: `generateInsights` (both project-scoped and chat-history upload), `pollInsights`, `getInsightsReport`, and `fetchInsightsRuns` — the last standing in for Python's `cluster.load_traces()`.

```ts
const report = await client.generateInsights({
  projectName: "my-agent",
  instructions: "What do users ask about?",
  lastNHours: 24 * 7,
  sample: 0.1,
});
await client.pollInsights({ report });
```

Adds `InsightsReport`, `InsightsReportResult`, `InsightsCluster`, `InsightsSummaryReport`, and `InsightsHighlightedTrace` to `schemas.ts`, re-exported from `index.ts`. Params are camelCase and response objects snake_case, matching each side's existing convention. `link` is computed eagerly because `getHostUrl()` / `_getTenantId()` are async.

## Test plan

| Check | Result |
|---|---|
| `TEST=tests/unit_tests/test_insights_report.py make tests` | 11 passed (6 new) |
| `make tests` (full Python unit) | 2090 passed, 1 pre-existing failure |
| `npx jest src/tests/insights.test.ts` | 13 passed (new file) |
| `pnpm test` (full JS unit) | 926 passed, 39 suites |
| `make format` / `make lint` (py) | clean except one pre-existing mypy error |
| `pnpm format` / `pnpm lint` / `pnpm check:types` | clean, no findings in changed files |

The two pre-existing failures are unrelated to this change and reproduce on a clean tree:

- `tests/unit_tests/test_utils.py::test_get_api_url` — a `LANGSMITH_ENDPOINT` shell env var leaks past the Makefile's `env -u` list.
- mypy `langsmith/utils.py:792` — `Executor.map` gained a `buffersize` param in Python 3.14 and the subclass override hasn't caught up.

New tests cover the project-scoped POST body (including that unset keys are omitted), `project_name` resolution, `trace_structure` passthrough, `Date` serialization of the time bounds, the argument-validation errors, the poll loop reaching `success` and `error`, and run pagination.

Not included, deliberately: no version bumps (separate release PRs per `CONTRIBUTING.md`), no change to the `sessions` skip in `stainless.yml`, and no Go/Java ergonomic parity (that lands in `langsmith-go-staging`).

---

This PR was written by Claude.
