### PR TITLE
fix(py): make >20MB multipart bodies re-sendable on retry

### DIFF
--- a/python/langsmith/_internal/_multipart.py
+++ b/python/langsmith/_internal/_multipart.py
@@ -4,6 +4,10 @@ from collections.abc import Iterable
 from io import BufferedReader
 from typing import Union
 
+from requests_toolbelt import (  # type: ignore[import-untyped]
+    multipart as rqtb_multipart,
+)
+
 MultipartPart = tuple[
     str, tuple[None, Union[bytes, BufferedReader], str, dict[str, str]]
 ]
@@ -18,6 +22,73 @@ class MultipartPartsAndContext:
     def __init__(self, parts: list[MultipartPart], context: str) -> None:
         self.parts = parts
         self.context = context
+
+
+class SeekableMultipartEncoder:
+    """A ``MultipartEncoder`` that supports ``tell``/``seek(0)`` for retries.
+
+    ``requests_toolbelt``'s ``MultipartEncoder`` exposes neither, so when it's
+    passed straight to ``requests`` as a streaming body, urllib3 can't rewind
+    it before resending on a retryable failure (a dropped connection, or a
+    502/503/504 response). The retry then resends a stale ``Content-Length``
+    against an already-exhausted stream -- zero body bytes -- so the server
+    hangs waiting for a body that will never arrive.
+
+    Below the size threshold where the body is buffered to ``bytes`` outright
+    this doesn't matter: urllib3 just resends the same immutable bytes, no
+    seek required. This wrapper gives the same resend guarantee to bodies
+    kept as a stream (to avoid loading huge attachments fully into memory),
+    by rebuilding the encoder and rewinding every underlying file-like part
+    back to its start on ``seek(0)``.
+    """
+
+    __slots__ = ("_parts", "_boundary", "_encoder", "_len", "_pos")
+
+    def __init__(self, parts: list[MultipartPart], boundary: str) -> None:
+        self._parts = parts
+        self._boundary = boundary
+        self._encoder = rqtb_multipart.MultipartEncoder(parts, boundary=boundary)
+        self._len = self._encoder.len
+        self._pos = 0
+
+    @property
+    def content_type(self) -> str:
+        return self._encoder.content_type
+
+    @property
+    def len(self) -> int:
+        return self._len
+
+    def __len__(self) -> int:
+        return self._len
+
+    def read(self, size: int = -1) -> bytes:
+        chunk = self._encoder.read(size)
+        self._pos += len(chunk)
+        return chunk
+
+    def tell(self) -> int:
+        return self._pos
+
+    def seek(self, pos: int, whence: int = 0) -> int:
+        if whence != 0 or pos != 0:
+            raise OSError(
+                "SeekableMultipartEncoder only supports seeking back to the start"
+            )
+        for _, (_, part_data, _, _) in self._parts:
+            rewind = getattr(part_data, "seek", None)
+            if rewind is not None:
+                rewind(0)
+        self._encoder = rqtb_multipart.MultipartEncoder(
+            self._parts, boundary=self._boundary
+        )
+        self._pos = 0
+        return self._pos
+
+    def to_bytes(self) -> bytes:
+        """Rewind and read the entire body, e.g. to dump it for debugging."""
+        self.seek(0)
+        return self.read()
 
 
 def join_multipart_parts_and_context(

--- a/python/langsmith/client.py
+++ b/python/langsmith/client.py
@@ -103,6 +103,7 @@ from langsmith._internal._hub import (
 from langsmith._internal._multipart import (
     MultipartPart,
     MultipartPartsAndContext,
+    SeekableMultipartEncoder,
     join_multipart_parts_and_context,
 )
 from langsmith._internal._operations import (
@@ -3604,7 +3605,7 @@ class Client:
                     if encoder.len <= 20_000_000:  # ~20 MB
                         data = encoder.to_string()
                     else:
-                        data = encoder
+                        data = SeekableMultipartEncoder(parts, boundary=_BOUNDARY)
                     self.request_with_retries(
                         "POST",
                         f"{target_api_url}/runs/multipart",
@@ -3642,13 +3643,7 @@ class Client:
                     _fail_exc = e
                 # Fell through — final attempt failed or non-retryable error.
                 self._dump_failed_trace(
-                    lambda: (
-                        data
-                        if isinstance(data, bytes)
-                        else rqtb_multipart.MultipartEncoder(
-                            parts, boundary=_BOUNDARY
-                        ).to_string()
-                    ),
+                    lambda: data if isinstance(data, bytes) else data.to_bytes(),
                     {"Content-Type": f"multipart/form-data; boundary={_BOUNDARY}"},
                 )
                 self._invoke_tracing_error_callback(_fail_exc)
@@ -6455,7 +6450,9 @@ class Client:
         ],
         include_dataset_id: bool = False,
         dangerously_allow_filesystem: bool = False,
-    ) -> tuple[Any, bytes, dict[str, io.BufferedReader]]:
+    ) -> tuple[
+        Any, Union[bytes, SeekableMultipartEncoder], dict[str, io.BufferedReader]
+    ]:
         parts: list[MultipartPart] = []
         opened_files_dict: dict[str, io.BufferedReader] = {}
         if include_dataset_id:
@@ -6631,7 +6628,7 @@ class Client:
         if encoder.len <= 20_000_000:  # ~20 MB
             data = encoder.to_string()
         else:
-            data = encoder
+            data = SeekableMultipartEncoder(parts, boundary=_BOUNDARY)
 
         return encoder, data, opened_files_dict
 

--- a/python/tests/unit_tests/test_multipart_retry_matrix.py
+++ b/python/tests/unit_tests/test_multipart_retry_matrix.py
@@ -25,13 +25,14 @@ from unittest import mock
 
 import pytest
 
+from langsmith import schemas as ls_schemas
 from langsmith import utils as ls_utils
 from langsmith._internal._multipart import join_multipart_parts_and_context
 from langsmith._internal._operations import (
     SerializedRunOperation,
     serialized_run_operation_to_multipart_parts_and_context,
 )
-from langsmith.client import Client
+from langsmith.client import Client, _close_files
 
 
 class _Endpoint:
@@ -95,13 +96,17 @@ def no_sleep():
         yield slept
 
 
-def _payload(n_runs=1):
+def _payload(n_runs=1, extra_inputs_bytes=0):
     """Build a payload through the real serializer, so the log context is real.
 
     The per-op context string is ``trace=<trace_id>,id=<run_id>``
     (``_operations.py``), and ``join_multipart_parts_and_context`` concatenates
     one of those per operation with ``"; "``. Hand-writing the context in a test
     would pin a message shape that never occurs in production.
+
+    ``extra_inputs_bytes`` pads ``inputs`` so the encoded multipart body
+    crosses the 20MB threshold where ``_send_multipart_req`` switches from
+    buffering to ``bytes`` to streaming a ``SeekableMultipartEncoder``.
     """
     ops = []
     ids = []
@@ -123,7 +128,7 @@ def _payload(n_runs=1):
                 id=run_id,
                 trace_id=run_id,
                 _none=run_json,
-                inputs=None,
+                inputs=(b"x" * extra_inputs_bytes) if extra_inputs_bytes else None,
                 outputs=None,
                 events=None,
                 extra=None,
@@ -140,6 +145,22 @@ def _payload(n_runs=1):
 
 def _one_run_payload():
     return _payload(1)[0]
+
+
+def _large_run_payload():
+    """A payload whose encoded body exceeds the 20MB streaming threshold."""
+    return _payload(1, extra_inputs_bytes=20_100_000)[0]
+
+
+def _large_example_payload():
+    """An examples-multipart body whose encoded size exceeds 20MB.
+
+    Exercises ``_prepare_multipart_data`` (used by ``upload_examples_multipart``
+    / ``update_examples_multipart``), which has the same >20MB streaming body
+    as ``_send_multipart_req`` but -- unlike it -- no app-level retry loop of
+    its own: it relies entirely on urllib3 being able to rewind the body.
+    """
+    return [ls_schemas.ExampleCreate(inputs={"x": "y" * 20_100_000})]
 
 
 def _client(endpoint, failed_traces_dir=None, monkeypatch=None):
@@ -195,6 +216,110 @@ def test_multipart_retry_counts(
     assert endpoint.count == expected_requests, (
         f"HTTP {status} (Retry-After={retry_after}) produced {endpoint.count} "
         f"requests, expected {expected_requests} (retried by: {retried_by})"
+    )
+
+
+# Only status codes that actually trigger a retry are worth re-running at
+# 20MB: a one-shot request/failure (200, 409, 401, ...) never touches
+# ``SeekableMultipartEncoder.seek()`` at all, so payload size can't affect
+# it -- those rows are already covered by the small-body matrix above.
+RETRYABLE_ROWS = [row for row in RETRY_MATRIX if row[2] > 1]
+
+
+@pytest.mark.parametrize(
+    "status,retry_after,expected_requests,retried_by",
+    RETRYABLE_ROWS,
+    ids=[f"{s}{'+retry-after' if ra else ''}" for s, ra, _, _ in RETRYABLE_ROWS],
+)
+def test_multipart_retry_counts_over_20mb(
+    endpoint, no_sleep, status, retry_after, expected_requests, retried_by
+):
+    """Same matrix, but over the 20MB threshold where the body streams instead
+    of being buffered to ``bytes`` up front.
+
+    Streaming bodies have no ``tell``/``seek`` unless wrapped, so urllib3
+    can't rewind them for a retry: it resends a stale ``Content-Length``
+    against an already-exhausted stream, and the server hangs waiting for a
+    body that never arrives. If that regresses, this test hangs instead of
+    failing fast -- see ``SeekableMultipartEncoder``.
+    """
+    endpoint.status = status
+    endpoint.retry_after = retry_after
+    client = _client(endpoint)
+
+    client._send_multipart_req(_large_run_payload())
+
+    assert endpoint.count == expected_requests, (
+        f"HTTP {status} (Retry-After={retry_after}) over 20MB produced "
+        f"{endpoint.count} requests, expected {expected_requests} "
+        f"(retried by: {retried_by})"
+    )
+
+
+# `_prepare_multipart_data` backs `upload_examples_multipart` /
+# `update_examples_multipart`. Unlike `_send_multipart_req` it makes a single
+# `request_with_retries` call with no app-level retry loop of its own, so
+# these counts are RETRY_MATRIX with the "+ app loop" rows (500, 408)
+# un-multiplied back down to urllib3's raw count -- everything here is
+# retried by urllib3 alone, or not at all.
+#
+# Only rows where a retry actually happens are included
+PREPARE_MULTIPART_DATA_RETRY_MATRIX = [
+    (500, None, 4, "urllib3"),
+    (502, None, 4, "urllib3"),
+    (503, None, 4, "urllib3"),
+    (504, None, 4, "urllib3"),
+    (425, None, 4, "urllib3"),
+    (408, None, 4, "urllib3"),
+    (429, 1, 4, "urllib3 (Retry-After delay)"),
+    (429, None, 4, "urllib3 (backoff_factor delay)"),
+    (413, 1, 4, "urllib3 (Retry-After only)"),
+]
+
+
+@pytest.mark.parametrize(
+    "status,retry_after,expected_requests,retried_by",
+    PREPARE_MULTIPART_DATA_RETRY_MATRIX,
+    ids=[
+        f"{s}{'+retry-after' if ra else ''}"
+        for s, ra, _, _ in PREPARE_MULTIPART_DATA_RETRY_MATRIX
+    ],
+)
+def test_prepare_multipart_data_retry_counts_over_20mb(
+    endpoint, no_sleep, status, retry_after, expected_requests, retried_by
+):
+    """Same >20MB streaming-body bug as ``_send_multipart_req``, but no
+    app-level retry loop to paper over a failed rewind -- this call path
+    relies entirely on urllib3 being able to resend the body.
+
+    Every row here is a status that ultimately fails (there's no app loop to
+    exhaust first), so the call is always expected to raise once urllib3
+    gives up retrying.
+    """
+    endpoint.status = status
+    endpoint.retry_after = retry_after
+    client = _client(endpoint)
+
+    encoder, data, opened_files_dict = client._prepare_multipart_data(
+        _large_example_payload(), include_dataset_id=False
+    )
+    try:
+        with pytest.raises(Exception):
+            client.request_with_retries(
+                "POST",
+                "/examples/multipart",
+                request_kwargs={
+                    "data": data,
+                    "headers": {"Content-Type": encoder.content_type},
+                },
+            )
+    finally:
+        _close_files(list(opened_files_dict.values()))
+
+    assert endpoint.count == expected_requests, (
+        f"HTTP {status} (Retry-After={retry_after}) over 20MB via "
+        f"_prepare_multipart_data produced {endpoint.count} requests, "
+        f"expected {expected_requests} (retried by: {retried_by})"
     )
 
 


### PR DESCRIPTION
Fixes [LSDK-460](https://linear.app/langchain/issue/LSDK-460/make-20mb-multipart-bodies-re-sendable-on-retry).

## Bug
`_send_multipart_req` streams a `MultipartEncoder` for bodies >20MB instead of buffering to `bytes`. That object has no `tell`/`seek`, so urllib3 can't rewind it before a retry (dropped connection, or 502/503/504). The retry resends a stale `Content-Length` against an already-exhausted stream — the server hangs waiting for a body that never arrives.

Same bug existed in `_prepare_multipart_data` (backs `upload_examples_multipart`/`update_examples_multipart`), with no app-level retry loop to fall back on.

## Fix
`SeekableMultipartEncoder` wraps the streaming encoder with `tell`/`seek(0)`: rewinds every underlying file-like part and rebuilds the encoder. Below 20MB, nothing changes — bytes never needed a seek. Used at both call sites.

## Tests
Extended `test_multipart_retry_matrix.py` with >20MB cases for both call sites, driven through a real local HTTP server (not mocks) so urllib3's actual retry layer is exercised. Verified by reverting the fix and confirming the test hangs on the exact bug (`recv_into` blocked waiting for a response that never comes); restored, all pass.
