### PR TITLE
fix(js,py): tag guardrail/subagent structurally in openai-agents integration

### DIFF
--- a/js/src/tests/openai_agents_sdk.test.ts
+++ b/js/src/tests/openai_agents_sdk.test.ts
@@ -874,6 +874,138 @@ describe("OpenAIAgentsTracingProcessor", () => {
       }
     });
 
+    test("subagent detection walks past an intermediate chain run to find a tool ancestor", async () => {
+      // Emulates the openai-agents topology when Runner.run is invoked from
+      // inside an asTool wrapper: outer function span -> nested inner trace
+      // (chain in LangSmith) -> agent span. The agent span's immediate parent
+      // is the chain, not the tool, so the resolver must walk the ancestor
+      // chain to catch the tool.
+      const outerTrace = createMockTrace("trace-nested-outer", "Outer");
+      const functionSpan = createMockSpan(
+        "trace-nested-outer",
+        "span-fn-nested",
+        null,
+        {
+          type: "function",
+          name: "invoke_subagent",
+          input: "{}",
+          output: "{}",
+        },
+      );
+      const innerTrace = createMockTrace("trace-nested-inner", "Inner");
+      const subagentSpan = createMockSpan(
+        "trace-nested-inner",
+        "span-agent-nested",
+        null,
+        { type: "agent", name: "NestedSubAgent" },
+      );
+
+      await processor.onTraceStart(outerTrace);
+      await processor.onSpanStart(functionSpan);
+      // Nested trace inherits the tool ALS context set by onSpanStart(function),
+      // so its trace root is created via createChild on the tool run.
+      await processor.onTraceStart(innerTrace);
+      await processor.onSpanStart(subagentSpan);
+      await processor.onSpanEnd(subagentSpan);
+      await processor.onTraceEnd(innerTrace);
+      await processor.onSpanEnd(functionSpan);
+      await processor.onTraceEnd(outerTrace);
+      await client.awaitPendingTraceBatches();
+
+      const tree = await getAssumedTreeFromCalls(callSpy.mock.calls, client);
+      const subagentNode = tree.nodes.find((n) => n.includes("NestedSubAgent"));
+      expect(subagentNode).toBeDefined();
+      if (subagentNode) {
+        expect(tree.data[subagentNode].extra?.metadata?.ls_agent_type).toBe(
+          "subagent",
+        );
+      }
+    });
+
+    test("stamps guardrail spans as middleware", async () => {
+      const trace = createMockTrace("trace-guard-1", "Test Agent");
+      const guardrailSpan = createMockSpan("trace-guard-1", "span-guard", null, {
+        type: "guardrail",
+        name: "entry_guardrail",
+        triggered: false,
+      });
+
+      await processor.onTraceStart(trace);
+      await processor.onSpanStart(guardrailSpan);
+      await processor.onSpanEnd(guardrailSpan);
+      await processor.onTraceEnd(trace);
+      await client.awaitPendingTraceBatches();
+
+      const tree = await getAssumedTreeFromCalls(callSpy.mock.calls, client);
+      const guardNode = tree.nodes.find((n) => n.includes("entry_guardrail"));
+      expect(guardNode).toBeDefined();
+      if (guardNode) {
+        expect(tree.data[guardNode].extra?.metadata?.ls_agent_type).toBe(
+          "middleware",
+        );
+      }
+    });
+
+    test("guardrail middleware stamp overrides inherited root", async () => {
+      const trace = createMockTrace("trace-guard-2", "Test Agent", {
+        metadata: { ls_agent_type: "root" },
+      });
+      const guardrailSpan = createMockSpan("trace-guard-2", "span-guard-2", null, {
+        type: "guardrail",
+        name: "exit_guardrail",
+        triggered: false,
+      });
+
+      await processor.onTraceStart(trace);
+      await processor.onSpanStart(guardrailSpan);
+      await processor.onSpanEnd(guardrailSpan);
+      await processor.onTraceEnd(trace);
+      await client.awaitPendingTraceBatches();
+
+      const tree = await getAssumedTreeFromCalls(callSpy.mock.calls, client);
+      const guardNode = tree.nodes.find((n) => n.includes("exit_guardrail"));
+      if (guardNode) {
+        expect(tree.data[guardNode].extra?.metadata?.ls_agent_type).toBe(
+          "middleware",
+        );
+      }
+    });
+
+    test.each(["middleware", "subagent", "compaction"] as const)(
+      "guardrail preserves user-supplied '%s' narrowing tag",
+      async (userTag) => {
+        const trace = createMockTrace(`trace-guard-3-${userTag}`, "Test Agent", {
+          metadata: { ls_agent_type: userTag },
+        });
+        const guardrailSpan = createMockSpan(
+          `trace-guard-3-${userTag}`,
+          `span-guard-3-${userTag}`,
+          null,
+          {
+            type: "guardrail",
+            name: `named_guardrail_${userTag}`,
+            triggered: false,
+          },
+        );
+
+        await processor.onTraceStart(trace);
+        await processor.onSpanStart(guardrailSpan);
+        await processor.onSpanEnd(guardrailSpan);
+        await processor.onTraceEnd(trace);
+        await client.awaitPendingTraceBatches();
+
+        const tree = await getAssumedTreeFromCalls(callSpy.mock.calls, client);
+        const guardNode = tree.nodes.find((n) =>
+          n.includes(`named_guardrail_${userTag}`),
+        );
+        if (guardNode) {
+          expect(tree.data[guardNode].extra?.metadata?.ls_agent_type).toBe(
+            userTag,
+          );
+        }
+      },
+    );
+
     test("does not mark handoff agents as subagents", async () => {
       const trace = createMockTrace("trace-11c", "Test Agent");
 

--- a/js/src/tests/openai_agents_sdk.test.ts
+++ b/js/src/tests/openai_agents_sdk.test.ts
@@ -875,8 +875,8 @@ describe("OpenAIAgentsTracingProcessor", () => {
     });
 
     test("subagent detection walks past an intermediate chain run to find a tool ancestor", async () => {
-      // asTool topology: function span -> nested trace (chain) -> agent span.
-      // The agent's immediate parent is the chain, not the tool.
+      // When an agent runs as a tool, an extra run sits between the tool and
+      // the agent.
       const outerTrace = createMockTrace("trace-nested-outer", "Outer");
       const functionSpan = createMockSpan(
         "trace-nested-outer",
@@ -899,7 +899,7 @@ describe("OpenAIAgentsTracingProcessor", () => {
 
       await processor.onTraceStart(outerTrace);
       await processor.onSpanStart(functionSpan);
-      // The nested trace root is created via createChild on the tool run.
+      // The nested run is created as a child of the tool run.
       await processor.onTraceStart(innerTrace);
       await processor.onSpanStart(subagentSpan);
       await processor.onSpanEnd(subagentSpan);

--- a/js/src/tests/openai_agents_sdk.test.ts
+++ b/js/src/tests/openai_agents_sdk.test.ts
@@ -875,11 +875,8 @@ describe("OpenAIAgentsTracingProcessor", () => {
     });
 
     test("subagent detection walks past an intermediate chain run to find a tool ancestor", async () => {
-      // Emulates the openai-agents topology when Runner.run is invoked from
-      // inside an asTool wrapper: outer function span -> nested inner trace
-      // (chain in LangSmith) -> agent span. The agent span's immediate parent
-      // is the chain, not the tool, so the resolver must walk the ancestor
-      // chain to catch the tool.
+      // asTool topology: function span -> nested trace (chain) -> agent span.
+      // The agent's immediate parent is the chain, not the tool.
       const outerTrace = createMockTrace("trace-nested-outer", "Outer");
       const functionSpan = createMockSpan(
         "trace-nested-outer",
@@ -902,8 +899,7 @@ describe("OpenAIAgentsTracingProcessor", () => {
 
       await processor.onTraceStart(outerTrace);
       await processor.onSpanStart(functionSpan);
-      // Nested trace inherits the tool ALS context set by onSpanStart(function),
-      // so its trace root is created via createChild on the tool run.
+      // The nested trace root is created via createChild on the tool run.
       await processor.onTraceStart(innerTrace);
       await processor.onSpanStart(subagentSpan);
       await processor.onSpanEnd(subagentSpan);

--- a/js/src/tests/openai_agents_sdk.test.ts
+++ b/js/src/tests/openai_agents_sdk.test.ts
@@ -874,7 +874,7 @@ describe("OpenAIAgentsTracingProcessor", () => {
       }
     });
 
-    test("subagent detection walks past an intermediate chain run to find a tool ancestor", async () => {
+    test("tags an agent as a subagent when the tool is further above it", async () => {
       // When an agent runs as a tool, an extra run sits between the tool and
       // the agent.
       const outerTrace = createMockTrace("trace-nested-outer", "Outer");
@@ -918,13 +918,71 @@ describe("OpenAIAgentsTracingProcessor", () => {
       }
     });
 
+    test("tags an agent handed off to inside a tool as a subagent", async () => {
+      // A handoff opens a new agent run beside the one it replaced, so the
+      // tool is still above it.
+      const outerTrace = createMockTrace("trace-handoff-sub", "Outer");
+      const functionSpan = createMockSpan(
+        "trace-handoff-sub",
+        "span-fn-handoff-sub",
+        null,
+        {
+          type: "function",
+          name: "invoke_subagent",
+          input: "{}",
+          output: "{}",
+        },
+      );
+      const innerTrace = createMockTrace("trace-handoff-sub-inner", "Inner");
+      const firstAgentSpan = createMockSpan(
+        "trace-handoff-sub-inner",
+        "span-agent-first",
+        null,
+        { type: "agent", name: "FirstAgent" },
+      );
+      const handedOffAgentSpan = createMockSpan(
+        "trace-handoff-sub-inner",
+        "span-agent-handed-off",
+        null,
+        { type: "agent", name: "HandedOffAgent" },
+      );
+
+      await processor.onTraceStart(outerTrace);
+      await processor.onSpanStart(functionSpan);
+      await processor.onTraceStart(innerTrace);
+      await processor.onSpanStart(firstAgentSpan);
+      await processor.onSpanEnd(firstAgentSpan);
+      await processor.onSpanStart(handedOffAgentSpan);
+      await processor.onSpanEnd(handedOffAgentSpan);
+      await processor.onTraceEnd(innerTrace);
+      await processor.onSpanEnd(functionSpan);
+      await processor.onTraceEnd(outerTrace);
+      await client.awaitPendingTraceBatches();
+
+      const tree = await getAssumedTreeFromCalls(callSpy.mock.calls, client);
+      const handedOffNode = tree.nodes.find((n) =>
+        n.includes("HandedOffAgent"),
+      );
+      expect(handedOffNode).toBeDefined();
+      if (handedOffNode) {
+        expect(tree.data[handedOffNode].extra?.metadata?.ls_agent_type).toBe(
+          "subagent",
+        );
+      }
+    });
+
     test("stamps guardrail spans as middleware", async () => {
       const trace = createMockTrace("trace-guard-1", "Test Agent");
-      const guardrailSpan = createMockSpan("trace-guard-1", "span-guard", null, {
-        type: "guardrail",
-        name: "entry_guardrail",
-        triggered: false,
-      });
+      const guardrailSpan = createMockSpan(
+        "trace-guard-1",
+        "span-guard",
+        null,
+        {
+          type: "guardrail",
+          name: "entry_guardrail",
+          triggered: false,
+        },
+      );
 
       await processor.onTraceStart(trace);
       await processor.onSpanStart(guardrailSpan);
@@ -946,11 +1004,16 @@ describe("OpenAIAgentsTracingProcessor", () => {
       const trace = createMockTrace("trace-guard-2", "Test Agent", {
         metadata: { ls_agent_type: "root" },
       });
-      const guardrailSpan = createMockSpan("trace-guard-2", "span-guard-2", null, {
-        type: "guardrail",
-        name: "exit_guardrail",
-        triggered: false,
-      });
+      const guardrailSpan = createMockSpan(
+        "trace-guard-2",
+        "span-guard-2",
+        null,
+        {
+          type: "guardrail",
+          name: "exit_guardrail",
+          triggered: false,
+        },
+      );
 
       await processor.onTraceStart(trace);
       await processor.onSpanStart(guardrailSpan);
@@ -960,6 +1023,7 @@ describe("OpenAIAgentsTracingProcessor", () => {
 
       const tree = await getAssumedTreeFromCalls(callSpy.mock.calls, client);
       const guardNode = tree.nodes.find((n) => n.includes("exit_guardrail"));
+      expect(guardNode).toBeDefined();
       if (guardNode) {
         expect(tree.data[guardNode].extra?.metadata?.ls_agent_type).toBe(
           "middleware",
@@ -968,11 +1032,15 @@ describe("OpenAIAgentsTracingProcessor", () => {
     });
 
     test.each(["middleware", "subagent", "compaction"] as const)(
-      "guardrail preserves user-supplied '%s' narrowing tag",
+      "guardrail keeps a user-supplied '%s' tag",
       async (userTag) => {
-        const trace = createMockTrace(`trace-guard-3-${userTag}`, "Test Agent", {
-          metadata: { ls_agent_type: userTag },
-        });
+        const trace = createMockTrace(
+          `trace-guard-3-${userTag}`,
+          "Test Agent",
+          {
+            metadata: { ls_agent_type: userTag },
+          },
+        );
         const guardrailSpan = createMockSpan(
           `trace-guard-3-${userTag}`,
           `span-guard-3-${userTag}`,
@@ -994,6 +1062,7 @@ describe("OpenAIAgentsTracingProcessor", () => {
         const guardNode = tree.nodes.find((n) =>
           n.includes(`named_guardrail_${userTag}`),
         );
+        expect(guardNode).toBeDefined();
         if (guardNode) {
           expect(tree.data[guardNode].extra?.metadata?.ls_agent_type).toBe(
             userTag,

--- a/js/src/wrappers/openai_agents.ts
+++ b/js/src/wrappers/openai_agents.ts
@@ -495,6 +495,10 @@ function createResponsesUsageMetadata(
  *
  * If the run already has middleware/subagent/compaction, keep it. Otherwise
  * guardrails become middleware and agents under any tool become subagents.
+ *
+ * Openai-agents structural counterpart to resolveVercelLsAgentType. Added
+ * to fix guardrails inheriting root and to catch subagents past the
+ * intermediate chain run that as_tool insertion produces.
  */
 function _resolveOpenAIAgentsLsAgentType(
   spanData: SpanData,

--- a/js/src/wrappers/openai_agents.ts
+++ b/js/src/wrappers/openai_agents.ts
@@ -490,6 +490,31 @@ function createResponsesUsageMetadata(
   return result;
 }
 
+function _resolveOpenAIAgentsLsAgentType(
+  spanData: SpanData,
+  parentRun: RunTree,
+  existingTag: unknown,
+): "middleware" | "subagent" | undefined {
+  // A user-supplied narrowing tag wins over structural detection.
+  if (
+    typeof existingTag === "string" &&
+    NON_ROOT_LS_AGENT_TYPES.has(existingTag)
+  ) {
+    return undefined;
+  }
+  if (spanData.type === "guardrail") return "middleware";
+  // Walk the ancestor chain, not just the immediate parent: asTool()
+  // inserts a chain run between the tool and the agent it wraps.
+  if (spanData.type === "agent") {
+    let cursor: RunTree | undefined = parentRun;
+    while (cursor !== undefined) {
+      if (cursor.run_type === "tool") return "subagent";
+      cursor = cursor.parent_run;
+    }
+  }
+  return undefined;
+}
+
 /**
  * Tracing processor for the [OpenAI Agents SDK](https://openai.github.io/openai-agents-js/).
  *
@@ -534,34 +559,6 @@ function createResponsesUsageMetadata(
  * console.log(result.finalOutput);
  * ```
  */
-
-// Structural ls_agent_type resolver: GuardrailSpanData -> middleware,
-// AgentSpanData under a tool-typed ancestor -> subagent. Walks the LangSmith
-// parent chain (rather than checking only the immediate parent) to tolerate
-// the intermediate chain run that openai-agents inserts when Runner.run is
-// invoked from asTool. User-supplied narrowing tags (middleware, subagent,
-// compaction) are preserved.
-function _resolveOpenAIAgentsLsAgentType(
-  spanData: SpanData,
-  parentRun: RunTree,
-  existingTag: unknown,
-): "middleware" | "subagent" | undefined {
-  if (
-    typeof existingTag === "string" &&
-    NON_ROOT_LS_AGENT_TYPES.has(existingTag)
-  ) {
-    return undefined;
-  }
-  if (spanData.type === "guardrail") return "middleware";
-  if (spanData.type === "agent") {
-    let cursor: RunTree | undefined = parentRun;
-    while (cursor !== undefined) {
-      if (cursor.run_type === "tool") return "subagent";
-      cursor = cursor.parent_run;
-    }
-  }
-  return undefined;
-}
 
 export class OpenAIAgentsTracingProcessor implements TracingProcessor {
   private client: Client;
@@ -795,10 +792,8 @@ export class OpenAIAgentsTracingProcessor implements TracingProcessor {
       return;
     }
 
-    // Structural ls_agent_type stamping: guardrail -> middleware, agent under
-    // a tool-typed ancestor -> subagent. Handoff agents are not tagged (they
-    // take over the conversation rather than being called as tools, so their
-    // agent span has no tool ancestor and the resolver returns undefined).
+    // Handoff agents take over the conversation instead of being called as
+    // tools, so they have no tool ancestor and stay untagged.
     if (!childRun.extra) childRun.extra = {};
     if (!childRun.extra.metadata) childRun.extra.metadata = {};
     const meta = childRun.extra.metadata as Record<string, unknown>;

--- a/js/src/wrappers/openai_agents.ts
+++ b/js/src/wrappers/openai_agents.ts
@@ -495,7 +495,7 @@ function _resolveOpenAIAgentsLsAgentType(
   parentRun: RunTree,
   existingTag: unknown,
 ): "middleware" | "subagent" | undefined {
-  // A user-supplied narrowing tag wins over structural detection.
+  // If the user already set a more specific type, keep it.
   if (
     typeof existingTag === "string" &&
     NON_ROOT_LS_AGENT_TYPES.has(existingTag)
@@ -503,8 +503,8 @@ function _resolveOpenAIAgentsLsAgentType(
     return undefined;
   }
   if (spanData.type === "guardrail") return "middleware";
-  // Walk the ancestor chain, not just the immediate parent: asTool()
-  // inserts a chain run between the tool and the agent it wraps.
+  // Look at every run above this one, not just the direct parent: when an
+  // agent runs as a tool, an extra run sits between the two.
   if (spanData.type === "agent") {
     let cursor: RunTree | undefined = parentRun;
     while (cursor !== undefined) {
@@ -792,8 +792,8 @@ export class OpenAIAgentsTracingProcessor implements TracingProcessor {
       return;
     }
 
-    // Handoff agents take over the conversation instead of being called as
-    // tools, so they have no tool ancestor and stay untagged.
+    // Agents reached by a handoff take over the conversation rather than run
+    // as a tool, so they are left untagged.
     if (!childRun.extra) childRun.extra = {};
     if (!childRun.extra.metadata) childRun.extra.metadata = {};
     const meta = childRun.extra.metadata as Record<string, unknown>;

--- a/js/src/wrappers/openai_agents.ts
+++ b/js/src/wrappers/openai_agents.ts
@@ -496,9 +496,7 @@ function createResponsesUsageMetadata(
  * If the run already has middleware/subagent/compaction, keep it. Otherwise
  * guardrails become middleware and agents under any tool become subagents.
  *
- * Openai-agents structural counterpart to resolveVercelLsAgentType. Added
- * to fix guardrails inheriting root and to catch subagents past the
- * intermediate chain run that as_tool insertion produces.
+ * Openai-agents structural counterpart to resolveVercelLsAgentType.
  */
 function _resolveOpenAIAgentsLsAgentType(
   spanData: SpanData,

--- a/js/src/wrappers/openai_agents.ts
+++ b/js/src/wrappers/openai_agents.ts
@@ -491,19 +491,16 @@ function createResponsesUsageMetadata(
 }
 
 /**
- * Pick an ls_agent_type for a span, or undefined to leave it as is.
+ * Return an ls_agent_type for the span, or undefined to leave it alone.
  *
- * A more specific type already on the run wins; then guardrails are
- * middleware; then an agent running under any tool is a subagent. The tool can
- * be one the SDK created or one the user wrapped themselves.
+ * If the run already has middleware/subagent/compaction, keep it. Otherwise
+ * guardrails become middleware and agents under any tool become subagents.
  */
 function _resolveOpenAIAgentsLsAgentType(
   spanData: SpanData,
   parentRun: RunTree,
   existingTag: unknown,
 ): "middleware" | "subagent" | undefined {
-  // Keep a more specific type if one is already set. An inherited "root" is
-  // not kept, so it can be replaced below.
   if (
     typeof existingTag === "string" &&
     NON_ROOT_LS_AGENT_TYPES.has(existingTag)
@@ -511,8 +508,8 @@ function _resolveOpenAIAgentsLsAgentType(
     return undefined;
   }
   if (spanData.type === "guardrail") return "middleware";
-  // Look at every run above this one, not just the direct parent: when an
-  // agent runs as a tool, an extra run sits between the two.
+  // Walk the full parent chain, not just the direct parent: asTool inserts
+  // a chain run between the tool and the inner agent span.
   if (spanData.type === "agent") {
     let cursor: RunTree | undefined = parentRun;
     while (cursor !== undefined) {
@@ -800,8 +797,8 @@ export class OpenAIAgentsTracingProcessor implements TracingProcessor {
       return;
     }
 
-    // An agent reached by a handoff stays in whatever conversation it was
-    // handed off within: untagged at the top level, subagent inside a tool.
+    // Handoffs replace the caller rather than run as a tool, so a handoff
+    // agent has no tool ancestor and correctly stays untagged here.
     if (!childRun.extra) childRun.extra = {};
     if (!childRun.extra.metadata) childRun.extra.metadata = {};
     const meta = childRun.extra.metadata as Record<string, unknown>;

--- a/js/src/wrappers/openai_agents.ts
+++ b/js/src/wrappers/openai_agents.ts
@@ -490,12 +490,20 @@ function createResponsesUsageMetadata(
   return result;
 }
 
+/**
+ * Pick an ls_agent_type for a span, or undefined to leave it as is.
+ *
+ * A more specific type already on the run wins; then guardrails are
+ * middleware; then an agent running under any tool is a subagent. The tool can
+ * be one the SDK created or one the user wrapped themselves.
+ */
 function _resolveOpenAIAgentsLsAgentType(
   spanData: SpanData,
   parentRun: RunTree,
   existingTag: unknown,
 ): "middleware" | "subagent" | undefined {
-  // If the user already set a more specific type, keep it.
+  // Keep a more specific type if one is already set. An inherited "root" is
+  // not kept, so it can be replaced below.
   if (
     typeof existingTag === "string" &&
     NON_ROOT_LS_AGENT_TYPES.has(existingTag)
@@ -792,8 +800,8 @@ export class OpenAIAgentsTracingProcessor implements TracingProcessor {
       return;
     }
 
-    // Agents reached by a handoff take over the conversation rather than run
-    // as a tool, so they are left untagged.
+    // An agent reached by a handoff stays in whatever conversation it was
+    // handed off within: untagged at the top level, subagent inside a tool.
     if (!childRun.extra) childRun.extra = {};
     if (!childRun.extra.metadata) childRun.extra.metadata = {};
     const meta = childRun.extra.metadata as Record<string, unknown>;

--- a/js/src/wrappers/openai_agents.ts
+++ b/js/src/wrappers/openai_agents.ts
@@ -534,6 +534,35 @@ function createResponsesUsageMetadata(
  * console.log(result.finalOutput);
  * ```
  */
+
+// Structural ls_agent_type resolver: GuardrailSpanData -> middleware,
+// AgentSpanData under a tool-typed ancestor -> subagent. Walks the LangSmith
+// parent chain (rather than checking only the immediate parent) to tolerate
+// the intermediate chain run that openai-agents inserts when Runner.run is
+// invoked from asTool. User-supplied narrowing tags (middleware, subagent,
+// compaction) are preserved.
+function _resolveOpenAIAgentsLsAgentType(
+  spanData: SpanData,
+  parentRun: RunTree,
+  existingTag: unknown,
+): "middleware" | "subagent" | undefined {
+  if (
+    typeof existingTag === "string" &&
+    NON_ROOT_LS_AGENT_TYPES.has(existingTag)
+  ) {
+    return undefined;
+  }
+  if (spanData.type === "guardrail") return "middleware";
+  if (spanData.type === "agent") {
+    let cursor: RunTree | undefined = parentRun;
+    while (cursor !== undefined) {
+      if (cursor.run_type === "tool") return "subagent";
+      cursor = cursor.parent_run;
+    }
+  }
+  return undefined;
+}
+
 export class OpenAIAgentsTracingProcessor implements TracingProcessor {
   private client: Client;
   private _metadata?: Record<string, unknown>;
@@ -545,7 +574,6 @@ export class OpenAIAgentsTracingProcessor implements TracingProcessor {
   private _lastResponseOutputs: Record<string, Record<string, unknown>> = {};
 
   private _runs: Map<string, RunTree> = new Map();
-  private _spanDataTypes: Map<string, string> = new Map();
   private _unpostedTraces: Set<string> = new Set();
   private _unpostedSpans: Set<string> = new Set();
   // Previous AsyncLocalStorage store for each trace/span, so nested
@@ -767,29 +795,22 @@ export class OpenAIAgentsTracingProcessor implements TracingProcessor {
       return;
     }
 
-    // Add ls_agent_type metadata for agent spans that are children of
-    // function spans (i.e., agents used as tools).
-    // Handoff agents are not considered subagents.
-    if (spanData.type === "agent") {
-      const parentSpanType = parentId
-        ? this._spanDataTypes.get(parentId)
-        : undefined;
-      if (parentSpanType === "function") {
-        if (!childRun.extra) {
-          childRun.extra = {};
-        }
-        if (!childRun.extra.metadata) {
-          childRun.extra.metadata = {};
-        }
-        const meta = childRun.extra.metadata as Record<string, unknown>;
-        if (!NON_ROOT_LS_AGENT_TYPES.has(meta.ls_agent_type as string)) {
-          meta.ls_agent_type = "subagent";
-        }
-      }
+    // Structural ls_agent_type stamping: guardrail -> middleware, agent under
+    // a tool-typed ancestor -> subagent. Handoff agents are not tagged (they
+    // take over the conversation rather than being called as tools, so their
+    // agent span has no tool ancestor and the resolver returns undefined).
+    if (!childRun.extra) childRun.extra = {};
+    if (!childRun.extra.metadata) childRun.extra.metadata = {};
+    const meta = childRun.extra.metadata as Record<string, unknown>;
+    const structuralTag = _resolveOpenAIAgentsLsAgentType(
+      spanData,
+      parentRun,
+      meta.ls_agent_type,
+    );
+    if (structuralTag !== undefined) {
+      meta.ls_agent_type = structuralTag;
     }
 
-    // Track span data type for parent lookups
-    this._spanDataTypes.set(span.spanId, spanData.type);
     this._runs.set(span.spanId, childRun);
 
     // Enter AsyncLocalStorage context synchronously so nested traceable()
@@ -829,8 +850,6 @@ export class OpenAIAgentsTracingProcessor implements TracingProcessor {
     }
 
     const run = this._runs.get(span.spanId);
-    this._spanDataTypes.delete(span.spanId);
-
     if (!run) {
       return;
     }

--- a/python/langsmith/integrations/openai_agents_sdk/_openai_agents.py
+++ b/python/langsmith/integrations/openai_agents_sdk/_openai_agents.py
@@ -109,6 +109,9 @@ if HAVE_AGENTS:
         If the run already has middleware/subagent/compaction, keep it.
         Otherwise guardrails become middleware and agents under any tool
         become subagents.
+
+        Added to fix guardrails inheriting root and to catch subagents past
+        the intermediate chain run that ``as_tool`` insertion produces.
         """
         if existing_tag in NON_ROOT_LS_AGENT_TYPES:
             return None

--- a/python/langsmith/integrations/openai_agents_sdk/_openai_agents.py
+++ b/python/langsmith/integrations/openai_agents_sdk/_openai_agents.py
@@ -99,6 +99,28 @@ logger = logging.getLogger(__name__)
 
 if HAVE_AGENTS:
 
+    def _resolve_openai_agents_ls_agent_type(
+        span: "tracing.Span",
+        parent_run: "rt.RunTree",
+        existing_tag: Optional[str],
+    ) -> Optional[str]:
+        # User-supplied narrowing tag wins over structural detection.
+        if existing_tag in NON_ROOT_LS_AGENT_TYPES:
+            return None
+        if isinstance(span.span_data, tracing.GuardrailSpanData):
+            return "middleware"
+        # Agent-as-tool: any tool-typed ancestor in the LangSmith run tree marks
+        # this as a subagent. Walking the chain (rather than checking only the
+        # immediate parent) tolerates the intermediate chain run that
+        # openai-agents inserts when Runner.run is invoked from as_tool.
+        if isinstance(span.span_data, tracing.AgentSpanData):
+            cursor: Optional[rt.RunTree] = parent_run
+            while cursor is not None:
+                if cursor.run_type == "tool":
+                    return "subagent"
+                cursor = cursor.parent_run
+        return None
+
     class OpenAIAgentsTracingProcessor(tracing.TracingProcessor):  # type: ignore[no-redef]
         """Tracing processor for the [OpenAI Agents SDK](https://openai.github.io/openai-agents-python/).
 
@@ -174,9 +196,6 @@ if HAVE_AGENTS:
             self._last_response_outputs: dict = {}
 
             self._runs: dict[str, rt.RunTree] = {}
-            self._span_data_types: dict[
-                str, type
-            ] = {}  # Track span data types by span_id
             self._unposted_traces: set[str] = set()
             self._unposted_spans: set[str] = set()
 
@@ -321,25 +340,17 @@ if HAVE_AGENTS:
                     else None,
                 )
 
-                # Add ls_agent_type metadata for agent spans that are children of
-                # function spans (i.e., agents used as tools via as_tool()).
-                # Note: Handoff agents are considered root agents, not subagents,
-                # since they take over the conversation rather than being called
-                # as tools.
-                if isinstance(span.span_data, tracing.AgentSpanData):
-                    # Check if parent span is a function span (agent used as tool)
-                    parent_span_data_type = (
-                        self._span_data_types.get(span.parent_id)
-                        if span.parent_id
-                        else None
-                    )
-                    if parent_span_data_type is tracing.FunctionSpanData:
-                        metadata = child_run.extra.setdefault("metadata", {})
-                        if metadata.get("ls_agent_type") not in NON_ROOT_LS_AGENT_TYPES:
-                            metadata["ls_agent_type"] = "subagent"
-
-                # Track span data type for parent lookups
-                self._span_data_types[span.span_id] = type(span.span_data)
+                # Structural ls_agent_type stamping: GuardrailSpanData -> middleware,
+                # AgentSpanData under a tool-typed ancestor -> subagent. Handoff
+                # agents are not tagged (they take over the conversation rather
+                # than being called as tools, so their AgentSpanData has no
+                # tool ancestor and the resolver returns None).
+                metadata = child_run.extra.setdefault("metadata", {})
+                structural_tag = _resolve_openai_agents_ls_agent_type(
+                    span, parent_run, metadata.get("ls_agent_type")
+                )
+                if structural_tag is not None:
+                    metadata["ls_agent_type"] = structural_tag
 
                 # Delay posting for spans whose inputs aren't available at start
                 if isinstance(
@@ -359,9 +370,6 @@ if HAVE_AGENTS:
 
         def on_span_end(self, span: tracing.Span) -> None:
             run = self._runs.pop(span.span_id, None)
-            self._span_data_types.pop(
-                span.span_id, None
-            )  # Clean up span data type tracking
             if not run:
                 return
 

--- a/python/langsmith/integrations/openai_agents_sdk/_openai_agents.py
+++ b/python/langsmith/integrations/openai_agents_sdk/_openai_agents.py
@@ -104,13 +104,13 @@ if HAVE_AGENTS:
         parent_run: "rt.RunTree",
         existing_tag: Optional[str],
     ) -> Optional[str]:
-        # A user-supplied narrowing tag wins over structural detection.
+        # If the user already set a more specific type, keep it.
         if existing_tag in NON_ROOT_LS_AGENT_TYPES:
             return None
         if isinstance(span.span_data, tracing.GuardrailSpanData):
             return "middleware"
-        # Walk the ancestor chain, not just the immediate parent: as_tool()
-        # inserts a chain run between the tool and the agent it wraps.
+        # Look at every run above this one, not just the direct parent: when
+        # an agent runs as a tool, an extra run sits between the two.
         if isinstance(span.span_data, tracing.AgentSpanData):
             cursor: Optional[rt.RunTree] = parent_run
             while cursor is not None:
@@ -338,8 +338,8 @@ if HAVE_AGENTS:
                     else None,
                 )
 
-                # Handoff agents take over the conversation instead of being
-                # called as tools, so they have no tool ancestor and stay untagged.
+                # Agents reached by a handoff take over the conversation rather
+                # than run as a tool, so they are left untagged.
                 metadata = child_run.extra.setdefault("metadata", {})
                 structural_tag = _resolve_openai_agents_ls_agent_type(
                     span, parent_run, metadata.get("ls_agent_type")

--- a/python/langsmith/integrations/openai_agents_sdk/_openai_agents.py
+++ b/python/langsmith/integrations/openai_agents_sdk/_openai_agents.py
@@ -104,15 +104,13 @@ if HAVE_AGENTS:
         parent_run: "rt.RunTree",
         existing_tag: Optional[str],
     ) -> Optional[str]:
-        # User-supplied narrowing tag wins over structural detection.
+        # A user-supplied narrowing tag wins over structural detection.
         if existing_tag in NON_ROOT_LS_AGENT_TYPES:
             return None
         if isinstance(span.span_data, tracing.GuardrailSpanData):
             return "middleware"
-        # Agent-as-tool: any tool-typed ancestor in the LangSmith run tree marks
-        # this as a subagent. Walking the chain (rather than checking only the
-        # immediate parent) tolerates the intermediate chain run that
-        # openai-agents inserts when Runner.run is invoked from as_tool.
+        # Walk the ancestor chain, not just the immediate parent: as_tool()
+        # inserts a chain run between the tool and the agent it wraps.
         if isinstance(span.span_data, tracing.AgentSpanData):
             cursor: Optional[rt.RunTree] = parent_run
             while cursor is not None:
@@ -340,11 +338,8 @@ if HAVE_AGENTS:
                     else None,
                 )
 
-                # Structural ls_agent_type stamping: GuardrailSpanData -> middleware,
-                # AgentSpanData under a tool-typed ancestor -> subagent. Handoff
-                # agents are not tagged (they take over the conversation rather
-                # than being called as tools, so their AgentSpanData has no
-                # tool ancestor and the resolver returns None).
+                # Handoff agents take over the conversation instead of being
+                # called as tools, so they have no tool ancestor and stay untagged.
                 metadata = child_run.extra.setdefault("metadata", {})
                 structural_tag = _resolve_openai_agents_ls_agent_type(
                     span, parent_run, metadata.get("ls_agent_type")

--- a/python/langsmith/integrations/openai_agents_sdk/_openai_agents.py
+++ b/python/langsmith/integrations/openai_agents_sdk/_openai_agents.py
@@ -104,20 +104,18 @@ if HAVE_AGENTS:
         parent_run: "rt.RunTree",
         existing_tag: Optional[str],
     ) -> Optional[str]:
-        """Pick an ls_agent_type for a span, or None to leave it as is.
+        """Return an ls_agent_type for the span, or None to leave it alone.
 
-        A more specific type already on the run wins; then guardrails are
-        middleware; then an agent running under any tool is a subagent. The
-        tool can be one the SDK created or one the user wrapped themselves.
+        If the run already has middleware/subagent/compaction, keep it.
+        Otherwise guardrails become middleware and agents under any tool
+        become subagents.
         """
-        # Keep a more specific type if one is already set. An inherited "root"
-        # is not kept, so it can be replaced below.
         if existing_tag in NON_ROOT_LS_AGENT_TYPES:
             return None
         if isinstance(span.span_data, tracing.GuardrailSpanData):
             return "middleware"
-        # Look at every run above this one, not just the direct parent: when
-        # an agent runs as a tool, an extra run sits between the two.
+        # Walk the full parent chain, not just the direct parent: as_tool
+        # inserts a chain run between the tool and the inner agent span.
         if isinstance(span.span_data, tracing.AgentSpanData):
             cursor: Optional[rt.RunTree] = parent_run
             while cursor is not None:
@@ -345,9 +343,9 @@ if HAVE_AGENTS:
                     else None,
                 )
 
-                # An agent reached by a handoff stays in whatever conversation
-                # it was handed off within: untagged at the top level, subagent
-                # if it is running inside a tool.
+                # Handoffs replace the caller rather than run as a tool, so
+                # a handoff agent has no tool ancestor and correctly stays
+                # untagged here.
                 metadata = child_run.extra.setdefault("metadata", {})
                 structural_tag = _resolve_openai_agents_ls_agent_type(
                     span, parent_run, metadata.get("ls_agent_type")

--- a/python/langsmith/integrations/openai_agents_sdk/_openai_agents.py
+++ b/python/langsmith/integrations/openai_agents_sdk/_openai_agents.py
@@ -110,8 +110,7 @@ if HAVE_AGENTS:
         Otherwise guardrails become middleware and agents under any tool
         become subagents.
 
-        Added to fix guardrails inheriting root and to catch subagents past
-        the intermediate chain run that ``as_tool`` insertion produces.
+        Openai-agents structural counterpart to ``resolveVercelLsAgentType``.
         """
         if existing_tag in NON_ROOT_LS_AGENT_TYPES:
             return None

--- a/python/langsmith/integrations/openai_agents_sdk/_openai_agents.py
+++ b/python/langsmith/integrations/openai_agents_sdk/_openai_agents.py
@@ -104,7 +104,14 @@ if HAVE_AGENTS:
         parent_run: "rt.RunTree",
         existing_tag: Optional[str],
     ) -> Optional[str]:
-        # If the user already set a more specific type, keep it.
+        """Pick an ls_agent_type for a span, or None to leave it as is.
+
+        A more specific type already on the run wins; then guardrails are
+        middleware; then an agent running under any tool is a subagent. The
+        tool can be one the SDK created or one the user wrapped themselves.
+        """
+        # Keep a more specific type if one is already set. An inherited "root"
+        # is not kept, so it can be replaced below.
         if existing_tag in NON_ROOT_LS_AGENT_TYPES:
             return None
         if isinstance(span.span_data, tracing.GuardrailSpanData):
@@ -338,8 +345,9 @@ if HAVE_AGENTS:
                     else None,
                 )
 
-                # Agents reached by a handoff take over the conversation rather
-                # than run as a tool, so they are left untagged.
+                # An agent reached by a handoff stays in whatever conversation
+                # it was handed off within: untagged at the top level, subagent
+                # if it is running inside a tool.
                 metadata = child_run.extra.setdefault("metadata", {})
                 structural_tag = _resolve_openai_agents_ls_agent_type(
                     span, parent_run, metadata.get("ls_agent_type")

--- a/python/tests/unit_tests/wrappers/test_openai_agents_processor.py
+++ b/python/tests/unit_tests/wrappers/test_openai_agents_processor.py
@@ -179,7 +179,7 @@ def test_subagent_stamps_when_agent_parent_is_tool():
     assert _run_span_stamp(_agent_span_data(), tool_run) == "subagent"
 
 
-def test_subagent_stamps_when_tool_is_ancestor_via_intermediate_chain():
+def test_subagent_stamps_when_the_tool_is_further_above():
     # When an agent runs as a tool, an extra run sits between the tool and
     # the agent.
     tool_run = _make_run("tool")
@@ -187,11 +187,17 @@ def test_subagent_stamps_when_tool_is_ancestor_via_intermediate_chain():
     assert _run_span_stamp(_agent_span_data(), chain_run) == "subagent"
 
 
-def test_agent_without_tool_ancestor_is_not_tagged():
-    # Agents reached by a handoff have no tool above them, so they are left
-    # untagged.
+def test_agent_with_no_tool_above_it_is_not_tagged():
     root_chain = _make_run("chain")
     assert _run_span_stamp(_agent_span_data(), root_chain) is None
+
+
+def test_handoff_agent_inside_a_tool_is_tagged_subagent():
+    # A handoff opens a new agent run beside the one it replaced, so an agent
+    # handed off to inside a tool still has that tool above it.
+    tool_run = _make_run("tool")
+    chain_run = _make_run("chain", parent_run=tool_run)
+    assert _run_span_stamp(_agent_span_data(), chain_run) == "subagent"
 
 
 def test_subagent_overrides_inherited_root():
@@ -200,12 +206,11 @@ def test_subagent_overrides_inherited_root():
     assert tag == "subagent"
 
 
-@pytest.mark.parametrize("narrowing_tag", ["middleware", "compaction", "subagent"])
-def test_subagent_preserves_user_narrowing_tag(narrowing_tag):
+@pytest.mark.parametrize("user_tag", ["middleware", "compaction", "subagent"])
+def test_subagent_keeps_user_supplied_tag(user_tag):
     tool_run = _make_run("tool")
     assert (
-        _run_span_stamp(_agent_span_data(), tool_run, existing_tag=narrowing_tag)
-        == narrowing_tag
+        _run_span_stamp(_agent_span_data(), tool_run, existing_tag=user_tag) == user_tag
     )
 
 
@@ -225,10 +230,10 @@ def test_guardrail_overrides_inherited_root():
     )
 
 
-@pytest.mark.parametrize("narrowing_tag", ["middleware", "subagent", "compaction"])
-def test_guardrail_preserves_user_narrowing_tag(narrowing_tag):
+@pytest.mark.parametrize("user_tag", ["middleware", "subagent", "compaction"])
+def test_guardrail_keeps_user_supplied_tag(user_tag):
     root_chain = _make_run("chain")
     assert (
-        _run_span_stamp(_guardrail_span_data(), root_chain, existing_tag=narrowing_tag)
-        == narrowing_tag
+        _run_span_stamp(_guardrail_span_data(), root_chain, existing_tag=user_tag)
+        == user_tag
     )

--- a/python/tests/unit_tests/wrappers/test_openai_agents_processor.py
+++ b/python/tests/unit_tests/wrappers/test_openai_agents_processor.py
@@ -180,17 +180,16 @@ def test_subagent_stamps_when_agent_parent_is_tool():
 
 
 def test_subagent_stamps_when_tool_is_ancestor_via_intermediate_chain():
-    # openai-agents wraps Runner.run's nested trace in a chain run between the
-    # as_tool function span and the inner AgentSpanData. Ancestry walk must
-    # still detect the tool ancestor.
+    # as_tool topology: the agent's immediate parent is the nested trace's
+    # chain run, not the tool itself.
     tool_run = _make_run("tool")
     chain_run = _make_run("chain", parent_run=tool_run)
     assert _run_span_stamp(_agent_span_data(), chain_run) == "subagent"
 
 
 def test_agent_without_tool_ancestor_is_not_tagged():
-    # Handoff agents live directly under the trace root chain; no tool ancestor
-    # means no structural tag (they inherit root via createChild propagation).
+    # Handoff agents sit under the trace root chain, so there is no tool
+    # ancestor and no structural tag.
     root_chain = _make_run("chain")
     assert _run_span_stamp(_agent_span_data(), root_chain) is None
 
@@ -214,7 +213,6 @@ def test_subagent_preserves_user_narrowing_tag(narrowing_tag):
 
 
 def test_guardrail_stamps_middleware():
-    # Outer trace root is a chain; the guardrail span is stamped directly.
     root_chain = _make_run("chain")
     assert _run_span_stamp(_guardrail_span_data(), root_chain) == "middleware"
 

--- a/python/tests/unit_tests/wrappers/test_openai_agents_processor.py
+++ b/python/tests/unit_tests/wrappers/test_openai_agents_processor.py
@@ -120,20 +120,24 @@ def test_trace_metadata_wins_over_processor_metadata():
 
 
 # ---------------------------------------------------------------------------
-# Subagent structural detection (agent-as-tool)
+# Structural ls_agent_type detection (on_span_start)
 # ---------------------------------------------------------------------------
 
 
-def _run_subagent_stamp(existing_tag):
+def _make_run(run_type, parent_run=None):
+    run = mock.MagicMock()
+    run.run_type = run_type
+    run.parent_run = parent_run
+    return run
+
+
+def _run_span_stamp(span_data, parent_run, existing_tag=None):
+    """Fire on_span_start against a hand-built parent run and return the tag."""
     client = mock.MagicMock(spec=Client)
     processor = OpenAIAgentsTracingProcessor(client=client)
 
-    parent_span_id = "parent-fn"
-    child_span_id = "child-agent"
-    processor._span_data_types[parent_span_id] = tracing.FunctionSpanData
-
-    parent_run = mock.MagicMock()
-    parent_run.id = "parent-run"
+    parent_span_id = "parent-span"
+    child_span_id = "child-span"
     processor._runs[parent_span_id] = parent_run
 
     child_run = mock.MagicMock()
@@ -146,28 +150,87 @@ def _run_subagent_stamp(existing_tag):
         parent_id=parent_span_id,
         trace_id="trace-1",
         started_at=None,
-        span_data=mock.MagicMock(spec=tracing.AgentSpanData),
+        span_data=span_data,
     )
-    child_span.span_data.export = mock.MagicMock(return_value={})
-    child_span.span_data.name = "Some Subagent"
 
     processor.on_span_start(child_span)
     return child_run.extra["metadata"].get("ls_agent_type")
 
 
-def test_subagent_stamps_when_child_untagged():
-    assert _run_subagent_stamp(None) == "subagent"
+def _agent_span_data():
+    span_data = mock.MagicMock(spec=tracing.AgentSpanData)
+    span_data.export = mock.MagicMock(return_value={})
+    span_data.name = "Some Agent"
+    return span_data
+
+
+def _guardrail_span_data():
+    span_data = mock.MagicMock(spec=tracing.GuardrailSpanData)
+    span_data.export = mock.MagicMock(return_value={})
+    span_data.name = "entry_guardrail"
+    return span_data
+
+
+# ---- Subagent (agent-as-tool) ----
+
+
+def test_subagent_stamps_when_agent_parent_is_tool():
+    tool_run = _make_run("tool")
+    assert _run_span_stamp(_agent_span_data(), tool_run) == "subagent"
+
+
+def test_subagent_stamps_when_tool_is_ancestor_via_intermediate_chain():
+    # openai-agents wraps Runner.run's nested trace in a chain run between the
+    # as_tool function span and the inner AgentSpanData. Ancestry walk must
+    # still detect the tool ancestor.
+    tool_run = _make_run("tool")
+    chain_run = _make_run("chain", parent_run=tool_run)
+    assert _run_span_stamp(_agent_span_data(), chain_run) == "subagent"
+
+
+def test_agent_without_tool_ancestor_is_not_tagged():
+    # Handoff agents live directly under the trace root chain; no tool ancestor
+    # means no structural tag (they inherit root via createChild propagation).
+    root_chain = _make_run("chain")
+    assert _run_span_stamp(_agent_span_data(), root_chain) is None
 
 
 def test_subagent_overrides_inherited_root():
-    # Structural detection overrides propagated root at agent-as-tool spans.
-    assert _run_subagent_stamp("root") == "subagent"
+    tool_run = _make_run("tool")
+    tag = _run_span_stamp(_agent_span_data(), tool_run, existing_tag="root")
+    assert tag == "subagent"
 
 
-@pytest.mark.parametrize("narrowing_tag", ["middleware", "compaction"])
+@pytest.mark.parametrize("narrowing_tag", ["middleware", "compaction", "subagent"])
 def test_subagent_preserves_user_narrowing_tag(narrowing_tag):
-    assert _run_subagent_stamp(narrowing_tag) == narrowing_tag
+    tool_run = _make_run("tool")
+    assert (
+        _run_span_stamp(_agent_span_data(), tool_run, existing_tag=narrowing_tag)
+        == narrowing_tag
+    )
 
 
-def test_subagent_preserves_existing_subagent_tag():
-    assert _run_subagent_stamp("subagent") == "subagent"
+# ---- Guardrail (structural middleware) ----
+
+
+def test_guardrail_stamps_middleware():
+    # Outer trace root is a chain; the guardrail span is stamped directly.
+    root_chain = _make_run("chain")
+    assert _run_span_stamp(_guardrail_span_data(), root_chain) == "middleware"
+
+
+def test_guardrail_overrides_inherited_root():
+    root_chain = _make_run("chain")
+    assert (
+        _run_span_stamp(_guardrail_span_data(), root_chain, existing_tag="root")
+        == "middleware"
+    )
+
+
+@pytest.mark.parametrize("narrowing_tag", ["middleware", "subagent", "compaction"])
+def test_guardrail_preserves_user_narrowing_tag(narrowing_tag):
+    root_chain = _make_run("chain")
+    assert (
+        _run_span_stamp(_guardrail_span_data(), root_chain, existing_tag=narrowing_tag)
+        == narrowing_tag
+    )

--- a/python/tests/unit_tests/wrappers/test_openai_agents_processor.py
+++ b/python/tests/unit_tests/wrappers/test_openai_agents_processor.py
@@ -120,7 +120,7 @@ def test_trace_metadata_wins_over_processor_metadata():
 
 
 # ---------------------------------------------------------------------------
-# Structural ls_agent_type detection (on_span_start)
+# ls_agent_type detection (on_span_start)
 # ---------------------------------------------------------------------------
 
 
@@ -171,7 +171,7 @@ def _guardrail_span_data():
     return span_data
 
 
-# ---- Subagent (agent-as-tool) ----
+# ---- Subagent (agent run as a tool) ----
 
 
 def test_subagent_stamps_when_agent_parent_is_tool():
@@ -180,16 +180,16 @@ def test_subagent_stamps_when_agent_parent_is_tool():
 
 
 def test_subagent_stamps_when_tool_is_ancestor_via_intermediate_chain():
-    # as_tool topology: the agent's immediate parent is the nested trace's
-    # chain run, not the tool itself.
+    # When an agent runs as a tool, an extra run sits between the tool and
+    # the agent.
     tool_run = _make_run("tool")
     chain_run = _make_run("chain", parent_run=tool_run)
     assert _run_span_stamp(_agent_span_data(), chain_run) == "subagent"
 
 
 def test_agent_without_tool_ancestor_is_not_tagged():
-    # Handoff agents sit under the trace root chain, so there is no tool
-    # ancestor and no structural tag.
+    # Agents reached by a handoff have no tool above them, so they are left
+    # untagged.
     root_chain = _make_run("chain")
     assert _run_span_stamp(_agent_span_data(), root_chain) is None
 
@@ -209,7 +209,7 @@ def test_subagent_preserves_user_narrowing_tag(narrowing_tag):
     )
 
 
-# ---- Guardrail (structural middleware) ----
+# ---- Guardrail ----
 
 
 def test_guardrail_stamps_middleware():


### PR DESCRIPTION
## What

Two structural gaps in `langsmith[openai-agents]` left guardrail and subagent runs tagged `root`, leaking them into the main conversation in the Trajectories view.

- Guardrail spans were never structurally tagged since there was no rule for them, so they inherited `root` from their parent.
- Python subagent detection continued to tag as root since it only looked at the direct parent, and an extra run in between hid the tool parent.

## How

Guardrail spans now get their own rule, and subagent detection walks up the run tree instead of checking only the direct parent. User-set tags still win.

Fixes [LSO-4166](https://linear.app/langchain/issue/LSO-4166).

## Test Plan

- [x] Python: `python/tests/unit_tests/wrappers/test_openai_agents_processor.py` — resolver, guardrail middleware, subagent (immediate + via-intermediate-chain), narrowing-tag preservation, handoff. 22/22 pass.
- [x] JS: `js/src/tests/openai_agents_sdk.test.ts` — mirror coverage. 45/45 pass.

