### PR TITLE
fix(py,js): drain the anonymizer walk queue in O(1) [LSDK-412]

### DIFF
--- a/js/src/anonymizer/index.ts
+++ b/js/src/anonymizer/index.ts
@@ -25,10 +25,11 @@ function extractStringNodes(data: unknown, options: { maxDepth?: number }) {
 
   let nextId = 0;
   const result: StringNodeInternal[] = [];
-  while (queue.length > 0) {
-    const task = queue.shift();
-    if (task == null) continue;
-    const [value, depth, path, parent, key] = task;
+  // Head index, not `queue.shift()`: shift is O(n) per call, and this walk runs
+  // inline on the caller's tick, so a quadratic drain stalls unrelated work.
+  let head = 0;
+  while (head < queue.length) {
+    const [value, depth, path, parent, key] = queue[head++];
     if (typeof value === "string") {
       result.push({
         value,

--- a/js/src/tests/anonymizer.test.ts
+++ b/js/src/tests/anonymizer.test.ts
@@ -548,3 +548,49 @@ describe("createSecretAnonymizer", () => {
     expect(JSON.stringify(data.outputs)).toContain(SECRET_PLACEHOLDER);
   });
 });
+
+describe("traversal scaling", () => {
+  // No rule matches, so this times the walk itself, not the masking.
+  const anonymizer = createAnonymizer([
+    { pattern: "no-such-secret-here", replace: "[redacted]" },
+  ]);
+
+  // Fastest of 3 runs: noise only ever adds time, so the min is the real cost.
+  const fastestMs = (n: number) => {
+    const payload = {
+      records: Array.from({ length: n }, (_, i) => ({
+        id: `r${i}`,
+        text: "x".repeat(32),
+      })),
+    };
+
+    let best = Infinity;
+    for (let i = 0; i < 3; i += 1) {
+      const start = performance.now();
+      anonymizer(payload);
+      best = Math.min(best, performance.now() - start);
+    }
+    return best;
+  };
+
+  test("8x the nodes costs ~8x the time, not ~64x", () => {
+    // With `queue.shift()`: 2k records 2.6ms, 16k records 121ms.
+    expect(fastestMs(16_000) / fastestMs(2_000)).toBeLessThan(20);
+  });
+
+  test("preserves BFS order, paths and maxDepth truncation", () => {
+    const seen: string[] = [];
+    const tap = (value: string, path?: string) => {
+      seen.push(`${path}=${value}`);
+      return value;
+    };
+    const data = { a: "1", b: ["2", { c: "3" }], n: 7, ok: true };
+
+    createAnonymizer(tap)(data);
+    expect(seen).toEqual(["a=1", "b[0]=2", "b[1].c=3"]);
+
+    seen.length = 0;
+    createAnonymizer(tap, { maxDepth: 2 })(data);
+    expect(seen).toEqual(["a=1", "b[0]=2"]);
+  });
+});

--- a/python/langsmith/anonymizer.py
+++ b/python/langsmith/anonymizer.py
@@ -1,7 +1,7 @@
 import re  # noqa
 import inspect
 from abc import abstractmethod
-from collections import defaultdict
+from collections import defaultdict, deque
 from typing import Any, Callable, Optional, TypedDict, Union
 
 
@@ -25,14 +25,13 @@ class StringNode(TypedDict):
 def _extract_string_nodes(data: Any, options: _ExtractOptions) -> list[StringNode]:
     max_depth = options.get("max_depth") or 10
 
-    queue: list[tuple[Any, int, list[Union[str, int]]]] = [(data, 0, [])]
+    # deque, not a list: `list.pop(0)` is O(n), and this walk runs inline on the
+    # caller's event loop, so a quadratic drain stalls unrelated requests.
+    queue: deque[tuple[Any, int, list[Union[str, int]]]] = deque([(data, 0, [])])
     result: list[StringNode] = []
 
     while queue:
-        task = queue.pop(0)
-        if task is None:
-            continue
-        value, depth, path = task
+        value, depth, path = queue.popleft()
 
         if isinstance(value, (dict, defaultdict)):
             if depth >= max_depth:

--- a/python/tests/unit_tests/test_anonymizer.py
+++ b/python/tests/unit_tests/test_anonymizer.py
@@ -1,7 +1,9 @@
 # mypy: disable-error-code="annotation-unchecked"
 import json
 import re
+import timeit
 import uuid
+from functools import partial
 from typing import List, Union, cast
 from unittest.mock import MagicMock
 from uuid import uuid4
@@ -15,6 +17,7 @@ from langsmith.anonymizer import (
     SECRET_PLACEHOLDER,
     RuleNodeProcessor,
     StringNodeRule,
+    _extract_string_nodes,
     create_anonymizer,
     create_secret_anonymizer,
 )
@@ -403,3 +406,31 @@ def test_secret_anonymizer_in_traceable():
     assert aws_key not in blob
     assert anthropic_key not in blob
     assert SECRET_PLACEHOLDER in blob
+
+
+def _fastest_walk_seconds(n: int) -> float:
+    """Fastest of 3 runs: noise only ever adds time, so the min is the real cost."""
+    payload = {"records": [{"id": f"r{i}", "text": "x" * 32} for i in range(n)]}
+    walk = partial(_extract_string_nodes, payload, {"max_depth": 10})
+    return min(timeit.repeat(walk, repeat=3, number=1))
+
+
+def test_extract_string_nodes_scales_linearly():
+    """8x the nodes must cost ~8x the time, not ~64x: `list.pop(0)` was O(n)."""
+    assert _fastest_walk_seconds(16_000) / _fastest_walk_seconds(2_000) < 20
+
+
+def test_extract_string_nodes_order_and_max_depth():
+    """Locks the traversal contract the scaling fix must not change."""
+    data = {"a": "1", "b": ["2", {"c": "3"}], "n": 7, "ok": True}
+
+    assert _extract_string_nodes(data, {"max_depth": 10}) == [
+        {"value": "1", "path": ["a"]},
+        {"value": "2", "path": ["b", 0]},
+        {"value": "3", "path": ["b", 1, "c"]},
+    ]
+    # Depth 2 reaches b[0] but not b[1]["c"]; non-strings are never emitted.
+    assert _extract_string_nodes(data, {"max_depth": 2}) == [
+        {"value": "1", "path": ["a"]},
+        {"value": "2", "path": ["b", 0]},
+    ]


### PR DESCRIPTION
## Summary

- **Problem:** `_extract_string_nodes` — the walk that flattens a traced payload so the anonymizer can redact secrets client-side — drained its BFS queue from the front (`list.pop(0)` in Python, `Array.prototype.shift()` in JS). Both are O(n) per pop, making the whole walk quadratic in node count. Because it runs inline on the caller's event loop, tracing one large payload stalled every concurrent request in the process. A customer measured 468ms for 5,000 records (~85,000 string nodes) and mitigated by dropping large payloads from their `@traceable` functions.
- **Fix:** Python uses `collections.deque` + `popleft()`. JS has no stdlib deque, so it walks with a head index (`queue[head++]`) instead. Both dequeue in O(1).

### Measured

| payload | Python before | Python after | JS before | JS after |
|---|---|---|---|---|
| 2,000 records | 2.4 ms | 1.4 ms | 2.6 ms | 1.4 ms |
| 16,000 records | 111 ms | 11.9 ms | 121 ms | 4.3 ms |

Doubling the records used to quadruple the time; it now scales linearly. This also unblocks the customer from adopting #3100, which they could not take because it traverses deeper with a larger rule set and made the quadratic cost worse.