### PR TITLE
fix(docs): correct README code examples and update model references    

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ await client.chat.completions.create({
   id: 'chatcmpl-8sOWEOYVyehDlyPcBiaDtTxWvr9v6',
   object: 'chat.completion',
   created: 1707974654,
-  model: 'gpt-5.4-0613',
+  model: 'gpt-5.4',
   choices: [
     {
       index: 0,

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ client = wrap_openai(openai.Client())
 
 client.chat.completions.create(
     messages=[{"role": "user", "content": "Hello, world"}],
-    model="gpt-3.5-turbo"
+    model="gpt-5.4"
 )
 ```
 
@@ -59,7 +59,7 @@ import { wrapOpenAI } from "langsmith/wrappers";
 const client = wrapOpenAI(new OpenAI());
 
 await client.chat.completions.create({
-  model: "gpt-3.5-turbo",
+  model: "gpt-5.4",
   messages: [{ content: "Hi there!", role: "user" }],
 });
 ```
@@ -69,7 +69,7 @@ await client.chat.completions.create({
   id: 'chatcmpl-8sOWEOYVyehDlyPcBiaDtTxWvr9v6',
   object: 'chat.completion',
   created: 1707974654,
-  model: 'gpt-3.5-turbo-0613',
+  model: 'gpt-5.4-0613',
   choices: [
     {
       index: 0,

--- a/js/README.md
+++ b/js/README.md
@@ -389,7 +389,7 @@ await nestedTrace("Why is the sky blue?");
   "id": "chatcmpl-8sPToJQLLVepJvyeTfzZMOMVIKjMo",
   "object": "chat.completion",
   "created": 1707978348,
-  "model": "gpt-5.4-0613",
+  "model": "gpt-5.4",
   "choices": [
     {
       "index": 0,

--- a/js/README.md
+++ b/js/README.md
@@ -341,7 +341,7 @@ import { wrapOpenAI } from "langsmith/wrappers";
 const openai = wrapOpenAI(new OpenAI());
 
 await openai.chat.completions.create({
-  model: "gpt-3.5-turbo",
+  model: "gpt-5.4",
   messages: [{ content: "Hi there!", role: "user" }],
 });
 ```
@@ -359,7 +359,7 @@ const createCompletion = traceable(
 );
 
 await createCompletion({
-  model: "gpt-3.5-turbo",
+  model: "gpt-5.4",
   messages: [{ content: "Hi there!", role: "user" }],
 });
 ```
@@ -375,7 +375,7 @@ within other functions wrapped with `traceable`.
 ```ts
 const nestedTrace = traceable(async (text: string) => {
   const completion = await openai.chat.completions.create({
-    model: "gpt-3.5-turbo",
+    model: "gpt-5.4",
     messages: [{ content: text, role: "user" }],
   });
   return completion;
@@ -389,7 +389,7 @@ await nestedTrace("Why is the sky blue?");
   "id": "chatcmpl-8sPToJQLLVepJvyeTfzZMOMVIKjMo",
   "object": "chat.completion",
   "created": 1707978348,
-  "model": "gpt-3.5-turbo-0613",
+  "model": "gpt-5.4-0613",
   "choices": [
     {
       "index": 0,
@@ -435,14 +435,14 @@ const handler = traceable(
     const openai = wrapOpenAI(new OpenAI());
 
     const completion = await openai.chat.completions.create({
-      model: "gpt-3.5-turbo",
+      model: "gpt-5.4",
       messages: [{ content: "Why is the sky blue?", role: "user" }],
     });
 
     const response1 = completion.choices[0].message.content;
 
     const completion2 = await openai.chat.completions.create({
-      model: "gpt-3.5-turbo",
+      model: "gpt-5.4",
       messages: [
         { content: "Why is the sky blue?", role: "user" },
         { content: response1, role: "assistant" },

--- a/python/README.md
+++ b/python/README.md
@@ -34,7 +34,7 @@ def pipeline(user_input: str):
 pipeline("Hello, world!")
 ```
 
-See the resulting nested trace [🌐 here](https://smith.langchain.com/public/b37ca9b1-60cd-4a2a-817e-3c4e4443fdc0/r).
+Every LLM call inside `pipeline` is nested under a single trace in the LangSmith UI.
 
 LangSmith helps you and your team develop and evaluate language models and intelligent agents. It is compatible with any LLM application.
 
@@ -323,7 +323,8 @@ client = wrap_openai(openai.Client())
 @traceable
 def argument_generator(query: str, additional_description: str = "") -> str:
     return client.chat.completions.create(
-        [
+        model="gpt-3.5-turbo",
+        messages=[
             {"role": "system", "content": "You are a debater making an argument on a topic."
              f"{additional_description}"
              f" The current time is {datetime.now()}"},
@@ -405,7 +406,7 @@ child_chain_run.post()
 try:
     # .... the component does work
     raise ValueError("Something went wrong")
-    child_chain_run.end(outputs={"output": "foo"}
+    child_chain_run.end(outputs={"output": "foo"})
     child_chain_run.patch()
 except Exception as e:
     child_chain_run.end(error=f"I errored again {e}")

--- a/python/README.md
+++ b/python/README.md
@@ -27,7 +27,7 @@ client = wrap_openai(openai.Client())
 def pipeline(user_input: str):
     result = client.chat.completions.create(
         messages=[{"role": "user", "content": user_input}],
-        model="gpt-3.5-turbo"
+        model="gpt-5.4"
     )
     return result.choices[0].message.content
 
@@ -323,7 +323,7 @@ client = wrap_openai(openai.Client())
 @traceable
 def argument_generator(query: str, additional_description: str = "") -> str:
     return client.chat.completions.create(
-        model="gpt-3.5-turbo",
+        model="gpt-5.4",
         messages=[
             {"role": "system", "content": "You are a debater making an argument on a topic."
              f"{additional_description}"
@@ -523,7 +523,7 @@ Now, you can use the OpenAI client as you normally would, but now everything is 
 
 ```python
 client.chat.completions.create(
-    model="gpt-4",
+    model="gpt-5.4",
     messages=[{"role": "user", "content": "Say this is a test"}],
 )
 ```
@@ -538,7 +538,7 @@ from langsmith import traceable
 @traceable(name="Call OpenAI")
 def my_function(text: str):
     return client.chat.completions.create(
-        model="gpt-4",
+        model="gpt-5.4",
         messages=[{"role": "user", "content": f"Say {text}"}],
     )
 
@@ -590,7 +590,7 @@ class UserDetail(BaseModel):
 
 
 user = client.chat.completions.create(
-    model="gpt-3.5-turbo",
+    model="gpt-5.4",
     response_model=UserDetail,
     messages=[
         {"role": "user", "content": "Extract Jason is 25 years old"},
@@ -606,7 +606,7 @@ See [this documentation](https://docs.smith.langchain.com/tracing/faq/logging_an
 @traceable()
 def my_function(text: str) -> UserDetail:
     return client.chat.completions.create(
-        model="gpt-3.5-turbo",
+        model="gpt-5.4",
         response_model=UserDetail,
         messages=[
             {"role": "user", "content": f"Extract {text}"},


### PR DESCRIPTION
 Fixes broken/inconsistent code examples across `README.md, js/README.md`, and `python/README.md`, and updates all   
 hardcoded OpenAI model references from the deprecated gpt-3.5-turbo (and stale gpt-4) to **gpt-5.4.**               
       