### PR TITLE
fix(js): avoid stored reasoning in OpenAI integration tests

### DIFF
--- a/js/src/tests/vercel/telemetry/openai.int.test.ts
+++ b/js/src/tests/vercel/telemetry/openai.int.test.ts
@@ -111,6 +111,7 @@ test("telemetry generateText with tools", async () => {
       }),
     },
     stopWhen: stepCountIs(10),
+    providerOptions: { openai: { store: false } },
     telemetry: {
       integrations: [LangSmithTelemetry({ client, tracingEnabled: true })],
     },
@@ -244,6 +245,7 @@ test("telemetry streamText", async () => {
       }),
     },
     stopWhen: stepCountIs(10),
+    providerOptions: { openai: { store: false } },
   });
 
   let total = "";

--- a/js/src/tests/vercel/wrapper/openai.int.test.ts
+++ b/js/src/tests/vercel/wrapper/openai.int.test.ts
@@ -45,6 +45,7 @@ test("wrap generateText", async () => {
       }),
     },
     stopWhen: stepCountIs(10),
+    providerOptions: { openai: { store: false } },
   });
   expect(result.text).toBeDefined();
   expect(result.text.length).toBeGreaterThan(0);
@@ -86,6 +87,7 @@ test("wrap generateText with tool class", async () => {
       ),
     },
     stopWhen: stepCountIs(10),
+    providerOptions: { openai: { store: false } },
   });
   expect(result.text).toBeDefined();
   expect(result.text.length).toBeGreaterThan(0);
@@ -164,6 +166,7 @@ test("wrap streamText", async () => {
       }),
     },
     stopWhen: stepCountIs(10),
+    providerOptions: { openai: { store: false } },
   });
   let total = "";
   for await (const chunk of result.textStream) {
@@ -356,6 +359,7 @@ test("should reuse tool def without double wrapping tool traces", async () => {
     ],
     tools: toolDef,
     stopWhen: stepCountIs(10),
+    providerOptions: { openai: { store: false } },
   });
   expect(result.text).toBeDefined();
   expect(result.text.length).toBeGreaterThan(0);
@@ -371,6 +375,7 @@ test("should reuse tool def without double wrapping tool traces", async () => {
     ],
     tools: toolDef,
     stopWhen: stepCountIs(10),
+    providerOptions: { openai: { store: false } },
   });
   expect(result2.text).toBeDefined();
   expect(result2.text.length).toBeGreaterThan(0);

--- a/js/src/tests/wrapped_openai.int.test.ts
+++ b/js/src/tests/wrapped_openai.int.test.ts
@@ -686,7 +686,7 @@ test("chat.completions.parse", async () => {
   callSpy.mockClear();
 });
 
-test("responses.create and retrieve workflow", async () => {
+test("responses.create without storage traces creation but not failed retrieval", async () => {
   const { client, callSpy } = mockClient();
 
   const openai = wrapOpenAI(new OpenAI(), {
@@ -697,6 +697,7 @@ test("responses.create and retrieve workflow", async () => {
   // Create a response (this should be traced)
   const createResponse = await openai.responses.create({
     model: "gpt-5-nano",
+    store: false,
     reasoning: {
       effort: "low",
     },
@@ -713,6 +714,7 @@ test("responses.create and retrieve workflow", async () => {
 
   expect(createResponse).toBeDefined();
   expect(createResponse.id).toBeDefined();
+  await client.awaitPendingTraceBatches();
 
   // Verify that create was traced
   const createCalls = callSpy.mock.calls.filter(
@@ -723,10 +725,13 @@ test("responses.create and retrieve workflow", async () => {
   const createCallCount = callSpy.mock.calls.length;
 
   // Retrieve the response (this should NOT be traced)
-  const retrieveResponse = await openai.responses.retrieve(createResponse.id);
-
-  expect(retrieveResponse).toBeDefined();
-  expect(retrieveResponse.id).toBe(createResponse.id);
+  await expect(
+    openai.responses.retrieve(createResponse.id),
+  ).rejects.toMatchObject({
+    status: 404,
+    message: expect.stringContaining(createResponse.id),
+  });
+  await client.awaitPendingTraceBatches();
 
   // Verify that retrieve did NOT add any new tracing calls
   expect(callSpy.mock.calls.length).toBe(createCallCount);
@@ -749,6 +754,7 @@ test("responses.create and retrieve workflow", async () => {
   const updateCalls = callSpy.mock.calls.filter(
     (call: any) => (call[1] as any).method === "PATCH",
   );
+  expect(updateCalls.length).toBeGreaterThanOrEqual(1);
   for (const call of updateCalls) {
     const body = parseRequestBody((call[1] as any).body);
     expect(body.outputs.usage_metadata).toBeDefined();

--- a/js/src/tests/wrapped_openai.test.ts
+++ b/js/src/tests/wrapped_openai.test.ts
@@ -1,0 +1,90 @@
+import { jest } from "@jest/globals";
+import { OpenAI } from "openai";
+import { wrapOpenAI } from "../wrappers/openai.js";
+import { mockClient } from "./utils/mock_client.js";
+import { getAssumedTreeFromCalls } from "./utils/tree.js";
+
+test.each([200, 404])(
+  "responses.create is traced but retrieval with status %i is not",
+  async (status) => {
+    const response = {
+      id: "resp_test",
+      object: "response",
+      status: "completed",
+      model: "gpt-5-nano",
+      output: [
+        {
+          id: "msg_test",
+          type: "message",
+          role: "assistant",
+          status: "completed",
+          content: [{ type: "output_text", text: "4", annotations: [] }],
+        },
+      ],
+      usage: { input_tokens: 10, output_tokens: 2, total_tokens: 12 },
+    };
+    const error = {
+      type: "invalid_request_error",
+      message: "Response with id 'resp_test' not found.",
+    };
+    const openaiFetch = jest
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(Response.json(response))
+      .mockResolvedValueOnce(
+        Response.json(status === 200 ? response : { error }, { status }),
+      );
+    const { client, callSpy } = mockClient();
+    const openai = wrapOpenAI(
+      new OpenAI({
+        apiKey: "MOCK",
+        baseURL: "https://openai.example.test/v1",
+        fetch: openaiFetch,
+        maxRetries: 0,
+      }),
+      { client, tracingEnabled: true },
+    );
+    const params = {
+      model: "gpt-5-nano",
+      input: "What is 2+2?",
+      store: true,
+      metadata: { request_key: "request_value" },
+    };
+
+    const created = await openai.responses.create(params);
+    expect(created).toMatchObject(response);
+    const tree = await getAssumedTreeFromCalls(callSpy.mock.calls, client);
+    expect(tree.nodes).toEqual(["ChatOpenAI:0"]);
+    expect(tree.data["ChatOpenAI:0"]).toMatchObject({
+      run_type: "llm",
+      inputs: params,
+      extra: {
+        metadata: { request_key: "request_value", ls_model_name: params.model },
+      },
+      outputs: {
+        id: response.id,
+        usage_metadata: response.usage,
+      },
+    });
+    const createCallCount = callSpy.mock.calls.length;
+
+    const retrieved = openai.responses.retrieve(created.id);
+    if (status === 200) {
+      await expect(retrieved).resolves.toMatchObject(response);
+    } else {
+      await expect(retrieved).rejects.toMatchObject({ status, error });
+    }
+    await client.awaitPendingTraceBatches();
+    expect(callSpy.mock.calls.length).toBe(createCallCount);
+    expect(openaiFetch).toHaveBeenCalledTimes(2);
+    expect(openaiFetch).toHaveBeenNthCalledWith(
+      1,
+      "https://openai.example.test/v1/responses",
+      expect.objectContaining({ method: "POST", body: JSON.stringify(params) }),
+    );
+    expect(openaiFetch).toHaveBeenNthCalledWith(
+      2,
+      `https://openai.example.test/v1/responses/${created.id}`,
+      expect.objectContaining({ method: "GET" }),
+    );
+  },
+);


### PR DESCRIPTION
## Problem

The OpenAI integration tests assumed responses are saved on the server. With Zero Data Retention (ZDR) turned on, they are not: OpenAI can return an answer and an ID without keeping a copy for later use. This was causing JavaScript CI failures like [this one](https://github.com/langchain-ai/langsmith-sdk/actions/runs/34470223379?pr=3509).

## Solution

Make the tests work without server-side storage while preserving coverage of reasoning, tools, and tracing:

- **Carry reasoning between requests.** Set `providerOptions: { openai: { store: false } }` on seven calls across six AI SDK tests. The existing provider requests encrypted reasoning and sends it with the next request instead of relying on saved data. Models, tools, multi-step behavior, and assertions stay intact.
- **Test retrieval independently of storage policy.** Add two unit tests using the real OpenAI client and LangSmith wrapper with **mocked** HTTP responses. They verify creation metadata and token usage are traced, requests are formed correctly, and retrieval either returns the response or propagates a 404 without adding traces.
- **Verify non-storage behavior against the live API.** Explicitly create with `store: false`, then assert retrieval returns a 404 mentioning that response ID. Preserve creation metadata and usage checks, and verify failed retrieval adds no traces. This expectation does not depend on whether the credential uses ZDR.

Retrieval checks wait for pending traces before and after the request, preventing delayed creation traces from affecting the comparison. The live test also requires a trace update so usage assertions cannot pass without checking any data.

## Scope

Test-only changes. No credentials, retention settings, dependencies, production SDK defaults, or additional test skips change. Successful retrieval from live OpenAI storage is no longer required: mocked tests cover both retrieval outcomes, and the live test covers explicitly unsaved responses.

## Validation

- Both mocked unit tests passed: `pnpm test --runInBand --no-colors --runTestsByPath src/tests/wrapped_openai.test.ts`.