### PR TITLE
release(js): 0.10.1

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langsmith",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Client library to connect to the LangSmith Observability and Evaluation Platform.",
   "packageManager": "pnpm@10.33.0",
   "files": [

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -54,7 +54,7 @@ export {
 } from "./_openapi_client/core/error.js";
 
 // Update using pnpm bump-version
-export const __version__ = "0.10.0";
+export const __version__ = "0.10.1";
 
 // Metadata key to hide a traced run from LangSmith's Messages View.
 export const LS_MESSAGE_VIEW_EXCLUDE = "ls_message_view_exclude" as const;


### PR DESCRIPTION
Bumps the TypeScript SDK from 0.10.0 to 0.10.1. The release workflow will publish the patch release after merge.

## Testing

- `pnpm check-version`
- `pnpm format`
- `pnpm lint` (0 errors; 333 existing warnings)
- Confirmed the diff is limited to `js/package.json` and `js/src/index.ts`

Made by [Open SWE](https://openswe.vercel.app/agents/23973626-1ed3-57c9-a297-19503ce268b2)