### PR TITLE
feat(sandbox): accept run_config on sandboxes, snapshots and commands

### DIFF
--- a/js/src/sandbox/README.md
+++ b/js/src/sandbox/README.md
@@ -391,15 +391,52 @@ try {
   const failed = await sandbox.run("exit 1");
   console.log(failed.exit_code);  // 1
 
-  // Pass environment variables and working directory
+  // Pass environment variables and a working directory
   const envResult = await sandbox.run("echo $MY_VAR", {
-    env: { MY_VAR: "test-value" },
-    cwd: "/tmp",
+    runConfig: { env_vars: { MY_VAR: "test-value" }, work_dir: "/tmp" },
   });
 } finally {
   await sandbox.delete();
 }
 ```
+
+## Run Configuration
+
+`runConfig` sets the account commands run as, their working directory, and
+their environment. It mirrors `docker run -u/-w/-e`: `user` and `work_dir`
+replace the value from the layer below, `env_vars` merge over it key by key.
+
+A snapshot built from a Docker image records that image's `USER`, `WORKDIR`
+and `ENV`, and sandboxes created from it run that way. Override it per
+snapshot, per sandbox, per update, or per command:
+
+```typescript
+// Per snapshot: what every sandbox from it boots with
+const snapshot = await client.createSnapshot("python", "python:3.12-slim", 1_073_741_824, {
+  runConfig: { user: "app", work_dir: "/srv" },
+});
+
+// Per sandbox: overrides the snapshot's
+const sandbox = await client.createSandbox(snapshot.id, {
+  runConfig: { user: "root" },
+});
+
+// Per update: applies to subsequent commands
+await client.updateSandbox(sandbox.name, {
+  runConfig: { env_vars: { STAGE: "beta" } },
+});
+
+// Per command
+const result = await sandbox.run("id -un", { runConfig: { user: "app" } });
+```
+
+`user` takes `name`, `uid`, `name:group` or `uid:gid`; `work_dir` must be
+absolute and is created if missing. Snapshot and sandbox responses report the
+`run_config` in effect.
+
+The per-command `cwd` and `env` options are deprecated in favour of
+`runConfig.work_dir` and `runConfig.env_vars`. They still work on their own;
+combining them with `runConfig` throws `LangSmithValidationError`.
 
 ## Streaming Execution (WebSocket)
 
@@ -886,6 +923,7 @@ try {
 | `fsCapacityBytes?` | Root filesystem capacity in bytes |
 | `mountConfig?` | High-level mount config from `mountConfig({ mounts, auth })`; sent as `mount_config` and expanded by the backend at runtime |
 | `proxyConfig?` | Per-sandbox proxy configuration (access control, rules, `no_proxy`) |
+| `runConfig?` | Overrides the snapshot's run config: `user` and `work_dir` replace, `env_vars` merge |
 
 ### ListSnapshotsOptions
 

--- a/js/src/sandbox/client.ts
+++ b/js/src/sandbox/client.ts
@@ -37,6 +37,7 @@ import {
   handleClientHttpError,
   handleSandboxCreationError,
   throwIfNotReady,
+  validateRunConfig,
   validateTtl,
 } from "./helpers.js";
 import { validateMountConfigProxyConfig } from "./mounts.js";
@@ -564,6 +565,7 @@ export class SandboxClient {
       fsCapacityBytes,
       mountConfig,
       proxyConfig,
+      runConfig,
     } = resolvedOptions;
 
     if (snapshotId && snapshotName) {
@@ -574,6 +576,7 @@ export class SandboxClient {
     }
     validateTtl(idleTtlSeconds, "idleTtlSeconds");
     validateTtl(deleteAfterStopSeconds, "deleteAfterStopSeconds");
+    validateRunConfig(runConfig);
 
     const url = `${this._baseUrl}/boxes`;
 
@@ -613,6 +616,9 @@ export class SandboxClient {
     }
     if (proxyConfig !== undefined) {
       payload.proxy_config = proxyConfig;
+    }
+    if (runConfig !== undefined) {
+      payload.run_config = runConfig;
     }
 
     const httpTimeout = waitForReady ? (timeout + 30) * 1000 : 30 * 1000;
@@ -721,16 +727,23 @@ export class SandboxClient {
         ? { newName: newNameOrOptions }
         : newNameOrOptions;
 
-    const { newName, idleTtlSeconds, deleteAfterStopSeconds, proxyConfig } =
-      options;
+    const {
+      newName,
+      idleTtlSeconds,
+      deleteAfterStopSeconds,
+      proxyConfig,
+      runConfig,
+    } = options;
     validateTtl(idleTtlSeconds, "idleTtlSeconds");
     validateTtl(deleteAfterStopSeconds, "deleteAfterStopSeconds");
+    validateRunConfig(runConfig);
 
     if (
       newName === undefined &&
       idleTtlSeconds === undefined &&
       deleteAfterStopSeconds === undefined &&
-      proxyConfig === undefined
+      proxyConfig === undefined &&
+      runConfig === undefined
     ) {
       return this.getSandbox(name);
     }
@@ -748,6 +761,9 @@ export class SandboxClient {
     }
     if (proxyConfig !== undefined) {
       payload.proxy_config = proxyConfig;
+    }
+    if (runConfig !== undefined) {
+      payload.run_config = runConfig;
     }
 
     const response = await this._fetch(url, {
@@ -998,7 +1014,8 @@ export class SandboxClient {
     fsCapacityBytes: number,
     options: CreateSnapshotOptions = {},
   ): Promise<Snapshot> {
-    const { registryId, timeout = 60, signal } = options;
+    const { registryId, runConfig, timeout = 60, signal } = options;
+    validateRunConfig(runConfig);
     const url = `${this._baseUrl}/snapshots`;
 
     const payload: Record<string, unknown> = {
@@ -1008,6 +1025,9 @@ export class SandboxClient {
     };
     if (registryId !== undefined) {
       payload.registry_id = registryId;
+    }
+    if (runConfig !== undefined) {
+      payload.run_config = runConfig;
     }
 
     const response = await this._postJson(url, payload, { signal });
@@ -1050,6 +1070,7 @@ export class SandboxClient {
       onBuildLog,
       vCpus,
       memBytes,
+      runConfig,
       timeout = 60,
     } = resolvedOptions;
     const { contextPath, dockerfileRel } = await resolveDockerfileContext(
@@ -1119,6 +1140,7 @@ export class SandboxClient {
       return await this.captureSnapshot(builder.name, name, {
         dockerImage: imageRef,
         fsCapacityBytes,
+        runConfig,
         timeout,
       });
     } finally {
@@ -1141,7 +1163,14 @@ export class SandboxClient {
     name: string,
     options: CaptureSnapshotOptions = {},
   ): Promise<Snapshot> {
-    const { dockerImage, fsCapacityBytes, timeout = 60, signal } = options;
+    const {
+      dockerImage,
+      fsCapacityBytes,
+      runConfig,
+      timeout = 60,
+      signal,
+    } = options;
+    validateRunConfig(runConfig);
     const url = this._boxUrl(sandboxName, "snapshot");
 
     const payload: Record<string, unknown> = { name };
@@ -1150,6 +1179,9 @@ export class SandboxClient {
     }
     if (fsCapacityBytes !== undefined) {
       payload.fs_capacity_bytes = fsCapacityBytes;
+    }
+    if (runConfig !== undefined) {
+      payload.run_config = runConfig;
     }
 
     const response = await this._postJson(url, payload, { signal });

--- a/js/src/sandbox/helpers.ts
+++ b/js/src/sandbox/helpers.ts
@@ -18,6 +18,7 @@ import {
   LangSmithSandboxOperationError,
   LangSmithValidationError,
 } from "./errors.js";
+import type { SandboxRunConfig } from "./types.js";
 
 // =============================================================================
 // Input validation
@@ -46,6 +47,104 @@ export function validateTtl(value: number | undefined, name: string): void {
       name,
     );
   }
+}
+
+const RUN_CONFIG_KEYS = ["user", "work_dir", "env_vars"];
+
+/**
+ * Validate a run config's shape.
+ *
+ * @param runConfig - Run config to check (`undefined` passes).
+ * @param field - Parameter name for error messages.
+ * @throws LangSmithValidationError if a key, `work_dir` or `env_vars` is invalid.
+ */
+export function validateRunConfig(
+  runConfig: SandboxRunConfig | undefined,
+  field = "runConfig",
+): void {
+  if (runConfig === undefined) {
+    return;
+  }
+  if (typeof runConfig !== "object" || Array.isArray(runConfig)) {
+    throw new LangSmithValidationError(`${field} must be an object`, field);
+  }
+  const unknown = Object.keys(runConfig).filter(
+    (key) => !RUN_CONFIG_KEYS.includes(key),
+  );
+  if (unknown.length > 0) {
+    throw new LangSmithValidationError(
+      `${field} has unsupported keys: ${unknown.sort().join(", ")}. ` +
+        `Supported: ${RUN_CONFIG_KEYS.join(", ")}`,
+      field,
+    );
+  }
+  const { user, work_dir: workDir, env_vars: envVars } = runConfig;
+  if (user !== undefined && (typeof user !== "string" || user.trim() === "")) {
+    throw new LangSmithValidationError(
+      `${field}.user must be a non-empty string`,
+      field,
+    );
+  }
+  if (workDir !== undefined) {
+    if (typeof workDir !== "string" || workDir.trim() === "") {
+      throw new LangSmithValidationError(
+        `${field}.work_dir must be a non-empty string`,
+        field,
+      );
+    }
+    if (!workDir.startsWith("/")) {
+      throw new LangSmithValidationError(
+        `${field}.work_dir must be an absolute path`,
+        field,
+      );
+    }
+  }
+  if (envVars !== undefined) {
+    if (typeof envVars !== "object" || Array.isArray(envVars)) {
+      throw new LangSmithValidationError(
+        `${field}.env_vars must be an object`,
+        field,
+      );
+    }
+    for (const [name, value] of Object.entries(envVars)) {
+      if (typeof value !== "string") {
+        throw new LangSmithValidationError(
+          `${field}.env_vars.${name} must be a string`,
+          field,
+        );
+      }
+    }
+  }
+}
+
+/**
+ * Validate a per-command run config against the deprecated `env` and `cwd`.
+ *
+ * The server rejects a request carrying both spellings, so reject it here
+ * with a message that names the replacement.
+ *
+ * @param runConfig - Per-command run config.
+ * @param env - Deprecated per-command environment.
+ * @param cwd - Deprecated per-command working directory.
+ * @throws LangSmithValidationError if combined, or if the run config is invalid.
+ */
+export function validateCommandRunConfig(
+  runConfig: SandboxRunConfig | undefined,
+  env: Record<string, string> | undefined,
+  cwd: string | undefined,
+): void {
+  if (runConfig !== undefined && (env !== undefined || cwd !== undefined)) {
+    const combined = [
+      ...(env !== undefined ? ["env"] : []),
+      ...(cwd !== undefined ? ["cwd"] : []),
+    ].join(" and ");
+    throw new LangSmithValidationError(
+      `runConfig cannot be combined with ${combined}; env is deprecated in ` +
+        "favour of runConfig.env_vars and cwd in favour of runConfig.work_dir",
+      "runConfig",
+    );
+  }
+  validateRunConfig(runConfig);
 }
 
 // =============================================================================

--- a/js/src/sandbox/index.ts
+++ b/js/src/sandbox/index.ts
@@ -69,6 +69,7 @@ export type {
   SandboxMountConfig,
   SandboxProxyConfig,
   SandboxProxyRule,
+  SandboxRunConfig,
   SandboxProxySecret,
   SandboxMount,
   MountCacheConfig,

--- a/js/src/sandbox/sandbox.ts
+++ b/js/src/sandbox/sandbox.ts
@@ -10,6 +10,7 @@ import type {
   GenerateDownloadURLOptions,
   RunOptions,
   SandboxData,
+  SandboxRunConfig,
   Snapshot,
   StartSandboxOptions,
 } from "./types.js";
@@ -19,7 +20,7 @@ import {
   LangSmithSandboxRetryableConnectionError,
   LangSmithStreamEndedBeforeStartedError,
 } from "./errors.js";
-import { handleSandboxHttpError } from "./helpers.js";
+import { handleSandboxHttpError, validateCommandRunConfig } from "./helpers.js";
 import { CommandHandle } from "./command_handle.js";
 import {
   connectDeadline,
@@ -89,6 +90,12 @@ export class Sandbox {
   readonly mem_bytes?: number;
   /** Root filesystem capacity in bytes. */
   readonly fs_capacity_bytes?: number;
+  /**
+   * What commands run with — the snapshot's run config, with any create or
+   * update override merged in. Absent on sandboxes created before run
+   * configs were recorded.
+   */
+  readonly run_config?: SandboxRunConfig;
 
   private _client: SandboxClient;
 
@@ -108,6 +115,7 @@ export class Sandbox {
     this.vCpus = data.vcpus;
     this.mem_bytes = data.mem_bytes;
     this.fs_capacity_bytes = data.fs_capacity_bytes;
+    this.run_config = data.run_config;
     this._client = client;
   }
 
@@ -191,6 +199,11 @@ export class Sandbox {
       ...restOptions
     } = options;
     const hasCallbacks = onStdout !== undefined || onStderr !== undefined;
+    validateCommandRunConfig(
+      restOptions.runConfig,
+      restOptions.env,
+      restOptions.cwd,
+    );
 
     if (!wait || hasCallbacks) {
       // WebSocket required for streaming / non-blocking
@@ -247,6 +260,7 @@ export class Sandbox {
       timeout = 60,
       env,
       cwd,
+      runConfig,
       shell = "/bin/bash",
       onStdout,
       onStderr,
@@ -278,6 +292,7 @@ export class Sandbox {
           timeout,
           env,
           cwd,
+          runConfig,
           shell,
           commandId: execCommandId,
           idleTimeout,
@@ -344,7 +359,7 @@ export class Sandbox {
     command: string,
     options: Omit<RunOptions, "wait" | "onStdout" | "onStderr"> = {},
   ): Promise<ExecutionResult> {
-    const { timeout = 60, env, cwd, shell = "/bin/bash" } = options;
+    const { timeout = 60, env, cwd, runConfig, shell = "/bin/bash" } = options;
     const dataplaneUrl = this.requireDataplaneUrl();
     const url = `${dataplaneUrl}/execute`;
 
@@ -358,6 +373,9 @@ export class Sandbox {
     }
     if (cwd !== undefined) {
       payload.cwd = cwd;
+    }
+    if (runConfig !== undefined) {
+      payload.run_config = runConfig;
     }
 
     const response = await this._client._fetch(url, {

--- a/js/src/sandbox/types.ts
+++ b/js/src/sandbox/types.ts
@@ -29,6 +29,22 @@ export interface ResourceStatus {
  * Snapshots are built from Docker images or captured from running sandboxes.
  * They are used to create new sandboxes.
  */
+/**
+ * What a sandbox's commands run with.
+ *
+ * Mirrors `docker run -u/-w/-e`: `user` and `work_dir` replace the value
+ * inherited from the layer below (the image, then the snapshot, then the
+ * sandbox), while `env_vars` merge over it key by key.
+ */
+export interface SandboxRunConfig {
+  /** Account commands run as: `name`, `uid`, `name:group` or `uid:gid`. */
+  user?: string;
+  /** Absolute working directory. */
+  work_dir?: string;
+  /** Environment variables, merged over the layer below. */
+  env_vars?: Record<string, string>;
+}
+
 export interface Snapshot {
   id: string;
   name: string;
@@ -44,6 +60,12 @@ export interface Snapshot {
   registry_id?: string;
   created_at?: string;
   updated_at?: string;
+  /**
+   * What sandboxes created from this snapshot boot with. Absent on snapshots
+   * built before run configs were recorded: those boot as root with only the
+   * sandbox's own environment.
+   */
+  run_config?: SandboxRunConfig;
 }
 
 /**
@@ -83,6 +105,12 @@ export interface SandboxData {
   mem_bytes?: number;
   /** Root filesystem capacity in bytes. */
   fs_capacity_bytes?: number;
+  /**
+   * What commands run with — the snapshot's run config, with any create or
+   * update override merged in. Absent on sandboxes created before run
+   * configs were recorded.
+   */
+  run_config?: SandboxRunConfig;
 }
 
 /**
@@ -153,10 +181,21 @@ export interface WsRunOptions {
    * run() passes the remainder of its overall connect budget. @internal
    */
   openTimeout?: number;
-  /** Environment variables to set for the command. */
+  /**
+   * Environment variables to set for the command.
+   * @deprecated Use `runConfig.env_vars`.
+   */
   env?: Record<string, string>;
-  /** Working directory for command execution. */
+  /**
+   * Working directory for command execution.
+   * @deprecated Use `runConfig.work_dir`.
+   */
   cwd?: string;
+  /**
+   * What this one command runs with, layered over the sandbox's own run
+   * config. Cannot be combined with the deprecated `env` and `cwd`.
+   */
+  runConfig?: SandboxRunConfig;
   /** Shell to use. Default: "/bin/bash". */
   shell?: string;
   /** Callback invoked with each stdout chunk. */
@@ -200,12 +239,19 @@ export interface RunOptions {
   timeout?: number;
   /**
    * Environment variables to set for the command.
+   * @deprecated Use `runConfig.env_vars`.
    */
   env?: Record<string, string>;
   /**
    * Working directory for command execution.
+   * @deprecated Use `runConfig.work_dir`.
    */
   cwd?: string;
+  /**
+   * What this one command runs with, layered over the sandbox's own run
+   * config. Cannot be combined with the deprecated `env` and `cwd`.
+   */
+  runConfig?: SandboxRunConfig;
   /**
    * Shell to use for command execution. Defaults to "/bin/bash".
    */
@@ -552,6 +598,12 @@ export interface CreateSandboxOptions {
    * auth.
    */
   proxyConfig?: SandboxProxyConfig;
+  /**
+   * Overrides the snapshot's run config: `user` and `work_dir` replace the
+   * snapshot's, `env_vars` merge over them. The result is stored on the
+   * sandbox and is what it boots with.
+   */
+  runConfig?: SandboxRunConfig;
 }
 
 /**
@@ -560,6 +612,12 @@ export interface CreateSandboxOptions {
 export interface CreateSnapshotOptions {
   /** Private registry ID. */
   registryId?: string;
+  /**
+   * Overrides the image's own `USER`, `WORKDIR` and `ENV`, which the snapshot
+   * otherwise records and every sandbox created from it adopts. `user` and
+   * `work_dir` replace the image's, `env_vars` merge over its `ENV`.
+   */
+  runConfig?: SandboxRunConfig;
   /** Timeout in seconds when waiting for ready. Default: 60. */
   timeout?: number;
   /** AbortSignal for cancellation. */
@@ -587,6 +645,11 @@ export interface CreateDockerfileSnapshotOptions {
   vCpus?: number;
   /** Memory in bytes for the temporary builder sandbox. */
   memBytes?: number;
+  /**
+   * Overrides the built image's `USER`, `WORKDIR` and `ENV`, which otherwise
+   * become the snapshot's run config.
+   */
+  runConfig?: SandboxRunConfig;
   /** Timeout in seconds for builder sandbox operations. Default: 60. */
   timeout?: number;
 }
@@ -602,6 +665,12 @@ export interface CaptureSnapshotOptions {
   dockerImage?: string;
   /** Filesystem capacity in bytes for Docker image export. */
   fsCapacityBytes?: number;
+  /**
+   * Overrides the run config the new snapshot records. A plain capture starts
+   * from what the sandbox was running with; a `dockerImage` export starts from
+   * that image's `USER`, `WORKDIR` and `ENV`.
+   */
+  runConfig?: SandboxRunConfig;
   /** Timeout in seconds when waiting for ready. Default: 60. */
   timeout?: number;
   /** AbortSignal for cancellation. */
@@ -724,6 +793,14 @@ export interface UpdateSandboxOptions {
    * `ready`; start a stopped one first.
    */
   proxyConfig?: SandboxProxyConfig;
+  /**
+   * Merged into the sandbox's stored run config: `user` and `work_dir`
+   * replace, `env_vars` merge key by key. It takes effect for commands
+   * started after the update; commands already running keep what they
+   * started with, and a stopped sandbox picks the change up on its next
+   * start.
+   */
+  runConfig?: SandboxRunConfig;
 }
 
 /**

--- a/js/src/sandbox/ws_execute.ts
+++ b/js/src/sandbox/ws_execute.ts
@@ -421,6 +421,7 @@ export async function runWsStream(
     timeout = 60,
     env,
     cwd,
+    runConfig,
     shell = "/bin/bash",
     onStdout,
     onStderr,
@@ -455,6 +456,7 @@ export async function runWsStream(
       };
       if (env) payload.env = env;
       if (cwd) payload.cwd = cwd;
+      if (runConfig) payload.run_config = runConfig;
       if (commandId) payload.command_id = commandId;
       if (pty) payload.pty = true;
 

--- a/js/src/tests/sandbox_run_config.test.ts
+++ b/js/src/tests/sandbox_run_config.test.ts
@@ -1,0 +1,187 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { jest, describe, it, expect } from "@jest/globals";
+import { SandboxClient } from "../sandbox/client.js";
+import { Sandbox } from "../sandbox/sandbox.js";
+import { LangSmithValidationError } from "../sandbox/errors.js";
+import {
+  validateCommandRunConfig,
+  validateRunConfig,
+} from "../sandbox/helpers.js";
+import type { SandboxRunConfig } from "../sandbox/types.js";
+
+const RUN_CONFIG: SandboxRunConfig = {
+  user: "app",
+  work_dir: "/srv",
+  env_vars: { LANG: "C" },
+};
+
+const createClientWithMock = (mockFetch: any) => {
+  const client = new SandboxClient({
+    apiEndpoint: "https://api.example.com/v2/sandboxes",
+    apiKey: "test-key",
+  });
+  (client as any)._caller = { call: (fn: any) => fn() };
+  (client as any)._fetchImpl = mockFetch;
+  return client;
+};
+
+const jsonResponse = (body: any) =>
+  jest.fn<typeof fetch>().mockResolvedValue({
+    ok: true,
+    json: async () => body,
+  } as Response);
+
+const requestBody = (mockFetch: any, call = 0) => {
+  const [, init] = mockFetch.mock.calls[call] as [string, RequestInit];
+  return JSON.parse(init.body as string);
+};
+
+describe("run config validation", () => {
+  it("accepts a full config", () => {
+    expect(() => validateRunConfig(RUN_CONFIG)).not.toThrow();
+  });
+
+  it("accepts undefined", () => {
+    expect(() => validateRunConfig(undefined)).not.toThrow();
+  });
+
+  it.each([
+    [{ workdir: "/srv" } as SandboxRunConfig, "unsupported keys: workdir"],
+    [{ user: "" }, "user must be a non-empty string"],
+    [{ work_dir: "srv" }, "work_dir must be an absolute path"],
+    [
+      { env_vars: ["LANG=C"] } as unknown as SandboxRunConfig,
+      "must be an object",
+    ],
+    [
+      { env_vars: { PORT: 8080 } } as unknown as SandboxRunConfig,
+      "must be a string",
+    ],
+  ])("rejects %p", (runConfig, message) => {
+    expect(() => validateRunConfig(runConfig)).toThrow(message);
+    expect(() => validateRunConfig(runConfig)).toThrow(
+      LangSmithValidationError,
+    );
+  });
+
+  it.each([
+    [{ LANG: "C" }, undefined],
+    [undefined, "/srv"],
+    [{ LANG: "C" }, "/srv"],
+  ])("rejects the deprecated env/cwd alongside runConfig", (env, cwd) => {
+    expect(() => validateCommandRunConfig(RUN_CONFIG, env, cwd)).toThrow(
+      "cannot be combined with",
+    );
+  });
+
+  it("allows the deprecated env/cwd on their own", () => {
+    expect(() =>
+      validateCommandRunConfig(undefined, { LANG: "C" }, "/srv"),
+    ).not.toThrow();
+  });
+});
+
+describe("client forwards run config", () => {
+  it("sends run_config on create", async () => {
+    const mockFetch = jsonResponse({ name: "test-sb", status: "ready" });
+    const client = createClientWithMock(mockFetch);
+
+    await client.createSandbox("snap-123", { runConfig: RUN_CONFIG });
+
+    expect(requestBody(mockFetch).run_config).toEqual(RUN_CONFIG);
+  });
+
+  it("sends run_config on update and surfaces the stored value", async () => {
+    const mockFetch = jsonResponse({
+      name: "test-sb",
+      status: "ready",
+      run_config: RUN_CONFIG,
+    });
+    const client = createClientWithMock(mockFetch);
+
+    const sandbox = await client.updateSandbox("test-sb", {
+      runConfig: RUN_CONFIG,
+    });
+
+    expect(requestBody(mockFetch).run_config).toEqual(RUN_CONFIG);
+    expect(sandbox.run_config).toEqual(RUN_CONFIG);
+  });
+
+  it("sends run_config on snapshot build", async () => {
+    const mockFetch = jsonResponse({
+      id: "snap-1",
+      name: "snap",
+      status: "ready",
+      run_config: RUN_CONFIG,
+    });
+    const client = createClientWithMock(mockFetch);
+
+    const snapshot = await client.createSnapshot(
+      "snap",
+      "python:3.12-slim",
+      1024,
+      {
+        runConfig: RUN_CONFIG,
+      },
+    );
+
+    expect(requestBody(mockFetch).run_config).toEqual(RUN_CONFIG);
+    expect(snapshot.run_config).toEqual(RUN_CONFIG);
+  });
+
+  it("sends run_config on capture", async () => {
+    const mockFetch = jsonResponse({
+      id: "snap-1",
+      name: "snap",
+      status: "ready",
+    });
+    const client = createClientWithMock(mockFetch);
+
+    await client.captureSnapshot("test-sb", "snap", { runConfig: RUN_CONFIG });
+
+    expect(requestBody(mockFetch).run_config).toEqual(RUN_CONFIG);
+  });
+
+  it("rejects a bad run config before calling the API", async () => {
+    const mockFetch = jest.fn<typeof fetch>();
+    const client = createClientWithMock(mockFetch);
+
+    await expect(
+      client.createSandbox("snap-123", { runConfig: { work_dir: "srv" } }),
+    ).rejects.toThrow("work_dir must be an absolute path");
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+});
+
+describe("per-command run config", () => {
+  const makeSandbox = (mockFetch: any) => {
+    const sandbox = new Sandbox(
+      { name: "test-sb", dataplane_url: "https://router.example.com/sb-123" },
+      createClientWithMock(mockFetch),
+    );
+    jest.spyOn(sandbox as any, "_wsAvailable").mockResolvedValue(false);
+    return sandbox;
+  };
+
+  it("sends run_config on the execute request", async () => {
+    const mockFetch = jsonResponse({ stdout: "", stderr: "", exit_code: 0 });
+    const sandbox = makeSandbox(mockFetch);
+
+    await sandbox.run("id", { runConfig: RUN_CONFIG });
+
+    const body = requestBody(mockFetch);
+    expect(body.run_config).toEqual(RUN_CONFIG);
+    expect(body.cwd).toBeUndefined();
+    expect(body.env).toBeUndefined();
+  });
+
+  it("rejects runConfig combined with the deprecated cwd", async () => {
+    const mockFetch = jest.fn<typeof fetch>();
+    const sandbox = makeSandbox(mockFetch);
+
+    await expect(
+      sandbox.run("pwd", { cwd: "/tmp", runConfig: RUN_CONFIG }),
+    ).rejects.toThrow("cannot be combined with cwd");
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+});

--- a/python/langsmith/sandbox/README.md
+++ b/python/langsmith/sandbox/README.md
@@ -380,6 +380,42 @@ with client.sandbox(snapshot_id=snapshot_id) as sb:
     print(result.exit_code)  # 1
 ```
 
+## Run Configuration
+
+`run_config` sets the account commands run as, their working directory, and
+their environment. It mirrors `docker run -u/-w/-e`: `user` and `work_dir`
+replace the value from the layer below, `env_vars` merge over it key by key.
+
+A snapshot built from a Docker image records that image's `USER`, `WORKDIR`
+and `ENV`, and sandboxes created from it run that way. Override it per
+snapshot, per sandbox, per update, or per command:
+
+```python
+# Per snapshot: what every sandbox from it boots with
+snapshot = client.create_snapshot(
+    "python",
+    "python:3.12-slim",
+    1 * 1024**3,
+    run_config={"user": "app", "work_dir": "/srv"},
+)
+
+# Per sandbox: overrides the snapshot's
+with client.sandbox(snapshot_id=snapshot.id, run_config={"user": "root"}) as sb:
+    # Per update: applies to subsequent commands
+    client.update_sandbox(sb.name, run_config={"env_vars": {"STAGE": "beta"}})
+
+    # Per command
+    result = sb.run("id -un", run_config={"user": "app"})
+```
+
+`user` takes `name`, `uid`, `name:group` or `uid:gid`; `work_dir` must be
+absolute and is created if missing. Snapshot and sandbox responses report the
+`run_config` in effect.
+
+The per-command `cwd` and `env` arguments are deprecated in favour of
+`run_config["work_dir"]` and `run_config["env_vars"]`. They still work on their
+own; combining them with `run_config` raises `ValueError`.
+
 ## Streaming Output
 
 For long-running commands, you can stream output in real time. This uses the

--- a/python/langsmith/sandbox/__init__.py
+++ b/python/langsmith/sandbox/__init__.py
@@ -102,6 +102,7 @@ from langsmith.sandbox._proxy_config import (
     proxy_config,
     workspace_secret,
 )
+from langsmith.sandbox._run_config import SandboxRunConfig
 from langsmith.sandbox._sandbox import Sandbox
 from langsmith.sandbox._tunnel import AsyncTunnel, Tunnel
 
@@ -125,6 +126,7 @@ __all__ = [
     "AsyncCommandHandle",
     "OutputChunk",
     "SandboxProxyConfig",
+    "SandboxRunConfig",
     "SandboxProxyRule",
     "SandboxProxySecret",
     "SandboxMount",

--- a/python/langsmith/sandbox/_async_client.py
+++ b/python/langsmith/sandbox/_async_client.py
@@ -50,6 +50,7 @@ from langsmith.sandbox._mounts import (
     validate_mount_config_proxy_config,
 )
 from langsmith.sandbox._proxy_config import SandboxProxyConfig
+from langsmith.sandbox._run_config import SandboxRunConfig, validate_run_config
 from langsmith.sandbox._transport import AsyncRetryTransport
 
 if TYPE_CHECKING:
@@ -265,6 +266,7 @@ class AsyncSandboxClient:
         fs_capacity_bytes: Optional[int] = None,
         mount_config: Optional[SandboxMountConfig] = None,
         proxy_config: Optional[SandboxProxyConfig] = None,
+        run_config: Optional[SandboxRunConfig] = None,
         headers: RequestHeaders = None,
     ) -> AsyncSandbox:
         """Create a sandbox and return an AsyncSandbox instance.
@@ -319,6 +321,10 @@ class AsyncSandboxClient:
                 ``~regex``). Use ``proxy_config`` with provider rule helpers
                 such as ``aws_auth`` to let the proxy sign supported
                 AWS HTTPS requests on the sandbox's behalf.
+            run_config: Overrides the snapshot's run config, as
+                ``{"user": ..., "work_dir": ..., "env_vars": {...}}``.
+                ``user`` and ``work_dir`` replace the snapshot's, ``env_vars``
+                merge over them. The result is what the sandbox boots with.
 
         Returns:
             AsyncSandbox instance.
@@ -343,6 +349,7 @@ class AsyncSandboxClient:
             fs_capacity_bytes=fs_capacity_bytes,
             mount_config=mount_config,
             proxy_config=proxy_config,
+            run_config=run_config,
             headers=headers,
         )
         sb._auto_delete = True
@@ -364,6 +371,7 @@ class AsyncSandboxClient:
         fs_capacity_bytes: Optional[int] = None,
         mount_config: Optional[SandboxMountConfig] = None,
         proxy_config: Optional[SandboxProxyConfig] = None,
+        run_config: Optional[SandboxRunConfig] = None,
         headers: RequestHeaders = None,
     ) -> AsyncSandbox:
         """Create a new Sandbox.
@@ -412,6 +420,11 @@ class AsyncSandboxClient:
                 ``~regex``). Use ``proxy_config`` with provider rule helpers
                 such as ``aws_auth`` to let the proxy sign supported
                 AWS HTTPS requests on the sandbox's behalf.
+            run_config: Overrides the snapshot's run config, as
+                ``{"user": ..., "work_dir": ..., "env_vars": {...}}``.
+                ``user`` and ``work_dir`` replace the snapshot's, ``env_vars``
+                merge over them. The result is stored on the sandbox and is
+                what it boots with.
 
         Returns:
             Created AsyncSandbox. When wait_for_ready=False, the sandbox will have
@@ -433,6 +446,7 @@ class AsyncSandboxClient:
             )
         validate_ttl(idle_ttl_seconds, "idle_ttl_seconds")
         validate_ttl(delete_after_stop_seconds, "delete_after_stop_seconds")
+        validate_run_config(run_config)
 
         url = f"{self._base_url}/boxes"
 
@@ -464,6 +478,8 @@ class AsyncSandboxClient:
             payload["mount_config"] = mount_config
         if proxy_config is not None:
             payload["proxy_config"] = proxy_config
+        if run_config is not None:
+            payload["run_config"] = run_config
 
         http_timeout = (timeout + 30) if wait_for_ready else 30
 
@@ -550,6 +566,7 @@ class AsyncSandboxClient:
         idle_ttl_seconds: Optional[int] = None,
         delete_after_stop_seconds: Optional[int] = None,
         proxy_config: Optional[SandboxProxyConfig] = None,
+        run_config: Optional[SandboxRunConfig] = None,
         headers: RequestHeaders = None,
     ) -> AsyncSandbox:
         """Update a sandbox's properties.
@@ -571,6 +588,11 @@ class AsyncSandboxClient:
                 from the current config, so rotating one credential does not
                 mean re-supplying secrets that can no longer be read. The
                 sandbox must be ``ready``; start a stopped one first.
+            run_config: Merged into the sandbox's stored run config: ``user``
+                and ``work_dir`` replace, ``env_vars`` merge key by key. It
+                takes effect for commands started after the update; commands
+                already running keep what they started with, and a stopped
+                sandbox picks the change up on its next start.
 
         Returns:
             Updated AsyncSandbox.
@@ -585,6 +607,7 @@ class AsyncSandboxClient:
         """
         validate_ttl(idle_ttl_seconds, "idle_ttl_seconds")
         validate_ttl(delete_after_stop_seconds, "delete_after_stop_seconds")
+        validate_run_config(run_config)
 
         url = _box_url(self._base_url, name)
         payload: dict[str, Any] = {}
@@ -596,6 +619,8 @@ class AsyncSandboxClient:
             payload["delete_after_stop_seconds"] = delete_after_stop_seconds
         if proxy_config is not None:
             payload["proxy_config"] = proxy_config
+        if run_config is not None:
+            payload["run_config"] = run_config
 
         try:
             response = await self._http.patch(
@@ -926,6 +951,7 @@ class AsyncSandboxClient:
         *,
         tag: Optional[str] = None,
         registry_id: Optional[str] = None,
+        run_config: Optional[SandboxRunConfig] = None,
         timeout: int = 60,
         headers: RequestHeaders = None,
     ) -> Snapshot:
@@ -938,6 +964,10 @@ class AsyncSandboxClient:
             docker_image: Docker image to build from (e.g., "python:3.12-slim").
             fs_capacity_bytes: Filesystem capacity in bytes.
             registry_id: Private registry ID.
+            run_config: Overrides the image's own ``USER``, ``WORKDIR`` and
+                ``ENV``, which the snapshot otherwise records and every
+                sandbox created from it adopts. ``user`` and ``work_dir``
+                replace the image's, ``env_vars`` merge over its ``ENV``.
             timeout: Timeout in seconds when waiting for ready.
 
         Returns:
@@ -948,6 +978,8 @@ class AsyncSandboxClient:
             ResourceCreationError: If snapshot build fails.
             SandboxClientError: For other errors.
         """
+        validate_run_config(run_config)
+
         url = f"{self._base_url}/snapshots"
 
         payload: dict[str, Any] = {
@@ -959,6 +991,8 @@ class AsyncSandboxClient:
             payload["tag"] = tag
         if registry_id is not None:
             payload["registry_id"] = registry_id
+        if run_config is not None:
+            payload["run_config"] = run_config
 
         try:
             response = await self._http.post(
@@ -986,10 +1020,14 @@ class AsyncSandboxClient:
         on_build_log: Optional[Callable[[str], Any]] = None,
         vcpus: Optional[int] = None,
         mem_bytes: Optional[int] = None,
+        run_config: Optional[SandboxRunConfig] = None,
         timeout: int = 60,
         headers: RequestHeaders = None,
     ) -> Snapshot:
         """Build a snapshot from a local Dockerfile context.
+
+        The built image's ``USER``, ``WORKDIR`` and ``ENV`` become the
+        snapshot's run config; ``run_config`` overrides them.
 
         When ``fs_capacity_bytes`` is omitted, the server applies its default.
         ``vcpus`` and ``mem_bytes`` size the temporary builder sandbox. The
@@ -1064,6 +1102,7 @@ class AsyncSandboxClient:
                 name,
                 docker_image=image_ref,
                 fs_capacity_bytes=fs_capacity_bytes,
+                run_config=run_config,
                 timeout=timeout,
                 headers=headers,
             )
@@ -1076,6 +1115,7 @@ class AsyncSandboxClient:
         tag: Optional[str] = None,
         docker_image: Optional[str] = None,
         fs_capacity_bytes: Optional[int] = None,
+        run_config: Optional[SandboxRunConfig] = None,
         timeout: int = 60,
         headers: RequestHeaders = None,
     ) -> Snapshot:
@@ -1089,6 +1129,10 @@ class AsyncSandboxClient:
             tag: Tag to publish the snapshot under, within ``name``. Re-using a
                 tag moves it to the new snapshot, leaving the previous one
                 addressable by id. Defaults server-side to ``latest``.
+            run_config: Overrides the run config the new snapshot records. A
+                plain capture starts from what the sandbox was running with;
+                a ``docker_image`` export starts from that image's ``USER``,
+                ``WORKDIR`` and ``ENV``.
             timeout: Timeout in seconds when waiting for ready.
 
         Returns:
@@ -1100,6 +1144,8 @@ class AsyncSandboxClient:
             ResourceCreationError: If snapshot capture fails.
             SandboxClientError: For other errors.
         """
+        validate_run_config(run_config)
+
         url = _box_url(self._base_url, sandbox_name, "snapshot")
 
         payload: dict[str, Any] = {"name": name}
@@ -1109,6 +1155,8 @@ class AsyncSandboxClient:
             payload["docker_image"] = docker_image
         if fs_capacity_bytes is not None:
             payload["fs_capacity_bytes"] = fs_capacity_bytes
+        if run_config is not None:
+            payload["run_config"] = run_config
 
         try:
             response = await self._http.post(

--- a/python/langsmith/sandbox/_async_sandbox.py
+++ b/python/langsmith/sandbox/_async_sandbox.py
@@ -24,6 +24,10 @@ from langsmith.sandbox._models import (
     Snapshot,
     _StreamEndedBeforeStarted,
 )
+from langsmith.sandbox._run_config import (
+    SandboxRunConfig,
+    validate_command_run_config,
+)
 from langsmith.sandbox._tunnel import AsyncTunnel
 from langsmith.sandbox._ws_execute import (
     WEBSOCKETS_AVAILABLE,
@@ -76,6 +80,10 @@ class AsyncSandbox:
         vcpus: Number of vCPUs allocated.
         mem_bytes: Memory allocation in bytes.
         fs_capacity_bytes: Root filesystem capacity in bytes.
+        run_config: What commands run with, as ``{"user": ..., "work_dir":
+            ..., "env_vars": {...}}`` — the snapshot's, with any create or
+            update override merged in. ``None`` on sandboxes created before
+            run configs were recorded.
 
     Example:
         async with await client.sandbox(
@@ -100,6 +108,7 @@ class AsyncSandbox:
     vcpus: Optional[int] = None
     mem_bytes: Optional[int] = None
     fs_capacity_bytes: Optional[int] = None
+    run_config: Optional[SandboxRunConfig] = None
 
     # Internal fields (not from API)
     _client: AsyncSandboxClient = field(repr=False, default=None)  # type: ignore
@@ -137,6 +146,7 @@ class AsyncSandbox:
             vcpus=data.get("vcpus"),
             mem_bytes=data.get("mem_bytes"),
             fs_capacity_bytes=data.get("fs_capacity_bytes"),
+            run_config=data.get("run_config"),
             _client=client,
             _auto_delete=auto_delete,
         )
@@ -173,6 +183,7 @@ class AsyncSandbox:
             vcpus=self.vcpus,
             mem_bytes=self.mem_bytes,
             fs_capacity_bytes=self.fs_capacity_bytes,
+            run_config=self.run_config,
             _client=client if client is not None else self._client.to_sync(),
             _auto_delete=False,
         )
@@ -224,6 +235,7 @@ class AsyncSandbox:
         timeout: int = ...,
         env: Optional[dict[str, str]] = ...,
         cwd: Optional[str] = ...,
+        run_config: Optional[SandboxRunConfig] = ...,
         shell: str = ...,
         on_stdout: Optional[Callable[[str], Any]] = ...,
         on_stderr: Optional[Callable[[str], Any]] = ...,
@@ -243,6 +255,7 @@ class AsyncSandbox:
         timeout: int = ...,
         env: Optional[dict[str, str]] = ...,
         cwd: Optional[str] = ...,
+        run_config: Optional[SandboxRunConfig] = ...,
         shell: str = ...,
         on_stdout: Optional[Callable[[str], Any]] = ...,
         on_stderr: Optional[Callable[[str], Any]] = ...,
@@ -261,6 +274,7 @@ class AsyncSandbox:
         timeout: int = 60,
         env: Optional[dict[str, str]] = None,
         cwd: Optional[str] = None,
+        run_config: Optional[SandboxRunConfig] = None,
         shell: str = "/bin/bash",
         on_stdout: Optional[Callable[[str], Any]] = None,
         on_stderr: Optional[Callable[[str], Any]] = None,
@@ -276,8 +290,14 @@ class AsyncSandbox:
         Args:
             command: Shell command to execute.
             timeout: Command timeout in seconds.
-            env: Environment variables to set for the command.
-            cwd: Working directory for command execution. If None, uses sandbox default.
+            env: Deprecated, use ``run_config["env_vars"]``. Environment
+                variables to set for the command.
+            cwd: Deprecated, use ``run_config["work_dir"]``. Working directory
+                for command execution. If None, uses the sandbox's.
+            run_config: What this one command runs with, as ``{"user": ...,
+                "work_dir": ..., "env_vars": {...}}``, layered over the
+                sandbox's own run config. Cannot be combined with the
+                deprecated ``env`` and ``cwd``.
             shell: Shell to use for command execution. Defaults to "/bin/bash".
             on_stdout: Callback invoked with each stdout chunk as it arrives.
                 Blocks until the command completes and returns ExecutionResult.
@@ -323,6 +343,7 @@ class AsyncSandbox:
                 "Cannot combine wait=False with on_stdout/on_stderr callbacks. "
                 "Use wait=False and iterate the CommandHandle, or use callbacks."
             )
+        validate_command_run_config(run_config, env, cwd)
 
         self._require_dataplane_url()
 
@@ -333,6 +354,7 @@ class AsyncSandbox:
                 timeout=timeout,
                 env=env,
                 cwd=cwd,
+                run_config=run_config,
                 shell=shell,
                 wait=wait,
                 on_stdout=on_stdout,
@@ -352,6 +374,7 @@ class AsyncSandbox:
                 timeout=timeout,
                 env=env,
                 cwd=cwd,
+                run_config=run_config,
                 shell=shell,
                 wait=True,
                 on_stdout=None,
@@ -367,6 +390,7 @@ class AsyncSandbox:
             timeout=timeout,
             env=env,
             cwd=cwd,
+            run_config=run_config,
             shell=shell,
             headers=headers,
         )
@@ -378,6 +402,7 @@ class AsyncSandbox:
         timeout: int,
         env: Optional[dict[str, str]],
         cwd: Optional[str],
+        run_config: Optional[SandboxRunConfig],
         shell: str,
         wait: bool,
         on_stdout: Optional[Callable[[str], Any]],
@@ -408,6 +433,7 @@ class AsyncSandbox:
             "timeout": timeout,
             "env": env,
             "cwd": cwd,
+            "run_config": run_config,
             "shell": shell,
             "idle_timeout": idle_timeout,
             "kill_on_disconnect": kill_on_disconnect,
@@ -472,6 +498,7 @@ class AsyncSandbox:
         timeout: int,
         env: Optional[dict[str, str]],
         cwd: Optional[str],
+        run_config: Optional[SandboxRunConfig],
         shell: str,
         headers: RequestHeaders,
     ) -> ExecutionResult:
@@ -487,6 +514,8 @@ class AsyncSandbox:
             payload["env"] = env
         if cwd is not None:
             payload["cwd"] = cwd
+        if run_config is not None:
+            payload["run_config"] = run_config
 
         try:
             response = await self._client._http.post(

--- a/python/langsmith/sandbox/_client.py
+++ b/python/langsmith/sandbox/_client.py
@@ -44,6 +44,7 @@ from langsmith.sandbox._mounts import (
     validate_mount_config_proxy_config,
 )
 from langsmith.sandbox._proxy_config import SandboxProxyConfig
+from langsmith.sandbox._run_config import SandboxRunConfig, validate_run_config
 from langsmith.sandbox._sandbox import Sandbox
 from langsmith.sandbox._transport import RetryTransport
 
@@ -383,6 +384,7 @@ class SandboxClient:
         fs_capacity_bytes: Optional[int] = None,
         mount_config: Optional[SandboxMountConfig] = None,
         proxy_config: Optional[SandboxProxyConfig] = None,
+        run_config: Optional[SandboxRunConfig] = None,
         headers: RequestHeaders = None,
     ) -> Sandbox:
         """Create a sandbox and return a Sandbox instance.
@@ -437,6 +439,10 @@ class SandboxClient:
                 ``~regex``). Use ``proxy_config`` with provider rule helpers
                 such as ``aws_auth`` to let the proxy sign supported
                 AWS HTTPS requests on the sandbox's behalf.
+            run_config: Overrides the snapshot's run config, as
+                ``{"user": ..., "work_dir": ..., "env_vars": {...}}``.
+                ``user`` and ``work_dir`` replace the snapshot's, ``env_vars``
+                merge over them. The result is what the sandbox boots with.
 
         Returns:
             Sandbox instance.
@@ -461,6 +467,7 @@ class SandboxClient:
             fs_capacity_bytes=fs_capacity_bytes,
             mount_config=mount_config,
             proxy_config=proxy_config,
+            run_config=run_config,
             headers=headers,
         )
         sb._auto_delete = True
@@ -482,6 +489,7 @@ class SandboxClient:
         fs_capacity_bytes: Optional[int] = None,
         mount_config: Optional[SandboxMountConfig] = None,
         proxy_config: Optional[SandboxProxyConfig] = None,
+        run_config: Optional[SandboxRunConfig] = None,
         headers: RequestHeaders = None,
     ) -> Sandbox:
         """Create a new Sandbox.
@@ -530,6 +538,11 @@ class SandboxClient:
                 ``~regex``). Use ``proxy_config`` with provider rule helpers
                 such as ``aws_auth`` to let the proxy sign supported
                 AWS HTTPS requests on the sandbox's behalf.
+            run_config: Overrides the snapshot's run config, as
+                ``{"user": ..., "work_dir": ..., "env_vars": {...}}``.
+                ``user`` and ``work_dir`` replace the snapshot's, ``env_vars``
+                merge over them. The result is stored on the sandbox and is
+                what it boots with.
 
         Returns:
             Created Sandbox. When wait_for_ready=False, the sandbox will have
@@ -551,6 +564,7 @@ class SandboxClient:
             )
         validate_ttl(idle_ttl_seconds, "idle_ttl_seconds")
         validate_ttl(delete_after_stop_seconds, "delete_after_stop_seconds")
+        validate_run_config(run_config)
 
         url = f"{self._base_url}/boxes"
 
@@ -582,6 +596,8 @@ class SandboxClient:
             payload["mount_config"] = mount_config
         if proxy_config is not None:
             payload["proxy_config"] = proxy_config
+        if run_config is not None:
+            payload["run_config"] = run_config
 
         http_timeout = (timeout + 30) if wait_for_ready else 30
 
@@ -660,6 +676,7 @@ class SandboxClient:
         idle_ttl_seconds: Optional[int] = None,
         delete_after_stop_seconds: Optional[int] = None,
         proxy_config: Optional[SandboxProxyConfig] = None,
+        run_config: Optional[SandboxRunConfig] = None,
         headers: RequestHeaders = None,
     ) -> Sandbox:
         """Update a sandbox's properties.
@@ -681,6 +698,11 @@ class SandboxClient:
                 from the current config, so rotating one credential does not
                 mean re-supplying secrets that can no longer be read. The
                 sandbox must be ``ready``; start a stopped one first.
+            run_config: Merged into the sandbox's stored run config: ``user``
+                and ``work_dir`` replace, ``env_vars`` merge key by key. It
+                takes effect for commands started after the update; commands
+                already running keep what they started with, and a stopped
+                sandbox picks the change up on its next start.
 
         Returns:
             Updated Sandbox.
@@ -695,6 +717,7 @@ class SandboxClient:
         """
         validate_ttl(idle_ttl_seconds, "idle_ttl_seconds")
         validate_ttl(delete_after_stop_seconds, "delete_after_stop_seconds")
+        validate_run_config(run_config)
 
         url = _box_url(self._base_url, name)
         payload: dict[str, Any] = {}
@@ -706,6 +729,8 @@ class SandboxClient:
             payload["delete_after_stop_seconds"] = delete_after_stop_seconds
         if proxy_config is not None:
             payload["proxy_config"] = proxy_config
+        if run_config is not None:
+            payload["run_config"] = run_config
 
         try:
             response = self._http.patch(
@@ -1029,6 +1054,7 @@ class SandboxClient:
         *,
         tag: Optional[str] = None,
         registry_id: Optional[str] = None,
+        run_config: Optional[SandboxRunConfig] = None,
         timeout: int = 60,
         headers: RequestHeaders = None,
     ) -> Snapshot:
@@ -1045,6 +1071,10 @@ class SandboxClient:
                 addressable by id. Defaults server-side to the Docker image's
                 own tag, else ``latest``.
             registry_id: Private registry ID.
+            run_config: Overrides the image's own ``USER``, ``WORKDIR`` and
+                ``ENV``, which the snapshot otherwise records and every
+                sandbox created from it adopts. ``user`` and ``work_dir``
+                replace the image's, ``env_vars`` merge over its ``ENV``.
             timeout: Timeout in seconds when waiting for ready.
 
         Returns:
@@ -1055,6 +1085,8 @@ class SandboxClient:
             ResourceCreationError: If snapshot build fails.
             SandboxClientError: For other errors.
         """
+        validate_run_config(run_config)
+
         url = f"{self._base_url}/snapshots"
 
         payload: dict[str, Any] = {
@@ -1066,6 +1098,8 @@ class SandboxClient:
             payload["tag"] = tag
         if registry_id is not None:
             payload["registry_id"] = registry_id
+        if run_config is not None:
+            payload["run_config"] = run_config
 
         try:
             response = self._http.post(
@@ -1091,10 +1125,14 @@ class SandboxClient:
         on_build_log: Optional[Callable[[str], Any]] = None,
         vcpus: Optional[int] = None,
         mem_bytes: Optional[int] = None,
+        run_config: Optional[SandboxRunConfig] = None,
         timeout: int = 60,
         headers: RequestHeaders = None,
     ) -> Snapshot:
         """Build a snapshot from a local Dockerfile context.
+
+        The built image's ``USER``, ``WORKDIR`` and ``ENV`` become the
+        snapshot's run config; ``run_config`` overrides them.
 
         When ``fs_capacity_bytes`` is omitted, the server applies its default.
         ``vcpus`` and ``mem_bytes`` size the temporary builder sandbox. The
@@ -1169,6 +1207,7 @@ class SandboxClient:
                 name,
                 docker_image=image_ref,
                 fs_capacity_bytes=fs_capacity_bytes,
+                run_config=run_config,
                 timeout=timeout,
                 headers=headers,
             )
@@ -1181,6 +1220,7 @@ class SandboxClient:
         tag: Optional[str] = None,
         docker_image: Optional[str] = None,
         fs_capacity_bytes: Optional[int] = None,
+        run_config: Optional[SandboxRunConfig] = None,
         timeout: int = 60,
         headers: RequestHeaders = None,
     ) -> Snapshot:
@@ -1197,6 +1237,10 @@ class SandboxClient:
             docker_image: Optional Docker image tag inside the sandbox to export
                 into the snapshot instead of capturing the live root filesystem.
             fs_capacity_bytes: Filesystem capacity in bytes for Docker image export.
+            run_config: Overrides the run config the new snapshot records. A
+                plain capture starts from what the sandbox was running with;
+                a ``docker_image`` export starts from that image's ``USER``,
+                ``WORKDIR`` and ``ENV``.
             timeout: Timeout in seconds when waiting for ready.
 
         Returns:
@@ -1208,6 +1252,8 @@ class SandboxClient:
             ResourceCreationError: If snapshot capture fails.
             SandboxClientError: For other errors.
         """
+        validate_run_config(run_config)
+
         url = _box_url(self._base_url, sandbox_name, "snapshot")
 
         payload: dict[str, Any] = {"name": name}
@@ -1217,6 +1263,8 @@ class SandboxClient:
             payload["docker_image"] = docker_image
         if fs_capacity_bytes is not None:
             payload["fs_capacity_bytes"] = fs_capacity_bytes
+        if run_config is not None:
+            payload["run_config"] = run_config
 
         try:
             response = self._http.post(

--- a/python/langsmith/sandbox/_models.py
+++ b/python/langsmith/sandbox/_models.py
@@ -14,6 +14,7 @@ from langsmith.sandbox._exceptions import (
     SandboxOperationError,
     SandboxServerReloadError,
 )
+from langsmith.sandbox._run_config import SandboxRunConfig
 
 if TYPE_CHECKING:
     from langsmith.sandbox._async_sandbox import AsyncSandbox
@@ -114,6 +115,10 @@ class Snapshot:
         updated_at: Timestamp when the snapshot was last updated.
         tags: Tags currently resolving to this snapshot, under its name. Empty
             means the snapshot is dangling — reachable only by id.
+        run_config: What sandboxes created from this snapshot boot with, as
+            ``{"user": ..., "work_dir": ..., "env_vars": {...}}``. ``None`` on
+            snapshots built before run configs were recorded: those boot as
+            root with only the sandbox's own environment.
     """
 
     id: str
@@ -131,6 +136,7 @@ class Snapshot:
     updated_at: Optional[str] = None
     # Appended last so existing positional constructions keep their meaning.
     tags: list[str] = field(default_factory=list)
+    run_config: Optional[SandboxRunConfig] = None
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> Snapshot:
@@ -150,6 +156,7 @@ class Snapshot:
             created_at=data.get("created_at"),
             updated_at=data.get("updated_at"),
             tags=list(data.get("tags") or []),
+            run_config=data.get("run_config"),
         )
 
 

--- a/python/langsmith/sandbox/_run_config.py
+++ b/python/langsmith/sandbox/_run_config.py
@@ -1,0 +1,101 @@
+"""Helpers and type definitions for sandbox run configuration."""
+
+from __future__ import annotations
+
+from typing import Any, Optional, TypedDict
+
+
+class SandboxRunConfig(TypedDict, total=False):
+    """What a sandbox's commands run with.
+
+    Mirrors ``docker run -u/-w/-e``: ``user`` and ``work_dir`` replace the
+    value inherited from the layer below (the image, then the snapshot, then
+    the sandbox), while ``env_vars`` merge over it key by key.
+    """
+
+    user: str
+    work_dir: str
+    env_vars: dict[str, str]
+
+
+_RUN_CONFIG_KEYS = frozenset({"user", "work_dir", "env_vars"})
+
+
+def validate_run_config(
+    run_config: Optional[SandboxRunConfig], field: str = "run_config"
+) -> Optional[SandboxRunConfig]:
+    """Check a run config client-side and return it unchanged.
+
+    Args:
+        run_config: Run config to check. ``None`` passes.
+        field: Name to use in error messages.
+
+    Returns:
+        The run config as given.
+
+    Raises:
+        ValueError: If the shape, ``work_dir`` or ``env_vars`` are invalid.
+    """
+    if run_config is None:
+        return None
+    if not isinstance(run_config, dict):
+        raise ValueError(f"{field} must be a mapping")
+    unknown = sorted(set(run_config) - _RUN_CONFIG_KEYS)
+    if unknown:
+        raise ValueError(
+            f"{field} has unsupported keys: {', '.join(unknown)}. "
+            f"Supported: {', '.join(sorted(_RUN_CONFIG_KEYS))}"
+        )
+    user = run_config.get("user")
+    if user is not None and (not isinstance(user, str) or not user.strip()):
+        raise ValueError(f"{field}['user'] must be a non-empty string")
+    work_dir = run_config.get("work_dir")
+    if work_dir is not None:
+        if not isinstance(work_dir, str) or not work_dir.strip():
+            raise ValueError(f"{field}['work_dir'] must be a non-empty string")
+        if not work_dir.startswith("/"):
+            raise ValueError(f"{field}['work_dir'] must be an absolute path")
+    env_vars: Any = run_config.get("env_vars")
+    if env_vars is not None:
+        if not isinstance(env_vars, dict):
+            raise ValueError(f"{field}['env_vars'] must be a mapping")
+        for name, value in env_vars.items():
+            if not isinstance(name, str) or not name:
+                raise ValueError(f"{field}['env_vars'] names must be strings")
+            if not isinstance(value, str):
+                raise ValueError(f"{field}['env_vars'][{name!r}] must be a string")
+    return run_config
+
+
+def validate_command_run_config(
+    run_config: Optional[SandboxRunConfig],
+    env: Optional[dict[str, str]],
+    cwd: Optional[str],
+) -> Optional[SandboxRunConfig]:
+    """Check a per-command run config against the deprecated ``env``/``cwd``.
+
+    The server rejects a request carrying both spellings, so reject it here
+    with a message that names the replacement.
+
+    Args:
+        run_config: Per-command run config.
+        env: Deprecated per-command environment.
+        cwd: Deprecated per-command working directory.
+
+    Returns:
+        The run config as given.
+
+    Raises:
+        ValueError: If ``run_config`` is combined with ``env`` or ``cwd``, or
+            if the run config itself is invalid.
+    """
+    if run_config is not None and (env is not None or cwd is not None):
+        combined = " and ".join(
+            name for name, value in (("env", env), ("cwd", cwd)) if value is not None
+        )
+        raise ValueError(
+            f"run_config cannot be combined with {combined}; "
+            "env is deprecated in favour of run_config['env_vars'] and "
+            "cwd in favour of run_config['work_dir']"
+        )
+    return validate_run_config(run_config)

--- a/python/langsmith/sandbox/_sandbox.py
+++ b/python/langsmith/sandbox/_sandbox.py
@@ -22,6 +22,10 @@ from langsmith.sandbox._models import (
     Snapshot,
     _StreamEndedBeforeStarted,
 )
+from langsmith.sandbox._run_config import (
+    SandboxRunConfig,
+    validate_command_run_config,
+)
 from langsmith.sandbox._tunnel import Tunnel
 from langsmith.sandbox._ws_execute import (
     WEBSOCKETS_AVAILABLE,
@@ -74,6 +78,10 @@ class Sandbox:
         vcpus: Number of vCPUs allocated.
         mem_bytes: Memory allocation in bytes.
         fs_capacity_bytes: Root filesystem capacity in bytes.
+        run_config: What commands run with, as ``{"user": ..., "work_dir":
+            ..., "env_vars": {...}}`` — the snapshot's, with any create or
+            update override merged in. ``None`` on sandboxes created before
+            run configs were recorded.
 
     Example:
         with client.sandbox(snapshot_id="<snapshot-uuid>") as sandbox:
@@ -96,6 +104,7 @@ class Sandbox:
     vcpus: Optional[int] = None
     mem_bytes: Optional[int] = None
     fs_capacity_bytes: Optional[int] = None
+    run_config: Optional[SandboxRunConfig] = None
 
     # Internal fields (not from API)
     _client: SandboxClient = field(repr=False, default=None)  # type: ignore
@@ -133,6 +142,7 @@ class Sandbox:
             vcpus=data.get("vcpus"),
             mem_bytes=data.get("mem_bytes"),
             fs_capacity_bytes=data.get("fs_capacity_bytes"),
+            run_config=data.get("run_config"),
             _client=client,
             _auto_delete=auto_delete,
         )
@@ -169,6 +179,7 @@ class Sandbox:
             vcpus=self.vcpus,
             mem_bytes=self.mem_bytes,
             fs_capacity_bytes=self.fs_capacity_bytes,
+            run_config=self.run_config,
             _client=client if client is not None else self._client.to_async(),
             _auto_delete=False,
         )
@@ -220,6 +231,7 @@ class Sandbox:
         timeout: int = ...,
         env: Optional[dict[str, str]] = ...,
         cwd: Optional[str] = ...,
+        run_config: Optional[SandboxRunConfig] = ...,
         shell: str = ...,
         on_stdout: Optional[Callable[[str], Any]] = ...,
         on_stderr: Optional[Callable[[str], Any]] = ...,
@@ -239,6 +251,7 @@ class Sandbox:
         timeout: int = ...,
         env: Optional[dict[str, str]] = ...,
         cwd: Optional[str] = ...,
+        run_config: Optional[SandboxRunConfig] = ...,
         shell: str = ...,
         on_stdout: Optional[Callable[[str], Any]] = ...,
         on_stderr: Optional[Callable[[str], Any]] = ...,
@@ -257,6 +270,7 @@ class Sandbox:
         timeout: int = 60,
         env: Optional[dict[str, str]] = None,
         cwd: Optional[str] = None,
+        run_config: Optional[SandboxRunConfig] = None,
         shell: str = "/bin/bash",
         on_stdout: Optional[Callable[[str], Any]] = None,
         on_stderr: Optional[Callable[[str], Any]] = None,
@@ -272,8 +286,14 @@ class Sandbox:
         Args:
             command: Shell command to execute.
             timeout: Command timeout in seconds.
-            env: Environment variables to set for the command.
-            cwd: Working directory for command execution. If None, uses sandbox default.
+            env: Deprecated, use ``run_config["env_vars"]``. Environment
+                variables to set for the command.
+            cwd: Deprecated, use ``run_config["work_dir"]``. Working directory
+                for command execution. If None, uses the sandbox's.
+            run_config: What this one command runs with, as ``{"user": ...,
+                "work_dir": ..., "env_vars": {...}}``, layered over the
+                sandbox's own run config. Cannot be combined with the
+                deprecated ``env`` and ``cwd``.
             shell: Shell to use for command execution. Defaults to "/bin/bash".
             on_stdout: Callback invoked with each stdout chunk as it arrives.
                 Blocks until the command completes and returns ExecutionResult.
@@ -319,6 +339,7 @@ class Sandbox:
                 "Cannot combine wait=False with on_stdout/on_stderr callbacks. "
                 "Use wait=False and iterate the CommandHandle, or use callbacks."
             )
+        validate_command_run_config(run_config, env, cwd)
 
         self._require_dataplane_url()
 
@@ -330,6 +351,7 @@ class Sandbox:
                 timeout=timeout,
                 env=env,
                 cwd=cwd,
+                run_config=run_config,
                 shell=shell,
                 wait=wait,
                 on_stdout=on_stdout,
@@ -349,6 +371,7 @@ class Sandbox:
                 timeout=timeout,
                 env=env,
                 cwd=cwd,
+                run_config=run_config,
                 shell=shell,
                 wait=True,
                 on_stdout=None,
@@ -364,6 +387,7 @@ class Sandbox:
             timeout=timeout,
             env=env,
             cwd=cwd,
+            run_config=run_config,
             shell=shell,
             headers=headers,
         )
@@ -375,6 +399,7 @@ class Sandbox:
         timeout: int,
         env: Optional[dict[str, str]],
         cwd: Optional[str],
+        run_config: Optional[SandboxRunConfig],
         shell: str,
         wait: bool,
         on_stdout: Optional[Callable[[str], Any]],
@@ -405,6 +430,7 @@ class Sandbox:
             "timeout": timeout,
             "env": env,
             "cwd": cwd,
+            "run_config": run_config,
             "shell": shell,
             "idle_timeout": idle_timeout,
             "kill_on_disconnect": kill_on_disconnect,
@@ -468,6 +494,7 @@ class Sandbox:
         timeout: int,
         env: Optional[dict[str, str]],
         cwd: Optional[str],
+        run_config: Optional[SandboxRunConfig],
         shell: str,
         headers: RequestHeaders,
     ) -> ExecutionResult:
@@ -483,6 +510,8 @@ class Sandbox:
             payload["env"] = env
         if cwd is not None:
             payload["cwd"] = cwd
+        if run_config is not None:
+            payload["run_config"] = run_config
 
         try:
             response = self._client._http.post(

--- a/python/langsmith/sandbox/_ws_execute.py
+++ b/python/langsmith/sandbox/_ws_execute.py
@@ -20,6 +20,7 @@ from langsmith.sandbox._exceptions import (
     SandboxServerReloadError,
 )
 from langsmith.sandbox._helpers import merge_headers
+from langsmith.sandbox._run_config import SandboxRunConfig
 
 logger = logging.getLogger(__name__)
 
@@ -340,6 +341,7 @@ def run_ws_stream(
     timeout: int = 60,
     env: Optional[dict[str, str]] = None,
     cwd: Optional[str] = None,
+    run_config: Optional[SandboxRunConfig] = None,
     shell: str = "/bin/bash",
     on_stdout: Optional[Callable[[str], Any]] = None,
     on_stderr: Optional[Callable[[str], Any]] = None,
@@ -397,6 +399,8 @@ def run_ws_stream(
                     payload["env"] = env
                 if cwd:
                     payload["cwd"] = cwd
+                if run_config:
+                    payload["run_config"] = run_config
                 if pty:
                     payload["pty"] = True
                 ws.send(json.dumps(payload))
@@ -547,6 +551,7 @@ async def run_ws_stream_async(
     timeout: int = 60,
     env: Optional[dict[str, str]] = None,
     cwd: Optional[str] = None,
+    run_config: Optional[SandboxRunConfig] = None,
     shell: str = "/bin/bash",
     on_stdout: Optional[Callable[[str], Any]] = None,
     on_stderr: Optional[Callable[[str], Any]] = None,
@@ -593,6 +598,8 @@ async def run_ws_stream_async(
                     payload["env"] = env
                 if cwd:
                     payload["cwd"] = cwd
+                if run_config:
+                    payload["run_config"] = run_config
                 if pty:
                     payload["pty"] = True
                 await ws.send(json.dumps(payload))

--- a/python/tests/unit_tests/sandbox/test_async_ws_execute.py
+++ b/python/tests/unit_tests/sandbox/test_async_ws_execute.py
@@ -908,6 +908,7 @@ class TestAsyncSandboxRunWs:
             timeout=60,
             env=None,
             cwd=None,
+            run_config=None,
             shell="/bin/bash",
             headers={"X-Test-Header": "sandbox-ws"},
             idle_timeout=300,

--- a/python/tests/unit_tests/sandbox/test_run_config.py
+++ b/python/tests/unit_tests/sandbox/test_run_config.py
@@ -1,0 +1,193 @@
+"""Tests for sandbox run configuration."""
+
+import json
+
+import pytest
+from pytest_httpx import HTTPXMock
+
+from langsmith.sandbox import Sandbox, SandboxClient, Snapshot
+from langsmith.sandbox._run_config import (
+    validate_command_run_config,
+    validate_run_config,
+)
+
+RUN_CONFIG = {"user": "app", "work_dir": "/srv", "env_vars": {"LANG": "C"}}
+
+
+@pytest.fixture
+def client():
+    """Create a SandboxClient with retries disabled for test isolation."""
+    return SandboxClient(api_endpoint="http://test-server:8080", max_retries=0)
+
+
+@pytest.fixture
+def sandbox(client: SandboxClient):
+    """Create a Sandbox instance."""
+    return Sandbox.from_dict(
+        data={
+            "name": "test-sandbox",
+            "dataplane_url": "https://sandbox-router.example.com/sb-123",
+        },
+        client=client,
+        auto_delete=False,
+    )
+
+
+class TestValidateRunConfig:
+    """Client-side checks on the run config shape."""
+
+    def test_accepts_full_config(self):
+        assert validate_run_config(RUN_CONFIG) == RUN_CONFIG
+
+    def test_accepts_none(self):
+        assert validate_run_config(None) is None
+
+    @pytest.mark.parametrize(
+        ("run_config", "message"),
+        [
+            ({"workdir": "/srv"}, "unsupported keys: workdir"),
+            ({"user": ""}, "must be a non-empty string"),
+            ({"work_dir": "srv"}, "must be an absolute path"),
+            ({"env_vars": ["LANG=C"]}, "must be a mapping"),
+            ({"env_vars": {"PORT": 8080}}, "must be a string"),
+        ],
+    )
+    def test_rejects_bad_config(self, run_config, message):
+        with pytest.raises(ValueError, match=message):
+            validate_run_config(run_config)
+
+    @pytest.mark.parametrize(
+        ("env", "cwd"),
+        [({"LANG": "C"}, None), (None, "/srv"), ({"LANG": "C"}, "/srv")],
+    )
+    def test_rejects_deprecated_fields_alongside_run_config(self, env, cwd):
+        with pytest.raises(ValueError, match="cannot be combined with"):
+            validate_command_run_config(RUN_CONFIG, env, cwd)
+
+    def test_allows_deprecated_fields_on_their_own(self):
+        assert validate_command_run_config(None, {"LANG": "C"}, "/srv") is None
+
+
+class TestClientForwardsRunConfig:
+    """run_config reaches the wire on every request that accepts it."""
+
+    def test_create_sandbox(self, client: SandboxClient, httpx_mock: HTTPXMock):
+        httpx_mock.add_response(
+            method="POST",
+            url="http://test-server:8080/boxes",
+            json={"name": "test-sandbox"},
+            status_code=201,
+        )
+
+        client.create_sandbox(snapshot_id="snap-1", run_config=RUN_CONFIG)
+
+        body = json.loads(httpx_mock.get_request().content)
+        assert body["run_config"] == RUN_CONFIG
+
+    def test_update_sandbox(self, client: SandboxClient, httpx_mock: HTTPXMock):
+        httpx_mock.add_response(
+            method="PATCH",
+            url="http://test-server:8080/boxes/test-sandbox",
+            json={"name": "test-sandbox", "run_config": RUN_CONFIG},
+        )
+
+        sandbox = client.update_sandbox("test-sandbox", run_config=RUN_CONFIG)
+
+        body = json.loads(httpx_mock.get_request().content)
+        assert body["run_config"] == RUN_CONFIG
+        assert sandbox.run_config == RUN_CONFIG
+
+    def test_create_snapshot(self, client: SandboxClient, httpx_mock: HTTPXMock):
+        httpx_mock.add_response(
+            method="POST",
+            url="http://test-server:8080/snapshots",
+            json={"id": "snap-1", "name": "snap", "status": "ready"},
+            status_code=201,
+        )
+        httpx_mock.add_response(
+            method="GET",
+            url="http://test-server:8080/snapshots/snap-1",
+            json={
+                "id": "snap-1",
+                "name": "snap",
+                "status": "ready",
+                "run_config": RUN_CONFIG,
+            },
+        )
+
+        snapshot = client.create_snapshot(
+            "snap", "python:3.12-slim", 1024, run_config=RUN_CONFIG
+        )
+
+        body = json.loads(httpx_mock.get_requests()[0].content)
+        assert body["run_config"] == RUN_CONFIG
+        assert snapshot.run_config == RUN_CONFIG
+
+    def test_capture_snapshot(self, client: SandboxClient, httpx_mock: HTTPXMock):
+        httpx_mock.add_response(
+            method="POST",
+            url="http://test-server:8080/boxes/test-sandbox/snapshot",
+            json={"id": "snap-1", "name": "snap", "status": "ready"},
+            status_code=201,
+        )
+        httpx_mock.add_response(
+            method="GET",
+            url="http://test-server:8080/snapshots/snap-1",
+            json={"id": "snap-1", "name": "snap", "status": "ready"},
+        )
+
+        client.capture_snapshot("test-sandbox", "snap", run_config=RUN_CONFIG)
+
+        body = json.loads(httpx_mock.get_requests()[0].content)
+        assert body["run_config"] == RUN_CONFIG
+
+    def test_rejects_bad_config_before_request(self, client: SandboxClient):
+        with pytest.raises(ValueError, match="must be an absolute path"):
+            client.create_sandbox(snapshot_id="snap-1", run_config={"work_dir": "srv"})
+
+
+class TestModelsCarryRunConfig:
+    """Responses surface the stored run config, and its absence."""
+
+    def test_snapshot(self):
+        assert Snapshot.from_dict({"run_config": RUN_CONFIG}).run_config == RUN_CONFIG
+
+    def test_snapshot_without_run_config(self):
+        assert Snapshot.from_dict({"id": "snap-1"}).run_config is None
+
+    def test_sandbox(self, client: SandboxClient):
+        sandbox = Sandbox.from_dict(
+            {"name": "test-sandbox", "run_config": RUN_CONFIG}, client=client
+        )
+        assert sandbox.run_config == RUN_CONFIG
+
+    def test_to_async_keeps_run_config(self, client: SandboxClient):
+        sandbox = Sandbox.from_dict(
+            {"name": "test-sandbox", "run_config": RUN_CONFIG}, client=client
+        )
+        assert sandbox.to_async().run_config == RUN_CONFIG
+
+
+class TestPerCommandRunConfig:
+    """run() over the HTTP fallback path."""
+
+    @pytest.fixture(autouse=True)
+    def _ws_unavailable(self, monkeypatch):
+        monkeypatch.setattr("langsmith.sandbox._sandbox.WEBSOCKETS_AVAILABLE", False)
+
+    def test_forwards_run_config(self, sandbox: Sandbox, httpx_mock: HTTPXMock):
+        httpx_mock.add_response(
+            method="POST",
+            url="https://sandbox-router.example.com/sb-123/execute",
+            json={"stdout": "", "stderr": "", "exit_code": 0},
+        )
+
+        sandbox.run("id", run_config=RUN_CONFIG)
+
+        body = json.loads(httpx_mock.get_request().content)
+        assert body["run_config"] == RUN_CONFIG
+        assert "cwd" not in body and "env" not in body
+
+    def test_rejects_run_config_with_cwd(self, sandbox: Sandbox):
+        with pytest.raises(ValueError, match="cannot be combined with cwd"):
+            sandbox.run("pwd", cwd="/tmp", run_config=RUN_CONFIG)

--- a/python/tests/unit_tests/sandbox/test_sync_async_conversion.py
+++ b/python/tests/unit_tests/sandbox/test_sync_async_conversion.py
@@ -26,6 +26,7 @@ SANDBOX_DATA = {
     "vcpus": 2,
     "mem_bytes": 1024**3,
     "fs_capacity_bytes": 10 * 1024**3,
+    "run_config": {"user": "app", "work_dir": "/srv"},
 }
 
 DATA_FIELDS = list(SANDBOX_DATA)

--- a/python/tests/unit_tests/sandbox/test_ws_execute.py
+++ b/python/tests/unit_tests/sandbox/test_ws_execute.py
@@ -872,6 +872,7 @@ class TestSandboxRunWs:
             timeout=60,
             env=None,
             cwd=None,
+            run_config=None,
             shell="/bin/bash",
             headers={"X-Test-Header": "sandbox-ws"},
             idle_timeout=300,


### PR DESCRIPTION
Adds `run_config` to the Python and TypeScript sandbox SDKs, for the server-side feature landed in langchain-ai/langchainplus#35583.

`run_config` (`user`, `work_dir`, `env_vars`) sets what commands run as. It mirrors `docker run -u/-w/-e`: `user` and `work_dir` replace the value from the layer below, `env_vars` merge over it key by key. It applies at four points:

- **Snapshot build and capture** — `create_snapshot`, `create_snapshot_from_dockerfile`, `capture_snapshot` (`createSnapshot`, `createSnapshotFromDockerfile`, `captureSnapshot`). A snapshot built from a Docker image records that image's `USER`, `WORKDIR` and `ENV`; this overrides them.
- **Sandbox create** — `sandbox()` / `create_sandbox` (`createSandbox`), over the snapshot's.
- **Sandbox update** — `update_sandbox` (`updateSandbox`), taking effect for subsequent commands.
- **Per command** — `run()`, over the sandbox's, on the blocking HTTP path and the WebSocket path alike.

Responses carry it too: `Snapshot.run_config` and `Sandbox.run_config` report the stored value, absent on resources created before it was recorded.

The per-command `cwd` and `env` arguments are deprecated in favour of `run_config["work_dir"]` and `run_config["env_vars"]` (`runConfig.work_dir`, `runConfig.env_vars`). They still work on their own; combining them with `run_config` is rejected client-side with the same rule the server applies, so the error names the replacement instead of costing a round trip. The TypeScript fields carry `@deprecated`.

Shapes are checked before the request goes out: unknown keys, a relative `work_dir`, and non-string env values fail locally.

## Test Plan

- [x] `make tests TEST=tests/unit_tests/sandbox` — 596 pass, including new coverage of every forwarding path, the deprecation conflict, and the response fields
- [x] `pnpm jest src/tests/sandbox` — 196 pass, same coverage on the TypeScript side
- [x] `tsc --noEmit`, `ruff check`, `ruff format`, `oxlint`, `oxfmt`
