### PR TITLE
evaluate: allow upload_results to be resolved per run

### DIFF
--- a/python/langsmith/evaluation/_runner.py
+++ b/python/langsmith/evaluation/_runner.py
@@ -99,7 +99,7 @@ UPLOAD_RESULTS_T = Union[bool, Callable[[schemas.Example], bool]]
 
 @overload
 def evaluate(
-    target: Union[TARGET_T, Runnable, EXPERIMENT_T],
+    target: Union[TARGET_T, Runnable],
     /,
     data: Optional[DATA_T] = None,
     evaluators: Optional[Sequence[EVALUATOR_T]] = None,
@@ -119,6 +119,29 @@ def evaluate(
 
 @overload
 def evaluate(
+    target: EXPERIMENT_T,
+    /,
+    data: Optional[DATA_T] = None,
+    evaluators: Optional[Sequence[EVALUATOR_T]] = None,
+    summary_evaluators: Optional[Sequence[SUMMARY_EVALUATOR_T]] = None,
+    metadata: Optional[dict] = None,
+    experiment_prefix: Optional[str] = None,
+    description: Optional[str] = None,
+    max_concurrency: Optional[int] = 0,
+    num_repetitions: int = 1,
+    client: Optional[langsmith.Client] = None,
+    blocking: bool = True,
+    experiment: Optional[EXPERIMENT_T] = None,
+    # No new runs are created when re-evaluating an existing experiment, so
+    # there's nothing for a per-run callable to decide -- only a plain bool
+    # is accepted here.
+    upload_results: bool = True,
+    **kwargs: Any,
+) -> ExperimentResults: ...
+
+
+@overload
+def evaluate(
     target: Union[tuple[EXPERIMENT_T, EXPERIMENT_T]],
     /,
     data: Optional[DATA_T] = None,
@@ -132,7 +155,10 @@ def evaluate(
     client: Optional[langsmith.Client] = None,
     blocking: bool = True,
     experiment: Optional[EXPERIMENT_T] = None,
-    upload_results: UPLOAD_RESULTS_T = True,
+    # No new runs are created when comparing two existing experiments, so
+    # there's nothing for a per-run callable to decide -- only a plain bool
+    # is accepted here.
+    upload_results: bool = True,
     **kwargs: Any,
 ) -> ComparativeExperimentResults: ...
 
@@ -206,6 +232,11 @@ def evaluate(
             examples), so a stateful/random callable can sample a subset of runs.
             Summary evaluator scores are still computed and uploaded over *all*
             runs regardless of which individual runs were uploaded.
+
+            Only a plain bool is accepted when `target` is an existing experiment
+            or a pair of experiments to compare — those paths don't create new
+            runs, so there's nothing for a per-run callable to decide, and one
+            is rejected with a `ValueError`.
 
     Returns:
         ExperimentResults: If target is a function, `Runnable`, or existing experiment.
@@ -327,7 +358,10 @@ def evaluate(
         invalid_args = {
             "num_repetitions": num_repetitions > 1,
             "experiment": bool(experiment),
-            "upload_results": not upload_results,
+            # A per-run callable only makes sense when new runs are being
+            # created; re-evaluating/comparing existing experiments doesn't
+            # create any, so only a plain, truthy bool is accepted here.
+            "upload_results": not upload_results or callable(upload_results),
             "experiment_prefix": bool(experiment_prefix),
             "data": bool(data),
         }
@@ -354,7 +388,10 @@ def evaluate(
         invalid_args = {
             "num_repetitions": num_repetitions > 1,
             "experiment": bool(experiment),
-            "upload_results": not upload_results,
+            # A per-run callable only makes sense when new runs are being
+            # created; re-evaluating/comparing existing experiments doesn't
+            # create any, so only a plain, truthy bool is accepted here.
+            "upload_results": not upload_results or callable(upload_results),
             "summary_evaluators": bool(summary_evaluators),
             "data": bool(data),
         }

--- a/python/langsmith/evaluation/_runner.py
+++ b/python/langsmith/evaluation/_runner.py
@@ -90,6 +90,11 @@ AEVALUATOR_T = Union[
     ],
 ]
 EXPERIMENT_T = Union[str, uuid.UUID, schemas.TracerSession]
+# Whether to upload a given run's trace + feedback to LangSmith. A bool applies
+# to every run in the call; a callable is invoked once per generated run
+# (once per repetition, for repeated examples) so it can sample or subset runs
+# while the aggregate/summary score is still computed over every run.
+UPLOAD_RESULTS_T = Union[bool, Callable[[schemas.Example], bool]]
 
 
 @overload
@@ -107,7 +112,7 @@ def evaluate(
     client: Optional[langsmith.Client] = None,
     blocking: bool = True,
     experiment: Optional[EXPERIMENT_T] = None,
-    upload_results: bool = True,
+    upload_results: UPLOAD_RESULTS_T = True,
     **kwargs: Any,
 ) -> ExperimentResults: ...
 
@@ -127,7 +132,7 @@ def evaluate(
     client: Optional[langsmith.Client] = None,
     blocking: bool = True,
     experiment: Optional[EXPERIMENT_T] = None,
-    upload_results: bool = True,
+    upload_results: UPLOAD_RESULTS_T = True,
     **kwargs: Any,
 ) -> ComparativeExperimentResults: ...
 
@@ -148,7 +153,7 @@ def evaluate(
     client: Optional[langsmith.Client] = None,
     blocking: bool = True,
     experiment: Optional[EXPERIMENT_T] = None,
-    upload_results: bool = True,
+    upload_results: UPLOAD_RESULTS_T = True,
     error_handling: Literal["log", "ignore"] = "log",
     **kwargs: Any,
 ) -> Union[ExperimentResults, ComparativeExperimentResults]:
@@ -193,6 +198,14 @@ def evaluate(
             `'log'` will trace the runs with the error message as part of the
             experiment, `'ignore'` will not count the run as part of the experiment at
             all.
+        upload_results (bool | Callable[[Example], bool], default=True): Whether to
+            upload each run's trace and feedback to LangSmith.
+
+            Pass a callable to decide per run instead of for the whole call — it's
+            invoked once per generated run (once per repetition, for repeated
+            examples), so a stateful/random callable can sample a subset of runs.
+            Summary evaluator scores are still computed and uploaded over *all*
+            runs regardless of which individual runs were uploaded.
 
     Returns:
         ExperimentResults: If target is a function, `Runnable`, or existing experiment.
@@ -270,6 +283,20 @@ def evaluate(
         View the evaluation results for experiment:...
         >>> for i, result in enumerate(results):  # doctest: +ELLIPSIS
         ...     pass
+
+        Uploading only a sample of runs, while still scoring every run:
+
+        >>> import random
+        >>> results = evaluate(
+        ...     predict,
+        ...     data=dataset_name,
+        ...     evaluators=[accuracy],
+        ...     summary_evaluators=[precision],
+        ...     num_repetitions=5,
+        ...     description="Only keep traces for 10% of runs.",
+        ...     upload_results=lambda example: random.random() < 0.1,
+        ... )  # doctest: +ELLIPSIS
+        View the evaluation results for experiment:...
 
 
 
@@ -1099,7 +1126,7 @@ def _evaluate(
     client: Optional[langsmith.Client] = None,
     blocking: bool = True,
     experiment: Optional[Union[schemas.TracerSession, str, uuid.UUID]] = None,
-    upload_results: bool = True,
+    upload_results: UPLOAD_RESULTS_T = True,
     error_handling: Literal["log", "ignore"] = "log",
 ) -> ExperimentResults:
     # Initialize the experiment manager.
@@ -1393,9 +1420,10 @@ class _ExperimentManager(_ExperimentManagerMixin):
         evaluator_keys: Optional[list[str]] = None,
         include_attachments: bool = False,
         reuse_attachments: bool = False,
-        upload_results: bool = True,
+        upload_results: UPLOAD_RESULTS_T = True,
         attachment_raw_data_dict: Optional[dict] = None,
         error_handling: Literal["log", "ignore"] = "log",
+        upload_decisions: Optional[dict[uuid.UUID, bool]] = None,
     ):
         super().__init__(
             experiment=experiment,
@@ -1420,6 +1448,19 @@ class _ExperimentManager(_ExperimentManagerMixin):
         self._upload_results = upload_results
         self._attachment_raw_data_dict = attachment_raw_data_dict
         self._error_handling = error_handling
+        # Per-run upload decisions, keyed by run id. Populated as predictions are
+        # made and read back when scoring, so a stochastic/subsetting
+        # `upload_results` callable is only ever resolved once per run. Shared
+        # (not copied) across `_copy()` calls so later stages of the pipeline
+        # (evaluators) see the same decision the prediction stage made.
+        self._upload_decisions: dict[uuid.UUID, bool] = (
+            upload_decisions if upload_decisions is not None else {}
+        )
+
+    def _resolve_upload(self, example: schemas.Example) -> bool:
+        if callable(self._upload_results):
+            return bool(self._upload_results(example))
+        return bool(self._upload_results)
 
     def _reset_example_attachment_readers(
         self, example: schemas.Example
@@ -1624,35 +1665,43 @@ class _ExperimentManager(_ExperimentManagerMixin):
 
         if max_concurrency == 0:
             for example in self.examples:
-                yield _forward(
+                upload = self._resolve_upload(example)
+                result = _forward(
                     fn,
                     example,
                     self.experiment_name,
                     self._metadata,
                     self.client,
-                    self._upload_results,
+                    upload,
                     include_attachments,
                     self._error_handling,
                 )
+                self._upload_decisions[result["run"].id] = upload
+                yield result
 
         else:
             with ls_utils.ContextThreadPoolExecutor(max_concurrency) as executor:
-                futures = [
-                    executor.submit(
+                future_uploads = {}
+                futures = []
+                for example in self.examples:
+                    upload = self._resolve_upload(example)
+                    future = executor.submit(
                         _forward,
                         fn,
                         example,
                         self.experiment_name,
                         self._metadata,
                         self.client,
-                        self._upload_results,
+                        upload,
                         include_attachments,
                         self._error_handling,
                     )
-                    for example in self.examples
-                ]
+                    future_uploads[future] = upload
+                    futures.append(future)
                 for future in cf.as_completed(futures):
-                    yield future.result()
+                    result = future.result()
+                    self._upload_decisions[result["run"].id] = future_uploads[future]
+                    yield result
         # Close out the project.
         self._end()
 
@@ -1663,6 +1712,16 @@ class _ExperimentManager(_ExperimentManagerMixin):
         executor: cf.ThreadPoolExecutor,
     ) -> ExperimentResultRow:
         current_context = rh.get_tracing_context()
+        # Whether *this specific run* was uploaded, not just whether uploads are
+        # enabled at all -- a run that wasn't uploaded has no trace on the server
+        # to attach feedback to. `dict.get`'s default is evaluated eagerly, so
+        # look the id up explicitly rather than re-invoking a (possibly
+        # stateful/random) `upload_results` callable a second time.
+        run_id = current_results["run"].id
+        if run_id in self._upload_decisions:
+            run_uploaded = self._upload_decisions[run_id]
+        else:
+            run_uploaded = self._resolve_upload(current_results["example"])
         metadata = {
             **(current_context["metadata"] or {}),
             **{
@@ -1676,7 +1735,7 @@ class _ExperimentManager(_ExperimentManagerMixin):
                 **current_context,
                 "project_name": "evaluators",
                 "metadata": metadata,
-                "enabled": "local" if not self._upload_results else True,
+                "enabled": "local" if not run_uploaded else True,
                 "client": self.client,
             }
         ):
@@ -1695,7 +1754,7 @@ class _ExperimentManager(_ExperimentManagerMixin):
                     eval_results["results"].extend(
                         self.client._select_eval_results(evaluator_response)
                     )
-                    if self._upload_results:
+                    if run_uploaded:
                         # TODO: This is a hack
                         self.client._log_evaluation_feedback(
                             evaluator_response,
@@ -1721,7 +1780,7 @@ class _ExperimentManager(_ExperimentManagerMixin):
                         eval_results["results"].extend(
                             self.client._select_eval_results(error_response)
                         )
-                        if self._upload_results:
+                        if run_uploaded:
                             # TODO: This is a hack
                             self.client._log_evaluation_feedback(
                                 error_response,
@@ -1904,6 +1963,7 @@ class _ExperimentManager(_ExperimentManagerMixin):
             "include_attachments": self._include_attachments,
             "reuse_attachments": self._reuse_attachments,
             "upload_results": self._upload_results,
+            "upload_decisions": self._upload_decisions,
             "attachment_raw_data_dict": self._attachment_raw_data_dict,
             "error_handling": self._error_handling,
         }

--- a/python/tests/unit_tests/evaluation/test_runner.py
+++ b/python/tests/unit_tests/evaluation/test_runner.py
@@ -257,6 +257,86 @@ async def test_aevaluate_feedback_includes_experiment_id_and_start_time() -> Non
     assert feedback["start_time"] == run["start_time"]
 
 
+def test_evaluate_upload_results_callable_samples_runs_but_scores_all() -> None:
+    """`upload_results` as a callable controls which runs are persisted, but
+    summary evaluators must still see -- and score -- every run/repetition."""
+    NUM_EXAMPLES = 3
+    NUM_REPETITIONS = 4
+    example_responses = [_create_example(i) for i in range(NUM_EXAMPLES)]
+    examples = [e[0] for e in example_responses]
+    client, fake_request = _fake_client_for_examples(
+        [e[1] for e in example_responses],
+        "00886375-eb2a-4038-9032-efff60309896",
+        "my-dataset",
+    )
+
+    def predict(inputs: dict) -> dict:
+        return {"output": inputs["in"] + 1}
+
+    def score(run, example):
+        return {"key": "quality", "score": 1}
+
+    summary_run_counts: List[int] = []
+
+    def summary_eval(runs_, examples_):
+        summary_run_counts.append(len(runs_))
+        return {"key": "count", "score": len(runs_)}
+
+    # Called once per generated run (once per repetition of each example), so a
+    # stateful predicate can sample independently across repetitions.
+    call_count = 0
+
+    def upload_every_other(example: ls_schemas.Example) -> bool:
+        nonlocal call_count
+        call_count += 1
+        return call_count % 2 == 1
+
+    results = evaluate(
+        predict,
+        client=client,
+        data=examples,
+        evaluators=[score],
+        summary_evaluators=[summary_eval],
+        num_repetitions=NUM_REPETITIONS,
+        upload_results=upload_every_other,
+        max_concurrency=0,
+    )
+    results_list = list(results)
+
+    total_runs = NUM_EXAMPLES * NUM_REPETITIONS
+    uploaded_runs = total_runs // 2
+    assert len(results_list) == total_runs
+    assert call_count == total_runs
+
+    # The experiment is still created even though only some runs are uploaded.
+    assert fake_request.created_session
+
+    # Only the sampled half of the target-fn runs -- and their matching
+    # per-row evaluator runs -- land on the server, plus one run for the
+    # summary evaluator itself (which always traces, since the aggregate is
+    # always uploaded).
+    expected_runs = uploaded_runs * 2 + 1
+    _wait_until(lambda: len(fake_request.runs) == expected_runs)
+    assert len(fake_request.runs) == expected_runs
+
+    # The summary evaluator saw every run, not just the uploaded ones.
+    assert summary_run_counts == [total_runs]
+
+    # Row-level feedback only exists for the runs that were actually uploaded,
+    # but the aggregate (project-level, run_id=None) feedback always reflects
+    # every run.
+    _wait_until(lambda: len(fake_request.feedbacks) == uploaded_runs + 1)
+    per_run_feedback = [
+        f for f in fake_request.feedbacks if f.get("run_id") is not None
+    ]
+    aggregate_feedback = [
+        f for f in fake_request.feedbacks if f.get("run_id") is None
+    ]
+    assert len(per_run_feedback) == uploaded_runs
+    assert len(aggregate_feedback) == 1
+    assert aggregate_feedback[0]["score"] == total_runs
+
+
 @pytest.mark.skipif(sys.version_info < (3, 9), reason="requires python3.9 or higher")
 @pytest.mark.parametrize("blocking", [False, True])
 @pytest.mark.parametrize("as_runnable", [False, True])

--- a/python/tests/unit_tests/evaluation/test_runner.py
+++ b/python/tests/unit_tests/evaluation/test_runner.py
@@ -337,6 +337,29 @@ def test_evaluate_upload_results_callable_samples_runs_but_scores_all() -> None:
     assert aggregate_feedback[0]["score"] == total_runs
 
 
+@pytest.mark.parametrize(
+    "target",
+    [
+        "00886375-eb2a-4038-9032-efff60309896",
+        (
+            "00886375-eb2a-4038-9032-efff60309896",
+            "11886375-eb2a-4038-9032-efff60309896",
+        ),
+    ],
+)
+def test_evaluate_rejects_callable_upload_results_for_experiment_targets(
+    target: Any,
+) -> None:
+    """A per-run callable only makes sense when new runs are being created.
+
+    Re-evaluating an existing experiment, or comparing two existing
+    experiments, doesn't create any new runs, so a callable `upload_results`
+    must be rejected rather than silently ignored.
+    """
+    with pytest.raises(ValueError, match="upload_results"):
+        evaluate(target, upload_results=lambda example: True)
+
+
 @pytest.mark.skipif(sys.version_info < (3, 9), reason="requires python3.9 or higher")
 @pytest.mark.parametrize("blocking", [False, True])
 @pytest.mark.parametrize("as_runnable", [False, True])


### PR DESCRIPTION
## Summary
- Lets someone running an evaluation decide, run by run, which ones get saved instead of saving everything — for example, only save 1 out of every 10 runs to cut down on data volume. The overall score still counts every run that happened, even the ones that weren't saved.

## Test plan
- [x] Unit tests