### PR TITLE
release(py): 0.12.0

### DIFF
--- a/python/.bumpversion.cfg
+++ b/python/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.11.2
+current_version = 0.12.0
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
 serialize = {major}.{minor}.{patch}
 search = {current_version}

--- a/python/langsmith/__init__.py
+++ b/python/langsmith/__init__.py
@@ -49,7 +49,7 @@ if TYPE_CHECKING:
 
 # Avoid calling into importlib on every call to __version__
 
-__version__ = "0.11.2"
+__version__ = "0.12.0"
 version = __version__  # for backwards compatibility
 
 # Metadata key to hide a traced run from LangSmith's Messages View.


### PR DESCRIPTION
0.11.2 → 0.12.0. Minor rather than patch because three changes since 0.11.2 alter existing behaviour, including the runtime HTTP dependency.

## Potential Breaking Changes

- #3406 — `chore(py)!: switch to httpx2 dependency while keeping httpx as a fallback`. The runtime HTTP dependency moves from `httpx>=0.23.0,<1` to `httpx2>=2,<3` (Pydantic's maintained fork). A backend-selection shim at `_openapi_client/_httpx.py` prefers `httpx2` and falls back to `httpx` when `httpx2` is absent. Net install effect is one extra package (`httpx` → `httpx2`, `httpcore` → `httpcore2`, plus `truststore` via `httpcore2`).
- #3183 — `fix(py,js)!: make trace sampling deterministic`. Sampling now keys on the trace via stable run-ID hashing, and feedback for sampled-out runs is filtered. With sampling enabled, direct `create_run`/`update_run` calls **on child runs** must pass a `trace_id` (or `dotted_order`) to stay consistent with their trace; without one the child's own ID is hashed and can land on the opposite side of the sample. Runs traced via `@traceable`/`RunTree` are unaffected.
- #3328 — `fix!: fail-closed when per-function anonymization callables fail`. When `process_inputs`/`process_outputs` raise, the payload is now replaced with an `ls_error` marker instead of being uploaded raw. This matches the existing client-level anonymizer behaviour.

## Other Python changes

- #3450 — `perf(py): serialize identical replicas once, into one frame`
- #3448 — `fix(py): compress replica writes that carry their own credentials`
- #3462 — `fix(py): suppress import-untyped on the optional langsmith_pyo3 import`

## Testing

- `python/.bumpversion.cfg` and `python/langsmith/__init__.py` both resolve to 0.12.0
- diff limited to the two version files; no tag pushed (the release workflow tags `v0.12.0` on `main`)
