### PR TITLE
fix(py): stop the parse() serializer warning in wrap_openai

### DIFF
--- a/python/langsmith/wrappers/_openai.py
+++ b/python/langsmith/wrappers/_openai.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import functools
 import logging
+import warnings
 from collections import defaultdict
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -268,6 +269,48 @@ def _reduce_completions(all_chunks: list[Completion]) -> dict:
     return d
 
 
+def _is_parsed_response(response: Any) -> bool:
+    """Whether this response came from a `.parse()` call rather than `.create()`.
+
+    `ParsedChatCompletion` and `ParsedResponse` are generic over the caller's
+    response format, and the SDK builds them with the type variable left
+    unsubstituted - the runtime type really is
+    `ParsedChatCompletion[~ResponseFormatT]`. Pydantic resolves that variable to
+    its `None` default when dumping, so it reports the caller's own model as an
+    unexpected value for `parsed` / `output_parsed`.
+
+    Identified by the field the parse types add, as `_anthropic`'s
+    `_message_to_outputs` identifies `ParsedBetaMessage` by `parsed_output`
+    (issue #2737).
+    """
+    if hasattr(response, "output_parsed"):
+        return True
+    choices = getattr(response, "choices", None)
+    if not isinstance(choices, Sequence):
+        return False
+    return any(
+        hasattr(getattr(choice, "message", None), "parsed") for choice in choices
+    )
+
+
+def _dump_response(response: Any, **kwargs: Any) -> dict:
+    """`model_dump` without the serializer warning a parsed response provokes.
+
+    The dumped payload is right - `parsed` carries the caller's model, dumped as
+    a dict - so only the declared type is wrong, and the warning is noise: one
+    `PydanticSerializationUnexpectedValue` per traced `parse()` call (issue
+    #3490). Filtered by message rather than with a blanket `simplefilter`, so a
+    serializer warning about anything else in the same dump still surfaces.
+    """
+    if not _is_parsed_response(response):
+        return response.model_dump(**kwargs)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", category=UserWarning, message="Pydantic serializer warnings"
+        )
+        return response.model_dump(**kwargs)
+
+
 def _process_chat_completion(outputs: Any):
     try:
         # Check if outputs is an APIResponse wrapper (from with_raw_response).
@@ -280,7 +323,7 @@ def _process_chat_completion(outputs: Any):
             except Exception:
                 pass
 
-        rdict = outputs.model_dump()
+        rdict = _dump_response(outputs)
         oai_token_usage = rdict.pop("usage", None)
         rdict["usage_metadata"] = (
             _create_usage_metadata(oai_token_usage, rdict.get("service_tier"))
@@ -593,7 +636,7 @@ def _process_responses_api_output(response: Any) -> dict:
                 except Exception:
                     pass
 
-            output = response.model_dump(exclude_none=True, mode="json")
+            output = _dump_response(response, exclude_none=True, mode="json")
             if usage := output.pop("usage", None):
                 output["usage_metadata"] = _create_usage_metadata(
                     usage, output.get("service_tier")

--- a/python/tests/unit_tests/wrappers/test_openai_processing.py
+++ b/python/tests/unit_tests/wrappers/test_openai_processing.py
@@ -1,12 +1,25 @@
 """Unit tests for OpenAI wrapper processing functions."""
 
+import warnings
 from types import SimpleNamespace
 
 import pytest
+from openai.lib._parsing import parse_chat_completion
+from openai.lib._parsing._responses import parse_response
+from openai.types.chat import ChatCompletion, ChatCompletionMessage
+from openai.types.chat.chat_completion import Choice
+from openai.types.responses import (
+    Response,
+    ResponseOutputMessage,
+    ResponseOutputText,
+)
+from pydantic import BaseModel
 
 from langsmith import run_helpers
 from langsmith.wrappers._openai import (
     _infer_invocation_params,
+    _process_chat_completion,
+    _process_responses_api_output,
     _traceable_kwargs_with_ls_agent_type,
 )
 
@@ -187,3 +200,142 @@ def test_nested_none_opt_out_overrides_propagated_tag():
     )
     assert "ls_agent_type" in result["child_metadata"]
     assert result["child_metadata"]["ls_agent_type"] is None
+
+
+# ---------------------------------------------------------------------------
+# Serializer warnings from `.parse()` responses (issue #3490)
+#
+# `ParsedChatCompletion` / `ParsedResponse` are generic over the caller's
+# response format and the SDK builds them with the type variable left
+# unsubstituted, so Pydantic resolves it to `None` and reports the caller's own
+# model as unexpected. One warning per traced `parse()` call, on a payload that
+# is nonetheless correct. The Anthropic wrapper already suppresses the same
+# warning for `ParsedBetaMessage` (issue #2737).
+# ---------------------------------------------------------------------------
+
+
+class _WeatherResponse(BaseModel):
+    city: str
+    temp: str
+
+
+_WEATHER_JSON = '{"city":"San Francisco","temp":"18C"}'
+
+
+def _chat_completion() -> ChatCompletion:
+    return ChatCompletion(
+        id="chatcmpl-1",
+        created=0,
+        model="gpt-4o-mini",
+        object="chat.completion",
+        choices=[
+            Choice(
+                finish_reason="stop",
+                index=0,
+                message=ChatCompletionMessage(role="assistant", content=_WEATHER_JSON),
+            )
+        ],
+        usage={"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+    )
+
+
+def _response() -> Response:
+    return Response(
+        id="resp-1",
+        created_at=0,
+        model="gpt-4o-mini",
+        object="response",
+        output=[
+            ResponseOutputMessage(
+                id="msg-1",
+                role="assistant",
+                status="completed",
+                type="message",
+                content=[
+                    ResponseOutputText(
+                        type="output_text", text=_WEATHER_JSON, annotations=[]
+                    )
+                ],
+            )
+        ],
+        parallel_tool_calls=False,
+        tool_choice="auto",
+        tools=[],
+    )
+
+
+def _caught(process, response) -> list[warnings.WarningMessage]:
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        process(response)
+    return list(caught)
+
+
+def test_parsed_chat_completion_emits_no_serializer_warning():
+    """`beta.chat.completions.parse()` traces without warning, and still traces
+    the parsed model."""
+    parsed = parse_chat_completion(
+        response_format=_WeatherResponse,
+        input_tools=[],
+        chat_completion=_chat_completion(),
+    )
+    # The unsubstituted type variable is what provokes the warning; if a future
+    # SDK resolves it, this case stops proving anything and should be revisited.
+    assert "~ResponseFormatT" in type(parsed).__name__
+
+    caught = _caught(_process_chat_completion, parsed)
+    assert caught == [], [str(w.message) for w in caught]
+
+    payload = _process_chat_completion(parsed)
+    assert payload["choices"][0]["message"]["parsed"] == {
+        "city": "San Francisco",
+        "temp": "18C",
+    }
+    assert payload["usage_metadata"]["input_tokens"] == 10
+
+
+def test_parsed_response_emits_no_serializer_warning():
+    """`responses.parse()` has the same defect and the same fix - the Anthropic
+    counterpart was fixed on one path only, which is how this one survived."""
+    parsed = parse_response(
+        text_format=_WeatherResponse, input_tools=[], response=_response()
+    )
+    assert "~TextFormatT" in type(parsed).__name__
+
+    caught = _caught(_process_responses_api_output, parsed)
+    assert caught == [], [str(w.message) for w in caught]
+
+    # `ParsedResponse.output_parsed` is a property rather than a field, so the
+    # parsed model reaches the trace through the text block it was parsed from.
+    payload = _process_responses_api_output(parsed)
+    assert payload["output"][0]["content"][0]["parsed"] == {
+        "city": "San Francisco",
+        "temp": "18C",
+    }
+
+
+@pytest.mark.parametrize(
+    ("process", "response"),
+    [
+        (_process_chat_completion, _chat_completion()),
+        (_process_responses_api_output, _response()),
+    ],
+)
+def test_unparsed_responses_are_unchanged(process, response):
+    """The `create()` paths were already silent and must stay untouched."""
+    assert _caught(process, response) == []
+
+
+def test_other_serializer_warnings_still_surface():
+    """Suppression is matched on the Pydantic serializer message, so an
+    unrelated warning raised during the same dump is not swallowed."""
+
+    class _Noisy:
+        choices = [SimpleNamespace(message=SimpleNamespace(parsed={"a": 1}))]
+
+        def model_dump(self, **_kwargs):
+            warnings.warn("something else entirely", UserWarning, stacklevel=2)
+            return {"choices": [], "usage": None}
+
+    caught = _caught(_process_chat_completion, _Noisy())
+    assert [str(w.message) for w in caught] == ["something else entirely"]


### PR DESCRIPTION
Fixes #3490.

## Reproduced, without network

Through the SDK's own parse path (`openai.lib._parsing.parse_chat_completion`), which is what `client.beta.chat.completions.parse()` calls:

```
type:           ParsedChatCompletion[~ResponseFormatT]
declared field: typing.Optional[~ResponseFormatT]
--- parse():  1 warning(s)
    Pydantic serializer warnings:
      PydanticSerializationUnexpectedValue(Expected `none` … [field_name='parsed',
      input_value=WeatherResponse(city='San Francisco', temp='18C')])
    parsed in payload: {'city': 'San Francisco', 'temp': '18C'}
--- create(): 0 warning(s)
```

The cause is visible in the first two lines: `parse_chat_completion` builds the object with `construct_type_unchecked(type_=ParsedChatCompletion[ResponseFormatT], …)`, and Python does not substitute a type variable at runtime, so the field's declared type stays `Optional[~ResponseFormatT]`. Pydantic resolves that variable to its `None` default when dumping and reports the caller's model as unexpected. The last line is the point: the payload is correct, only the declared type is wrong, so the warning is pure noise — one per traced structured call.

## `responses.parse()` has it too

Same probe on `openai.lib._parsing._responses.parse_response` and `_process_responses_api_output`:

```
type: ParsedResponse[~TextFormatT]
--- responses.parse():  1 warning(s)   (same PydanticSerializationUnexpectedValue)
--- responses.create(): 0 warning(s)
```

`client.responses.parse` is wrapped by the same `_get_parse_wrapper` (`_openai.py:568`). Fixing only the chat path would repeat exactly the mistake this issue reports — #2783 fixed `wrap_anthropic`'s `ParsedBetaMessage` and left this module's parse paths untouched — so both are covered here.

## The change

One helper, two call sites, no duplication:

```python
def _dump_response(response: Any, **kwargs: Any) -> dict:
    if not _is_parsed_response(response):
        return response.model_dump(**kwargs)
    with warnings.catch_warnings():
        warnings.filterwarnings(
            "ignore", category=UserWarning, message="Pydantic serializer warnings"
        )
        return response.model_dump(**kwargs)
```

`_is_parsed_response` identifies the parse types by the field they add — `output_parsed` on `ParsedResponse`, `choices[].message.parsed` on `ParsedChatCompletion` — the way `_anthropic._message_to_outputs` identifies `ParsedBetaMessage` by `parsed_output`. `ChatCompletionMessage` has no `parsed` field, so the `create()` paths do not match.

One deliberate difference from the Anthropic precedent: it filters on the Pydantic serializer message instead of `simplefilter("ignore")`, so a serializer warning about anything *else* in the same dump still reaches the user — that is what the reporter's own workaround was careful about. `_anthropic` could be tightened the same way; I left it alone rather than widen this PR, happy to follow up if you want them identical.

## Testing

`python/tests/unit_tests/wrappers/test_openai_processing.py`, all offline:

- `test_parsed_chat_completion_emits_no_serializer_warning` — no warning, and `parsed` still reaches the payload as `{"city": …, "temp": …}` with `usage_metadata` intact.
- `test_parsed_response_emits_no_serializer_warning` — the responses path. (`ParsedResponse.output_parsed` turns out to be a `property`, not a field, so the parsed model reaches the trace through the text block it was parsed from; the assertion follows that.)
- `test_unparsed_responses_are_unchanged` — parametrized over both `create()` paths, which were already silent.
- `test_other_serializer_warnings_still_surface` — an unrelated `UserWarning` raised during the same dump is not swallowed.

Both parse cases assert `"~ResponseFormatT" in type(parsed).__name__` first, so if a future OpenAI SDK resolves the type variable the cases say so instead of passing vacuously.

```
pytest tests/unit_tests/wrappers/           492 passed
ruff check .                                All checks passed
ruff format --check                         clean
mypy langsmith                              no issues found in 121 source files
```

Negative controls: reverting both dump sites reddens the two parse cases and nothing else; replacing the message filter with `simplefilter("ignore")` reddens only `test_other_serializer_warnings_still_surface`.

Versions here are `openai 2.52.0` / `pydantic 2.13.5`, newer than the reporter's `2.30.0` / `2.12.5` — the behaviour is unchanged on both.
