### PR TITLE
release(js): 0.10.3

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langsmith",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "Client library to connect to the LangSmith Observability and Evaluation Platform.",
   "packageManager": "pnpm@10.33.0",
   "files": [

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -54,7 +54,7 @@ export {
 } from "./_openapi_client/core/error.js";
 
 // Update using pnpm bump-version
-export const __version__ = "0.10.2";
+export const __version__ = "0.10.3";
 
 // Metadata key to hide a traced run from LangSmith's Messages View.
 export const LS_MESSAGE_VIEW_EXCLUDE = "ls_message_view_exclude" as const;


### PR DESCRIPTION
Bumps JS SDK to `0.10.3`.

Patch release covering everything that landed in `js/` since `0.10.2` (#3495).

### What ships

**Features**

- `feat(sandbox): support proxy_config in update_sandbox` (#3430)

**Fixes**

- `fix(docs): correct README code examples and update model references` (#3503)
- `fix: preserve sandbox API error IDs` (#3515)

_Also landed, but test/CI-only and not shipped in the package: `fix(js): avoid stored reasoning in OpenAI integration tests` (#3519), `fix(js): update vulnerable test dependencies` (#3525), `chore(deps): bump js-yaml in test-exports-metro` (#3526)._
