### PR TITLE
fix: preserve sandbox API error IDs

### DIFF
--- a/js/src/sandbox/helpers.ts
+++ b/js/src/sandbox/helpers.ts
@@ -78,10 +78,14 @@ export async function parseErrorResponse(
 
     // Standardized format: {"detail": {"error": "...", "message": "..."}}
     if (detail && typeof detail === "object" && !Array.isArray(detail)) {
+      const message =
+        detail.message || `HTTP ${response.status}: ${response.statusText}`;
       return {
         errorType: detail.error,
         message:
-          detail.message || `HTTP ${response.status}: ${response.statusText}`,
+          typeof detail.error_id === "string" && detail.error_id
+            ? `${message} (error_id=${detail.error_id})`
+            : message,
       };
     }
 

--- a/js/src/tests/sandbox_error_handling.test.ts
+++ b/js/src/tests/sandbox_error_handling.test.ts
@@ -4,6 +4,7 @@ import { SandboxClient } from "../sandbox/client.js";
 import {
   LangSmithValidationError,
   LangSmithSandboxCreationError,
+  LangSmithSandboxAPIError,
 } from "../sandbox/errors.js";
 
 let server: Server;
@@ -36,6 +37,29 @@ function makeClient(): SandboxClient {
 }
 
 describe("handleClientHttpError body consumption", () => {
+  it("preserves the server error ID", async () => {
+    nextResponse = {
+      status: 500,
+      body: {
+        detail: {
+          error: "SandboxSnapshotFailed",
+          message: "Snapshot capture failed.",
+          error_id: "6a39f608-e9aa-4247-8e61-846870563681",
+        },
+      },
+    };
+
+    const client = makeClient();
+
+    await expect(
+      client.captureSnapshot("test-sandbox", "my-snapshot"),
+    ).rejects.toThrow(
+      new LangSmithSandboxAPIError(
+        "Snapshot capture failed. (error_id=6a39f608-e9aa-4247-8e61-846870563681)",
+      ),
+    );
+  });
+
   it("handles 422 with pydantic validation details without crashing", async () => {
     nextResponse = {
       status: 422,

--- a/python/langsmith/sandbox/_helpers.py
+++ b/python/langsmith/sandbox/_helpers.py
@@ -96,6 +96,12 @@ def validate_ttl(value: Optional[int], name: str) -> None:
 # =============================================================================
 
 
+def _message_with_error_id(message: str, error_id: Any) -> str:
+    if isinstance(error_id, str) and error_id:
+        return f"{message} (error_id={error_id})"
+    return message
+
+
 def parse_error_response(error: httpx.HTTPStatusError) -> dict[str, Any]:
     """Parse standardized error response.
 
@@ -113,7 +119,9 @@ def parse_error_response(error: httpx.HTTPStatusError) -> dict[str, Any]:
         if isinstance(detail, dict):
             return {
                 "error_type": detail.get("error"),
-                "message": detail.get("message", str(error)),
+                "message": _message_with_error_id(
+                    detail.get("message", str(error)), detail.get("error_id")
+                ),
             }
 
         # Pydantic validation error format: {"detail": [{"loc": [...], "msg": "..."}]}
@@ -144,7 +152,9 @@ def parse_error_response_simple(error: httpx.HTTPStatusError) -> dict[str, Any]:
         if isinstance(detail, dict):
             return {
                 "error_type": detail.get("error"),
-                "message": detail.get("message", str(error)),
+                "message": _message_with_error_id(
+                    detail.get("message", str(error)), detail.get("error_id")
+                ),
             }
 
         return {"error_type": None, "message": detail or str(error)}

--- a/python/tests/unit_tests/sandbox/test_helpers.py
+++ b/python/tests/unit_tests/sandbox/test_helpers.py
@@ -2,7 +2,7 @@
 
 import httpx
 
-from langsmith.sandbox._helpers import merge_headers
+from langsmith.sandbox._helpers import merge_headers, parse_error_response
 
 
 def test_merge_headers_override_wins() -> None:
@@ -37,3 +37,28 @@ def test_merge_headers_override_replaces_across_casing() -> None:
         v.decode() for k, v in request.headers.raw if k.lower() == b"x-service-key"
     ]
     assert on_wire == ["override"]
+
+
+def test_parse_error_response_preserves_error_id() -> None:
+    request = httpx.Request(
+        "POST", "https://example.com/v2/sandboxes/boxes/box/snapshot"
+    )
+    response = httpx.Response(
+        500,
+        request=request,
+        json={
+            "detail": {
+                "error": "SandboxSnapshotFailed",
+                "message": "Snapshot capture failed.",
+                "error_id": "6a39f608-e9aa-4247-8e61-846870563681",
+            }
+        },
+    )
+    error = httpx.HTTPStatusError("server error", request=request, response=response)
+
+    assert parse_error_response(error) == {
+        "error_type": "SandboxSnapshotFailed",
+        "message": (
+            "Snapshot capture failed. (error_id=6a39f608-e9aa-4247-8e61-846870563681)"
+        ),
+    }


### PR DESCRIPTION
### Summary

The sandbox API returns support correlation IDs in `detail.error_id`, but the Python and TypeScript error parsers discarded that field. As a result, exceptions told users to contact support with an error ID without showing it.

Append structured error IDs to sandbox exception messages in both SDKs while leaving responses without an ID unchanged.

### Test Plan

- [x] Added Python coverage for a structured 500 response with `error_id`
- [x] Added TypeScript client coverage for snapshot errors with `error_id`
- [x] Ran focused Python and TypeScript tests
- [x] Ran Python formatting and Ruff; repository-wide mypy remains blocked by a pre-existing `Executor.map` signature error in `langsmith/utils.py`
- [x] Ran TypeScript formatting and lint

Made by [Open SWE](https://openswe.vercel.app/agents/d0079f7b-71e4-5e3a-87ef-7ba76064ee4a) · openai:gpt-5.6-sol (high)