### PR TITLE
fix(js): preserve 403 JSON error body in raiseForStatus

### DIFF
--- a/js/src/tests/error.test.ts
+++ b/js/src/tests/error.test.ts
@@ -1,0 +1,63 @@
+import { raiseForStatus } from "../utils/error.js";
+
+// A real `Response` body is a single-use stream: once `raiseForStatus` reads it
+// with `response.json()`, the fallback `response.text()` can no longer read it.
+// These tests use real `Response` objects so the consumed-stream behaviour the
+// 403 branch has to cope with is reproduced faithfully.
+describe("raiseForStatus 403 handling", () => {
+  it("includes the JSON error body for a non-org-scoped 403", async () => {
+    const body = {
+      error: "trace_project_forbidden",
+      detail: "API key cannot write to the target project",
+    };
+    const response = new Response(JSON.stringify(body), {
+      status: 403,
+      statusText: "Forbidden",
+      headers: { "content-type": "application/json" },
+    });
+
+    await expect(
+      raiseForStatus(response, "send multipart request"),
+    ).rejects.toThrow(/trace_project_forbidden/);
+  });
+
+  it("does not leave an empty Message when the body was valid JSON", async () => {
+    // Regression guard for the bug where response.json() consumed the body and
+    // the response.text() fallback then read a spent stream and yielded "".
+    const body = { error: "some_other_error" };
+    const response = new Response(JSON.stringify(body), {
+      status: 403,
+      statusText: "Forbidden",
+      headers: { "content-type": "application/json" },
+    });
+
+    await expect(
+      raiseForStatus(response, "send multipart request"),
+    ).rejects.toThrow(/Message: (?!\s*$).+/);
+  });
+
+  it("keeps the descriptive message for org_scoped_key_requires_workspace", async () => {
+    const body = { error: "org_scoped_key_requires_workspace" };
+    const response = new Response(JSON.stringify(body), {
+      status: 403,
+      statusText: "Forbidden",
+      headers: { "content-type": "application/json" },
+    });
+
+    await expect(
+      raiseForStatus(response, "send multipart request"),
+    ).rejects.toThrow(/org-scoped and requires workspace specification/);
+  });
+
+  it("throws a bare status for a non-JSON 403 body", async () => {
+    const response = new Response("<html>403 Forbidden</html>", {
+      status: 403,
+      statusText: "Forbidden",
+      headers: { "content-type": "text/html" },
+    });
+
+    await expect(
+      raiseForStatus(response, "send multipart request"),
+    ).rejects.toThrow("403 Forbidden");
+  });
+});

--- a/js/src/utils/error.ts
+++ b/js/src/utils/error.ts
@@ -153,6 +153,11 @@ export async function raiseForStatus(
           "This API key is org-scoped and requires workspace specification. " +
           "Please provide 'workspaceId' parameter, " +
           "or set LANGSMITH_WORKSPACE_ID environment variable.";
+      } else {
+        // Preserve the reason the server returned. response.json() above has
+        // already consumed the body, so the response.text() fallback below
+        // would read a spent stream and yield "" — dropping the cause.
+        errorBody = JSON.stringify(errorData);
       }
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } catch (_e: any) {


### PR DESCRIPTION
## Description

Fixes #3517.

In `raiseForStatus` (`js/src/utils/error.ts`), the `403` branch reads the body with `await response.json()` to inspect `errorData.error`, but only assigns `errorBody` when the code is `org_scoped_key_requires_workspace`. For every other 403 error code, the parsed `errorData` was discarded and control fell through to `if (errorBody === undefined)`, which calls `await response.text()` on the **already-consumed** body. That second read of a spent stream returns `""`, so the thrown error's `Message:` is empty and the reason the server sent is lost.

This surfaces prominently on the multipart trace-upload path — a 403 rejection logs `Failed to send multipart request. Received status [403]: Forbidden. Message:` with nothing after `Message:`, making the failure undiagnosable even though the server named the cause in the JSON body.

Introduced in #1920, where the special-case `if` was added without an `else`.

## Change

Assign `errorBody = JSON.stringify(errorData)` for any other 403 code, preserving the server's reason instead of re-reading the consumed stream:

```ts
if (errorCode === "org_scoped_key_requires_workspace") {
  errorBody =
    "This API key is org-scoped and requires workspace specification. ...";
} else {
  errorBody = JSON.stringify(errorData);
}
```

The non-JSON body path (`catch`) is unchanged and still throws the bare `<status> <statusText>`.

## Notes

- One-line behavioral change scoped to the 403 branch; the `ok`, 404, and 409 paths are untouched.
- Happy to add a unit test covering a 403 with a JSON body whose `error` code is not `org_scoped_key_requires_workspace` if you'd like — point me at the preferred spec location.
