### PR TITLE
fix(py): carry the ADK tool call ids into traced messages [LSDK-509]

### DIFF
--- a/python/langsmith/integrations/google_adk/_client.py
+++ b/python/langsmith/integrations/google_adk/_client.py
@@ -14,7 +14,11 @@ from langsmith._internal._package_version import get_package_version
 from langsmith.run_helpers import get_current_run_tree, set_tracing_parent, trace
 
 from ._config import get_tracing_config
-from ._messages import convert_llm_request_to_messages, has_function_calls
+from ._messages import (
+    ToolIdState,
+    convert_llm_request_to_messages,
+    has_function_calls,
+)
 from ._usage import extract_model_name, extract_usage_from_response
 
 _LS_PROVIDER_VERTEXAI = "google_vertexai"
@@ -353,6 +357,7 @@ async def wrap_flow_call_llm_async(
     )
 
     posted = False
+    id_state = ToolIdState()
 
     def _capture_inputs_and_post() -> None:
         """Capture the final llm_request state and post the run (idempotent)."""
@@ -361,7 +366,11 @@ async def wrap_flow_call_llm_async(
             return
 
         model_name = extract_model_name(llm_request) if llm_request else None
-        messages = convert_llm_request_to_messages(llm_request) if llm_request else None
+        messages = (
+            convert_llm_request_to_messages(llm_request, id_state)
+            if llm_request
+            else None
+        )
         tools = extract_tools_from_llm_request(llm_request) if llm_request else []
 
         if messages:
@@ -431,7 +440,12 @@ async def wrap_flow_call_llm_async(
                     fc = part.function_call
                     tool_calls.append(
                         {
-                            "id": getattr(fc, "id", None) or f"call_{len(tool_calls)}",
+                            "id": id_state.call_id(
+                                {
+                                    "id": getattr(fc, "id", None),
+                                    "name": getattr(fc, "name", ""),
+                                }
+                            ),
                             "type": "function",
                             "function": {
                                 "name": getattr(fc, "name", ""),

--- a/python/langsmith/integrations/google_adk/_client.py
+++ b/python/langsmith/integrations/google_adk/_client.py
@@ -421,16 +421,17 @@ async def wrap_flow_call_llm_async(
             and content_source.content
         ):
             parts = getattr(content_source.content, "parts", None) or []
-            text_parts, tool_calls = [], []
+            text_parts: list[str] = []
+            tool_calls: list[dict[str, Any]] = []
 
-            for i, part in enumerate(parts):
+            for part in parts:
                 if hasattr(part, "text") and part.text:
                     text_parts.append(str(part.text))
                 elif hasattr(part, "function_call") and part.function_call:
                     fc = part.function_call
                     tool_calls.append(
                         {
-                            "id": f"call_{i}",
+                            "id": getattr(fc, "id", None) or f"call_{len(tool_calls)}",
                             "type": "function",
                             "function": {
                                 "name": getattr(fc, "name", ""),

--- a/python/langsmith/integrations/google_adk/_messages.py
+++ b/python/langsmith/integrations/google_adk/_messages.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import base64
+import itertools
 import json
+from collections import defaultdict, deque
 from typing import Any
 
 
@@ -47,6 +49,7 @@ def _serialize_part(part: Any) -> dict[str, Any]:
         fc = part.function_call
         return {
             "type": "tool_use",
+            "id": getattr(fc, "id", None),
             "name": getattr(fc, "name", "unknown"),
             "input": dict(getattr(fc, "args", None) or {}),
         }
@@ -55,6 +58,7 @@ def _serialize_part(part: Any) -> dict[str, Any]:
         fr = part.function_response
         return {
             "type": "tool_result",
+            "id": getattr(fr, "id", None),
             "name": getattr(fr, "name", "unknown"),
             "content": _safe_serialize(getattr(fr, "response", None)),
         }
@@ -107,6 +111,33 @@ def _safe_serialize(obj: Any) -> Any:
     return str(obj)
 
 
+def _tool_call_id(
+    tool_call: dict[str, Any],
+    fallback_ids: itertools.count,
+    unanswered: dict[str, deque[str]],
+) -> str:
+    """Return the id of an assistant tool call, preferring the one ADK set."""
+    call_id = tool_call.get("id")
+    if call_id:
+        return str(call_id)
+    call_id = f"call_{next(fallback_ids)}"
+    unanswered[tool_call.get("name", "")].append(call_id)
+    return call_id
+
+
+def _tool_result_id(
+    tool_result: dict[str, Any],
+    fallback_ids: itertools.count,
+    unanswered: dict[str, deque[str]],
+) -> str:
+    """Return the id of the call a tool result answers, preferring ADK's own."""
+    result_id = tool_result.get("id")
+    if result_id:
+        return str(result_id)
+    pending = unanswered[tool_result.get("name", "")]
+    return pending.popleft() if pending else f"call_{next(fallback_ids)}"
+
+
 def convert_llm_request_to_messages(llm_request: Any) -> list[dict[str, Any]]:
     """Convert LlmRequest to OpenAI-compatible message format."""
     messages: list[dict[str, Any]] = []
@@ -121,6 +152,10 @@ def convert_llm_request_to_messages(llm_request: Any) -> list[dict[str, Any]]:
     contents = getattr(llm_request, "contents", None)
     if not contents:
         return messages
+
+    # ADK sets a matching id on every FunctionCall and its FunctionResponse.
+    fallback_ids = itertools.count()
+    unanswered: dict[str, deque[str]] = defaultdict(deque)
 
     for content in contents:
         role = getattr(content, "role", "user")
@@ -148,14 +183,14 @@ def convert_llm_request_to_messages(llm_request: Any) -> list[dict[str, Any]]:
                     "content": " ".join(text_parts) if text_parts else None,
                     "tool_calls": [
                         {
-                            "id": f"call_{i}",
+                            "id": _tool_call_id(tc, fallback_ids, unanswered),
                             "type": "function",
                             "function": {
                                 "name": tc.get("name", ""),
                                 "arguments": json.dumps(tc.get("input", {})),
                             },
                         }
-                        for i, tc in enumerate(tool_calls)
+                        for tc in tool_calls
                     ],
                 }
             )
@@ -165,6 +200,7 @@ def convert_llm_request_to_messages(llm_request: Any) -> list[dict[str, Any]]:
                 messages.append(
                     {
                         "role": "tool",
+                        "tool_call_id": _tool_result_id(tr, fallback_ids, unanswered),
                         "name": tr.get("name", ""),
                         "content": (
                             json.dumps(c) if isinstance(c, dict) else str(c or "")

--- a/python/langsmith/integrations/google_adk/_messages.py
+++ b/python/langsmith/integrations/google_adk/_messages.py
@@ -47,21 +47,25 @@ def _serialize_part(part: Any) -> dict[str, Any]:
 
     if hasattr(part, "function_call") and part.function_call:
         fc = part.function_call
-        return {
+        call: dict[str, Any] = {
             "type": "tool_use",
-            "id": getattr(fc, "id", None),
             "name": getattr(fc, "name", "unknown"),
             "input": dict(getattr(fc, "args", None) or {}),
         }
+        if call_id := getattr(fc, "id", None):
+            call["id"] = str(call_id)
+        return call
 
     if hasattr(part, "function_response") and part.function_response:
         fr = part.function_response
-        return {
+        result: dict[str, Any] = {
             "type": "tool_result",
-            "id": getattr(fr, "id", None),
             "name": getattr(fr, "name", "unknown"),
             "content": _safe_serialize(getattr(fr, "response", None)),
         }
+        if result_id := getattr(fr, "id", None):
+            result["tool_use_id"] = str(result_id)
+        return result
 
     if hasattr(part, "text") and part.text is not None:
         return {"type": "text", "text": str(part.text)}
@@ -111,34 +115,29 @@ def _safe_serialize(obj: Any) -> Any:
     return str(obj)
 
 
-def _tool_call_id(
-    tool_call: dict[str, Any],
-    fallback_ids: itertools.count,
-    unanswered: dict[str, deque[str]],
-) -> str:
-    """Return the id of an assistant tool call, preferring the one ADK set."""
-    call_id = tool_call.get("id")
-    if call_id:
-        return str(call_id)
-    call_id = f"call_{next(fallback_ids)}"
-    unanswered[tool_call.get("name", "")].append(call_id)
-    return call_id
+class ToolIdState:
+    """Shared tool call id numbering for one LLM call."""
+
+    def __init__(self) -> None:
+        self._fallback_ids = itertools.count()
+        self._unanswered: dict[str, deque[str]] = defaultdict(deque)
+
+    def call_id(self, tool_call: dict[str, Any]) -> str:
+        """Return the id of an assistant tool call, preferring the one ADK set."""
+        call_id = str(tool_call.get("id") or f"ls-adk-{next(self._fallback_ids)}")
+        self._unanswered[tool_call.get("name", "")].append(call_id)
+        return call_id
+
+    def result_id(self, tool_result: dict[str, Any]) -> str:
+        """Return the id of the call a tool result answers, or "" if unknown."""
+        pending = self._unanswered[tool_result.get("name", "")]
+        own_id = tool_result.get("tool_use_id")
+        return str(own_id or (pending.popleft() if pending else ""))
 
 
-def _tool_result_id(
-    tool_result: dict[str, Any],
-    fallback_ids: itertools.count,
-    unanswered: dict[str, deque[str]],
-) -> str:
-    """Return the id of the call a tool result answers, preferring ADK's own."""
-    result_id = tool_result.get("id")
-    if result_id:
-        return str(result_id)
-    pending = unanswered[tool_result.get("name", "")]
-    return pending.popleft() if pending else f"call_{next(fallback_ids)}"
-
-
-def convert_llm_request_to_messages(llm_request: Any) -> list[dict[str, Any]]:
+def convert_llm_request_to_messages(
+    llm_request: Any, id_state: ToolIdState | None = None
+) -> list[dict[str, Any]]:
     """Convert LlmRequest to OpenAI-compatible message format."""
     messages: list[dict[str, Any]] = []
 
@@ -153,9 +152,7 @@ def convert_llm_request_to_messages(llm_request: Any) -> list[dict[str, Any]]:
     if not contents:
         return messages
 
-    # ADK sets a matching id on every FunctionCall and its FunctionResponse.
-    fallback_ids = itertools.count()
-    unanswered: dict[str, deque[str]] = defaultdict(deque)
+    id_state = id_state or ToolIdState()
 
     for content in contents:
         role = getattr(content, "role", "user")
@@ -183,7 +180,7 @@ def convert_llm_request_to_messages(llm_request: Any) -> list[dict[str, Any]]:
                     "content": " ".join(text_parts) if text_parts else None,
                     "tool_calls": [
                         {
-                            "id": _tool_call_id(tc, fallback_ids, unanswered),
+                            "id": id_state.call_id(tc),
                             "type": "function",
                             "function": {
                                 "name": tc.get("name", ""),
@@ -197,16 +194,14 @@ def convert_llm_request_to_messages(llm_request: Any) -> list[dict[str, Any]]:
         elif tool_results:
             for tr in tool_results:
                 c = tr.get("content")
-                messages.append(
-                    {
-                        "role": "tool",
-                        "tool_call_id": _tool_result_id(tr, fallback_ids, unanswered),
-                        "name": tr.get("name", ""),
-                        "content": (
-                            json.dumps(c) if isinstance(c, dict) else str(c or "")
-                        ),
-                    }
-                )
+                message = {
+                    "role": "tool",
+                    "name": tr.get("name", ""),
+                    "content": (json.dumps(c) if isinstance(c, dict) else str(c or "")),
+                }
+                if tool_call_id := id_state.result_id(tr):
+                    message["tool_call_id"] = tool_call_id
+                messages.append(message)
         else:
             messages.append(
                 {

--- a/python/langsmith/integrations/google_adk/_messages.py
+++ b/python/langsmith/integrations/google_adk/_messages.py
@@ -132,7 +132,15 @@ class ToolIdState:
         """Return the id of the call a tool result answers, or "" if unknown."""
         pending = self._unanswered[tool_result.get("name", "")]
         own_id = tool_result.get("tool_use_id")
-        return str(own_id or (pending.popleft() if pending else ""))
+        if own_id:
+            # Drop the call this answers, so a later result whose id ADK stripped
+            # cannot re-pair with it.
+            try:
+                pending.remove(str(own_id))
+            except ValueError:
+                pass
+            return str(own_id)
+        return str(pending.popleft() if pending else "")
 
 
 def convert_llm_request_to_messages(

--- a/python/tests/unit_tests/wrappers/test_google_adk.py
+++ b/python/tests/unit_tests/wrappers/test_google_adk.py
@@ -425,3 +425,67 @@ def test_wrap_tool_run_async_sets_tool_as_active_context(mock_ls_client: Client)
         f"Expected active context inside tool to be the tool span "
         f"({tool_run['id']}), got {captured_run_id}"
     )
+
+
+def _tool_call_request(*ids: str | None):
+    """Build an LlmRequest alternating one tool call and its response per id."""
+    from google.adk.models.llm_request import LlmRequest
+    from google.genai import types
+
+    contents = []
+    for call_id in ids:
+        contents.append(
+            types.Content(
+                role="model",
+                parts=[
+                    types.Part(
+                        function_call=types.FunctionCall(
+                            id=call_id, name="get_weather", args={"city": "Haifa"}
+                        )
+                    )
+                ],
+            )
+        )
+        contents.append(
+            types.Content(
+                role="user",
+                parts=[
+                    types.Part(
+                        function_response=types.FunctionResponse(
+                            id=call_id, name="get_weather", response={"c": 29}
+                        )
+                    )
+                ],
+            )
+        )
+    return LlmRequest(contents=contents)
+
+
+def test_tool_messages_pair_with_the_ids_adk_assigned():
+    """A tool message carries the id of the call it answers, per ADK."""
+    from langsmith.integrations.google_adk._messages import (
+        convert_llm_request_to_messages,
+    )
+
+    messages = convert_llm_request_to_messages(
+        _tool_call_request("adk-1111", "adk-2222")
+    )
+    calls = [m["tool_calls"][0]["id"] for m in messages if m.get("tool_calls")]
+    results = [m["tool_call_id"] for m in messages if m["role"] == "tool"]
+
+    assert calls == ["adk-1111", "adk-2222"]
+    assert results == ["adk-1111", "adk-2222"]
+
+
+def test_synthesised_tool_call_ids_stay_unique_across_turns():
+    """Without ADK ids, turns must not all reuse the same synthesised id."""
+    from langsmith.integrations.google_adk._messages import (
+        convert_llm_request_to_messages,
+    )
+
+    messages = convert_llm_request_to_messages(_tool_call_request(None, None))
+    calls = [m["tool_calls"][0]["id"] for m in messages if m.get("tool_calls")]
+    results = [m["tool_call_id"] for m in messages if m["role"] == "tool"]
+
+    assert len(set(calls)) == 2, calls
+    assert results == calls

--- a/python/tests/unit_tests/wrappers/test_google_adk.py
+++ b/python/tests/unit_tests/wrappers/test_google_adk.py
@@ -427,20 +427,20 @@ def test_wrap_tool_run_async_sets_tool_as_active_context(mock_ls_client: Client)
     )
 
 
-def _tool_call_request(*ids: str | None):
-    """Build an LlmRequest alternating one tool call and its response per id."""
+def _tool_call_request(*calls: tuple[str | None, str | None], name: str = "weather"):
+    """Build an LlmRequest of one tool call and its response per (call, result) id."""
     from google.adk.models.llm_request import LlmRequest
     from google.genai import types
 
     contents = []
-    for call_id in ids:
+    for call_id, result_id in calls:
         contents.append(
             types.Content(
                 role="model",
                 parts=[
                     types.Part(
                         function_call=types.FunctionCall(
-                            id=call_id, name="get_weather", args={"city": "Haifa"}
+                            id=call_id, name=name, args={"city": "Haifa"}
                         )
                     )
                 ],
@@ -452,7 +452,7 @@ def _tool_call_request(*ids: str | None):
                 parts=[
                     types.Part(
                         function_response=types.FunctionResponse(
-                            id=call_id, name="get_weather", response={"c": 29}
+                            id=result_id, name=name, response={"c": 29}
                         )
                     )
                 ],
@@ -461,31 +461,92 @@ def _tool_call_request(*ids: str | None):
     return LlmRequest(contents=contents)
 
 
-def test_tool_messages_pair_with_the_ids_adk_assigned():
-    """A tool message carries the id of the call it answers, per ADK."""
+def _call_and_result_ids(llm_request):
     from langsmith.integrations.google_adk._messages import (
         convert_llm_request_to_messages,
     )
 
-    messages = convert_llm_request_to_messages(
-        _tool_call_request("adk-1111", "adk-2222")
+    messages = convert_llm_request_to_messages(llm_request)
+    return (
+        [m["tool_calls"][0]["id"] for m in messages if m.get("tool_calls")],
+        [m.get("tool_call_id") for m in messages if m["role"] == "tool"],
     )
-    calls = [m["tool_calls"][0]["id"] for m in messages if m.get("tool_calls")]
-    results = [m["tool_call_id"] for m in messages if m["role"] == "tool"]
+
+
+def test_tool_messages_pair_with_the_ids_adk_assigned():
+    """When ADK keeps its ids, a tool message carries the id of the call it answers."""
+    calls, results = _call_and_result_ids(
+        _tool_call_request(("adk-1111", "adk-1111"), ("adk-2222", "adk-2222"))
+    )
 
     assert calls == ["adk-1111", "adk-2222"]
-    assert results == ["adk-1111", "adk-2222"]
+    assert results == calls
 
 
-def test_synthesised_tool_call_ids_stay_unique_across_turns():
-    """Without ADK ids, turns must not all reuse the same synthesised id."""
-    from langsmith.integrations.google_adk._messages import (
-        convert_llm_request_to_messages,
+def test_tool_messages_pair_when_adk_strips_its_ids():
+    """The default Gemini path: ADK strips every ``adk-`` id before the request.
+
+    Pinned to ADK's own stripping rather than a hand-built request, because this,
+    not the branch above, is what a plain ``Gemini`` agent produces.
+    """
+    from google.adk.flows.llm_flows.functions import (
+        generate_client_function_call_id,
+        remove_client_function_call_id,
     )
 
-    messages = convert_llm_request_to_messages(_tool_call_request(None, None))
-    calls = [m["tool_calls"][0]["id"] for m in messages if m.get("tool_calls")]
-    results = [m["tool_call_id"] for m in messages if m["role"] == "tool"]
+    minted = [generate_client_function_call_id() for _ in range(2)]
+    llm_request = _tool_call_request(*((call_id, call_id) for call_id in minted))
+    for content in llm_request.contents:
+        remove_client_function_call_id(content)
 
+    calls, results = _call_and_result_ids(llm_request)
+
+    assert all(call_id is None for call_id in _raw_part_ids(llm_request)), (
+        "ADK no longer strips its ids; the fallback is no longer the primary path"
+    )
     assert len(set(calls)) == 2, calls
     assert results == calls
+
+
+def _raw_part_ids(llm_request):
+    ids = []
+    for content in llm_request.contents:
+        for part in content.parts:
+            fc, fr = part.function_call, part.function_response
+            ids.append(fc.id if fc else fr.id)
+    return ids
+
+
+@pytest.mark.parametrize(
+    "ids, expected_calls, expected_results",
+    [
+        # A provider id on one side is carried over to the other.
+        ([("call_abc", None)], ["call_abc"], ["call_abc"]),
+        # Except the other way round: nothing links the two, so they stay apart.
+        ([(None, "call_abc")], ["ls-adk-0"], ["call_abc"]),
+        # A synthesised id must not collide with a real one.
+        (
+            [(None, None), ("call_0", "call_0")],
+            ["ls-adk-0", "call_0"],
+            ["ls-adk-0", "call_0"],
+        ),
+    ],
+    ids=["call-id-only", "result-id-only", "no-collision"],
+)
+def test_partial_tool_call_ids(ids, expected_calls, expected_results):
+    """An id present on one side only must not mis-pair the other."""
+    calls, results = _call_and_result_ids(_tool_call_request(*ids))
+
+    assert calls == expected_calls
+    assert results == expected_results
+
+
+def test_orphan_tool_result_gets_no_id():
+    """A result with no call to answer gets no id rather than an invented one."""
+    llm_request = _tool_call_request((None, None))
+    llm_request.contents = [c for c in llm_request.contents if c.role != "model"]
+
+    calls, results = _call_and_result_ids(llm_request)
+
+    assert calls == []
+    assert results == [None]

--- a/python/tests/unit_tests/wrappers/test_google_adk.py
+++ b/python/tests/unit_tests/wrappers/test_google_adk.py
@@ -530,8 +530,14 @@ def _raw_part_ids(llm_request):
             ["ls-adk-0", "call_0"],
             ["ls-adk-0", "call_0"],
         ),
+        # An answered call must not be re-paired with a later stripped result.
+        (
+            [("adk-1", "adk-1"), (None, None)],
+            ["adk-1", "ls-adk-0"],
+            ["adk-1", "ls-adk-0"],
+        ),
     ],
-    ids=["call-id-only", "result-id-only", "no-collision"],
+    ids=["call-id-only", "result-id-only", "no-collision", "mixed-history"],
 )
 def test_partial_tool_call_ids(ids, expected_calls, expected_results):
     """An id present on one side only must not mis-pair the other."""


### PR DESCRIPTION
Every tool call in a traced ADK request now gets a stable id, and the
result that answers it carries that id as its `tool_call_id`, so the trace
view pairs the two instead of rendering the result's role as Unknown.
Before, tool results had no `tool_call_id` key at all, and assistant-side
ids were numbered inside the per-content loop, so two single-call turns
both emitted `call_0`.

A shared `ToolIdState` does the numbering, under an `ls-adk-` prefix that
cannot collide with a real `call_*` id. It spans the whole request rather
than one turn, and `_client.py` and the request conversion share an
instance, so an id survives from one run's outputs into the next run's
inputs. Calls are queued per tool name, so parallel and out-of-order
results still pair.

Where ADK does supply its own `adk-` ids, `_serialize_part` keeps them,
and a result consuming one drops the matching call from the queue. That is
the narrower path: ADK preserves its ids only for models that pair tool
calls by id (`AnthropicLlm`, `LiteLlm`, `OpenAIResponsesLlm`, `Gemini`
with `use_interactions_api`); everywhere else `preserve_function_call_ids`
is False and every id is stripped from the request (adk-python
contents.py:47-80, :677-683), and the response path yields the raw
`LlmResponse` before the ids are populated.
