### PR TITLE
fix(livekit): support agents 1.7 and 1.8 telemetry [Closes LSDK-506]

### DIFF
--- a/python/langsmith/_internal/voice/_helpers.py
+++ b/python/langsmith/_internal/voice/_helpers.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Mapping
 from typing import Any, Optional
 
 
@@ -14,6 +15,164 @@ def build_user_message(content: str) -> dict[str, Any]:
 def build_assistant_message(content: str) -> dict[str, Any]:
     """Build an ``assistant`` chat message for the ``gen_ai.*`` message keys."""
     return {"role": "assistant", "content": content}
+
+
+def build_tool_message(
+    content: str,
+    *,
+    tool_call_id: Optional[str] = None,
+    name: Optional[str] = None,
+) -> dict[str, object]:
+    """Build a ``tool`` result message, with its call id / name when present."""
+    message: dict[str, object] = {"role": "tool", "content": content}
+    if tool_call_id:
+        message["tool_call_id"] = str(tool_call_id)
+    if name:
+        message["name"] = str(name)
+    return message
+
+
+def build_assistant_tool_call_message(
+    call_id: str, name: str, arguments: str
+) -> dict[str, object]:
+    """Build an assistant message containing one tool call."""
+    return {
+        "role": "assistant",
+        "content": "",
+        "tool_calls": [
+            {
+                "id": call_id,
+                "type": "function",
+                "function": {"name": name, "arguments": arguments},
+            }
+        ],
+    }
+
+
+def _try_parse_json_list(value: object) -> Optional[list[object]]:
+    if isinstance(value, str):
+        try:
+            value = json.loads(value)
+        except (ValueError, RecursionError):
+            return None
+    return value if isinstance(value, list) else None
+
+
+def _json_text(value: object) -> str:
+    return value if isinstance(value, str) else json.dumps(value)
+
+
+def _message_from_gen_ai_parts(
+    role: str, parts: list[object]
+) -> list[dict[str, object]]:
+    """Convert an OTel GenAI part array into LangSmith chat messages."""
+    content: list[dict[str, object]] = []
+    text_parts: list[str] = []
+    tool_calls: list[dict[str, object]] = []
+    tool_results: list[dict[str, object]] = []
+    for raw_part in parts:
+        if not isinstance(raw_part, Mapping):
+            continue
+        part: Mapping[object, object] = raw_part
+        kind = part.get("type")
+        part_content = part.get("content")
+        transcript = part.get("transcript")
+        uri = part.get("uri")
+        call_id = part.get("id")
+        tool_name = part.get("name")
+        if kind == "text" and isinstance(part_content, str):
+            content.append({"type": "text", "text": part_content})
+            text_parts.append(part_content)
+        elif (
+            kind == "blob"
+            and part.get("modality") == "audio"
+            and isinstance(transcript, str)
+        ):
+            content.append({"type": "text", "text": transcript})
+            text_parts.append(transcript)
+        elif (
+            kind == "uri"
+            and part.get("modality") == "image"
+            and isinstance(uri, str)
+            and uri
+        ):
+            content.append({"type": "image_url", "image_url": {"url": uri}})
+        elif (
+            kind == "tool_call"
+            and role == "assistant"
+            and isinstance(call_id, str)
+            and isinstance(tool_name, str)
+        ):
+            tool_calls.append(
+                {
+                    "id": call_id,
+                    "type": "function",
+                    "function": {
+                        "name": tool_name,
+                        "arguments": _json_text(part.get("arguments", {})),
+                    },
+                }
+            )
+        elif (
+            kind == "tool_call_response"
+            and role == "tool"
+            and isinstance(call_id, str)
+            and "response" in part
+        ):
+            tool_results.append(
+                build_tool_message(_json_text(part["response"]), tool_call_id=call_id)
+            )
+    messages: list[dict[str, object]] = []
+    if content or tool_calls:
+        message: dict[str, object] = {"role": role}
+        message["content"] = (
+            "\n".join(text_parts) if len(text_parts) == len(content) else content
+        )
+        if tool_calls:
+            message["tool_calls"] = tool_calls
+        messages.append(message)
+    return messages + tool_results
+
+
+def build_messages_from_gen_ai(
+    value: object,
+) -> Optional[list[dict[str, object]]]:
+    """Convert OTel GenAI message envelopes into LangSmith chat messages.
+
+    ``None`` means missing or malformed input, allowing a caller to use an older
+    telemetry source as a fallback. A present empty list remains authoritative.
+    """
+    items = _try_parse_json_list(value)
+    if items is None:
+        return None
+    messages: list[dict[str, object]] = []
+    for raw_item in items:
+        if not isinstance(raw_item, Mapping):
+            continue
+        item: Mapping[object, object] = raw_item
+        role = item.get("role")
+        parts = item.get("parts")
+        if not isinstance(role, str) or role not in (
+            "system",
+            "developer",
+            "user",
+            "assistant",
+            "tool",
+        ):
+            continue
+        if isinstance(parts, list):
+            messages.extend(_message_from_gen_ai_parts(role, parts))
+    return messages
+
+
+def build_system_messages_from_gen_ai(
+    value: object,
+) -> Optional[list[dict[str, object]]]:
+    """Convert an OTel ``gen_ai.system_instructions`` part array to messages."""
+    parts = _try_parse_json_list(value)
+    if parts is None:
+        return None
+    return _message_from_gen_ai_parts("system", parts)
 
 
 def try_parse_json_object(value: Any) -> Optional[dict]:

--- a/python/langsmith/_internal/voice/_helpers.py
+++ b/python/langsmith/_internal/voice/_helpers.py
@@ -32,6 +32,15 @@ def build_tool_message(
     return message
 
 
+def build_tool_call(call_id: str, name: str, arguments: str) -> dict[str, object]:
+    """Build one OpenAI-shaped function tool call."""
+    return {
+        "id": call_id,
+        "type": "function",
+        "function": {"name": name, "arguments": arguments},
+    }
+
+
 def build_assistant_tool_call_message(
     call_id: str, name: str, arguments: str
 ) -> dict[str, object]:
@@ -39,13 +48,7 @@ def build_assistant_tool_call_message(
     return {
         "role": "assistant",
         "content": "",
-        "tool_calls": [
-            {
-                "id": call_id,
-                "type": "function",
-                "function": {"name": name, "arguments": arguments},
-            }
-        ],
+        "tool_calls": [build_tool_call(call_id, name, arguments)],
     }
 
 
@@ -104,14 +107,11 @@ def _message_from_gen_ai_parts(
             and isinstance(tool_name, str)
         ):
             tool_calls.append(
-                {
-                    "id": call_id,
-                    "type": "function",
-                    "function": {
-                        "name": tool_name,
-                        "arguments": _json_text(part.get("arguments", {})),
-                    },
-                }
+                build_tool_call(
+                    call_id,
+                    tool_name,
+                    _json_text(part.get("arguments", {})),
+                )
             )
         elif (
             kind == "tool_call_response"

--- a/python/langsmith/integrations/livekit/_helpers.py
+++ b/python/langsmith/integrations/livekit/_helpers.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 import logging
+from collections.abc import Mapping
 from typing import Any, Optional
 
 from langsmith._internal.voice._helpers import try_parse_json_object
@@ -29,6 +30,126 @@ _PROVIDER_ALIASES = (
     "mistral",
     "groq",
 )
+
+
+def get_content_attribute(attributes: Mapping[str, Any], name: str) -> Any:
+    """Read a LiveKit content field across the 1.7 ``lk.pii.*`` rename.
+
+    A present new key is authoritative, even when empty: do not replace withheld
+    content with an older value. ``name`` is the suffix without ``lk.``.
+    """
+    pii_key = f"lk.pii.{name}"
+    if pii_key in attributes:
+        return attributes[pii_key]
+    return attributes.get(f"lk.{name}")
+
+
+def _json_list(raw: Any) -> Optional[list]:
+    if isinstance(raw, str):
+        try:
+            raw = json.loads(raw)
+        except (ValueError, RecursionError):
+            return None
+    return raw if isinstance(raw, list) else None
+
+
+def _json_text(value: Any) -> str:
+    return value if isinstance(value, str) else json.dumps(value)
+
+
+def _message_from_parts(role: str, parts: list) -> list[dict]:
+    content: list[dict] = []
+    tool_calls: list[dict] = []
+    tool_results: list[dict] = []
+    for part in parts:
+        if not isinstance(part, dict):
+            continue
+        kind = part.get("type")
+        if kind == "text" and isinstance(part.get("content"), str):
+            content.append({"type": "text", "text": part["content"]})
+        elif (
+            kind == "blob"
+            and part.get("modality") == "audio"
+            and isinstance(part.get("transcript"), str)
+        ):
+            content.append({"type": "text", "text": part["transcript"]})
+        elif (
+            kind == "uri"
+            and part.get("modality") == "image"
+            and isinstance(part.get("uri"), str)
+            and part["uri"]
+        ):
+            content.append({"type": "image_url", "image_url": {"url": part["uri"]}})
+        elif (
+            kind == "tool_call"
+            and role == "assistant"
+            and isinstance(part.get("id"), str)
+            and isinstance(part.get("name"), str)
+        ):
+            tool_calls.append(
+                {
+                    "id": part["id"],
+                    "type": "function",
+                    "function": {
+                        "name": part["name"],
+                        "arguments": _json_text(part.get("arguments", {})),
+                    },
+                }
+            )
+        elif (
+            kind == "tool_call_response"
+            and role == "tool"
+            and isinstance(part.get("id"), str)
+            and "response" in part
+        ):
+            tool_results.append(
+                build_tool_message(
+                    _json_text(part["response"]), tool_call_id=part["id"]
+                )
+            )
+    messages: list[dict] = []
+    if content or tool_calls:
+        message: dict = {"role": role}
+        message["content"] = (
+            "\n".join(p["text"] for p in content)
+            if all(p["type"] == "text" for p in content)
+            else content
+        )
+        if tool_calls:
+            message["tool_calls"] = tool_calls
+        messages.append(message)
+    return messages + tool_results
+
+
+def build_messages_from_gen_ai(raw: Any) -> Optional[list[dict]]:
+    """Convert LiveKit 1.8+ GenAI message parts to OpenAI-shaped messages.
+
+    ``None`` means missing/malformed input, allowing legacy event fallback;
+    an empty list is authoritative. Unknown parts are skipped, without fetching
+    media or logging conversation content.
+    """
+    items = _json_list(raw)
+    if items is None:
+        return None
+    messages: list[dict] = []
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        role = item.get("role")
+        parts = item.get("parts")
+        if role not in ("system", "developer", "user", "assistant", "tool"):
+            continue
+        if isinstance(parts, list):
+            messages.extend(_message_from_parts(role, parts))
+    return messages
+
+
+def build_system_messages_from_gen_ai(raw: Any) -> Optional[list[dict]]:
+    """Read the separate ``gen_ai.system_instructions`` text-part array."""
+    parts = _json_list(raw)
+    if parts is None:
+        return None
+    return _message_from_parts("system", parts)
 
 
 def normalize_provider(raw: Any) -> Optional[str]:

--- a/python/langsmith/integrations/livekit/_helpers.py
+++ b/python/langsmith/integrations/livekit/_helpers.py
@@ -9,12 +9,15 @@ from __future__ import annotations
 
 import json
 import logging
-from collections.abc import Mapping
 from typing import Any, Optional
 
 from opentelemetry.util.types import AttributeValue
 
-from langsmith._internal.voice._helpers import try_parse_json_object
+from langsmith._internal.voice._helpers import (
+    build_assistant_tool_call_message,
+    build_tool_message,
+    try_parse_json_object,
+)
 from langsmith._internal.voice.translated_span import TranslatedSpan
 
 logger = logging.getLogger(__name__)
@@ -45,129 +48,6 @@ def get_content_attribute(tspan: TranslatedSpan, name: str) -> Optional[Attribut
     if pii_key in tspan.attributes:
         return tspan.attributes[pii_key]
     return tspan.attributes.get(f"lk.{name}")
-
-
-def _json_list(raw: object) -> Optional[list[object]]:
-    if isinstance(raw, str):
-        try:
-            raw = json.loads(raw)
-        except (ValueError, RecursionError):
-            return None
-    return raw if isinstance(raw, list) else None
-
-
-def _json_text(value: object) -> str:
-    return value if isinstance(value, str) else json.dumps(value)
-
-
-def _message_from_parts(role: str, parts: list[object]) -> list[dict[str, object]]:
-    content: list[dict[str, object]] = []
-    text_parts: list[str] = []
-    tool_calls: list[dict[str, object]] = []
-    tool_results: list[dict[str, object]] = []
-    for raw_part in parts:
-        if not isinstance(raw_part, Mapping):
-            continue
-        part: Mapping[object, object] = raw_part
-        kind = part.get("type")
-        part_content = part.get("content")
-        transcript = part.get("transcript")
-        uri = part.get("uri")
-        call_id = part.get("id")
-        tool_name = part.get("name")
-        if kind == "text" and isinstance(part_content, str):
-            text = part_content
-            content.append({"type": "text", "text": text})
-            text_parts.append(text)
-        elif (
-            kind == "blob"
-            and part.get("modality") == "audio"
-            and isinstance(transcript, str)
-        ):
-            content.append({"type": "text", "text": transcript})
-            text_parts.append(transcript)
-        elif (
-            kind == "uri"
-            and part.get("modality") == "image"
-            and isinstance(uri, str)
-            and uri
-        ):
-            content.append({"type": "image_url", "image_url": {"url": uri}})
-        elif (
-            kind == "tool_call"
-            and role == "assistant"
-            and isinstance(call_id, str)
-            and isinstance(tool_name, str)
-        ):
-            tool_calls.append(
-                {
-                    "id": call_id,
-                    "type": "function",
-                    "function": {
-                        "name": tool_name,
-                        "arguments": _json_text(part.get("arguments", {})),
-                    },
-                }
-            )
-        elif (
-            kind == "tool_call_response"
-            and role == "tool"
-            and isinstance(call_id, str)
-            and "response" in part
-        ):
-            tool_results.append(
-                build_tool_message(_json_text(part["response"]), tool_call_id=call_id)
-            )
-    messages: list[dict[str, object]] = []
-    if content or tool_calls:
-        message: dict[str, object] = {"role": role}
-        message["content"] = (
-            "\n".join(text_parts) if len(text_parts) == len(content) else content
-        )
-        if tool_calls:
-            message["tool_calls"] = tool_calls
-        messages.append(message)
-    return messages + tool_results
-
-
-def build_messages_from_gen_ai(raw: object) -> Optional[list[dict[str, object]]]:
-    """Convert LiveKit 1.8+ GenAI message parts to OpenAI-shaped messages.
-
-    ``None`` means missing/malformed input, allowing legacy event fallback;
-    an empty list is authoritative. Unknown parts are skipped, without fetching
-    media or logging conversation content.
-    """
-    items = _json_list(raw)
-    if items is None:
-        return None
-    messages: list[dict[str, object]] = []
-    for raw_item in items:
-        if not isinstance(raw_item, Mapping):
-            continue
-        item: Mapping[object, object] = raw_item
-        role = item.get("role")
-        parts = item.get("parts")
-        if not isinstance(role, str) or role not in (
-            "system",
-            "developer",
-            "user",
-            "assistant",
-            "tool",
-        ):
-            continue
-        if isinstance(parts, list):
-            messages.extend(_message_from_parts(role, parts))
-    return messages
-
-
-def build_system_messages_from_gen_ai(
-    raw: object,
-) -> Optional[list[dict[str, object]]]:
-    """Read the separate ``gen_ai.system_instructions`` text-part array."""
-    parts = _json_list(raw)
-    if parts is None:
-        return None
-    return _message_from_parts("system", parts)
 
 
 def normalize_provider(raw: Any) -> Optional[str]:
@@ -318,38 +198,6 @@ def flatten_lk_attributes_to_ls_metadata(
         ):
             flat[name] = list(v)
     return flat
-
-
-def build_tool_message(
-    content: str,
-    *,
-    tool_call_id: Optional[str] = None,
-    name: Optional[str] = None,
-) -> dict[str, object]:
-    """Build a ``tool`` result message, with its call id / name when present."""
-    msg: dict[str, object] = {"role": "tool", "content": content}
-    if tool_call_id:
-        msg["tool_call_id"] = str(tool_call_id)
-    if name:
-        msg["name"] = str(name)
-    return msg
-
-
-def build_assistant_tool_call_message(
-    call_id: str, name: str, arguments: str
-) -> dict[str, object]:
-    """Build an assistant message containing one tool call."""
-    return {
-        "role": "assistant",
-        "content": "",
-        "tool_calls": [
-            {
-                "id": call_id,
-                "type": "function",
-                "function": {"name": name, "arguments": arguments},
-            }
-        ],
-    }
 
 
 def build_message_from_event(role: str, event: Any) -> dict:

--- a/python/langsmith/integrations/livekit/_helpers.py
+++ b/python/langsmith/integrations/livekit/_helpers.py
@@ -12,7 +12,10 @@ import logging
 from collections.abc import Mapping
 from typing import Any, Optional
 
+from opentelemetry.util.types import AttributeValue
+
 from langsmith._internal.voice._helpers import try_parse_json_object
+from langsmith._internal.voice.translated_span import TranslatedSpan
 
 logger = logging.getLogger(__name__)
 
@@ -32,19 +35,19 @@ _PROVIDER_ALIASES = (
 )
 
 
-def get_content_attribute(attributes: Mapping[str, Any], name: str) -> Any:
+def get_content_attribute(tspan: TranslatedSpan, name: str) -> Optional[AttributeValue]:
     """Read a LiveKit content field across the 1.7 ``lk.pii.*`` rename.
 
     A present new key is authoritative, even when empty: do not replace withheld
     content with an older value. ``name`` is the suffix without ``lk.``.
     """
     pii_key = f"lk.pii.{name}"
-    if pii_key in attributes:
-        return attributes[pii_key]
-    return attributes.get(f"lk.{name}")
+    if pii_key in tspan.attributes:
+        return tspan.attributes[pii_key]
+    return tspan.attributes.get(f"lk.{name}")
 
 
-def _json_list(raw: Any) -> Optional[list]:
+def _json_list(raw: object) -> Optional[list[object]]:
     if isinstance(raw, str):
         try:
             raw = json.loads(raw)
@@ -53,45 +56,55 @@ def _json_list(raw: Any) -> Optional[list]:
     return raw if isinstance(raw, list) else None
 
 
-def _json_text(value: Any) -> str:
+def _json_text(value: object) -> str:
     return value if isinstance(value, str) else json.dumps(value)
 
 
-def _message_from_parts(role: str, parts: list) -> list[dict]:
-    content: list[dict] = []
-    tool_calls: list[dict] = []
-    tool_results: list[dict] = []
-    for part in parts:
-        if not isinstance(part, dict):
+def _message_from_parts(role: str, parts: list[object]) -> list[dict[str, object]]:
+    content: list[dict[str, object]] = []
+    text_parts: list[str] = []
+    tool_calls: list[dict[str, object]] = []
+    tool_results: list[dict[str, object]] = []
+    for raw_part in parts:
+        if not isinstance(raw_part, Mapping):
             continue
+        part: Mapping[object, object] = raw_part
         kind = part.get("type")
-        if kind == "text" and isinstance(part.get("content"), str):
-            content.append({"type": "text", "text": part["content"]})
+        part_content = part.get("content")
+        transcript = part.get("transcript")
+        uri = part.get("uri")
+        call_id = part.get("id")
+        tool_name = part.get("name")
+        if kind == "text" and isinstance(part_content, str):
+            text = part_content
+            content.append({"type": "text", "text": text})
+            text_parts.append(text)
         elif (
             kind == "blob"
             and part.get("modality") == "audio"
-            and isinstance(part.get("transcript"), str)
+            and isinstance(transcript, str)
         ):
-            content.append({"type": "text", "text": part["transcript"]})
+            content.append({"type": "text", "text": transcript})
+            text_parts.append(transcript)
         elif (
             kind == "uri"
             and part.get("modality") == "image"
-            and isinstance(part.get("uri"), str)
-            and part["uri"]
+            and isinstance(uri, str)
+            and uri
         ):
-            content.append({"type": "image_url", "image_url": {"url": part["uri"]}})
+            content.append({"type": "image_url", "image_url": {"url": uri}})
         elif (
             kind == "tool_call"
             and role == "assistant"
-            and isinstance(part.get("id"), str)
-            and isinstance(part.get("name"), str)
+            and isinstance(call_id, str)
+            and isinstance(tool_name, str)
         ):
             tool_calls.append(
                 {
-                    "id": part["id"],
+                    "id": call_id,
                     "type": "function",
                     "function": {
-                        "name": part["name"],
+                        "name": tool_name,
                         "arguments": _json_text(part.get("arguments", {})),
                     },
                 }
@@ -99,21 +112,17 @@ def _message_from_parts(role: str, parts: list) -> list[dict]:
         elif (
             kind == "tool_call_response"
             and role == "tool"
-            and isinstance(part.get("id"), str)
+            and isinstance(call_id, str)
             and "response" in part
         ):
             tool_results.append(
-                build_tool_message(
-                    _json_text(part["response"]), tool_call_id=part["id"]
-                )
+                build_tool_message(_json_text(part["response"]), tool_call_id=call_id)
             )
-    messages: list[dict] = []
+    messages: list[dict[str, object]] = []
     if content or tool_calls:
-        message: dict = {"role": role}
+        message: dict[str, object] = {"role": role}
         message["content"] = (
-            "\n".join(p["text"] for p in content)
-            if all(p["type"] == "text" for p in content)
-            else content
+            "\n".join(text_parts) if len(text_parts) == len(content) else content
         )
         if tool_calls:
             message["tool_calls"] = tool_calls
@@ -121,7 +130,7 @@ def _message_from_parts(role: str, parts: list) -> list[dict]:
     return messages + tool_results
 
 
-def build_messages_from_gen_ai(raw: Any) -> Optional[list[dict]]:
+def build_messages_from_gen_ai(raw: object) -> Optional[list[dict[str, object]]]:
     """Convert LiveKit 1.8+ GenAI message parts to OpenAI-shaped messages.
 
     ``None`` means missing/malformed input, allowing legacy event fallback;
@@ -131,20 +140,29 @@ def build_messages_from_gen_ai(raw: Any) -> Optional[list[dict]]:
     items = _json_list(raw)
     if items is None:
         return None
-    messages: list[dict] = []
-    for item in items:
-        if not isinstance(item, dict):
+    messages: list[dict[str, object]] = []
+    for raw_item in items:
+        if not isinstance(raw_item, Mapping):
             continue
+        item: Mapping[object, object] = raw_item
         role = item.get("role")
         parts = item.get("parts")
-        if role not in ("system", "developer", "user", "assistant", "tool"):
+        if not isinstance(role, str) or role not in (
+            "system",
+            "developer",
+            "user",
+            "assistant",
+            "tool",
+        ):
             continue
         if isinstance(parts, list):
             messages.extend(_message_from_parts(role, parts))
     return messages
 
 
-def build_system_messages_from_gen_ai(raw: Any) -> Optional[list[dict]]:
+def build_system_messages_from_gen_ai(
+    raw: object,
+) -> Optional[list[dict[str, object]]]:
     """Read the separate ``gen_ai.system_instructions`` text-part array."""
     parts = _json_list(raw)
     if parts is None:
@@ -307,9 +325,9 @@ def build_tool_message(
     *,
     tool_call_id: Optional[str] = None,
     name: Optional[str] = None,
-) -> dict:
+) -> dict[str, object]:
     """Build a ``tool`` result message, with its call id / name when present."""
-    msg: dict = {"role": "tool", "content": content}
+    msg: dict[str, object] = {"role": "tool", "content": content}
     if tool_call_id:
         msg["tool_call_id"] = str(tool_call_id)
     if name:
@@ -317,7 +335,9 @@ def build_tool_message(
     return msg
 
 
-def build_assistant_tool_call_message(call_id: str, name: str, arguments: str) -> dict:
+def build_assistant_tool_call_message(
+    call_id: str, name: str, arguments: str
+) -> dict[str, object]:
     """Build an assistant message containing one tool call."""
     return {
         "role": "assistant",

--- a/python/langsmith/integrations/livekit/processor.py
+++ b/python/langsmith/integrations/livekit/processor.py
@@ -26,6 +26,8 @@ from opentelemetry.sdk.trace import Span, SpanProcessor
 from langsmith._internal._package_version import get_package_version
 from langsmith._internal.voice._helpers import (
     build_assistant_message,
+    build_messages_from_gen_ai,
+    build_system_messages_from_gen_ai,
     build_user_message,
     try_parse_json_object,
 )
@@ -37,8 +39,6 @@ from langsmith._internal.voice.base_span_processor import (
 from ._helpers import (
     build_message_from_event,
     build_messages_from_chat_history,
-    build_messages_from_gen_ai,
-    build_system_messages_from_gen_ai,
     extract_llm_usage,
     extract_model_from_lk_metrics,
     extract_provider_from_lk_metrics,

--- a/python/langsmith/integrations/livekit/processor.py
+++ b/python/langsmith/integrations/livekit/processor.py
@@ -37,11 +37,14 @@ from langsmith._internal.voice.base_span_processor import (
 from ._helpers import (
     build_message_from_event,
     build_messages_from_chat_history,
+    build_messages_from_gen_ai,
+    build_system_messages_from_gen_ai,
     extract_llm_usage,
     extract_model_from_lk_metrics,
     extract_provider_from_lk_metrics,
     extract_realtime_usage,
     flatten_lk_attributes_to_ls_metadata,
+    get_content_attribute,
     is_livekit_span,
     normalize_provider,
 )
@@ -572,7 +575,7 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
             normalize_provider(tspan.attributes.get("gen_ai.provider.name"))
         )
 
-        transcript = tspan.attributes.get("lk.user_transcript")
+        transcript = get_content_attribute(tspan.attributes, "user_transcript")
         if transcript:
             tspan.set_messages(
                 prompt=[build_user_message(f'Audio for: "{transcript}"')]
@@ -581,21 +584,37 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         tspan.exclude_from_message_view()
 
     def _handle_llm_request(self, tspan: TranslatedSpan) -> None:
-        """``llm_request``: rebuild prompt/completion from the gen_ai.* events.
+        """Read GenAI message attributes (1.8+) or legacy message events.
 
         The translated events are then stripped so the ingester doesn't render
         them twice.
         """
         tspan.set_kind("llm")
 
-        prompt: list[dict] = []
-        completion: list[dict] = []
+        prompt = build_messages_from_gen_ai(
+            tspan.attributes.get("gen_ai.input.messages")
+        )
+        completion = build_messages_from_gen_ai(
+            tspan.attributes.get("gen_ai.output.messages")
+        )
+        instructions = build_system_messages_from_gen_ai(
+            tspan.attributes.get("gen_ai.system_instructions")
+        )
+        legacy_prompt: list[dict] = []
+        legacy_completion: list[dict] = []
         for event in tspan.events:
             if event.name == _LLM_CHOICE_EVENT:
-                completion.append(build_message_from_event("assistant", event))
+                legacy_completion.append(build_message_from_event("assistant", event))
             elif (role := _LLM_EVENT_ROLES.get(event.name)) is not None:
-                prompt.append(build_message_from_event(role, event))
-        tspan.set_messages(prompt=prompt or None, completion=completion or None)
+                if instructions is None or role != "system":
+                    legacy_prompt.append(build_message_from_event(role, event))
+        if prompt is None:
+            prompt = legacy_prompt or None
+        if instructions is not None:
+            prompt = instructions + (prompt or [])
+        if completion is None:
+            completion = legacy_completion or None
+        tspan.set_messages(prompt=prompt, completion=completion)
 
         provider = extract_provider_from_lk_metrics(
             tspan.attributes.get("lk.llm_metrics")
@@ -616,12 +635,13 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         tspan.set_kind("llm")
         tspan.exclude_from_message_view()
 
-        text = (
-            tspan.attributes.get("lk.input_text")
-            or tspan.attributes.get("lk.request.text")
-            or tspan.attributes.get("lk.text")
-            or ""
-        )
+        text = get_content_attribute(tspan.attributes, "input_text")
+        if text is None:
+            text = get_content_attribute(tspan.attributes, "request.text")
+        if text is None:
+            text = get_content_attribute(tspan.attributes, "text")
+        if text is None:
+            text = ""
         tspan.set_messages(
             prompt=[build_user_message(str(text))],
             completion=[build_assistant_message(f'Generated audio for: "{text}"')],
@@ -646,8 +666,8 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
             "llm" if "lk.realtime_model_metrics" in tspan.attributes else "chain"
         )
 
-        user_input = tspan.attributes.get("lk.user_input")
-        response = tspan.attributes.get("lk.response.text")
+        user_input = get_content_attribute(tspan.attributes, "user_input")
+        response = get_content_attribute(tspan.attributes, "response.text")
         trace_id = tspan.span.context.trace_id
         start = tspan.span.start_time
         if user_input:
@@ -735,13 +755,13 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
 
     def _handle_tool(self, tspan: TranslatedSpan) -> None:
         tspan.set_kind("tool")
-        tool_name = tspan.attributes.get("lk.function_tool.name")
+        tool_name = get_content_attribute(tspan.attributes, "function_tool.name")
         if tool_name:
             tspan.set_metadata("tool_name", str(tool_name))
-        args = tspan.attributes.get("lk.function_tool.arguments")
+        args = get_content_attribute(tspan.attributes, "function_tool.arguments")
         if args is not None:
             tspan.set_tool_input(args)
-        output = tspan.attributes.get("lk.function_tool.output")
+        output = get_content_attribute(tspan.attributes, "function_tool.output")
         if output is not None:
             tspan.set_tool_output(output)
 

--- a/python/langsmith/integrations/livekit/processor.py
+++ b/python/langsmith/integrations/livekit/processor.py
@@ -575,7 +575,7 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
             normalize_provider(tspan.attributes.get("gen_ai.provider.name"))
         )
 
-        transcript = get_content_attribute(tspan.attributes, "user_transcript")
+        transcript = get_content_attribute(tspan, "user_transcript")
         if transcript:
             tspan.set_messages(
                 prompt=[build_user_message(f'Audio for: "{transcript}"')]
@@ -635,11 +635,11 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
         tspan.set_kind("llm")
         tspan.exclude_from_message_view()
 
-        text = get_content_attribute(tspan.attributes, "input_text")
+        text = get_content_attribute(tspan, "input_text")
         if text is None:
-            text = get_content_attribute(tspan.attributes, "request.text")
+            text = get_content_attribute(tspan, "request.text")
         if text is None:
-            text = get_content_attribute(tspan.attributes, "text")
+            text = get_content_attribute(tspan, "text")
         if text is None:
             text = ""
         tspan.set_messages(
@@ -666,8 +666,8 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
             "llm" if "lk.realtime_model_metrics" in tspan.attributes else "chain"
         )
 
-        user_input = get_content_attribute(tspan.attributes, "user_input")
-        response = get_content_attribute(tspan.attributes, "response.text")
+        user_input = get_content_attribute(tspan, "user_input")
+        response = get_content_attribute(tspan, "response.text")
         trace_id = tspan.span.context.trace_id
         start = tspan.span.start_time
         if user_input:
@@ -755,13 +755,13 @@ class LiveKitLangSmithSpanProcessor(BaseLangSmithSpanProcessor):
 
     def _handle_tool(self, tspan: TranslatedSpan) -> None:
         tspan.set_kind("tool")
-        tool_name = get_content_attribute(tspan.attributes, "function_tool.name")
+        tool_name = get_content_attribute(tspan, "function_tool.name")
         if tool_name:
             tspan.set_metadata("tool_name", str(tool_name))
-        args = get_content_attribute(tspan.attributes, "function_tool.arguments")
+        args = get_content_attribute(tspan, "function_tool.arguments")
         if args is not None:
             tspan.set_tool_input(args)
-        output = get_content_attribute(tspan.attributes, "function_tool.output")
+        output = get_content_attribute(tspan, "function_tool.output")
         if output is not None:
             tspan.set_tool_output(output)
 

--- a/python/tests/unit_tests/wrappers/test_livekit.py
+++ b/python/tests/unit_tests/wrappers/test_livekit.py
@@ -21,6 +21,7 @@ from langsmith.integrations.livekit import configure_livekit
 from langsmith.integrations.livekit._helpers import (
     build_assistant_tool_call_message,
     build_message_from_event,
+    build_messages_from_gen_ai,
     normalize_provider,
 )
 from langsmith.integrations.livekit.processor import (
@@ -1598,6 +1599,389 @@ class TestMessageFromEvent:
         )
         assert msg["tool_call_id"] == "call_1"
         assert msg["name"] == "lookup"
+
+
+class TestContentAttributeVersions:
+    @pytest.mark.parametrize("prefix", ["lk.", "lk.pii."])
+    def test_stt_and_tts(self, prefix):
+        proc = _processor()
+        proc.on_end(_make_span("user_turn", {f"{prefix}user_transcript": "Hello"}))
+        attrs = proc.downstream.on_end.call_args.args[0]._attributes
+        assert json.loads(attrs["gen_ai.completion"])["messages"] == [
+            {"role": "assistant", "content": "Hello"}
+        ]
+        assert attrs["langsmith.metadata.ls_message_view_exclude"] is True
+
+        proc.on_end(_make_span("tts_request", {f"{prefix}input_text": "Welcome"}))
+        attrs = proc.downstream.on_end.call_args.args[0]._attributes
+        assert json.loads(attrs["gen_ai.prompt"])["messages"] == [
+            {"role": "user", "content": "Welcome"}
+        ]
+
+    @pytest.mark.parametrize("prefix", ["lk.", "lk.pii."])
+    def test_turn_and_root_transcript(self, prefix):
+        proc = _processor()
+        proc.on_end(_make_span("job", parent=None))
+        proc.on_end(
+            _make_span(
+                "agent_turn",
+                {f"{prefix}user_input": "Hi", f"{prefix}response.text": "Hello"},
+                span_id=2,
+            )
+        )
+        attrs = proc.downstream.on_end.call_args.args[0]._attributes
+        assert json.loads(attrs["gen_ai.prompt"])["messages"][0]["content"] == "Hi"
+        assert (
+            json.loads(attrs["gen_ai.completion"])["messages"][0]["content"] == "Hello"
+        )
+        proc.on_end(_make_span("agent_session", span_id=3))
+        root = next(
+            call.args[0]._attributes
+            for call in proc.downstream.on_end.call_args_list
+            if call.args[0]._attributes.get("langsmith.root_span")
+        )
+        assert json.loads(root["gen_ai.prompt"])["messages"] == [
+            {"role": "user", "content": "Hi"},
+            {"role": "assistant", "content": "Hello"},
+        ]
+        assert not proc._state_by_trace
+
+    @pytest.mark.parametrize("prefix", ["lk.", "lk.pii."])
+    @pytest.mark.parametrize("output", ['{"temperature": 20}', "", 0, False])
+    def test_tool_payloads(self, prefix, output):
+        proc = _processor()
+        proc.on_end(
+            _make_span(
+                "function_tool",
+                {
+                    # LiveKit 1.7+ still uses this non-PII name.
+                    "lk.function_tool.name": "weather",
+                    f"{prefix}function_tool.arguments": '{"city": "Paris"}',
+                    f"{prefix}function_tool.output": output,
+                },
+            )
+        )
+        attrs = proc.downstream.on_end.call_args.args[0]._attributes
+        assert attrs["langsmith.metadata.tool_name"] == "weather"
+        assert json.loads(attrs["gen_ai.prompt"]) == {"city": "Paris"}
+        assert attrs["gen_ai.completion"] == (
+            output if isinstance(output, str) else json.dumps(output)
+        )
+
+    @pytest.mark.parametrize("value", ["current", ""])
+    @pytest.mark.parametrize(
+        "span_name,field,io_key",
+        [
+            ("user_turn", "user_transcript", "gen_ai.completion"),
+            ("tts_request", "input_text", "gen_ai.prompt"),
+            ("agent_turn", "user_input", "gen_ai.prompt"),
+            ("agent_turn", "response.text", "gen_ai.completion"),
+            ("function_tool", "function_tool.arguments", "gen_ai.prompt"),
+            ("function_tool", "function_tool.output", "gen_ai.completion"),
+        ],
+    )
+    def test_new_field_wins_even_when_empty(self, span_name, field, io_key, value):
+        proc = _processor()
+        proc.on_end(
+            _make_span(span_name, {f"lk.{field}": "stale", f"lk.pii.{field}": value})
+        )
+        attrs = proc.downstream.on_end.call_args.args[0]._attributes
+        assert "stale" not in attrs.get(io_key, "")
+        if value:
+            assert value in attrs[io_key]
+
+
+class TestGenAIMessageAttributes:
+    """Fixtures follow LiveKit 1.8 telemetry/gen_ai.py's serialized part shapes."""
+
+    @staticmethod
+    def _event(name, **attributes):
+        return SimpleNamespace(name=name, attributes=attributes)
+
+    def _export(self, attributes=None, events=()):
+        proc = _processor()
+        span = _make_span("llm_request", attributes)
+        span.events = list(events)
+        proc.on_end(span)
+        proc.downstream.on_end.assert_called_once()
+        return proc.downstream.on_end.call_args.args[0]
+
+    def test_legacy_event_conversation(self):
+        call = {
+            "id": "call_1",
+            "type": "function",
+            "function": {"name": "weather", "arguments": '{"city":"Paris"}'},
+        }
+        events = [
+            self._event("gen_ai.system.message", content="Be helpful"),
+            self._event("gen_ai.user.message", content="Weather?"),
+            self._event("gen_ai.assistant.message", tool_calls=[json.dumps(call)]),
+            self._event("gen_ai.tool.message", content="Sunny", id="call_1"),
+            self._event("gen_ai.choice", content="It is sunny"),
+        ]
+        span = self._export(events=events)
+        prompt = json.loads(span._attributes["gen_ai.prompt"])["messages"]
+        assert [m["role"] for m in prompt] == ["system", "user", "assistant", "tool"]
+        assert prompt[2]["tool_calls"] == [call]
+        assert prompt[3]["tool_call_id"] == "call_1"
+        assert json.loads(span._attributes["gen_ai.completion"])["messages"] == [
+            {"role": "assistant", "content": "It is sunny"}
+        ]
+        assert not span.events
+
+    def test_part_based_conversation_and_tool_round_trip(self):
+        call = {
+            "type": "tool_call",
+            "id": "call_1",
+            "name": "weather",
+            "arguments": {"city": "Paris"},
+        }
+        inputs = [
+            {"role": "user", "parts": [{"type": "text", "content": "Weather?"}]},
+            {
+                "role": "assistant",
+                "parts": [{"type": "text", "content": "Checking"}, call],
+            },
+            {
+                "role": "tool",
+                "parts": [
+                    {
+                        "type": "tool_call_response",
+                        "id": "call_1",
+                        "response": {"temp": 20},
+                    }
+                ],
+            },
+        ]
+        outputs = [
+            {
+                "role": "assistant",
+                "parts": [{"type": "text", "content": "20 degrees"}],
+                "finish_reason": "stop",
+            }
+        ]
+        attrs = {
+            "gen_ai.system_instructions": json.dumps(
+                [
+                    {"type": "text", "content": "Be helpful"},
+                    {"type": "text", "content": "Be brief"},
+                ]
+            ),
+            "gen_ai.input.messages": json.dumps(inputs),
+            "gen_ai.output.messages": json.dumps(outputs),
+            "lk.llm_metrics": json.dumps(
+                {"prompt_tokens": 20, "completion_tokens": 5, "total_tokens": 25}
+            ),
+        }
+        span = self._export(attrs)
+        prompt = json.loads(span._attributes["gen_ai.prompt"])["messages"]
+        assert prompt[0] == {"role": "system", "content": "Be helpful\nBe brief"}
+        assert prompt[1] == {"role": "user", "content": "Weather?"}
+        assert prompt[2]["content"] == "Checking"
+        tool_call = prompt[2]["tool_calls"][0]
+        assert tool_call["id"] == "call_1"
+        assert tool_call["function"]["name"] == "weather"
+        assert json.loads(tool_call["function"]["arguments"]) == {"city": "Paris"}
+        assert prompt[3]["tool_call_id"] == "call_1"
+        assert json.loads(prompt[3]["content"]) == {"temp": 20}
+        assert json.loads(span._attributes["gen_ai.completion"])["messages"] == [
+            {"role": "assistant", "content": "20 degrees"}
+        ]
+        assert json.loads(span._attributes["langsmith.usage_metadata"]) == {
+            "input_tokens": 20,
+            "output_tokens": 5,
+            "total_tokens": 25,
+        }
+        assert attrs["gen_ai.input.messages"] == json.dumps(inputs)
+
+    @pytest.mark.parametrize(
+        "arguments", [{"city": "Paris"}, '{"city":"Paris"}', "partial{"]
+    )
+    def test_output_tool_calls(self, arguments):
+        span = self._export(
+            {
+                "gen_ai.output.messages": json.dumps(
+                    [
+                        {
+                            "role": "assistant",
+                            "parts": [
+                                {
+                                    "type": "tool_call",
+                                    "id": "a",
+                                    "name": "weather",
+                                    "arguments": arguments,
+                                },
+                                {
+                                    "type": "tool_call",
+                                    "id": "b",
+                                    "name": "time",
+                                    "arguments": {},
+                                },
+                            ],
+                        }
+                    ]
+                )
+            }
+        )
+        message = json.loads(span._attributes["gen_ai.completion"])["messages"][0]
+        assert message["content"] == ""
+        assert [c["id"] for c in message["tool_calls"]] == ["a", "b"]
+        assert message["tool_calls"][0]["function"]["arguments"] == (
+            arguments if isinstance(arguments, str) else json.dumps(arguments)
+        )
+
+    @pytest.mark.parametrize("raw", [None, "not json", "{}", "null", "123"])
+    def test_missing_or_malformed_fields_fall_back_independently(self, raw):
+        span = self._export(
+            {
+                "gen_ai.input.messages": raw,
+                "gen_ai.output.messages": json.dumps(
+                    [
+                        {
+                            "role": "assistant",
+                            "parts": [{"type": "text", "content": "New answer"}],
+                        }
+                    ]
+                ),
+            },
+            [
+                self._event("gen_ai.user.message", content="Old prompt"),
+                self._event("gen_ai.choice", content="Old answer"),
+            ],
+        )
+        assert (
+            json.loads(span._attributes["gen_ai.prompt"])["messages"][0]["content"]
+            == "Old prompt"
+        )
+        assert (
+            json.loads(span._attributes["gen_ai.completion"])["messages"][0]["content"]
+            == "New answer"
+        )
+
+    def test_new_fields_prevent_duplicates_and_empty_arrays_are_authoritative(self):
+        diagnostic = self._event("diagnostic", detail="kept")
+        span = self._export(
+            {
+                "gen_ai.input.messages": "[]",
+                "gen_ai.output.messages": "[]",
+                "gen_ai.system_instructions": json.dumps(
+                    [{"type": "text", "content": "New instructions"}]
+                ),
+            },
+            [
+                self._event("gen_ai.system.message", content="Old instructions"),
+                self._event("gen_ai.user.message", content="Old prompt"),
+                self._event("gen_ai.choice", content="Old answer"),
+                diagnostic,
+            ],
+        )
+        assert json.loads(span._attributes["gen_ai.prompt"])["messages"] == [
+            {"role": "system", "content": "New instructions"}
+        ]
+        assert json.loads(span._attributes["gen_ai.completion"])["messages"] == []
+        assert list(span.events) == [diagnostic]
+
+    def test_instructions_only_and_legacy_output(self):
+        span = self._export(
+            {
+                "gen_ai.system_instructions": json.dumps(
+                    [{"type": "text", "content": "New instructions"}]
+                )
+            },
+            [
+                self._event("gen_ai.system.message", content="Old instructions"),
+                self._event("gen_ai.user.message", content="Hi"),
+                self._event("gen_ai.choice", content="Hello"),
+            ],
+        )
+        assert json.loads(span._attributes["gen_ai.prompt"])["messages"] == [
+            {"role": "system", "content": "New instructions"},
+            {"role": "user", "content": "Hi"},
+        ]
+        assert (
+            json.loads(span._attributes["gen_ai.completion"])["messages"][0]["content"]
+            == "Hello"
+        )
+
+    def test_omitted_content_does_not_fabricate_messages(self):
+        attrs = self._export()._attributes
+        assert "gen_ai.prompt" not in attrs
+        assert "gen_ai.completion" not in attrs
+
+    def test_multimodal_and_malformed_parts(self):
+        messages = build_messages_from_gen_ai(
+            json.dumps(
+                [
+                    None,
+                    123,
+                    {"role": [], "parts": []},
+                    {"role": "user", "parts": {}},
+                    {
+                        "role": "user",
+                        "parts": [
+                            None,
+                            "bad",
+                            {"type": "text", "content": {}},
+                            {"type": "unknown"},
+                            {
+                                "type": "blob",
+                                "modality": "audio",
+                                "content": "",
+                                "transcript": "Look here",
+                            },
+                            {
+                                "type": "uri",
+                                "modality": "image",
+                                "uri": "https://example.com/image.png",
+                            },
+                            {"type": "uri", "modality": "image", "uri": ""},
+                        ],
+                    },
+                ]
+            )
+        )
+        assert messages == [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Look here"},
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": "https://example.com/image.png"},
+                    },
+                ],
+            }
+        ]
+
+    @pytest.mark.parametrize(
+        "response", ["plain text", {"temp": 20}, [1, 2], None, False, 0, ""]
+    )
+    def test_tool_response_values(self, response):
+        messages = build_messages_from_gen_ai(
+            json.dumps(
+                [
+                    {
+                        "role": "tool",
+                        "parts": [
+                            {
+                                "type": "tool_call_response",
+                                "id": "call_1",
+                                "response": response,
+                            }
+                        ],
+                    }
+                ]
+            )
+        )
+        assert messages == [
+            {
+                "role": "tool",
+                "tool_call_id": "call_1",
+                "content": response
+                if isinstance(response, str)
+                else json.dumps(response),
+            }
+        ]
 
 
 class TestProviderAttribution:

--- a/python/tests/unit_tests/wrappers/test_livekit.py
+++ b/python/tests/unit_tests/wrappers/test_livekit.py
@@ -17,11 +17,13 @@ from unittest.mock import MagicMock
 import pytest
 
 from langsmith._internal.voice import set_thread_id
+from langsmith._internal.voice._helpers import (
+    build_assistant_tool_call_message,
+    build_messages_from_gen_ai,
+)
 from langsmith.integrations.livekit import configure_livekit
 from langsmith.integrations.livekit._helpers import (
-    build_assistant_tool_call_message,
     build_message_from_event,
-    build_messages_from_gen_ai,
     normalize_provider,
 )
 from langsmith.integrations.livekit.processor import (


### PR DESCRIPTION
LiveKit Agents 1.7 moved conversation fields under `lk.pii.*`, and 1.8 replaced GenAI message span events with part-based `gen_ai.input.messages`, `gen_ai.output.messages`, and `gen_ai.system_instructions` attributes. As a result, LangSmith traces could contain spans but no conversation content.

This change reads the current attributes while preserving fallbacks for older LiveKit versions. It converts text, audio transcripts, image URIs, tool calls, and tool responses into LangSmith message shapes, and treats present empty/new fields as authoritative to avoid reviving stale or intentionally omitted content.

Validation:

- [x] tested locally and it works
