### PR TITLE
release(js): 0.10.2

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langsmith",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Client library to connect to the LangSmith Observability and Evaluation Platform.",
   "packageManager": "pnpm@10.33.0",
   "files": [

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -54,7 +54,7 @@ export {
 } from "./_openapi_client/core/error.js";
 
 // Update using pnpm bump-version
-export const __version__ = "0.10.1";
+export const __version__ = "0.10.2";
 
 // Metadata key to hide a traced run from LangSmith's Messages View.
 export const LS_MESSAGE_VIEW_EXCLUDE = "ls_message_view_exclude" as const;


### PR DESCRIPTION
Publishes JavaScript SDK 0.10.2, including sandbox WebSocket 429 retry support from #3493.

## Test Plan

- [x] Verified the release diff contains only the two JavaScript version files.
- [x] Ran `pnpm run check-version`.