### PR TITLE
release(js): 0.10.0

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langsmith",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Client library to connect to the LangSmith Observability and Evaluation Platform.",
   "packageManager": "pnpm@10.33.0",
   "files": [

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -54,7 +54,7 @@ export {
 } from "./_openapi_client/core/error.js";
 
 // Update using pnpm bump-version
-export const __version__ = "0.9.0";
+export const __version__ = "0.10.0";
 
 // Metadata key to hide a traced run from LangSmith's Messages View.
 export const LS_MESSAGE_VIEW_EXCLUDE = "ls_message_view_exclude" as const;


### PR DESCRIPTION
0.9.0 → 0.10.0. Minor rather than patch because two changes since 0.9.0 alter behaviour for existing users.

## Potential Breaking Changes

- #3183 — `fix(py,js)!: make trace sampling deterministic`. Sampling now keys on the trace via stable run-ID hashing, and feedback for sampled-out runs is filtered so it is no longer ingested and retried. With sampling enabled, direct `createRun`/`updateRun` calls **on child runs** must pass a `trace_id` (or `dotted_order`) to stay consistent with their trace; without one the child's own ID is hashed and can land on the opposite side of the sample. Runs traced via `traceable()`/`RunTree` are unaffected.
- #3328 — `fix!: fail-closed when per-function anonymization callables fail`. When `processInputs`/`processOutputs` reject, the payload is now replaced with an `ls_error` marker (`{"ls_error": "Processing failed; outputs dropped (processOutputs)"}`) instead of the run being uploaded with the raw, unredacted payload. This matches the existing client-level `anonymizer` behaviour.

## Other JS changes

- #3378 — `fix(js): close the argument-shape bypass in Anthropic MCP redaction`
- #3445 — `fix(py,js): consistent (non-v7) UUID rewriting for replicas`
- #3411 — `fix(js): send langsmith-js User-Agent on generated client calls`
- #3421 — `fix: point migration guide links at their new per-area pages`
- #3407 — `chore: sync langsmith_api`

## Testing

- `js/package.json` and `js/src/index.ts` both resolve to 0.10.0
- diff limited to the two version files; `npm view langsmith version` confirms 0.9.0 is the currently published latest, so `check-npm-version` will see 0.10.0 as new
