### PR TITLE
fix(wrappers): suppress OpenAI parse serialization warnings

### DIFF
--- a/python/langsmith/wrappers/_openai.py
+++ b/python/langsmith/wrappers/_openai.py
@@ -268,7 +268,9 @@ def _reduce_completions(all_chunks: list[Completion]) -> dict:
     return d
 
 
-def _process_chat_completion(outputs: Any):
+def _process_chat_completion(
+    outputs: Any, *, suppress_pydantic_serialization_warnings: bool = False
+):
     try:
         # Check if outputs is an APIResponse wrapper (from with_raw_response).
         # The OpenAI SDK's APIResponse wraps the actual response object.
@@ -280,7 +282,15 @@ def _process_chat_completion(outputs: Any):
             except Exception:
                 pass
 
-        rdict = outputs.model_dump()
+        if suppress_pydantic_serialization_warnings:
+            # ParsedChatCompletion can contain a user-defined Pydantic model in
+            # message.parsed while its runtime generic resolves to NoneType. The
+            # value still serializes correctly, so ask Pydantic not to report
+            # serializer warnings for this dump. Avoid process-global filters since
+            # wrappers can run concurrently in user applications.
+            rdict = outputs.model_dump(warnings=False)
+        else:
+            rdict = outputs.model_dump()
         oai_token_usage = rdict.pop("usage", None)
         rdict["usage_metadata"] = (
             _create_usage_metadata(oai_token_usage, rdict.get("service_tier"))
@@ -517,7 +527,10 @@ def wrap_openai(
         client.beta.chat.completions.parse = _get_parse_wrapper(  # type: ignore[method-assign]
             client.beta.chat.completions.parse,  # type: ignore
             chat_name,
-            _process_chat_completion,
+            functools.partial(
+                _process_chat_completion,
+                suppress_pydantic_serialization_warnings=True,
+            ),
             tracing_extra=tracing_extra_rest,
             invocation_params_fn=functools.partial(
                 _infer_invocation_params,
@@ -537,7 +550,10 @@ def wrap_openai(
         client.chat.completions.parse = _get_parse_wrapper(  # type: ignore[method-assign]
             client.chat.completions.parse,  # type: ignore
             chat_name,
-            _process_chat_completion,
+            functools.partial(
+                _process_chat_completion,
+                suppress_pydantic_serialization_warnings=True,
+            ),
             tracing_extra=tracing_extra_rest,
             invocation_params_fn=functools.partial(
                 _infer_invocation_params,

--- a/python/tests/unit_tests/wrappers/test_openai_processing.py
+++ b/python/tests/unit_tests/wrappers/test_openai_processing.py
@@ -1,14 +1,188 @@
 """Unit tests for OpenAI wrapper processing functions."""
 
+import warnings as py_warnings
 from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import pytest
+from openai.types.chat.parsed_chat_completion import (
+    ParsedChatCompletion,
+    ParsedChatCompletionMessage,
+    ParsedChoice,
+)
+from openai.types.completion_usage import CompletionUsage
+from pydantic import BaseModel
 
 from langsmith import run_helpers
 from langsmith.wrappers._openai import (
     _infer_invocation_params,
+    _process_chat_completion,
     _traceable_kwargs_with_ls_agent_type,
+    wrap_openai,
 )
+
+
+class _WeatherResponse(BaseModel):
+    city: str
+    temp: str
+
+
+def _parsed_chat_completion_with_mismatched_runtime_type():
+    message = ParsedChatCompletionMessage[None].model_construct(
+        role="assistant",
+        content="{}",
+        refusal=None,
+        annotations=[],
+        audio=None,
+        parsed=_WeatherResponse(city="San Francisco", temp="60F"),
+    )
+    choice = ParsedChoice[None](
+        finish_reason="stop", index=0, logprobs=None, message=message
+    )
+    return ParsedChatCompletion[None](
+        id="completion-id",
+        choices=[choice],
+        created=0,
+        model="gpt-4o-mini",
+        object="chat.completion",
+        service_tier=None,
+        system_fingerprint=None,
+        usage=CompletionUsage(
+            completion_tokens=5,
+            prompt_tokens=10,
+            total_tokens=15,
+        ),
+    )
+
+
+def _is_pydantic_serialization_warning(warning):
+    message = str(warning.message)
+    return (
+        "Pydantic serializer warnings" in message
+        or "PydanticSerializationUnexpectedValue" in message
+    )
+
+
+class TestProcessParsedChatCompletion:
+    def test_suppresses_pydantic_warnings_for_parse_outputs(self):
+        completion = _parsed_chat_completion_with_mismatched_runtime_type()
+
+        with py_warnings.catch_warnings(record=True) as original_warnings:
+            py_warnings.simplefilter("always")
+            completion.model_dump()
+
+        assert any(
+            _is_pydantic_serialization_warning(warning) for warning in original_warnings
+        )
+
+        with py_warnings.catch_warnings(record=True) as caught:
+            py_warnings.simplefilter("always")
+            result = _process_chat_completion(
+                completion, suppress_pydantic_serialization_warnings=True
+            )
+
+        assert not [
+            warning for warning in caught if _is_pydantic_serialization_warning(warning)
+        ]
+        assert result["choices"][0]["message"]["parsed"] == {
+            "city": "San Francisco",
+            "temp": "60F",
+        }
+        assert result["usage_metadata"]["input_tokens"] == 10
+        assert result["usage_metadata"]["output_tokens"] == 5
+        assert result["usage_metadata"]["total_tokens"] == 15
+
+    def test_parse_suppression_does_not_install_global_warning_filter(self):
+        model_dump_calls = []
+
+        def _model_dump_with_warning(*, warnings=True):
+            model_dump_calls.append(warnings)
+            py_warnings.warn("unrelated warning", UserWarning, stacklevel=2)
+            if warnings:
+                py_warnings.warn(
+                    "PydanticSerializationUnexpectedValue",
+                    UserWarning,
+                    stacklevel=2,
+                )
+            return {"choices": [], "usage": None}
+
+        completion = SimpleNamespace(model_dump=_model_dump_with_warning)
+
+        with py_warnings.catch_warnings(record=True) as caught:
+            py_warnings.simplefilter("always")
+            _process_chat_completion(
+                completion, suppress_pydantic_serialization_warnings=True
+            )
+
+        assert model_dump_calls == [False]
+        assert [str(warning.message) for warning in caught] == ["unrelated warning"]
+
+    def test_regular_chat_completion_warnings_are_not_suppressed(self):
+        def _model_dump_with_warning():
+            py_warnings.warn("some other warning", UserWarning, stacklevel=2)
+            return {"choices": [], "usage": None}
+
+        completion = SimpleNamespace(model_dump=_model_dump_with_warning)
+
+        with py_warnings.catch_warnings(record=True) as caught:
+            py_warnings.simplefilter("always")
+            _process_chat_completion(completion)
+
+        assert len(caught) == 1
+        assert "some other warning" in str(caught[0].message)
+
+
+@pytest.mark.parametrize("parse_api", ["beta", "stable"])
+@pytest.mark.parametrize("is_async", [False, True])
+@pytest.mark.asyncio
+async def test_wrap_openai_parse_suppresses_pydantic_warnings(parse_api, is_async):
+    completion = _parsed_chat_completion_with_mismatched_runtime_type()
+
+    def _sync_parse(*args, **kwargs):
+        return completion
+
+    async def _async_parse(*args, **kwargs):
+        return completion
+
+    parse_implementation = _async_parse if is_async else _sync_parse
+    client = SimpleNamespace(
+        beta=SimpleNamespace(
+            chat=SimpleNamespace(
+                completions=SimpleNamespace(parse=parse_implementation)
+            )
+        ),
+        chat=SimpleNamespace(
+            completions=SimpleNamespace(
+                create=parse_implementation, parse=parse_implementation
+            )
+        ),
+        completions=SimpleNamespace(create=parse_implementation),
+    )
+    wrapped_client = wrap_openai(client, tracing_extra={"client": MagicMock()})
+    parse = (
+        wrapped_client.beta.chat.completions.parse
+        if parse_api == "beta"
+        else wrapped_client.chat.completions.parse
+    )
+    runs = []
+
+    with run_helpers.tracing_context(enabled=True):
+        with py_warnings.catch_warnings(record=True) as caught:
+            py_warnings.simplefilter("always")
+            if is_async:
+                result = await parse(langsmith_extra={"on_end": runs.append})
+            else:
+                result = parse(langsmith_extra={"on_end": runs.append})
+
+    assert not [
+        warning for warning in caught if _is_pydantic_serialization_warning(warning)
+    ]
+    assert result is completion
+    assert runs[0].outputs["choices"][0]["message"]["parsed"] == {
+        "city": "San Francisco",
+        "temp": "60F",
+    }
+
 
 # ---------------------------------------------------------------------------
 # _infer_invocation_params


### PR DESCRIPTION
## Summary

- suppress the known Pydantic serializer warning while tracing `beta.chat.completions.parse` and `chat.completions.parse`
- keep ordinary chat-completion warning behavior unchanged and avoid process-global warning filters
- verify parsed output and token usage across beta/stable and sync/async parse clients

Fixes #3490.

## Test Plan

- [x] `make format`
- [x] `make lint`
- [x] `make tests` (2,184 passed, 6 skipped, 1 xfailed)
- [x] `OPENAI_API_KEY=test-key INT_TEST="tests/integration_tests/wrappers/test_openai.py::test_parse_sync_api tests/integration_tests/wrappers/test_openai.py::test_parse_async_api" make integration_tests`
- [x] Verified the declared OpenAI/Pydantic compatibility floor accepts `model_dump(warnings=False)` and preserves parsed output
