### PR TITLE
release(py): 0.12.1

### DIFF
--- a/python/.bumpversion.cfg
+++ b/python/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.12.0
+current_version = 0.12.1
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
 serialize = {major}.{minor}.{patch}
 search = {current_version}

--- a/python/langsmith/__init__.py
+++ b/python/langsmith/__init__.py
@@ -49,7 +49,7 @@ if TYPE_CHECKING:
 
 # Avoid calling into importlib on every call to __version__
 
-__version__ = "0.12.0"
+__version__ = "0.12.1"
 version = __version__  # for backwards compatibility
 
 # Metadata key to hide a traced run from LangSmith's Messages View.


### PR DESCRIPTION
Bumps the Python SDK from 0.12.0 to 0.12.1. The release workflow will publish the patch release after merge.

## Testing

- `make format`
- `make lint` *(Ruff passes; mypy reports a pre-existing `Executor.map` override mismatch in `langsmith/utils.py:792` under the current Python typing signature)*
- Confirmed the diff is limited to `python/.bumpversion.cfg` and `python/langsmith/__init__.py`
- Confirmed both version declarations resolve to `0.12.1`

Made by [Open SWE](https://openswe.vercel.app/agents/23973626-1ed3-57c9-a297-19503ce268b2)