### PR TITLE
fix(js): patch fast-uri advisories

### DIFF
--- a/js/internal/environment_tests/test-exports-webpack/package.json
+++ b/js/internal/environment_tests/test-exports-webpack/package.json
@@ -12,5 +12,10 @@
   "devDependencies": {
     "webpack": "^5.90.0",
     "webpack-cli": "^5.1.0"
+  },
+  "pnpm": {
+    "overrides": {
+      "fast-uri": "3.1.6"
+    }
   }
 }

--- a/js/internal/environment_tests/test-exports-webpack/pnpm-lock.yaml
+++ b/js/internal/environment_tests/test-exports-webpack/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  fast-uri: 3.1.6
+
 importers:
 
   .:
@@ -24,6 +27,9 @@ packages:
   '@aws-sdk/core@3.977.4':
     resolution: {integrity: sha512-CEkcQlMOQJCvul60U7wdAOACjtdgFWDsfJI+6wUOGdhGNV2lGbuJpi/R50QLpFG3Tp+sQxa/RmzC3X7KHbhuTA==}
     engines: {node: '>=20.0.0'}
+    deprecated: |-
+      Deprecated due to Document number parsing bug in JSON, see
+        https://github.com/aws/aws-sdk-js-v3/issues/8246. Newer version available.
 
   '@aws-sdk/credential-provider-env@3.972.65':
     resolution: {integrity: sha512-lJT2aRw9wCV8jPHyFJjdZLD4HTydL6/22AnCSOB8e/LqOc55nEJGLHkJQeSxhn8QiqyjFwPKQFtMw0ovjRUY/g==}
@@ -405,8 +411,8 @@ packages:
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
-  fast-uri@3.1.5:
-    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
+  fast-uri@3.1.6:
+    resolution: {integrity: sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==}
 
   fastest-levenshtein@1.0.16:
     resolution: {integrity: sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==}
@@ -1181,7 +1187,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.5
+      fast-uri: 3.1.6
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -1256,7 +1262,7 @@ snapshots:
 
   fast-deep-equal@3.1.3: {}
 
-  fast-uri@3.1.5: {}
+  fast-uri@3.1.6: {}
 
   fastest-levenshtein@1.0.16: {}
 

--- a/js/package.json
+++ b/js/package.json
@@ -486,7 +486,7 @@
       "brace-expansion@<1.1.16": "1.1.16",
       "brace-expansion@>=2.0.0 <2.1.2": "2.1.2",
       "brace-expansion@>=3.0.0 <5.0.7": "5.0.7",
-      "fast-uri": "3.1.5",
+      "fast-uri": "3.1.6",
       "postcss": "8.5.23",
       "js-yaml": "4.3.1",
       "hono": "4.12.34",

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -9,7 +9,7 @@ overrides:
   brace-expansion@<1.1.16: 1.1.16
   brace-expansion@>=2.0.0 <2.1.2: 2.1.2
   brace-expansion@>=3.0.0 <5.0.7: 5.0.7
-  fast-uri: 3.1.5
+  fast-uri: 3.1.6
   postcss: 8.5.23
   js-yaml: 4.3.1
   hono: 4.12.34
@@ -3679,8 +3679,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.1.5:
-    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
+  fast-uri@3.1.6:
+    resolution: {integrity: sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==}
 
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
@@ -9150,7 +9150,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.5
+      fast-uri: 3.1.6
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -9812,7 +9812,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.1.5: {}
+  fast-uri@3.1.6: {}
 
   fast-wrap-ansi@0.2.2:
     dependencies:


### PR DESCRIPTION
## Summary

- bump the JS `fast-uri` override from 3.1.5 to 3.1.6
- add the same override to the standalone webpack export test fixture
- regenerate both affected pnpm lockfiles
- resolves Dependabot alerts #421-#424 and #427-#430 (GHSA-5jgf-p345-68v8, GHSA-f65p-4m7j-42xc, GHSA-fph4-wmhf-6fwf, GHSA-jqff-g426-hqxp)

## Test Plan

- [x] `pnpm install --frozen-lockfile` in `js/`
- [x] `pnpm build` in `js/`
- [x] `pnpm install --frozen-lockfile` in `js/internal/environment_tests/test-exports-webpack/`
- [x] `pnpm test` in `js/internal/environment_tests/test-exports-webpack/`

`pnpm audit --prod --audit-level high` was attempted, but the npm audit endpoint was unreachable from the sandbox. The resolved `fast-uri` version in both lockfiles is 3.1.6, matching GitHub’s first patched version.
