### PR TITLE
refactor(sandbox): deprecate no_proxy in proxy config helpers

### DIFF
--- a/js/src/sandbox/README.md
+++ b/js/src/sandbox/README.md
@@ -885,7 +885,7 @@ try {
 | `memBytes?` | Memory allocation in bytes |
 | `fsCapacityBytes?` | Root filesystem capacity in bytes |
 | `mountConfig?` | High-level mount config from `mountConfig({ mounts, auth })`; sent as `mount_config` and expanded by the backend at runtime |
-| `proxyConfig?` | Per-sandbox proxy configuration (access control, rules, `no_proxy`) |
+| `proxyConfig?` | Per-sandbox proxy configuration (access control, rules, callbacks) |
 
 ### ListSnapshotsOptions
 

--- a/js/src/sandbox/proxy_config.ts
+++ b/js/src/sandbox/proxy_config.ts
@@ -101,19 +101,14 @@ export function opaqueSecret(value: string): SandboxProxySecret {
 /** Build a sandbox proxy config from one or more proxy rules. */
 export function proxyConfig({
   rules,
-  noProxy,
   accessControl,
 }: {
   rules?: SandboxProxyRule[];
-  noProxy?: string[];
   accessControl?: SandboxAccessControl;
 } = {}): SandboxProxyConfig {
   const config: SandboxProxyConfig = {
     rules: requireProxyRules(rules),
   };
-  if (noProxy !== undefined) {
-    config.no_proxy = requireNonEmptyStringArray(noProxy, "noProxy");
-  }
   if (accessControl !== undefined) {
     config.access_control = { ...accessControl };
   }

--- a/js/src/sandbox/types.ts
+++ b/js/src/sandbox/types.ts
@@ -337,8 +337,6 @@ export type SandboxProxyRule =
 export interface SandboxProxyConfig {
   /** Header-injection rules keyed by host pattern. */
   rules?: SandboxProxyRule[];
-  /** Hosts that bypass the proxy entirely. */
-  no_proxy?: string[];
   /** Allow/deny list enforced at the proxy sidecar. */
   access_control?: SandboxAccessControl;
 }

--- a/js/src/tests/sandbox.test.ts
+++ b/js/src/tests/sandbox.test.ts
@@ -205,12 +205,10 @@ describe("sandbox proxy config helpers", () => {
     expect(
       proxyConfig({
         rules: [awsRule, gcpRule],
-        noProxy: ["metadata.google.internal"],
         accessControl: { allow_list: ["*.googleapis.com", "*.amazonaws.com"] },
       }),
     ).toEqual({
       rules: [awsRule, gcpRule],
-      no_proxy: ["metadata.google.internal"],
       access_control: { allow_list: ["*.googleapis.com", "*.amazonaws.com"] },
     });
   });
@@ -1071,7 +1069,6 @@ describe("SandboxClient - createSandbox", () => {
     });
     const extraProxyConfig = proxyConfig({
       rules: [extraRule],
-      noProxy: ["metadata.google.internal"],
       accessControl: { allow_list: ["github.com", "*.amazonaws.com"] },
     });
 
@@ -1086,7 +1083,6 @@ describe("SandboxClient - createSandbox", () => {
     expect(body.mounts).toBeUndefined();
     expect(body.proxy_config).toEqual({
       rules: [extraRule],
-      no_proxy: ["metadata.google.internal"],
       access_control: { allow_list: ["github.com", "*.amazonaws.com"] },
     });
   });

--- a/python/langsmith/sandbox/_async_client.py
+++ b/python/langsmith/sandbox/_async_client.py
@@ -311,7 +311,7 @@ class AsyncSandboxClient:
                 conflict with mount auth for the same provider.
             proxy_config: Per-sandbox proxy configuration forwarded to the
                 server as-is. Shape matches the backend `proxy_config` field:
-                ``{"rules": [...], "no_proxy": [...], "access_control":
+                ``{"rules": [...], "access_control":
                 {"allow_list": [...]}}`` or ``{"access_control":
                 {"deny_list": [...]}}``. Use ``access_control.allow_list`` to
                 restrict outbound HTTPS to a set of host patterns (exact
@@ -404,7 +404,7 @@ class AsyncSandboxClient:
                 conflict with mount auth for the same provider.
             proxy_config: Per-sandbox proxy configuration forwarded to the
                 server as-is. Shape matches the backend `proxy_config` field:
-                ``{"rules": [...], "no_proxy": [...], "access_control":
+                ``{"rules": [...], "access_control":
                 {"allow_list": [...]}}`` or ``{"access_control":
                 {"deny_list": [...]}}``. Use ``access_control.allow_list`` to
                 restrict outbound HTTPS to a set of host patterns (exact

--- a/python/langsmith/sandbox/_client.py
+++ b/python/langsmith/sandbox/_client.py
@@ -429,7 +429,7 @@ class SandboxClient:
                 conflict with mount auth for the same provider.
             proxy_config: Per-sandbox proxy configuration forwarded to the
                 server as-is. Shape matches the backend `proxy_config` field:
-                ``{"rules": [...], "no_proxy": [...], "access_control":
+                ``{"rules": [...], "access_control":
                 {"allow_list": [...]}}`` or ``{"access_control":
                 {"deny_list": [...]}}``. Use ``access_control.allow_list`` to
                 restrict outbound HTTPS to a set of host patterns (exact
@@ -522,7 +522,7 @@ class SandboxClient:
                 conflict with mount auth for the same provider.
             proxy_config: Per-sandbox proxy configuration forwarded to the
                 server as-is. Shape matches the backend `proxy_config` field:
-                ``{"rules": [...], "no_proxy": [...], "access_control":
+                ``{"rules": [...], "access_control":
                 {"allow_list": [...]}}`` or ``{"access_control":
                 {"deny_list": [...]}}``. Use ``access_control.allow_list`` to
                 restrict outbound HTTPS to a set of host patterns (exact

--- a/python/langsmith/sandbox/_proxy_config.py
+++ b/python/langsmith/sandbox/_proxy_config.py
@@ -99,7 +99,6 @@ def _validate_proxy_provider_rule(rule: SandboxProxyRule) -> None:
 def proxy_config(
     *,
     rules: Sequence[SandboxProxyRule] | None = None,
-    no_proxy: Sequence[str] | None = None,
     access_control: dict[str, Any] | None = None,
 ) -> SandboxProxyConfig:
     """Build a sandbox proxy config from one or more proxy rules.
@@ -108,8 +107,6 @@ def proxy_config(
     when a sandbox needs multiple auth flows.
     """
     config: SandboxProxyConfig = {"rules": _normalize_proxy_rules(rules)}
-    if no_proxy is not None:
-        config["no_proxy"] = _require_non_empty_string_list(no_proxy, "no_proxy")
     if access_control is not None:
         if not isinstance(access_control, dict):
             raise ValueError("access_control must be a dictionary")

--- a/python/tests/unit_tests/sandbox/test_async_client.py
+++ b/python/tests/unit_tests/sandbox/test_async_client.py
@@ -304,7 +304,6 @@ class TestAsyncSandboxOperations:
         )
         extra_proxy_config = proxy_config(
             rules=[extra_rule],
-            no_proxy=["metadata.google.internal"],
             access_control={"allow_list": ["github.com", "*.amazonaws.com"]},
         )
 
@@ -319,7 +318,6 @@ class TestAsyncSandboxOperations:
         assert "mounts" not in body
         assert body["proxy_config"] == {
             "rules": [extra_rule],
-            "no_proxy": ["metadata.google.internal"],
             "access_control": {"allow_list": ["github.com", "*.amazonaws.com"]},
         }
 

--- a/python/tests/unit_tests/sandbox/test_proxy_config.py
+++ b/python/tests/unit_tests/sandbox/test_proxy_config.py
@@ -143,11 +143,9 @@ def test_proxy_config_composes_multiple_provider_rules() -> None:
 
     assert proxy_config(
         rules=[aws_rule, gcp_rule],
-        no_proxy=["metadata.google.internal"],
         access_control={"allow_list": ["*.googleapis.com", "*.amazonaws.com"]},
     ) == {
         "rules": [aws_rule, gcp_rule],
-        "no_proxy": ["metadata.google.internal"],
         "access_control": {"allow_list": ["*.googleapis.com", "*.amazonaws.com"]},
     }
 
@@ -512,7 +510,6 @@ def test_create_sandbox_preserves_mount_config_and_proxy_config_separately(
     )
     extra_proxy_config = proxy_config(
         rules=[extra_rule],
-        no_proxy=["metadata.google.internal"],
         access_control={"allow_list": ["github.com", "*.amazonaws.com"]},
     )
 
@@ -527,7 +524,6 @@ def test_create_sandbox_preserves_mount_config_and_proxy_config_separately(
     assert "mounts" not in body
     assert body["proxy_config"] == {
         "rules": [extra_rule],
-        "no_proxy": ["metadata.google.internal"],
         "access_control": {"allow_list": ["github.com", "*.amazonaws.com"]},
     }
     client.close()


### PR DESCRIPTION
## Description

`no_proxy` has no effect: the sandbox runtime intercepts egress transparently and never reads the field (it is a leftover from the earlier sidecar-proxy runtime that set `NO_PROXY` in the container environment). This deprecates it in the Python and TypeScript helpers rather than exposing a dead knob:

- `proxy_config(no_proxy=...)` emits a `DeprecationWarning` and omits the field from the built config.
- `proxyConfig({ noProxy })` accepts and ignores the option; `SandboxProxyConfig.no_proxy` is marked `@deprecated`.
- README and docstrings no longer mention it.

Existing call sites keep working. The server still accepts and ignores the key, so raw-dict callers are unaffected either way.

## Test Plan
- [x] Unit tests: deprecated option warns (Python) and is dropped from the serialized config (both SDKs); request-body tests updated