### PR TITLE
fix(py,js): retry rate-limited sandbox websocket connections

### DIFF
--- a/js/src/sandbox/errors.ts
+++ b/js/src/sandbox/errors.ts
@@ -59,9 +59,12 @@ export class LangSmithSandboxConnectionError extends LangSmithSandboxError {
  * deduplicate an attempt whose outcome is unknown.
  */
 export class LangSmithSandboxRetryableConnectionError extends LangSmithSandboxConnectionError {
-  constructor(message: string) {
+  readonly retryAfterSeconds?: number;
+
+  constructor(message: string, retryAfterSeconds?: number) {
     super(message);
     this.name = "LangSmithSandboxRetryableConnectionError";
+    this.retryAfterSeconds = retryAfterSeconds;
   }
 }
 

--- a/js/src/sandbox/sandbox.ts
+++ b/js/src/sandbox/sandbox.ts
@@ -315,6 +315,9 @@ export class Sandbox {
           CommandHandle.BACKOFF_BASE * 2 ** (attempt - 1),
           CommandHandle.BACKOFF_MAX,
         );
+        if (e instanceof LangSmithSandboxRetryableConnectionError) {
+          delay = e.retryAfterSeconds ?? delay * (0.8 + Math.random() * 0.2);
+        }
         const remaining = remainingBudget(deadline);
         if (remaining !== undefined) {
           if (remaining <= 0) {

--- a/js/src/sandbox/ws_execute.ts
+++ b/js/src/sandbox/ws_execute.ts
@@ -38,7 +38,16 @@ export const WS_CONNECT_BUDGET = envTimeout(
   "SANDBOX_WS_TIMEOUT_CONNECT_BUDGET",
   120,
 );
-const RETRYABLE_HANDSHAKE_STATUS_CODES = new Set([500, 502, 503, 504]);
+const RETRYABLE_HANDSHAKE_STATUS_CODES = new Set([429, 500, 502, 503, 504]);
+
+function retryAfterSeconds(
+  headers: Record<string, string | string[] | undefined> | undefined,
+): number | undefined {
+  const raw = headers?.["retry-after"];
+  if (typeof raw !== "string" || raw.trim() === "") return undefined;
+  const value = Number(raw);
+  return Number.isFinite(value) && value >= 0 ? value : undefined;
+}
 
 function nowSeconds(): number {
   return performance.now() / 1000;
@@ -256,22 +265,27 @@ async function connectWs(
       "unexpected-response",
       (
         req: { destroy?: () => void },
-        res: { statusCode?: number; resume?: () => void },
+        res: {
+          statusCode?: number;
+          headers?: Record<string, string | string[] | undefined>;
+          resume?: () => void;
+        },
       ) => {
         res.resume?.();
         req.destroy?.();
         if (settled) return;
         settled = true;
-        const ErrorType = RETRYABLE_HANDSHAKE_STATUS_CODES.has(
-          res.statusCode ?? 0,
-        )
-          ? LangSmithSandboxRetryableConnectionError
-          : LangSmithSandboxConnectionError;
-        reject(
-          new ErrorType(
-            `WebSocket upgrade to ${url} rejected by server (HTTP ${res.statusCode})`,
-          ),
-        );
+        const message = `WebSocket upgrade to ${url} rejected by server (HTTP ${res.statusCode})`;
+        if (RETRYABLE_HANDSHAKE_STATUS_CODES.has(res.statusCode ?? 0)) {
+          reject(
+            new LangSmithSandboxRetryableConnectionError(
+              message,
+              retryAfterSeconds(res.headers),
+            ),
+          );
+        } else {
+          reject(new LangSmithSandboxConnectionError(message));
+        }
       },
     );
 

--- a/js/src/tests/sandbox_command_id_retry.test.ts
+++ b/js/src/tests/sandbox_command_id_retry.test.ts
@@ -169,6 +169,82 @@ describe("run() early-close retry", () => {
     expect(first.commandId).toBe(second.commandId);
   });
 
+  it("waits for Retry-After before retrying a rate-limited handshake", async () => {
+    jest.useFakeTimers();
+    try {
+      const sandbox = makeSandbox();
+
+      runWsStream
+        .mockImplementationOnce((..._args: unknown[]) => [
+          failingStream(
+            new LangSmithSandboxRetryableConnectionError("HTTP 429", 10),
+          ),
+          null,
+        ])
+        .mockImplementationOnce((...args: unknown[]) => {
+          const opts = args[3] as { commandId: string };
+          return [
+            makeStream([
+              { type: "started", command_id: opts.commandId, pid: 1 },
+              { type: "exit", exit_code: 0 },
+            ]),
+            null,
+          ];
+        });
+
+      const resultPromise = sandbox.run("echo hi");
+      await jest.advanceTimersByTimeAsync(9_999);
+      expect(runWsStream).toHaveBeenCalledTimes(1);
+
+      await jest.advanceTimersByTimeAsync(1);
+      const result = await resultPromise;
+
+      expect(result.exit_code).toBe(0);
+      const first = runWsStream.mock.calls[0][3] as { commandId: string };
+      const second = runWsStream.mock.calls[1][3] as { commandId: string };
+      expect(first.commandId).toBe(second.commandId);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it("jitters retries without Retry-After", async () => {
+    jest.useFakeTimers();
+    const random = jest.spyOn(Math, "random").mockReturnValue(0.5);
+    try {
+      const sandbox = makeSandbox();
+
+      runWsStream
+        .mockImplementationOnce((..._args: unknown[]) => [
+          failingStream(
+            new LangSmithSandboxRetryableConnectionError("HTTP 429"),
+          ),
+          null,
+        ])
+        .mockImplementationOnce((...args: unknown[]) => {
+          const opts = args[3] as { commandId: string };
+          return [
+            makeStream([
+              { type: "started", command_id: opts.commandId, pid: 1 },
+              { type: "exit", exit_code: 0 },
+            ]),
+            null,
+          ];
+        });
+
+      const resultPromise = sandbox.run("echo hi");
+      await jest.advanceTimersByTimeAsync(449);
+      expect(runWsStream).toHaveBeenCalledTimes(1);
+
+      await jest.advanceTimersByTimeAsync(1);
+      expect(runWsStream).toHaveBeenCalledTimes(2);
+      await expect(resultPromise).resolves.toMatchObject({ exit_code: 0 });
+    } finally {
+      random.mockRestore();
+      jest.useRealTimers();
+    }
+  });
+
   it("does not retry a rejected handshake", async () => {
     const sandbox = makeSandbox();
     runWsStream.mockImplementation((..._args: unknown[]) => [

--- a/js/src/tests/sandbox_ws_handshake.test.ts
+++ b/js/src/tests/sandbox_ws_handshake.test.ts
@@ -7,6 +7,7 @@ import {
 
 const response = {
   statusCode: 503,
+  headers: {} as Record<string, string>,
   resume: jest.fn(),
 };
 const request = { destroy: jest.fn() };
@@ -38,6 +39,7 @@ async function rejectedUpgrade(statusCode: number): Promise<unknown> {
 
 describe("WebSocket upgrade rejection", () => {
   beforeEach(() => {
+    response.headers = {};
     response.resume.mockClear();
     request.destroy.mockClear();
   });
@@ -53,7 +55,31 @@ describe("WebSocket upgrade rejection", () => {
     },
   );
 
-  it.each([400, 401, 403, 404, 429, 505])(
+  it("treats HTTP 429 as retryable and preserves Retry-After", async () => {
+    response.headers = { "retry-after": "10" };
+
+    const error = await rejectedUpgrade(429).catch(
+      (rejection: unknown) => rejection,
+    );
+
+    expect(error).toBeInstanceOf(LangSmithSandboxRetryableConnectionError);
+    expect(error).toHaveProperty("retryAfterSeconds", 10);
+  });
+
+  it.each(["", "-1", "nan", "Infinity"])(
+    "ignores unusable Retry-After %p",
+    async (retryAfter) => {
+      response.headers = { "retry-after": retryAfter };
+
+      const error = await rejectedUpgrade(429).catch(
+        (rejection: unknown) => rejection,
+      );
+
+      expect(error).toHaveProperty("retryAfterSeconds", undefined);
+    },
+  );
+
+  it.each([400, 401, 403, 404, 505])(
     "keeps HTTP %i permanent",
     async (statusCode) => {
       const error = await rejectedUpgrade(statusCode).catch(

--- a/python/langsmith/sandbox/_async_sandbox.py
+++ b/python/langsmith/sandbox/_async_sandbox.py
@@ -27,6 +27,7 @@ from langsmith.sandbox._models import (
 from langsmith.sandbox._tunnel import AsyncTunnel
 from langsmith.sandbox._ws_execute import (
     WEBSOCKETS_AVAILABLE,
+    _retry_delay,
     connect_deadline,
     open_timeout_for,
 )
@@ -440,7 +441,7 @@ class AsyncSandbox:
             except (
                 _StreamEndedBeforeStarted,
                 SandboxRetryableConnectionError,
-            ):
+            ) as exc:
                 # Idempotent re-issue (same command_id): neither an early close
                 # nor a failed connect can have started a second command.
                 attempt += 1
@@ -450,6 +451,8 @@ class AsyncSandbox:
                     AsyncCommandHandle._BACKOFF_BASE * (2 ** (attempt - 1)),
                     AsyncCommandHandle._BACKOFF_MAX,
                 )
+                if isinstance(exc, SandboxRetryableConnectionError):
+                    backoff = _retry_delay(exc, backoff)
                 if deadline is not None:
                     remaining = deadline - time.monotonic()
                     if remaining <= 0:

--- a/python/langsmith/sandbox/_exceptions.py
+++ b/python/langsmith/sandbox/_exceptions.py
@@ -49,9 +49,15 @@ class SandboxRetryableConnectionError(SandboxConnectionError):
 
     ``run()`` retries this error with the same command ID, so the server can
     deduplicate an attempt whose outcome is unknown.
+
+    Attributes:
+        retry_after: Optional server-provided delay in seconds before retrying.
     """
 
-    pass
+    def __init__(self, message: str, *, retry_after: Optional[float] = None):
+        """Initialize the error."""
+        super().__init__(message)
+        self.retry_after = retry_after
 
 
 class SandboxConnectTimeoutError(SandboxRetryableConnectionError):

--- a/python/langsmith/sandbox/_sandbox.py
+++ b/python/langsmith/sandbox/_sandbox.py
@@ -25,6 +25,7 @@ from langsmith.sandbox._models import (
 from langsmith.sandbox._tunnel import Tunnel
 from langsmith.sandbox._ws_execute import (
     WEBSOCKETS_AVAILABLE,
+    _retry_delay,
     connect_deadline,
     open_timeout_for,
 )
@@ -436,7 +437,7 @@ class Sandbox:
             except (
                 _StreamEndedBeforeStarted,
                 SandboxRetryableConnectionError,
-            ):
+            ) as exc:
                 # Idempotent re-issue (same command_id): neither an early close
                 # nor a failed connect can have started a second command.
                 attempt += 1
@@ -446,6 +447,8 @@ class Sandbox:
                     CommandHandle._BACKOFF_BASE * (2 ** (attempt - 1)),
                     CommandHandle._BACKOFF_MAX,
                 )
+                if isinstance(exc, SandboxRetryableConnectionError):
+                    backoff = _retry_delay(exc, backoff)
                 if deadline is not None:
                     remaining = deadline - time.monotonic()
                     if remaining <= 0:

--- a/python/langsmith/sandbox/_ws_execute.py
+++ b/python/langsmith/sandbox/_ws_execute.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import json
 import logging
+import math
+import random
 import time
 from collections.abc import AsyncIterator, Iterator, Mapping
 from typing import Any, Callable, Optional
@@ -209,7 +211,7 @@ class _AsyncWSStreamControl:
 # =============================================================================
 
 
-_TRANSIENT_HANDSHAKE_STATUSES = frozenset({500, 502, 503, 504})
+_TRANSIENT_HANDSHAKE_STATUSES = frozenset({429, 500, 502, 503, 504})
 _MAX_HANDSHAKE_ERROR_BYTES = 16 * 1024
 
 
@@ -239,6 +241,28 @@ def _handshake_server_detail(exc: Exception) -> Optional[str]:
     return " (".join(parts) + ("" if len(parts) < 2 else ")") if parts else None
 
 
+def _handshake_retry_after(exc: Exception) -> Optional[float]:
+    """Return a non-negative Retry-After delay from a rejected handshake."""
+    headers = getattr(getattr(exc, "response", None), "headers", None)
+    if headers is None:
+        return None
+    try:
+        raw = headers.get("Retry-After")
+        delay = float(raw)
+    except (AttributeError, TypeError, ValueError):
+        return None
+    return delay if math.isfinite(delay) and delay >= 0 else None
+
+
+def _retry_delay(
+    exc: SandboxRetryableConnectionError, exponential_backoff: float
+) -> float:
+    """Prefer a server hint, otherwise jitter the local backoff."""
+    if exc.retry_after is not None:
+        return exc.retry_after
+    return random.uniform(exponential_backoff * 0.8, exponential_backoff)
+
+
 def _raise_for_invalid_handshake(exc: Exception, ws_url: str) -> None:
     """Raise a clear error when the WebSocket upgrade handshake fails.
 
@@ -260,7 +284,8 @@ def _raise_for_invalid_handshake(exc: Exception, ws_url: str) -> None:
         ) from exc
     if status in _TRANSIENT_HANDSHAKE_STATUSES:
         raise SandboxRetryableConnectionError(
-            f"WebSocket upgrade temporarily rejected by server (HTTP {status}){suffix}"
+            f"WebSocket upgrade temporarily rejected by server (HTTP {status}){suffix}",
+            retry_after=_handshake_retry_after(exc),
         ) from exc
     if status is not None:
         raise SandboxConnectionError(

--- a/python/tests/unit_tests/sandbox/test_async_ws_execute.py
+++ b/python/tests/unit_tests/sandbox/test_async_ws_execute.py
@@ -12,6 +12,7 @@ import pytest
 from langsmith.sandbox._exceptions import (
     SandboxConnectionError,
     SandboxOperationError,
+    SandboxRetryableConnectionError,
     SandboxServerReloadError,
 )
 from langsmith.sandbox._models import (
@@ -790,6 +791,36 @@ class TestAsyncSandboxRunWs:
         assert isinstance(result, ExecutionResult)
         assert result.stdout == "output"
         assert result.exit_code == 0
+
+    @pytest.mark.asyncio
+    @patch("langsmith.sandbox._ws_execute.run_ws_stream_async")
+    async def test_run_retries_rate_limited_handshake_after_retry_after(
+        self, mock_run_ws
+    ):
+        """Async execution waits for a 429 hint and reuses the command ID."""
+        rate_limited = SandboxRetryableConnectionError("HTTP 429", retry_after=10.0)
+
+        async def rejected_stream():
+            raise rate_limited
+            yield
+
+        mock_run_ws.side_effect = [
+            (rejected_stream(), _AsyncWSStreamControl()),
+            (
+                _make_async_stream([_started_msg(), _exit_msg(0)]),
+                _AsyncWSStreamControl(),
+            ),
+        ]
+        sandbox = self._make_sandbox()
+
+        with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            result = await sandbox.run("echo hello")
+
+        assert result.exit_code == 0
+        mock_sleep.assert_awaited_once_with(10.0)
+        first_id = mock_run_ws.call_args_list[0].kwargs["command_id"]
+        second_id = mock_run_ws.call_args_list[1].kwargs["command_id"]
+        assert first_id == second_id
 
     @pytest.mark.asyncio
     @patch("langsmith.sandbox._ws_execute.run_ws_stream_async")

--- a/python/tests/unit_tests/sandbox/test_ws_execute.py
+++ b/python/tests/unit_tests/sandbox/test_ws_execute.py
@@ -750,6 +750,53 @@ class TestSandboxRunWs:
         assert result.exit_code == 0
 
     @patch("langsmith.sandbox._ws_execute.run_ws_stream")
+    def test_run_retries_rate_limited_handshake_after_retry_after(self, mock_run_ws):
+        """A pre-execution 429 waits for the server hint and reuses the command ID."""
+        rate_limited = SandboxRetryableConnectionError("HTTP 429", retry_after=10.0)
+
+        def rejected_stream():
+            raise rate_limited
+            yield
+
+        mock_run_ws.side_effect = [
+            (rejected_stream(), _WSStreamControl()),
+            (_make_stream([_started_msg(), _exit_msg(0)]), _WSStreamControl()),
+        ]
+        sandbox = self._make_sandbox()
+
+        with patch("time.sleep") as mock_sleep:
+            result = sandbox.run("echo hello")
+
+        assert result.exit_code == 0
+        mock_sleep.assert_called_once_with(10.0)
+        first_id = mock_run_ws.call_args_list[0].kwargs["command_id"]
+        second_id = mock_run_ws.call_args_list[1].kwargs["command_id"]
+        assert first_id == second_id
+
+    @patch("langsmith.sandbox._ws_execute.run_ws_stream")
+    def test_run_jitters_retry_without_retry_after(self, mock_run_ws):
+        """Retries without a server hint do not synchronize on a fixed delay."""
+
+        def rejected_stream():
+            raise SandboxRetryableConnectionError("HTTP 429")
+            yield
+
+        mock_run_ws.side_effect = [
+            (rejected_stream(), _WSStreamControl()),
+            (_make_stream([_started_msg(), _exit_msg(0)]), _WSStreamControl()),
+        ]
+        sandbox = self._make_sandbox()
+
+        with (
+            patch("random.uniform", return_value=0.45),
+            patch("time.sleep") as mock_sleep,
+        ):
+            result = sandbox.run("echo hello")
+
+        assert result.exit_code == 0
+        mock_sleep.assert_called_once_with(0.45)
+
+    @patch("langsmith.sandbox._ws_execute.run_ws_stream")
     def test_run_wait_false(self, mock_run_ws):
         """wait=False returns CommandHandle."""
         mock_run_ws.return_value = (
@@ -1023,6 +1070,37 @@ class TestRaiseForInvalidHandshake:
 
         with pytest.raises(SandboxConnectionError, match="HTTP 403"):
             _raise_for_invalid_handshake(exc, "ws://example.com/sb-123/execute/ws")
+
+    def test_429_is_retryable_and_preserves_retry_after(self):
+        from langsmith.sandbox._ws_execute import _raise_for_invalid_handshake
+
+        mock_response = MagicMock()
+        mock_response.status_code = 429
+        mock_response.headers = {"Retry-After": "10"}
+        mock_response.body = b""
+        exc = Exception("server rejected WebSocket connection: HTTP 429")
+        exc.response = mock_response
+
+        with pytest.raises(SandboxRetryableConnectionError) as exc_info:
+            _raise_for_invalid_handshake(exc, "ws://example.com/sb-123/execute/ws")
+
+        assert exc_info.value.retry_after == 10.0
+
+    @pytest.mark.parametrize("retry_after", ["nan", "inf", "-inf"])
+    def test_429_ignores_non_finite_retry_after(self, retry_after):
+        from langsmith.sandbox._ws_execute import _raise_for_invalid_handshake
+
+        mock_response = MagicMock()
+        mock_response.status_code = 429
+        mock_response.headers = {"Retry-After": retry_after}
+        mock_response.body = b""
+        exc = Exception("server rejected WebSocket connection: HTTP 429")
+        exc.response = mock_response
+
+        with pytest.raises(SandboxRetryableConnectionError) as exc_info:
+            _raise_for_invalid_handshake(exc, "ws://example.com/sb-123/execute/ws")
+
+        assert exc_info.value.retry_after is None
 
     def test_503_is_retryable(self):
         from langsmith.sandbox._ws_execute import _raise_for_invalid_handshake


### PR DESCRIPTION
## Summary

- Treat HTTP 429 WebSocket upgrade responses as transient in the Python and JavaScript sandbox SDKs.
- Honor finite numeric `Retry-After` hints within the existing connect budget and use bounded jittered backoff when no usable hint is present.
- Reuse the command ID across retries so reconnect attempts remain idempotent.

## Test Plan

- [x] Added Python sync and async coverage for 429 retries, `Retry-After`, jitter, malformed values, and command-ID reuse.
- [x] Added JavaScript coverage for 429 handshake classification, valid and malformed `Retry-After`, jitter timing, and command-ID reuse.
- [x] Ran focused Python sandbox WebSocket tests (113 tests).
- [x] Ran focused JavaScript sandbox WebSocket tests (24 tests), formatting, lint, and TypeScript checks.