### PR TITLE
test(py): benchmark compressed trace ingestion

### DIFF
--- a/python/bench/cases.py
+++ b/python/bench/cases.py
@@ -3,6 +3,7 @@
 Each entry is ``(name, fn, input)``; ``fn(input)`` is the timed call.
 """
 
+from bench.create_compressed_run_tree import create_compressed_run_trees
 from bench.create_run_tree import create_run_trees
 from bench.dumps_json import (
     DeeplyNestedModel,
@@ -31,6 +32,21 @@ BENCHMARKS = (
     (
         "create_20_000_run_trees",
         create_run_trees,
+        20_000,
+    ),
+    (
+        "create_5_000_compressed_run_trees",
+        create_compressed_run_trees,
+        5_000,
+    ),
+    (
+        "create_10_000_compressed_run_trees",
+        create_compressed_run_trees,
+        10_000,
+    ),
+    (
+        "create_20_000_compressed_run_trees",
+        create_compressed_run_trees,
         20_000,
     ),
     (

--- a/python/bench/create_compressed_run_tree.py
+++ b/python/bench/create_compressed_run_tree.py
@@ -1,0 +1,26 @@
+import threading
+from unittest.mock import MagicMock
+
+from langsmith import RunTree
+from langsmith._internal import _background_thread as bt
+from langsmith._internal._compressed_traces import CompressedTraces
+from langsmith.client import Client
+
+
+def create_compressed_run_trees(count: int) -> None:
+    session = MagicMock()
+    response = session.request.return_value
+    response.status_code = 202
+    response.text = "Accepted"
+    client = Client(session=session, api_key="fake", auto_batch_tracing=False)
+    client.compressed_traces = CompressedTraces()
+    client._data_available_event = threading.Event()
+
+    for i in range(count):
+        RunTree(name=str(i), ls_client=client).post()
+
+    stream, info, destinations = bt._tracing_thread_drain_compressed_buffer(
+        client, size_limit=1, size_limit_bytes=1
+    )
+    if stream is not None:
+        client._send_compressed_multipart_req(stream, info, destinations=destinations)


### PR DESCRIPTION
The existing `create_*_run_trees` CodSpeed cases instantiate the client against a mocked `/info` response without `zstd_compression_enabled`, so they exercise the uncompressed tracing queue and `_send_multipart_req` path.

This adds equivalent 5k, 10k, and 20k cases that explicitly configure the real `CompressedTraces` buffer, post through `RunTree`, drain the zstd frame, and send it through `_send_compressed_multipart_req`. The network remains mocked, keeping the benchmarks focused on SDK serialization, multipart encoding, compression, and dispatch costs.

Made by [Open SWE](https://openswe.vercel.app/agents/ce82d5ee-acb3-57f6-87e5-462acdc867e7)