### PR TITLE
release(py): 0.12.3

### DIFF
--- a/python/.bumpversion.cfg
+++ b/python/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.12.2
+current_version = 0.12.3
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
 serialize = {major}.{minor}.{patch}
 search = {current_version}

--- a/python/langsmith/__init__.py
+++ b/python/langsmith/__init__.py
@@ -50,7 +50,7 @@ if TYPE_CHECKING:
 
 # Avoid calling into importlib on every call to __version__
 
-__version__ = "0.12.2"
+__version__ = "0.12.3"
 version = __version__  # for backwards compatibility
 
 # Metadata key to hide a traced run from LangSmith's Messages View.


### PR DESCRIPTION
Bumps Python SDK to `0.12.3`.

Patch release covering everything that landed in `python/` since `v0.12.2`.

### What ships

**Features**

- `feat: LangSmithSecret class for redacting sensitive function parameters` (#3484)
- `feat(sandbox): support proxy_config in update_sandbox` (#3430)

**Fixes**

- `fix(py): make the multipart body replayable across both retry layers` (#3483)
- `fix(docs): correct README code examples and update model references` (#3503)

**Performance**

- `perf: avoid ThreadPoolExecutor churn in hybrid tracing` (#3005, closes LSDK-213)

**Internal**

- `test(py): benchmark compressed trace ingestion` (#3497)

